### PR TITLE
Fix SSRF-safe federated actor banner fetch

### DIFF
--- a/packages/backend/src/__tests__/services/federationService.test.ts
+++ b/packages/backend/src/__tests__/services/federationService.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -23,6 +24,9 @@ const mocks = vi.hoisted(() => ({
   recordAccess: vi.fn(),
   postCreatorCreate: vi.fn(),
   followExists: vi.fn(),
+  fetchUpstreamFollowingRedirects: vi.fn(),
+  userSettingsUpdateOne: vi.fn(),
+  uploadProfileBanner: vi.fn(),
 }));
 
 vi.mock('../../utils/federation/crypto', () => ({
@@ -76,13 +80,21 @@ vi.mock('../../models/Like', () => ({
 
 vi.mock('../../models/UserSettings', () => ({
   default: {
-    updateOne: vi.fn(),
+    updateOne: mocks.userSettingsUpdateOne,
   },
 }));
 
 vi.mock('../../utils/oxyHelpers', () => ({
   getServiceOxyClient: mocks.getServiceOxyClient,
 }));
+
+vi.mock('../../utils/safeUpstreamFetch', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/safeUpstreamFetch')>();
+  return {
+    ...actual,
+    fetchUpstreamFollowingRedirects: mocks.fetchUpstreamFollowingRedirects,
+  };
+});
 
 vi.mock('../../services/mediaCache/cacheWorker', () => ({
   persistRemoteMediaForFederatedOwnerDetailed: mocks.persistRemoteMedia,
@@ -174,8 +186,12 @@ beforeEach(() => {
   mocks.recordAccess.mockResolvedValue(undefined);
   mocks.postCreatorCreate.mockResolvedValue({ _id: 'created_post_1' });
   mocks.makeServiceRequest.mockResolvedValue({ id: 'oxy_user_1' });
+  mocks.uploadProfileBanner.mockResolvedValue({ file: { id: 'banner_file_1' } });
+  mocks.userSettingsUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  mocks.fetchUpstreamFollowingRedirects.mockReset();
   mocks.getServiceOxyClient.mockReturnValue({
     makeServiceRequest: mocks.makeServiceRequest,
+    uploadProfileBanner: mocks.uploadProfileBanner,
   });
 });
 
@@ -246,6 +262,90 @@ describe('federationService.fetchRemoteActor', () => {
       }),
     );
   });
+
+  it('downloads actor banners through the SSRF-safe media fetcher with content validation and a size cap', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://remote.example/users/alice') {
+        return jsonResponse({
+          id: 'https://remote.example/users/alice',
+          type: 'Person',
+          preferredUsername: 'alice',
+          name: 'Alice',
+          inbox: 'https://remote.example/users/alice/inbox',
+          image: ['http://127.0.0.1/latest/meta-data', { url: 'https://remote.example/banner.jpg' }],
+        });
+      }
+
+      throw new Error(`unexpected global fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const body = new PassThrough();
+    body.end(Buffer.from('fake-image-bytes'));
+    Object.assign(body, {
+      statusCode: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue({
+      response: body,
+      finalUrl: 'http://127.0.0.1/latest/meta-data',
+    });
+
+    await federationService.fetchRemoteActor('https://remote.example/users/alice');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalledWith('http://127.0.0.1/latest/meta-data');
+    expect(mocks.fetchUpstreamFollowingRedirects).toHaveBeenCalledWith(
+      'http://127.0.0.1/latest/meta-data',
+      {},
+      expect.any(AbortSignal),
+    );
+    expect(mocks.uploadProfileBanner).toHaveBeenCalledTimes(1);
+    expect(mocks.userSettingsUpdateOne).toHaveBeenCalledWith(
+      { oxyUserId: 'oxy_user_1' },
+      { $set: { profileHeaderImage: 'banner_file_1' } },
+      { upsert: true },
+    );
+  });
+
+  it('rejects non-image actor banner responses before upload', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://remote.example/users/bob') {
+        return jsonResponse({
+          id: 'https://remote.example/users/bob',
+          type: 'Person',
+          preferredUsername: 'bob',
+          inbox: 'https://remote.example/users/bob/inbox',
+          image: 'https://remote.example/banner.txt',
+        });
+      }
+
+      throw new Error(`unexpected global fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const body = new PassThrough();
+    body.end(Buffer.from('not an image'));
+    Object.assign(body, {
+      statusCode: 200,
+      headers: { 'content-type': 'text/plain' },
+    });
+    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue({
+      response: body,
+      finalUrl: 'https://remote.example/banner.txt',
+    });
+
+    await federationService.fetchRemoteActor('https://remote.example/users/bob');
+
+    expect(mocks.fetchUpstreamFollowingRedirects).toHaveBeenCalledWith(
+      'https://remote.example/banner.txt',
+      {},
+      expect.any(AbortSignal),
+    );
+    expect(mocks.uploadProfileBanner).not.toHaveBeenCalled();
+    expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
+  });
+
 });
 
 describe('federationService.syncOutboxPostsDetailed', () => {

--- a/packages/backend/src/services/federation/ActorService.ts
+++ b/packages/backend/src/services/federation/ActorService.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from 'node:http';
 import { logger } from '../../utils/logger';
 import sanitizeHtml from 'sanitize-html';
 import FederatedActor, { IFederatedActor } from '../../models/FederatedActor';
@@ -10,6 +11,8 @@ import {
 import { htmlToPlainText } from '../../utils/federation/htmlToPlainText';
 import { decode as decodeEntities } from 'he';
 import { getServiceOxyClient } from '../../utils/oxyHelpers';
+import { contentTypeFamily, fetchUpstreamFollowingRedirects } from '../../utils/safeUpstreamFetch';
+import { isAllowedMediaType } from '../mediaCache/mediaTypes';
 import UserSettings from '../../models/UserSettings';
 import {
   signedFetch,
@@ -31,6 +34,31 @@ const ACTOR_REFRESH_MIN_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 const ACTOR_STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 const WEBFINGER_TIMEOUT_MS = 10000;
+
+/** Maximum bytes accepted for a remote federated actor banner image. */
+const ACTOR_BANNER_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
+
+async function readBoundedResponseBody(response: IncomingMessage, maxBytes: number): Promise<ArrayBuffer> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  try {
+    for await (const chunk of response) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > maxBytes) {
+        response.destroy(new Error('remote banner exceeds size limit'));
+        throw new Error('remote banner exceeds size limit');
+      }
+      chunks.push(buffer);
+    }
+  } finally {
+    if (!response.destroyed) response.destroy();
+  }
+
+  const body = Buffer.concat(chunks, totalBytes);
+  return body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength);
+}
 
 /**
  * Resolution, caching and refresh of remote ActivityPub actors.
@@ -241,13 +269,20 @@ export class ActorService {
           if (oxyId && fedActor.oxyUserId !== oxyId) {
             await FederatedActor.updateOne({ _id: fedActor._id }, { $set: { oxyUserId: oxyId } });
           }
-          // Download and upload remote banner to Oxy (same pattern as avatar)
+          // Download and upload remote banner to Oxy (same pattern as avatar), but
+          // only through the shared SSRF-safe upstream fetcher: it validates the
+          // original URL and every redirect hop, pins DNS, and applies timeouts.
           if (oxyId && headerUrl) {
             try {
-              const imgRes = await fetch(headerUrl);
-              if (imgRes.ok) {
-                const contentType = imgRes.headers.get('content-type') || 'image/jpeg';
-                const buffer = await imgRes.arrayBuffer();
+              const deadline = AbortSignal.timeout(WEBFINGER_TIMEOUT_MS);
+              const { response: imgRes } = await fetchUpstreamFollowingRedirects(headerUrl, {}, deadline);
+              if ((imgRes.statusCode ?? 0) >= 200 && (imgRes.statusCode ?? 0) < 300) {
+                const contentType = contentTypeFamily(imgRes.headers);
+                if (!contentType.startsWith('image/') || !isAllowedMediaType(contentType)) {
+                  imgRes.destroy();
+                  throw new Error(`remote banner content-type not allowed: ${contentType || 'unknown'}`);
+                }
+                const buffer = await readBoundedResponseBody(imgRes, ACTOR_BANNER_MAX_BYTES);
                 const blob = new Blob([buffer], { type: contentType });
                 const asset = await oxyClient.uploadProfileBanner(blob, oxyId);
                 const fileId = asset?.file?.id;
@@ -258,6 +293,8 @@ export class ActorService {
                     { upsert: true },
                   );
                 }
+              } else {
+                imgRes.destroy();
               }
             } catch (bannerErr) {
               logger.debug(`Failed to sync banner for ${actorUri}:`, bannerErr);


### PR DESCRIPTION
### Motivation
- The actor parsing helper `firstStringUrl` expanded accepted `actor.image` forms (bare strings/arrays) and those values were later fetched directly via `fetch(headerUrl)`, creating an SSRF/large-download exposure. 
- Banner downloads must be subject to the same SSRF-safe contract used by the media proxy to enforce per-hop URL validation, DNS pinning, redirect checks, timeouts and size/content-type limits. 

### Description
- Replace the unsafe direct banner download in `ActorService.fetchRemoteActor` with the shared SSRF-safe primitive `fetchUpstreamFollowingRedirects` and an `AbortSignal` deadline to ensure redirect-aware URL validation and pinned DNS lookups. 
- Add server-side validation: derive the media family via `contentTypeFamily(...)`, enforce `image/` + `isAllowedMediaType(...)`, and cap banner buffering at `ACTOR_BANNER_MAX_BYTES = 10 MiB` using `readBoundedResponseBody(...)` before creating the upload blob and calling the Oxy upload helper. 
- Add unit/regression tests that mock the safe fetcher to assert that array/bare-string actor `image` values route through the SSRF-safe fetcher and that non-image responses are rejected before calling `uploadProfileBanner`. 
- Files changed: `packages/backend/src/services/federation/ActorService.ts` and `packages/backend/src/__tests__/services/federationService.test.ts`.

### Testing
- Added unit tests in `packages/backend/src/__tests__/services/federationService.test.ts` covering the safe-banner path and non-image rejection, but they could not be executed in this environment because `bun install` failed (npm registry returned `403` for required packages) and `vitest` was not available. 
- Ran repository checks such as `git diff --check` locally in the workspace which passed. 
- Attempted `cd packages/backend && bun run test -- federationService.test.ts` which failed due to missing `vitest` in the environment, so automated tests remain unrun here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3f6058c08323a3c9417119c86e70)