### PR TITLE
fix: scope ActivityPub inbox dedupe to verified actor

### DIFF
--- a/packages/backend/src/__tests__/queue/producers.test.ts
+++ b/packages/backend/src/__tests__/queue/producers.test.ts
@@ -30,15 +30,17 @@ beforeEach(() => {
 });
 
 describe('enqueueInboxActivity', () => {
-  it('dedupes inbound activities on a stable jobId derived from the activity id', async () => {
+  it('dedupes inbound activities on a stable jobId derived from the verified actor and activity id', async () => {
     const activity = { id: 'https://remote/users/bob/statuses/1/activity', type: 'Like' };
     const ok = await enqueueInboxActivity({ activity, verifiedActorUri: 'https://remote/users/bob' });
 
     expect(ok).toBe(true);
+    const expectedJobId = `inbox:${shortHash(`https://remote/users/bob|${activity.id}`)}`;
+
     expect(mocks.inboxAdd).toHaveBeenCalledWith(
       'inbox',
       { activity, verifiedActorUri: 'https://remote/users/bob' },
-      { jobId: `inbox:${shortHash(activity.id)}` },
+      { jobId: expectedJobId },
     );
   });
 
@@ -50,6 +52,22 @@ describe('enqueueInboxActivity', () => {
     const firstJobId = mocks.inboxAdd.mock.calls[0][2].jobId;
     const secondJobId = mocks.inboxAdd.mock.calls[1][2].jobId;
     expect(firstJobId).toBe(secondJobId);
+  });
+
+  it('does not collide when different verified actors reuse the same activity id', async () => {
+    const activity = { id: 'https://remote/shared/activity', type: 'Like' };
+
+    await enqueueInboxActivity({ activity, verifiedActorUri: 'https://remote/users/bob' });
+    await enqueueInboxActivity({ activity, verifiedActorUri: 'https://evil.example/users/mallory' });
+
+    const firstJobId = mocks.inboxAdd.mock.calls[0][2].jobId;
+    const secondJobId = mocks.inboxAdd.mock.calls[1][2].jobId;
+    const bobJobId = `inbox:${shortHash(`https://remote/users/bob|${activity.id}`)}`;
+    const malloryJobId = `inbox:${shortHash(`https://evil.example/users/mallory|${activity.id}`)}`;
+
+    expect(firstJobId).toBe(bobJobId);
+    expect(secondJobId).toBe(malloryJobId);
+    expect(firstJobId).not.toBe(secondJobId);
   });
 
   it('falls back (returns false) when the activity has no stable id to dedupe on', async () => {

--- a/packages/backend/src/queue/producers.ts
+++ b/packages/backend/src/queue/producers.ts
@@ -23,7 +23,8 @@ function shortHash(input: string): string {
 
 /**
  * Enqueue an inbound activity for asynchronous processing. Dedupes on the
- * activity `id` so a redelivered activity is processed at most once. Returns
+ * verified actor URI and activity `id` so redelivery from the same actor is
+ * idempotent without letting another actor suppress a reused activity id. Returns
  * false when no queue is available (caller should process inline) — that
  * includes the case where the activity has no stable `id` to dedupe on.
  */
@@ -35,7 +36,7 @@ export async function enqueueInboxActivity(data: InboxJobData): Promise<boolean>
   if (!activityId) return false;
 
   await queue.add('inbox', data, {
-    jobId: `inbox:${shortHash(activityId)}`,
+    jobId: `inbox:${shortHash(`${data.verifiedActorUri}|${activityId}`)}`,
   });
   return true;
 }


### PR DESCRIPTION
### Motivation
- Prevent a malicious federated actor from suppressing delivery of another actor's ActivityPub activities by reusing the same attacker-controlled activity `id` which was previously used as the sole BullMQ dedupe key.

### Description
- Include the verified signing actor URI in the inbox jobId hash so deduplication is scoped to `(verifiedActorUri + activityId)` instead of `activityId` alone (change in `packages/backend/src/queue/producers.ts`).
- Add a regression unit test that asserts two different verified actors with the same activity id produce distinct inbox jobIds and therefore do not collide (change in `packages/backend/src/__tests__/queue/producers.test.ts`).

### Testing
- Updated unit tests in `packages/backend/src/__tests__/queue/producers.test.ts` to cover actor-scoped jobId behavior; the new test verifies there is no cross-actor collision for the same activity id.
- Attempted to run the package tests with `cd packages/backend && bun run test src/__tests__/queue/producers.test.ts`, but the test runner (`vitest`) was not available in the execution environment so tests could not be executed here (failure due to missing runner, not test failures).
- Ran a local static/diff check (`git diff --check`) which reported no whitespace/format issues in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450aed608323a7d9db2d2db9f6e9)