### PR TITLE
Fix federated outbox sync cooldown bypass

### DIFF
--- a/packages/backend/src/__tests__/utils/outboxSyncCooldown.test.ts
+++ b/packages/backend/src/__tests__/utils/outboxSyncCooldown.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { isWithinOutboxSyncCooldown, shouldForceUntrackedOutboxSync } from '../../utils/federation/outboxSyncCooldown';
+
+const COOLDOWN_MS = 15 * 60 * 1000;
+const NOW_MS = Date.UTC(2026, 5, 25, 12, 0, 0);
+
+describe('outbox sync cooldown', () => {
+  it('honors recent cooldown stamps for untracked positive-count outboxes', () => {
+    const recentSync = new Date(NOW_MS - 60_000);
+
+    expect(shouldForceUntrackedOutboxSync({
+      postsCount: 3,
+      lastOutboxSyncAt: recentSync,
+      nowMs: NOW_MS,
+      cooldownMs: COOLDOWN_MS,
+    })).toBe(false);
+    expect(isWithinOutboxSyncCooldown(recentSync, COOLDOWN_MS, NOW_MS)).toBe(true);
+  });
+
+  it('forces one sync for stale untracked positive-count outboxes', () => {
+    expect(shouldForceUntrackedOutboxSync({
+      postsCount: 3,
+      lastOutboxSyncAt: new Date(NOW_MS - COOLDOWN_MS - 1),
+      nowMs: NOW_MS,
+      cooldownMs: COOLDOWN_MS,
+    })).toBe(true);
+  });
+
+  it('does not force a sync for tracked or empty outboxes', () => {
+    expect(shouldForceUntrackedOutboxSync({
+      outboxStatus: 'complete',
+      postsCount: 3,
+      nowMs: NOW_MS,
+      cooldownMs: COOLDOWN_MS,
+    })).toBe(false);
+    expect(shouldForceUntrackedOutboxSync({
+      postsCount: 0,
+      nowMs: NOW_MS,
+      cooldownMs: COOLDOWN_MS,
+    })).toBe(false);
+  });
+});

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -47,6 +47,10 @@ import { threadSlicingService } from '../services/ThreadSlicingService';
 import FederatedActor, { IFederatedActor } from '../models/FederatedActor';
 import { federationService, isPermanentlyUnavailableOutboxReason } from '../services/FederationService';
 import { FEDERATION_ENABLED } from '../utils/federation/constants';
+import {
+  isWithinOutboxSyncCooldown,
+  shouldForceUntrackedOutboxSync,
+} from '../utils/federation/outboxSyncCooldown';
 
 /**
  * Minimum interval between background outbox re-syncs for the same federated
@@ -1070,13 +1074,15 @@ class FeedController {
           // Cooldown: skip the (expensive) outbox re-fetch+dedupe if we synced
           // this actor's outbox within the cooldown window. Profile views are
           // frequent; the outbox rarely changes between back-to-back views.
-          const lastSyncMs = actor.lastOutboxSyncAt?.getTime();
-          const shouldClassifyUntrackedOutbox =
-            !outboxStatus && typeof actor.postsCount === 'number' && actor.postsCount > 0;
+          const shouldClassifyUntrackedOutbox = shouldForceUntrackedOutboxSync({
+            outboxStatus,
+            postsCount: actor.postsCount,
+            lastOutboxSyncAt: actor.lastOutboxSyncAt,
+            cooldownMs: OUTBOX_SYNC_MIN_INTERVAL_MS,
+          });
           const syncedRecently = !refreshedActorForSync
             && !shouldClassifyUntrackedOutbox
-            && typeof lastSyncMs === 'number'
-            && Date.now() - lastSyncMs < OUTBOX_SYNC_MIN_INTERVAL_MS;
+            && isWithinOutboxSyncCooldown(actor.lastOutboxSyncAt, OUTBOX_SYNC_MIN_INTERVAL_MS);
           if (syncedRecently) {
             logger.info(`[FedSync] outbox sync skipped (cooldown) for ${actor.acct}`);
             return;

--- a/packages/backend/src/utils/federation/outboxSyncCooldown.ts
+++ b/packages/backend/src/utils/federation/outboxSyncCooldown.ts
@@ -1,0 +1,28 @@
+export interface ShouldForceUntrackedOutboxSyncInput {
+  outboxStatus?: string;
+  postsCount?: number;
+  lastOutboxSyncAt?: Date;
+  nowMs?: number;
+  cooldownMs: number;
+}
+
+export function isWithinOutboxSyncCooldown(
+  lastOutboxSyncAt: Date | undefined,
+  cooldownMs: number,
+  nowMs = Date.now(),
+): boolean {
+  const lastSyncMs = lastOutboxSyncAt?.getTime();
+  return typeof lastSyncMs === 'number' && nowMs - lastSyncMs < cooldownMs;
+}
+
+export function shouldForceUntrackedOutboxSync({
+  outboxStatus,
+  postsCount,
+  lastOutboxSyncAt,
+  nowMs = Date.now(),
+  cooldownMs,
+}: ShouldForceUntrackedOutboxSyncInput): boolean {
+  if (outboxStatus) return false;
+  if (typeof postsCount !== 'number' || postsCount <= 0) return false;
+  return !isWithinOutboxSyncCooldown(lastOutboxSyncAt, cooldownMs, nowMs);
+}


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated actors from repeatedly triggering expensive background ActivityPub outbox syncs when an actor has `postsCount > 0` but no persisted `outboxBackfill` state, which bypassed the `lastOutboxSyncAt` cooldown and caused repeated fetch/DOS work.

### Description
- Add `packages/backend/src/utils/federation/outboxSyncCooldown.ts` with `isWithinOutboxSyncCooldown` and `shouldForceUntrackedOutboxSync` helpers to centralize cooldown logic for tracked and untracked outboxes.
- Update the profile-triggered background sync in `packages/backend/src/controllers/feed.controller.ts` to call `shouldForceUntrackedOutboxSync` and `isWithinOutboxSyncCooldown` instead of the previous inline condition, preserving the cooldown for untracked positive-count outboxes.
- Add unit tests `packages/backend/src/__tests__/utils/outboxSyncCooldown.test.ts` to cover recent, stale, tracked, and empty outbox scenarios.

### Testing
- Ran a quick runtime assertion using `bun -e` that exercised `shouldForceUntrackedOutboxSync` and `isWithinOutboxSyncCooldown` and passed the expected behavior checks (recent vs stale vs tracked/empty cases).
- Added a `vitest` unit test file at `packages/backend/src/__tests__/utils/outboxSyncCooldown.test.ts` (could not run via `bun run test` because project dependencies could not be installed in this environment due to registry 403 errors).
- Attempted `bun install` for full test execution but the environment returned 403 for package tarball downloads, so full automated test suite execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450af20c832392f4de9a013e5760)