### PR TITLE
Harden federated outbox backfill against SSRF and unbounded fan‑out

### DIFF
--- a/packages/backend/src/__tests__/services/federation/outboxValidation.test.ts
+++ b/packages/backend/src/__tests__/services/federation/outboxValidation.test.ts
@@ -325,3 +325,57 @@ describe('OutboxSyncService — Announce item imports as a boost', () => {
     );
   });
 });
+
+describe('OutboxSyncService — outbox URL SSRF hardening', () => {
+  it('does not fetch cross-origin string items or Create.object URLs from an outbox page', async () => {
+    const fetchMock = stubOutbox({
+      type: 'OrderedCollection',
+      totalItems: 2,
+      orderedItems: [
+        'http://169.254.169.254/latest/meta-data/',
+        {
+          id: `${ACTOR_URI}/activities/create-evil`,
+          type: 'Create',
+          actor: ACTOR_URI,
+          object: 'http://127.0.0.1/private-note',
+        },
+      ],
+    });
+
+    const result = await runSync();
+
+    expect(result).toMatchObject({
+      syncedCount: 0,
+      reason: 'no-candidates',
+      candidateCount: 0,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      OUTBOX_URL,
+      expect.objectContaining({ headers: expect.objectContaining({ Accept: expect.stringContaining('application/activity+json') }) }),
+    );
+  });
+
+  it('caps inspected non-candidate items and returns an item-offset cursor', async () => {
+    const orderedItems = Array.from({ length: 105 }, (_, index) => `http://169.254.169.254/latest/meta-data/${index}`);
+    const fetchMock = stubOutbox({
+      type: 'OrderedCollection',
+      totalItems: orderedItems.length,
+      orderedItems,
+    });
+
+    const result = await outboxSyncService.syncOutboxPostsDetailed(
+      { uri: ACTOR_URI, acct: 'alice@mastodon.social', outboxUrl: OUTBOX_URL, oxyUserId: 'oxy_alice' },
+      { limit: 10, maxPages: 1 },
+    );
+
+    expect(result).toMatchObject({
+      syncedCount: 0,
+      reason: 'no-candidates',
+      candidateCount: 0,
+      nextCursor: { url: OUTBOX_URL, itemOffset: 100 },
+      reachedEnd: false,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/services/federation/OutboxSyncService.ts
+++ b/packages/backend/src/services/federation/OutboxSyncService.ts
@@ -17,6 +17,7 @@ import {
 } from '../contentClassification/spamQuality';
 import type { PostClassificationScores } from '@mention/shared-types';
 import { POST_CLASSIFICATION_PENDING } from '../../models/Post';
+import { assertSafePublicUrl } from '../../utils/ssrfGuard';
 import { actorService } from './ActorService';
 import {
   isAbsoluteHttpUrl,
@@ -65,6 +66,16 @@ const OUTBOX_ACTOR_RESOLVE_TIMEOUT_MS = 20 * 1000; // 20 seconds
  * parallelized in small batches rather than run strictly sequentially.
  */
 const OUTBOX_BOOST_IMPORT_CONCURRENCY = 4;
+
+/**
+ * Hard cap on how many untrusted outbox items a single page pass may inspect.
+ * The candidate limit only bounds successfully imported candidates; malicious
+ * pages can otherwise fill `orderedItems` with non-candidates that each trigger
+ * URL resolution work. Keep this independent from the page-size advertised by
+ * a remote server so backfill advances via the item-offset cursor instead of
+ * spending an entire run on attacker-controlled fan-out.
+ */
+const OUTBOX_MAX_ITEMS_INSPECTED_PER_PAGE = 100;
 
 /**
  * A candidate extracted from a remote actor's outbox during backfill.
@@ -152,6 +163,15 @@ export interface OutboxSyncOptions {
  * the schema's `pending` default plus the Stage-A deterministic fields. `status`
  * stays `pending` so the async AI batch still enriches the post.
  */
+function isSameOriginHttpUrl(value: string, sourceUrl: string): boolean {
+  if (!isAbsoluteHttpUrl(value) || !isAbsoluteHttpUrl(sourceUrl)) return false;
+  try {
+    return new URL(value).origin === new URL(sourceUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
 interface RawPostClassificationSeed {
   status: typeof POST_CLASSIFICATION_PENDING;
   attempts: number;
@@ -325,7 +345,7 @@ export class OutboxSyncService {
         const items = activityPubItems(pageData);
         const normalizedOffset = Math.max(0, Math.min(startItemOffset, items.length));
         if (items.length > 0) {
-          const nextItemOffset = await this.extractCandidates(items, candidates, limit, normalizedOffset);
+          const nextItemOffset = await this.extractCandidates(items, candidates, limit, pageUrl, normalizedOffset);
           if (nextItemOffset < items.length) {
             nextCursor = { url: pageUrl, itemOffset: nextItemOffset };
             return;
@@ -333,7 +353,7 @@ export class OutboxSyncService {
         }
 
         const nextPageUrl = activityPubLinkUrl(pageData.next);
-        if (nextPageUrl) {
+        if (nextPageUrl && isSameOriginHttpUrl(nextPageUrl, pageUrl)) {
           nextCursor = { url: nextPageUrl, itemOffset: 0 };
         } else {
           nextCursor = undefined;
@@ -342,6 +362,13 @@ export class OutboxSyncService {
       };
 
       const fetchAndProcessPage = async (pageUrl: string, startItemOffset: number): Promise<void> => {
+        if (!isSameOriginHttpUrl(pageUrl, actor.outboxUrl)) {
+          logger.info(`[FedSync] rejected cross-origin outbox page for ${actor.acct}: ${pageUrl}`);
+          paginationFailed = true;
+          nextCursor = undefined;
+          return;
+        }
+
         if (visitedPageUrls.has(pageUrl)) {
           logger.info(`[FedSync] outbox pagination loop detected for ${actor.acct} at ${pageUrl}`);
           paginationFailed = true;
@@ -392,7 +419,7 @@ export class OutboxSyncService {
 
       const firstPageObject = asRecord(collection.first);
       const inlineItems = activityPubItems(collection);
-      if (options.startPageUrl) {
+      if (options.startPageUrl && isSameOriginHttpUrl(options.startPageUrl, actor.outboxUrl)) {
         nextCursor = { url: options.startPageUrl, itemOffset: Math.max(0, options.startItemOffset) };
       } else if (inlineItems.length > 0) {
         await processPage(collection, actor.outboxUrl, 0);
@@ -400,7 +427,7 @@ export class OutboxSyncService {
         await processPage(firstPageObject, activityPubLinkUrl(firstPageObject.id) ?? actor.outboxUrl, 0);
       } else {
         const firstPageUrl = activityPubLinkUrl(collection.first) ?? activityPubLinkUrl(collection.next);
-        if (firstPageUrl) {
+        if (firstPageUrl && isSameOriginHttpUrl(firstPageUrl, actor.outboxUrl)) {
           nextCursor = { url: firstPageUrl, itemOffset: 0 };
         }
       }
@@ -707,12 +734,14 @@ export class OutboxSyncService {
     items: unknown[],
     candidates: OutboxCandidate[],
     limit: number,
+    sourcePageUrl: string,
     startIndex = 0,
   ): Promise<number> {
-    for (let index = startIndex; index < items.length; index++) {
+    const maxIndexExclusive = Math.min(items.length, startIndex + OUTBOX_MAX_ITEMS_INSPECTED_PER_PAGE);
+    for (let index = startIndex; index < maxIndexExclusive; index++) {
       if (candidates.length >= limit) return index;
 
-      const activity = await this.resolveOutboxActivity(items[index]);
+      const activity = await this.resolveOutboxActivity(items[index], sourcePageUrl);
       if (!activity) continue;
 
       // Each outbox item is untrusted remote JSON: it is either a wrapping
@@ -742,7 +771,7 @@ export class OutboxSyncService {
         continue;
       }
 
-      const note = await this.extractOutboxNote(activity);
+      const note = await this.extractOutboxNote(activity, sourcePageUrl);
       if (!note) continue;
       // The note may have been FETCHED from a remote URL (Create with a string
       // `object`), so it is independently untrusted — validate it too. A
@@ -762,25 +791,25 @@ export class OutboxSyncService {
       candidates.push({ kind: 'note', note, activity, activityId });
     }
 
-    return items.length;
+    return maxIndexExclusive;
   }
 
-  private async resolveOutboxActivity(item: unknown): Promise<Record<string, any> | null> {
+  private async resolveOutboxActivity(item: unknown, sourcePageUrl: string): Promise<Record<string, any> | null> {
     const inlineActivity = asRecord(item);
     if (inlineActivity) return inlineActivity;
 
-    if (typeof item !== 'string' || !isAbsoluteHttpUrl(item)) return null;
+    if (typeof item !== 'string' || !isSameOriginHttpUrl(item, sourcePageUrl)) return null;
     return fetchActivityPubObject(item);
   }
 
-  private async extractOutboxNote(activity: Record<string, any>): Promise<Record<string, any> | null> {
+  private async extractOutboxNote(activity: Record<string, any>, sourcePageUrl: string): Promise<Record<string, any> | null> {
     if (activity.type === 'Note' || activity.type === 'Article') return activity;
     if (activity.type !== 'Create') return null;
 
     const inlineObject = asRecord(activity.object);
     if (inlineObject) return inlineObject;
 
-    if (typeof activity.object === 'string' && isAbsoluteHttpUrl(activity.object)) {
+    if (typeof activity.object === 'string' && isSameOriginHttpUrl(activity.object, sourcePageUrl)) {
       return fetchActivityPubObject(activity.object);
     }
 
@@ -886,6 +915,12 @@ export class OutboxSyncService {
       { _id: 1 },
     ).lean();
     if (existing) return String(existing._id);
+
+    const objectGuard = await assertSafePublicUrl(objectUri);
+    if (!objectGuard.ok) {
+      logger.info(`[FedSync] rejected unsafe boosted object URL ${objectUri}: ${objectGuard.reason}`);
+      return null;
+    }
 
     // Fetch the announced object (the boosted Note) from its origin.
     let note: Record<string, any>;

--- a/packages/backend/src/services/federation/OutboxSyncService.ts
+++ b/packages/backend/src/services/federation/OutboxSyncService.ts
@@ -289,6 +289,12 @@ export class OutboxSyncService {
     if (!actor.outboxUrl) {
       return { syncedCount: 0, shouldStampCooldown: false, reason: 'missing-outbox' };
     }
+    // Capture the narrowed value: `actor.outboxUrl` is `string | undefined`, and
+    // the guard above only narrows the property at the method-body level. The
+    // pagination closures below (`fetchAndProcessPage`) re-widen a property access
+    // back to `string | undefined` because TS cannot prove it is not reassigned.
+    // A `const` preserves the narrowing into those closures.
+    const outboxUrl = actor.outboxUrl;
 
     const options: Required<Pick<OutboxSyncOptions, 'limit' | 'maxPages' | 'startItemOffset'>>
       & Pick<OutboxSyncOptions, 'startPageUrl'> = typeof limitOrOptions === 'number'
@@ -304,9 +310,9 @@ export class OutboxSyncService {
 
     try {
       // Fetch the outbox collection (signed for authorized-fetch servers)
-      const res = await signedFetch(actor.outboxUrl, AP_CONTENT_TYPE);
+      const res = await signedFetch(outboxUrl, AP_CONTENT_TYPE);
       if (!res.ok) {
-        logger.info(`[FedSync] outbox fetch failed: ${res.status} ${res.statusText} for ${actor.outboxUrl}`);
+        logger.info(`[FedSync] outbox fetch failed: ${res.status} ${res.statusText} for ${outboxUrl}`);
         return { syncedCount: 0, shouldStampCooldown: false, reason: `outbox-http-${res.status}` };
       }
 
@@ -321,7 +327,7 @@ export class OutboxSyncService {
       const collectionParse = parseOrderedCollection(rawCollection);
       if (!collectionParse.ok) {
         logger.warn(
-          `[FedSync] outbox collection failed validation for ${actor.acct} (${actor.outboxUrl}); aborting sync: ${collectionParse.error.message}`,
+          `[FedSync] outbox collection failed validation for ${actor.acct} (${outboxUrl}); aborting sync: ${collectionParse.error.message}`,
         );
         return { syncedCount: 0, shouldStampCooldown: false, reason: 'invalid-collection' };
       }
@@ -336,6 +342,14 @@ export class OutboxSyncService {
       let nextCursor: OutboxSyncResult['nextCursor'];
       let reachedEnd = false;
       let paginationFailed = false;
+      // Set when a page is processed only partially this run — either the
+      // candidate limit was reached or the per-page inspection cap
+      // (`OUTBOX_MAX_ITEMS_INSPECTED_PER_PAGE`) bounded the scan before the page
+      // was exhausted. The returned cursor points back at the SAME page+offset,
+      // so the run must STOP and hand that cursor to the next run instead of
+      // re-fetching the same page to drain its remaining (possibly
+      // attacker-controlled) items in one pass.
+      let pausedMidPage = false;
       const visitedPageUrls = new Set<string>();
 
       const processPage = async (
@@ -349,6 +363,7 @@ export class OutboxSyncService {
           const nextItemOffset = await this.extractCandidates(items, candidates, limit, pageUrl, normalizedOffset);
           if (nextItemOffset < items.length) {
             nextCursor = { url: pageUrl, itemOffset: nextItemOffset };
+            pausedMidPage = true;
             return;
           }
         }
@@ -363,7 +378,7 @@ export class OutboxSyncService {
       };
 
       const fetchAndProcessPage = async (pageUrl: string, startItemOffset: number): Promise<void> => {
-        if (!isSameOriginHttpUrl(pageUrl, actor.outboxUrl)) {
+        if (!isSameOriginHttpUrl(pageUrl, outboxUrl)) {
           logger.info(`[FedSync] rejected cross-origin outbox page for ${actor.acct}: ${pageUrl}`);
           paginationFailed = true;
           nextCursor = undefined;
@@ -420,27 +435,29 @@ export class OutboxSyncService {
 
       const firstPageObject = asRecord(collection.first);
       const inlineItems = activityPubItems(collection);
-      if (options.startPageUrl && isSameOriginHttpUrl(options.startPageUrl, actor.outboxUrl)) {
+      if (options.startPageUrl && isSameOriginHttpUrl(options.startPageUrl, outboxUrl)) {
         nextCursor = { url: options.startPageUrl, itemOffset: Math.max(0, options.startItemOffset) };
       } else if (inlineItems.length > 0) {
-        await processPage(collection, actor.outboxUrl, 0);
+        await processPage(collection, outboxUrl, 0);
       } else if (firstPageObject && activityPubItems(firstPageObject).length > 0) {
-        await processPage(firstPageObject, activityPubLinkUrl(firstPageObject.id) ?? actor.outboxUrl, 0);
+        await processPage(firstPageObject, activityPubLinkUrl(firstPageObject.id) ?? outboxUrl, 0);
       } else {
         const firstPageUrl = activityPubLinkUrl(collection.first) ?? activityPubLinkUrl(collection.next);
-        if (firstPageUrl && isSameOriginHttpUrl(firstPageUrl, actor.outboxUrl)) {
+        if (firstPageUrl && isSameOriginHttpUrl(firstPageUrl, outboxUrl)) {
           nextCursor = { url: firstPageUrl, itemOffset: 0 };
         }
       }
 
-      // Paginate through pages until we have enough candidates, run out of pages,
-      // or exhaust the per-run page budget. The returned cursor is opaque remote
+      // Paginate through pages until we have enough candidates, pause mid-page
+      // (candidate limit or per-page inspection cap), run out of pages, or
+      // exhaust the per-run page budget. The returned cursor is opaque remote
       // state: we persist it exactly and never synthesize pagination URLs.
       while (
         nextCursor
         && candidates.length < limit
         && !reachedEnd
         && !paginationFailed
+        && !pausedMidPage
       ) {
         const cursor = nextCursor;
         await fetchAndProcessPage(cursor.url, cursor.itemOffset);


### PR DESCRIPTION
### Motivation
- Remote outbox pages could contain string item/object URLs that were fetched without SSRF protections or a per-page inspection cap, allowing attacker-controlled SSRF probes and unbounded sequential fetch work.

### Description
- Add a same-origin URL check `isSameOriginHttpUrl` and require string outbox items and `Create.object` string references to be same-origin with the outbox page before fetching in `OutboxSyncService` (`packages/backend/src/services/federation/OutboxSyncService.ts`).
- Introduce `OUTBOX_MAX_ITEMS_INSPECTED_PER_PAGE = 100` and limit per-page inspection to that cap so non-candidate string entries cannot force sequential fetches, and advance the opaque item-offset cursor when the cap is hit. 
- Reject cross-origin stored cursors and pagination URLs (first/next/startPageUrl) before following them so pagination cannot be abused to cross origins. 
- Apply the existing SSRF guard `assertSafePublicUrl` before fetching boosted Announce objects (in `ensureFederatedNote`) to reuse the vetted resolution/denylist logic. 
- Add regression tests exercising cross-origin string item/object rejection and the per-page inspection cap in `packages/backend/src/__tests__/services/federation/outboxValidation.test.ts`.

### Testing
- Added unit tests covering the new same-origin rejection and per-page inspection cap (`packages/backend/src/__tests__/services/federation/outboxValidation.test.ts`).
- Ran `git diff --check` which reported no check failures. 
- Attempted to run the backend tests via `cd packages/backend && bun run test`, but execution was blocked because project dependencies could not be installed (`bun install` failed due to remote registry responses), so the new tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3d1254388323938cbed87b1e8ff7)