### PR TITLE
fix(backend): bound federated actor hydration lookup

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -26,13 +26,14 @@ const BOOSTER_OXY_ID = 'oxy-booster';
 const ORIGINAL_AUTHOR_OXY_ID = 'oxy-original-author';
 const VIEWER_ID = 'oxy-viewer';
 
-const { getUserById, getUsersByIds, cacheStore, postFind, postFindOne, federatedActorFind } = vi.hoisted(() => ({
+const { getUserById, getUsersByIds, cacheStore, postFind, postFindOne, federatedActorFind, federatedActorQueryState } = vi.hoisted(() => ({
   getUserById: vi.fn(),
   getUsersByIds: vi.fn(),
   cacheStore: new Map<string, CachedUserSummary>(),
   postFind: vi.fn(),
   postFindOne: vi.fn(),
   federatedActorFind: vi.fn(),
+  federatedActorQueryState: { limit: undefined as number | undefined, maxTimeMS: undefined as number | undefined },
 }));
 
 vi.mock('../../../server', () => ({
@@ -60,10 +61,13 @@ vi.mock('../../utils/privacyHelpers', () => ({
 // A chainable Mongoose query stub. `.select().sort().limit().maxTimeMS().lean()`
 // all return `this`; `.lean()` resolves the provided rows (an array, or `null`
 // for the `findOne` paths that return a single doc / no doc).
-function chainable(rows: unknown[] | null) {
+function chainable(rows: unknown[] | null, onChain?: (method: string, value: unknown) => void) {
   const q: Record<string, unknown> = {};
   for (const m of ['select', 'sort', 'limit', 'maxTimeMS']) {
-    q[m] = () => q;
+    q[m] = (value: unknown) => {
+      onChain?.(m, value);
+      return q;
+    };
   }
   q.lean = async () => rows;
   q.then = undefined;
@@ -80,7 +84,12 @@ vi.mock('../../models/Poll', () => ({ default: { find: () => chainable([]) } }))
 vi.mock('../../models/Like', () => ({ default: { find: () => chainable([]) } }));
 vi.mock('../../models/Bookmark', () => ({ default: { find: () => chainable([]) } }));
 vi.mock('../../models/FederatedActor', () => ({
-  default: { find: (...args: unknown[]) => chainable(federatedActorFind(...args)) },
+  default: {
+    find: (...args: unknown[]) => chainable(federatedActorFind(...args), (method, value) => {
+      if (method === 'limit') federatedActorQueryState.limit = value as number;
+      if (method === 'maxTimeMS') federatedActorQueryState.maxTimeMS = value as number;
+    }),
+  },
 }));
 vi.mock('../../models/UserSettings', () => ({
   UserSettings: { find: () => chainable([]), findOne: () => chainable(null) },
@@ -162,6 +171,8 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     postFind.mockReset();
     postFindOne.mockReset();
     federatedActorFind.mockReset();
+    federatedActorQueryState.limit = undefined;
+    federatedActorQueryState.maxTimeMS = undefined;
     // No remote actor records resolve by default — orphaned federated posts fall
     // back to the deterministic domain placeholder. Individual tests override.
     federatedActorFind.mockReturnValue([]);
@@ -311,5 +322,20 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     expect(hydrated.boost?.originalPost?.user?.instance).toBe('zpravobot.news');
     // Remote avatar is carried through (resolved, not dropped).
     expect(hydrated.boost?.originalPost?.user?.avatarUrl).toBeTruthy();
+
+    const [query] = federatedActorFind.mock.calls.at(-1) ?? [];
+    expect(query).toEqual({
+      uri: {
+        $in: [
+          'https://zpravobot.news/users/TerribleMaps/statuses/123',
+          'https://zpravobot.news/users/TerribleMaps/statuses',
+          'https://zpravobot.news/users/TerribleMaps',
+          'https://zpravobot.news/users',
+        ],
+      },
+    });
+    expect(query).not.toHaveProperty('domain');
+    expect(federatedActorQueryState.limit).toBe(4);
+    expect(federatedActorQueryState.maxTimeMS).toBe(1000);
   });
 });

--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -370,7 +370,8 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     // Remote avatar is carried through (resolved, not dropped).
     expect(hydrated.boost?.originalPost?.user?.avatarUrl).toBeTruthy();
 
-    const [query] = federatedActorFind.mock.calls.at(-1) ?? [];
+    const calls = federatedActorFind.mock.calls;
+    const [query] = calls[calls.length - 1] ?? [];
     expect(query).toEqual({
       uri: {
         $in: [

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -671,6 +671,30 @@ export class PostHydrationService {
   }
 
   /**
+   * Derive a bounded set of possible ActivityPub actor URI prefixes from an
+   * object/activity URI. This intentionally does not query by domain because a
+   * single popular instance can contain an unbounded number of actors.
+   */
+  private deriveFederatedActorUriCandidates(activityId: string): string[] {
+    let url: URL;
+    try {
+      url = new URL(activityId);
+    } catch {
+      return [];
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    if (segments.length === 0) return [];
+
+    const candidates: string[] = [];
+    const maxSegments = Math.min(segments.length, 16);
+    for (let count = maxSegments; count >= 1; count--) {
+      candidates.push(`${url.origin}/${segments.slice(0, count).join('/')}`);
+    }
+    return candidates;
+  }
+
+  /**
    * Build the per-post REMOTE-actor map for FEDERATED posts whose `oxyUserId` was
    * never linked to an Oxy user (orphaned actor). Such a post is public and
    * physically exists, so it must render with a real author rather than a blank
@@ -680,17 +704,20 @@ export class PostHydrationService {
    * the REMOTE {@link FederatedActor}, so its real `displayName` and remote
    * `avatarUrl` are carried through. The link from post → actor follows the same
    * convention the `/federation/actor/posts` route uses: a `FederatedActor.uri`
-   * is a PREFIX of the post's `federation.activityId`. Actors are batch-fetched
-   * by domain, then matched per-post by longest matching `uri` prefix. Posts
+   * is a PREFIX of the post's `federation.activityId`. Hydration must not
+   * query a whole remote domain; instead it derives a bounded set of possible
+   * actor URI prefixes from the visible post URI and only fetches exact URI
+   * candidates. Posts
    * with no matching actor fall back to the deterministic domain placeholder
    * ({@link buildFederatedDomainAuthor}) so the displayName is NEVER blank.
    */
   private async buildFederatedAuthorMap(nodes: HydratedGraphNode[]): Promise<Map<string, PostActorSummary>> {
     const map = new Map<string, PostActorSummary>();
 
-    // Collect orphaned federated posts (no Oxy author) and their origin domains.
+    // Collect orphaned federated posts (no Oxy author) and bounded candidate
+    // actor URIs derived from each post's ActivityPub object URI.
     const orphans: Array<{ postId: string; activityId: string; domain: string }> = [];
-    const domains = new Set<string>();
+    const candidateUris = new Set<string>();
     for (const { post } of nodes) {
       if (post?.oxyUserId) continue;
       const federation = post?.federation as { activityId?: string; url?: string } | undefined;
@@ -706,35 +733,43 @@ export class PostHydrationService {
       const postId = this.resolveId(post);
       if (!postId) continue;
       orphans.push({ postId, activityId: source, domain });
-      domains.add(domain);
+      for (const candidateUri of this.deriveFederatedActorUriCandidates(source)) {
+        candidateUris.add(candidateUri);
+      }
     }
 
     if (orphans.length === 0) {
       return map;
     }
 
-    // Batch-fetch every remote actor on the relevant domains, then match each
-    // orphan to the actor whose `uri` is the LONGEST prefix of its activity URI.
+    if (candidateUris.size === 0) {
+      return map;
+    }
+
+    // Fetch only exact candidate actor URIs. This keeps public hydration bounded
+    // by the number of posts/path segments in the response, not by the number of
+    // actors known for a remote domain.
+    const candidateUriList = [...candidateUris];
     let actors: Array<{ uri: string; username: string; displayName?: string; avatarUrl?: string; domain: string; acct: string }> = [];
     try {
       actors = await FederatedActor.find(
-        { domain: { $in: [...domains] } },
+        { uri: { $in: candidateUriList } },
         { uri: 1, username: 1, displayName: 1, avatarUrl: 1, domain: 1, acct: 1 },
-      ).lean();
+      )
+        .limit(candidateUriList.length)
+        .maxTimeMS(1000)
+        .lean();
     } catch (error) {
       logger.warn('[PostHydration] Failed to resolve federated actors for orphaned posts:', error);
       actors = [];
     }
 
-    const actorsByDomain = new Map<string, typeof actors>();
-    for (const actor of actors) {
-      const list = actorsByDomain.get(actor.domain);
-      if (list) list.push(actor);
-      else actorsByDomain.set(actor.domain, [actor]);
-    }
+    const actorsByUri = new Map(actors.map((actor) => [actor.uri, actor]));
 
     for (const { postId, activityId, domain } of orphans) {
-      const candidates = actorsByDomain.get(domain) ?? [];
+      const candidates = this.deriveFederatedActorUriCandidates(activityId)
+        .map((uri) => actorsByUri.get(uri))
+        .filter((actor): actor is typeof actors[number] => Boolean(actor));
       let best: typeof actors[number] | undefined;
       for (const actor of candidates) {
         if (activityId === actor.uri || activityId.startsWith(actor.uri + '/')) {


### PR DESCRIPTION
### Motivation
- Hydrating orphaned federated posts previously performed an unbounded `FederatedActor.find({ domain: { $in: [...] } })` and an in-memory prefix scan, which can be exploited to force large DB reads and CPU work via public feed GET endpoints and cause a DoS. 
- The change aims to keep post hydration deterministic and safe while preserving the intended behavior of resolving remote actor display names and avatars for orphaned federated posts.

### Description
- Add a new helper `deriveFederatedActorUriCandidates(activityId: string)` that produces a bounded list of plausible actor `uri` prefixes derived from the post's ActivityPub URI. 
- Replace the domain-wide lookup with an exact-URI lookup using `{ uri: { $in: candidateUriList } }`, and add query guardrails via `.limit(candidateUriList.length)` and `.maxTimeMS(1000)` to bound DB work and time. 
- Change in-memory matching to map fetched actors by `uri` and select the longest-prefix actor only from the fetched candidate set, preserving longest-prefix semantics without scanning entire domains. 
- Extend the boost hydration unit test (`packages/backend/src/__tests__/services/postHydrationBoost.test.ts`) to assert the resolver queries by `uri` `$in` (not `domain`) and that `limit` and `maxTimeMS` are applied.

### Testing
- Ran `git diff --check` to validate the workspace formatting and diffs, which passed without issues. 
- Attempted to run the focused unit test with `bun test packages/backend/src/__tests__/services/postHydrationBoost.test.ts`, but the test run in this environment failed due to missing runtime dependencies (`mongoose`), so the automated test could not be executed here. 
- The updated unit test includes assertions verifying the new bounded query shape and guardrails; it should pass in CI or a developer environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d301010cc832397250bb8d6509a72)