### PR TITLE
fix(feed): guard hydrated boost originals

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -131,6 +131,7 @@ function boostRow() {
     metadata: { createdAt: new Date('2024-01-01T00:00:00Z') },
     createdAt: new Date('2024-01-01T00:00:00Z'),
     visibility: 'public',
+    status: 'published',
     hashtags: [],
     mentions: [],
   };
@@ -147,6 +148,7 @@ function originalRow() {
     metadata: { createdAt: new Date('2023-12-31T00:00:00Z') },
     createdAt: new Date('2023-12-31T00:00:00Z'),
     visibility: 'public',
+    status: 'published',
     hashtags: [],
     mentions: [],
   };
@@ -221,6 +223,29 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     for (let i = 0; i < 25; i++) {
       const [hydrated] = await hydrateBoost(VIEWER_ID);
       expect(hydrated.boost?.originalPost?.id, `iteration ${i}: original not embedded (authed)`).toBe(ORIGINAL_ID);
+    }
+  });
+
+  it('does not embed non-public or unpublished boost originals', async () => {
+    service = new PostHydrationService();
+
+    for (const blockedOriginal of [
+      { ...originalRow(), visibility: 'private', status: 'published' },
+      { ...originalRow(), visibility: 'followers_only', status: 'published' },
+      { ...originalRow(), visibility: 'public', status: 'draft' },
+      { ...originalRow(), visibility: 'public', status: 'scheduled' },
+    ]) {
+      postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+        const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+        if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+          return [blockedOriginal];
+        }
+        return [];
+      });
+
+      const [hydrated] = await hydrateBoost(undefined);
+      expect(hydrated.boost, `${blockedOriginal.visibility}/${blockedOriginal.status}: boost context leaked`).toBeNull();
+      expect(hydrated.originalPost, `${blockedOriginal.visibility}/${blockedOriginal.status}: original leaked`).toBeNull();
     }
   });
 

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -1340,6 +1340,19 @@ class FeedController {
         return res.status(400).json({ error: 'Original post ID is required' });
       }
 
+      const originalPost = await Post.findOne({
+        _id: originalPostId,
+        visibility: PostVisibility.PUBLIC,
+        status: 'published'
+      })
+        .select('_id')
+        .maxTimeMS(FEED_CONSTANTS.QUERY_TIMEOUT_MS)
+        .lean();
+
+      if (!originalPost) {
+        return res.status(404).json({ error: 'Post not found' });
+      }
+
       // Check if user already boosted this
       const existingBoost = await Post.findOne({
         oxyUserId: currentUserId,

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -287,7 +287,7 @@ export class PostHydrationService {
       return [];
     }
 
-    const graph = await this.collectPostsWithDepth(initialPosts, maxDepth, viewerContext.blockedIds);
+    const graph = await this.collectPostsWithDepth(initialPosts, maxDepth, viewerContext);
 
     const postIds = Array.from(graph.keys());
     const postsForHydration = Array.from(graph.values());
@@ -567,7 +567,7 @@ export class PostHydrationService {
   private async collectPostsWithDepth(
     initialPosts: RawPost[],
     maxDepth: number,
-    blockedIds: Set<string>,
+    viewerContext: ExtendedViewerContext,
   ): Promise<Map<string, HydratedGraphNode>> {
     const result = new Map<string, HydratedGraphNode>();
     const visited = new Set<string>();
@@ -590,7 +590,7 @@ export class PostHydrationService {
         visited.add(id);
 
         const authorId = entry.post?.oxyUserId ? String(entry.post.oxyUserId) : undefined;
-        if (authorId && blockedIds.has(authorId)) {
+        if (authorId && viewerContext.blockedIds.has(authorId)) {
           continue;
         }
 
@@ -638,10 +638,13 @@ export class PostHydrationService {
           .select('-metadata.likedBy -metadata.savedBy -translations')
           .lean();
 
-        currentLevel = fetched.map((post) => ({
-          post: post as unknown as RawPost,
-          depth: nextIdMap.get(this.resolveId(post as unknown as RawPost)!) ?? depth + 1,
-        }));
+        currentLevel = fetched
+          .map((post) => post as unknown as RawPost)
+          .filter((post) => this.canHydrateReferencedPost(post, viewerContext))
+          .map((post) => ({
+            post,
+            depth: nextIdMap.get(this.resolveId(post)!) ?? depth + 1,
+          }));
       } catch (error) {
         logger.error('[PostHydration] Failed to fetch referenced posts:', error);
         break;
@@ -649,6 +652,36 @@ export class PostHydrationService {
     }
 
     return result;
+  }
+
+  private canHydrateReferencedPost(post: RawPost, viewerContext: ExtendedViewerContext): boolean {
+    const authorId = post?.oxyUserId ? String(post.oxyUserId) : undefined;
+    if (authorId && viewerContext.blockedIds.has(authorId)) {
+      return false;
+    }
+
+    if (post.status !== 'published') {
+      return false;
+    }
+
+    const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility;
+    if (visibility === PostVisibility.PUBLIC) {
+      return true;
+    }
+
+    if (!authorId || !viewerContext.viewerId) {
+      return false;
+    }
+
+    if (authorId === viewerContext.viewerId) {
+      return true;
+    }
+
+    if (visibility === PostVisibility.FOLLOWERS_ONLY) {
+      return viewerContext.follows.has(authorId);
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Public profile feeds started hydrating boost/quote referenced posts at `maxDepth:1`, which caused `PostHydrationService` to fetch referenced posts by ID without enforcing per-post visibility or publication checks and could leak non-public content.
- The boost creation path also allowed creating a public boost referencing a non-public or unpublished original, making the exposure exploitable when the hydration path then embedded the original.

### Description
- Change `PostHydrationService.collectPostsWithDepth` to accept the full viewer context and filter fetched referenced posts through a new `canHydrateReferencedPost` guard that enforces `status === 'published'`, blocks authors in `viewerContext.blockedIds`, and enforces visibility rules (`public` allowed, `followers_only` allowed only if the viewer follows the author, and authors may always see their own posts).
- Filter the referenced-post population so only posts that pass `canHydrateReferencedPost` are added to the hydration graph and therefore eligible to be attached as `originalPost`/`quotedPost`/`boost.originalPost`.
- Harden `createBoost` in `feed.controller` to verify the target original exists and is `visibility: PostVisibility.PUBLIC` and `status: 'published'` before allowing a public boost to be created.
- Add a regression test `does not embed non-public or unpublished boost originals` to `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` and adjust test fixtures to include `status: 'published'` where needed.

### Testing
- Ran `git diff --check` and committed the changes successfully with the branch-local commit message `fix(feed): guard hydrated boost originals`.
- Added unit test coverage for the regression case in `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` but could not execute the test runner in this environment because `vitest`/test tooling is not available; attempted `cd packages/backend && bun run test src/__tests__/services/postHydrationBoost.test.ts` failed with `vitest: command not found`.
- No other automated CI/test runs were possible in the current sandbox; the PR includes the new test so CI should validate the behavior once run in the repository CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3a5229448323bebe8af545155695)