### PR TITLE
ci(deps): bump checkout v6, paths-filter v4, aws-credentials v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -25,10 +25,10 @@ jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials (OIDC, no stored keys)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -20,8 +20,8 @@ jobs:
       frontend: ${{ steps.changes.outputs.frontend }}
       agora: ${{ steps.changes.outputs.agora }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -42,7 +42,7 @@ jobs:
     if: needs.detect-changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
@@ -68,7 +68,7 @@ jobs:
     if: needs.detect-changes.outputs.agora == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'


### PR DESCRIPTION
Consolidates dependabot CI-action bumps. Pure workflow YAML, no lockfile.

- `actions/checkout` v4 → v6 (ci, deploy-aws, deploy-frontends) — clears the deprecated-Node-20 CI warning
- `dorny/paths-filter` v3 → v4 (deploy-frontends)
- `aws-actions/configure-aws-credentials` v4 → v6 (deploy-aws)

All are drop-in for our usage (basic checkout, `filters` input + outputs unchanged, OIDC `role-to-assume`+`aws-region` stable across majors).

Supersedes #147 #148 #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->