### PR TITLE
fix: verify federated actor self identity

### DIFF
--- a/packages/backend/src/__tests__/services/federationService.test.ts
+++ b/packages/backend/src/__tests__/services/federationService.test.ts
@@ -288,6 +288,60 @@ describe('federationService.fetchRemoteActor', () => {
     );
   });
 
+  it('rejects actor documents that claim a different origin than the fetched URI', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://evil.example/users/mallory') {
+        return jsonResponse({
+          id: 'https://victim.example/users/alice',
+          type: 'Person',
+          preferredUsername: 'alice',
+          name: 'Alice',
+          inbox: 'https://evil.example/users/mallory/inbox',
+          publicKey: {
+            id: 'https://victim.example/users/alice#main-key',
+            publicKeyPem: 'attacker-public',
+          },
+        });
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const actor = await federationService.fetchRemoteActor('https://evil.example/users/mallory');
+
+    expect(actor).toBeNull();
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(mocks.makeServiceRequest).not.toHaveBeenCalled();
+  });
+
+  it('rejects actor documents with a cross-origin public key id', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://remote.example/users/alice') {
+        return jsonResponse({
+          id: 'https://remote.example/users/alice',
+          type: 'Person',
+          preferredUsername: 'alice',
+          name: 'Alice',
+          inbox: 'https://remote.example/users/alice/inbox',
+          publicKey: {
+            id: 'https://victim.example/users/alice#main-key',
+            publicKeyPem: 'remote-public',
+          },
+        });
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const actor = await federationService.fetchRemoteActor('https://remote.example/users/alice');
+
+    expect(actor).toBeNull();
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(mocks.makeServiceRequest).not.toHaveBeenCalled();
+  });
+
   it('does not trust cross-domain acct hints or actor webfinger claims', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url === 'https://evil.example/users/mallory') {

--- a/packages/backend/src/services/federation/ActorService.ts
+++ b/packages/backend/src/services/federation/ActorService.ts
@@ -35,6 +35,27 @@ const ACTOR_STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 const WEBFINGER_TIMEOUT_MS = 10000;
 
+function sameOriginUrl(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin.toLowerCase() === new URL(b).origin.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+function actorPublicKeyIsSelfConsistent(actor: Record<string, any>): boolean {
+  const publicKey = actor.publicKey;
+  if (!publicKey || typeof publicKey !== 'object') return true;
+
+  const publicKeyId = typeof publicKey.id === 'string' ? publicKey.id : undefined;
+  if (publicKeyId && !sameOriginUrl(publicKeyId, actor.id)) return false;
+
+  const owner = typeof publicKey.owner === 'string' ? publicKey.owner : undefined;
+  if (owner && owner !== actor.id) return false;
+
+  return true;
+}
+
 function acctMatchesActorHost(acct: string | undefined, actorHost: string): acct is string {
   if (!acct) return false;
   const domain = domainFromAcct(acct)?.toLowerCase();
@@ -170,6 +191,16 @@ export class ActorService {
       const actor = await res.json() as Record<string, any>;
       if (!actor.id || !actor.inbox) {
         logger.info(`[FedSync] fetchRemoteActor missing fields for ${actorUri}: id=${!!actor.id} inbox=${!!actor.inbox} type=${actor.type} keys=${Object.keys(actor).join(',')}`);
+        return null;
+      }
+
+      if (!sameOriginUrl(actorUri, actor.id)) {
+        logger.warn(`[FedSync] rejecting actor ${actorUri}: fetched URI is not authoritative for claimed id ${actor.id}`);
+        return null;
+      }
+
+      if (!actorPublicKeyIsSelfConsistent(actor)) {
+        logger.warn(`[FedSync] rejecting actor ${actorUri}: publicKey is not self-consistent for claimed id ${actor.id}`);
         return null;
       }
 


### PR DESCRIPTION
### Motivation
- Prevent cache-poisoning and actor-spoofing by ensuring a fetched ActivityPub actor document is authoritative for the URI that was requested.
- Ensure the stored `FederatedActor` record and cached public-key metadata cannot be poisoned by attacker-controlled actor documents that claim another actor's `id` or cross-origin `publicKey.id`.

### Description
- Add `sameOriginUrl` and `actorPublicKeyIsSelfConsistent` helpers and use them from `fetchRemoteActor` to validate that `actor.id` is authoritative for the fetched `actorUri` and that any embedded `publicKey.id`/`publicKey.owner` are self-consistent with the claimed actor `id` (rejecting the actor when checks fail).
- Reject and do not upsert actor documents when the fetched URI origin does not match the claimed `actor.id` or the embedded public key is cross-origin or mis-owned, logging a warning and returning `null` from `fetchRemoteActor`.
- Add regression tests in `packages/backend/src/__tests__/services/federationService.test.ts` that assert `fetchRemoteActor` returns `null` and does not call `findOneAndUpdate` / Oxy resolution for (a) an actor claiming a different origin than the fetched URI and (b) an actor with a cross-origin `publicKey.id`.
- Modified files: `packages/backend/src/services/federation/ActorService.ts` and `packages/backend/src/__tests__/services/federationService.test.ts`.

### Testing
- Ran `git diff --check` successfully to validate formatting and diffs.
- Added unit tests covering the two rejection cases (`fetchRemoteActor` returns `null` for cross-origin `actor.id` and cross-origin `publicKey.id`) in `packages/backend/src/__tests__/services/federationService.test.ts`.
- Attempted to run `cd packages/backend && bun run test -- src/__tests__/services/federationService.test.ts` and `bun install`, but test execution was blocked in this environment because `vitest` / dependency installation failed due to npm registry `403` responses, so the new tests could not be executed here; the tests are included in the commit for CI to run where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6696738c8323b054483d62fc4a53)