### PR TITLE
fix: verify federated outbox authorship

### DIFF
--- a/packages/backend/src/__tests__/services/federation/outboxValidation.test.ts
+++ b/packages/backend/src/__tests__/services/federation/outboxValidation.test.ts
@@ -287,6 +287,84 @@ describe('OutboxSyncService — per-item zod validation', () => {
     expect(activityIds).not.toContain(`${ACTOR_URI}/statuses/bad`);
   });
 
+
+  it('rejects Create items whose actor or attributedTo does not match the synced outbox owner', async () => {
+    const victimUri = 'https://victim.example/users/bob';
+    stubOutbox(
+      { type: 'OrderedCollection', totalItems: 2, first: FIRST_PAGE_URL },
+      {
+        type: 'OrderedCollectionPage',
+        id: FIRST_PAGE_URL,
+        orderedItems: [
+          {
+            ...createNoteActivity('forged-actor', '2023-04-04T12:00:00Z'),
+            actor: victimUri,
+          },
+          {
+            id: `${ACTOR_URI}/statuses/forged-attributed/activity`,
+            type: 'Create',
+            actor: ACTOR_URI,
+            published: '2023-04-05T12:00:00Z',
+            object: {
+              id: `${ACTOR_URI}/statuses/forged-attributed`,
+              type: 'Note',
+              attributedTo: victimUri,
+              content: '<p>forged</p>',
+              published: '2023-04-05T12:00:00Z',
+              to: ['https://www.w3.org/ns/activitystreams#Public'],
+            },
+          },
+        ],
+      },
+    );
+
+    const result = await runSync();
+
+    expect(result).toMatchObject({ syncedCount: 0, candidateCount: 0, reason: 'no-candidates' });
+    expect(mocks.postInsertMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects outbox notes whose activity id belongs to another actor and stores verified actorUri on accepted notes', async () => {
+    stubOutbox(
+      { type: 'OrderedCollection', totalItems: 2, first: FIRST_PAGE_URL },
+      {
+        type: 'OrderedCollectionPage',
+        id: FIRST_PAGE_URL,
+        orderedItems: [
+          {
+            id: 'https://victim.example/users/bob/statuses/forged-id/activity',
+            type: 'Create',
+            actor: ACTOR_URI,
+            published: '2023-04-04T12:00:00Z',
+            object: {
+              id: 'https://victim.example/users/bob/statuses/forged-id',
+              type: 'Note',
+              attributedTo: ACTOR_URI,
+              content: '<p>forged id</p>',
+              published: '2023-04-04T12:00:00Z',
+              to: ['https://www.w3.org/ns/activitystreams#Public'],
+            },
+          },
+          createNoteActivity('accepted', '2023-04-05T12:00:00Z'),
+        ],
+      },
+    );
+
+    const result = await runSync();
+
+    expect(result.candidateCount).toBe(1);
+    expect(result.newPostCount).toBe(1);
+    const inserted = mocks.postInsertMany.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].oxyUserId).toBe('oxy_alice');
+    expect(inserted[0].federation).toEqual(
+      expect.objectContaining({
+        activityId: `${ACTOR_URI}/statuses/accepted`,
+        actorUri: ACTOR_URI,
+      }),
+    );
+  });
+
   it('preserves the original past published date on a valid item (no date regression)', async () => {
     const pastPublished = '2020-01-15T08:30:00.000Z';
     stubOutbox(

--- a/packages/backend/src/models/Post.ts
+++ b/packages/backend/src/models/Post.ts
@@ -13,6 +13,7 @@ export type ReplyPermission = 'anyone' | 'followers' | 'following' | 'mentioned'
 
 export interface PostFederationData {
   activityId?: string;   // AP activity URI
+  actorUri?: string;     // Verified ActivityPub actor/signing URI that authored this activity
   inReplyTo?: string;    // AP URI of parent post
   url?: string;          // canonical web URL on remote instance
   sensitive?: boolean;   // content warning flag
@@ -287,6 +288,7 @@ const PostMetadataSchema = new Schema({
 
 const FederationSchema = new Schema({
   activityId: { type: String },
+  actorUri: { type: String },
   inReplyTo: { type: String },
   url: { type: String },
   sensitive: { type: Boolean, default: false },

--- a/packages/backend/src/services/FederationJobScheduler.ts
+++ b/packages/backend/src/services/FederationJobScheduler.ts
@@ -1,6 +1,6 @@
 import { logger } from '../utils/logger';
 import type { Types } from 'mongoose';
-import { FEDERATION_ENABLED, extractActorUriFromActivityId } from '../utils/federation/constants';
+import { FEDERATION_ENABLED } from '../utils/federation/constants';
 import FederatedActor, { type FederatedOutboxBackfillState } from '../models/FederatedActor';
 import FederatedFollow from '../models/FederatedFollow';
 import FederationDeliveryQueue, { getNextRetryTime } from '../models/FederationDeliveryQueue';
@@ -725,8 +725,10 @@ class FederationJobScheduler {
   }
 
   /**
-   * One-time backfill: set oxyUserId on federated posts that were stored without one.
-   * Uses bulk operations to avoid N+1 queries.
+   * Backfill oxyUserId only when a post already stores a verified ActivityPub
+   * actor URI from its original inbox/outbox import. Older posts that only have
+   * an activityId are intentionally skipped: activity IDs are attacker-controlled
+   * strings and are not proof of authorship.
    *
    * Public so the BullMQ periodic worker can invoke it.
    */
@@ -739,29 +741,21 @@ class FederationJobScheduler {
     try {
       const posts = await Post.find({
         federation: { $ne: null },
+        'federation.actorUri': { $exists: true, $ne: null },
         $or: [{ oxyUserId: null }, { oxyUserId: { $exists: false } }],
       })
-        .select('federation')
+        .select('federation.actorUri')
         .limit(500)
         .lean();
 
       if (posts.length === 0) return;
 
-      logger.info(`[FedSync] Backfilling oxyUserId for ${posts.length} federated posts`);
+      logger.info(`[FedSync] Backfilling oxyUserId for ${posts.length} federated posts with verified actor URIs`);
 
-      // Derive actor URIs from activity IDs using the shared utility
-      const postActorMap = new Map<string, string[]>(); // actorUri → [postId, ...]
-
+      const postActorMap = new Map<string, string[]>();
       for (const post of posts) {
-        const activityId = (post.federation as { activityId?: string } | undefined)?.activityId;
-        if (!activityId) continue;
-
-        const actorUri = extractActorUriFromActivityId(activityId);
-        if (!actorUri) {
-          logger.debug(`[FedSync] Backfill: could not extract actor URI from ${activityId}`);
-          continue;
-        }
-
+        const actorUri = (post.federation as { actorUri?: string } | undefined)?.actorUri;
+        if (!actorUri) continue;
         const postIds = postActorMap.get(actorUri) ?? [];
         postIds.push(String(post._id));
         postActorMap.set(actorUri, postIds);
@@ -769,7 +763,6 @@ class FederationJobScheduler {
 
       if (postActorMap.size === 0) return;
 
-      // Single batch query for all actor URIs
       const actors = await FederatedActor.find({
         uri: { $in: [...postActorMap.keys()] },
         oxyUserId: { $ne: null },
@@ -777,14 +770,13 @@ class FederationJobScheduler {
         .select('uri oxyUserId')
         .lean();
 
-      // Build bulk updates grouped by oxyUserId
       const bulkOps: Array<{ updateMany: { filter: Record<string, unknown>; update: Record<string, unknown> } }> = [];
       for (const actor of actors) {
         const postIds = postActorMap.get(actor.uri);
         if (!postIds?.length || !actor.oxyUserId) continue;
         bulkOps.push({
           updateMany: {
-            filter: { _id: { $in: postIds } },
+            filter: { _id: { $in: postIds }, 'federation.actorUri': actor.uri },
             update: { $set: { oxyUserId: actor.oxyUserId } },
           },
         });

--- a/packages/backend/src/services/federation/InboxProcessingService.ts
+++ b/packages/backend/src/services/federation/InboxProcessingService.ts
@@ -318,6 +318,7 @@ export class InboxProcessingService {
       oxyUserId: actor.oxyUserId ?? null,
       federation: {
         activityId: object.id,
+        actorUri,
         inReplyTo: object.inReplyTo || undefined,
         url: object.url || object.id,
         sensitive: object.sensitive || false,

--- a/packages/backend/src/services/federation/OutboxSyncService.ts
+++ b/packages/backend/src/services/federation/OutboxSyncService.ts
@@ -4,6 +4,7 @@ import { Post } from '../../models/Post';
 import {
   FEDERATION_MAX_CONTENT_LENGTH,
   AP_CONTENT_TYPE,
+  extractActorUriFromActivityId,
 } from '../../utils/federation/constants';
 import { PostVisibility } from '@mention/shared-types';
 import { htmlToPlainText } from '../../utils/federation/htmlToPlainText';
@@ -171,6 +172,41 @@ function isSameOriginHttpUrl(value: string, sourceUrl: string): boolean {
   } catch {
     return false;
   }
+}
+
+
+function normalizeActorUriForCompare(uri: string | null | undefined): string | null {
+  if (!uri || !isAbsoluteHttpUrl(uri)) return null;
+  try {
+    const parsed = new URL(uri);
+    parsed.hash = '';
+    parsed.search = '';
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function actorUrisMatch(actual: string | null | undefined, expected: string): boolean {
+  const normalizedActual = normalizeActorUriForCompare(actual);
+  const normalizedExpected = normalizeActorUriForCompare(expected);
+  return Boolean(normalizedActual && normalizedExpected && normalizedActual === normalizedExpected);
+}
+
+function activityIdBelongsToActor(activityId: string, actorUri: string): boolean {
+  if (!isAbsoluteHttpUrl(activityId)) return false;
+
+  try {
+    const activityUrl = new URL(activityId);
+    const actorUrl = new URL(actorUri);
+    if (activityUrl.origin !== actorUrl.origin) return false;
+  } catch {
+    return false;
+  }
+
+  const derivedActorUri = extractActorUriFromActivityId(activityId);
+  return !derivedActorUri || actorUrisMatch(derivedActorUri, actorUri);
 }
 
 interface RawPostClassificationSeed {
@@ -360,7 +396,7 @@ export class OutboxSyncService {
         const items = activityPubItems(pageData);
         const normalizedOffset = Math.max(0, Math.min(startItemOffset, items.length));
         if (items.length > 0) {
-          const nextItemOffset = await this.extractCandidates(items, candidates, limit, pageUrl, normalizedOffset);
+          const nextItemOffset = await this.extractCandidates(items, candidates, limit, pageUrl, actor.uri, normalizedOffset);
           if (nextItemOffset < items.length) {
             nextCursor = { url: pageUrl, itemOffset: nextItemOffset };
             pausedMidPage = true;
@@ -578,8 +614,8 @@ export class OutboxSyncService {
         const published = parseApPublished(note.published ?? activity.published);
 
         // Resolve author's Oxy User ID
-        const actorUri = extractActorUri(note.attributedTo);
-        const resolvedOxyUserId = actorUri ? actorOxyMap.get(actorUri) || null : null;
+        const actorUri = actor.uri;
+        const resolvedOxyUserId = actorOxyMap.get(actorUri) || null;
         if (!resolvedOxyUserId) {
           logger.debug(`[FedSync] no oxyUserId resolved for actorUri=${actorUri} activityId=${activityId}`);
         }
@@ -620,6 +656,7 @@ export class OutboxSyncService {
           oxyUserId: resolvedOxyUserId,
           federation: {
             activityId,
+            actorUri,
             inReplyTo: note.inReplyTo || undefined,
             url: note.url || note.id,
             sensitive: note.sensitive || false,
@@ -753,6 +790,7 @@ export class OutboxSyncService {
     candidates: OutboxCandidate[],
     limit: number,
     sourcePageUrl: string,
+    expectedActorUri: string,
     startIndex = 0,
   ): Promise<number> {
     const maxIndexExclusive = Math.min(items.length, startIndex + OUTBOX_MAX_ITEMS_INSPECTED_PER_PAGE);
@@ -785,6 +823,8 @@ export class OutboxSyncService {
         const activityId = activity.id;
         const announcedUri = extractAnnouncedObjectUri(activity.object);
         if (!activityId || !announcedUri) continue;
+        if (!actorUrisMatch(extractActorUri(activity.actor), expectedActorUri)) continue;
+        if (!activityIdBelongsToActor(activityId, expectedActorUri)) continue;
         candidates.push({ kind: 'announce', activity, activityId, announcedUri });
         continue;
       }
@@ -805,6 +845,11 @@ export class OutboxSyncService {
 
       const activityId = note.id || activity.id;
       if (!activityId) continue;
+
+      const attributedTo = extractActorUri(note.attributedTo);
+      if (!actorUrisMatch(attributedTo, expectedActorUri)) continue;
+      if (activity.type === 'Create' && !actorUrisMatch(extractActorUri(activity.actor), expectedActorUri)) continue;
+      if (!activityIdBelongsToActor(activityId, expectedActorUri)) continue;
 
       candidates.push({ kind: 'note', note, activity, activityId });
     }
@@ -899,6 +944,7 @@ export class OutboxSyncService {
         visibility: PostVisibility.PUBLIC,
         federation: {
           activityId: announceId,
+          actorUri: typeof announceActivity.actor === 'string' ? announceActivity.actor : undefined,
           url: typeof announceActivity.url === 'string' ? announceActivity.url : announceId,
         },
         status: 'published',


### PR DESCRIPTION
### Motivation
- A periodic outbox sync and a startup backfill trusted unverified ActivityPub fields (`note.attributedTo` / `activity.id`) and could attribute attacker-controlled content to a victim actor, allowing forged posts to appear under another actor's `oxyUserId`.
- The intent is to ensure imported outbox items are authored by the outbox owner and only backfill `oxyUserId` when there is a previously-verified actor signing provenance.

### Description
- Enforce authorship checks in `OutboxSyncService.extractCandidates` so `Note`/`Create` and `Announce` candidates are accepted only when the item’s `actor`/`attributedTo` and derived `activityId` belong to the synced actor (`actor.uri`) before treating them as candidates.  (see `packages/backend/src/services/federation/OutboxSyncService.ts`).
- Persist a verified `federation.actorUri` on federation metadata for imported posts and boosts, and populate it from inbound inbox imports and outbox imports (schema change in `packages/backend/src/models/Post.ts`, inbox wiring in `InboxProcessingService.ts`, boost imports in `OutboxSyncService.ts`).
- Resolve `oxyUserId` for outbox notes using the verified synced actor (the outbox owner) rather than trusting each note’s untrusted `attributedTo` field, and include `actorUri` in the stored `federation` subdoc for accepted items.
- Restrict `backfillFederatedPostOxyUserIds` to only update posts that already have a verified `federation.actorUri`; do not derive ownership from raw `activityId` heuristics (change in `packages/backend/src/services/FederationJobScheduler.ts`).
- Add regression tests covering forged outbox attribution, cross-actor activity IDs, and verified `actorUri` persistence (tests updated in `packages/backend/src/__tests__/services/federation/outboxValidation.test.ts`).

### Testing
- Ran `git diff --check` to validate patch formatting and found no issues (success).
- Attempted `bun run --cwd packages/backend build` but the build is blocked in this environment due to existing TypeScript deprecation config errors in `packages/backend/tsconfig.json` (blocked). 
- Attempted `bun --check` on modified TS files but the environment produced Bun resource/VM errors (OOM / crash) so type-check could not be completed here (blocked). 
- Attempted to run the federation outbox unit test file with `bun run --cwd packages/backend test ...`, but `vitest` is not available in this environment and tests could not be executed (blocked).

If you want, I can split the changes into smaller commits, add explicit unit tests for the new `activityIdBelongsToActor` and `actorUrisMatch` helpers, or help adapt CI/test config to run the new tests in your CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d68ba547c832389d3e41b90353ada)