### PR TITLE
fix(backend): scope mention replacement to declared mentions

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationMentions.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationMentions.test.ts
@@ -162,6 +162,23 @@ describe('PostHydrationService.replaceMentionPlaceholders', () => {
     expect(result).toBe('who is [mention:u9]?');
   });
 
+  it('does not replace undeclared placeholders from the shared hydration cache', async () => {
+    const mentionCache = new Map<string, PostActorSummary>([
+      ['attacker', { id: 'attacker', handle: 'attacker', displayName: 'Attacker', isVerified: false }],
+      ['victim', { id: 'victim', handle: 'victim', displayName: 'Victim', isVerified: false }],
+    ]);
+
+    const result = await asReplacer(service).replaceMentionPlaceholders(
+      'declared [mention:attacker], raw spoof [mention:victim]',
+      ['attacker'],
+      mentionCache,
+    );
+
+    expect(result).toBe('declared [@Attacker](attacker), raw spoof [mention:victim]');
+    expect(getUsersByIds).not.toHaveBeenCalled();
+    expect(getUserById).not.toHaveBeenCalled();
+  });
+
   it('leaves placeholders for ids not listed in mentions untouched', async () => {
     getUsersByIds.mockResolvedValue([makeOxyUser('u1', 'alice', 'Alice')]);
 

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1647,10 +1647,10 @@ export class PostHydrationService {
       return text;
     }
 
-    // Normalize mention IDs and collect those whose placeholder is present in
-    // the text but not yet in the per-request cache. Only placeholders that
-    // actually appear are worth resolving.
-    const uncachedIds: string[] = [];
+    // Normalize the current post's declared mention IDs. The per-request
+    // cache is intentionally shared across a hydration batch, so replacement
+    // must be scoped to this per-post allowlist rather than every cached user.
+    const declaredMentionIds = new Set<string>();
     for (const mentionIdRaw of mentions) {
       let mentionId: string;
       if (typeof mentionIdRaw === 'string') {
@@ -1661,7 +1661,17 @@ export class PostHydrationService {
       } else {
         mentionId = String(mentionIdRaw || '');
       }
-      if (mentionId && text.includes(`[mention:${mentionId}]`) && !mentionCache.has(mentionId)) {
+      if (mentionId) {
+        declaredMentionIds.add(mentionId);
+      }
+    }
+
+    // Collect declared mention placeholders present in the text but not yet in
+    // the per-request cache. Only placeholders that actually appear are worth
+    // resolving.
+    const uncachedIds: string[] = [];
+    for (const mentionId of declaredMentionIds) {
+      if (text.includes(`[mention:${mentionId}]`) && !mentionCache.has(mentionId)) {
         uncachedIds.push(mentionId);
       }
     }
@@ -1684,12 +1694,15 @@ export class PostHydrationService {
       }
     }
 
-    // Single-pass replacement: build the placeholder→replacement map, then run
-    // ONE regex over the text. An unresolved mention (absent from the map) is
-    // left as its original placeholder.
+    // Single-pass replacement: build the placeholder→replacement map for only
+    // this post's declared mention IDs, then run ONE regex over the text. An
+    // undeclared or unresolved mention is left as its original placeholder.
     const replacements = new Map<string, string>();
-    for (const [mentionId, mentionUser] of mentionCache) {
-      replacements.set(mentionId, `[@${mentionUser.displayName}](${mentionUser.handle})`);
+    for (const mentionId of declaredMentionIds) {
+      const mentionUser = mentionCache.get(mentionId);
+      if (mentionUser) {
+        replacements.set(mentionId, `[@${mentionUser.displayName}](${mentionUser.handle})`);
+      }
     }
 
     return text.replace(/\[mention:([^\]]+)\]/g, (placeholder, mentionId: string) => {


### PR DESCRIPTION
### Motivation

- Prevent a content-integrity/UI-spoofing issue where the batch-wide hydration cache could cause undeclared `[mention:<id>]` tokens to be rendered as clickable mentions when an unrelated user was present in the shared cache.  

### Description

- Restrict mention placeholder replacement in `replaceMentionPlaceholders` to a per-post allowlist by normalizing declared mention IDs into `declaredMentionIds` before resolving or replacing placeholders.  
- Only resolve uncached placeholders that are both declared in the current post and present in the text via the existing `resolveUserSummaries` path, and write resolved summaries back into the shared `mentionCache`.  
- Build the single-pass replacement map from the `declaredMentionIds` only, leaving undeclared or unresolved `[mention:<id>]` tokens unchanged.  
- Add a regression test in `packages/backend/src/__tests__/services/postHydrationMentions.test.ts` that asserts an undeclared placeholder remains untouched even when that user exists in the shared hydration cache.  

### Testing

- Ran `git diff --check` to validate no whitespace/index issues and it succeeded.  
- Attempted `cd packages/backend && bun run test src/__tests__/services/postHydrationMentions.test.ts`, but the test runner could not be executed because `vitest` was not available in the environment.  
- Attempted `bun install --frozen-lockfile` to install dependencies for full test run, but dependency downloads failed due to npm registry HTTP 403 responses, preventing running the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d340790a88323b751b6f6852e7290)