### PR TITLE
fix(federation): guard outbound ActivityPub delivery with SSRF-safe fetcher

### DIFF
--- a/packages/backend/src/__tests__/services/federationService.test.ts
+++ b/packages/backend/src/__tests__/services/federationService.test.ts
@@ -202,8 +202,12 @@ beforeEach(() => {
   // that assert on the `fetch(url, { headers })` shape keep exercising the real
   // signing/redirect logic — the only thing that changed is the transport.
   mocks.fetchUpstreamSingleHop.mockImplementation(
-    async (url: string, options: { headers: Record<string, string> }) => {
-      const res: Response = await (globalThis.fetch as typeof fetch)(url, { headers: options.headers });
+    async (url: string, options: { headers: Record<string, string>; method?: string; body?: BodyInit }) => {
+      const res: Response = await (globalThis.fetch as typeof fetch)(url, {
+        headers: options.headers,
+        method: options.method,
+        body: options.body,
+      });
       const bodyBuffer = Buffer.from(await res.arrayBuffer());
       const headers: Record<string, string> = {};
       res.headers.forEach((value, key) => {
@@ -217,6 +221,62 @@ beforeEach(() => {
   mocks.getServiceOxyClient.mockReturnValue({
     makeServiceRequest: mocks.makeServiceRequest,
     uploadProfileBanner: mocks.uploadProfileBanner,
+  });
+});
+
+describe('federationService.deliverActivity', () => {
+  it('posts via the SSRF-safe single-hop fetcher instead of global fetch', async () => {
+    const fetchMock = vi.fn(async () => new Response('should not be used', { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stream = new PassThrough();
+    stream.end('accepted');
+    mocks.fetchUpstreamSingleHop.mockResolvedValueOnce({
+      response: stream,
+      status: 202,
+      headers: {},
+    });
+
+    const delivered = await federationService.deliverActivity(
+      { type: 'Follow', id: 'https://mention.earth/ap/users/alice/follows/1' },
+      'https://remote.example/users/bob/inbox',
+      'oxy_alice',
+      'alice',
+    );
+
+    expect(delivered).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.fetchUpstreamSingleHop).toHaveBeenCalledWith(
+      'https://remote.example/users/bob/inbox',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/activity+json',
+          'User-Agent': expect.any(String),
+        }),
+        body: expect.stringContaining('"type":"Follow"'),
+      }),
+    );
+  });
+
+  it('returns false when the SSRF-safe fetcher rejects a blocked inbox URL', async () => {
+    const fetchMock = vi.fn(async () => new Response('should not be used', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    mocks.fetchUpstreamSingleHop.mockRejectedValueOnce(new Error('literal ip in blocked range'));
+
+    const delivered = await federationService.deliverActivity(
+      { type: 'Follow', id: 'https://mention.earth/ap/users/alice/follows/2' },
+      'http://127.0.0.1/internal-admin/inbox',
+      'oxy_alice',
+      'alice',
+    );
+
+    expect(delivered).toBe(false);
+    expect(mocks.fetchUpstreamSingleHop).toHaveBeenCalledWith(
+      'http://127.0.0.1/internal-admin/inbox',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/src/services/federation/ActorService.ts
+++ b/packages/backend/src/services/federation/ActorService.ts
@@ -11,7 +11,7 @@ import {
 import { htmlToPlainText } from '../../utils/federation/htmlToPlainText';
 import { decode as decodeEntities } from 'he';
 import { getServiceOxyClient } from '../../utils/oxyHelpers';
-import { contentTypeFamily, fetchUpstreamFollowingRedirects } from '../../utils/safeUpstreamFetch';
+import { contentTypeFamily, fetchUpstreamFollowingRedirects, fetchUpstreamSingleHop } from '../../utils/safeUpstreamFetch';
 import { isAllowedMediaType } from '../mediaCache/mediaTypes';
 import UserSettings from '../../models/UserSettings';
 import {
@@ -34,6 +34,7 @@ const ACTOR_REFRESH_MIN_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 const ACTOR_STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 const WEBFINGER_TIMEOUT_MS = 10000;
+const WEBFINGER_MAX_BYTES = 256 * 1024;
 
 function acctMatchesActorHost(acct: string | undefined, actorHost: string): acct is string {
   if (!acct) return false;
@@ -101,13 +102,18 @@ export class ActorService {
     const url = `https://${domain}/.well-known/webfinger?resource=${encodeURIComponent(resource)}`;
 
     try {
-      const res = await fetch(url, {
+      const { response, status } = await fetchUpstreamSingleHop(url, {
         headers: { Accept: 'application/jrd+json, application/json' },
         signal: AbortSignal.timeout(WEBFINGER_TIMEOUT_MS),
+        headersTimeoutMs: WEBFINGER_TIMEOUT_MS,
       });
-      if (!res.ok) return null;
+      if (status < 200 || status >= 300) {
+        response.destroy();
+        return null;
+      }
 
-      const data = await res.json() as {
+      const body = await readBoundedResponseBody(response, WEBFINGER_MAX_BYTES);
+      const data = JSON.parse(Buffer.from(body).toString('utf8')) as {
         links?: Array<{ rel?: string; type?: string; href?: string }>;
       };
       const link = data.links?.find(

--- a/packages/backend/src/services/federation/FollowService.ts
+++ b/packages/backend/src/services/federation/FollowService.ts
@@ -14,8 +14,31 @@ import {
 import { PostVisibility } from '@mention/shared-types';
 import { enqueueDelivery } from '../../queue/producers';
 import { actorService } from './ActorService';
+import { fetchUpstreamSingleHop } from '../../utils/safeUpstreamFetch';
 
 const DELIVER_ACTIVITY_TIMEOUT_MS = 15000;
+const DELIVERY_RESPONSE_PREVIEW_MAX_BYTES = 1024;
+
+async function readResponsePreview(response: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  try {
+    for await (const chunk of response) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+      chunks.push(buffer);
+      if (totalBytes >= DELIVERY_RESPONSE_PREVIEW_MAX_BYTES) break;
+    }
+  } catch {
+    return '';
+  } finally {
+    const maybeDestroy = response as NodeJS.ReadableStream & { destroy?: () => void };
+    maybeDestroy.destroy?.();
+  }
+
+  return Buffer.concat(chunks).toString('utf8', 0, DELIVERY_RESPONSE_PREVIEW_MAX_BYTES);
+}
 
 /**
  * Outbound activity delivery + follow lifecycle (Follow / Undo(Follow) /
@@ -55,17 +78,21 @@ export class FollowService {
 
       logger.debug(`[FedDeliver] POST ${targetInbox} body=${body} sig-headers=${sigHeaders['Signature']?.match(/headers="([^"]+)"/)?.[1]}`);
 
-      const res = await fetch(targetInbox, {
+      const { response, status } = await fetchUpstreamSingleHop(targetInbox, {
         method: 'POST',
         headers: allHeaders,
         body,
         signal: AbortSignal.timeout(DELIVER_ACTIVITY_TIMEOUT_MS),
+        headersTimeoutMs: DELIVER_ACTIVITY_TIMEOUT_MS,
       });
 
-      if (res.ok || res.status === 202) return true;
+      if ((status >= 200 && status < 300) || status === 202) {
+        response.destroy();
+        return true;
+      }
 
-      const responseBody = await res.text().catch(() => '');
-      logger.debug(`Activity delivery failed to ${targetInbox}: ${res.status} ${res.statusText} body=${responseBody.slice(0, 500)}`);
+      const responseBody = await readResponsePreview(response);
+      logger.debug(`Activity delivery failed to ${targetInbox}: ${status} body=${responseBody.slice(0, 500)}`);
       return false;
     } catch (err) {
       logger.debug(`Activity delivery error to ${targetInbox}:`, err);

--- a/packages/backend/src/utils/safeUpstreamFetch.ts
+++ b/packages/backend/src/utils/safeUpstreamFetch.ts
@@ -97,13 +97,14 @@ function buildRequestOptions(
   pinnedFamily: 4 | 6,
   headers: Record<string, string>,
   signal: AbortSignal,
+  method: string = 'GET',
 ): https.RequestOptions {
   return {
     protocol: target.protocol,
     hostname: target.hostname,
     port: target.port || (target.protocol === 'https:' ? 443 : 80),
     path: `${target.pathname}${target.search}`,
-    method: 'GET',
+    method,
     headers,
     // Aborts the in-flight request when an external deadline fires.
     signal,
@@ -131,11 +132,12 @@ function buildRequestOptions(
   };
 }
 
-/** Perform a single upstream GET (no auto-redirect). */
+/** Perform a single upstream request (no auto-redirect). */
 function fetchOnce(
   options: https.RequestOptions,
   isHttps: boolean,
   headersTimeoutMs: number = UPSTREAM_HEADERS_TIMEOUT_MS,
+  body?: string | Buffer,
 ): Promise<IncomingMessage> {
   return new Promise<IncomingMessage>((resolve, reject) => {
     const transport = isHttps ? https : http;
@@ -145,7 +147,7 @@ function fetchOnce(
       req.destroy(new Error('upstream headers timeout'));
     });
     req.on('error', (err) => reject(err));
-    req.end();
+    req.end(body);
   });
 }
 
@@ -232,10 +234,14 @@ export interface SingleHopOptions {
   signal: AbortSignal;
   /** Time-to-first-byte deadline; defaults to {@link UPSTREAM_HEADERS_TIMEOUT_MS}. */
   headersTimeoutMs?: number;
+  /** HTTP method to use. Defaults to GET. */
+  method?: 'GET' | 'POST';
+  /** Optional request body for POST requests. */
+  body?: string | Buffer;
 }
 
 /**
- * Perform ONE SSRF-safe upstream GET. The URL is validated by
+ * Perform ONE SSRF-safe upstream request. The URL is validated by
  * {@link assertSafePublicUrl} and the TCP connection is PINNED to the validated
  * IP via a custom `lookup` — DNS is NOT re-resolved at connect time, closing the
  * DNS-rebind TOCTOU window.
@@ -259,8 +265,15 @@ export async function fetchUpstreamSingleHop(
   }
 
   const target = new URL(url);
-  const requestOptions = buildRequestOptions(target, guard.ip, guard.family, options.headers, options.signal);
-  const response = await fetchOnce(requestOptions, target.protocol === 'https:', options.headersTimeoutMs);
+  const requestOptions = buildRequestOptions(
+    target,
+    guard.ip,
+    guard.family,
+    options.headers,
+    options.signal,
+    options.method ?? 'GET',
+  );
+  const response = await fetchOnce(requestOptions, target.protocol === 'https:', options.headersTimeoutMs, options.body);
   return {
     response,
     status: response.statusCode ?? 0,


### PR DESCRIPTION
### Motivation
- The federation follow/delivery path could be induced to fetch attacker-controlled actor URLs and actor-supplied inbox/outbox/follower URLs without the SSRF protections used elsewhere, exposing blind SSRF from authenticated requests.

### Description
- Route outbound ActivityPub POST delivery through the existing SSRF-safe single-hop fetcher by replacing direct `fetch(...)` calls with `fetchUpstreamSingleHop(...)` and handling pinned-IP responses and small response previews (`packages/backend/src/services/federation/FollowService.ts`).
- Extend the safe upstream fetch primitive to support `POST` method and request bodies while preserving `assertSafePublicUrl` validation, DNS pinning, per-hop timeouts and redirect semantics (`packages/backend/src/utils/safeUpstreamFetch.ts`).
- Use the SSRF-safe single-hop fetcher for WebFinger lookups and bound the WebFinger response body before parsing to avoid unbounded reads (`packages/backend/src/services/federation/ActorService.ts`).
- Add regression tests that assert federation delivery uses the SSRF-safe fetcher (does not call global `fetch`) and that blocked inbox URLs cause delivery to fail (`packages/backend/src/__tests__/services/federationService.test.ts`).

### Testing
- Added unit regression tests in `packages/backend/src/__tests__/services/federationService.test.ts` exercising `deliverActivity` behavior (new tests included but full suite not executed here). (tests added)
- Attempted `bun run test` for the backend tests, but execution was blocked because the environment lacked `vitest`/installed dependencies; test runner was not available so tests could not be executed here. (unable to run)
- Attempted TypeScript checks (`bunx tsc`) and file-level checks, but they were blocked by missing/install errors and upstream registry access failures in this environment; no failing behavior from the changed files was observed locally via static edits. (partial/static checks attempted, unable to complete)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d654de3888323b4bf3d508f216bcd)