### PR TITLE
fix(backend): prevent nested post hydration leaks

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -131,6 +131,7 @@ function boostRow() {
     metadata: { createdAt: new Date('2024-01-01T00:00:00Z') },
     createdAt: new Date('2024-01-01T00:00:00Z'),
     visibility: 'public',
+    status: 'published',
     hashtags: [],
     mentions: [],
   };
@@ -147,6 +148,7 @@ function originalRow() {
     metadata: { createdAt: new Date('2023-12-31T00:00:00Z') },
     createdAt: new Date('2023-12-31T00:00:00Z'),
     visibility: 'public',
+    status: 'published',
     hashtags: [],
     mentions: [],
   };
@@ -241,6 +243,70 @@ describe('PostHydrationService — boost original embedding is deterministic', (
       expect(hydrated.boost?.originalPost?.id, `maxDepth ${depth}: boost original missing`).toBe(ORIGINAL_ID);
       expect(hydrated.originalPost?.id, `maxDepth ${depth}: top-level originalPost missing`).toBe(ORIGINAL_ID);
     }
+  });
+
+
+  it('does not embed a non-public boosted original for another viewer', async () => {
+    service = new PostHydrationService();
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          visibility: 'private',
+          status: 'draft',
+          content: { text: 'SECRET: draft body' },
+        }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await hydrateBoost(VIEWER_ID);
+
+    expect(hydrated).toBeTruthy();
+    expect(hydrated.boost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
+  });
+
+  it('does not embed a quoted private post from a public reply for an anonymous viewer', async () => {
+    service = new PostHydrationService();
+    const replyId = '650000000000000000000003';
+    const reply = {
+      _id: replyId,
+      oxyUserId: BOOSTER_OXY_ID,
+      type: 'text',
+      quoteOf: ORIGINAL_ID,
+      content: { text: 'public reply quoting private context' },
+      stats: { likesCount: 0, boostsCount: 0, commentsCount: 0, downvotesCount: 0, viewsCount: 0 },
+      createdAt: new Date('2024-01-02T00:00:00Z'),
+      visibility: 'public',
+      status: 'published',
+      hashtags: [],
+      mentions: [],
+    };
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          visibility: 'private',
+          status: 'draft',
+          content: { text: 'SECRET: private quoted body' },
+        }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await service.hydratePosts([reply], {
+      maxDepth: 1,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    expect(hydrated).toBeTruthy();
+    expect(hydrated.quotedPost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
   });
 
   it('still embeds the original when the original has a NULL oxyUserId (orphaned federated actor)', async () => {

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -1340,6 +1340,17 @@ class FeedController {
         return res.status(400).json({ error: 'Original post ID is required' });
       }
 
+      const originalPost = await Post.findOne({
+        _id: originalPostId,
+        visibility: PostVisibility.PUBLIC,
+        status: 'published',
+      })
+        .maxTimeMS(FEED_CONSTANTS.QUERY_TIMEOUT_MS);
+
+      if (!originalPost) {
+        return res.status(404).json({ error: 'Original post not found' });
+      }
+
       // Check if user already boosted this
       const existingBoost = await Post.findOne({
         oxyUserId: currentUserId,

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1256,6 +1256,43 @@ export class PostHydrationService {
     return replierMap;
   }
 
+  private canViewerReadPost(
+    post: RawPost,
+    authorId: string,
+    viewerContext: ViewerContext,
+    isFederatedPost: boolean,
+  ): boolean {
+    const isOwner = Boolean(viewerContext.viewerId && viewerContext.viewerId === authorId);
+    if (isOwner) {
+      return true;
+    }
+
+    // Federated posts are imported only from public ActivityPub objects. Some
+    // older imported rows may not have a local status/visibility stamp, so keep
+    // them renderable unless they explicitly carry a non-public local state.
+    if (isFederatedPost) {
+      const status = post.status ? String(post.status) : 'published';
+      const visibility = post.visibility ? String(post.visibility) : PostVisibility.PUBLIC;
+      return status === 'published' && visibility === PostVisibility.PUBLIC;
+    }
+
+    const status = post.status ? String(post.status) : 'published';
+    if (status !== 'published') {
+      return false;
+    }
+
+    const visibility = (post.visibility ?? PostVisibility.PUBLIC) as string;
+    if (visibility === PostVisibility.PUBLIC) {
+      return true;
+    }
+
+    if (visibility === PostVisibility.FOLLOWERS_ONLY) {
+      return Boolean(viewerContext.viewerId && viewerContext.follows.has(authorId));
+    }
+
+    return false;
+  }
+
   private async buildPostSummary(params: {
     post: RawPost;
     viewerContext: ViewerContext;
@@ -1293,6 +1330,14 @@ export class PostHydrationService {
       ? (federatedAuthorMap?.get(postId) ?? this.buildFederatedDomainAuthor(post))
       : undefined;
     const authorId = resolvedAuthorId ?? federatedFallback?.id ?? `federated:${postId}`;
+
+    // Never hydrate content that the current viewer is not allowed to read.
+    // This is especially important for nested boost/quote references, which are
+    // fetched by id during hydration and may be attached to otherwise-public
+    // payloads.
+    if (!this.canViewerReadPost(post, authorId, viewerContext, isFederatedPost)) {
+      return null;
+    }
 
     // Privacy checks only apply to local users (federated posts are public by definition)
     if (!isFederatedPost) {


### PR DESCRIPTION
### Motivation

- A recent change hydrated boosts/replies at `maxDepth:1` and caused nested `boostOf`/`quoteOf` posts to be fetched and embedded without enforcing viewer-level visibility, which can leak private/draft/scheduled content into public responses and socket emits. 
- The intent is to stop disclosing referenced posts that the requesting viewer (or public endpoints) is not allowed to read while preserving boost rendering for legitimately visible originals.

### Description

- Require the boost target to exist and be `status: 'published'` and `visibility: PostVisibility.PUBLIC` in `createBoost` before creating a public boost, returning `404` if the target is not an allowed public post. 
- Add a `canViewerReadPost` helper to `PostHydrationService` and short-circuit `buildPostSummary` to return `null` for posts the viewer is not permitted to read, preventing nested referenced summaries from being attached during hydration. 
- Update `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` to include explicit `status: 'published'` fixtures and add regression tests that assert private/draft boosted originals and quoted private posts are not embedded for viewers who may not read them. 

### Testing

- Ran `git diff --check` to validate whitespace/formatting, which completed successfully. 
- Attempted to run the backend unit test command `cd packages/backend && bun run test src/__tests__/services/postHydrationBoost.test.ts`, but test execution was blocked because `vitest` is not available in this environment. 
- Attempted to install dependencies with `bun install`, but the run failed due to the environment's inability to download registry packages (HTTP 403), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d2d5738a883239a98499dc058b0d3)