### PR TITLE
fix(federation): align ActivityPub accept negotiation

### DIFF
--- a/packages/backend/src/__tests__/utils/activityPubAccept.test.ts
+++ b/packages/backend/src/__tests__/utils/activityPubAccept.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isActivityPubAccept } from '../../utils/federation/constants';
+
+describe('isActivityPubAccept', () => {
+  it('matches ActivityPub and JSON-LD Accept variants used for actor discovery', () => {
+    expect(isActivityPubAccept('application/activity+json')).toBe(true);
+    expect(isActivityPubAccept('Application/Activity+Json')).toBe(true);
+    expect(isActivityPubAccept('application/ld+json')).toBe(true);
+    expect(isActivityPubAccept('application/ld+json; profile="https://www.w3.org/ns/activitystreams"')).toBe(true);
+    expect(isActivityPubAccept('text/html, application/ld+json;q=0.9')).toBe(true);
+  });
+
+  it('does not match ordinary browser HTML requests', () => {
+    expect(isActivityPubAccept(undefined)).toBe(false);
+    expect(isActivityPubAccept('text/html,application/xhtml+xml')).toBe(false);
+  });
+});

--- a/packages/backend/src/routes/federation.routes.ts
+++ b/packages/backend/src/routes/federation.routes.ts
@@ -9,7 +9,7 @@ import {
   FEDERATION_ENABLED,
   AP_CONTEXT,
   AP_CONTENT_TYPE,
-  AP_ACCEPT_TYPES,
+  isActivityPubAccept,
   actorUrl,
   inboxUrl,
   outboxUrl,
@@ -41,8 +41,7 @@ router.use(apRateLimiter);
  * Content negotiation: check if request wants ActivityPub JSON-LD.
  */
 function wantsActivityPub(req: Request): boolean {
-  const accept = req.headers.accept || '';
-  return AP_ACCEPT_TYPES.some((type) => accept.includes(type));
+  return isActivityPubAccept(req.headers.accept);
 }
 
 /** Extract username param safely as a string. */

--- a/packages/backend/src/utils/federation/constants.ts
+++ b/packages/backend/src/utils/federation/constants.ts
@@ -27,6 +27,21 @@ export const AP_ACCEPT_TYPES = [
   'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
 ];
 
+/**
+ * Returns true when an Accept header asks for ActivityPub JSON.
+ *
+ * Some federated clients send plain `application/ld+json`, differently-cased
+ * media types, or profiled JSON-LD variants. Keep this intentionally aligned
+ * with the Cloudflare Pages profile worker to avoid profile URL ↔ actor URL
+ * redirect loops during ActivityPub discovery.
+ */
+export function isActivityPubAccept(accept: string | string[] | undefined): boolean {
+  if (!accept) return false;
+  const value = Array.isArray(accept) ? accept.join(',') : accept;
+  const lower = value.toLowerCase();
+  return lower.includes('activity+json') || lower.includes('ld+json');
+}
+
 export function actorUrl(username: string): string {
   return `https://${ACTOR_DOMAIN}/ap/users/${username}`;
 }


### PR DESCRIPTION
### Motivation
- The Cloudflare Pages worker treated any `Accept` containing `activity+json` or `ld+json` as ActivityPub, but the backend used a stricter, case-sensitive set of exact strings, which caused profile URL ↔ actor URL redirect loops for some valid JSON-LD Accept headers.

### Description
- Add a shared backend matcher `isActivityPubAccept` in `packages/backend/src/utils/federation/constants.ts` that case-insensitively recognizes ActivityPub/JSON-LD Accept variants (including plain `application/ld+json`).
- Replace the backend actor route negotiation to use the new `isActivityPubAccept` helper in `packages/backend/src/routes/federation.routes.ts` so requests redirected by the frontend worker are accepted by the actor endpoint.
- Add a regression unit test `packages/backend/src/__tests__/utils/activityPubAccept.test.ts` covering common `Accept` header variants and non-AP browser Accept headers.

### Testing
- Added a vitest unit test `packages/backend/src/__tests__/utils/activityPubAccept.test.ts` and attempted to run it with `cd packages/backend && bun run test src/__tests__/utils/activityPubAccept.test.ts`, but the test runner could not execute because `vitest` is not available in this execution environment (`vitest: command not found`), so the test was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450ac4408323ad0519514127c06b)