### PR TITLE
Fix public room stream credential sanitization

### DIFF
--- a/packages/backend/src/__tests__/routes/roomsSanitization.test.ts
+++ b/packages/backend/src/__tests__/routes/roomsSanitization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { stripInternalStreamFields } from '../../routes/rooms.routes';
+
+describe('room response sanitization', () => {
+  it('removes internal stream credentials from public room payloads', () => {
+    const room = {
+      _id: 'room-1',
+      title: 'Live room',
+      host: 'host-1',
+      activeIngressId: 'ingress-1',
+      activeStreamUrl: 'https://example.com/source.m3u8',
+      rtmpUrl: 'rtmp://livekit.example/live',
+      rtmpStreamKey: 'LK_sensitive_stream_key',
+      streamTitle: 'Public stream title',
+    };
+
+    expect(stripInternalStreamFields(room)).toEqual({
+      _id: 'room-1',
+      title: 'Live room',
+      host: 'host-1',
+      streamTitle: 'Public stream title',
+    });
+  });
+});

--- a/packages/backend/src/routes/rooms.routes.ts
+++ b/packages/backend/src/routes/rooms.routes.ts
@@ -50,6 +50,21 @@ interface IngressReplacementResult {
   previousDeletedBeforeCreate: boolean;
 }
 
+type InternalStreamFields = {
+  activeStreamUrl?: unknown;
+  activeIngressId?: unknown;
+  rtmpUrl?: unknown;
+  rtmpStreamKey?: unknown;
+};
+
+export function stripInternalStreamFields<T extends InternalStreamFields>(room: T): T {
+  delete room.activeStreamUrl;
+  delete room.activeIngressId;
+  delete room.rtmpUrl;
+  delete room.rtmpStreamKey;
+  return room;
+}
+
 async function canManageRoom(room: RoomOwnershipFields, userId: string): Promise<boolean> {
   if (room.host === userId) {
     return true;
@@ -509,7 +524,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       : undefined;
 
     res.json({
-      rooms: roomsToReturn,
+      rooms: roomsToReturn.map((room) => stripInternalStreamFields(room)),
       hasMore,
       nextCursor,
     });
@@ -574,10 +589,7 @@ router.get('/:id', async (req: AuthRequest, res: Response) => {
       : false;
 
     if (!canViewInternalStreamFields) {
-      delete room.activeStreamUrl;
-      delete room.activeIngressId;
-      delete room.rtmpUrl;
-      delete room.rtmpStreamKey;
+      stripInternalStreamFields(room);
     }
 
     res.json({ room });


### PR DESCRIPTION
### Motivation
- The public `/rooms` listing became anonymously reachable and returned raw Room documents containing sensitive streaming fields (`activeIngressId`, `activeStreamUrl`, `rtmpUrl`, `rtmpStreamKey`), which allows unauthenticated attackers to discover RTMP credentials.

### Description
- Added a sanitizer `stripInternalStreamFields` in `packages/backend/src/routes/rooms.routes.ts` to remove internal LiveKit/RTMP fields from room payloads. 
- Applied the sanitizer to the public `GET /rooms` list response so the list no longer leaks `rtmpUrl`/`rtmpStreamKey` and related ingress fields. 
- Reused the sanitizer in the room detail path to preserve the existing manager-only behavior for internal stream fields. 
- Added a regression unit test `packages/backend/src/__tests__/routes/roomsSanitization.test.ts` that verifies the sanitizer removes RTMP/ingress fields while preserving public stream metadata.

### Testing
- Ran `git diff --check` which completed with no whitespace errors. 
- Added a unit test that exercises `stripInternalStreamFields`; test execution was attempted but `vitest`/test runner could not be run in this environment because `bun install --frozen-lockfile` failed due to the npm registry returning 403 errors, so the test could not be executed here. 
- Manual inspection and local static verification of the modified response mapping and sanitizer logic were performed in lieu of runnable CI in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d41617bfc8323a80b37002050ee11)