### PR TITLE
fix(backend): restrict For You popular fallback to published posts

### DIFF
--- a/packages/backend/src/__tests__/forYouFeedPipeline.test.ts
+++ b/packages/backend/src/__tests__/forYouFeedPipeline.test.ts
@@ -152,6 +152,18 @@ describe('ForYouFeed.fetch — never-blank fallback', () => {
     expect(res.items.length).toBeGreaterThan(0);
   });
 
+  it('only queries published posts in the popular fallback', async () => {
+    gatherMock.mockResolvedValue([]);
+    rankMock.mockResolvedValue([]);
+    aggregateMock.mockResolvedValue([{ _id: oid(100), oxyUserId: 'popular-author' }]);
+    hydratePostsMock.mockResolvedValue([{ id: oid(100).toString() }]);
+
+    const feed = new ForYouFeed();
+    await feed.fetch({ cursor: '0:000000000000000000000001', limit: 30 }, { currentUserId: 'viewer', followingIds: [] });
+
+    expect(popularMatch().status).toBe('published');
+  });
+
   it('falls back to fetchPopular when ranking produces zero deduped candidates', async () => {
     gatherMock.mockResolvedValue([{ _id: oid(1), oxyUserId: 'a' }]);
     rankMock.mockResolvedValue([]); // ranking dropped everything

--- a/packages/backend/src/mtn/feed/feeds/ForYouFeed.ts
+++ b/packages/backend/src/mtn/feed/feeds/ForYouFeed.ts
@@ -34,6 +34,7 @@ export class ForYouFeed implements FeedAPI {
   async peekLatest(context: FeedContext): Promise<HydratedPost | undefined> {
     const post = await Post.findOne({
       visibility: 'public',
+      status: 'published',
       $and: [{ $or: [{ boostOf: null }, { boostOf: { $exists: false } }] }],
     })
       .select(FEED_FIELDS)
@@ -230,6 +231,7 @@ export class ForYouFeed implements FeedAPI {
     const allowSensitive = context.showSensitiveContent === true;
     const match: Record<string, unknown> = {
       visibility: 'public',
+      status: 'published',
       ...(allowSensitive ? {} : DISCOVERY_SAFE_MATCH),
       $and: [{ $or: [{ boostOf: null }, { boostOf: { $exists: false } }] }],
     };


### PR DESCRIPTION
### Motivation
- The authenticated For You path could fall back to a popular-aggregate query that did not require `status: 'published'`, allowing public `draft` or `scheduled` posts to be returned via crafted cursors or when the unseen pool was exhausted. 
- The change closes this confidentiality leak by ensuring discovery/fallback queries only surface published posts.

### Description
- Added `status: 'published'` to the `peekLatest` `Post.findOne` query in `packages/backend/src/mtn/feed/feeds/ForYouFeed.ts` so latest discovery only considers published posts. 
- Added `status: 'published'` to the `fetchPopular` aggregation `match` in `packages/backend/src/mtn/feed/feeds/ForYouFeed.ts` so the never-blank fallback cannot return drafts or scheduled posts. 
- Added a regression assertion to `packages/backend/src/__tests__/forYouFeedPipeline.test.ts` that exercises the crafted score-cursor fallback path and verifies the popular aggregate includes the published-status constraint. 
- The never-blank behavior is preserved: the fallback still runs when the ranked/deduplicated candidate set is empty but now is constrained to published public posts.

### Testing
- Attempted to run the targeted unit test `cd packages/backend && bun test src/__tests__/forYouFeedPipeline.test.ts`, but the test run failed with an unresolved dependency error (`Cannot find package 'mongoose'`) because `bun install --frozen-lockfile` was blocked by repeated `403` responses from the npm registry. 
- Because dependency installation failed, automated tests could not be executed to completion in this environment and are therefore blocked; the added test is included and should pass once normal dependency installation is available. 
- The change is confined to the For You feed code paths and the unit test; please run the backend test suite (`cd packages/backend && bun test`) in CI or a developer environment after dependencies are installed to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d347e7e108323ba0c4f7e34caaaf8)