### PR TITLE
fix(profile): make profile banner Oxy asset public so it renders (mirror avatars)

### DIFF
--- a/packages/backend/src/__tests__/utils/oxyHelpers.test.ts
+++ b/packages/backend/src/__tests__/utils/oxyHelpers.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Shared mock state. Declared via `vi.hoisted` so it is initialised before the
+ * hoisted `vi.mock` factory below runs (vitest lifts `vi.mock` to the top of the
+ * module). Records every constructed OxyServices instance so each test can
+ * inspect the scoped client built inside `ensureProfileMediaPublic` (tokens
+ * planted + visibility call). The class is mocked because the helper otherwise
+ * performs a real network PATCH to Oxy.
+ */
+const mockState = vi.hoisted(() => {
+  const instances: Array<{
+    setTokens: ReturnType<typeof vi.fn>;
+    assetUpdateVisibility: ReturnType<typeof vi.fn>;
+  }> = [];
+  const control: { reject?: unknown } = {};
+  return { instances, control };
+});
+
+vi.mock('@oxyhq/core', () => {
+  class OxyServices {
+    setTokens = vi.fn();
+    configureServiceAuth = vi.fn();
+    assetUpdateVisibility = vi.fn().mockImplementation(() =>
+      mockState.control.reject !== undefined
+        ? Promise.reject(mockState.control.reject)
+        : Promise.resolve({ file: { id: 'x', visibility: 'public' } }),
+    );
+
+    constructor() {
+      mockState.instances.push(this);
+    }
+  }
+  return { OxyServices };
+});
+
+vi.mock('../../utils/privacyHelpers', () => ({}));
+
+import { ensureProfileMediaPublic } from '../../utils/oxyHelpers';
+
+/** The scoped client is the LAST constructed instance (after the module-level singleton). */
+function lastScopedClient() {
+  return mockState.instances[mockState.instances.length - 1];
+}
+
+describe('ensureProfileMediaPublic', () => {
+  beforeEach(() => {
+    mockState.control.reject = undefined;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('promotes a bare Oxy file id to public using the owner access token', async () => {
+    const before = mockState.instances.length;
+    await ensureProfileMediaPublic('owner-token', 'file-123');
+
+    // A new scoped client was constructed for this call.
+    expect(mockState.instances.length).toBe(before + 1);
+    const client = lastScopedClient();
+    expect(client.setTokens).toHaveBeenCalledWith('owner-token');
+    expect(client.assetUpdateVisibility).toHaveBeenCalledWith('file-123', 'public');
+  });
+
+  it('does nothing when there is no access token', async () => {
+    const before = mockState.instances.length;
+    await ensureProfileMediaPublic(undefined, 'file-123');
+    expect(mockState.instances.length).toBe(before);
+  });
+
+  it('skips empty, temp, and absolute-URL refs', async () => {
+    const before = mockState.instances.length;
+    await ensureProfileMediaPublic('owner-token', '');
+    await ensureProfileMediaPublic('owner-token', 'temp-abc');
+    await ensureProfileMediaPublic('owner-token', 'https://example.com/banner.png');
+    await ensureProfileMediaPublic('owner-token', 'http://example.com/banner.png');
+    expect(mockState.instances.length).toBe(before);
+  });
+
+  it('never throws when the visibility call fails', async () => {
+    mockState.control.reject = new Error('403 Access denied');
+    await expect(
+      ensureProfileMediaPublic('owner-token', 'file-456'),
+    ).resolves.toBeUndefined();
+    expect(lastScopedClient().assetUpdateVisibility).toHaveBeenCalledWith('file-456', 'public');
+  });
+});

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -7,6 +7,7 @@ import Like from '../models/Like';
 // Block and Restrict routes removed - frontend should use Oxy services directly
 import { requireOxyAuth as requireAuth, type OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { buildSettingsResponseForViewer, ensureUserSettings } from '../utils/userSettings';
+import { ensureProfileMediaPublic } from '../utils/oxyHelpers';
 import { sendErrorResponse, sendSuccessResponse, validateRequired } from '../utils/apiHelpers';
 import { getRequiredOxyUserId as getAuthenticatedUserId } from '@oxyhq/core/server';
 import { logger } from '../utils/logger';
@@ -71,7 +72,11 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
 
     const update: Record<string, any> = {};
     const unset: Record<string, ''> = {};
-    
+    // The Oxy file id newly set as the profile banner (if any). Captured here so
+    // we can promote it to public AFTER the settings persist — profile banners
+    // are public-facing media that an anonymous <img> must be able to load.
+    let newBannerFileId: string | undefined;
+
     if (appearance) {
       update['appearance'] = {};
       if (appearance.themeMode && ['light', 'dark', 'system'].includes(appearance.themeMode)) {
@@ -88,6 +93,7 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
       const trimmedProfileHeaderImage = profileHeaderImage.trim();
       if (trimmedProfileHeaderImage) {
         update.profileHeaderImage = trimmedProfileHeaderImage;
+        newBannerFileId = trimmedProfileHeaderImage;
       } else {
         unset.profileHeaderImage = '';
       }
@@ -228,6 +234,17 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
         { upsert: true, new: true }
       ).lean()
       : await ensureUserSettings(oxyUserId);
+
+    // Profile banners are public-facing media: an anonymous <img> on a profile
+    // page can't send a bearer token, so a private Oxy asset is denied and the
+    // banner never renders. Promote the newly set banner asset to public using
+    // the owner's own session token (Oxy's visibility route requires it). This
+    // mirrors how Oxy auto-publishes avatars on PUT /users/me; the banner is a
+    // Mention-only field, so Mention owns this promotion. Best-effort: it never
+    // throws and never blocks the settings update.
+    if (newBannerFileId) {
+      await ensureProfileMediaPublic(req.accessToken, newBannerFileId);
+    }
 
     return sendSuccessResponse(res, 200, doc);
   } catch (err) {

--- a/packages/backend/src/utils/oxyHelpers.ts
+++ b/packages/backend/src/utils/oxyHelpers.ts
@@ -47,6 +47,58 @@ export function getServiceOxyClient(): OxyServices {
 }
 
 /**
+ * Promote an Oxy asset that a user has set as public-facing profile media
+ * (e.g. the Mention profile banner) to `public` visibility, so it renders for
+ * anonymous viewers.
+ *
+ * Why this is needed: profile media is displayed by a bare `<img>`/`Image`,
+ * which cannot send an Authorization header or a signed token. A private Oxy
+ * asset requested anonymously is denied (403 on `/assets/:id/stream`, 404 on
+ * the public CDN), so the banner never renders — not even for the owner.
+ * Oxy already does this for avatars/banners owned via `PUT /users/me`
+ * (`assetService.ensureOwnedAssetPublic`), but the Mention banner is a
+ * Mention-only field that never flows through that endpoint, so Mention must
+ * promote it itself.
+ *
+ * Auth path: Oxy's `PATCH /assets/:id/visibility` requires a session-based
+ * user bearer token and enforces `file.ownerUserId === req.user._id`. A service
+ * token (no `sessionId`) is rejected by that route, so this MUST use the
+ * owner's own access token — which is exactly the token on the authenticated
+ * profile-settings request. Building a scoped client (never mutating the
+ * singleton) keeps it race-safe under concurrent requests.
+ *
+ * Best-effort and owner-gated by Oxy: it skips empty/temp/absolute refs, never
+ * throws, and never blocks the profile update. A non-owner or already-public
+ * asset is a no-op on the Oxy side.
+ *
+ * @param accessToken - The authenticated owner's Oxy session bearer token.
+ * @param fileId - The Oxy file id just persisted as profile media.
+ */
+export async function ensureProfileMediaPublic(
+  accessToken: string | undefined,
+  fileId: string,
+): Promise<void> {
+  if (!accessToken) return;
+  // Only bare Oxy file ids are promotable. Skip empties, client-side temp ids,
+  // and absolute URLs (federated/external media has no Oxy visibility flag).
+  if (!fileId || fileId.startsWith('temp-') || /^https?:\/\//i.test(fileId)) return;
+
+  try {
+    const client = new OxyServices({ baseURL: OXY_BASE_URL });
+    client.setTokens(accessToken);
+    await client.assetUpdateVisibility(fileId, 'public');
+    logger.info('[oxyHelpers] Promoted profile media asset to public', { fileId });
+  } catch (error) {
+    // Non-fatal: a failed visibility flip must never block the profile update.
+    // Ownership/already-public cases are handled on the Oxy side; log the rest.
+    logger.warn('[oxyHelpers] Failed to promote profile media asset to public', {
+      fileId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
  * Mention's Oxy `Application` `_id`. Sent as `clientId` on
  * `POST /profiles/recommendations` so Oxy selects Mention's per-app weight
  * profile when scoring recommendations (`REC_SCORING_V2`). When unset the Oxy


### PR DESCRIPTION
## Problem
Profile **banner** (`profileHeaderImage`) never rendered for anyone, including the owner. Avatars worked.

## Root cause
The banner is a Mention-only field whose URL resolves to a **tokenless** `api.oxy.so/assets/<id>/stream`. Unlike Oxy avatars (auto-published by oxy-api `PUT /users/me` → `ensureOwnedAssetPublic`), Mention had **zero** asset-visibility promotion, so the banner Oxy asset stayed **private** → tokenless `<img>` → denied → placeholder.

## Fix (Mention backend — the owning layer)
- `utils/oxyHelpers.ts`: `ensureProfileMediaPublic(accessToken, fileId)` — scoped `OxyServices` → `setTokens` → `assetUpdateVisibility(fileId, 'public')`. Owner-gated by Oxy, best-effort, never throws/blocks. Mirrors Oxy's `ensureOwnedAssetPublic`.
- `routes/profileSettings.ts`: `PUT /settings` promotes the newly set banner fileId after the DB write.
- `__tests__/utils/oxyHelpers.test.ts`: 4 cases.

Uses the owner's session bearer (already on the request) because oxy-api `PATCH /assets/:id/visibility` requires a `sessionId` token (service tokens rejected). No Oxy code change. No frontend change (banners are selected from the user's existing Oxy library; federated banners already upload `public`).

## Existing banners
nate's pre-existing private banner was promoted to public via a one-shot ECS task on the deployed oxy-api image (`assetService.ensureOwnedAssetPublic`) — renders now.

## Evidence (no auth, after fix)
- `cloud.oxy.so/<id>` → 302 → 200 image/png (real banner)
- `cloud.oxy.so/<id>?variant=thumb` → 302 → 200 image/webp

## Tests
backend tsc clean; 73 files / 824 tests pass; frozen-lockfile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)