### PR TITLE
fix(feed): scope memory cache by viewer

### DIFF
--- a/packages/frontend/hooks/useFeedState.ts
+++ b/packages/frontend/hooks/useFeedState.ts
@@ -135,8 +135,15 @@ export function useFeedState({
     // scroll offset lands on the same items. Recomputed only when identity
     // inputs change.
     const feedScrollKey = useMemo(
-        () => buildFeedScrollKey({ type, userId, showOnlySaved, filters }),
-        [type, userId, showOnlySaved, filters]
+        () => buildFeedScrollKey({
+            type,
+            userId,
+            showOnlySaved,
+            filters,
+            isAuthenticated,
+            currentViewerId: currentUserId,
+        }),
+        [type, userId, showOnlySaved, filters, isAuthenticated, currentUserId]
     );
 
     // Warm-start seed: in memory mode, if we retained this feed's slice from a

--- a/packages/frontend/utils/__tests__/buildFeedScrollKey.test.ts
+++ b/packages/frontend/utils/__tests__/buildFeedScrollKey.test.ts
@@ -36,6 +36,34 @@ describe('buildFeedScrollKey', () => {
         expect(a).toBe(b);
     });
 
+    it('distinguishes feeds by authenticated viewer', () => {
+        expect(
+            buildFeedScrollKey({
+                type: 'for_you',
+                isAuthenticated: true,
+                currentViewerId: 'alice',
+            }),
+        ).not.toBe(
+            buildFeedScrollKey({
+                type: 'for_you',
+                isAuthenticated: true,
+                currentViewerId: 'bob',
+            }),
+        );
+    });
+
+    it('distinguishes authenticated and anonymous feeds for the same feed identity', () => {
+        expect(
+            buildFeedScrollKey({
+                type: 'for_you',
+                isAuthenticated: true,
+                currentViewerId: 'alice',
+            }),
+        ).not.toBe(
+            buildFeedScrollKey({ type: 'for_you', isAuthenticated: false }),
+        );
+    });
+
     it('distinguishes feeds by type', () => {
         expect(buildFeedScrollKey({ type: 'for_you' })).not.toBe(
             buildFeedScrollKey({ type: 'following' }),

--- a/packages/frontend/utils/feedUtils.ts
+++ b/packages/frontend/utils/feedUtils.ts
@@ -67,6 +67,13 @@ export interface FeedIdentityParams {
     userId?: string;
     showOnlySaved?: boolean;
     filters?: FeedFilters;
+    /**
+     * Authenticated viewer that the feed response is authorized for. Feed
+     * contents are viewer-dependent, so retained in-memory slices must never
+     * be shared across logout/login or account-switch boundaries.
+     */
+    currentViewerId?: string;
+    isAuthenticated?: boolean;
 }
 
 /**
@@ -88,15 +95,18 @@ function serializeFeedFilters(filters?: FeedFilters): string {
  *
  * The same inputs always produce the same key (so scroll offset / cached items
  * restore correctly across an unmount→remount), while distinct feeds (different
- * type, user, saved view, or filters) produce distinct keys so they never share
- * state. `showOnlySaved` collapses to the `'saved'` effective type, matching the
- * effective-type logic in `useFeedState`.
+ * viewer, type, user, saved view, or filters) produce distinct keys so they never
+ * share state. `showOnlySaved` collapses to the `'saved'` effective type, matching
+ * the effective-type logic in `useFeedState`.
  */
 export function buildFeedScrollKey(params: FeedIdentityParams): string {
     const effectiveType = params.showOnlySaved ? 'saved' : params.type;
+    const viewerKey = params.isAuthenticated
+        ? `auth:${params.currentViewerId || 'pending'}`
+        : 'anon';
     const userId = params.userId ?? '';
     const filterKey = serializeFeedFilters(params.filters);
-    return `${effectiveType}|${userId}|${filterKey}`;
+    return `${viewerKey}|${effectiveType}|${userId}|${filterKey}`;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Memory-mode feed slices were cached by a viewer-agnostic feed key, allowing retained HydratedPost arrays to be reused across logout/login or account-switch boundaries and exposing another viewer's private/follower-only/saved content.

### Description
- Add `currentViewerId?: string` and `isAuthenticated?: boolean` to `FeedIdentityParams` and include them in `buildFeedScrollKey`, which now prefixes keys with `auth:<viewer>` or `anon` so memory cache entries are isolated per authenticated identity. (`packages/frontend/utils/feedUtils.ts`)
- Update `useFeedState` to pass `isAuthenticated` and `currentUserId` into `buildFeedScrollKey` and to recompute the feed identity when auth state changes. (`packages/frontend/hooks/useFeedState.ts`)
- Add regression unit tests asserting that keys differ between two authenticated viewers and between authenticated vs anonymous sessions. (`packages/frontend/utils/__tests__/buildFeedScrollKey.test.ts`)

### Testing
- Static check: `git diff --check` was run and reported no issues.
- Unit tests: a regression test was added for `buildFeedScrollKey` but running `bun --cwd packages/frontend test --runInBand packages/frontend/utils/__tests__/buildFeedScrollKey.test.ts` in this environment failed because `jest` is not installed, so tests could not be executed here. 
- Type checking: attempted `bun --cwd packages/frontend typecheck` but it could not run because the `tsc` binary is not present in this environment, so full type-check was not performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d49faa5bc8323a88bada18ddf2239)