### PR TITLE
fix: pin Wrangler version for Cloudflare Pages deploys

### DIFF
--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -61,6 +61,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: 'bun'
+          wranglerVersion: '4.81.0'
           command: pages deploy packages/frontend/dist --project-name=mention-frontend --branch=main
 
   deploy-agora:
@@ -87,4 +88,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: 'bun'
+          wranglerVersion: '4.81.0'
           command: pages deploy packages/agora/dist --project-name=agora-frontend --branch=main


### PR DESCRIPTION
### Motivation
- Restore an explicit Wrangler pin for Cloudflare Pages deploy steps to make deployments reproducible and reduce CI supply-chain risk when the job runs with Cloudflare credentials.

### Description
- Add `wranglerVersion: '4.81.0'` to both Cloudflare Pages deploy steps in `.github/workflows/deploy-frontends.yml` so the `cloudflare/wrangler-action@v4` invocation uses a fixed Wrangler release.

### Testing
- Verified both deploy blocks contain the new `wranglerVersion: '4.81.0'` entry with a small content-assertion script that reads `.github/workflows/deploy-frontends.yml` and confirmed success; and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d70713e5883239ae30059e3e2b560)