### PR TITLE
fix(mcp): use canonical boost and quote endpoints

### DIFF
--- a/packages/mcp/tools/interactions.ts
+++ b/packages/mcp/tools/interactions.ts
@@ -81,8 +81,14 @@ export function registerInteractionsTools(server: McpServer): void {
     },
     async ({ id }) => {
       try {
-        const result = await api.post(`/posts/${encodeURIComponent(id)}/boost`);
-        return { content: [{ type: "text" as const, text: `Post ${id} boosted.\n\n${formatPost(result as Record<string, unknown>)}` }] };
+        const result = await api.post(`/feed/boost`, {
+          originalPostId: id,
+          content: { text: "" },
+          mentions: [],
+          hashtags: [],
+        });
+        const boost = (result as { boost?: unknown }).boost ?? result;
+        return { content: [{ type: "text" as const, text: `Post ${id} boosted.\n\n${formatPost(boost as Record<string, unknown>)}` }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: formatApiError(error) }], isError: true };
       }
@@ -99,8 +105,15 @@ export function registerInteractionsTools(server: McpServer): void {
     },
     async ({ id, text }) => {
       try {
-        const result = await api.post(`/posts/${encodeURIComponent(id)}/quote`, { content: { text } });
-        return { content: [{ type: "text" as const, text: `Quote post created.\n\n${formatPost(result as Record<string, unknown>)}` }] };
+        const result = await api.post(`/posts`, {
+          content: { text, media: [] },
+          hashtags: [],
+          mentions: [],
+          visibility: "public",
+          quoted_post_id: id,
+        });
+        const post = (result as { post?: unknown }).post ?? result;
+        return { content: [{ type: "text" as const, text: `Quote post created.\n\n${formatPost(post as Record<string, unknown>)}` }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: formatApiError(error) }], isError: true };
       }


### PR DESCRIPTION
### Motivation
- MCP tools were calling removed backend endpoints (`POST /posts/:id/boost` and `POST /posts/:id/quote`) which returned 404s and broke MCP boost/quote workflows.
- The backend now exposes canonical endpoints: boosts via `POST /feed/boost` and quotes via the main `POST /posts` path with `quoted_post_id`, so the MCP tools must be updated to match the server API.

### Description
- Updated the MCP interactions tool implementation in `packages/mcp/tools/interactions.ts` to use the canonical boost route by calling `POST /feed/boost` with an `originalPostId` payload and preserved boost semantics (empty content body, mentions/hashtags fields).
- Updated the MCP quote tool to create a quote via `POST /posts` with the top-level `quoted_post_id` field, matching the backend wire format for quotes.
- Unwrapped the API responses to extract the created `boost`/`post` object before passing to `formatPost` so tool output continues to render the created DTO as before.

### Testing
- Ran a static assertion script (`python3` one-liner) that verifies the removed endpoints are no longer referenced and the canonical endpoints are present, and it succeeded.
- Ran `git diff --check` to validate no whitespace/patch issues, which succeeded.
- Attempted `bun run --cwd packages/mcp typecheck` but it failed due to missing dependency type definitions (`@types/node`) because `bun install` could not complete.
- Attempted `bun install` to restore dependencies, but it failed due to the npm registry returning 403 responses for package tarballs, blocking a full typecheck and runtime test.

Files changed: `packages/mcp/tools/interactions.ts`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d34077cf88323a814b108d3bdd95d)