### PR TITLE
docs: redact service credential metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Remote/federated post media (images, video, audio) is proxied and cached through
 - **Key code locations**: `packages/backend/src/services/mediaCache/*`, `routes/media.ts`, `utils/safeUpstreamFetch.ts`, `utils/ssrfGuard.ts`, `utils/videoPoster.ts`.
 - **Gated by env**: `FEDERATION_MEDIA_CACHE_WRITE_ENABLED=true` (set on the mention ECS task in `oxy-infra/terraform-uswest2/app-services-realtime.tf`). Unset = proxy works but nothing is written to S3.
 - **Post storage**: federated media URLs are stored RAW (remote) on the post (`content.media[].id`). The cache keys off the remote URL and never rewrites the post.
-- **SSM secrets**: `OXY_SERVICE_API_KEY` + `OXY_SERVICE_API_SECRET` are live in SSM at `/oxy/mention/OXY_SERVICE_API_KEY` and `/oxy/mention/OXY_SERVICE_API_SECRET`, wired into the ECS task definition.
+- **Service credentials**: media-cache writes use the backend service credential injected into the ECS task definition. Do not document production secret names, paths, or values in this repository.
 - **Error classification + negative cache (shipped 2026-06-21, tests 382/382):** upstream 4xx (deleted/protected media) were previously relayed as our 502, causing ~12% 5XX rate on the ALB target group. Fix: `classifyUpstreamStatus` in `routes/mediaProxyStatus.ts` maps upstream 4xx → our 404 (logged debug), genuine upstream 5xx + connection errors → 502, oversized body → 413. A **negative cache** (`services/mediaCache/negativeCache.ts`) backed by the existing Redis singleton (`mediaproxy:neg:<sha256(url)>`, client-error TTL 600s, connection-error TTL 60s, graceful no-op when `REDIS_URL` unset) short-circuits known-dead URLs to 404 with zero upstream fetch. First-byte/headers timeout tightened 10s→8s (`UPSTREAM_HEADERS_TIMEOUT_MS` in `safeUpstreamFetch.ts`); post-headers stream timers (`UPSTREAM_SOCKET_TIMEOUT_MS=30s` / `MAX_REQUEST_DURATION_MS=60s`) unchanged so large videos still stream.
 - **Perf context:** infra is NOT resource-bound (Mongo ~1%, Valkey ~0.5%, ECS CPU 1–4%); the 5XX + p99 tail were purely this endpoint's outbound-federation I/O + mislabeling. Do NOT scale instances for this.
 
@@ -111,15 +111,11 @@ The canonical Oxy media URL is **`https://cloud.oxy.so/<fileId>?variant=<v>`**. 
 
 ## Federation — Service Credential & Outbox Sync
 
-Federated post sync requires a valid Oxy `service`-type ApplicationCredential. Flow: view federated profile → `syncOutboxPosts` → `getKeyPair('instance')` → `getServiceToken()` (`POST api.oxy.so/auth/service-token`) → signs the GET to the remote ActivityPub outbox.
+Federated post sync requires a valid Oxy `service`-type ApplicationCredential. The backend service client acquires short-lived service tokens through the Oxy SDK and uses them to sign authorized ActivityPub outbox fetches.
 
-**Silent sticky outage pattern:** a bad/missing service token causes `getServiceToken()` to fail → signed fetch returns 0 posts. The outbox-sync cooldown (`OUTBOX_SYNC_MIN_INTERVAL_MS`, stamps `lastOutboxSyncAt` in `feed.controller.ts`) then makes this empty first sync PERMANENT (`pending:true`, 0 posts) until `lastOutboxSyncAt` is manually cleared from the DB. A bad service token is invisible at `LOG_LEVEL=info` — service-token and signed-fetch failures now log at `error`/`warn` (commit `7138fbaf`).
+**Silent sticky outage pattern:** a bad/missing service credential causes service-token acquisition to fail → signed fetch returns 0 posts. The outbox-sync cooldown (`OUTBOX_SYNC_MIN_INTERVAL_MS`, stamps `lastOutboxSyncAt` in `feed.controller.ts`) then makes this empty first sync PERMANENT (`pending:true`, 0 posts) until `lastOutboxSyncAt` is manually cleared from the DB. A bad service credential is invisible at `LOG_LEVEL=info` — service-token and signed-fetch failures now log at `error`/`warn` (commit `7138fbaf`).
 
-**Current service credential:** Oxy ApplicationCredential id `6a30ca4b5b15dc1bb793ad53` under the "Mention" Application, scopes `federation:write` + `user:read` + `files:write`. Secrets in GitHub `OxyHQ/Mention` → SSM `/oxy/mention/OXY_SERVICE_API_KEY|SECRET`.
-
-**Recreating creds:** use `~/Oxy/OxyHQServices/packages/api/scripts/create-service-credential.ts` (generic/idempotent; not committed — OxyHQServices working tree has an in-progress rewrite). Always use the real `ApplicationCredential.create` (SHA-256 secretHash). NEVER do a raw DB insert. Run prod-DB one-shots as a Fargate task in the oxy-api SG/subnets.
-
-**Mention is the only app using the Oxy service-token flow** (no other app needed a service credential as of 2026-06-16).
+**Credential handling:** do not document production credential identifiers, scopes, secret storage paths, or internal recreation/runbook details in this repository. Operators should use the private Oxy credential-management runbook and the approved secret-management console for rotation or recovery.
 
 ## Compose Intent URL
 

