### PR TITLE
fix: bridge Oxy follow with AP Follow for federated profiles

### DIFF
--- a/packages/frontend/components/Profile/ProfileContent.tsx
+++ b/packages/frontend/components/Profile/ProfileContent.tsx
@@ -98,6 +98,7 @@ export const ProfileContent = memo(function ProfileContent({
           <ProfileActions
             isOwnProfile={isOwnProfile}
             isFederated={profileData.isFederated}
+            actorUri={profileData.actorUri}
             currentUsername={currentUsername}
             profileUsername={profileData.username}
             profileId={profileData.id}

--- a/packages/frontend/components/Profile/ProfileHeader.tsx
+++ b/packages/frontend/components/Profile/ProfileHeader.tsx
@@ -11,6 +11,7 @@ import { Gear } from '@/assets/icons/gear-icon';
 import { PrivateBadge } from './PrivateBadge';
 import { PresenceIndicator } from '@/components/PresenceIndicator';
 import { usePoke } from './hooks/usePoke';
+import { useFederatedFollowSync } from './hooks/useFederatedFollowSync';
 import type {
   ProfileHeaderDefaultProps,
   ProfileHeaderMinimalistProps,
@@ -39,6 +40,7 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
 }: ProfileHeaderDefaultProps) {
   const { t } = useTranslation();
   const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || !!isFederated);
+  useFederatedFollowSync(profileId, isFederated, actorUri);
 
   return (
     <View className="flex-row justify-between items-end mb-2.5" style={{ marginTop: -45 }}>
@@ -187,6 +189,7 @@ export const ProfileHeaderMinimalist = memo(function ProfileHeaderMinimalist({
 export const ProfileActions = memo(function ProfileActions({
   isOwnProfile,
   isFederated,
+  actorUri,
   currentUsername,
   profileUsername,
   profileId,
@@ -195,6 +198,7 @@ export const ProfileActions = memo(function ProfileActions({
 }: {
   isOwnProfile: boolean;
   isFederated?: boolean;
+  actorUri?: string;
   currentUsername?: string;
   profileUsername?: string;
   profileId?: string;
@@ -204,6 +208,7 @@ export const ProfileActions = memo(function ProfileActions({
   const theme = useTheme();
   const { t } = useTranslation();
   const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || !!isFederated);
+  useFederatedFollowSync(profileId, isFederated, actorUri);
 
   if (!isOwnProfile || currentUsername !== profileUsername) {
     if (!profileId) return null;

--- a/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
+++ b/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
@@ -38,7 +38,6 @@ export function useFederatedFollowSync(
       prevFollowingRef.current = isFollowing;
       return;
     }
-    }
 
     const wasFollowing = prevFollowingRef.current;
     prevFollowingRef.current = isFollowing;

--- a/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
+++ b/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
@@ -47,11 +47,11 @@ export function useFederatedFollowSync(
 
     if (isFollowing) {
       feedService.followFederatedActor(actorUri).catch(err => {
-        console.warn('[Federation] Failed to send AP Follow:', err);
+        logger.warn('[Federation] Failed to send AP Follow:', { error: err });
       });
     } else {
       feedService.unfollowFederatedActor(actorUri).catch(err => {
-        console.warn('[Federation] Failed to send AP Unfollow:', err);
+        logger.warn('[Federation] Failed to send AP Unfollow:', { error: err });
       });
     }
   }, [isFederated, actorUri, profileId, isFollowing]);

--- a/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
+++ b/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
@@ -19,6 +19,14 @@ export function useFederatedFollowSync(
 
   const settledRef = useRef(false);
   const prevFollowingRef = useRef(isFollowing);
+  const prevIdentityRef = useRef(oxyUserId);
+
+  // Reset tracking when the profile identity changes (mirrors ProfileScreen pattern)
+  if (prevIdentityRef.current !== oxyUserId) {
+    prevIdentityRef.current = oxyUserId;
+    settledRef.current = false;
+    prevFollowingRef.current = isFollowing;
+  }
 
   useEffect(() => {
     if (!isFederated || !actorUri || !profileId) return;
@@ -29,6 +37,7 @@ export function useFederatedFollowSync(
       settledRef.current = true;
       prevFollowingRef.current = isFollowing;
       return;
+    }
     }
 
     const wasFollowing = prevFollowingRef.current;

--- a/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
+++ b/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { useFollow } from '@oxyhq/services';
+import { feedService } from '@/services/feedService';
+
+/**
+ * Watches the Oxy follow state for a federated profile and bridges it
+ * to the ActivityPub layer by calling the federation follow/unfollow
+ * endpoints when the local follow state transitions.
+ *
+ * This hook is a no-op when `isFederated` is false or `actorUri` is absent.
+ */
+export function useFederatedFollowSync(
+  profileId: string | undefined,
+  isFederated: boolean | undefined,
+  actorUri: string | undefined,
+) {
+  const oxyUserId = isFederated && profileId ? profileId : '';
+  const { isFollowing } = useFollow(oxyUserId);
+
+  const settledRef = useRef(false);
+  const prevFollowingRef = useRef(isFollowing);
+
+  useEffect(() => {
+    if (!isFederated || !actorUri || !profileId) return;
+
+    // Skip the first value — it's the initial hydration from the store,
+    // not a user-initiated transition.
+    if (!settledRef.current) {
+      settledRef.current = true;
+      prevFollowingRef.current = isFollowing;
+      return;
+    }
+
+    const wasFollowing = prevFollowingRef.current;
+    prevFollowingRef.current = isFollowing;
+
+    if (wasFollowing === isFollowing) return;
+
+    if (isFollowing) {
+      feedService.followFederatedActor(actorUri).catch(err => {
+        console.warn('[Federation] Failed to send AP Follow:', err);
+      });
+    } else {
+      feedService.unfollowFederatedActor(actorUri).catch(err => {
+        console.warn('[Federation] Failed to send AP Unfollow:', err);
+      });
+    }
+  }, [isFederated, actorUri, profileId, isFollowing]);
+}

--- a/packages/frontend/services/feedService.ts
+++ b/packages/frontend/services/feedService.ts
@@ -584,6 +584,26 @@ class FeedService {
       // Non-critical — swallow errors
     }
   }
+
+  // ────────────────────────────────────────────────────────────
+  // Federation — ActivityPub follow/unfollow
+  // ────────────────────────────────────────────────────────────
+
+  /**
+   * Send an ActivityPub Follow activity to a remote federated actor.
+   */
+  async followFederatedActor(actorUri: string): Promise<{ success: boolean; pending: boolean }> {
+    const response = await authenticatedClient.post('/federation/follow', { actorUri });
+    return response.data;
+  }
+
+  /**
+   * Send an ActivityPub Undo(Follow) activity to a remote federated actor.
+   */
+  async unfollowFederatedActor(actorUri: string): Promise<{ success: boolean }> {
+    const response = await authenticatedClient.post('/federation/unfollow', { actorUri });
+    return response.data;
+  }
 }
 
 export const feedService = new FeedService(); 


### PR DESCRIPTION
## Summary
- Adds `followFederatedActor` and `unfollowFederatedActor` methods to `feedService` that call `POST /api/federation/follow` and `/unfollow`
- Creates `useFederatedFollowSync` hook that watches the Oxy follow state (via `useFollow`) and fires the AP Follow/Unfollow when the local state transitions
- Wires the hook into `ProfileHeaderDefault` (default mode) and `ProfileActions` (minimalist mode) so both profile layouts bridge follows to ActivityPub

## Test plan
- [ ] Navigate to a federated profile (e.g. `@mark@threads.net`)
- [ ] Click Follow and verify network tab shows `POST /api/federation/follow` with the correct `actorUri`
- [ ] Click Unfollow and verify `POST /api/federation/unfollow` fires
- [ ] Verify non-federated profiles do not trigger federation API calls
- [ ] Verify the hook does not fire on initial page load (only on user-initiated follow transitions)
- [ ] Test in minimalist mode profile layout to confirm `ProfileActions` path also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
