### PR TITLE
fix(media-proxy): prevent negative cache poisoning

### DIFF
--- a/packages/backend/src/__tests__/routes/mediaProxy.test.ts
+++ b/packages/backend/src/__tests__/routes/mediaProxy.test.ts
@@ -162,6 +162,53 @@ describe('GET /media/proxy — upstream status mapping', () => {
     expect(res.status).toBe(413);
   });
 
+  it('does NOT negative-cache request-specific 400 responses', async () => {
+    fetchUpstreamFollowingRedirects.mockResolvedValue({ response: fakeResponse(400), finalUrl: REMOTE });
+
+    const res = await request(app).get('/media/proxy').set('Range', 'bytes=not-a-range').query({ url: REMOTE });
+
+    expect(res.status).toBe(404);
+    expect(markNegativelyCached).not.toHaveBeenCalled();
+  });
+
+  it('does NOT negative-cache transient upstream 429 responses', async () => {
+    fetchUpstreamFollowingRedirects.mockResolvedValue({ response: fakeResponse(429), finalUrl: REMOTE });
+
+    const res = await request(app).get('/media/proxy').query({ url: REMOTE });
+
+    expect(res.status).toBe(404);
+    expect(markNegativelyCached).not.toHaveBeenCalled();
+  });
+
+  it('does NOT negative-cache 4xx responses to ranged requests', async () => {
+    fetchUpstreamFollowingRedirects.mockResolvedValue({ response: fakeResponse(403), finalUrl: REMOTE });
+
+    const res = await request(app).get('/media/proxy').set('Range', 'bytes=0-1').query({ url: REMOTE });
+
+    expect(res.status).toBe(404);
+    expect(markNegativelyCached).not.toHaveBeenCalled();
+  });
+
+  it('does NOT negative-cache 4xx responses to conditional requests', async () => {
+    fetchUpstreamFollowingRedirects.mockResolvedValue({ response: fakeResponse(404), finalUrl: REMOTE });
+
+    const res = await request(app).get('/media/proxy').set('If-None-Match', '"stale"').query({ url: REMOTE });
+
+    expect(res.status).toBe(404);
+    expect(markNegativelyCached).not.toHaveBeenCalled();
+  });
+
+  it('does NOT use the URL-only negative cache for ranged requests', async () => {
+    isNegativelyCached.mockResolvedValue(true);
+    fetchUpstreamFollowingRedirects.mockResolvedValue({ response: fakeResponse(416), finalUrl: REMOTE });
+
+    const res = await request(app).get('/media/proxy').set('Range', 'bytes=999-1000').query({ url: REMOTE });
+
+    expect(res.status).toBe(416);
+    expect(isNegativelyCached).not.toHaveBeenCalled();
+    expect(fetchUpstreamFollowingRedirects).toHaveBeenCalled();
+  });
+
   it('relays a 416 range-not-satisfiable as 416', async () => {
     fetchUpstreamFollowingRedirects.mockResolvedValue({
       response: fakeResponse(416, { 'content-range': 'bytes */1024' }),

--- a/packages/backend/src/routes/media.ts
+++ b/packages/backend/src/routes/media.ts
@@ -350,6 +350,15 @@ async function tryServePosterFromCache(remoteUrl: string, res: Response): Promis
   }
 }
 
+function shouldNegativeCacheClientError(status: number, hasRequestSpecificUpstreamHeaders: boolean): boolean {
+  if (hasRequestSpecificUpstreamHeaders) return false;
+
+  // Only memo stable "this asset is unavailable" statuses. Avoid transient or
+  // request-specific 4xx such as 400 (malformed Range/conditional validators) and
+  // 429 (remote rate limiting), which could otherwise poison the URL-only cache.
+  return status === 401 || status === 403 || status === 404 || status === 410 || status === 451;
+}
+
 // --- Route ------------------------------------------------------------------
 
 /**
@@ -371,16 +380,6 @@ router.get('/proxy', mediaProxyRateLimiter, async (req: Request, res: Response):
     return;
   }
 
-  // --- Negative cache short-circuit ---
-  // Deleted/forbidden/hotlink-protected remote media keeps being re-requested on
-  // every feed render. If a recent fetch of THIS url already failed with a
-  // client-class (4xx) or connection error, answer 404 immediately without
-  // re-hitting the dead upstream. Degrades to a normal fetch when Redis is down.
-  if (await isNegativelyCached(rawUrl)) {
-    res.status(HTTP_STATUS.NOT_FOUND).json({ error: 'Upstream media unavailable' });
-    return;
-  }
-
   // --- Activity-based cache front (only when the cache is enabled) ---
   // When the federated media cache is disabled it is COMPLETELY INERT: we touch
   // FederatedMediaCache ZERO times (no lookup, no access bump, no enqueue) and
@@ -393,8 +392,13 @@ router.get('/proxy', mediaProxyRateLimiter, async (req: Request, res: Response):
   // seek semantics we only short-circuit for full (non-range) GETs; ranged
   // requests fall through to the existing range-aware remote stream while still
   // recording access.
+  const rangeHeader = req.headers.range;
+  const hasRange = typeof rangeHeader === 'string' && rangeHeader.length > 0;
+  const hasConditionalHeader =
+    typeof req.headers['if-none-match'] === 'string' || typeof req.headers['if-modified-since'] === 'string';
+  const hasRequestSpecificUpstreamHeaders = hasRange || hasConditionalHeader;
+
   if (isMediaCacheEnabled()) {
-    const hasRange = typeof req.headers.range === 'string' && req.headers.range.length > 0;
     if (!hasRange) {
       const cacheServed = await tryServeFromCache(rawUrl, res);
       if (cacheServed) return;
@@ -408,8 +412,19 @@ router.get('/proxy', mediaProxyRateLimiter, async (req: Request, res: Response):
     }
   }
 
+  // --- Negative cache short-circuit ---
+  // Check this only after the normal cache front has had a chance to serve full
+  // requests, so a stale negative marker can never suppress already cached media.
+  // URL-only negative entries are also skipped for ranged/conditional requests:
+  // those forwarded headers can make an otherwise valid upstream reply with a
+  // request-specific 4xx/304/416 and must not poison or consume the URL cache.
+  if (!hasRequestSpecificUpstreamHeaders && (await isNegativelyCached(rawUrl))) {
+    res.status(HTTP_STATUS.NOT_FOUND).json({ error: 'Upstream media unavailable' });
+    return;
+  }
+
   const extras = {
-    range: typeof req.headers.range === 'string' ? req.headers.range : undefined,
+    range: hasRange && typeof rangeHeader === 'string' ? rangeHeader : undefined,
     ifNoneMatch: typeof req.headers['if-none-match'] === 'string' ? req.headers['if-none-match'] : undefined,
     ifModifiedSince:
       typeof req.headers['if-modified-since'] === 'string' ? req.headers['if-modified-since'] : undefined,
@@ -485,7 +500,9 @@ router.get('/proxy', mediaProxyRateLimiter, async (req: Request, res: Response):
   if (statusClass === 'client-error') {
     response.resume();
     logger.debug('[MediaProxy] Upstream returned client-error status', { status: upstreamStatus });
-    void markNegativelyCached(rawUrl, 'client-error');
+    if (shouldNegativeCacheClientError(upstreamStatus, hasRequestSpecificUpstreamHeaders)) {
+      void markNegativelyCached(rawUrl, 'client-error');
+    }
     res.status(HTTP_STATUS.NOT_FOUND).json({ error: 'Upstream media unavailable' });
     return;
   }


### PR DESCRIPTION
### Motivation
- The URL-only negative cache for `/media/proxy` could be poisoned by request-specific upstream 4xx responses (e.g. malformed `Range` or transient `429`) because forwarded request headers were not considered when short-circuiting or writing the marker. 
- The change aims to preserve the performance benefit of negative caching for genuinely unavailable assets while preventing an attacker or transient upstream condition from denying availability for all clients.

### Description
- Move the negative-cache short-circuit to run after the normal media-cache front for full (non-range, non-conditional) requests so existing cached media cannot be suppressed. 
- Detect request-specific upstream headers (`Range`, `If-None-Match`, `If-Modified-Since`) and skip URL-only negative-cache reads and writes when such headers are present. 
- Add `shouldNegativeCacheClientError(status, hasRequestSpecificUpstreamHeaders)` to restrict client-error memoization to stable unavailable statuses (`401`, `403`, `404`, `410`, `451`) and avoid caching transient/request-specific statuses such as `400` and `429`. 
- Preserve forwarding of valid `Range` and conditional headers to the upstream fetch and update how `extras.range` is populated. 
- Add regression tests to `packages/backend/src/__tests__/routes/mediaProxy.test.ts` that assert malformed ranged `400`, transient `429`, ranged/conditional 4xx, and ranged negative-cache-bypass behaviors do not write/read the URL-only negative cache.

### Testing
- Ran `bun test packages/backend/src/__tests__/routes/mediaProxyStatus.test.ts`, which passed all cases. 
- Added unit tests in `packages/backend/src/__tests__/routes/mediaProxy.test.ts` covering the new negative-cache guards, but running the full test file was blocked by missing runtime dependencies (`Cannot find package 'express'`) in this environment. 
- Attempted `bun install` to run the full spec but dependency fetches failed due to registry 403 responses, so the new tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450ac7608323bd64fed4f5586221)