### PR TITLE
Preserve cache-ineligible federated media

### DIFF
--- a/packages/backend/src/__tests__/services/mediaCacheDurableFailure.test.ts
+++ b/packages/backend/src/__tests__/services/mediaCacheDurableFailure.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  fetchUpstreamFollowingRedirects: vi.fn(),
+  uploadFederatedMedia: vi.fn(),
+  uploadCachedMedia: vi.fn(),
+  deleteCachedMedia: vi.fn(),
+  updateOne: vi.fn(),
+}));
+
+vi.mock('../../utils/safeUpstreamFetch', async () => {
+  class SsrfRejection extends Error {}
+  return {
+    SsrfRejection,
+    fetchUpstreamFollowingRedirects: mocks.fetchUpstreamFollowingRedirects,
+    contentTypeFamily: (headers: Record<string, unknown>) => String(headers['content-type'] ?? '').split(';')[0],
+  };
+});
+
+vi.mock('../../services/mediaCache/oxyMediaStore', () => ({
+  MediaStoreUnavailableError: class MediaStoreUnavailableError extends Error {},
+  isMediaCacheEnabled: () => true,
+  uploadFederatedMedia: mocks.uploadFederatedMedia,
+  uploadCachedMedia: mocks.uploadCachedMedia,
+  deleteCachedMedia: mocks.deleteCachedMedia,
+}));
+
+vi.mock('../../models/FederatedMediaCache', () => ({
+  default: {
+    updateOne: mocks.updateOne,
+  },
+}));
+
+function upstreamResponse(statusCode: number, headers: Record<string, unknown>) {
+  return {
+    response: {
+      statusCode,
+      headers,
+      resume: vi.fn(),
+      destroy: vi.fn(),
+      setTimeout: vi.fn(),
+    },
+  };
+}
+
+describe('durable federated media failure classification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('treats non-cacheable content types as cache-policy failures, not unavailable media', async () => {
+    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue(
+      upstreamResponse(200, { 'content-type': 'text/html', 'content-length': '42' }),
+    );
+    const { persistRemoteMediaForFederatedOwnerDetailed } = await import(
+      '../../services/mediaCache/cacheWorker',
+    );
+
+    await expect(
+      persistRemoteMediaForFederatedOwnerDetailed('https://remote.example/media', 'oxy_user'),
+    ).resolves.toMatchObject({ ok: false, reason: 'not-media', permanent: false });
+  });
+
+  it('treats over-cap media as a cache-policy failure, not unavailable media', async () => {
+    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue(
+      upstreamResponse(200, { 'content-type': 'image/jpeg', 'content-length': String(100 * 1024 * 1024) }),
+    );
+    const { persistRemoteMediaForFederatedOwnerDetailed } = await import(
+      '../../services/mediaCache/cacheWorker',
+    );
+
+    await expect(
+      persistRemoteMediaForFederatedOwnerDetailed('https://remote.example/huge.jpg', 'oxy_user'),
+    ).resolves.toMatchObject({ ok: false, reason: 'too-large', permanent: false });
+  });
+
+  it('still treats upstream 404/410 as permanently unavailable media', async () => {
+    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue(upstreamResponse(410, {}));
+    const { persistRemoteMediaForFederatedOwnerDetailed } = await import(
+      '../../services/mediaCache/cacheWorker',
+    );
+
+    await expect(
+      persistRemoteMediaForFederatedOwnerDetailed('https://remote.example/gone.jpg', 'oxy_user'),
+    ).resolves.toMatchObject({ ok: false, reason: 'upstream-error', status: 410, permanent: true });
+  });
+});

--- a/packages/backend/src/__tests__/services/mediaCacheDurableFailure.test.ts
+++ b/packages/backend/src/__tests__/services/mediaCacheDurableFailure.test.ts
@@ -10,10 +10,16 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../utils/safeUpstreamFetch', async () => {
   class SsrfRejection extends Error {}
+  const contentTypeFamilyFromString = (raw: string | undefined) =>
+    typeof raw === 'string' ? (raw.split(';')[0]?.trim().toLowerCase() ?? '') : '';
   return {
     SsrfRejection,
     fetchUpstreamFollowingRedirects: mocks.fetchUpstreamFollowingRedirects,
-    contentTypeFamily: (headers: Record<string, unknown>) => String(headers['content-type'] ?? '').split(';')[0],
+    contentTypeFamilyFromString,
+    contentTypeFamily: (headers: Record<string, unknown>) =>
+      contentTypeFamilyFromString(
+        typeof headers['content-type'] === 'string' ? (headers['content-type'] as string) : undefined,
+      ),
   };
 });
 
