### PR TITLE
ci: pin AWS deploy workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -25,10 +25,10 @@ jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Configure AWS credentials (OIDC, no stored keys)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
         with:
           role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
           aws-region: ${{ env.AWS_REGION }}
@@ -54,7 +54,7 @@ jobs:
           done
 
       - name: Login to ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
       - name: Build and push (linux/arm64)
         run: |


### PR DESCRIPTION
### Motivation
- Remediate a CI/CD supply-chain risk where the privileged AWS deploy workflow used mutable action tags, which could allow a compromised/retagged action to request an OIDC token and assume the deploy role.

### Description
- Pin `actions/checkout`, `aws-actions/configure-aws-credentials`, and `aws-actions/amazon-ecr-login` to their full 40-character commit SHAs in `.github/workflows/deploy-aws.yml` while preserving the original major-version comments for reviewer context, with no change to the OIDC/assume-role or deployment behavior.

### Testing
- Confirmed all `uses:` refs in `.github/workflows/deploy-aws.yml` are pinned to full 40-character SHAs with an automated checker, validated the workflow YAML via `ruby -e "require 'yaml'; YAML.load_file(...)"`, and ran `git diff --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d53559f248323a4c618f1194e16b6)