### PR TITLE
Fix cross-user profile settings privacy leak

### DIFF
--- a/packages/backend/src/__tests__/utils/userSettings.test.ts
+++ b/packages/backend/src/__tests__/utils/userSettings.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../utils/oxyHelpers', () => ({
   }),
 }));
 
-import { extractPublicProfileData } from '../../utils/userSettings';
+import { buildSettingsResponseForViewer, extractPublicProfileData } from '../../utils/userSettings';
 
 describe('extractPublicProfileData', () => {
   it('exposes profileHeaderImage as the canonical resolved banner field', () => {
@@ -38,5 +38,53 @@ describe('extractPublicProfileData', () => {
       coverPhotoEnabled: true,
       minimalistMode: false,
     });
+  });
+});
+
+describe('buildSettingsResponseForViewer', () => {
+  it('returns the full settings document to the owner', () => {
+    const doc = {
+      oxyUserId: 'user-1',
+      privacy: {
+        profileVisibility: 'public' as const,
+        showSensitiveContent: true,
+        hiddenWords: ['private'],
+      },
+    };
+
+    expect(buildSettingsResponseForViewer(doc, 'user-1', 'user-1')).toBe(doc);
+  });
+
+  it('redacts private preferences from cross-user settings responses', () => {
+    const result = buildSettingsResponseForViewer(
+      {
+        oxyUserId: 'target-user',
+        appearance: { primaryColor: '#00f' },
+        profileHeaderImage: 'banner-file',
+        profileCustomization: {
+          coverPhotoEnabled: true,
+          minimalistMode: false,
+        },
+        privacy: {
+          profileVisibility: 'public',
+          showSensitiveContent: true,
+          hiddenWords: ['private'],
+          restrictedUsers: ['blocked-user'],
+        },
+      },
+      'target-user',
+      'viewer-user',
+    );
+
+    expect(result).toEqual({
+      oxyUserId: 'target-user',
+      appearance: { primaryColor: '#00f' },
+      profileHeaderImage: 'https://api.oxy.so/assets/banner-file/stream',
+      profileCustomization: {
+        coverPhotoEnabled: true,
+        minimalistMode: false,
+      },
+    });
+    expect('privacy' in result).toBe(false);
   });
 });

