### PR TITLE
fix: authorize post translation access

### DIFF
--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -2257,8 +2257,23 @@ export const translatePost = async (req: AuthRequest, res: Response): Promise<vo
       return;
     }
 
-    const post = await Post.findById(id).select('content.text translations').lean();
+    const post = await Post.findById(id)
+      .select('_id oxyUserId content.text translations visibility status federation createdAt')
+      .lean();
     if (!post) {
+      res.status(404).json({ message: 'Post not found' });
+      return;
+    }
+
+    const visiblePosts = await postHydrationService.hydratePosts([post], {
+      viewerId: req.user?.id,
+      oxyClient: createScopedOxyClient(req),
+      maxDepth: 0,
+      includeLinkMetadata: false,
+      includeFullArticleBody: false,
+      includeFullMetadata: false,
+    });
+    if (visiblePosts.length === 0) {
       res.status(404).json({ message: 'Post not found' });
       return;
     }


### PR DESCRIPTION
### Motivation
- Prevent unauthorized disclosure of post text (drafts, scheduled, private, followers-only, or posts from private profiles) to external Alia API by enforcing the same visibility checks used by post retrieval/hydration before any text is read or sent.

### Description
- `translatePost` in `packages/backend/src/controllers/posts.controller.ts` now fetches the post with `_id oxyUserId content.text translations visibility status federation createdAt` and runs it through `postHydrationService.hydratePosts(...)` using `viewerId: req.user?.id` and a scoped Oxy client to apply the canonical access controls before proceeding.
- The hydration call is conservative for performance: `maxDepth: 0` with `includeLinkMetadata`, `includeFullArticleBody`, and `includeFullMetadata` disabled, and a `404` is returned when hydration filters out the post for the requester.
- All existing translation behavior (cache lookup, `aliaChat` call, and caching of translation results) is preserved and only executed after access is confirmed.

### Testing
- Ran `git diff --check` which passed with no whitespace/format issues.
- Attempted backend unit tests via `cd packages/backend && bun run test --runInBand` but the environment failed because `vitest` is not available (test run could not be executed).
- Attempted build via `bun run build:backend` which invoked `tsc` and failed due to a TypeScript deprecation error (`moduleResolution=node10`) in the current environment rather than a runtime/test failure in the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d82ff8afc8323a6327d1556bdbb90)