### PR TITLE
fix: require published posts in public MTN feeds

### DIFF
--- a/packages/backend/src/__tests__/feedQueryBuilder.profileCursor.test.ts
+++ b/packages/backend/src/__tests__/feedQueryBuilder.profileCursor.test.ts
@@ -25,6 +25,7 @@ describe('FeedQueryBuilder.buildUserProfileQuery — chronological cursor', () =
 
     expect(query.oxyUserId).toBe(userId);
     expect(query.visibility).toBeTruthy();
+    expect(query.status).toBe('published');
     expect(query.parentPostId).toBeNull();
 
     // No pagination clause when there is no cursor.
@@ -96,7 +97,15 @@ describe('FeedQueryBuilder.buildUserProfileQuery — chronological cursor', () =
     const query = FeedQueryBuilder.buildUserProfileQuery(userId, 'replies', cursor);
 
     expect(query.parentPostId).toEqual({ $ne: null });
+    expect(query.status).toBe('published');
     expect(query._id).toBeUndefined();
     expect(Array.isArray(query.$or)).toBe(true);
   });
+
+  it('adds the published-status boundary to legacy public feed helper queries', () => {
+    expect(FeedQueryBuilder.buildFollowingQuery(['followed-user']).status).toBe('published');
+    expect(FeedQueryBuilder.buildExploreQuery().status).toBe('published');
+    expect(FeedQueryBuilder.buildMediaQuery().status).toBe('published');
+  });
+
 });

--- a/packages/backend/src/mtn/feed/feeds/ExploreFeed.ts
+++ b/packages/backend/src/mtn/feed/feeds/ExploreFeed.ts
@@ -158,6 +158,7 @@ export class ExploreFeed implements FeedAPI {
     const trendingCutoff = new Date(Date.now() - MtnConfig.feed.trendingWindowMs);
     const match: Record<string, unknown> = {
       visibility: 'public',
+      status: 'published',
       createdAt: { $gte: trendingCutoff },
       $and: [
         { $or: [{ parentPostId: null }, { parentPostId: { $exists: false } }] },

--- a/packages/backend/src/utils/feedQueryBuilder.ts
+++ b/packages/backend/src/utils/feedQueryBuilder.ts
@@ -257,7 +257,8 @@ export class FeedQueryBuilder {
     filters?: Record<string, unknown>
   ): Record<string, unknown> {
     const query: Record<string, unknown> = {
-      _id: { $in: savedPostIds }
+      _id: { $in: savedPostIds },
+      status: 'published',
     };
     
     // Apply search query filter if provided
@@ -429,6 +430,7 @@ export class FeedQueryBuilder {
     const query: Record<string, unknown> = {
       oxyUserId: { $in: followingIds },
       visibility: PostVisibility.PUBLIC,
+      status: 'published',
       // No parentPostId filter — replies flow through for thread slicing
       // Exclude boosts (they are shown differently)
       $and: [
@@ -450,6 +452,7 @@ export class FeedQueryBuilder {
   static buildExploreQuery(cursor?: string): Record<string, unknown> {
     const match: Record<string, unknown> = {
       visibility: PostVisibility.PUBLIC,
+      status: 'published',
       $and: [
         { $or: [{ parentPostId: null }, { parentPostId: { $exists: false } }] },
         { $or: [{ boostOf: null }, { boostOf: { $exists: false } }] }
@@ -470,6 +473,7 @@ export class FeedQueryBuilder {
   static buildMediaQuery(cursor?: string): Record<string, unknown> {
     const query: Record<string, unknown> = {
       visibility: PostVisibility.PUBLIC,
+      status: 'published',
       $and: [
         { $or: [
           { type: { $in: [PostType.IMAGE, PostType.VIDEO] } },
@@ -502,7 +506,8 @@ export class FeedQueryBuilder {
   ): Record<string, unknown> {
     const query: Record<string, unknown> = {
       oxyUserId: userId,
-      visibility: PostVisibility.PUBLIC
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
     };
 
     // Filter by content type


### PR DESCRIPTION
### Motivation
- Public MTN feed endpoints were matching posts by `visibility: public` but not enforcing `status: 'published'`, which allows drafts/scheduled posts (saved with public visibility) to be returned to other users or unauthenticated callers.
- The change closes the confidentiality gap by ensuring only published content is exposed on public/cross-user feed queries.

### Description
- Added `status: 'published'` to the Explore peek query so `/feed/mtn/peek` cannot surface draft or scheduled content (`packages/backend/src/mtn/feed/feeds/ExploreFeed.ts`).
- Added a published-status boundary to shared feed query helpers used by multiple public feeds (saved-post lookup, following, explore, media, and user profile queries) (`packages/backend/src/utils/feedQueryBuilder.ts`).
- Extended the `FeedQueryBuilder` regression test to assert that legacy public feed helper queries include `status: 'published'` (`packages/backend/src/__tests__/feedQueryBuilder.profileCursor.test.ts`).

### Testing
- Added unit assertions to `packages/backend/src/__tests__/feedQueryBuilder.profileCursor.test.ts` to verify the `status: 'published'` predicate is present; these tests are included with the change but could not be executed in this environment because `vitest`/test runner is unavailable (`vitest: command not found`).
- Ran static verification and search (`rg`) across the MTN feed code to confirm `status: 'published'` was added to the public feed queries; results show the updated locations as expected.
- Ran `git diff --check` / whitespace checks locally (no issues reported in the diff produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6c98b490832383f3333c11b5cc9b)