### PR TITLE
fix(feed): keep list subscriptions public-only

### DIFF
--- a/packages/backend/src/__tests__/followingFeed.test.ts
+++ b/packages/backend/src/__tests__/followingFeed.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const capturedFindQueries: Array<Record<string, unknown>> = [];
+const hydrateSlicesMock = vi.fn();
+const sliceFeedMock = vi.fn();
+
+vi.mock('../models/Post', () => ({
+  Post: {
+    find: vi.fn((query: Record<string, unknown>) => {
+      capturedFindQueries.push(query);
+      return {
+        select: () => ({
+          sort: () => ({
+            limit: () => ({
+              maxTimeMS: () => ({
+                lean: () => Promise.resolve([]),
+              }),
+            }),
+          }),
+        }),
+      };
+    }),
+  },
+}));
+
+vi.mock('../services/PostHydrationService', () => ({
+  postHydrationService: {
+    hydrateSlices: () => hydrateSlicesMock(),
+  },
+}));
+
+vi.mock('../services/ThreadSlicingService', () => ({
+  threadSlicingService: { sliceFeed: (...args: unknown[]) => sliceFeedMock(...args) },
+}));
+
+import { FollowingFeed } from '../mtn/feed/feeds/FollowingFeed';
+
+beforeEach(() => {
+  capturedFindQueries.length = 0;
+  vi.clearAllMocks();
+  sliceFeedMock.mockResolvedValue({ slices: [] });
+  hydrateSlicesMock.mockResolvedValue([]);
+});
+
+describe('FollowingFeed visibility authorization', () => {
+  it('keeps subscribed-list authors public-only instead of granting followers-only access', async () => {
+    const feed = new FollowingFeed();
+
+    await feed.fetch(
+      { cursor: undefined, limit: 20 },
+      {
+        currentUserId: 'viewer',
+        followingIds: ['real-follow'],
+        subscribedListMemberIds: ['list-only'],
+      },
+    );
+
+    expect(capturedFindQueries).toHaveLength(1);
+    expect(capturedFindQueries[0]).toMatchObject({
+      status: 'published',
+      $and: [
+        {
+          $or: [
+            {
+              oxyUserId: { $in: ['viewer', 'real-follow'] },
+              visibility: { $in: ['public', 'followers_only'] },
+            },
+            {
+              oxyUserId: { $in: ['list-only'] },
+              visibility: 'public',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('does not duplicate real follows in the public-only subscribed-list branch', async () => {
+    const feed = new FollowingFeed();
+
+    await feed.fetch(
+      { cursor: undefined, limit: 20 },
+      {
+        currentUserId: 'viewer',
+        followingIds: ['real-follow'],
+        subscribedListMemberIds: ['viewer', 'real-follow', 'list-only'],
+      },
+    );
+
+    expect(capturedFindQueries[0]).toMatchObject({
+      $and: [
+        {
+          $or: [
+            {
+              oxyUserId: { $in: ['viewer', 'real-follow'] },
+              visibility: { $in: ['public', 'followers_only'] },
+            },
+            {
+              oxyUserId: { $in: ['list-only'] },
+              visibility: 'public',
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/backend/src/__tests__/forYouCandidateSources.test.ts
+++ b/packages/backend/src/__tests__/forYouCandidateSources.test.ts
@@ -90,6 +90,33 @@ beforeEach(() => {
 });
 
 describe('gatherForYouCandidates — union semantics', () => {
+  it('includes subscribed-list authors through a public-only source', async () => {
+    findRouter = (match) => {
+      const oxy = match.oxyUserId as { $in?: string[] } | undefined;
+      if (oxy?.$in?.includes('list-only')) return [makePost(oid(11), 'list-only')];
+      return [];
+    };
+
+    const pool = await gatherForYouCandidates({
+      viewerId: 'viewer',
+      followingIds: ['real-follow'],
+      subscribedListMemberIds: ['viewer', 'real-follow', 'list-only'],
+      userBehavior: {},
+      seenPostIds: [],
+      contentAffinityService: affinityStub([]),
+    });
+
+    expect(pool.map((p) => p.oxyUserId)).toContain('list-only');
+    const listSource = findCalls.find((match) => {
+      const oxy = match.oxyUserId as { $in?: string[] } | undefined;
+      return oxy?.$in?.includes('list-only');
+    });
+    expect(listSource).toMatchObject({
+      oxyUserId: { $in: ['list-only'] },
+      visibility: PostVisibility.PUBLIC,
+    });
+  });
+
   it('includes following + affinity + topic/language matches, not just global', async () => {
     const followingIds = ['follow-1'];
     const affinity = affinityStub(['affinity-1']);

--- a/packages/backend/src/mtn/controllers/feed.controller.ts
+++ b/packages/backend/src/mtn/controllers/feed.controller.ts
@@ -98,32 +98,6 @@ async function mergeFederatedFollowIds(
   }
 }
 
-/**
- * Merge member oxyUserIds from lists the user SUBSCRIBES to (a 'list' EntityFollow)
- * into the given followingIds array, deduplicating in-place.
- *
- * Following a list is a subscription, NOT a follow: this only changes which posts
- * the viewer SEES in their main feed (the author candidate set). It does not create
- * any follow relationship and does not alter follower/following counts.
- *
- * Excludes the viewer's own id and any id already present in followingIds.
- */
-async function mergeSubscribedListMemberIds(
-  localUserId: string,
-  followingIds: string[],
-): Promise<void> {
-  const memberIds = await listSubscriptionService.getSubscribedListMemberIds(localUserId);
-  if (memberIds.length === 0) return;
-
-  const existing = new Set(followingIds);
-  existing.add(localUserId);
-  for (const id of memberIds) {
-    if (!existing.has(id)) {
-      followingIds.push(id);
-      existing.add(id);
-    }
-  }
-}
 
 class MtnFeedController {
   /**
@@ -152,6 +126,7 @@ class MtnFeedController {
       // parallel. `userBehavior` feeds personalized candidate generation
       // (For You multi-source) and ranking; it soft-fails to undefined.
       let followingIds: string[] = [];
+      let subscribedListMemberIds: string[] = [];
       let userBehavior: IUserBehavior | undefined;
       // The viewer's sensitive-content opt-in. Anonymous → false; loaded
       // soft-failing to false below so a settings error never relaxes the gate.
@@ -175,7 +150,7 @@ class MtnFeedController {
         }
 
         try {
-          await mergeSubscribedListMemberIds(currentUserId, followingIds);
+          subscribedListMemberIds = await listSubscriptionService.getSubscribedListMemberIds(currentUserId);
         } catch (error) {
           logger.warn('[MtnFeedController] Failed to load subscribed-list members', error);
         }
@@ -199,6 +174,7 @@ class MtnFeedController {
       const context = {
         currentUserId,
         followingIds,
+        subscribedListMemberIds,
         userBehavior,
         oxyClient,
         showSensitiveContent,
@@ -273,6 +249,7 @@ class MtnFeedController {
         : null;
 
       let followingIds: string[] = [];
+      let subscribedListMemberIds: string[] = [];
       if (currentUserId) {
         try {
           const followingRes = await oxyClient.getUserFollowing(currentUserId);
@@ -288,7 +265,7 @@ class MtnFeedController {
         }
 
         try {
-          await mergeSubscribedListMemberIds(currentUserId, followingIds);
+          subscribedListMemberIds = await listSubscriptionService.getSubscribedListMemberIds(currentUserId);
         } catch (error) {
           logger.warn('[MtnFeedController] Failed to load subscribed-list members', error);
         }
@@ -297,6 +274,7 @@ class MtnFeedController {
       const context = {
         currentUserId,
         followingIds,
+        subscribedListMemberIds,
         oxyClient,
       };
 

--- a/packages/backend/src/mtn/feed/FeedAPI.ts
+++ b/packages/backend/src/mtn/feed/FeedAPI.ts
@@ -26,6 +26,12 @@ export interface FeedFetchOptions {
 export interface FeedContext {
   currentUserId?: string;
   followingIds?: string[];
+  /**
+   * Author ids from lists the viewer subscribes to. These are feed-inclusion
+   * candidates only and MUST NOT be treated as follow relationships for
+   * followers-only visibility checks.
+   */
+  subscribedListMemberIds?: string[];
   userBehavior?: RankingUserBehavior;
   feedSettings?: FeedRankingSettings;
   oxyClient?: OxyClient;

--- a/packages/backend/src/mtn/feed/feeds/FollowingFeed.ts
+++ b/packages/backend/src/mtn/feed/feeds/FollowingFeed.ts
@@ -5,8 +5,7 @@
  * Replaces FollowingFeedStrategy.
  */
 
-import { HydratedPost } from '@mention/shared-types';
-import { MtnConfig } from '@mention/shared-types';
+import { HydratedPost, MtnConfig, PostVisibility } from '@mention/shared-types';
 import { Post } from '../../../models/Post';
 import { postHydrationService } from '../../../services/PostHydrationService';
 import { threadSlicingService } from '../../../services/ThreadSlicingService';
@@ -15,15 +14,56 @@ import { FeedAPI, FeedAPIResponse, FeedFetchOptions, FeedContext, FEED_FIELDS } 
 import { ChronoCursor, didCursorAdvance } from '../CursorBuilder';
 import { logger } from '../../../utils/logger';
 
+function buildFollowingVisibilityMatch(
+  currentUserId: string,
+  followingIds: string[] = [],
+  subscribedListMemberIds: string[] = [],
+): Record<string, unknown> {
+  const followAuthorizedIds = Array.from(new Set([currentUserId, ...followingIds]));
+  const publicOnlyListIds = Array.from(
+    new Set(subscribedListMemberIds.filter((id) => id !== currentUserId && !followAuthorizedIds.includes(id))),
+  );
+
+  if (publicOnlyListIds.length === 0) {
+    return {
+      oxyUserId: { $in: followAuthorizedIds },
+      visibility: { $in: [PostVisibility.PUBLIC, PostVisibility.FOLLOWERS_ONLY] },
+    };
+  }
+
+  return {
+    $and: [
+      {
+        $or: [
+          {
+            oxyUserId: { $in: followAuthorizedIds },
+            visibility: { $in: [PostVisibility.PUBLIC, PostVisibility.FOLLOWERS_ONLY] },
+          },
+          {
+            oxyUserId: { $in: publicOnlyListIds },
+            visibility: PostVisibility.PUBLIC,
+          },
+        ],
+      },
+    ],
+  };
+}
+
 export class FollowingFeed implements FeedAPI {
   readonly descriptor = 'following' as const;
 
   async peekLatest(context: FeedContext): Promise<HydratedPost | undefined> {
-    if (!context.currentUserId || !context.followingIds?.length) return undefined;
+    if (
+      !context.currentUserId
+      || (!context.followingIds?.length && !context.subscribedListMemberIds?.length)
+    ) return undefined;
 
     const post = await Post.findOne({
-      oxyUserId: { $in: [context.currentUserId, ...context.followingIds] },
-      visibility: { $in: ['public', 'followers_only'] },
+      ...buildFollowingVisibilityMatch(
+        context.currentUserId,
+        context.followingIds,
+        context.subscribedListMemberIds,
+      ),
       status: 'published',
     })
       .select(FEED_FIELDS)
@@ -41,14 +81,13 @@ export class FollowingFeed implements FeedAPI {
 
   async fetch(options: FeedFetchOptions, context: FeedContext): Promise<FeedAPIResponse> {
     const { cursor, limit } = options;
-    const { currentUserId, followingIds } = context;
+    const { currentUserId, followingIds, subscribedListMemberIds } = context;
 
     const empty: FeedAPIResponse = { slices: [], items: [], hasMore: false, totalCount: 0 };
-    if (!currentUserId || !followingIds?.length) return empty;
+    if (!currentUserId || (!followingIds?.length && !subscribedListMemberIds?.length)) return empty;
 
     const match: Record<string, unknown> = {
-      oxyUserId: { $in: [currentUserId, ...followingIds] },
-      visibility: { $in: ['public', 'followers_only'] },
+      ...buildFollowingVisibilityMatch(currentUserId, followingIds, subscribedListMemberIds),
       status: 'published',
     };
     ChronoCursor.applyToQuery(match, cursor);

--- a/packages/backend/src/mtn/feed/feeds/ForYouFeed.ts
+++ b/packages/backend/src/mtn/feed/feeds/ForYouFeed.ts
@@ -84,6 +84,7 @@ export class ForYouFeed implements FeedAPI {
     const candidatePosts = await gatherForYouCandidates({
       viewerId: currentUserId,
       followingIds: context.followingIds ?? [],
+      subscribedListMemberIds: context.subscribedListMemberIds,
       userBehavior: context.userBehavior as CandidateUserBehavior | undefined,
       viewerRegion: context.viewerRegion,
       seenPostIds,

--- a/packages/backend/src/mtn/feed/feeds/forYouCandidateSources.ts
+++ b/packages/backend/src/mtn/feed/feeds/forYouCandidateSources.ts
@@ -13,8 +13,7 @@
  * page → cursor pipeline unchanged.
  *
  * Sources:
- *   1. FOLLOWING  — posts from authors the viewer follows (incl. federated +
- *      subscribed-list members already merged into `followingIds`).
+ *   1. FOLLOWING  — posts from authors the viewer actually follows (incl. federated).
  *   2. AFFINITY   — posts from authors the viewer engages with
  *      (`userBehavior.preferredAuthors` ∪ `ContentAffinityService`).
  *   3. TOPICS     — DISCOVERY: posts whose classification topics match the
@@ -59,8 +58,10 @@ export interface CandidateUserBehavior {
 /** Inputs to candidate gathering, resolved by `ForYouFeed.fetch`. */
 export interface GatherForYouCandidatesParams {
   viewerId: string;
-  /** Author ids the viewer follows (already includes federated + subscribed lists). */
+  /** Author ids the viewer actually follows (including accepted federated follows). */
   followingIds: string[];
+  /** Author ids from subscribed lists; feed-inclusion only, never follow authorization. */
+  subscribedListMemberIds?: string[];
   /** Lean UserBehavior document, or undefined when the viewer has none yet. */
   userBehavior?: CandidateUserBehavior;
   /**
@@ -214,6 +215,10 @@ export async function gatherForYouCandidates(
   const since = new Date(Date.now() - cfg.recencyWindowMs);
 
   const followingIds = params.followingIds.slice(0, cfg.maxAuthorIds);
+  const followSet = new Set([params.viewerId, ...params.followingIds]);
+  const subscribedListMemberIds = Array.from(new Set(params.subscribedListMemberIds ?? []))
+    .filter((id) => id !== params.viewerId && !followSet.has(id))
+    .slice(0, cfg.maxAuthorIds);
 
   const preferredTopics = (params.userBehavior?.preferredTopics ?? [])
     .filter((t): t is { topic: string; weight?: number } => typeof t.topic === 'string' && t.topic.length > 0)
@@ -245,6 +250,16 @@ export async function gatherForYouCandidates(
     ? runSource('following', {
         ...buildBaseMatch(seenObjectIds, since),
         oxyUserId: { $in: followingIds },
+      }, cfg.perSource.following)
+    : Promise.resolve([]);
+
+  // --- SUBSCRIBED LISTS: public posts from list authors only. List subscriptions
+  // are feed-inclusion signals, not follow relationships, so they must never
+  // make followers-only posts eligible.
+  const subscribedListsSource: Promise<CandidatePost[]> = subscribedListMemberIds.length > 0
+    ? runSource('subscribed-lists', {
+        ...buildBaseMatch(seenObjectIds, since),
+        oxyUserId: { $in: subscribedListMemberIds },
       }, cfg.perSource.following)
     : Promise.resolve([]);
 
@@ -322,8 +337,9 @@ export async function gatherForYouCandidates(
     cfg.perSource.global,
   );
 
-  const [following, affinity, topics, language, regionPosts, trending, global] = await Promise.all([
+  const [following, subscribedLists, affinity, topics, language, regionPosts, trending, global] = await Promise.all([
     followingSource,
+    subscribedListsSource,
     affinitySource,
     topicsSource,
     languageSource,
@@ -345,6 +361,7 @@ export async function gatherForYouCandidates(
   // through here, so it is unaffected either way.)
   const sources: CandidatePost[][] = [
     following,
+    subscribedLists,
     affinity,
     topics,
     language,


### PR DESCRIPTION
### Motivation
- Fix an authorization regression where subscribed-list member IDs were merged into the viewer's `followingIds`, allowing followers-only posts from arbitrary victims to be visible to list subscribers. 
- Preserve list-subscription as a feed-inclusion signal (For You visibility) while preventing it from acting as a follow-equivalent authorization vector for followers-only content.

### Description
- Add a new `subscribedListMemberIds` field to the feed `context` and stop merging list member IDs into `followingIds` in the feed controller (`mtn/controllers/feed.controller.ts`).
- Restrict the chronological Following feed by introducing `buildFollowingVisibilityMatch` so only the viewer and actual follows are eligible for `followers_only` posts while subscribed-list-only authors are limited to `public` posts (`mtn/feed/feeds/FollowingFeed.ts`).
- Wire subscribed-list authors into the For You candidate pipeline as a separate public-only source and thread `subscribedListMemberIds` into `ForYouFeed` / `gatherForYouCandidates` without granting follow privileges (`mtn/feed/feeds/ForYouFeed.ts`, `mtn/feed/feeds/forYouCandidateSources.ts`).
- Add regression tests that assert the Following feed authorization boundary and the For You subscribed-list public-only candidate source (`packages/backend/src/__tests__/followingFeed.test.ts`, updated `forYouCandidateSources.test.ts`).

### Testing
- Ran `git diff --check` which reported no whitespace/merge errors and committed the changes successfully. 
- Added unit tests: `FollowingFeed visibility authorization` (`packages/backend/src/__tests__/followingFeed.test.ts`) and a subscribed-list case in `forYouCandidateSources` tests (`packages/backend/src/__tests__/forYouCandidateSources.test.ts`).
- Attempted to run the backend tests (`cd packages/backend && bun run test ...`) and install deps (`bun install --frozen-lockfile --ignore-scripts`), but execution was blocked because test runner binaries are not available in the environment and `bun install` failed with npm registry 403 errors, so the new tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3c85441c8323abb5be2f073ac53f)