@@ -53,7 +59,7 @@ describe('durable federated media failure classification', () => {
       upstreamResponse(200, { 'content-type': 'text/html', 'content-length': '42' }),
     );
     const { persistRemoteMediaForFederatedOwnerDetailed } = await import(
-      '../../services/mediaCache/cacheWorker',
+      '../../services/mediaCache/cacheWorker'
     );
 
     await expect(
@@ -66,7 +72,7 @@ describe('durable federated media failure classification', () => {
       upstreamResponse(200, { 'content-type': 'image/jpeg', 'content-length': String(100 * 1024 * 1024) }),
     );
     const { persistRemoteMediaForFederatedOwnerDetailed } = await import(
-      '../../services/mediaCache/cacheWorker',
+      '../../services/mediaCache/cacheWorker'
     );
 
     await expect(
@@ -77,7 +83,7 @@ describe('durable federated media failure classification', () => {
   it('still treats upstream 404/410 as permanently unavailable media', async () => {
     mocks.fetchUpstreamFollowingRedirects.mockResolvedValue(upstreamResponse(410, {}));
     const { persistRemoteMediaForFederatedOwnerDetailed } = await import(
-      '../../services/mediaCache/cacheWorker',
+      '../../services/mediaCache/cacheWorker'
     );
 
     await expect(

--- a/packages/backend/src/services/mediaCache/cacheWorker.ts
+++ b/packages/backend/src/services/mediaCache/cacheWorker.ts
@@ -181,7 +181,7 @@ async function processEntry(remoteUrl: string): Promise<void> {
 
     if (!outcome.ok) {
       // not-media / too-large / gone media are permanent for this URL → mark failed (proxy-only).
-      if (isPermanentDownloadFailure(outcome)) {
+      if (isPermanentCacheFailure(outcome)) {
         await FederatedMediaCache.updateOne(
           { remoteUrl },
           { $set: { state: 'failed' }, $unset: { nextAttemptAt: '' } },
@@ -306,8 +306,12 @@ export type PersistFederatedMediaResult =
       permanent: boolean;
     };
 
-function isPermanentDownloadFailure(outcome: Extract<DownloadOutcome, { ok: false }>): boolean {
+function isPermanentCacheFailure(outcome: Extract<DownloadOutcome, { ok: false }>): boolean {
   if (outcome.reason === 'not-media' || outcome.reason === 'too-large') return true;
+  return isPermanentlyUnavailableDownloadFailure(outcome);
+}
+
+function isPermanentlyUnavailableDownloadFailure(outcome: Extract<DownloadOutcome, { ok: false }>): boolean {
   if (outcome.reason === 'upstream-error' && (outcome.status === 404 || outcome.status === 410)) {
     return true;
   }
@@ -338,7 +342,7 @@ export async function persistRemoteMediaForFederatedOwnerDetailed(
         ok: false,
         reason: outcome.reason,
         status: outcome.status,
-        permanent: isPermanentDownloadFailure(outcome),
+        permanent: isPermanentlyUnavailableDownloadFailure(outcome),
       };
     }
 


### PR DESCRIPTION
### Motivation
- Prevent durable federated-media persistence from treating cache-policy failures (`not-media`, `too-large`) as permanent missing media which caused remote URLs to be removed from posts.
- Align durable persistence semantics with the proxy policy that allows streaming non-cached media from the remote origin while only treating true upstream disappearance (HTTP `404`/`410`) as permanent.

### Description
- Split the permanence predicate in `packages/backend/src/services/mediaCache/cacheWorker.ts` into a cache-only terminal check `isPermanentCacheFailure()` and an availability-only check `isPermanentlyUnavailableDownloadFailure()` used for durable persistence.
- Make the cache worker (`processEntry`) keep its existing behavior of marking cache rows `failed` for `not-media`/`too-large`, while making `persistRemoteMediaForFederatedOwnerDetailed()` report `permanent: true` only when the upstream status is a true disappearance (`404`/`410`).
- Update the call sites so durable callers (federation import and backfill paths) retain original remote URLs when the failure is a cache-policy decision rather than an upstream 404/410.
- Add focused unit tests in `packages/backend/src/__tests__/services/mediaCacheDurableFailure.test.ts` that assert `not-media` and `too-large` return non-permanent failures while upstream `410` remains permanent.

### Testing
- Ran `git diff --check` which produced no whitespace or patch errors for the changes and new test file (success).
- Added targeted unit tests at `packages/backend/src/__tests__/services/mediaCacheDurableFailure.test.ts` that exercise `persistRemoteMediaForFederatedOwnerDetailed()` for `not-media`, `too-large`, and `410` scenarios (tests authored but not executed in this environment).
- Attempted to run `cd packages/backend && bun run test src/__tests__/services/mediaCacheDurableFailure.test.ts` but execution was blocked with `vitest: command not found` because dependencies are not installed, and `bun install` also failed due to registry tarball access errors (HTTP 403), so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450b13848323a4d2b14e1b7edd93)