### PR TITLE
Fix public profile counts to exclude unpublished posts

### DIFF
--- a/packages/backend/src/__tests__/routes/profileDesign.test.ts
+++ b/packages/backend/src/__tests__/routes/profileDesign.test.ts
@@ -1,0 +1,61 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { countDocuments, findOne } = vi.hoisted(() => ({
+  countDocuments: vi.fn(),
+  findOne: vi.fn(),
+}));
+
+vi.mock('../../models/Post', () => ({
+  default: { countDocuments },
+}));
+
+vi.mock('../../models/UserSettings', () => ({
+  default: { findOne },
+}));
+
+vi.mock('../../utils/privacyHelpers', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/privacyHelpers')>('../../utils/privacyHelpers');
+  return {
+    ...actual,
+    checkFollowAccess: vi.fn().mockResolvedValue(true),
+  };
+});
+
+import profileDesignRoutes from '../../routes/profileDesign';
+
+const app = express();
+app.use('/profile/design', profileDesignRoutes);
+
+describe('profile design public counts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) });
+    countDocuments.mockResolvedValue(0);
+  });
+
+  it('counts only published public posts, boosts, and replies', async () => {
+    await request(app).get('/profile/design/user-1').expect(200);
+
+    expect(countDocuments).toHaveBeenCalledTimes(3);
+    expect(countDocuments).toHaveBeenNthCalledWith(1, {
+      oxyUserId: 'user-1',
+      visibility: 'public',
+      status: 'published',
+      parentPostId: null,
+    });
+    expect(countDocuments).toHaveBeenNthCalledWith(2, {
+      oxyUserId: 'user-1',
+      visibility: 'public',
+      status: 'published',
+      type: 'boost',
+    });
+    expect(countDocuments).toHaveBeenNthCalledWith(3, {
+      oxyUserId: 'user-1',
+      visibility: 'public',
+      status: 'published',
+      parentPostId: { $ne: null },
+    });
+  });
+});

--- a/packages/backend/src/routes/profileDesign.ts
+++ b/packages/backend/src/routes/profileDesign.ts
@@ -84,8 +84,8 @@ router.get('/:userId', async (req: AuthRequest, res: Response) => {
     const response = extractPublicProfileData(doc, userId) as PublicProfileDesignResponse;
 
     // Calculate post-related counts in parallel. All three are scoped to the
-    // user's public content and leverage existing indexes (oxyUserId, type,
-    // parentPostId, boostOf), so there is no N+1.
+    // user's published public content and leverage existing indexes (oxyUserId,
+    // type, parentPostId, boostOf), so there is no N+1.
     // - postsCount: top-level posts (not replies) — matches getUserProfileFeed.
     //   `parentPostId: null` matches null OR a missing field in MongoDB.
     // - boostsCount: documents authored as boosts (type=boost, boostOf set).
@@ -94,16 +94,19 @@ router.get('/:userId', async (req: AuthRequest, res: Response) => {
       Post.countDocuments({
         oxyUserId: userId,
         visibility: PostVisibility.PUBLIC,
+        status: 'published',
         parentPostId: null,
       }),
       Post.countDocuments({
         oxyUserId: userId,
         visibility: PostVisibility.PUBLIC,
+        status: 'published',
         type: PostType.BOOST,
       }),
       Post.countDocuments({
         oxyUserId: userId,
         visibility: PostVisibility.PUBLIC,
+        status: 'published',
         parentPostId: { $ne: null },
       }),
     ]);


### PR DESCRIPTION
### Motivation
- Prevent leakage of draft or scheduled activity through the public profile design endpoint by aligning its counters with feed visibility rules that only surface published content.

### Description
- Added `status: 'published'` to the `Post.countDocuments` predicates for `postsCount`, `boostsCount`, and `repliesCount` in `packages/backend/src/routes/profileDesign.ts` so counts only include published public posts.
- Updated the explanatory comment to state that counts are for published public content.
- Added a regression test `packages/backend/src/__tests__/routes/profileDesign.test.ts` that asserts the three count queries include the `status: 'published'` filter.

### Testing
- A static assertion script verified the three count queries include `status: 'published'` (succeeded).
- A route unit test was added to verify the query shapes but could not be executed in this environment because test dependencies are not installed (attempted `bun run test` failed due to `vitest` not found) and `bun install` failed due to external registry access errors (403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5a4d32448323a8a77544309917e8)