### PR TITLE
Enforce ACLs during post hydration to prevent leakage of private/draft referenced posts

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -25,6 +25,7 @@ const ORIGINAL_ID = '650000000000000000000002';
 const BOOSTER_OXY_ID = 'oxy-booster';
 const ORIGINAL_AUTHOR_OXY_ID = 'oxy-original-author';
 const VIEWER_ID = 'oxy-viewer';
+const ATTACKER_POST_ID = '650000000000000000000003';
 
 const { getUserById, getUsersByIds, cacheStore, postFind, postFindOne, federatedActorFind } = vi.hoisted(() => ({
   getUserById: vi.fn(),
@@ -147,6 +148,23 @@ function originalRow() {
     metadata: { createdAt: new Date('2023-12-31T00:00:00Z') },
     createdAt: new Date('2023-12-31T00:00:00Z'),
     visibility: 'public',
+    hashtags: [],
+    mentions: [],
+  };
+}
+
+function quoteRow() {
+  return {
+    _id: ATTACKER_POST_ID,
+    oxyUserId: BOOSTER_OXY_ID,
+    type: 'post',
+    quoteOf: ORIGINAL_ID,
+    content: { text: 'attacker quote' },
+    stats: { likesCount: 0, boostsCount: 0, commentsCount: 0, downvotesCount: 0, viewsCount: 0 },
+    metadata: { createdAt: new Date('2024-01-02T00:00:00Z') },
+    createdAt: new Date('2024-01-02T00:00:00Z'),
+    visibility: 'public',
+    status: 'published',
     hashtags: [],
     mentions: [],
   };
@@ -311,5 +329,63 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     expect(hydrated.boost?.originalPost?.user?.instance).toBe('zpravobot.news');
     // Remote avatar is carried through (resolved, not dropped).
     expect(hydrated.boost?.originalPost?.user?.avatarUrl).toBeTruthy();
+  });
+
+  it('does not embed a quoted draft/private post for a non-author viewer', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          content: { text: 'secret draft body' },
+          visibility: 'private',
+          status: 'draft',
+        }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await service.hydratePosts([quoteRow()], {
+      viewerId: VIEWER_ID,
+      maxDepth: 1,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    expect(hydrated?.id).toBe(ATTACKER_POST_ID);
+    expect(hydrated?.quotedPost).toBeNull();
+    expect(hydrated?.originalPost).toBeNull();
+  });
+
+  it('still lets authors hydrate their own draft/private quoted posts', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          content: { text: 'my own draft body' },
+          visibility: 'private',
+          status: 'draft',
+        }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await service.hydratePosts([{
+      ...quoteRow(),
+      oxyUserId: ORIGINAL_AUTHOR_OXY_ID,
+    }], {
+      viewerId: ORIGINAL_AUTHOR_OXY_ID,
+      maxDepth: 1,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    expect(hydrated?.quotedPost?.id).toBe(ORIGINAL_ID);
+    expect(hydrated?.quotedPost?.content?.text).toBe('my own draft body');
   });
 });

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -104,6 +104,31 @@ const DEFAULT_PRIVACY = {
   hideSaveCounts: false,
 };
 
+function canViewerAccessPost(post: RawPost, authorId: string, viewerContext: ViewerContext): boolean {
+  const viewerId = viewerContext.viewerId;
+  const isAuthor = Boolean(viewerId && viewerId === authorId);
+  const status = post.status ?? 'published';
+
+  // Drafts and scheduled posts are author-only. Referenced-post hydration is
+  // frequently driven by attacker-controlled ids (quote/boost), so never embed
+  // unpublished content for non-authors even if the caller accidentally fetched
+  // it by `_id`.
+  if (status !== 'published' && !isAuthor) {
+    return false;
+  }
+
+  const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility | string;
+  if (visibility === PostVisibility.PRIVATE) {
+    return isAuthor;
+  }
+
+  if (visibility === PostVisibility.FOLLOWERS_ONLY) {
+    return isAuthor || Boolean(viewerId && viewerContext.follows.has(authorId));
+  }
+
+  return true;
+}
+
 /**
  * URLs currently being resolved in the background by {@link PostHydrationService.warmLinkPreviews}.
  * Single-flight guard so concurrent feed requests never fetch the same remote
@@ -1293,6 +1318,10 @@ export class PostHydrationService {
       ? (federatedAuthorMap?.get(postId) ?? this.buildFederatedDomainAuthor(post))
       : undefined;
     const authorId = resolvedAuthorId ?? federatedFallback?.id ?? `federated:${postId}`;
+
+    if (!canViewerAccessPost(post, authorId, viewerContext)) {
+      return null;
+    }
 
     // Privacy checks only apply to local users (federated posts are public by definition)
     if (!isFederatedPost) {


### PR DESCRIPTION
### Motivation
- Prevent leakage where attacker-controlled `quoteOf`/`boostOf` IDs could cause `createPost` responses (hydrated via `PostHydrationService`) to include private, draft, or followers-only referenced posts accessible to non-authors.
- Harden the hydration path so referenced posts are subject to the same per-post visibility/status checks as direct reads, closing a confidentiality vulnerability introduced by returning hydrated posts on create.

### Description
- Add a `canViewerAccessPost` guard in `packages/backend/src/services/PostHydrationService.ts` that enforces post `status` (draft/scheduled), `visibility` (`private` / `followers_only`) and follow relationships before a referenced post may be embedded.  The function checks author ownership and whether the viewer follows the author.
- Invoke the guard early in `buildPostSummary` (inside `PostHydrationService`) to return `null` for summaries of referenced posts the viewer is not allowed to see, preventing them being attached as `quotedPost` / `originalPost` / `boost.originalPost` in hydrated responses.
- Add regression tests in `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` that assert an attacker-post quoting a `private`/`draft` post does not receive the quoted/original content for a non-author viewer and that the post author can still hydrate their own unpublished/private post.
- Commit message: `fix: enforce post ACL during hydration`.

### Testing
- Added unit tests (`packages/backend/src/__tests__/services/postHydrationBoost.test.ts`) covering quoted/boosted referenced-post ACL behavior; they exercise `PostHydrationService.hydratePosts` with mocked DB/service calls and assert referenced summaries are omitted for unauthorized viewers and allowed for owners.
- Ran a targeted test run `bun test packages/backend/src/__tests__/services/postHydrationBoost.test.ts` which could not execute due to missing runtime dependency resolution (`Cannot find package 'mongoose'`); test invocation failed at runtime because repository dependencies could not be installed in this environment.
- Attempted `bun install --frozen-lockfile` but it failed due to npm registry tarball fetch errors (HTTP 403), so automated test execution in this environment is blocked; the new tests and service changes are in place and should pass in CI once dependencies install successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3d36561c832395a211a3e6b2943e)