### PR TITLE
Enforce visibility and published status on hashtag and custom-feed reads

### DIFF
--- a/packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts
+++ b/packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../../server', () => ({
   roomsNamespace: { emit: vi.fn() },
 }));
 
-import { buildPostsByTopicFilter } from '../../controllers/posts.controller';
+import { buildPostsByHashtagFilter, buildPostsByTopicFilter } from '../../controllers/posts.controller';
 
 describe('buildPostsByTopicFilter — canonical topicRefs.name OR slug topics match', () => {
   it('matches the canonical topicRefs.name AND the slug-only postClassification.topics (lowercased)', () => {
@@ -41,6 +41,25 @@ describe('buildPostsByTopicFilter — canonical topicRefs.name OR slug topics ma
       { 'postClassification.topicRefs.name': 'tech' },
       { 'postClassification.topics': 'tech' },
     ]);
+    expect(filter.visibility).toBe('public');
+  });
+});
+
+describe('buildPostsByHashtagFilter — hashtag discovery visibility scope', () => {
+  it('matches normalized hashtags only on public, published posts', () => {
+    const filter = buildPostsByHashtagFilter('MixedCase');
+
+    expect(filter.hashtags).toEqual({ $in: ['mixedcase'] });
+    expect(filter.status).toBe('published');
+    expect(filter.visibility).toBe('public');
+    expect(filter._id).toBeUndefined();
+  });
+
+  it('adds the cursor range clause without dropping ACL filters', () => {
+    const filter = buildPostsByHashtagFilter('Tech', 'cursor-456');
+
+    expect(filter._id).toEqual({ $lt: 'cursor-456' });
+    expect(filter.status).toBe('published');
     expect(filter.visibility).toBe('public');
   });
 });

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -1705,20 +1705,30 @@ export const moveBookmarkToFolder = async (req: AuthRequest, res: Response) => {
 };
 
 // Get posts by hashtag
+export function buildPostsByHashtagFilter(
+  hashtag: string,
+  cursor?: string,
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = {
+    hashtags: { $in: [hashtag.toLowerCase()] },
+    status: 'published',
+    visibility: PostVisibility.PUBLIC,
+  };
+
+  if (cursor) {
+    filter._id = { $lt: cursor };
+  }
+
+  return filter;
+}
+
 export const getPostsByHashtag = async (req: AuthRequest, res: Response) => {
   try {
     const hashtag = String(req.params.hashtag);
     const cursor = req.query.cursor as string | undefined;
     const limit = Math.min(parseInt(req.query.limit as string) || DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
 
-    const filter: Record<string, unknown> = {
-      hashtags: { $in: [hashtag.toLowerCase()] },
-      status: 'published',
-    };
-
-    if (cursor) {
-      filter._id = { $lt: cursor };
-    }
+    const filter = buildPostsByHashtagFilter(hashtag, cursor);
 
     const posts = await Post.find(filter)
       .sort({ createdAt: -1 })

--- a/packages/backend/src/routes/customFeeds.routes.ts
+++ b/packages/backend/src/routes/customFeeds.routes.ts
@@ -515,6 +515,7 @@ router.get('/:id/timeline', validateObjectId('id'), async (req: AuthRequest, res
     // Build query based on feed configuration
     const q: Record<string, unknown> = {
       visibility: 'public',
+      status: 'published',
     };
 
     // Collect all conditions in $and array for proper MongoDB query structure


### PR DESCRIPTION
### Motivation
- Normalize/backfill of hashtags made mixed-case tags match lowercased read queries and risked exposing non-public or unpublished posts through hashtag/custom-feed endpoints. 
- The intent is to ensure hashtag discovery and custom-feed keyword matching only surface content that is both public and published.

### Description
- Add a reusable `buildPostsByHashtagFilter` in `packages/backend/src/controllers/posts.controller.ts` that matches normalized hashtags and requires `status: 'published'` and `visibility: PostVisibility.PUBLIC` before querying.
- Update `getPostsByHashtag` in `packages/backend/src/controllers/posts.controller.ts` to use `buildPostsByHashtagFilter` for consistent ACL scoping.
- Require `status: 'published'` in the custom feed timeline base query in `packages/backend/src/routes/customFeeds.routes.ts` so keyword/hashtag matches cannot return drafts or scheduled posts.
- Extend controller unit tests (`packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts`) with `buildPostsByHashtagFilter` checks to assert ACL and cursor behavior.

### Testing
- Added unit test coverage in `packages/backend/src/__tests__/controllers/getPostsByTopicFilter.test.ts` for the hashtag filter, but running `bun run test` in this environment failed because test dependencies (`vitest`) are not installed here, so tests were not executed locally. 
- Ran static checks (`git diff --check`) which reported no issues. 
- Manual inspection and targeted test addition verify the new filter logic and that custom-feed queries now include `status: 'published'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4bc979148323a2098a643c0dda83)