### PR TITLE
fix: guard image processing dimensions

### DIFF
--- a/packages/backend/src/__tests__/utils/imageDimensionGuard.test.ts
+++ b/packages/backend/src/__tests__/utils/imageDimensionGuard.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InputImageTooLargeError,
+  assertSafeInputImageBuffer,
+  assertSafeInputImageDimensions,
+  readInputImageDimensions,
+} from '../../utils/imageDimensionGuard';
+
+function makePngHeader(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(33);
+  buffer.writeUInt8(0x89, 0);
+  buffer.write('PNG', 1, 'ascii');
+  buffer.writeUInt8(0x0d, 4);
+  buffer.writeUInt8(0x0a, 5);
+  buffer.writeUInt8(0x1a, 6);
+  buffer.writeUInt8(0x0a, 7);
+  buffer.writeUInt32BE(13, 8);
+  buffer.write('IHDR', 12, 'ascii');
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  return buffer;
+}
+
+describe('assertSafeInputImageDimensions', () => {
+  it('accepts images within dimension and pixel limits', () => {
+    expect(() =>
+      assertSafeInputImageDimensions(
+        { width: 1200, height: 800 },
+        { maxWidth: 1600, maxHeight: 1200, maxPixels: 2_000_000 },
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects images above the maximum width or height', () => {
+    expect(() =>
+      assertSafeInputImageDimensions(
+        { width: 20_000, height: 100 },
+        { maxWidth: 16_000, maxHeight: 16_000, maxPixels: 50_000_000 },
+      ),
+    ).toThrow(InputImageTooLargeError);
+  });
+
+  it('rejects compressed pixel bombs that fit byte limits but exceed pixel limits', () => {
+    expect(() =>
+      assertSafeInputImageDimensions(
+        { width: 10_000, height: 10_000 },
+        { maxWidth: 16_000, maxHeight: 16_000, maxPixels: 50_000_000 },
+      ),
+    ).toThrow(InputImageTooLargeError);
+  });
+});
+
+describe('readInputImageDimensions', () => {
+  it('reads PNG dimensions without decoding the image payload', () => {
+    expect(readInputImageDimensions(makePngHeader(20_000, 20_000))).toEqual({
+      width: 20_000,
+      height: 20_000,
+    });
+  });
+
+  it('rejects an over-limit PNG before native image processing', () => {
+    expect(() => assertSafeInputImageBuffer(makePngHeader(20_000, 20_000))).toThrow(
+      InputImageTooLargeError,
+    );
+  });
+});

--- a/packages/backend/src/services/imageCacheService.ts
+++ b/packages/backend/src/services/imageCacheService.ts
@@ -7,6 +7,7 @@ import crypto from 'crypto';
 import { Transformer, ResizeFit } from '@napi-rs/image';
 import { getS3Client, getBucket, getCdnUrl } from '../utils/spaces';
 import { PutObjectCommand, GetObjectCommand, DeleteObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import { assertSafeInputImageBuffer, assertSafeInputImageDimensions, isInputImageTooLargeError } from '../utils/imageDimensionGuard';
 
 /**
  * Service to cache and optimize images from external URLs.
@@ -208,8 +209,11 @@ class ImageCacheService {
       return { buffer: imageBuffer, contentType: 'image/svg+xml' };
     }
 
+    assertSafeInputImageBuffer(imageBuffer);
+
     const transformer = new Transformer(imageBuffer);
     const metadata = await transformer.metadata();
+    assertSafeInputImageDimensions(metadata);
 
     // GIF images: return as-is to preserve animation
     if (metadata.format === 'gif') {
@@ -306,6 +310,10 @@ class ImageCacheService {
       try {
         processedResult = await this.processImage(imageBuffer);
       } catch (error) {
+        if (isInputImageTooLargeError(error)) {
+          throw error;
+        }
+
         logger.warn('[ImageCacheService] Image processing failed, using original:', {
           url: normalizedUrl,
           error: error instanceof Error ? error.message : String(error)
@@ -436,6 +444,10 @@ class ImageCacheService {
       try {
         processedResult = await this.processImage(imageBuffer, options);
       } catch (error) {
+        if (isInputImageTooLargeError(error)) {
+          throw error;
+        }
+
         logger.warn('[ImageCacheService] Image processing failed for optimized variant, using original:', {
           url: normalizedUrl,
           error: error instanceof Error ? error.message : String(error)

--- a/packages/backend/src/utils/imageDimensionGuard.ts
+++ b/packages/backend/src/utils/imageDimensionGuard.ts
@@ -1,0 +1,148 @@
+export const DEFAULT_MAX_INPUT_IMAGE_WIDTH = 16_000;
+export const DEFAULT_MAX_INPUT_IMAGE_HEIGHT = 16_000;
+export const DEFAULT_MAX_INPUT_IMAGE_PIXELS = 50_000_000;
+
+export const MAX_INPUT_IMAGE_WIDTH = Number(
+  process.env.MAX_INPUT_IMAGE_WIDTH ?? DEFAULT_MAX_INPUT_IMAGE_WIDTH,
+);
+export const MAX_INPUT_IMAGE_HEIGHT = Number(
+  process.env.MAX_INPUT_IMAGE_HEIGHT ?? DEFAULT_MAX_INPUT_IMAGE_HEIGHT,
+);
+export const MAX_INPUT_IMAGE_PIXELS = Number(
+  process.env.MAX_INPUT_IMAGE_PIXELS ?? DEFAULT_MAX_INPUT_IMAGE_PIXELS,
+);
+
+export interface ImageDimensions {
+  width?: number | null;
+  height?: number | null;
+}
+
+export class InputImageTooLargeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InputImageTooLargeError';
+  }
+}
+
+function isValidDimension(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+export function assertSafeInputImageDimensions(
+  dimensions: ImageDimensions,
+  limits = {
+    maxWidth: MAX_INPUT_IMAGE_WIDTH,
+    maxHeight: MAX_INPUT_IMAGE_HEIGHT,
+    maxPixels: MAX_INPUT_IMAGE_PIXELS,
+  },
+): void {
+  const { width, height } = dimensions;
+
+  if (!isValidDimension(width) || !isValidDimension(height)) {
+    throw new InputImageTooLargeError('Unable to determine input image dimensions');
+  }
+
+  if (width > limits.maxWidth || height > limits.maxHeight) {
+    throw new InputImageTooLargeError(
+      `Input image dimensions exceed limit (${width}x${height}; max ${limits.maxWidth}x${limits.maxHeight})`,
+    );
+  }
+
+  const pixels = width * height;
+  if (!Number.isSafeInteger(pixels) || pixels > limits.maxPixels) {
+    throw new InputImageTooLargeError(
+      `Input image pixel count exceeds limit (${pixels}; max ${limits.maxPixels})`,
+    );
+  }
+}
+
+export function readInputImageDimensions(buffer: Buffer): ImageDimensions | null {
+  if (buffer.length >= 24 &&
+      buffer[0] === 0x89 &&
+      buffer[1] === 0x50 &&
+      buffer[2] === 0x4e &&
+      buffer[3] === 0x47 &&
+      buffer[4] === 0x0d &&
+      buffer[5] === 0x0a &&
+      buffer[6] === 0x1a &&
+      buffer[7] === 0x0a) {
+    return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+  }
+
+  if (buffer.length >= 10 &&
+      buffer[0] === 0x47 &&
+      buffer[1] === 0x49 &&
+      buffer[2] === 0x46) {
+    return { width: buffer.readUInt16LE(6), height: buffer.readUInt16LE(8) };
+  }
+
+  if (buffer.length >= 30 && buffer.toString('ascii', 0, 4) === 'RIFF' && buffer.toString('ascii', 8, 12) === 'WEBP') {
+    const chunk = buffer.toString('ascii', 12, 16);
+    if (chunk === 'VP8X' && buffer.length >= 30) {
+      const width = 1 + buffer.readUIntLE(24, 3);
+      const height = 1 + buffer.readUIntLE(27, 3);
+      return { width, height };
+    }
+    if (chunk === 'VP8 ' && buffer.length >= 30) {
+      const width = buffer.readUInt16LE(26) & 0x3fff;
+      const height = buffer.readUInt16LE(28) & 0x3fff;
+      return { width, height };
+    }
+    if (chunk === 'VP8L' && buffer.length >= 25) {
+      const bits = buffer.readUInt32LE(21);
+      const width = (bits & 0x3fff) + 1;
+      const height = ((bits >> 14) & 0x3fff) + 1;
+      return { width, height };
+    }
+  }
+
+  if (buffer.length >= 4 && buffer[0] === 0xff && buffer[1] === 0xd8) {
+    let offset = 2;
+    while (offset + 9 < buffer.length) {
+      if (buffer[offset] !== 0xff) {
+        offset += 1;
+        continue;
+      }
+
+      const marker = buffer[offset + 1];
+      offset += 2;
+
+      if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+        continue;
+      }
+
+      if (offset + 2 > buffer.length) {
+        return null;
+      }
+
+      const segmentLength = buffer.readUInt16BE(offset);
+      if (segmentLength < 2 || offset + segmentLength > buffer.length) {
+        return null;
+      }
+
+      if (
+        (marker >= 0xc0 && marker <= 0xc3) ||
+        (marker >= 0xc5 && marker <= 0xc7) ||
+        (marker >= 0xc9 && marker <= 0xcb) ||
+        (marker >= 0xcd && marker <= 0xcf)
+      ) {
+        return { width: buffer.readUInt16BE(offset + 5), height: buffer.readUInt16BE(offset + 3) };
+      }
+
+      offset += segmentLength;
+    }
+  }
+
+  return null;
+}
+
+export function assertSafeInputImageBuffer(buffer: Buffer): void {
+  const dimensions = readInputImageDimensions(buffer);
+  if (dimensions) {
+    assertSafeInputImageDimensions(dimensions);
+  }
+}
+
+export function isInputImageTooLargeError(error: unknown): error is InputImageTooLargeError {
+  return error instanceof InputImageTooLargeError;
+}

--- a/packages/backend/src/utils/imageProcessor.ts
+++ b/packages/backend/src/utils/imageProcessor.ts
@@ -1,4 +1,5 @@
 import { Transformer, ResizeFit } from '@napi-rs/image';
+import { assertSafeInputImageBuffer, assertSafeInputImageDimensions } from './imageDimensionGuard';
 
 type ImagePreset = 'avatar' | 'cover' | 'roomImage';
 
@@ -13,7 +14,13 @@ export async function processImage(
   preset: ImagePreset,
 ): Promise<{ buffer: Buffer; contentType: string }> {
   const { width, height, quality } = PRESETS[preset];
-  const buffer = await new Transformer(input)
+  assertSafeInputImageBuffer(input);
+
+  const transformer = new Transformer(input);
+  const metadata = await transformer.metadata();
+  assertSafeInputImageDimensions(metadata);
+
+  const buffer = await transformer
     .resize(width, height, undefined, ResizeFit.Cover)
     .webp(quality);
   return { buffer, contentType: 'image/webp' };


### PR DESCRIPTION
### Motivation
- Replacing `sharp` with `@napi-rs/image` removed the prior decoder protections that limited input pixel counts, exposing public image-processing endpoints to decompression-bomb attacks (small compressed size but enormous dimensions) that can exhaust memory/CPU. 
- The public `/images/optimize` and shared upload image pipeline accept attacker-controlled buffers and previously only enforced a byte-size limit, so an explicit input-dimension/pixel guard is required before native decoding/transform.

### Description
- Add a new utility `packages/backend/src/utils/imageDimensionGuard.ts` that parses common image headers (PNG, GIF, WEBP, JPEG) and exposes `readInputImageDimensions`, `assertSafeInputImageBuffer`, and `assertSafeInputImageDimensions` with configurable limits via `MAX_INPUT_IMAGE_*` env vars.
- Enforce header-only checks by calling `assertSafeInputImageBuffer(imageBuffer)` before constructing `Transformer` in `packages/backend/src/services/imageCacheService.ts` and `packages/backend/src/utils/imageProcessor.ts` and re-validate decoded metadata via `assertSafeInputImageDimensions(metadata)` before transforming.
- Treat over-limit inputs as hard failures by rethrowing `InputImageTooLargeError` so the public optimized caching path does not silently fall back to storing the original untransformed image.
- Add unit tests `packages/backend/src/__tests__/utils/imageDimensionGuard.test.ts` that cover header parsing and rejection of oversized dimensions/pixel counts, and make limits configurable via env.

### Testing
- Ran `bun test packages/backend/src/__tests__/utils/imageDimensionGuard.test.ts` and observed all tests passed (`5 pass, 0 fail`).
- Attempted `cd packages/backend && bun run build` to compile the package; TypeScript emit failed due to existing deprecation/TS config issues (`moduleResolution=node10` / `baseUrl`) unrelated to this change.
- `bun install` in this environment failed due to registry `403` responses, so full integration test (install + all package tests) could not be executed here; the newly added unit tests cover the guard logic and passed locally in the sandbox.

Files changed: `packages/backend/src/utils/imageDimensionGuard.ts`, `packages/backend/src/services/imageCacheService.ts`, `packages/backend/src/utils/imageProcessor.ts`, `packages/backend/src/__tests__/utils/imageDimensionGuard.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6ed0ae208323bca9d29d980292b8)