### PR TITLE
Fix profile header click-through on web

### DIFF
--- a/packages/frontend/components/ProfileScreen.tsx
+++ b/packages/frontend/components/ProfileScreen.tsx
@@ -613,14 +613,16 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
                             preserved) → 1 once scrolled (opaque, matching the tabs).
                             `web:z-[100]` paints it ABOVE the feed content (z-3) and the
                             tabs (z-5) but BELOW the chrome icons/name overlay (z-101),
-                            so the icons stay on top. `pointer-events-none` + the
-                            `-48px` bottom margin (cancels its flow height, like the
-                            banner's `-170px`) keep it a pure 0-flow overlay. Empty on
-                            native, where the chrome is an absolute overlay over the
-                            non-scrolling root. */}
+                            so the icons stay on top. It intentionally receives web
+                            pointer events to prevent clicks from reaching covered feed
+                            content while the band is opaque; the higher z-101 header
+                            controls remain interactive. The `-48px` bottom margin
+                            (cancels its flow height, like the banner's `-170px`)
+                            keeps it a 0-flow overlay. Empty on native, where the chrome
+                            is an absolute overlay over the non-scrolling root. */}
                         {IS_WEB && (
                             <View
-                                className="left-0 right-0 web:sticky web:z-[100] web:pointer-events-none web:[margin-bottom:-48px]"
+                                className="left-0 right-0 web:sticky web:z-[100] web:pointer-events-auto web:[margin-bottom:-48px]"
                                 style={[panelStickyTopInset, { height: PANEL_HEADER_HEIGHT }]}
                             >
                                 <Animated.View


### PR DESCRIPTION
### Motivation
- The web-only opaque sticky header band visually covers the feed but was marked `web:pointer-events-none`, allowing clicks to pass through to interactive content underneath and causing click-through/redress issues.

### Description
- Change the web header band's utility from `web:pointer-events-none` to `web:pointer-events-auto` so the opaque band intercepts pointer events while preserving existing z-index ordering and leaving header controls above it. 
- Clarify the in-source comment to document that the band intentionally receives pointer events on web so covered feed content cannot be clicked through.

### Testing
- Ran `git diff --check` to validate no whitespace/patch problems; it succeeded. 
- Ran a targeted search `rg -n "header-band|web:pointer-events-(none|auto)|headerBackgroundOpacity" packages/frontend/components/ProfileScreen.tsx` to verify the change is present; it succeeded. 
- Executed `bun run lint` in this environment but lint failed due to missing `expo` binary and an ESLint configuration mismatch in `@mention/shared-types`, so full repo lint could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3406c700832393af7f6eaa7a5876)