### PR TITLE
fix(backend): retract removed recommendation endorsements

### DIFF
--- a/packages/backend/src/__tests__/services/endorsementSignalService.test.ts
+++ b/packages/backend/src/__tests__/services/endorsementSignalService.test.ts
@@ -41,6 +41,9 @@ function makeService() {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.outboxUpdateOne.mockResolvedValue({});
+  mocks.outboxFindOne.mockReturnValue({
+    select: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(null) }),
+  });
   mocks.outboxDeleteOne.mockResolvedValue({ catch: vi.fn() });
   mocks.outboxDeleteOne.mockReturnValue(Promise.resolve({}));
   mocks.pushEndorsements.mockResolvedValue(undefined);
@@ -105,6 +108,30 @@ describe('EndorsementSignalService.syncScope', () => {
     expect(setSent).toBeUndefined();
   });
 
+  it('retries pending remove edges captured from an earlier failed membership change', async () => {
+    mocks.listFindById.mockImplementation(
+      findByIdLean({ ownerOxyUserId: 'owner', memberOxyUserIds: ['keep'] }),
+    );
+    mocks.outboxFindOne.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue({
+          pendingRemoveOwnerId: 'owner',
+          pendingRemoveMemberIds: ['removed', 'owner'],
+        }),
+      }),
+    });
+
+    const service = makeService();
+    await service.syncScope('accountList', 'list_1');
+
+    expect(mocks.pushEndorsements).toHaveBeenCalledWith([
+      { ownerId: 'owner', memberId: 'removed', op: 'remove', sourceId: 'list_1' },
+      { ownerId: 'owner', memberId: 'keep', op: 'add', sourceId: 'list_1' },
+    ]);
+    const setSent = mocks.outboxUpdateOne.mock.calls.find((c) => c[1]?.$set?.status === 'sent');
+    expect(setSent?.[1].$unset).toEqual({ pendingRemoveOwnerId: '', pendingRemoveMemberIds: '' });
+  });
+
   it('pushes an empty add set (no-op) and marks sent when the scope no longer exists', async () => {
     mocks.packFindById.mockImplementation(findByIdLean(null));
 
@@ -114,6 +141,53 @@ describe('EndorsementSignalService.syncScope', () => {
     expect(mocks.pushEndorsements).toHaveBeenCalledWith([]);
     const setSent = mocks.outboxUpdateOne.mock.calls.find((c) => c[1]?.$set?.status === 'sent');
     expect(setSent).toBeDefined();
+  });
+});
+
+describe('EndorsementSignalService.syncScopeMembershipChange', () => {
+  it('pushes remove edges for pruned members and add edges for the current members', async () => {
+    mocks.listFindById.mockImplementation(
+      findByIdLean({ ownerOxyUserId: 'owner', memberOxyUserIds: ['keep', 'added'] }),
+    );
+
+    const service = makeService();
+    await service.syncScopeMembershipChange(
+      'accountList',
+      'list_1',
+      'owner',
+      ['removed', 'keep', 'owner'],
+      ['keep', 'added'],
+    );
+
+    const armUpdate = mocks.outboxUpdateOne.mock.calls[0][1];
+    expect(armUpdate.$addToSet).toEqual({ pendingRemoveMemberIds: { $each: ['removed'] } });
+    expect(mocks.pushEndorsements).toHaveBeenCalledWith([
+      { ownerId: 'owner', memberId: 'removed', op: 'remove', sourceId: 'list_1' },
+      { ownerId: 'owner', memberId: 'keep', op: 'add', sourceId: 'list_1' },
+      { ownerId: 'owner', memberId: 'added', op: 'add', sourceId: 'list_1' },
+    ]);
+  });
+
+  it('leaves captured removed members pending when the push fails', async () => {
+    mocks.packFindById.mockImplementation(
+      findByIdLean({ ownerOxyUserId: 'owner', memberOxyUserIds: ['keep'] }),
+    );
+    mocks.pushEndorsements.mockRejectedValue(new Error('oxy down'));
+    mocks.outboxFindOne.mockReturnValue({
+      select: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue({ attempts: 0 }) }),
+    });
+
+    const service = makeService();
+    await service.syncScopeMembershipChange('starterPack', 'pack_1', 'owner', ['removed', 'keep'], ['keep']);
+
+    const armUpdate = mocks.outboxUpdateOne.mock.calls[0][1];
+    expect(armUpdate.$addToSet).toEqual({ pendingRemoveMemberIds: { $each: ['removed'] } });
+    const failUpdate = mocks.outboxUpdateOne.mock.calls.find(
+      (c) => c[1]?.$set?.status === 'pending' && typeof c[1]?.$set?.attempts === 'number',
+    );
+    expect(failUpdate?.[1].$set.error).toBe('oxy down');
+    const setSent = mocks.outboxUpdateOne.mock.calls.find((c) => c[1]?.$set?.status === 'sent');
+    expect(setSent).toBeUndefined();
   });
 });
 

