### PR TITLE
fix(media): use thumb variant for video posters

### DIFF
--- a/packages/backend/src/__tests__/utils/mediaResolver.test.ts
+++ b/packages/backend/src/__tests__/utils/mediaResolver.test.ts
@@ -142,6 +142,16 @@ describe('resolveMediaItems', () => {
     expect(items[1].fullUrl).toBeUndefined();
   });
 
+  it('uses the native thumb variant for Oxy video posters', () => {
+    const items = resolveMediaItems([{ id: 'video-file', type: 'video' }]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].url).toBe(`${OXY_BASE}/assets/video-file/stream`);
+    expect(items[0].thumbUrl).toBe(`${OXY_BASE}/assets/video-file/stream?variant=thumb`);
+    expect(items[0].posterUrl).toBe(`${OXY_BASE}/assets/video-file/stream?variant=thumb`);
+    expect(items[0].fullUrl).toBeUndefined();
+  });
+
   it('drops items without an id and tolerates empty input', () => {
     expect(resolveMediaItems([])).toEqual([]);
     expect(resolveMediaItems(undefined)).toEqual([]);

--- a/packages/backend/src/utils/mediaResolver.ts
+++ b/packages/backend/src/utils/mediaResolver.ts
@@ -24,7 +24,8 @@ import { logger } from './logger';
  *        sees same-origin, cacheable, range-seekable bytes.
  *  - anything else → treated as an Oxy file id and turned into a CDN/stream URL
  *    via the SDK's synchronous `getFileDownloadUrl` (pure URL construction, no
- *    network), with a `thumb` variant for the thumbnail.
+ *    network), with image variants for image thumbnails/fullscreen and the
+ *    native `thumb` variant for video posters.
  *
  * This module NEVER throws: on any failure it degrades to the safest passthrough
  * (`{ url: ref }` or `undefined`).
@@ -201,6 +202,22 @@ export function resolveMediaItems(items: MediaItem[] | undefined | null): MediaI
     .filter((item): item is MediaItem => Boolean(item) && typeof item.id === 'string' && item.id.length > 0)
     .map((item) => {
       const resolved = resolveMediaRef(item.id);
+
+      if (item.type === 'video' && !isAbsoluteHttpUrl(item.id)) {
+        try {
+          const posterUrl = getServiceOxyClient().getFileDownloadUrl(item.id, MEDIA_VARIANT_AVATAR);
+          return {
+            id: item.id,
+            type: item.type,
+            url: resolved.url || undefined,
+            thumbUrl: posterUrl,
+            posterUrl,
+          };
+        } catch (error) {
+          logger.warn('[mediaResolver] Failed to resolve video poster; falling back to media ref:', error);
+        }
+      }
+
       return {
         id: item.id,
         type: item.type,


### PR DESCRIPTION
### Motivation
- Native Oxy video poster URLs were inheriting the image display variant (`MEDIA_VARIANT_THUMB` mapped to an image-width variant), which can produce invalid poster URLs for videos and break client-side poster rendering.  
- The resolver must preserve the native video poster variant (`thumb`/square) and avoid attaching image-only `fullUrl` variants to video items so the frontend can correctly fall back to `videoPosterUrl` when needed.

### Description
- Branch `resolveMediaItems` for video items and, for non-HTTP Oxy file ids, resolve the poster/thumb using the native avatar/thumb variant via `getServiceOxyClient().getFileDownloadUrl(..., MEDIA_VARIANT_AVATAR)` and emit that as both `thumbUrl` and `posterUrl`.  
- Wrap the video-poster resolution in a `try/catch` and log a warning to gracefully fall back to the generic `resolveMediaRef` result on failure.  
- Update the resolver documentation comment to clarify that image variants differ from the native video `thumb` poster variant.  
- Add a regression unit test asserting that Oxy video items produce `?variant=thumb` for `thumbUrl`/`posterUrl` and do not include a `fullUrl`.

### Testing
- Ran `git diff --check` to validate patch formatting and basic repo checks, which passed.  
- Added a unit test `packages/backend/src/__tests__/utils/mediaResolver.test.ts` covering Oxy video poster resolution, but running the test runner was blocked in this environment because `vitest`/test tooling is not installed, so the new test was not executed here.  
- Attempted `cd packages/backend && bun run test src/__tests__/utils/mediaResolver.test.ts` and it failed due to `vitest: command not found`, so automated test execution is pending in CI or a developer environment with test tooling installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3406ba588323b06b017df1029581)