### PR TITLE
fix(feed): restrict thread child slices to public published posts

### DIFF
--- a/packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts
+++ b/packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { PostActorSummary } from '@mention/shared-types';
+import { PostVisibility, type PostActorSummary } from '@mention/shared-types';
 import type { CachedUserSummary } from '../../services/userSummaryCache';
 
 /**
@@ -146,5 +146,41 @@ describe('ThreadSlicingService reply-context parent author', () => {
     expect(reason.parentAuthor.displayName).toBe(PARENT_AUTHOR_ID);
     expect(reason.parentAuthor.handle).not.toBe('');
     expect(reason.parentAuthor.displayName).not.toBe('');
+  });
+});
+
+describe('ThreadSlicingService thread children visibility', () => {
+  it('fetches self-thread children only when public and published', async () => {
+    postFind.mockImplementation(() => []);
+    resolveUserSummaries.mockResolvedValue(new Map<string, CachedUserSummary>());
+
+    const root = {
+      _id: '650000000000000000000101',
+      oxyUserId: 'oxy-thread-author',
+      parentPostId: undefined,
+      threadId: 'thread-1',
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+      content: { text: 'public root' },
+    };
+
+    await threadSlicingService.sliceFeed([root], {
+      enableThreadGrouping: true,
+      enableReplyContext: false,
+      maxSliceSize: 3,
+    });
+
+    expect(postFind).toHaveBeenCalledTimes(1);
+    expect(postFind.mock.calls[0][0]).toMatchObject({
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+      $or: [
+        {
+          threadId: 'thread-1',
+          oxyUserId: 'oxy-thread-author',
+          parentPostId: { $ne: null, $exists: true },
+        },
+      ],
+    });
   });
 });

--- a/packages/backend/src/services/ThreadSlicingService.ts
+++ b/packages/backend/src/services/ThreadSlicingService.ts
@@ -7,7 +7,14 @@
  *   2. Reply context injection: posts with parentPostId → prepend parent as context
  */
 
-import { FeedPostSlice, FeedSliceItem, FeedSliceReason, MtnConfig, PostActorSummary } from '@mention/shared-types';
+import {
+  FeedPostSlice,
+  FeedSliceItem,
+  FeedSliceReason,
+  MtnConfig,
+  PostActorSummary,
+  PostVisibility,
+} from '@mention/shared-types';
 import { Post } from '../models/Post';
 import { logger } from '../utils/logger';
 import { resolveUserSummaries } from './PostHydrationService';
@@ -200,6 +207,8 @@ class ThreadSlicingService {
 
     try {
       const children = await Post.find({
+        visibility: PostVisibility.PUBLIC,
+        status: 'published',
         $or: orConditions,
       })
         .select('_id oxyUserId createdAt parentPostId threadId content stats metadata hashtags mentions language visibility type boostOf quoteOf')


### PR DESCRIPTION
### Motivation
- The media feed enabled thread grouping which caused `ThreadSlicingService` to fetch thread children without enforcing `visibility`/`status` guards, allowing non-public or unpublished child posts to be hydrated and leaked in public feed responses.
- The change prevents an authenticated attacker from receiving draft/private/scheduled child posts when a public media thread root is included in a feed.

### Description
- Import `PostVisibility` and add `visibility: PostVisibility.PUBLIC` and `status: 'published'` predicates to the thread-children `Post.find` in `packages/backend/src/services/ThreadSlicingService.ts` to ensure only public, published children are fetched for self-thread grouping.
- Add a regression unit test in `packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts` that asserts the thread-child query includes the `visibility` and `status` guards.
- Files changed: `packages/backend/src/services/ThreadSlicingService.ts` and `packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts`.

### Testing
- Ran `bun test packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts`, which failed to execute due to a missing runtime dependency (`Cannot find package 'pino'`), so the new test could not be run end-to-end in this environment.
- Attempted `bun install` to resolve deps but it was blocked by registry errors (HTTP 403), preventing full test execution in the CI-like sandbox.
- Verified the change compiles as a source edit and committed the fix (`fix(feed): restrict thread children in slices`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4bb4a4248323ac941ecfc69a12c5)