--- a/packages/backend/src/services/OxyRankingClient.ts
+++ b/packages/backend/src/services/OxyRankingClient.ts
@@ -17,13 +17,13 @@
  *
  * The Oxy `POST /profiles/recommendations` endpoint authenticates with
  * `optionalUserOrServiceAuth` and resolves the personalization viewer via
- * `resolveViewerId`: a SERVICE principal that holds the viewer-delegation scope
- * (`user:read`, which Mention's service credential has) names the viewer through
+ * `resolveViewerId`: an authorized SERVICE principal can name the viewer through
  * `X-Oxy-User-Id`. So a service-token call WITH a forwarded viewer id is
  * personalized end to end — the forwarded id seeds the viewer's mutual-overlap
  * graph and the supplied content-affinity boosts join the candidate union. A
- * service credential WITHOUT `user:read`, or a call with no/invalid viewer id,
- * resolves to anonymous (popular-public fallback) — never an error.
+ * service credential without viewer-delegation permission, or a call with
+ * no/invalid viewer id, resolves to anonymous (popular-public fallback) — never
+ * an error.
  */
 
 import type { UserNameResponse } from '@oxyhq/contracts';

--- a/packages/backend/src/utils/federation/crypto.ts
+++ b/packages/backend/src/utils/federation/crypto.ts
@@ -40,8 +40,9 @@ function isNonEmptyString(value: unknown): value is string {
  * Oxy owns all federation key material. This returns the mention.earth-scoped
  * keyId (`https://<FEDERATION_DOMAIN>/ap/users/<username>#main-key`) and the
  * matching public key PEM, used to build the actor's `publicKey` block. The
- * private key is never returned. Requires a valid service token with
- * `federation:write`; the OxyServices client auto-acquires/refreshes it.
+ * private key is never returned. Requires a valid service token with the
+ * appropriate federation permission; the OxyServices client
+ * auto-acquires/refreshes it.
  */
 export async function getPublicKey(username: string): Promise<FederationPublicKey> {
   const cached = publicKeyCache.get(username);
@@ -80,8 +81,9 @@ export async function getPublicKey(username: string): Promise<FederationPublicKe
 /**
  * Ask Oxy to sign an HTTP-Signature signing string with the private key that
  * backs `keyId`. The private key never leaves Oxy. Returns the base64 RSA-SHA256
- * signature. Requires a service token with `federation:write`; the keyId host
- * must be Mention's authorized domain (enforced by Oxy).
+ * signature. Requires a service token with the appropriate federation
+ * permission; the keyId host must be Mention's authorized domain (enforced by
+ * Oxy).
  */
 export async function signViaOxy(keyId: string, signingString: string): Promise<string> {
   let response: OxySignResponse;

--- a/packages/backend/src/utils/oxyHelpers.ts
+++ b/packages/backend/src/utils/oxyHelpers.ts
@@ -53,10 +53,8 @@ export function getServiceOxyClient(): OxyServices {
  * endpoint falls back to its default weight profile, so the value is optional
  * and the recommendation adapter simply omits `clientId` rather than failing.
  *
- * Provisioned alongside `OXY_SERVICE_API_KEY` / `OXY_SERVICE_API_SECRET` (SSM
- * `/oxy/mention/MENTION_OXY_CLIENT_ID`). It is the SAME Application that owns the
- * `6a30ca4b5b15dc1bb793ad53` service credential; the credential id and the
- * Application `_id` are distinct values.
+ * Provisioned separately from the service credential. Keep production
+ * credential identifiers and secret storage locations out of repository docs.
  */
 export function getMentionOxyClientId(): string | undefined {
   const value = process.env.MENTION_OXY_CLIENT_ID?.trim();


### PR DESCRIPTION
### Motivation
- Remove an information-disclosure in repository documentation that named production Oxy service credential identifiers, secret storage paths, scopes, endpoint flow details, and internal recreation/runbook instructions.
- Prevent these operational details from aiding targeted attacks or secret-hunting while preserving necessary operational guidance about outage modes.

### Description
- Redacted the federated service-credential runbook in `AGENTS.md` to remove credential ids, SSM paths, scopes, service-token endpoint details, and internal recreation instructions and replaced them with a repository-safe credential-handling note.
- Replaced explicit production-secret references in the media-cache doc line with a generic `Service credentials` note in `AGENTS.md` to avoid exposing secret names/paths.
- Generalized backend comments in `packages/backend/src/utils/oxyHelpers.ts`, `packages/backend/src/utils/federation/crypto.ts`, and `packages/backend/src/services/OxyRankingClient.ts` to avoid naming concrete production scopes/credential relationships while preserving the functional behavior and required authorization guidance.

### Testing
- Ran a targeted Python scan that searches for the sensitive markers from the report and verified none of the tracked files contain those markers (script succeeded).
- Ran `git diff --check` to validate formatting/whitespace and inspected the diffs; no formatting issues were found and changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450abf348323aeed9330ced88b62)