### PR TITLE
fix(backend): restrict topic discovery to public posts

### DIFF
--- a/packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts
+++ b/packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts
@@ -5,7 +5,8 @@ import { describe, expect, it, vi } from 'vitest';
  * `getPostsByTopic` controller runs. It must match a post whose CANONICAL
  * registry-linked `postClassification.topicRefs.name` OR slug-only
  * `postClassification.topics` equals the lowercased topic, always scoped to
- * `status: 'published'`.
+ * public, published posts so topic discovery cannot expose followers-only or
+ * private content.
  *
  * The controller pulls in the server bootstrap; stub it (and the OxyServices
  * client it constructs) so importing the controller stays pure/no-network.
@@ -28,6 +29,7 @@ describe('buildPostsByTopicFilter — canonical topicRefs.name OR slug topics ma
       { 'postClassification.topics': 'basketball' },
     ]);
     expect(filter.status).toBe('published');
+    expect(filter.visibility).toBe('public');
     // No cursor → no _id range clause.
     expect(filter._id).toBeUndefined();
   });
@@ -39,5 +41,6 @@ describe('buildPostsByTopicFilter — canonical topicRefs.name OR slug topics ma
       { 'postClassification.topicRefs.name': 'tech' },
       { 'postClassification.topics': 'tech' },
     ]);
+    expect(filter.visibility).toBe('public');
   });
 });

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -1754,8 +1754,9 @@ export const getPostsByHashtag = async (req: AuthRequest, res: Response) => {
  * registry-linked `postClassification.topicRefs.name` OR slug-only
  * `postClassification.topics` equals the normalized (lowercased) topic — the two
  * forms of the one canonical topic list (Stage-B AI refs and the Stage-A
- * rule-based slug baseline). Topics are stored lowercase, so the lookup is
- * lowercased for index efficiency. Exported for unit testing the canonical `$or`
+ * rule-based slug baseline). Topic discovery is a public surface, so the
+ * filter is constrained to public posts. Topics are stored lowercase, so the
+ * lookup is lowercased for index efficiency. Exported for unit testing the canonical `$or`
  * contract without booting the controller's server import chain.
  */
 export function buildPostsByTopicFilter(
@@ -1769,6 +1770,7 @@ export function buildPostsByTopicFilter(
       { 'postClassification.topics': normalizedTopic },
     ],
     status: 'published',
+    visibility: PostVisibility.PUBLIC,
   };
   if (cursor) {
     filter._id = { $lt: cursor };


### PR DESCRIPTION
### Motivation
- The topic discovery path matched `postClassification.topicRefs.name` but only required `status: 'published'`, which allowed followers-only and private posts to be returned when the classifier populated `topicRefs` for non-public published posts.

### Description
- Constrain the topic-page query by adding `visibility: PostVisibility.PUBLIC` to `buildPostsByTopicFilter` so topic lookups only return public, published posts.
- Update the unit test `packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts` and the controller comment to document and assert the visibility requirement for both normal and cursor queries.

### Testing
- Attempted to run the updated unit test with `cd packages/backend && bun run test src/__tests__/controllers/getPostsByTopicFilter.test.ts`, but the test run could not be executed because the environment lacks the test runner (`vitest` command not found), so no tests were run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d335b8bf48323a212d7a1bd3cf529)