### PR TITLE
fix(recommendations): batch affinity ACL follow checks to avoid Oxy fan-out

### DIFF
--- a/packages/backend/src/__tests__/services/contentAffinityService.test.ts
+++ b/packages/backend/src/__tests__/services/contentAffinityService.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
   entityFollowFind: vi.fn(),
   userBehaviorFindOne: vi.fn(),
   userSettingsFind: vi.fn(),
-  checkFollowAccess: vi.fn(),
+  getFollowingIdSet: vi.fn(),
   blockFind: vi.fn(),
   muteFind: vi.fn(),
   restrictFind: vi.fn(),
@@ -31,7 +31,7 @@ vi.mock('../../utils/redis', () => ({
 vi.mock('../../utils/privacyHelpers', () => ({
   ProfileVisibility: { PUBLIC: 'public', PRIVATE: 'private', FOLLOWERS_ONLY: 'followers_only' },
   requiresAccessCheck: (visibility: string | undefined) => visibility === 'private' || visibility === 'followers_only',
-  checkFollowAccess: mocks.checkFollowAccess,
+  getFollowingIdSet: mocks.getFollowingIdSet,
 }));
 
 // The authority blend dynamically imports these; stub them so the blend is a
@@ -78,7 +78,7 @@ function noSignals(): void {
   // topic-affinity, and negative-signal inputs all run empty.
   mocks.userBehaviorFindOne.mockImplementation(leanFindOne(null));
   mocks.userSettingsFind.mockImplementation(leanQuery([]));
-  mocks.checkFollowAccess.mockResolvedValue(false);
+  mocks.getFollowingIdSet.mockResolvedValue(new Set());
 }
 
 beforeEach(() => {
@@ -284,17 +284,40 @@ describe('ContentAffinityService.getContentCandidates', () => {
       { oxyUserId: 'followers_author', privacy: { profileVisibility: 'followers_only' } },
       { oxyUserId: 'followed_private_author', privacy: { profileVisibility: 'private' } },
     ]));
-    mocks.checkFollowAccess.mockImplementation(
-      async (_viewerId: string, targetId: string) => targetId === 'followed_private_author',
+    mocks.getFollowingIdSet.mockImplementation(
+      async (_viewerId: string) => new Set(['followed_private_author']),
     );
 
     const service = makeService();
     const result = await service.getContentCandidates('viewer_1');
 
     expect(result.map((c) => c.userId).sort()).toEqual(['followed_private_author', 'public_author']);
-    expect(mocks.checkFollowAccess).toHaveBeenCalledWith('viewer_1', 'private_author');
-    expect(mocks.checkFollowAccess).toHaveBeenCalledWith('viewer_1', 'followers_author');
-    expect(mocks.checkFollowAccess).toHaveBeenCalledWith('viewer_1', 'followed_private_author');
+    expect(mocks.getFollowingIdSet).toHaveBeenCalledTimes(1);
+    expect(mocks.getFollowingIdSet).toHaveBeenCalledWith('viewer_1');
+  });
+
+  it('batches profile ACL follow checks across all protected candidates', async () => {
+    mocks.entityFollowFind.mockImplementation(leanQuery([{ entityId: 'rust' }]));
+    const protectedCandidates = Array.from({ length: 75 }, (_, i) => ({
+      _id: `private_author_${i}`,
+      matchedTags: [['rust']],
+      postCount: i + 1,
+    }));
+    mocks.postAggregate.mockResolvedValue(protectedCandidates);
+    mocks.userSettingsFind.mockImplementation(leanQuery(
+      protectedCandidates.map((candidate) => ({
+        oxyUserId: candidate._id,
+        privacy: { profileVisibility: 'private' },
+      })),
+    ));
+    mocks.getFollowingIdSet.mockResolvedValue(new Set(['private_author_7']));
+
+    const service = makeService();
+    const result = await service.getContentCandidates('viewer_1', { limit: 5 });
+
+    expect(result.map((c) => c.userId)).toEqual(['private_author_7']);
+    expect(mocks.getFollowingIdSet).toHaveBeenCalledTimes(1);
+    expect(mocks.getFollowingIdSet).toHaveBeenCalledWith('viewer_1');
   });
 
   it('resolves engagement authors only from published public target posts', async () => {

--- a/packages/backend/src/services/ContentAffinityService.ts
+++ b/packages/backend/src/services/ContentAffinityService.ts
@@ -61,7 +61,7 @@ import Mute from '../models/Mute';
 import Restrict from '../models/Restrict';
 import { getRedisClient } from '../utils/redis';
 import { logger } from '../utils/logger';
-import { checkFollowAccess, ProfileVisibility, requiresAccessCheck } from '../utils/privacyHelpers';
+import { getFollowingIdSet, ProfileVisibility, requiresAccessCheck } from '../utils/privacyHelpers';
 
 /** Recency window for content signals (days). */
 const WINDOW_DAYS = 30;
@@ -461,14 +461,16 @@ export class ContentAffinityService {
         );
       }
 
-      await Promise.all(
-        authorIds.map(async (authorId) => {
-          const visibility = visibilityByAuthor.get(authorId) ?? ProfileVisibility.PUBLIC;
-          if (!requiresAccessCheck(visibility)) return;
-          const hasAccess = authorId === viewerId || await checkFollowAccess(viewerId, authorId);
-          if (!hasAccess) merged.delete(authorId);
-        }),
-      );
+      const protectedAuthorIds = authorIds.filter((authorId) => {
+        const visibility = visibilityByAuthor.get(authorId) ?? ProfileVisibility.PUBLIC;
+        return requiresAccessCheck(visibility);
+      });
+      if (protectedAuthorIds.length === 0) return;
+
+      const followingIds = await getFollowingIdSet(viewerId);
+      for (const authorId of protectedAuthorIds) {
+        if (!followingIds.has(authorId)) merged.delete(authorId);
+      }
     } catch (error) {
       logger.warn('[ContentAffinity] candidate profile ACL filter failed; dropping candidates:', error);
       merged.clear();

--- a/packages/backend/src/utils/privacyHelpers.ts
+++ b/packages/backend/src/utils/privacyHelpers.ts
@@ -198,6 +198,25 @@ export function extractFollowersIds(followersRes: unknown): string[] {
     .filter((id): id is string => Boolean(id));
 }
 
+
+/**
+ * Fetch the viewer's following list once and expose it as a Set for batched
+ * access checks within a single request path.
+ * @param viewerId - The user checking access
+ * @param client - Optional per-request OxyServices instance
+ * @returns Set of user IDs followed by the viewer
+ */
+export async function getFollowingIdSet(viewerId: string, client?: OxyClient): Promise<Set<string>> {
+  try {
+    const c = client || oxy;
+    const followingRes = await c.getUserFollowing(viewerId);
+    return new Set(extractFollowingIds(followingRes));
+  } catch (error) {
+    logger.error('Error fetching following list for access check:', error);
+    return new Set(); // On error, deny access for privacy
+  }
+}
+
 /**
  * Check if a user is following another user
  * @param viewerId - The user checking access
@@ -206,15 +225,8 @@ export function extractFollowersIds(followersRes: unknown): string[] {
  * @returns true if viewer follows target, false otherwise
  */
 export async function checkFollowAccess(viewerId: string, targetUserId: string, client?: OxyClient): Promise<boolean> {
-  try {
-    const c = client || oxy;
-    const followingRes = await c.getUserFollowing(viewerId);
-    const followingIds = extractFollowingIds(followingRes);
-    return followingIds.includes(targetUserId);
-  } catch (error) {
-    logger.error('Error checking follow access:', error);
-    return false; // On error, deny access for privacy
-  }
+  const followingIds = await getFollowingIdSet(viewerId, client);
+  return followingIds.has(targetUserId);
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Prevent cost-amplification and availability impact caused by per-candidate `getUserFollowing` calls when ACL-filtering a large merged candidate set for recommendations.
- Ensure private/followers-only profile checks reuse a single viewer following-list fetch rather than issuing N identical downstream requests.

### Description
- Replace per-candidate `checkFollowAccess` calls with a single `getFollowingIdSet(viewerId)` call in `ContentAffinityService.filterCandidateProfileAccess`, and use the returned `Set` to filter protected authors.
- Add `getFollowingIdSet` to `packages/backend/src/utils/privacyHelpers.ts` which fetches the viewer's following list once and return a `Set`, and make the existing `checkFollowAccess` delegate to it for compatibility.
- Update `packages/backend/src/__tests__/services/contentAffinityService.test.ts` to mock the batched helper and add a regression test that simulates 75 protected pre-limit candidates and asserts only one following-list lookup occurs.

### Testing
- Ran `git diff --check` to validate workspace diffs; no whitespace errors reported.
- Updated unit tests in `packages/backend/src/__tests__/services/contentAffinityService.test.ts` to assert batched behavior and added a 75-candidate regression case (test code updated to mock `getFollowingIdSet`).
- Attempted to run `bun test packages/backend/src/__tests__/services/contentAffinityService.test.ts` but test execution was blocked because `bun install` failed in this environment due to npm registry `403` responses (dependencies such as `mongoose` could not be installed), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d58e117d483238d45bc65af485894)