### PR TITLE
Trending: enforce public/published visibility in aggregation

### DIFF
--- a/packages/backend/src/__tests__/services/trendingService.test.ts
+++ b/packages/backend/src/__tests__/services/trendingService.test.ts
@@ -55,6 +55,9 @@ describe('TrendingService.aggregateHashtags — NSFW/sensitive exclusion', () =>
 
     const pipeline = mocks.postAggregate.mock.calls[0][0];
     const match = pipeline.find((stage: Record<string, unknown>) => '$match' in stage).$match;
+    expect(match.status).toBe('published');
+    expect(match.visibility).toBe('public');
+    expect(match.boostOf).toEqual({ $exists: false });
     expect(match['postClassification.sensitive']).toEqual({ $ne: true });
     expect(match['metadata.isSensitive']).toEqual({ $ne: true });
     expect(match['federation.sensitive']).toEqual({ $ne: true });
@@ -93,6 +96,9 @@ describe('TrendingService.aggregateTopics — NSFW/sensitive exclusion', () => {
     const pipeline = mocks.postAggregate.mock.calls[0][0];
     const matchStages = pipeline.filter((stage: Record<string, unknown>) => '$match' in stage);
     const firstMatch = matchStages[0].$match;
+    expect(firstMatch.status).toBe('published');
+    expect(firstMatch.visibility).toBe('public');
+    expect(firstMatch.boostOf).toEqual({ $exists: false });
     expect(firstMatch['postClassification.sensitive']).toEqual({ $ne: true });
     expect(firstMatch['metadata.isSensitive']).toEqual({ $ne: true });
     expect(firstMatch['federation.sensitive']).toEqual({ $ne: true });

--- a/packages/backend/src/services/TrendingService.ts
+++ b/packages/backend/src/services/TrendingService.ts
@@ -1,6 +1,6 @@
 import { Post } from '../models/Post';
 import Trending, { TrendingType, ITrending } from '../models/Trending';
-import { TopicType } from '@mention/shared-types';
+import { PostVisibility, TopicType } from '@mention/shared-types';
 import TrendBatch from '../models/TrendBatch';
 import { logger } from '../utils/logger';
 import { getRedisClient } from '../utils/redis';
@@ -161,6 +161,9 @@ class TrendingService {
         $match: {
           createdAt: { $gte: oneDayAgo },
           hashtags: { $exists: true, $ne: [] },
+          status: 'published',
+          visibility: PostVisibility.PUBLIC,
+          boostOf: { $exists: false },
           // Sensitive/NSFW-flagged posts never feed trending counts.
           ...SENSITIVE_EXCLUDE_MATCH,
         },
@@ -227,6 +230,7 @@ class TrendingService {
         $match: {
           createdAt: { $gte: oneDayAgo },
           status: 'published',
+          visibility: PostVisibility.PUBLIC,
           boostOf: { $exists: false },
           // At least one topic source must be present.
           $or: [


### PR DESCRIPTION
### Motivation
- Close a privacy leak where aggregated AI-extracted topics/hashtags from non-public posts could surface in public trends by ensuring only public, published, non-boost posts contribute to trending counts. 

### Description
- Require `status: 'published'`, `visibility: PostVisibility.PUBLIC`, and `boostOf: { $exists: false }` in the aggregation `$match` for both `aggregateHashtags()` and `aggregateTopics()` in `packages/backend/src/services/TrendingService.ts` and import `PostVisibility` for the check. 
- Add assertions to `packages/backend/src/__tests__/services/trendingService.test.ts` that verify the aggregation `$match` stages include `status`, `visibility`, and `boostOf` constraints. 

### Testing
- Verified the updated aggregation pipelines via local source inspection and `git diff --check` to ensure no style/runtime diff errors. 
- Attempted to run the targeted unit tests with `cd packages/backend && bun run test src/__tests__/services/trendingService.test.ts`, but test execution was blocked because the test runner (`vitest`) was not available in the environment. 
- Attempted `bun install` to restore dependencies but it failed due to registry tarball `403` responses, so full test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d81fbce3c8323b3a4092606ea8096)