### PR TITLE
fix(federation): restrict boosted post hydration

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -312,4 +312,38 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     // Remote avatar is carried through (resolved, not dropped).
     expect(hydrated.boost?.originalPost?.user?.avatarUrl).toBeTruthy();
   });
+
+  it('does not embed non-public boost originals when publicReferencesOnly is enabled', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (!Array.isArray(idIn) || !idIn.map(String).includes(ORIGINAL_ID)) {
+        return [];
+      }
+
+      expect(query).toMatchObject({
+        status: 'published',
+        visibility: 'public',
+      });
+
+      // Model the database predicate: a private/draft original does not match
+      // the public-reference query and therefore must not be embedded into the
+      // public actor-posts response.
+      return [];
+    });
+
+    const [hydrated] = await service.hydratePosts([boostRow()], {
+      viewerId: undefined,
+      maxDepth: 1,
+      publicReferencesOnly: true,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    expect(hydrated).toBeTruthy();
+    expect(hydrated.boost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
+  });
+
 });

--- a/packages/backend/src/routes/federation.api.routes.ts
+++ b/packages/backend/src/routes/federation.api.routes.ts
@@ -258,6 +258,7 @@ router.get('/actor/posts', async (req: AuthRequest, res: Response) => {
       viewerId: req.user?.id,
       oxyClient: createScopedOxyClient(req),
       maxDepth: 1,
+      publicReferencesOnly: true,
       includeLinkMetadata: false,
     });
 

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -64,6 +64,13 @@ interface HydrationOptions {
   includeLinkMetadata?: boolean;
   includeFullArticleBody?: boolean; // For feed, skip full article bodies
   includeFullMetadata?: boolean; // For feed, skip some metadata fields
+  /**
+   * When hydrating posts for public federation surfaces, referenced posts
+   * (boost/quote originals) must not bypass their own publication controls.
+   * Root posts are still supplied by the caller's query; this only constrains
+   * graph expansion by id.
+   */
+  publicReferencesOnly?: boolean;
 }
 
 interface HydratedGraphNode {
@@ -287,7 +294,12 @@ export class PostHydrationService {
       return [];
     }
 
-    const graph = await this.collectPostsWithDepth(initialPosts, maxDepth, viewerContext.blockedIds);
+    const graph = await this.collectPostsWithDepth(
+      initialPosts,
+      maxDepth,
+      viewerContext.blockedIds,
+      options.publicReferencesOnly === true,
+    );
 
     const postIds = Array.from(graph.keys());
     const postsForHydration = Array.from(graph.values());
@@ -568,6 +580,7 @@ export class PostHydrationService {
     initialPosts: RawPost[],
     maxDepth: number,
     blockedIds: Set<string>,
+    publicReferencesOnly: boolean,
   ): Promise<Map<string, HydratedGraphNode>> {
     const result = new Map<string, HydratedGraphNode>();
     const visited = new Set<string>();
@@ -633,8 +646,14 @@ export class PostHydrationService {
       }
 
       const nextIds = Array.from(nextIdMap.keys());
+      const referenceQuery: Record<string, unknown> = { _id: { $in: nextIds } };
+      if (publicReferencesOnly) {
+        referenceQuery.status = 'published';
+        referenceQuery.visibility = PostVisibility.PUBLIC;
+      }
+
       try {
-        const fetched = await Post.find({ _id: { $in: nextIds } })
+        const fetched = await Post.find(referenceQuery)
           .select('-metadata.likedBy -metadata.savedBy -translations')
           .lean();
 

--- a/packages/backend/src/services/federation/sharedFederationHelpers.ts
+++ b/packages/backend/src/services/federation/sharedFederationHelpers.ts
@@ -308,7 +308,11 @@ export function mapApVisibility(to?: string[], cc?: string[]): PostVisibility {
 export async function resolvePostIdFromObjectUri(objectUri: string): Promise<string | null> {
   const localPostId = extractLocalPostIdFromApUri(objectUri);
   if (localPostId && mongoose.Types.ObjectId.isValid(localPostId)) {
-    const local = await Post.findById(localPostId, { _id: 1 }).lean();
+    const local = await Post.findOne({
+      _id: localPostId,
+      status: 'published',
+      visibility: PostVisibility.PUBLIC,
+    }, { _id: 1 }).lean();
     if (local) return String(local._id);
   }
 


### PR DESCRIPTION
### Motivation
- Close a federation disclosure where `GET /federation/actor/posts` could embed a boost's referenced original and leak non-public/draft content because referenced posts were fetched by `_id` without enforcing publication controls. 
- Ensure public federation surfaces only expand referenced originals that are actually `published` and `public`, and prevent inbound Announces from resolving local non-public posts into published boosts.

### Description
- Add a `publicReferencesOnly` option to `HydrationOptions` and thread it through `hydratePosts` → `collectPostsWithDepth` to allow callers to require that referenced posts match `status: 'published'` and `visibility: PostVisibility.PUBLIC` when expanded. (`packages/backend/src/services/PostHydrationService.ts`)
- Apply `publicReferencesOnly: true` for the public federation actor posts endpoint so `GET /federation/actor/posts` may still hydrate boosts but only pull published/public originals. (`packages/backend/src/routes/federation.api.routes.ts`)
- Harden ActivityPub object-to-local-post resolution to only resolve local ObjectId URIs when the local post is `published` and `public`, preventing inbound Announce/boost imports from targeting non-public local posts. (`packages/backend/src/services/federation/sharedFederationHelpers.ts`)
- Add a regression unit that asserts non-public boost originals are not embedded when `publicReferencesOnly` is enabled. (`packages/backend/src/__tests__/services/postHydrationBoost.test.ts`)

### Testing
- Added a focused regression test in `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` exercising the `publicReferencesOnly` path; the test was committed with the fix.
- Attempted to run the test with `bun test packages/backend/src/__tests__/services/postHydrationBoost.test.ts`, but execution was blocked because project dependencies could not be installed (`bun install` failed with npm registry 403s) and the test runner failed with unresolved `mongoose`, so automated test execution in this environment could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3b34c8308323801e19811cb9cc16)