### PR TITLE
Guard nested hydration to prevent leaking non-public referenced posts

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -152,6 +152,15 @@ function originalRow() {
   };
 }
 
+function protectedOriginalRow() {
+  return {
+    ...originalRow(),
+    content: { text: 'protected original note body' },
+    visibility: 'followers_only',
+    status: 'draft',
+  };
+}
+
 describe('PostHydrationService — boost original embedding is deterministic', () => {
   let service: PostHydrationService;
 
@@ -204,6 +213,24 @@ describe('PostHydrationService — boost original embedding is deterministic', (
       expect(hydrated.boost?.originalPost?.id, `iteration ${i}: original not embedded`).toBe(ORIGINAL_ID);
       expect(hydrated.originalPost?.id).toBe(ORIGINAL_ID);
     }
+  });
+
+  it('does not embed a non-public or non-published boosted original for an anonymous viewer', async () => {
+    service = new PostHydrationService();
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [protectedOriginalRow()];
+      }
+      return [];
+    });
+
+    const [hydrated] = await hydrateBoost(undefined);
+
+    expect(hydrated, 'public boost row should still hydrate').toBeTruthy();
+    expect(hydrated.boost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
+    expect(JSON.stringify(hydrated)).not.toContain('protected original note body');
   });
 
   it('embeds the boosted original identically for anon (fetch 1) and authed (fetch 2)', async () => {

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1296,6 +1296,10 @@ export class PostHydrationService {
 
     // Privacy checks only apply to local users (federated posts are public by definition)
     if (!isFederatedPost) {
+      if (!this.canViewerAccessLocalPost(post, authorId, viewerContext)) {
+        return null;
+      }
+
       if (viewerContext.restrictedIds.has(authorId) && viewerContext.viewerId !== authorId) {
         return null;
       }
@@ -1517,6 +1521,33 @@ export class PostHydrationService {
       isBoosted: viewerContext.boostedPosts.has(postId),
       isSaved: viewerContext.savedPosts.has(postId),
     };
+  }
+
+  private canViewerAccessLocalPost(post: RawPost, authorId: string, viewerContext: ViewerContext): boolean {
+    const viewerId = viewerContext.viewerId;
+    const isOwner = viewerId === authorId;
+
+    if (isOwner) {
+      return true;
+    }
+
+    // Older imported/test posts may not carry an explicit status; preserve the
+    // historical default-public behavior for missing values, but never expose
+    // explicitly non-published local posts through nested boost/quote hydration.
+    if (post.status && post.status !== 'published') {
+      return false;
+    }
+
+    switch (post.visibility ?? PostVisibility.PUBLIC) {
+      case PostVisibility.PUBLIC:
+        return true;
+      case PostVisibility.FOLLOWERS_ONLY:
+        return Boolean(viewerId && viewerContext.follows.has(authorId));
+      case PostVisibility.PRIVATE:
+        return false;
+      default:
+        return false;
+    }
   }
 
   private buildPermissions(post: RawPost, authorId: string, viewerContext: ViewerContext): PostPermissions {


### PR DESCRIPTION
### Motivation
- Hydrating boosts/quotes at `maxDepth:1` caused referenced posts to be fetched by ID without applying status/visibility/viewer ACLs, exposing followers-only/draft/private content via public author feeds. 
- The goal is to keep boost/quote embedding (useful for rendering) while preventing accidental disclosure of non-public local posts to unauthorized viewers.

### Description
- Add `canViewerAccessLocalPost` to `PostHydrationService` to centralize visibility/status checks for local posts and return false for non-owners when the post is non-published or private. 
- Guard `buildPostSummary` with the new access check so nested referenced posts (boosts/quotes) are dropped for unauthorized viewers before being attached as `originalPost`/`quotedPost`/`boost.originalPost`. 
- Preserve owner access and the historical fallback for missing `status` fields while restricting `followers_only` posts to followers only and denying `private` or explicit non-published posts. 
- Add a regression unit test in `postHydrationBoost.test.ts` that asserts an anonymous viewer does not receive a draft/followers-only boosted original while still receiving the public boost row.

### Testing
- Ran `git diff --check` to validate formatting and there were no whitespace errors. 
- Added a targeted unit test `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` to assert the prevention of protected content embedding, but executing `bun test src/__tests__/services/postHydrationBoost.test.ts` in this environment failed due to missing dependencies. 
- `bun install --frozen-lockfile` could not complete in this environment because registry fetches returned HTTP 403, so the new test could not be executed here; the test is included and should pass in CI once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3aa5984c83238c89b1a25b961ce9)