### PR TITLE
Enforce profile ACLs on recommendation affinity boosts

### DIFF
--- a/packages/backend/src/__tests__/services/contentAffinityService.test.ts
+++ b/packages/backend/src/__tests__/services/contentAffinityService.test.ts
@@ -6,6 +6,8 @@ const mocks = vi.hoisted(() => ({
   postAggregate: vi.fn(),
   entityFollowFind: vi.fn(),
   userBehaviorFindOne: vi.fn(),
+  userSettingsFind: vi.fn(),
+  checkFollowAccess: vi.fn(),
   blockFind: vi.fn(),
   muteFind: vi.fn(),
   restrictFind: vi.fn(),
@@ -18,12 +20,18 @@ vi.mock('../../models/Like', () => ({ default: { find: mocks.likeFind } }));
 vi.mock('../../models/Post', () => ({ Post: { find: mocks.postFind, aggregate: mocks.postAggregate } }));
 vi.mock('../../models/EntityFollow', () => ({ EntityFollow: { find: mocks.entityFollowFind } }));
 vi.mock('../../models/UserBehavior', () => ({ default: { findOne: mocks.userBehaviorFindOne } }));
+vi.mock('../../models/UserSettings', () => ({ default: { find: mocks.userSettingsFind } }));
 vi.mock('../../models/Block', () => ({ default: { find: mocks.blockFind } }));
 vi.mock('../../models/Mute', () => ({ default: { find: mocks.muteFind } }));
 vi.mock('../../models/Restrict', () => ({ default: { find: mocks.restrictFind } }));
 
 vi.mock('../../utils/redis', () => ({
   getRedisClient: mocks.getRedisClient,
+}));
+vi.mock('../../utils/privacyHelpers', () => ({
+  ProfileVisibility: { PUBLIC: 'public', PRIVATE: 'private', FOLLOWERS_ONLY: 'followers_only' },
+  requiresAccessCheck: (visibility: string | undefined) => visibility === 'private' || visibility === 'followers_only',
+  checkFollowAccess: mocks.checkFollowAccess,
 }));
 
 // The authority blend dynamically imports these; stub them so the blend is a
@@ -69,6 +77,8 @@ function noSignals(): void {
   // No maintained behavior aggregate by default (cold viewer) → preferred-author,
   // topic-affinity, and negative-signal inputs all run empty.
   mocks.userBehaviorFindOne.mockImplementation(leanFindOne(null));
+  mocks.userSettingsFind.mockImplementation(leanQuery([]));
+  mocks.checkFollowAccess.mockResolvedValue(false);
 }
 
 beforeEach(() => {
@@ -259,6 +269,51 @@ describe('ContentAffinityService.getContentCandidates', () => {
 
     const ids = result.map((c) => c.userId);
     expect(ids).toEqual(['good']);
+  });
+
+  it('filters private and followers-only profile candidates unless the viewer follows them', async () => {
+    mocks.entityFollowFind.mockImplementation(leanQuery([{ entityId: 'rust' }]));
+    mocks.postAggregate.mockResolvedValue([
+      { _id: 'public_author', matchedTags: [['rust']], postCount: 1 },
+      { _id: 'private_author', matchedTags: [['rust']], postCount: 1 },
+      { _id: 'followers_author', matchedTags: [['rust']], postCount: 1 },
+      { _id: 'followed_private_author', matchedTags: [['rust']], postCount: 1 },
+    ]);
+    mocks.userSettingsFind.mockImplementation(leanQuery([
+      { oxyUserId: 'private_author', privacy: { profileVisibility: 'private' } },
+      { oxyUserId: 'followers_author', privacy: { profileVisibility: 'followers_only' } },
+      { oxyUserId: 'followed_private_author', privacy: { profileVisibility: 'private' } },
+    ]));
+    mocks.checkFollowAccess.mockImplementation(
+      async (_viewerId: string, targetId: string) => targetId === 'followed_private_author',
+    );
+
+    const service = makeService();
+    const result = await service.getContentCandidates('viewer_1');
+
+    expect(result.map((c) => c.userId).sort()).toEqual(['followed_private_author', 'public_author']);
+    expect(mocks.checkFollowAccess).toHaveBeenCalledWith('viewer_1', 'private_author');
+    expect(mocks.checkFollowAccess).toHaveBeenCalledWith('viewer_1', 'followers_author');
+    expect(mocks.checkFollowAccess).toHaveBeenCalledWith('viewer_1', 'followed_private_author');
+  });
+
+  it('resolves engagement authors only from published public target posts', async () => {
+    mocks.likeFind.mockImplementation(leanQuery([{ postId: 'p_public' }, { postId: 'p_private' }]));
+    mocks.postFind.mockImplementation((match: Record<string, unknown>) => {
+      if (match.type === 'boost') return leanQuery([])();
+      if (match.parentPostId) return leanQuery([])();
+      expect(match).toMatchObject({
+        _id: { $in: ['p_public', 'p_private'] },
+        status: 'published',
+        visibility: 'public',
+      });
+      return leanQuery([{ _id: 'p_public', oxyUserId: 'public_author' }])();
+    });
+
+    const service = makeService();
+    const result = await service.getContentCandidates('viewer_1');
+
+    expect(result.map((c) => c.userId)).toEqual(['public_author']);
   });
 
   it('respects the candidate cap', async () => {

--- a/packages/backend/src/services/ContentAffinityService.ts
+++ b/packages/backend/src/services/ContentAffinityService.ts
@@ -55,11 +55,13 @@ import Like from '../models/Like';
 import { Post, type IPost } from '../models/Post';
 import { EntityFollow } from '../models/EntityFollow';
 import UserBehavior, { type IUserBehavior } from '../models/UserBehavior';
+import UserSettings from '../models/UserSettings';
 import Block from '../models/Block';
 import Mute from '../models/Mute';
 import Restrict from '../models/Restrict';
 import { getRedisClient } from '../utils/redis';
 import { logger } from '../utils/logger';
+import { checkFollowAccess, ProfileVisibility, requiresAccessCheck } from '../utils/privacyHelpers';
 
 /** Recency window for content signals (days). */
 const WINDOW_DAYS = 30;
@@ -99,7 +101,7 @@ const MAX_AUTHORS_PER_TOPIC = 200;
 const CACHE_TTL_SECONDS = 120;
 
 /** Redis key namespace for cached content-affinity candidates. */
-const CACHE_PREFIX = 'rec:affinity:v1:';
+const CACHE_PREFIX = 'rec:affinity:v2:';
 
 /**
  * Base weights per signal. Engagement is a direct, intentional signal and is
@@ -222,6 +224,13 @@ export class ContentAffinityService {
         }
       }
     }
+
+    if (merged.size === 0) {
+      await this.writeCache(cacheKey, []);
+      return [];
+    }
+
+    await this.filterCandidateProfileAccess(viewerId, merged);
 
     if (merged.size === 0) {
       await this.writeCache(cacheKey, []);
@@ -421,6 +430,49 @@ export class ContentAffinityService {
       return new Map();
     }
     return result;
+  }
+
+  /**
+   * Remove candidates whose Mention profile ACLs are not visible to the viewer.
+   * Oxy Ranking only receives boosted user ids, so local Mention-only profile
+   * visibility must be enforced before boosts leave this service. Missing
+   * settings default to public, matching the UserSettings schema default; query
+   * failures fail closed by clearing all candidates.
+   */
+  private async filterCandidateProfileAccess(
+    viewerId: string,
+    merged: Map<string, AuthorAccumulator>,
+  ): Promise<void> {
+    const authorIds = Array.from(merged.keys()).filter((id) => id !== viewerId);
+    if (authorIds.length === 0) return;
+
+    try {
+      const rows = await UserSettings.find(
+        { oxyUserId: { $in: authorIds } },
+        { oxyUserId: 1, 'privacy.profileVisibility': 1 },
+      ).lean();
+      const visibilityByAuthor = new Map<string, string>();
+      for (const row of rows) {
+        const authorId = typeof row?.oxyUserId === 'string' ? row.oxyUserId : '';
+        if (!authorId) continue;
+        visibilityByAuthor.set(
+          authorId,
+          row.privacy?.profileVisibility ?? ProfileVisibility.PUBLIC,
+        );
+      }
+
+      await Promise.all(
+        authorIds.map(async (authorId) => {
+          const visibility = visibilityByAuthor.get(authorId) ?? ProfileVisibility.PUBLIC;
+          if (!requiresAccessCheck(visibility)) return;
+          const hasAccess = authorId === viewerId || await checkFollowAccess(viewerId, authorId);
+          if (!hasAccess) merged.delete(authorId);
+        }),
+      );
+    } catch (error) {
+      logger.warn('[ContentAffinity] candidate profile ACL filter failed; dropping candidates:', error);
+      merged.clear();
+    }
   }
 
   /**
@@ -684,8 +736,21 @@ export class ContentAffinityService {
     try {
       const match: QueryFilter<IPost> =
         kind === 'boost'
-          ? { oxyUserId: viewerId, type: PostType.BOOST, boostOf: { $ne: null }, createdAt: { $gte: since } }
-          : { oxyUserId: viewerId, parentPostId: { $ne: null }, createdAt: { $gte: since } };
+          ? {
+            oxyUserId: viewerId,
+            type: PostType.BOOST,
+            boostOf: { $ne: null },
+            status: 'published',
+            visibility: 'public',
+            createdAt: { $gte: since },
+          }
+          : {
+            oxyUserId: viewerId,
+            parentPostId: { $ne: null },
+            status: 'published',
+            visibility: 'public',
+            createdAt: { $gte: since },
+          };
       const field = kind === 'boost' ? { boostOf: 1, _id: 0 } : { parentPostId: 1, _id: 0 };
 
       const rows = await Post.find(match, field)
@@ -714,7 +779,7 @@ export class ContentAffinityService {
     if (postIds.length === 0) return map;
     try {
       const rows = await Post.find(
-        { _id: { $in: postIds } },
+        { _id: { $in: postIds }, status: 'published', visibility: 'public' },
         { oxyUserId: 1 },
       ).lean();
       for (const row of rows) {


### PR DESCRIPTION
### Motivation
- Prevent leakage of private or followers-only Mention profiles via content-affinity candidate boosts sent to the Oxy ranking service.
- Ensure engagement-derived author resolution only uses visible, published public posts so private/draft targets cannot produce candidate boosts.
- Keep the service fail-closed on ACL/query failures to avoid accidentally exposing restricted user ids to the ranking pipeline.

### Description
- Added `filterCandidateProfileAccess(viewerId, merged)` to `ContentAffinityService` to load `UserSettings`, apply `requiresAccessCheck`, and call `checkFollowAccess` so candidates with `private`/`followers_only` visibility are removed unless the viewer has access, with any query error clearing the candidate set (fail-closed). 
- Restricted engagement-path queries by requiring `status: 'published'` and `visibility: 'public'` when collecting viewer interaction targets and when resolving post authors, so only visible posts produce engagement-derived candidates. 
- Bumped the content-affinity Redis cache namespace from `rec:affinity:v1:` to `rec:affinity:v2:` to avoid re-serving pre-filtered cached candidates. 
- Added regression tests in `packages/backend/src/__tests__/services/contentAffinityService.test.ts` that cover filtering of `private`/`followers_only` candidates and that engagement authors are resolved only from published public posts.

### Testing
- Ran `git diff --check` which produced no whitespace or diff-check errors. (passed)
- Attempted `bun install --frozen-lockfile` and `bun test packages/backend/src/__tests__/services/contentAffinityService.test.ts`, but installation and tests were blocked by external registry failures (npm registry returned 403 for required packages), causing the test run to error with missing `mongoose` and preventing full automated test execution. (blocked/failure due to environment dependency fetch issues)
- Added unit tests exercising the new ACL filter and engagement constraints; the tests were committed but could not be executed in this environment due to the dependency installation failure. (tests added, not executed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450af36483239e12c82c1a6b1364)