--- a/packages/backend/src/models/EndorsementOutbox.ts
+++ b/packages/backend/src/models/EndorsementOutbox.ts
@@ -4,10 +4,10 @@ import mongoose, { Document, Schema } from 'mongoose';
  * Outbox for endorsement-signal pushes to Oxy (`POST /app-signals/ingest`).
  *
  * Mirrors {@link FederationDeliveryQueue}: each row is a unit of work that is
- * attempted immediately and retried with backoff until it succeeds. Unlike the
- * delivery queue, an endorsement push is DESIRED-STATE — the row records the
- * `(source, sourceId)` scope to re-sync, NOT a frozen edge list, so a retry
- * recomputes the CURRENT member set and is self-healing/idempotent.
+ * attempted immediately and retried with backoff until it succeeds. The normal
+ * path is DESIRED-STATE — the row records the `(source, sourceId)` scope to
+ * re-sync. Membership removals also append the removed member ids to the row so
+ * retries can retract edges that no longer exist in the source document.
  *
  * There is at most ONE row per `(source, sourceId)` (unique index). A new
  * mutation on an already-pending scope upserts the same row (bumping
@@ -33,6 +33,10 @@ export interface IEndorsementOutbox extends Document {
   lastAttemptAt?: Date;
   /** Last error message, when the most recent attempt failed. */
   error?: string;
+  /** Owner for pending removal edges captured before members were pruned. */
+  pendingRemoveOwnerId?: string;
+  /** Removed members that must be retracted before the row can be considered sent. */
+  pendingRemoveMemberIds?: string[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -73,6 +77,8 @@ const EndorsementOutboxSchema = new Schema<IEndorsementOutbox>({
   nextAttemptAt: { type: Date, required: true, default: Date.now, index: true },
   lastAttemptAt: { type: Date },
   error: { type: String },
+  pendingRemoveOwnerId: { type: String },
+  pendingRemoveMemberIds: { type: [String], default: undefined },
 }, {
   timestamps: true,
 });

--- a/packages/backend/src/routes/lists.ts
+++ b/packages/backend/src/routes/lists.ts
@@ -20,6 +20,17 @@ function syncListEndorsements(listId: string): void {
     .catch((error) => logger.warn(`[Lists] endorsement sync failed for ${listId}:`, error));
 }
 
+function syncListMembershipChange(
+  listId: string,
+  ownerId: string,
+  previousMemberIds: string[],
+  nextMemberIds: string[],
+): void {
+  void endorsementSignalService
+    .syncScopeMembershipChange('accountList', listId, ownerId, previousMemberIds, nextMemberIds)
+    .catch((error) => logger.warn(`[Lists] endorsement membership sync failed for ${listId}:`, error));
+}
+
 type LeanAccountList = Pick<
   IAccountList,
   'ownerOxyUserId' | 'title' | 'description' | 'isPublic' | 'memberOxyUserIds' | 'subscriberCount' | 'createdAt' | 'updatedAt'
@@ -100,9 +111,14 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     if (title !== undefined) list.title = String(title);
     if (description !== undefined) list.description = String(description);
     if (isPublic !== undefined) list.isPublic = !!isPublic;
+    const previousMemberIds = [...(list.memberOxyUserIds || [])];
     if (Array.isArray(memberOxyUserIds)) list.memberOxyUserIds = memberOxyUserIds;
     await list.save();
-    syncListEndorsements(String(list._id));
+    if (Array.isArray(memberOxyUserIds)) {
+      syncListMembershipChange(String(list._id), list.ownerOxyUserId, previousMemberIds, list.memberOxyUserIds || []);
+    } else {
+      syncListEndorsements(String(list._id));
+    }
     res.json(list);
   } catch (error) {
     res.status(500).json({ error: 'Failed to update list' });
@@ -155,10 +171,11 @@ router.delete('/:id/members', async (req: AuthRequest, res: Response) => {
     const list = await AccountList.findById(req.params.id);
     if (!list) return res.status(404).json({ error: 'List not found' });
     if (list.ownerOxyUserId !== userId) return res.status(403).json({ error: 'Not allowed' });
+    const previousMemberIds = [...(list.memberOxyUserIds || [])];
     const toRemove = new Set(Array.isArray(userIds) ? userIds : []);
     list.memberOxyUserIds = (list.memberOxyUserIds || []).filter(id => !toRemove.has(id));
     await list.save();
-    syncListEndorsements(String(list._id));
+    syncListMembershipChange(String(list._id), list.ownerOxyUserId, previousMemberIds, list.memberOxyUserIds || []);
     res.json(list);
   } catch (error) {
     res.status(500).json({ error: 'Failed to remove members' });

--- a/packages/backend/src/routes/starterPacks.ts
+++ b/packages/backend/src/routes/starterPacks.ts
@@ -17,6 +17,17 @@ function syncPackEndorsements(packId: string): void {
     .catch((error) => logger.warn(`[StarterPacks] endorsement sync failed for ${packId}:`, error));
 }
 
+function syncPackMembershipChange(
+  packId: string,
+  ownerId: string,
+  previousMemberIds: string[],
+  nextMemberIds: string[],
+): void {
+  void endorsementSignalService
+    .syncScopeMembershipChange('starterPack', packId, ownerId, previousMemberIds, nextMemberIds)
+    .catch((error) => logger.warn(`[StarterPacks] endorsement membership sync failed for ${packId}:`, error));
+}
+
 const router = express.Router();
 
 const MAX_MEMBERS = 150;
@@ -162,12 +173,17 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     const { name, description, memberOxyUserIds } = req.body || {};
     if (name !== undefined) pack.name = String(name);
     if (description !== undefined) pack.description = String(description);
+    const previousMemberIds = [...(pack.memberOxyUserIds || [])];
     if (Array.isArray(memberOxyUserIds)) {
       if (memberOxyUserIds.length > MAX_MEMBERS) return res.status(400).json({ error: `Maximum ${MAX_MEMBERS} members allowed` });
       pack.memberOxyUserIds = memberOxyUserIds;
     }
     await pack.save();
-    syncPackEndorsements(String(pack._id));
+    if (Array.isArray(memberOxyUserIds)) {
+      syncPackMembershipChange(String(pack._id), pack.ownerOxyUserId, previousMemberIds, pack.memberOxyUserIds || []);
+    } else {
+      syncPackEndorsements(String(pack._id));
+    }
     res.json(pack);
   } catch (error) {
     res.status(500).json({ error: 'Failed to update starter pack' });
@@ -224,10 +240,11 @@ router.delete('/:id/members', async (req: AuthRequest, res: Response) => {
     if (!pack) return res.status(404).json({ error: 'Starter pack not found' });
     if (pack.ownerOxyUserId !== userId) return res.status(403).json({ error: 'Not allowed' });
 
+    const previousMemberIds = [...(pack.memberOxyUserIds || [])];
     const toRemove = new Set(Array.isArray(userIds) ? userIds : []);
     pack.memberOxyUserIds = (pack.memberOxyUserIds || []).filter(id => !toRemove.has(id));
     await pack.save();
-    syncPackEndorsements(String(pack._id));
+    syncPackMembershipChange(String(pack._id), pack.ownerOxyUserId, previousMemberIds, pack.memberOxyUserIds || []);
     res.json(pack);
   } catch (error) {
     res.status(500).json({ error: 'Failed to remove members' });

--- a/packages/backend/src/services/EndorsementSignalService.ts
+++ b/packages/backend/src/services/EndorsementSignalService.ts
@@ -10,11 +10,11 @@
  * Desired-state + idempotent + self-healing:
  *  - {@link syncScope} recomputes the CURRENT member set for one pack/list and
  *    pushes it as `add` edges for that scope.
- *  - When the scope no longer exists (or has no members), it pushes `remove`
- *    edges for the members it last knew about — but since we don't persist the
- *    previous set, deletion is handled by passing the removed members explicitly
- *    (see {@link syncScopeRemoval}); a plain delete with no known members is a
- *    no-op push that simply marks the outbox row sent.
+ *  - {@link syncScopeMembershipChange} captures members removed by an update
+ *    before MongoDB loses them, persists those pending retractions in the
+ *    outbox, and then re-syncs the scope.
+ *  - When the scope is deleted, the deletion path captures the final member set
+ *    and passes it explicitly to {@link syncScopeRemoval}.
  *
  * Reliability: every sync writes/refreshes an {@link EndorsementOutbox} row
  * FIRST, then attempts an immediate push. Success marks the row `sent`; failure
@@ -26,6 +26,7 @@ import AccountList from '../models/AccountList';
 import EndorsementOutbox, {
   getEndorsementNextAttempt,
   type EndorsementSource,
+  type IEndorsementOutbox,
 } from '../models/EndorsementOutbox';
 import { oxySignalsClient, type OxySignalsClient, type EndorsementEdge } from './OxySignalsClient';
 import { logger } from '../utils/logger';
@@ -75,17 +76,39 @@ export class EndorsementSignalService {
     }));
   }
 
+  /** Build `remove` edges for captured, no-longer-current members. */
+  private buildRemoveEdges(ownerId: string | undefined, memberIds: string[] | undefined, sourceId: string): EndorsementEdge[] {
+    if (!ownerId) return [];
+    const unique = new Set((memberIds ?? []).filter((id) => id && id !== ownerId));
+    return Array.from(unique).map((memberId) => ({
+      ownerId,
+      memberId,
+      op: 'remove' as const,
+      sourceId,
+    }));
+  }
+
   /**
    * Upsert/re-arm the outbox row for a scope so it is `pending` and due now.
    * Returns the row's current attempt count (0 for a fresh row).
    */
-  private async armOutbox(source: EndorsementSource, sourceId: string): Promise<void> {
+  private async armOutbox(
+    source: EndorsementSource,
+    sourceId: string,
+    removal?: { ownerId: string; memberIds: string[] },
+  ): Promise<void> {
+    const update: Record<string, unknown> = {
+      $set: { status: 'pending', nextAttemptAt: new Date() },
+      $setOnInsert: { attempts: 0 },
+    };
+    const removed = removal?.memberIds.filter((id) => id && id !== removal.ownerId) ?? [];
+    if (removal && removed.length > 0) {
+      update.$set = { ...(update.$set as Record<string, unknown>), pendingRemoveOwnerId: removal.ownerId };
+      update.$addToSet = { pendingRemoveMemberIds: { $each: removed } };
+    }
     await EndorsementOutbox.updateOne(
       { source, sourceId },
-      {
-        $set: { status: 'pending', nextAttemptAt: new Date() },
-        $setOnInsert: { attempts: 0 },
-      },
+      update,
       { upsert: true },
     );
   }
@@ -94,7 +117,10 @@ export class EndorsementSignalService {
   private async markSent(source: EndorsementSource, sourceId: string): Promise<void> {
     await EndorsementOutbox.updateOne(
       { source, sourceId },
-      { $set: { status: 'sent', attempts: 0, lastAttemptAt: new Date(), error: undefined } },
+      {
+        $set: { status: 'sent', attempts: 0, lastAttemptAt: new Date(), error: undefined },
+        $unset: { pendingRemoveOwnerId: '', pendingRemoveMemberIds: '' },
+      },
     );
   }
 
@@ -128,12 +154,55 @@ export class EndorsementSignalService {
     await this.armOutbox(source, sourceId);
 
     try {
-      const state = await this.loadScopeState(source, sourceId);
-      const edges = state ? this.buildAddEdges(state, sourceId) : [];
+      const [state, row] = await Promise.all([
+        this.loadScopeState(source, sourceId),
+        EndorsementOutbox.findOne({ source, sourceId })
+          .select('pendingRemoveOwnerId pendingRemoveMemberIds')
+          .lean<Pick<IEndorsementOutbox, 'pendingRemoveOwnerId' | 'pendingRemoveMemberIds'> | null>(),
+      ]);
+      const edges = [
+        ...this.buildRemoveEdges(row?.pendingRemoveOwnerId, row?.pendingRemoveMemberIds, sourceId),
+        ...(state ? this.buildAddEdges(state, sourceId) : []),
+      ];
       await this.signalsClient.pushEndorsements(edges);
       await this.markSent(source, sourceId);
     } catch (error) {
       logger.warn(`[EndorsementSignal] sync failed for ${source}:${sourceId}; left pending:`, error);
+      await this.markFailed(source, sourceId, error);
+    }
+  }
+
+  /**
+   * Re-sync a scope after a membership replacement/removal. The caller passes
+   * the pre-save and post-save member lists so members that disappeared can be
+   * emitted as durable `remove` edges even though they are no longer in MongoDB.
+   */
+  async syncScopeMembershipChange(
+    source: EndorsementSource,
+    sourceId: string,
+    ownerId: string,
+    previousMemberIds: string[],
+    nextMemberIds: string[],
+  ): Promise<void> {
+    const next = new Set(nextMemberIds);
+    const removed = Array.from(new Set(previousMemberIds.filter((id) => id && !next.has(id))));
+    await this.armOutbox(source, sourceId, { ownerId, memberIds: removed });
+
+    try {
+      const [state, row] = await Promise.all([
+        this.loadScopeState(source, sourceId),
+        EndorsementOutbox.findOne({ source, sourceId })
+          .select('pendingRemoveOwnerId pendingRemoveMemberIds')
+          .lean<Pick<IEndorsementOutbox, 'pendingRemoveOwnerId' | 'pendingRemoveMemberIds'> | null>(),
+      ]);
+      const edges = [
+        ...this.buildRemoveEdges(row?.pendingRemoveOwnerId ?? ownerId, row?.pendingRemoveMemberIds ?? removed, sourceId),
+        ...(state ? this.buildAddEdges(state, sourceId) : []),
+      ];
+      await this.signalsClient.pushEndorsements(edges);
+      await this.markSent(source, sourceId);
+    } catch (error) {
+      logger.warn(`[EndorsementSignal] membership sync failed for ${source}:${sourceId}; left pending:`, error);
       await this.markFailed(source, sourceId, error);
     }
   }


### PR DESCRIPTION
### Motivation
- Close a logic vulnerability where removed list/starter-pack members were never retracted from the Oxy endorsement graph, allowing stale endorsements to persist.
- Ensure endorsement pushes can emit durable `remove` edges for members pruned by update/remove operations so Oxy's cross-app recommendations remain correct.

### Description
- Persist pending removal metadata on the endorsement outbox by adding `pendingRemoveOwnerId` and `pendingRemoveMemberIds` to `EndorsementOutbox` so retries can emit retraction edges.
- Update `EndorsementSignalService` to capture and push `remove` edges: add `buildRemoveEdges`, extend `armOutbox` to accept removal captures, include pending removes when composing `syncScope` pushes, add `syncScopeMembershipChange` to handle update/removal diffs, and clear pending-remove fields on successful send.
- Wire list and starter-pack routes to capture `previousMemberIds` before pruning/saving and call the new membership-change sync path (`syncScopeMembershipChange`) instead of the add-only re-sync in those cases, while preserving fire-and-forget behavior.
- Add/extend unit tests in `endorsementSignalService.test.ts` to cover captured removal retries, membership-change push behavior, and failure/backoff handling for removal pushes.

### Testing
- Ran `git diff --check` which completed without issues.
- Added targeted unit tests in `packages/backend/src/__tests__/services/endorsementSignalService.test.ts`; attempted to run `bun test packages/backend/src/__tests__/services/endorsementSignalService.test.ts` but the run failed due to missing runtime dependencies (`mongoose` not found) in the environment, so tests could not be executed here.
- Attempted `bun install --frozen-lockfile` to install deps but the job was blocked by npm registry 403 responses, so automated test execution was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450b0a8c8323885e5806251293b1)