--- a/packages/backend/src/__tests__/utils/userSettings.test.ts
+++ b/packages/backend/src/__tests__/utils/userSettings.test.ts
@@ -59,7 +59,7 @@ describe('buildSettingsResponseForViewer', () => {
     const result = buildSettingsResponseForViewer(
       {
         oxyUserId: 'target-user',
-        appearance: { primaryColor: '#00f' },
+        appearance: { themeMode: 'system', primaryColor: '#00f' },
         profileHeaderImage: 'banner-file',
         profileCustomization: {
           coverPhotoEnabled: true,
@@ -76,6 +76,7 @@ describe('buildSettingsResponseForViewer', () => {
       'viewer-user',
     );
 
+    expect(result).toBeTruthy();
     expect(result).toEqual({
       oxyUserId: 'target-user',
       appearance: { primaryColor: '#00f' },
@@ -85,6 +86,8 @@ describe('buildSettingsResponseForViewer', () => {
         minimalistMode: false,
       },
     });
-    expect('privacy' in result).toBe(false);
+    if (result) {
+      expect('privacy' in result).toBe(false);
+    }
   });
 });

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -6,7 +6,7 @@ import Bookmark from '../models/Bookmark';
 import Like from '../models/Like';
 // Block and Restrict routes removed - frontend should use Oxy services directly
 import { requireOxyAuth as requireAuth, type OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
-import { ensureUserSettings } from '../utils/userSettings';
+import { buildSettingsResponseForViewer, ensureUserSettings } from '../utils/userSettings';
 import { sendErrorResponse, sendSuccessResponse, validateRequired } from '../utils/apiHelpers';
 import { getRequiredOxyUserId as getAuthenticatedUserId } from '@oxyhq/core/server';
 import { logger } from '../utils/logger';
@@ -43,14 +43,17 @@ router.get('/settings/me', async (req: AuthRequest, res: Response) => {
 router.get('/settings/:userId', async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.params.userId as string;
+    const viewerUserId = getAuthenticatedUserId(req);
 
     const validationError = validateRequired(userId, 'userId');
     if (validationError) {
       return sendErrorResponse(res, 400, 'Bad Request', validationError);
     }
 
-    const doc = await ensureUserSettings(userId);
-    return sendSuccessResponse(res, 200, doc);
+    const doc = userId === viewerUserId
+      ? await ensureUserSettings(userId)
+      : await UserSettings.findOne({ oxyUserId: userId }).lean().exec();
+    return sendSuccessResponse(res, 200, buildSettingsResponseForViewer(doc, userId, viewerUserId));
   } catch (err) {
     logger.error('[ProfileSettings] Error fetching user settings:', { userId: req.user?.id, targetUserId: req.params.userId, error: err });
     return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to fetch settings');

--- a/packages/backend/src/utils/userSettings.ts
+++ b/packages/backend/src/utils/userSettings.ts
@@ -71,3 +71,23 @@ export function extractPublicProfileData(doc: Partial<UserSettingsData> | null |
     profileCustomization,
   };
 }
+
+/**
+ * Returns the appropriate settings payload for a viewer.
+ *
+ * Full settings documents include private preferences (for example NSFW opt-in
+ * and hidden words) and must only be returned to the settings owner. Other
+ * authenticated viewers receive the same public-safe profile data used by
+ * profile surfaces.
+ */
+export function buildSettingsResponseForViewer(
+  doc: Partial<UserSettingsData> | null | undefined,
+  targetUserId: string,
+  viewerUserId: string,
+) {
+  if (targetUserId === viewerUserId) {
+    return doc;
+  }
+
+  return extractPublicProfileData(doc, targetUserId);
+}


### PR DESCRIPTION
### Motivation
- A privacy-sensitive preference `privacy.showSensitiveContent` was added to `UserSettings` and was exposed to any authenticated caller via `GET /api/profile/settings/:userId`, leaking a user's NSFW opt-in to other users.
- The goal is to ensure full settings (including NSFW opt-in and hidden words) are only returned to the settings owner while other viewers receive a public-safe projection.

### Description
- Added `buildSettingsResponseForViewer` in `packages/backend/src/utils/userSettings.ts` to return the full document to the owner and a public-safe projection for other viewers using `extractPublicProfileData`.
- Updated `GET /api/profile/settings/:userId` in `packages/backend/src/routes/profileSettings.ts` to detect the authenticated viewer via `getRequiredOxyUserId(req)` and return owner-only full settings or a redacted public-safe response for non-owners, and to avoid creating/upserting a settings document for cross-user reads.
- Added unit tests in `packages/backend/src/__tests__/utils/userSettings.test.ts` covering owner access (returns full doc) and cross-user access (redacts `privacy.showSensitiveContent`, `hiddenWords`, and `restrictedUsers`) and adjusted imports accordingly.

### Testing
- Ran `git diff --check` to verify no whitespace/index issues; it passed.
- Attempted to run the new unit test with `cd packages/backend && bun run test src/__tests__/utils/userSettings.test.ts`, but execution was blocked because `vitest` was not available in the environment (error: `vitest: command not found`).
- Attempted to install dependencies with `bun install --frozen-lockfile`, but it failed due to registry HTTP 403 errors preventing dependency installation, so full test and type-check runs were not possible in this environment.
- Performed a local code inspection and lightweight checks (`bun --check` surfaced missing runtime deps like `mongoose` due to the failed install), and the new unit tests are added to the repo for CI to run where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d33083a2483238bd3dece240ec357)