### PR TITLE
fix(backend): restrict topic posts to public visibility

### DIFF
--- a/packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts
+++ b/packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
  * `getPostsByTopic` controller runs. It must match a post whose CANONICAL
  * registry-linked `postClassification.topicRefs.name` OR slug-only
  * `postClassification.topics` equals the lowercased topic, always scoped to
- * `status: 'published'`.
+ * published public posts so non-public posts cannot leak through topic pages.
  *
  * The controller pulls in the server bootstrap; stub it (and the OxyServices
  * client it constructs) so importing the controller stays pure/no-network.
@@ -28,6 +28,7 @@ describe('buildPostsByTopicFilter — canonical topicRefs.name OR slug topics ma
       { 'postClassification.topics': 'basketball' },
     ]);
     expect(filter.status).toBe('published');
+    expect(filter.visibility).toBe('public');
     // No cursor → no _id range clause.
     expect(filter._id).toBeUndefined();
   });
@@ -35,6 +36,7 @@ describe('buildPostsByTopicFilter — canonical topicRefs.name OR slug topics ma
   it('adds the cursor range clause when a cursor is provided', () => {
     const filter = buildPostsByTopicFilter('tech', 'cursor-123');
     expect(filter._id).toEqual({ $lt: 'cursor-123' });
+    expect(filter.visibility).toBe('public');
     expect(filter.$or).toEqual([
       { 'postClassification.topicRefs.name': 'tech' },
       { 'postClassification.topics': 'tech' },

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -1769,6 +1769,7 @@ export function buildPostsByTopicFilter(
       { 'postClassification.topics': normalizedTopic },
     ],
     status: 'published',
+    visibility: PostVisibility.PUBLIC,
   };
   if (cursor) {
     filter._id = { $lt: cursor };


### PR DESCRIPTION
### Motivation
- Close an ACL gap where `/posts/topic/:topic` could return non-public published posts because the topic filter matched `postClassification.topics` without constraining `visibility` to public.

### Description
- Add `visibility: PostVisibility.PUBLIC` to `buildPostsByTopicFilter` in `packages/backend/src/controllers/posts.controller.ts` and update the unit test in `packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts` to assert the public visibility requirement.

### Testing
- Ran `git diff --check` successfully to validate no whitespace/format issues; updated unit test asserts the new `visibility` clause; attempted `cd packages/backend && bun run test src/__tests__/controllers/getPostsByTopicFilter.test.ts` but the environment lacks `vitest` so the test run could not be executed here (CI will run the full test suite where `vitest` is available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d2e3c36448323b4ff7cb0a96c0c4a)