### PR TITLE
fix: guard federated inbox delivery against SSRF

### DIFF
--- a/packages/backend/src/__tests__/services/federationService.test.ts
+++ b/packages/backend/src/__tests__/services/federationService.test.ts
@@ -122,6 +122,7 @@ vi.mock('../../services/serviceRegistry', () => ({
 }));
 
 import { federationService } from '../../services/FederationService';
+import { SsrfRejection } from '../../utils/safeUpstreamFetch';
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -202,8 +203,19 @@ beforeEach(() => {
   // that assert on the `fetch(url, { headers })` shape keep exercising the real
   // signing/redirect logic — the only thing that changed is the transport.
   mocks.fetchUpstreamSingleHop.mockImplementation(
-    async (url: string, options: { headers: Record<string, string> }) => {
-      const res: Response = await (globalThis.fetch as typeof fetch)(url, { headers: options.headers });
+    async (
+      url: string,
+      options: {
+        method?: 'GET' | 'POST';
+        headers: Record<string, string>;
+        body?: string | Buffer;
+      },
+    ) => {
+      const res: Response = await (globalThis.fetch as typeof fetch)(url, {
+        method: options.method ?? 'GET',
+        headers: options.headers,
+        body: options.body,
+      });
       const bodyBuffer = Buffer.from(await res.arrayBuffer());
       const headers: Record<string, string> = {};
       res.headers.forEach((value, key) => {
@@ -217,6 +229,55 @@ beforeEach(() => {
   mocks.getServiceOxyClient.mockReturnValue({
     makeServiceRequest: mocks.makeServiceRequest,
     uploadProfileBanner: mocks.uploadProfileBanner,
+  });
+});
+
+describe('federationService.deliverActivity', () => {
+  it('posts through the SSRF-safe single-hop transport instead of global fetch', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('should not be called', { status: 500 })));
+    mocks.fetchUpstreamSingleHop.mockResolvedValue({
+      response: new PassThrough(),
+      status: 202,
+      headers: {},
+    });
+
+    const delivered = await federationService.deliverActivity(
+      { id: 'https://mention.earth/ap/users/alice/accepts/1', type: 'Accept' },
+      'https://remote.example/users/mallory/inbox',
+      'oxy_alice',
+      'alice',
+    );
+
+    expect(delivered).toBe(true);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(mocks.fetchUpstreamSingleHop).toHaveBeenCalledWith(
+      'https://remote.example/users/mallory/inbox',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/activity+json',
+          Accept: 'application/activity+json',
+        }),
+        body: expect.stringContaining('"type":"Accept"'),
+      }),
+    );
+  });
+
+  it('blocks unsafe inbox URLs before delivery', async () => {
+    mocks.fetchUpstreamSingleHop.mockRejectedValue(new SsrfRejection('literal ip in blocked range'));
+
+    const delivered = await federationService.deliverActivity(
+      { id: 'https://mention.earth/ap/users/alice/accepts/2', type: 'Accept' },
+      'http://127.0.0.1/internal/admin/task',
+      'oxy_alice',
+      'alice',
+    );
+
+    expect(delivered).toBe(false);
+    expect(mocks.fetchUpstreamSingleHop).toHaveBeenCalledWith(
+      'http://127.0.0.1/internal/admin/task',
+      expect.objectContaining({ method: 'POST' }),
+    );
   });
 });
 

