### PR TITLE
fix(backend): block cross-site authenticated mutations

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -85,6 +85,7 @@ import { RedisStore } from "./src/middleware/rateLimitStore";
 import { bruteForceProtection } from "./src/middleware/security";
 import { feedRateLimiter } from "./src/middleware/rateLimiter";
 import { performanceMiddleware } from "./src/middleware/performance";
+import { csrfProtection } from "./src/middleware/csrfProtection";
 
 import helmet from 'helmet';
 
@@ -900,7 +901,7 @@ app.use('/media', mediaRoutes);
 
 // Mount public and authenticated API routers
 app.use("/", publicApiRouter);
-app.use("/", oxy.auth(), authenticatedApiRouter);
+app.use("/", csrfProtection, oxy.auth(), authenticatedApiRouter);
 
 // Global error handler — must be the LAST middleware registered.
 // Catches unhandled errors from route handlers and prevents raw error leakage.

--- a/packages/backend/src/__tests__/csrfProtection.test.ts
+++ b/packages/backend/src/__tests__/csrfProtection.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import { csrfProtection } from '../middleware/csrfProtection';
+
+vi.mock('../utils/allowedOrigins', () => ({
+  isAllowedOrigin: (origin: string) => origin === 'https://mention.earth',
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: { warn: vi.fn() },
+}));
+
+function runMiddleware(method: string, headers: Request['headers'] = {}) {
+  const req = {
+    method,
+    headers,
+    originalUrl: '/posts',
+    url: '/posts',
+  } as Request;
+
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+
+  const next = vi.fn() as NextFunction;
+
+  csrfProtection(req, res, next);
+
+  return { res, next };
+}
+
+describe('csrfProtection', () => {
+  it('allows safe requests without checking Origin', () => {
+    const { res, next } = runMiddleware('GET', { origin: 'https://evil.example' });
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows state-changing requests from an allowed Origin', () => {
+    const { res, next } = runMiddleware('POST', { origin: 'https://mention.earth' });
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('blocks state-changing requests from a disallowed Origin', () => {
+    const { res, next } = runMiddleware('POST', { origin: 'https://evil.example' });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+  });
+
+  it('uses Referer origin when Origin is absent', () => {
+    const { res, next } = runMiddleware('DELETE', { referer: 'https://evil.example/form.html' });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows headerless state-changing requests for non-browser clients', () => {
+    const { res, next } = runMiddleware('POST');
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/middleware/csrfProtection.ts
+++ b/packages/backend/src/middleware/csrfProtection.ts
@@ -1,0 +1,55 @@
+import type { NextFunction, Request, Response } from 'express';
+import { isAllowedOrigin } from '../utils/allowedOrigins';
+import { logger } from '../utils/logger';
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+function getHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function getOriginFromReferer(referer: string | undefined): string | undefined {
+  if (!referer) return undefined;
+
+  try {
+    return new URL(referer).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Reject browser-originated cross-site state-changing requests before auth.
+ *
+ * CORS does not stop HTML form CSRF, so authenticated API routes need a server-
+ * side same-origin check when a browser supplies Origin/Referer metadata. Non-
+ * browser clients and native apps commonly omit both headers, so headerless
+ * requests are allowed and still rely on normal Oxy authentication.
+ */
+export function csrfProtection(req: Request, res: Response, next: NextFunction) {
+  if (SAFE_METHODS.has(req.method.toUpperCase())) {
+    return next();
+  }
+
+  const origin = getHeaderValue(req.headers.origin);
+  const refererOrigin = getOriginFromReferer(getHeaderValue(req.headers.referer));
+  const requestOrigin = origin || refererOrigin;
+
+  if (!requestOrigin) {
+    return next();
+  }
+
+  if (isAllowedOrigin(requestOrigin)) {
+    return next();
+  }
+
+  logger.warn('Blocked cross-site state-changing request', {
+    method: req.method,
+    path: req.originalUrl || req.url,
+    origin,
+    refererOrigin,
+  });
+
+  return res.status(403).json({ error: 'Forbidden' });
+}


### PR DESCRIPTION
### Motivation
- A cross-domain SSO upgrade can cause browsers to send ambient auth cookies to `api.mention.earth`, and the backend accepted `application/x-www-form-urlencoded` bodies with authenticated POST routes protected only by `oxy.auth()`, enabling HTML-form CSRF; this change prevents browser-originated cross-site state-changing requests from reaching authenticated handlers.

### Description
- Add `packages/backend/src/middleware/csrfProtection.ts` which allows safe methods, extracts `Origin`/`Referer` origin, and blocks unsafe browser-supplied requests whose origin is not allowed via `isAllowedOrigin` (returns HTTP 403).
- Mount the middleware before Oxy auth in `packages/backend/server.ts` so the same-origin check runs prior to `oxy.auth()` for the authenticated API router (`app.use('/', csrfProtection, oxy.auth(), authenticatedApiRouter)`).
- Add unit tests in `packages/backend/src/__tests__/csrfProtection.test.ts` covering safe methods, allowed origins, disallowed origins, `Referer` fallback, and headerless non-browser clients.

### Testing
- Added a targeted unit test file `packages/backend/src/__tests__/csrfProtection.test.ts` but automated test execution in this environment failed because test tooling is not installed (`vitest: command not found`) when running `cd packages/backend && bun run test src/__tests__/csrfProtection.test.ts`.
- The new middleware and mounting change were committed (`fix(backend): block cross-site authenticated mutations`) and basic static inspection confirms the middleware is invoked before authenticated routes; no runtime test results could be obtained in the current container due to missing dev dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5a4cf6ec8323b00ab24875ffd72d)