### PR TITLE
Fix: keep sliced feed `items` and counts consistent after tuner/filtering

### DIFF
--- a/packages/backend/src/__tests__/feedResponseBuilder.test.ts
+++ b/packages/backend/src/__tests__/feedResponseBuilder.test.ts
@@ -65,6 +65,16 @@ describe('FeedResponseBuilder.buildSlicedResponse', () => {
     expect(result.hasMore).toBe(false);
   });
 
+  it('can rebuild backward-compatible items after slice-level filtering', () => {
+    const originalSlices = makeSlices(3);
+    const filteredSlices = originalSlices.filter((slice) => slice._sliceKey !== 'slice-1');
+
+    const items = FeedResponseBuilder.flattenSlicesToItems(filteredSlices);
+
+    expect(items.map((item) => item.id)).toEqual(['post-0-0', 'post-2-0']);
+    expect(items).toHaveLength(filteredSlices.length);
+  });
+
   it('paginates a full page of single-post slices', () => {
     const result = FeedResponseBuilder.buildSlicedResponse({
       slices: makeSlices(20),

--- a/packages/backend/src/mtn/controllers/feed.controller.ts
+++ b/packages/backend/src/mtn/controllers/feed.controller.ts
@@ -7,10 +7,11 @@
 
 import { Request, Response } from 'express';
 import { isValidFeedDescriptor, MtnConfig } from '@mention/shared-types';
-import type { FeedDescriptor } from '@mention/shared-types';
+import type { FeedDescriptor, SlicedFeedResponse } from '@mention/shared-types';
 import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { feedAPIRegistry } from '../feed/FeedAPIRegistry';
 import { FeedTuner } from '../feed/FeedTuner';
+import { FeedResponseBuilder } from '../../utils/FeedResponseBuilder';
 import { UserPrivacyManager } from '../UserPrivacyManager';
 import { trackFeedInteraction } from '../feed/FeedInteractionTracker';
 import { logger } from '../../utils/logger';
@@ -26,6 +27,11 @@ import type { IUserBehavior } from '../../models/UserBehavior';
 import type { TunerContext } from '../feed/FeedTuner';
 
 type MutePreference = NonNullable<TunerContext['preferences']['muteWords']>;
+
+function syncFlattenedItemsWithSlices(response: Pick<SlicedFeedResponse, 'slices' | 'items' | 'totalCount'>): void {
+  response.items = FeedResponseBuilder.flattenSlicesToItems(response.slices);
+  response.totalCount = response.items.length;
+}
 
 /**
  * Load the user's muted words/hashtags and map them into the tuner-preference
@@ -222,9 +228,11 @@ class MtnFeedController {
           return !authorId || !privacyState.excludedUserIds.has(authorId);
         });
         response.slices = response.slices.filter((slice: any) => {
-          const anchorAuthor = slice.items?.[0]?.author?.id || slice.items?.[0]?.oxyUserId;
+          const anchorPost = slice.items?.[0]?.post ?? slice.items?.[0];
+          const anchorAuthor = anchorPost?.author?.id || anchorPost?.oxyUserId;
           return !anchorAuthor || !privacyState.excludedUserIds.has(anchorAuthor);
         });
+        syncFlattenedItemsWithSlices(response);
       }
 
       // Apply tuner pipeline
@@ -240,6 +248,7 @@ class MtnFeedController {
             hideSensitive: false,
           },
         });
+        syncFlattenedItemsWithSlices(response);
       }
 
       res.json({

--- a/packages/backend/src/utils/FeedResponseBuilder.ts
+++ b/packages/backend/src/utils/FeedResponseBuilder.ts
@@ -29,6 +29,21 @@ export interface FeedResponseOptions {
 
 export class FeedResponseBuilder {
   /**
+   * Flatten feed slices into the backward-compatible `items` array. Use this
+   * any time a post-fetch tuner mutates `slices` so legacy clients never see
+   * stale posts that were removed from the canonical sliced response.
+   */
+  static flattenSlicesToItems(slices: FeedPostSlice[]): HydratedPost[] {
+    const items: HydratedPost[] = [];
+    for (const slice of slices) {
+      for (const item of slice.items) {
+        items.push(item.post as HydratedPost);
+      }
+    }
+    return items;
+  }
+
+  /**
    * Build feed response with consistent deduplication, cursor handling, and transformation
    */
   static async buildResponse(options: FeedResponseOptions): Promise<FeedResponse> {
@@ -168,12 +183,7 @@ export class FeedResponseBuilder {
     const slicesToReturn = slices;
 
     // Flatten slices into items for backward compatibility
-    const items: HydratedPost[] = [];
-    for (const slice of slicesToReturn) {
-      for (const item of slice.items) {
-        items.push(item.post as HydratedPost);
-      }
-    }
+    const items = FeedResponseBuilder.flattenSlicesToItems(slicesToReturn);
 
     // Calculate cursor from last slice's anchor post (first post in the slice)
     let nextCursor: string | undefined;


### PR DESCRIPTION
### Motivation
- Sliced MTN feed responses applied mute-word and privacy tuners to `slices` but left the backward-compatible flattened `items` array and `totalCount` unchanged, allowing filtered posts to be returned and sometimes rendered by clients.
- The goal is to ensure the canonical sliced response and the legacy `items` view remain consistent after any post-fetch tuning so user content-filtering preferences cannot be bypassed.

### Description
- Add `FeedResponseBuilder.flattenSlicesToItems()` to centralize slice→flat-item flattening logic and reuse it everywhere the flattened array must be produced. 
- After privacy filtering and after running the `FeedTuner` pipeline in the feed controller, rebuild `response.items` from the (possibly reduced) `response.slices` and update `response.totalCount` to match the visible item set. 
- Tighten the privacy-slice anchor lookup to handle both legacy item shapes and hydrated `post` wrappers when checking excluded authors. 
- Add a regression unit test to `packages/backend/src/__tests__/feedResponseBuilder.test.ts` that verifies `items` can be rebuilt from a filtered slice list so stale posts are not kept in the flat compatibility array.

### Testing
- Added a unit test exercising `flattenSlicesToItems` and `buildSlicedResponse`; test was committed but running `bun run test` in CI/local was blocked because test runner dependencies were not installable in the current environment (registry returned 403), so no tests were executed here. 
- Attempted a TypeScript check with `tsc --noEmit` but it failed in this environment due to missing installed dependencies/types caused by the failed package install, so no successful full typecheck could be produced locally. 
- `git diff --check` and local repository checks passed prior to the change being prepared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450acfb88323a4faeb2c6ea7a6bc)