### PR TITLE
fix(backend): validate boost and quote targets

### DIFF
--- a/packages/backend/src/__tests__/postAccessControl.test.ts
+++ b/packages/backend/src/__tests__/postAccessControl.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { PostVisibility } from '@mention/shared-types';
+import { validatePublicShareTarget } from '../utils/postAccessControl';
+
+describe('validatePublicShareTarget', () => {
+  it('rejects missing targets', () => {
+    const result = validatePublicShareTarget(null, { action: 'boost' });
+    expect(result).toEqual({ ok: false, status: 404, message: 'Post not found' });
+  });
+
+  it('rejects unpublished targets', () => {
+    const result = validatePublicShareTarget(
+      { status: 'draft', visibility: PostVisibility.PUBLIC },
+      { action: 'quote' },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(403);
+  });
+
+  it('rejects private targets', () => {
+    const result = validatePublicShareTarget(
+      { status: 'published', visibility: PostVisibility.PRIVATE },
+      { action: 'boost' },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(403);
+  });
+
+  it('rejects followers-only targets', () => {
+    const result = validatePublicShareTarget(
+      { status: 'published', visibility: PostVisibility.FOLLOWERS_ONLY },
+      { action: 'quote' },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(403);
+  });
+
+  it('rejects quote targets with quotes disabled', () => {
+    const result = validatePublicShareTarget(
+      { status: 'published', visibility: PostVisibility.PUBLIC, quotesDisabled: true },
+      { action: 'quote' },
+    );
+    expect(result).toEqual({ ok: false, status: 403, message: 'Quotes are disabled for this post' });
+  });
+
+  it('allows published public targets', () => {
+    const result = validatePublicShareTarget(
+      { status: 'published', visibility: PostVisibility.PUBLIC },
+      { action: 'boost' },
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -40,6 +40,7 @@ import {
 import { metrics } from '../utils/metrics';
 import { config } from '../config';
 import { mergeHashtags } from '../utils/textProcessing';
+import { validatePublicShareTarget } from '../utils/postAccessControl';
 import { baselineContentClassifier } from '../services/BaselineContentClassifier';
 import { createScopedOxyClient, getServiceOxyClient } from '../utils/oxyHelpers';
 import type { User } from '@oxyhq/core';
@@ -1344,6 +1345,14 @@ class FeedController {
 
       if (!originalPostId) {
         return res.status(400).json({ error: 'Original post ID is required' });
+      }
+
+      const originalPost = await Post.findById(originalPostId)
+        .maxTimeMS(FEED_CONSTANTS.QUERY_TIMEOUT_MS)
+        .lean();
+      const shareValidation = validatePublicShareTarget(originalPost, { action: 'boost' });
+      if (!shareValidation.ok) {
+        return res.status(shareValidation.status).json({ error: shareValidation.message });
       }
 
       // Check if user already boosted this

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -18,6 +18,7 @@ import { config } from '../config';
 import { mergeHashtags, escapeRegex } from '../utils/textProcessing';
 import { createScopedOxyClient } from '../utils/oxyHelpers';
 import { aliaChat } from '../utils/alia';
+import { validatePublicShareTarget } from '../utils/postAccessControl';
 
 // Constants from centralized config
 const MAX_SOURCES = config.posts.maxSources;
@@ -644,6 +645,22 @@ export const createPost = async (req: AuthRequest, res: Response) => {
     const isScheduled = postStatus === 'scheduled';
 
     const postMetadata = buildPostMetadata(req.body.metadata);
+
+    if (quoted_post_id) {
+      const quotedPost = await Post.findById(quoted_post_id).maxTimeMS(5000).lean();
+      const quoteValidation = validatePublicShareTarget(quotedPost, { action: 'quote' });
+      if (!quoteValidation.ok) {
+        return res.status(quoteValidation.status).json({ message: quoteValidation.message });
+      }
+    }
+
+    if (boost_of) {
+      const boostedPost = await Post.findById(boost_of).maxTimeMS(5000).lean();
+      const boostValidation = validatePublicShareTarget(boostedPost, { action: 'boost' });
+      if (!boostValidation.ok) {
+        return res.status(boostValidation.status).json({ message: boostValidation.message });
+      }
+    }
 
     const post = await postCreationService.create({
       oxyUserId: userId,

--- a/packages/backend/src/utils/postAccessControl.ts
+++ b/packages/backend/src/utils/postAccessControl.ts
@@ -1,0 +1,45 @@
+import { PostVisibility } from '@mention/shared-types';
+
+export type ShareTargetPost = {
+  status?: string;
+  visibility?: string;
+  quotesDisabled?: boolean;
+};
+
+export type ShareValidationResult =
+  | { ok: true }
+  | { ok: false; status: number; message: string };
+
+export type ShareValidationOptions = {
+  action: 'boost' | 'quote';
+};
+
+/**
+ * Enforce post-level access before creating a public wrapper around another post.
+ *
+ * Boosts and quotes are currently always created as public posts. Therefore the
+ * target must itself be published and public; otherwise hydration could expose a
+ * private, followers-only, draft, or scheduled post through the public wrapper.
+ */
+export function validatePublicShareTarget(
+  targetPost: ShareTargetPost | null | undefined,
+  options: ShareValidationOptions,
+): ShareValidationResult {
+  if (!targetPost) {
+    return { ok: false, status: 404, message: 'Post not found' };
+  }
+
+  if ((targetPost.status ?? 'published') !== 'published') {
+    return { ok: false, status: 403, message: `You cannot ${options.action} this post` };
+  }
+
+  if ((targetPost.visibility ?? PostVisibility.PUBLIC) !== PostVisibility.PUBLIC) {
+    return { ok: false, status: 403, message: `You cannot ${options.action} this post` };
+  }
+
+  if (options.action === 'quote' && targetPost.quotesDisabled) {
+    return { ok: false, status: 403, message: 'Quotes are disabled for this post' };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
### Motivation
- Prevent public boost/quote wrappers from referencing and thereby leaking content from posts that are unpublished, private, followers-only, or have quoting disabled.
- Address an exposure where callers (MCP or other tools) could create public wrapper posts by supplying an attacker-controlled target ID without the backend validating the target's publication/visibility state.

### Description
- Add a centralized validator `validatePublicShareTarget` in `packages/backend/src/utils/postAccessControl.ts` that ensures a target post exists, has `status: 'published'`, is `visibility: 'public'`, and (for quotes) respects `quotesDisabled` before allowing a public wrapper. 
- Enforce the validator in the canonical boost creation path (`/feed/boost`) by loading the target (`Post.findById`) and rejecting inaccessible targets before creating the boost. 
- Enforce the validator in generic post creation (`/posts`) for both `quoted_post_id` and `boost_of` request fields before creating the wrapper post. 
- Add unit tests covering missing targets, unpublished targets, private targets, followers-only targets, quote-disabled targets, and an allowed published public target in `packages/backend/src/__tests__/postAccessControl.test.ts`.

### Testing
- Ran the new unit test file with the repo test harness: `bun test packages/backend/src/__tests__/postAccessControl.test.ts` and all 6 tests passed.
- Attempted package-level test/run tooling and build checks surfaced environment/configuration issues unrelated to the changes: running `vitest` via the environment failed to resolve `vitest` (registry 403) and `bun run build:backend` stopped on an existing TypeScript deprecation in shared-types (TS5107); these failures are due to environment or existing repo configuration, not the validator logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5482b1e88323901cf46d3c16e16e)