### PR TITLE
Validate actor WebFinger/acct host to prevent federated identity spoofing

### DIFF
--- a/packages/backend/src/__tests__/services/federationService.test.ts
+++ b/packages/backend/src/__tests__/services/federationService.test.ts
@@ -246,6 +246,60 @@ describe('federationService.fetchRemoteActor', () => {
       }),
     );
   });
+
+  it('does not trust cross-domain acct hints or actor webfinger claims', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://evil.example/users/mallory') {
+        return jsonResponse({
+          id: 'https://evil.example/users/mallory',
+          type: 'Person',
+          preferredUsername: 'mallory',
+          name: 'Mallory',
+          webfinger: 'victim@trusted.example',
+          inbox: 'https://evil.example/users/mallory/inbox',
+          outbox: 'https://evil.example/users/mallory/outbox',
+          publicKey: {
+            id: 'https://evil.example/users/mallory#main-key',
+            publicKeyPem: 'remote-public',
+          },
+        });
+      }
+
+      if (url === 'https://evil.example/users/mallory/outbox') {
+        return jsonResponse({ type: 'OrderedCollection', totalItems: 0 });
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await federationService.fetchRemoteActor(
+      'https://evil.example/users/mallory',
+      false,
+      'victim@trusted.example',
+    );
+
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledWith(
+      { uri: 'https://evil.example/users/mallory' },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          uri: 'https://evil.example/users/mallory',
+          acct: 'mallory@evil.example',
+          domain: 'evil.example',
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(mocks.makeServiceRequest).toHaveBeenCalledWith(
+      'PUT',
+      '/users/resolve',
+      expect.objectContaining({
+        username: 'mallory@evil.example',
+        actorUri: 'https://evil.example/users/mallory',
+        domain: 'evil.example',
+      }),
+    );
+  });
 });
 
 describe('federationService.syncOutboxPostsDetailed', () => {

--- a/packages/backend/src/services/federation/ActorService.ts
+++ b/packages/backend/src/services/federation/ActorService.ts
@@ -32,6 +32,14 @@ const ACTOR_STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 const WEBFINGER_TIMEOUT_MS = 10000;
 
+
+function acctMatchesActorHost(acct: string | undefined, actorHost: string): acct is string {
+  const domain = domainFromAcct(acct)?.toLowerCase();
+  if (!domain) return false;
+  const normalizedActorHost = actorHost.toLowerCase();
+  return domain === normalizedActorHost || normalizedActorHost === `www.${domain}`;
+}
+
 /**
  * Resolution, caching and refresh of remote ActivityPub actors.
  *
@@ -142,8 +150,14 @@ export class ActorService {
       const actorWebfinger = typeof actor.webfinger === 'string'
         ? normalizeFederatedAcct(actor.webfinger)
         : undefined;
-      const acct = canonicalAcctHint
-        || actorWebfinger
+      const verifiedAcctHint = acctMatchesActorHost(canonicalAcctHint, actorHost)
+        ? canonicalAcctHint
+        : undefined;
+      const verifiedActorWebfinger = acctMatchesActorHost(actorWebfinger, actorHost)
+        ? actorWebfinger
+        : undefined;
+      const acct = verifiedAcctHint
+        || verifiedActorWebfinger
         || normalizeFederatedAcct(`${username}@${actorHost}`)
         || `${String(username).toLowerCase()}@${actorHost}`;
       const domain = domainFromAcct(acct) || actorHost;


### PR DESCRIPTION
### Motivation
- Prevent a federated identity spoofing issue where unverified `acct` hints or an actor's `webfinger` field could be trusted across domains and be persisted/sent as the canonical federated handle. 

### Description
- Validate `acct` origin in `fetchRemoteActor` by only accepting a caller-supplied `acctHint` or the actor `webfinger` when the claimed domain matches the fetched actor URI host (allowing `www.` host variants); otherwise fall back to `preferredUsername@<actorHost>`; implemented `acctMatchesActorHost` to perform this check in `packages/backend/src/services/federation/ActorService.ts`.
- Preserve existing host-block checks and other profile extraction logic while ensuring `acct`/`domain` persisted into `FederatedActor` are host-consistent.
- Add a regression unit test that verifies a malicious remote actor claiming `victim@trusted.example` cannot make the system persist or resolve that cross-domain handle, in `packages/backend/src/__tests__/services/federationService.test.ts`.
- Files changed: `packages/backend/src/services/federation/ActorService.ts` and `packages/backend/src/__tests__/services/federationService.test.ts`.

### Testing
- Added a vitest regression test exercising a malicious actor `webfinger` claim and asserting the stored `acct`/`domain` use the actor host; the test is included under `packages/backend/src/__tests__`.
- Attempted to run the package backend tests via `cd packages/backend && bun run test src/__tests__/services/federationService.test.ts` but the runtime environment lacks dependencies (`vitest: command not found`), so tests could not be executed locally here.
- Ran repository static checks (`git diff --check`) with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3e7eb9f08323b81f85f7c7e3954c)