### PR TITLE
fix(backend): guard boost original visibility

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -312,4 +312,59 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     // Remote avatar is carried through (resolved, not dropped).
     expect(hydrated.boost?.originalPost?.user?.avatarUrl).toBeTruthy();
   });
+  it('does not embed a boosted original that is not published', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          status: 'draft',
+          content: { text: 'victim draft body' },
+        }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await service.hydratePosts([boostRow()], {
+      viewerId: VIEWER_ID,
+      maxDepth: 0,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    expect(hydrated).toBeTruthy();
+    expect(hydrated.boost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
+  });
+
+  it('does not embed a boosted original that is private to another user', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          status: 'published',
+          visibility: 'private',
+          content: { text: 'victim private body' },
+        }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await service.hydratePosts([boostRow()], {
+      viewerId: VIEWER_ID,
+      maxDepth: 0,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    expect(hydrated).toBeTruthy();
+    expect(hydrated.boost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
+  });
+
 });

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -1340,6 +1340,19 @@ class FeedController {
         return res.status(400).json({ error: 'Original post ID is required' });
       }
 
+      const originalPost = await Post.findOne({
+        _id: originalPostId,
+        status: 'published',
+        visibility: PostVisibility.PUBLIC,
+      })
+        .select('_id')
+        .maxTimeMS(FEED_CONSTANTS.QUERY_TIMEOUT_MS)
+        .lean();
+
+      if (!originalPost) {
+        return res.status(404).json({ error: 'Original post not found or cannot be boosted' });
+      }
+
       // Check if user already boosted this
       const existingBoost = await Post.findOne({
         oxyUserId: currentUserId,

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1256,6 +1256,34 @@ export class PostHydrationService {
     return replierMap;
   }
 
+  private canViewerSeePost(post: RawPost, viewerContext: ViewerContext): boolean {
+    const authorId = post?.oxyUserId ? String(post.oxyUserId) : undefined;
+    const isOwnPost = Boolean(authorId && viewerContext.viewerId === authorId);
+
+    // Older records/tests may omit status; the schema default is published.
+    // Drafts and scheduled posts are only visible to their owner and must never
+    // be embedded through a public boost/quote hydration path.
+    const status = typeof post.status === 'string' ? post.status : 'published';
+    if (status !== 'published' && !isOwnPost) {
+      return false;
+    }
+
+    const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility | string;
+    if (visibility === PostVisibility.PUBLIC) {
+      return true;
+    }
+
+    if (isOwnPost) {
+      return true;
+    }
+
+    if (visibility === PostVisibility.FOLLOWERS_ONLY) {
+      return Boolean(authorId && viewerContext.viewerId && viewerContext.follows.has(authorId));
+    }
+
+    return false;
+  }
+
   private async buildPostSummary(params: {
     post: RawPost;
     viewerContext: ViewerContext;
@@ -1273,6 +1301,10 @@ export class PostHydrationService {
     if (!postId) return null;
 
     const isFederatedPost = !!post?.federation;
+    if (!this.canViewerSeePost(post, viewerContext)) {
+      return null;
+    }
+
     const resolvedAuthorId = post?.oxyUserId ? String(post.oxyUserId) : undefined;
 
     // A federated post whose author actor was never linked to an Oxy user


### PR DESCRIPTION
### Motivation

- Prevent a regression that forced boost-original hydration at feed maxDepth 0 from exposing non-public or unpublished post content by fetching boost targets with no visibility/status authorization checks.
- Harden boost creation to avoid allowing a public boost to be created against a non-public or non-published target.

### Description

- Added `canViewerSeePost` to `PostHydrationService` and early-return from `buildPostSummary` so nested originals are only attached when the viewer is allowed to see the referenced post (checks `status`, `visibility`, ownership, and follower access).
- Kept the federated-orphan rendering behavior for federated posts while ensuring local non-published or non-viewable posts are not embedded into boost/quote contexts.
- Validated `originalPostId` in the boost creation path in `feed.controller.ts` to ensure the target resolves to a `published` + `public` post before creating a public boost.
- Added regression tests in `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` asserting that draft/unpublished and private boosted originals are not embedded into hydrated responses.

### Testing

- Ran `git diff --check` which passed with no whitespace errors.
- Attempted `cd packages/backend && bun run test src/__tests__/services/postHydrationBoost.test.ts` but the test run was blocked because `vitest` is not available in the execution environment (`vitest: command not found`).
- Attempted `bun install` to restore test dependencies but it failed due to `npm registry` 403 responses while fetching dependencies, preventing full automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d2d52b0c08323ab352e580c1ead3a)