### PR TITLE
fix(federation): guard signed ActivityPub fetches

### DIFF
--- a/packages/backend/src/__tests__/services/federationService.test.ts
+++ b/packages/backend/src/__tests__/services/federationService.test.ts
@@ -124,6 +124,17 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   });
 }
 
+function streamResponse(body: unknown, init: { statusCode?: number; headers?: Record<string, string> } = {}) {
+  const stream = new PassThrough();
+  stream.end(typeof body === 'string' ? body : JSON.stringify(body));
+  Object.assign(stream, {
+    statusCode: init.statusCode ?? 200,
+    statusMessage: init.statusCode && init.statusCode >= 400 ? 'Error' : 'OK',
+    headers: init.headers ?? { 'content-type': 'application/activity+json' },
+  });
+  return stream;
+}
+
 function createNoteActivity(id: string, actorUri = 'https://mastodon.social/users/alice') {
   return {
     id: `${actorUri}/statuses/${id}/activity`,
@@ -189,6 +200,18 @@ beforeEach(() => {
   mocks.uploadProfileBanner.mockResolvedValue({ file: { id: 'banner_file_1' } });
   mocks.userSettingsUpdateOne.mockResolvedValue({ modifiedCount: 1 });
   mocks.fetchUpstreamFollowingRedirects.mockReset();
+  mocks.fetchUpstreamFollowingRedirects.mockImplementation(async (url: string, extras?: { headers?: Record<string, string> }) => {
+    const res = await fetch(url, { headers: extras?.headers });
+    const body = await res.arrayBuffer();
+    const stream = new PassThrough();
+    stream.end(Buffer.from(body));
+    Object.assign(stream, {
+      statusCode: res.status,
+      statusMessage: res.statusText,
+      headers: Object.fromEntries(res.headers.entries()),
+    });
+    return { response: stream, finalUrl: url };
+  });
   mocks.getServiceOxyClient.mockReturnValue({
     makeServiceRequest: mocks.makeServiceRequest,
     uploadProfileBanner: mocks.uploadProfileBanner,
@@ -197,9 +220,9 @@ beforeEach(() => {
 
 describe('federationService.fetchRemoteActor', () => {
   it('preserves canonical www hostnames such as Threads actor URIs', async () => {
-    const fetchMock = vi.fn(async (url: string) => {
+    mocks.fetchUpstreamFollowingRedirects.mockImplementation(async (url: string) => {
       if (url === 'https://www.threads.net/ap/users/mosseri/') {
-        return jsonResponse({
+        return { response: streamResponse({
           id: 'https://www.threads.net/ap/users/mosseri/',
           type: 'Person',
           preferredUsername: 'mosseri',
@@ -210,16 +233,15 @@ describe('federationService.fetchRemoteActor', () => {
             id: 'https://www.threads.net/ap/users/mosseri/#main-key',
             publicKeyPem: 'remote-public',
           },
-        });
+        }), finalUrl: url };
       }
 
       if (url === 'https://www.threads.net/ap/users/mosseri/outbox') {
-        return jsonResponse({ type: 'OrderedCollection', totalItems: 12 });
+        return { response: streamResponse({ type: 'OrderedCollection', totalItems: 12 }), finalUrl: url };
       }
 
-      throw new Error(`unexpected fetch ${url}`);
+      throw new Error(`unexpected safe fetch ${url}`);
     });
-    vi.stubGlobal('fetch', fetchMock);
 
     const actor = await federationService.fetchRemoteActor(
       'https://www.threads.net/ap/users/mosseri/',
@@ -228,16 +250,18 @@ describe('federationService.fetchRemoteActor', () => {
     );
 
     expect(actor?.uri).toBe('https://www.threads.net/ap/users/mosseri/');
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(mocks.fetchUpstreamFollowingRedirects).toHaveBeenCalledWith(
       'https://www.threads.net/ap/users/mosseri/',
       expect.objectContaining({
         headers: expect.objectContaining({
           Accept: expect.stringContaining('application/activity+json'),
         }),
       }),
+      expect.any(AbortSignal),
     );
-    expect(fetchMock).not.toHaveBeenCalledWith(
+    expect(mocks.fetchUpstreamFollowingRedirects).not.toHaveBeenCalledWith(
       expect.stringContaining('https://threads.net/ap/users/mosseri/'),
+      expect.anything(),
       expect.anything(),
     );
     expect(mocks.findOneAndUpdate).toHaveBeenCalledWith(
@@ -264,37 +288,36 @@ describe('federationService.fetchRemoteActor', () => {
   });
 
   it('downloads actor banners through the SSRF-safe media fetcher with content validation and a size cap', async () => {
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === 'https://remote.example/users/alice') {
-        return jsonResponse({
-          id: 'https://remote.example/users/alice',
-          type: 'Person',
-          preferredUsername: 'alice',
-          name: 'Alice',
-          inbox: 'https://remote.example/users/alice/inbox',
-          image: ['http://127.0.0.1/latest/meta-data', { url: 'https://remote.example/banner.jpg' }],
-        });
-      }
-
-      throw new Error(`unexpected global fetch ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
     const body = new PassThrough();
     body.end(Buffer.from('fake-image-bytes'));
     Object.assign(body, {
       statusCode: 200,
       headers: { 'content-type': 'image/jpeg' },
     });
-    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue({
-      response: body,
-      finalUrl: 'http://127.0.0.1/latest/meta-data',
+    mocks.fetchUpstreamFollowingRedirects.mockImplementation(async (url: string) => {
+      if (url === 'https://remote.example/users/alice') {
+        return { response: streamResponse({
+          id: 'https://remote.example/users/alice',
+          type: 'Person',
+          preferredUsername: 'alice',
+          name: 'Alice',
+          inbox: 'https://remote.example/users/alice/inbox',
+          image: ['http://127.0.0.1/latest/meta-data', { url: 'https://remote.example/banner.jpg' }],
+        }), finalUrl: url };
+      }
+      return {
+        response: body,
+        finalUrl: 'http://127.0.0.1/latest/meta-data',
+      };
     });
 
     await federationService.fetchRemoteActor('https://remote.example/users/alice');
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).not.toHaveBeenCalledWith('http://127.0.0.1/latest/meta-data');
+    expect(mocks.fetchUpstreamFollowingRedirects).not.toHaveBeenCalledWith(
+      'http://127.0.0.1/latest/meta-data',
+      expect.objectContaining({ headers: expect.anything() }),
+      expect.any(AbortSignal),
+    );
     expect(mocks.fetchUpstreamFollowingRedirects).toHaveBeenCalledWith(
       'http://127.0.0.1/latest/meta-data',
       {},
@@ -309,30 +332,26 @@ describe('federationService.fetchRemoteActor', () => {
   });
 
   it('rejects non-image actor banner responses before upload', async () => {
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === 'https://remote.example/users/bob') {
-        return jsonResponse({
-          id: 'https://remote.example/users/bob',
-          type: 'Person',
-          preferredUsername: 'bob',
-          inbox: 'https://remote.example/users/bob/inbox',
-          image: 'https://remote.example/banner.txt',
-        });
-      }
-
-      throw new Error(`unexpected global fetch ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
     const body = new PassThrough();
     body.end(Buffer.from('not an image'));
     Object.assign(body, {
       statusCode: 200,
       headers: { 'content-type': 'text/plain' },
     });
-    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue({
-      response: body,
-      finalUrl: 'https://remote.example/banner.txt',
+    mocks.fetchUpstreamFollowingRedirects.mockImplementation(async (url: string) => {
+      if (url === 'https://remote.example/users/bob') {
+        return { response: streamResponse({
+          id: 'https://remote.example/users/bob',
+          type: 'Person',
+          preferredUsername: 'bob',
+          inbox: 'https://remote.example/users/bob/inbox',
+          image: 'https://remote.example/banner.txt',
+        }), finalUrl: url };
+      }
+      return {
+        response: body,
+        finalUrl: 'https://remote.example/banner.txt',
+      };
     });
 
     await federationService.fetchRemoteActor('https://remote.example/users/bob');

--- a/packages/backend/src/services/federation/sharedFederationHelpers.ts
+++ b/packages/backend/src/services/federation/sharedFederationHelpers.ts
@@ -11,8 +11,10 @@ import { PostVisibility } from '@mention/shared-types';
 import { extractApMediaFromNote, type ApMediaType } from '../../utils/federation/apMedia';
 import { normalizeHashtag } from '../../utils/textProcessing';
 import { recordAccessAndMaybeEnqueue } from '../mediaCache/cacheStore';
+import { fetchUpstreamFollowingRedirects } from '../../utils/safeUpstreamFetch';
 import { assertSafePublicUrl } from '../../utils/ssrfGuard';
 import { persistRemoteMediaForFederatedOwnerDetailed } from '../mediaCache/cacheWorker';
+import { Readable } from 'node:stream';
 
 /**
  * Shared low-level helpers used by more than one federation sub-service
@@ -142,51 +144,81 @@ function requestInitHeaders(init: RequestInit): Record<string, string> {
   return init.headers as Record<string, string>;
 }
 
+function nodeResponseToFetchResponse(response: import('node:http').IncomingMessage): Response {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(response.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item);
+    } else if (typeof value === 'string') {
+      headers.set(key, value);
+    }
+  }
+
+  return new Response(Readable.toWeb(response) as ReadableStream, {
+    status: response.statusCode ?? 502,
+    statusText: response.statusMessage,
+    headers,
+  });
+}
+
+async function ssrfSafeGet(url: string, headers: Record<string, string>, signal: AbortSignal, followRedirects: boolean): Promise<Response> {
+  const { response } = await fetchUpstreamFollowingRedirects(url, { headers, followRedirects }, signal);
+  return nodeResponseToFetchResponse(response);
+}
+
 export async function signedFetch(url: string, accept: string, init: RequestInit = {}): Promise<Response> {
   const acceptHeader = `${accept}, application/ld+json; profile="https://www.w3.org/ns/activitystreams"`;
-  const { keyId } = await getPublicKey('instance');
-  const sigHeaders = await signRequest(keyId, 'GET', url);
   const extraHeaders = requestInitHeaders(init);
+  const signal = init.signal ?? AbortSignal.timeout(SIGNED_FETCH_TIMEOUT_MS);
+  const followRedirects = init.redirect !== 'manual';
+  let currentUrl = url;
 
-  const res = await fetch(url, {
-    ...init,
-    headers: {
+  for (let hop = 0; hop <= MAX_ACTIVITYPUB_REDIRECTS; hop++) {
+    const { keyId } = await getPublicKey('instance');
+    const sigHeaders = await signRequest(keyId, 'GET', currentUrl);
+    const res = await ssrfSafeGet(currentUrl, {
       Accept: acceptHeader,
       'User-Agent': USER_AGENT,
       ...sigHeaders,
       ...extraHeaders,
-    },
-    signal: init.signal ?? AbortSignal.timeout(SIGNED_FETCH_TIMEOUT_MS),
-  });
+    }, signal, false);
 
-  // If the remote server returns a 5xx (e.g. it can't resolve our keyId to verify
-  // the signature), retry without the signature as a fallback for public resources.
-  if (res.status >= 500) {
-    logger.info(`[FedSync] signedFetch got ${res.status} for ${url}, retrying unsigned`);
-    return fetch(url, {
-      ...init,
-      headers: {
+    if (followRedirects && REDIRECT_STATUS_CODES.has(res.status)) {
+      const location = res.headers.get('location');
+      await res.body?.cancel().catch(() => undefined);
+      if (!location || hop === MAX_ACTIVITYPUB_REDIRECTS) return res;
+      currentUrl = new URL(location, currentUrl).toString();
+      continue;
+    }
+
+    // If the remote server returns a 5xx (e.g. it can't resolve our keyId to verify
+    // the signature), retry without the signature as a fallback for public resources.
+    if (res.status >= 500) {
+      await res.body?.cancel().catch(() => undefined);
+      logger.info(`[FedSync] signedFetch got ${res.status} for ${currentUrl}, retrying unsigned`);
+      return ssrfSafeGet(currentUrl, {
         Accept: acceptHeader,
         'User-Agent': USER_AGENT,
         ...extraHeaders,
-      },
-      signal: init.signal ?? AbortSignal.timeout(SIGNED_FETCH_TIMEOUT_MS),
-    });
+      }, signal, followRedirects);
+    }
+
+    // A 401/403 on a signed request means the remote rejected OUR signature
+    // (e.g. it could not resolve/verify our keyId, or our instance key pair is
+    // missing/invalid because the service token could not be acquired). Without a
+    // log this silently yields zero results — surface it so the failure mode is
+    // observable in production. The caller still receives the response and decides
+    // how to proceed; we do not change control flow here.
+    if (res.status === 401 || res.status === 403) {
+      logger.warn(
+        `[FedSync] signedFetch got ${res.status} ${res.statusText} for ${currentUrl} — remote rejected our HTTP signature (check instance key pair / service token); returning the failed response so no posts are imported from this source`,
+      );
+    }
+
+    return res;
   }
 
-  // A 401/403 on a signed request means the remote rejected OUR signature
-  // (e.g. it could not resolve/verify our keyId, or our instance key pair is
-  // missing/invalid because the service token could not be acquired). Without a
-  // log this silently yields zero results — surface it so the failure mode is
-  // observable in production. The caller still receives the response and decides
-  // how to proceed; we do not change control flow here.
-  if (res.status === 401 || res.status === 403) {
-    logger.warn(
-      `[FedSync] signedFetch got ${res.status} ${res.statusText} for ${url} — remote rejected our HTTP signature (check instance key pair / service token); returning the failed response so no posts are imported from this source`,
-    );
-  }
-
-  return res;
+  throw new Error('too many ActivityPub redirects');
 }
 
 

--- a/packages/backend/src/utils/safeUpstreamFetch.ts
+++ b/packages/backend/src/utils/safeUpstreamFetch.ts
@@ -73,6 +73,10 @@ export interface UpstreamRequestExtras {
   ifNoneMatch?: string;
   /** Client `If-Modified-Since` validator to forward. */
   ifModifiedSince?: string;
+  /** Additional request headers to send upstream after the proxy defaults. */
+  headers?: Record<string, string>;
+  /** When false, return redirect responses after validating the current hop. */
+  followRedirects?: boolean;
 }
 
 export interface UpstreamResult {
@@ -101,6 +105,7 @@ function buildRequestOptions(
     // buffered prefix is the raw container ffmpeg expects.
     'Accept-Encoding': 'identity',
   };
+  Object.assign(headers, extras.headers ?? {});
   if (extras.range) headers.Range = extras.range;
   if (extras.ifNoneMatch) headers['If-None-Match'] = extras.ifNoneMatch;
   if (extras.ifModifiedSince) headers['If-Modified-Since'] = extras.ifModifiedSince;
@@ -179,6 +184,9 @@ export async function fetchUpstreamFollowingRedirects(
 
     const status = response.statusCode ?? 0;
     if (REDIRECT_STATUS_CODES.has(status)) {
+      if (extras.followRedirects === false) {
+        return { response, finalUrl: currentUrl };
+      }
       const location = response.headers.location;
       // We only need the Location header. Destroy immediately rather than
       // draining (resume()) the redirect body, which could be unbounded.


### PR DESCRIPTION
### Motivation
- Public profile views and scheduled actor refreshes could trigger signed ActivityPub GETs that performed raw `fetch()` calls to attacker-controlled actor and banner URLs without the repository's SSRF protections, exposing internal services via SSRF. 
- The goal is to ensure every signed ActivityPub fetch uses the same DNS-pinned, per-hop-validated, timeouted upstream-fetch contract already used by the media proxy so actor/collection/banner downloads are SSRF-guarded.

### Description
- Route signed ActivityPub GETs through the shared SSRF-safe upstream fetcher by changing `signedFetch` to use `fetchUpstreamFollowingRedirects` (via a small `ssrfSafeGet` shim) so actor, collection and banner downloads get DNS validation, redirect re-validation, pinned lookups and timeouts; changed in `packages/backend/src/services/federation/sharedFederationHelpers.ts`.
- Extended the upstream fetch helper `fetchUpstreamFollowingRedirects` with caller-supplied `headers` and a `followRedirects` flag so federation callers can send signed headers and optionally request validated redirect responses; changed in `packages/backend/src/utils/safeUpstreamFetch.ts`.
- Preserved existing behavior: signed requests still retry unsigned on 5xx, honor manual-redirect callers, and keep previous timeouts and content-type/size validation for banners (the banner path still reads via the safe fetcher and enforces `ACTOR_BANNER_MAX_BYTES` and `image/*` checks).
- Updated federation unit tests to exercise the new seam by mocking `fetchUpstreamFollowingRedirects` and adding small stream helpers so the tests continue to validate banner handling and canonical-host behavior; changed `packages/backend/src/__tests__/services/federationService.test.ts`.

### Testing
- Ran `git diff --check` which passed with no whitespace/conflict errors. 
- Attempted to run backend unit tests with `cd packages/backend && bun run test -- src/__tests__/services/federationService.test.ts src/__tests__/utils/ssrfGuard.test.ts` but the test runner was not available in the checkout (`vitest` not installed), so tests could not be executed here. 
- Attempted TypeScript/static checks (`bun --check` / `bunx tsc --noEmit -p packages/backend/tsconfig.json`) but they failed in this environment due to missing project dependencies and type packages (e.g. `mongoose` / `@types/node`) so full typecheck could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4f3ab8448323984f0a2878f2e83d)