### PR TITLE
fix(frontend): compare all feed row keys

### DIFF
--- a/packages/frontend/utils/__tests__/feedEquality.test.ts
+++ b/packages/frontend/utils/__tests__/feedEquality.test.ts
@@ -4,7 +4,7 @@
  *
  *  - `shallowFiltersEqual`: one-level key-by-key equality for the flat FeedFilters
  *    bag (used by `arePropsEqual` in the Feed components).
- *  - `feedArrayEqual`: reference short-circuit + length/boundary-key signature for
+ *  - `feedArrayEqual`: reference short-circuit + full ordered-key equality for
  *    the feed `items`/`slices` arrays.
  *  - `depsShallowEqual`: element-wise dependency-list equality (used by the
  *    useDeepCompareMemo/Effect hooks). Arrays via `feedArrayEqual`; Sets/Maps by
@@ -14,8 +14,8 @@
  * memo must recompute only when the SET / ORDER / membership of rows changes.
  * Per-post content updates (likes/replies) reach the row through PostItem's own
  * `dataVersion` store subscription, so they do not need this memo to re-run.
- * Therefore `feedArrayEqual` returns equal only when length AND the first/mid/last
- * keys all match — any add/remove/reorder is detected.
+ * Therefore `feedArrayEqual` returns equal only when length AND every ordered key
+ * matches — any add/remove/reorder is detected.
  */
 
 import { shallowFiltersEqual, feedArrayEqual, depsShallowEqual } from '../feedUtils';
@@ -99,19 +99,11 @@ describe('feedArrayEqual', () => {
         ).toBe(false);
     });
 
-    it('detects an interior reorder via the middle-key sample (same length, same boundaries)', () => {
+    it('detects an interior reorder even when first, middle, and last keys are unchanged', () => {
         expect(
             feedArrayEqual(
                 [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }],
                 [{ id: '1' }, { id: '4' }, { id: '3' }, { id: '2' }, { id: '5' }],
-                keyOf,
-            ),
-        ).toBe(true); // middle (index 2) unchanged → not detected, acceptable
-        // A reorder that DOES move the middle element is detected.
-        expect(
-            feedArrayEqual(
-                [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }],
-                [{ id: '1' }, { id: '3' }, { id: '2' }, { id: '4' }, { id: '5' }],
                 keyOf,
             ),
         ).toBe(false);
@@ -143,7 +135,7 @@ describe('depsShallowEqual', () => {
         expect(depsShallowEqual([items], [[{ id: '1' }, { id: '2' }, { id: '3' }]])).toBe(false);
     });
 
-    it('compares slice arrays by _sliceKey boundary signature', () => {
+    it('compares slice arrays by _sliceKey ordered equality', () => {
         const a = [{ _sliceKey: 's1', items: [] }, { _sliceKey: 's2', items: [] }];
         const b = [{ _sliceKey: 's1', items: [] }, { _sliceKey: 's2', items: [] }];
         expect(depsShallowEqual([a], [b])).toBe(true);

--- a/packages/frontend/utils/feedUtils.ts
+++ b/packages/frontend/utils/feedUtils.ts
@@ -154,9 +154,8 @@ export function shallowFiltersEqual(a?: FeedFilters, b?: FeedFilters): boolean {
  * when the underlying data changes (SQLite re-`.map`s rows on each `dataVersion`;
  * memory mode replaces the array on every setter), so the reference short-circuit
  * safely catches the common "re-render, same data" case. For changed references,
- * a length + head/middle/tail-key signature detects any add / remove / reorder
- * (mirrors the native `dataHash` first/mid/last sampling) — so a real structural
- * change is never missed and the feed can never silently blank.
+ * a full key-by-key pass is still cheap relative to rebuilding rows, and is required
+ * to detect same-length interior replacements / reorders without stale row sets.
  */
 export function feedArrayEqual<T>(
     a: readonly T[] | undefined,
@@ -166,18 +165,16 @@ export function feedArrayEqual<T>(
     if (a === b) return true;
     if (!a || !b) return false;
     if (a.length !== b.length) return false;
-    if (a.length === 0) return true;
-    const last = a.length - 1;
-    const mid = last >> 1;
-    return (
-        keyOf(a[0]) === keyOf(b[0]) &&
-        keyOf(a[mid]) === keyOf(b[mid]) &&
-        keyOf(a[last]) === keyOf(b[last])
-    );
+
+    for (let i = 0; i < a.length; i++) {
+        if (keyOf(a[i]) !== keyOf(b[i])) return false;
+    }
+
+    return true;
 }
 
 /**
- * Element key for {@link feedArrayEqual}'s boundary signature that works for BOTH
+ * Element key for {@link feedArrayEqual}'s ordered-key comparison that works for BOTH
  * feed array shapes: a {@link FeedPostSlice} (keyed by its deterministic
  * `_sliceKey`) and a hydrated post item (keyed by {@link getItemKey}). A slice is
  * detected by its `_sliceKey` field; everything else falls back to the post key.
@@ -196,10 +193,9 @@ function feedElementKey(element: unknown): string {
  *
  * Each element is compared by its runtime type:
  *  - Arrays (the feed `items`/`slices`): {@link feedArrayEqual} — a reference
- *    short-circuit plus a length + head/tail-key signature (via
- *    {@link feedElementKey}). Both feed data paths allocate a new array reference
- *    on every real change (see {@link feedArrayEqual}), so the reference path is
- *    correct; the signature is a defensive backstop so the feed can never blank.
+ *    short-circuit plus full ordered-key equality (via {@link feedElementKey}).
+ *    Both feed data paths allocate a new array reference on every real change
+ *    (see {@link feedArrayEqual}), so the reference path is the common fast path.
  *  - `Set`/`Map` (e.g. the privacy `blockedSet`): reference — the owning store
  *    allocates a new instance only when membership changes, so reference equality
  *    is both correct and far cheaper than serializing (the old path stringified a


### PR DESCRIPTION
### Motivation
- The feed dependency equality used a sampled first/middle/last key signature which could treat different same-length arrays as equal and cause memoized feed rows to remain stale. 
- This produced client-side incorrect ordering/staleness for interior replacements/reorders even though per-post updates still propagated via PostItem subscriptions.

### Description
- Replace the sampled boundary signature in `feedArrayEqual` with a full ordered key-by-key comparison while preserving the reference and length fast paths in `packages/frontend/utils/feedUtils.ts`.
- Update the explanatory comments and `depsShallowEqual` documentation to reflect that array deps use full ordered-key equality via `feedElementKey`.
- Update the unit test to assert that interior reorders (where first/middle/last keys are unchanged) are detected and cause `feedArrayEqual` to return `false` in `packages/frontend/utils/__tests__/feedEquality.test.ts`.

### Testing
- Ran `bun test packages/frontend/utils/__tests__/feedEquality.test.ts`, which passed all tests (23 pass, 0 fail). 
- Attempted `cd packages/frontend && bun run test --runTestsByPath utils/__tests__/feedEquality.test.ts` but the environment lacks `jest`, so that package-local script could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3406d150832398e6656da2c24cf2)