--- a/packages/backend/src/services/federation/FollowService.ts
+++ b/packages/backend/src/services/federation/FollowService.ts
@@ -14,8 +14,23 @@ import {
 import { PostVisibility } from '@mention/shared-types';
 import { enqueueDelivery } from '../../queue/producers';
 import { actorService } from './ActorService';
+import { assertSafePublicUrl } from '../../utils/ssrfGuard';
+import { fetchUpstreamSingleHop, SsrfRejection } from '../../utils/safeUpstreamFetch';
 
 const DELIVER_ACTIVITY_TIMEOUT_MS = 15000;
+const DELIVERY_ERROR_BODY_LIMIT_BYTES = 1024;
+
+async function readSmallResponseBody(stream: AsyncIterable<unknown>): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    chunks.push(buffer);
+    total += buffer.length;
+    if (total >= DELIVERY_ERROR_BODY_LIMIT_BYTES) break;
+  }
+  return Buffer.concat(chunks, Math.min(total, DELIVERY_ERROR_BODY_LIMIT_BYTES)).toString('utf8');
+}
 
 /**
  * Outbound activity delivery + follow lifecycle (Follow / Undo(Follow) /
@@ -55,19 +70,24 @@ export class FollowService {
 
       logger.debug(`[FedDeliver] POST ${targetInbox} body=${body} sig-headers=${sigHeaders['Signature']?.match(/headers="([^"]+)"/)?.[1]}`);
 
-      const res = await fetch(targetInbox, {
+      const res = await fetchUpstreamSingleHop(targetInbox, {
         method: 'POST',
         headers: allHeaders,
         body,
         signal: AbortSignal.timeout(DELIVER_ACTIVITY_TIMEOUT_MS),
+        headersTimeoutMs: DELIVER_ACTIVITY_TIMEOUT_MS,
       });
 
-      if (res.ok || res.status === 202) return true;
+      if ((res.status >= 200 && res.status < 300) || res.status === 202) return true;
 
-      const responseBody = await res.text().catch(() => '');
-      logger.debug(`Activity delivery failed to ${targetInbox}: ${res.status} ${res.statusText} body=${responseBody.slice(0, 500)}`);
+      const responseBody = await readSmallResponseBody(res.response);
+      logger.debug(`Activity delivery failed to ${targetInbox}: ${res.status} body=${responseBody.slice(0, 500)}`);
       return false;
     } catch (err) {
+      if (err instanceof SsrfRejection) {
+        logger.warn(`[FedDeliver] blocked unsafe inbox URL ${targetInbox}: ${err.message}`);
+        return false;
+      }
       logger.debug(`Activity delivery error to ${targetInbox}:`, err);
       return false;
     }
@@ -86,6 +106,12 @@ export class FollowService {
     targetInbox: string,
     senderOxyUserId: string,
   ): Promise<void> {
+    const guard = await assertSafePublicUrl(targetInbox);
+    if (!guard.ok) {
+      logger.warn(`[FedDeliver] not queueing unsafe inbox URL ${targetInbox}: ${guard.reason}`);
+      return;
+    }
+
     const enqueued = await enqueueDelivery({
       activityJson: activity,
       targetInbox,

--- a/packages/backend/src/utils/safeUpstreamFetch.ts
+++ b/packages/backend/src/utils/safeUpstreamFetch.ts
@@ -97,13 +97,14 @@ function buildRequestOptions(
   pinnedFamily: 4 | 6,
   headers: Record<string, string>,
   signal: AbortSignal,
+  method = 'GET',
 ): https.RequestOptions {
   return {
     protocol: target.protocol,
     hostname: target.hostname,
     port: target.port || (target.protocol === 'https:' ? 443 : 80),
     path: `${target.pathname}${target.search}`,
-    method: 'GET',
+    method,
     headers,
     // Aborts the in-flight request when an external deadline fires.
     signal,
@@ -136,6 +137,7 @@ function fetchOnce(
   options: https.RequestOptions,
   isHttps: boolean,
   headersTimeoutMs: number = UPSTREAM_HEADERS_TIMEOUT_MS,
+  body?: string | Buffer,
 ): Promise<IncomingMessage> {
   return new Promise<IncomingMessage>((resolve, reject) => {
     const transport = isHttps ? https : http;
@@ -145,7 +147,7 @@ function fetchOnce(
       req.destroy(new Error('upstream headers timeout'));
     });
     req.on('error', (err) => reject(err));
-    req.end();
+    req.end(body);
   });
 }
 
@@ -226,8 +228,12 @@ export interface SingleHopResult {
 
 /** Options for {@link fetchUpstreamSingleHop}. */
 export interface SingleHopOptions {
+  /** HTTP method to use for this single hop. Defaults to GET. */
+  method?: 'GET' | 'POST';
   /** The EXACT request headers to send (the caller assembles these). */
   headers: Record<string, string>;
+  /** Optional request body for POST deliveries. */
+  body?: string | Buffer;
   /** Aborts the in-flight request when the signal fires. */
   signal: AbortSignal;
   /** Time-to-first-byte deadline; defaults to {@link UPSTREAM_HEADERS_TIMEOUT_MS}. */
@@ -259,8 +265,20 @@ export async function fetchUpstreamSingleHop(
   }
 
   const target = new URL(url);
-  const requestOptions = buildRequestOptions(target, guard.ip, guard.family, options.headers, options.signal);
-  const response = await fetchOnce(requestOptions, target.protocol === 'https:', options.headersTimeoutMs);
+  const requestOptions = buildRequestOptions(
+    target,
+    guard.ip,
+    guard.family,
+    options.headers,
+    options.signal,
+    options.method ?? 'GET',
+  );
+  const response = await fetchOnce(
+    requestOptions,
+    target.protocol === 'https:',
+    options.headersTimeoutMs,
+    options.body,
+  );
   return {
     response,
     status: response.statusCode ?? 0,


### PR DESCRIPTION
### Motivation
- Prevent a blind SSRF introduced by sending Accept/other ActivityPub POSTs to remote actor inbox URLs that were not validated, which allowed attacker-controlled inboxes (localhost/link‑local) to receive server-originated POSTs.
- Ensure outbound federation delivery reuses the existing IP‑pinned, DNS‑checked transport used elsewhere (media/federation signed fetches) and avoid persisting unsafe targets for retry.

### Description
- Route outbound ActivityPub POST delivery through the SSRF‑safe single‑hop transport (`fetchUpstreamSingleHop`) so the URL is validated, DNS is resolved and the TCP connection is pinned to a vetted IP before connecting, and keep HTTP signatures and Accept/Content headers intact (`packages/backend/src/services/federation/FollowService.ts`).
- Extend the shared upstream helper to support single‑hop POST requests with bodies and a method parameter while preserving existing GET/redirect behavior (`packages/backend/src/utils/safeUpstreamFetch.ts`).
- Validate inbox URLs at queue time with `assertSafePublicUrl` and skip/emit a warning instead of enqueueing deliveries to blocked addresses, and treat SSRF rejections specially when delivering to avoid retries (`FollowService.queueDelivery` / `deliverActivity`).
- Add a small helper to safely read a bounded error response body and add unit test coverage asserting the safe delivery transport is used and that unsafe localhost inbox delivery is blocked (`packages/backend/src/__tests__/services/federationService.test.ts`).

### Testing
- Added unit tests in `packages/backend/src/__tests__/services/federationService.test.ts` covering that delivery uses `fetchUpstreamSingleHop` and that an unsafe inbox URL is blocked; the tests were added but could not be executed in this environment because test runner dependencies (`vitest`) and npm packages were not installed (install failed due to registry access), so automated test execution is pending in CI.
- Ran local static checks (`tsc` / type check) and test invocation attempts were attempted but were blocked by missing type/dependency installs in this environment, so full TypeScript build and test runs should be validated in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d67519e248323969bf523fc3e2cd7)