### PR TITLE
fix(backend): prevent socket hydration privacy leak

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -53,8 +53,8 @@ vi.mock('../../utils/oxyHelpers', () => ({
 vi.mock('../../utils/privacyHelpers', () => ({
   getBlockedUserIds: vi.fn(async () => []),
   getRestrictedUserIds: vi.fn(async () => []),
-  extractFollowingIds: () => [],
-  extractFollowersIds: () => [],
+  extractFollowingIds: vi.fn(() => []),
+  extractFollowersIds: vi.fn(() => []),
 }));
 
 // A chainable Mongoose query stub. `.select().sort().limit().maxTimeMS().lean()`
@@ -222,6 +222,53 @@ describe('PostHydrationService — boost original embedding is deterministic', (
       const [hydrated] = await hydrateBoost(VIEWER_ID);
       expect(hydrated.boost?.originalPost?.id, `iteration ${i}: original not embedded (authed)`).toBe(ORIGINAL_ID);
     }
+  });
+
+  it('does not embed a non-public referenced original for an anonymous/global broadcast viewer', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          visibility: 'private',
+          status: 'draft',
+          content: { text: 'private draft secret' },
+        }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await hydrateBoost(undefined);
+
+    expect(hydrated, 'public boost should still hydrate').toBeTruthy();
+    expect(hydrated.boost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
+  });
+
+  it('allows a referenced followers-only original only for an authenticated follower viewer', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          visibility: 'followers_only',
+          status: 'published',
+        }];
+      }
+      return [];
+    });
+
+    const { extractFollowingIds } = await import('../../utils/privacyHelpers');
+    vi.mocked(extractFollowingIds).mockReturnValueOnce([ORIGINAL_AUTHOR_OXY_ID]);
+
+    const [hydrated] = await hydrateBoost(VIEWER_ID);
+
+    expect(hydrated.boost?.originalPost?.id).toBe(ORIGINAL_ID);
+    expect(hydrated.originalPost?.id).toBe(ORIGINAL_ID);
   });
 
   // The core root-cause assertion: a boost's original is part of the boost's

--- a/packages/backend/src/services/PostCreationService.ts
+++ b/packages/backend/src/services/PostCreationService.ts
@@ -296,7 +296,8 @@ class PostCreationService {
       }
     }
 
-    if (!params.skipSocketEmit) {
+    const shouldEmitGlobally = post.visibility === 'public' && (post.status ?? 'published') === 'published';
+    if (!params.skipSocketEmit && shouldEmitGlobally) {
       try {
         const io = global.io;
         if (io) {
@@ -307,7 +308,10 @@ class PostCreationService {
           // maxDepth:1 is REQUIRED so a created boost embeds its boostOf target
           // (a boost has an intentionally empty body and renders blank otherwise).
           const [hydratedPost] = await postHydrationService.hydratePosts([post.toObject()], {
-            viewerId: oxyUserId ?? undefined,
+            // This DTO is broadcast to all sockets, so hydrate as an anonymous
+            // viewer. Nested quote/boost references that are not publicly
+            // visible are omitted instead of leaking via a creator-specific ACL.
+            viewerId: undefined,
             oxyClient: getServiceOxyClient(),
             maxDepth: 1,
             includeLinkMetadata: true,

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1294,19 +1294,38 @@ export class PostHydrationService {
       : undefined;
     const authorId = resolvedAuthorId ?? federatedFallback?.id ?? `federated:${postId}`;
 
-    // Privacy checks only apply to local users (federated posts are public by definition)
+    // Privacy checks only apply to local users (federated posts are public by definition).
+    // Hydration can be used for globally-broadcast DTOs and for nested quote/boost
+    // references fetched by id, so enforce post-level ACL here instead of relying
+    // on callers to pre-filter every referenced post.
     if (!isFederatedPost) {
-      if (viewerContext.restrictedIds.has(authorId) && viewerContext.viewerId !== authorId) {
+      const viewerOwnsPost = viewerContext.viewerId === authorId;
+
+      if ((post.status ?? 'published') !== 'published' && !viewerOwnsPost) {
         return null;
       }
 
-      // Filter posts from private/followers_only profiles
-      // Own posts are always visible; public profiles pass through
-      if (viewerContext.privateProfileIds.has(authorId) && viewerContext.viewerId !== authorId) {
-        // If not authenticated, hide private profiles
-        if (!viewerContext.viewerId) return null;
-        // If viewer doesn't follow the author, hide the post
-        if (!viewerContext.follows.has(authorId)) return null;
+      const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility;
+      if (visibility === PostVisibility.PRIVATE && !viewerOwnsPost) {
+        return null;
+      }
+
+      if (visibility === PostVisibility.FOLLOWERS_ONLY && !viewerOwnsPost) {
+        if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
+          return null;
+        }
+      }
+
+      if (viewerContext.restrictedIds.has(authorId) && !viewerOwnsPost) {
+        return null;
+      }
+
+      // Filter posts from private/followers_only profiles. Own posts are always
+      // visible; public profiles pass through.
+      if (viewerContext.privateProfileIds.has(authorId) && !viewerOwnsPost) {
+        if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
+          return null;
+        }
       }
     }
 


### PR DESCRIPTION
### Motivation

- Prevent accidental disclosure of non-public referenced posts (draft/private/followers-only) when a created post is hydrated and broadcast on the global socket namespace.
- Ensure the post-create real-time path cannot be used to leak referenced content simply by creating a boost/quote that points to an ID.

### Description

- Gate global post-create socket emissions so they only run for posts that are both `public` and `published` in `PostCreationService`.
- When broadcasting a global DTO, hydrate the DTO as an anonymous viewer (`viewerId: undefined`) so nested references must be publicly visible to be included.
- Enforce post-level ACLs in `PostHydrationService` for local posts so referenced posts fetched by id are dropped unless the viewer is allowed to see their `status`/`visibility` (blocks draft/scheduled, `private`, `followers_only` unless the viewer is the owner or follows as appropriate, and respects restricted/private-profile cases).
- Add regression tests in `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` to cover that a boost referencing a private/draft original does not embed the original for anonymous/global broadcasts and that followers-only originals are available to authenticated follower viewers, and make a small mock adjustment in the test helpers to allow per-test follower overrides.

### Testing

- Ran `git diff --check` to validate no whitespace/git-diff issues and it passed.
- Added unit test cases in `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` that exercise the new ACL behavior; test file updated and committed.
- Attempted to run the backend test command `cd packages/backend && bun run test src/__tests__/services/postHydrationBoost.test.ts` but the environment missing the test runner caused `vitest: command not found`, so the tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d2cb9ae4083239dd84e80aeab7c77)