### PR TITLE
fix: avoid caching SSE user tokens

### DIFF
--- a/packages/mcp/server-http.ts
+++ b/packages/mcp/server-http.ts
@@ -21,8 +21,6 @@ const PORT = parseInt(process.env.MCP_PORT || "3100", 10);
 // ── Transport store ──────────────────────────────────────────
 const transports: Record<string, StreamableHTTPServerTransport | SSEServerTransport> = {};
 const sessionLastActivity: Map<string, number> = new Map();
-/** Map session IDs to their user tokens for SSE sessions (long-lived). */
-const sessionUserTokens: Map<string, string> = new Map();
 
 const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
@@ -37,7 +35,6 @@ const cleanupInterval = setInterval(() => {
       transport.close().catch(() => {});
       delete transports[id];
       sessionLastActivity.delete(id);
-      sessionUserTokens.delete(id);
       cleaned++;
     }
   }
@@ -89,7 +86,6 @@ function sendJsonRpcError(res: ServerResponse, httpStatus: number, code: number,
 function cleanupSession(id: string): void {
   delete transports[id];
   sessionLastActivity.delete(id);
-  sessionUserTokens.delete(id);
 }
 
 // ── Main ─────────────────────────────────────────────────────
@@ -205,13 +201,9 @@ async function main() {
 
     // ── SSE: GET /sse ────────────────────────────────────────
     if (pathname === "/sse" && req.method === "GET") {
-      const userToken = extractBearerToken(headers, query);
       const server = createMcpServer();
       const transport = new SSEServerTransport("/messages", res);
       transports[transport.sessionId] = transport;
-      if (userToken) {
-        sessionUserTokens.set(transport.sessionId, userToken);
-      }
 
       res.on("close", () => {
         cleanupSession(transport.sessionId);
@@ -231,8 +223,10 @@ async function main() {
         return;
       }
 
-      // Use per-request Bearer token, or fall back to the token from session init
-      const userToken = extractBearerToken(headers, query) || (sessionId ? sessionUserTokens.get(sessionId) : undefined);
+      // Do not reuse the token from GET /sse here: session IDs are carried in URLs
+      // and must not become bearer credentials for a user account. Require callers
+      // to present any user token on each POST /messages request instead.
+      const userToken = extractBearerToken(headers, query);
       const body = await readBody(req);
       await requestContext.run({ userToken }, () =>
         transport.handlePostMessage(req, res, body),


### PR DESCRIPTION
### Motivation
- Prevent SSE session IDs from becoming bearer credentials by eliminating a process-wide map that stored users' Oxy JWTs keyed by SSE sessionId.
- Close an authentication vulnerability where an attacker knowing an active `sessionId` could replay the stored token to make API calls as the victim.

### Description
- Removed the `sessionUserTokens` map and all code that saved the Bearer token during `GET /sse` in `packages/mcp/server-http.ts`.
- Stopped referring to any stored token during `POST /messages`; `POST /messages` now only uses a token presented on that individual request via the Authorization header or query token.
- Adjusted session cleanup to no longer delete user-token state since it is no longer tracked.
- Change is confined to the MCP HTTP transport implementation (`packages/mcp/server-http.ts`) and preserves SSE/transport lifecycle behavior.

### Testing
- Ran `git diff --check` to validate workspace diffs and ensure no trailing whitespace issues, which passed.
- Searched the MCP server source for remaining references to the SSE token cache (`rg "sessionUserTokens|session init|sessionUserTokens\.get"`) and confirmed none remain.
- Attempted TypeScript typecheck (`bun run --cwd packages/mcp typecheck` / `tsc --noEmit`) but it was blocked by dependency fetch errors from the environment (registry tarball `403`), so full typecheck could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d917942fc832386aa3ffcbfdad57d)