### PR TITLE
fix: restrict federated actor posts to public visibility

### DIFF
--- a/packages/backend/src/routes/federation.api.routes.ts
+++ b/packages/backend/src/routes/federation.api.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import { z } from 'zod';
 import { getRequiredOxyUserId, type OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
+import { PostVisibility } from '@mention/shared-types';
 import { logger } from '../utils/logger';
 import { federationService, isPermanentlyUnavailableOutboxReason } from '../services/FederationService';
 import FederatedActor from '../models/FederatedActor';
@@ -219,8 +220,11 @@ router.get('/actor/posts', async (req: AuthRequest, res: Response) => {
     // Query by oxyUserId (the canonical user identity in Oxy) for federated posts.
     // Falls back to the activity ID range query if the actor has no Oxy link yet.
     const query: Record<string, unknown> = actor.oxyUserId
-      ? { oxyUserId: actor.oxyUserId, federation: { $ne: null } }
-      : { 'federation.activityId': { $gte: actor.uri + '/', $lt: actor.uri + '/\uffff' } };
+      ? { oxyUserId: actor.oxyUserId, federation: { $ne: null }, visibility: PostVisibility.PUBLIC }
+      : {
+          'federation.activityId': { $gte: actor.uri + '/', $lt: actor.uri + '/\uffff' },
+          visibility: PostVisibility.PUBLIC,
+        };
     if (parsed.data.cursor) {
       query.createdAt = { $lt: new Date(parsed.data.cursor) };
     }


### PR DESCRIPTION
### Motivation
- Prevent leaking non-public federated posts via the public `/federation/actor/posts` endpoint by enforcing that only posts with `PostVisibility.PUBLIC` are returned, because federated posts may be stored as `followers_only` and `PostHydrationService` skips privacy checks for federated posts.

### Description
- Import `PostVisibility` and add `visibility: PostVisibility.PUBLIC` to both the `oxyUserId`-based query and the actor-URI activityId-range fallback in `packages/backend/src/routes/federation.api.routes.ts`, so the public actor timeline only returns public federated posts while preserving the existing hydration and background sync behavior.

### Testing
- Attempted to build the backend with `cd packages/backend && bun run build`, but the build was blocked by TypeScript deprecation errors in `tsconfig.json` (unrelated to this change). 
- Attempted to run unit tests with `cd packages/backend && bun run test`, but the test run could not be executed in this environment because the test runner (`vitest`) is not available; no test failures were introduced by the change itself based on static inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d63f887bc8323bcd667fd00eeba67)