### PR TITLE
security: bound federation delivery error-body read to prevent DoS

### DIFF
--- a/packages/backend/src/__tests__/services/federation/followServiceDeliveryBody.test.ts
+++ b/packages/backend/src/__tests__/services/federation/followServiceDeliveryBody.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { readDeliveryFailureBodyPrefix } from '../../../utils/federation/deliveryFailureBody';
+
+describe('readDeliveryFailureBodyPrefix', () => {
+  it('does not read oversized bodies when content-length exceeds the cap', async () => {
+    const res = {
+      headers: new Headers({ 'content-length': '4096' }),
+      get body(): ReadableStream<Uint8Array> {
+        throw new Error('body should not be accessed for oversized responses');
+      },
+    } as Response;
+
+    const prefix = await readDeliveryFailureBodyPrefix(res, 16);
+
+    expect(prefix).toBe('<body omitted: content-length 4096 exceeds 16 bytes>');
+  });
+
+  it('streams only a bounded prefix when content-length is absent', async () => {
+    const cancelCalls: unknown[] = [];
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('abcdefghijklmnopqrstuvwxyz'));
+      },
+      cancel(reason) {
+        cancelCalls.push(reason);
+      },
+    });
+
+    const res = new Response(body, { status: 500 });
+
+    const prefix = await readDeliveryFailureBodyPrefix(res, 10);
+
+    expect(prefix).toBe('abcdefghij…<truncated>');
+    expect(cancelCalls).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/services/federation/FollowService.ts
+++ b/packages/backend/src/services/federation/FollowService.ts
@@ -14,6 +14,7 @@ import {
 import { PostVisibility } from '@mention/shared-types';
 import { enqueueDelivery } from '../../queue/producers';
 import { actorService } from './ActorService';
+import { readDeliveryFailureBodyPrefix } from '../../utils/federation/deliveryFailureBody';
 
 const DELIVER_ACTIVITY_TIMEOUT_MS = 15000;
 
@@ -64,7 +65,7 @@ export class FollowService {
 
       if (res.ok || res.status === 202) return true;
 
-      const responseBody = await res.text().catch(() => '');
+      const responseBody = await readDeliveryFailureBodyPrefix(res).catch(() => '');
       logger.debug(`Activity delivery failed to ${targetInbox}: ${res.status} ${res.statusText} body=${responseBody.slice(0, 500)}`);
       return false;
     } catch (err) {

--- a/packages/backend/src/utils/federation/deliveryFailureBody.ts
+++ b/packages/backend/src/utils/federation/deliveryFailureBody.ts
@@ -1,0 +1,54 @@
+export const DELIVERY_FAILURE_LOG_BODY_BYTES = 2048;
+
+export async function readDeliveryFailureBodyPrefix(
+  res: Response,
+  maxBytes = DELIVERY_FAILURE_LOG_BODY_BYTES,
+): Promise<string> {
+  const contentLength = Number(res.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    return `<body omitted: content-length ${contentLength} exceeds ${maxBytes} bytes>`;
+  }
+
+  if (!res.body) return '';
+
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytesRead = 0;
+  let truncated = false;
+
+  try {
+    while (bytesRead < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      const remaining = maxBytes - bytesRead;
+      if (value.byteLength > remaining) {
+        chunks.push(value.slice(0, remaining));
+        bytesRead += remaining;
+        truncated = true;
+        break;
+      }
+
+      chunks.push(value);
+      bytesRead += value.byteLength;
+    }
+
+    if (bytesRead >= maxBytes) truncated = true;
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  const prefix = new TextDecoder().decode(concatUint8Arrays(chunks, bytesRead));
+  return truncated ? `${prefix}…<truncated>` : prefix;
+}
+
+function concatUint8Arrays(chunks: Uint8Array[], totalLength: number): Uint8Array {
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}


### PR DESCRIPTION
### Motivation
- A failing ActivityPub delivery path previously did an unbounded `await res.text()` and then truncated for logs, allowing a remote inbox to cause large memory buffering and potential process instability. 

### Description
- Replace the unbounded `res.text()` call in the delivery path with a bounded prefix reader `readDeliveryFailureBodyPrefix` that short-circuits on large `Content-Length` and streams at most a configurable byte cap (default 2048 bytes) while cancelling the stream after the prefix is read. 
- Wire the new reader into the outbound delivery flow by calling `readDeliveryFailureBodyPrefix(res)` instead of `res.text()` in the FollowService delivery logic. 
- Add a small utility file `packages/backend/src/utils/federation/deliveryFailureBody.ts` containing the reader and constant `DELIVERY_FAILURE_LOG_BODY_BYTES`. 
- Add unit tests `packages/backend/src/__tests__/services/federation/followServiceDeliveryBody.test.ts` that cover the `Content-Length` short-circuit path and the streaming/truncation + cancellation behavior.

### Testing
- Ran the new unit tests with `bun test packages/backend/src/__tests__/services/federation/followServiceDeliveryBody.test.ts`, which passed (2 tests, 0 failures). 
- Attempted package-level test runs using the repository `test` script and `vitest`, but those were blocked because installing dev dependencies failed due to registry 403 errors during `bun install` (external registry access issue), so broader test matrix could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6360d4bc8323b6c34e9892de393a)