### PR TITLE
fix(feed): guard impression view telemetry

### DIFF
--- a/packages/backend/src/__tests__/feedViewCounter.test.ts
+++ b/packages/backend/src/__tests__/feedViewCounter.test.ts
@@ -12,6 +12,10 @@ vi.mock('../utils/redis', () => ({
     isReady: true,
     isOpen: true,
     connect: vi.fn().mockResolvedValue(undefined),
+    // `ensureRedisConnected` verifies a ready client with a ping before running
+    // the operation; a healthy client must resolve it, otherwise the connection
+    // check fails and `withRedisFallback` returns the no-op fallback.
+    ping: vi.fn().mockResolvedValue('PONG'),
     set: mocks.redisSet,
   }),
 }));
@@ -45,13 +49,35 @@ describe('feedViewCounter', () => {
     });
   });
 
-  it('does not allocate a Redis dedupe key or increment for nonexistent/private/draft posts', async () => {
+  it('does not allocate a Redis dedupe key or increment for nonexistent/private/followers-only/draft posts', async () => {
+    // The eligibility query (`{ visibility: PUBLIC, status: 'published' }`) does
+    // not match private, followers-only, draft, or nonexistent posts, so Mongo
+    // resolves `Post.exists` to `null` for every one of those cases — modelling
+    // the security guard that keeps forged client telemetry off non-public ids.
     mocks.postExists.mockResolvedValueOnce(null);
 
     await expect(recordDedupedView(POST_ID, 'attacker_oxy_user')).resolves.toBe(false);
 
+    expect(mocks.postExists).toHaveBeenCalledWith({
+      _id: POST_ID,
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+    });
     expect(mocks.redisSet).not.toHaveBeenCalled();
     expect(mocks.postUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('treats a followers-only post as ineligible for impression telemetry', async () => {
+    // A FOLLOWERS_ONLY post never satisfies the `visibility: PUBLIC` predicate, so
+    // `Post.exists` returns null and no view side effects run.
+    mocks.postExists.mockResolvedValueOnce(null);
+
+    await expect(isPostEligibleForViewTelemetry(POST_ID)).resolves.toBe(false);
+    expect(mocks.postExists).toHaveBeenCalledWith({
+      _id: POST_ID,
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+    });
   });
 
   it('keeps the increment guarded by the same public published predicate', async () => {

--- a/packages/backend/src/__tests__/feedViewCounter.test.ts
+++ b/packages/backend/src/__tests__/feedViewCounter.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PostVisibility } from '@mention/shared-types';
+
+const mocks = vi.hoisted(() => ({
+  redisSet: vi.fn(),
+  postExists: vi.fn(),
+  postUpdateOne: vi.fn(),
+}));
+
+vi.mock('../utils/redis', () => ({
+  getRedisClient: vi.fn().mockReturnValue({
+    isReady: true,
+    isOpen: true,
+    connect: vi.fn().mockResolvedValue(undefined),
+    set: mocks.redisSet,
+  }),
+}));
+
+vi.mock('../models/Post', () => ({
+  Post: {
+    exists: mocks.postExists,
+    updateOne: mocks.postUpdateOne,
+  },
+}));
+
+import { isPostEligibleForViewTelemetry, recordDedupedView } from '../services/feedViewCounter';
+
+const POST_ID = '507f1f77bcf86cd799439011';
+
+describe('feedViewCounter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.redisSet.mockResolvedValue('OK');
+    mocks.postUpdateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
+  });
+
+  it('only treats public published posts as eligible for impression side effects', async () => {
+    mocks.postExists.mockResolvedValueOnce({ _id: POST_ID });
+
+    await expect(isPostEligibleForViewTelemetry(POST_ID)).resolves.toBe(true);
+    expect(mocks.postExists).toHaveBeenCalledWith({
+      _id: POST_ID,
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+    });
+  });
+
+  it('does not allocate a Redis dedupe key or increment for nonexistent/private/draft posts', async () => {
+    mocks.postExists.mockResolvedValueOnce(null);
+
+    await expect(recordDedupedView(POST_ID, 'attacker_oxy_user')).resolves.toBe(false);
+
+    expect(mocks.redisSet).not.toHaveBeenCalled();
+    expect(mocks.postUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('keeps the increment guarded by the same public published predicate', async () => {
+    mocks.postExists.mockResolvedValueOnce({ _id: POST_ID });
+
+    await expect(recordDedupedView(POST_ID, 'viewer_oxy_user')).resolves.toBe(true);
+
+    expect(mocks.redisSet).toHaveBeenCalledWith(`viewseen:${POST_ID}:viewer_oxy_user`, '1', {
+      NX: true,
+      EX: expect.any(Number),
+    });
+    expect(mocks.postUpdateOne).toHaveBeenCalledWith(
+      { _id: POST_ID, visibility: PostVisibility.PUBLIC, status: 'published' },
+      { $inc: { 'stats.viewsCount': 1 } },
+    );
+  });
+});

--- a/packages/backend/src/mtn/feed/FeedInteractionTracker.ts
+++ b/packages/backend/src/mtn/feed/FeedInteractionTracker.ts
@@ -8,7 +8,7 @@
 import mongoose from 'mongoose';
 import { MtnConfig } from '@mention/shared-types';
 import { logger } from '../../utils/logger';
-import { recordDedupedView } from '../../services/feedViewCounter';
+import { isPostEligibleForViewTelemetry, recordDedupedView } from '../../services/feedViewCounter';
 import { userPreferenceService } from '../../services/UserPreferenceService';
 
 export type InteractionEvent = 'impression' | 'click' | 'like' | 'reply' | 'boost' | 'save';
@@ -65,6 +65,14 @@ async function applyImpressionSignals(interaction: FeedInteractionData): Promise
   const postId = interaction.postUri;
   if (!postId || !mongoose.isValidObjectId(postId)) {
     return; // Not a local post id — nothing to count or learn from.
+  }
+
+  // Client telemetry is untrusted: only derive view/preference side effects for
+  // real public, published local posts. This prevents forged impressions from
+  // mutating stats or learning against private/draft/nonexistent post ids.
+  const eligible = await isPostEligibleForViewTelemetry(postId);
+  if (!eligible) {
+    return;
   }
 
   // 1. Deduped real view count (no-op without Redis / on duplicate).

--- a/packages/backend/src/services/feedViewCounter.ts
+++ b/packages/backend/src/services/feedViewCounter.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { MtnConfig } from '@mention/shared-types';
+import { MtnConfig, PostVisibility } from '@mention/shared-types';
 import { Post } from '../models/Post';
 import { getRedisClient } from '../utils/redis';
 import { withRedisFallback, ensureRedisConnected } from '../utils/redisHelpers';
@@ -36,6 +36,26 @@ function keyFor(postId: string, viewerId: string): string {
 }
 
 /**
+ * Verify a client-reported impression references a real post that is safe to
+ * count as feed-visible telemetry. Telemetry is client-controlled, so this
+ * intentionally only accepts public, published local posts before creating any
+ * Redis dedupe marker or updating ranking/view statistics.
+ */
+export async function isPostEligibleForViewTelemetry(postId: string): Promise<boolean> {
+  if (!postId || !mongoose.isValidObjectId(postId)) {
+    return false;
+  }
+
+  const post = await Post.exists({
+    _id: postId,
+    visibility: PostVisibility.PUBLIC,
+    status: 'published',
+  });
+
+  return Boolean(post);
+}
+
+/**
  * Increment a post's view count for `viewerId`, deduped within the configured
  * window. Returns `true` when this call counted a NEW view (and thus performed
  * the increment), `false` when it was a duplicate or Redis was unavailable.
@@ -47,6 +67,11 @@ function keyFor(postId: string, viewerId: string): string {
  */
 export async function recordDedupedView(postId: string, viewerId: string): Promise<boolean> {
   if (!postId || !viewerId || !mongoose.isValidObjectId(postId)) {
+    return false;
+  }
+
+  const eligible = await isPostEligibleForViewTelemetry(postId);
+  if (!eligible) {
     return false;
   }
 
@@ -74,7 +99,10 @@ export async function recordDedupedView(postId: string, viewerId: string): Promi
   }
 
   try {
-    await Post.updateOne({ _id: postId }, { $inc: { 'stats.viewsCount': 1 } });
+    await Post.updateOne(
+      { _id: postId, visibility: PostVisibility.PUBLIC, status: 'published' },
+      { $inc: { 'stats.viewsCount': 1 } },
+    );
     return true;
   } catch (error) {
     logger.debug('[FeedViewCounter] viewsCount increment failed', {


### PR DESCRIPTION
### Motivation

- Prevent client-controlled/forged impression telemetry from creating Redis dedupe keys or incrementing `Post.stats.viewsCount` for nonexistent, private, draft, scheduled, or non-local posts.
- Ensure view-count and preference-learning side effects are only applied for posts that the server confirms are visible (public + published) to avoid integrity manipulation of engagement signals.

### Description

- Added `isPostEligibleForViewTelemetry(postId)` in `packages/backend/src/services/feedViewCounter.ts` to verify a post exists and is `visibility: PUBLIC` and `status: 'published'` before any side effects occur.
- Guarded `recordDedupedView` to call `isPostEligibleForViewTelemetry` before allocating the Redis dedupe marker and before performing the Mongo `$inc` (the `$inc` now includes the same visibility/status predicate).
- Updated `applyImpressionSignals` in `packages/backend/src/mtn/feed/FeedInteractionTracker.ts` to skip both the deduped view increment and the `UserPreference` learning signal when `isPostEligibleForViewTelemetry` returns false.
- Added unit tests `packages/backend/src/__tests__/feedViewCounter.test.ts` that assert eligibility checks, that no Redis key or increment is performed for ineligible posts, and that eligible posts still allocate the dedupe marker and increment guarded by the public/published predicate.

### Testing

- Added unit test file `packages/backend/src/__tests__/feedViewCounter.test.ts` covering eligibility, ineligible short-circuit, and guarded increment behavior; tests committed to the branch.
- Attempted to run the test: `cd packages/backend && bun run test src/__tests__/feedViewCounter.test.ts` but the environment could not execute `vitest` (`vitest: command not found`) so tests were not executed here.
- Attempted `bun install --frozen-lockfile` to install deps but it failed due to registry 403 responses, so CI/local test execution should be run in a networked environment with package registry access to validate the new tests (they are unit-level and mock external deps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d43844ccc8323b12cf2eda56c354c)