### PR TITLE
ci: restrict AWS SSM secret sync allowlist

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -36,9 +36,24 @@ jobs:
       - name: Sync GitHub secrets -> SSM (GitHub is the source of truth)
         env:
           SECRETS_JSON: ${{ toJSON(secrets) }}
+          # Explicit backend runtime allowlist. Do not sync unrelated CI/CD
+          # credentials (for example Cloudflare or DigitalOcean deploy tokens)
+          # into the AWS SSM parameter hierarchy.
+          SSM_SECRET_ALLOWLIST: >-
+            ADMIN_USER_IDS ALIA_API_KEY DO_SPACES_KEY DO_SPACES_SECRET
+            FIREBASE_SERVICE_ACCOUNT_BASE64 FIREBASE_PROJECT_ID KLIPY_APP_KEY
+            LIVEKIT_API_KEY LIVEKIT_API_SECRET MENTION_OXY_CLIENT_ID
+            MONGODB_URI OXY_DB_URI OXY_SERVICE_API_KEY OXY_SERVICE_API_SECRET
+            OXY_SERVICE_TOKEN REDIS_URL REDIS_URI REDIS_HOST REDIS_PASSWORD
+            AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
         run: |
           SHARED="AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY REDIS_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET"
-          echo "$SECRETS_JSON" | jq -r 'to_entries[] | select((.key|ascii_upcase) as $k | ($k=="GITHUB_TOKEN" or ($k|startswith("ACTIONS_")))|not) | [.key,.value]|@tsv' | \
+          echo "$SECRETS_JSON" | jq -r --arg allowlist "$SSM_SECRET_ALLOWLIST" '
+            ($allowlist | split(" ")) as $allowed
+            | to_entries[]
+            | select(.key as $k | $allowed | index($k))
+            | [.key,.value]|@tsv
+          ' | \
           while IFS=$'\t' read -r k v; do
             [ -z "$k" ] && continue
             if [ -z "$v" ] || [ "$v" = "-" ]; then


### PR DESCRIPTION
### Motivation
- The deploy workflow previously serialized and copied nearly all repository secrets into AWS SSM, which risked exposing unrelated CI/CD and cross-provider tokens to any principal with SSM read access under the `/oxy/...` prefixes.
- The change adds an explicit backend runtime allowlist so only secrets required by the backend runtime are synced to SSM, reducing blast radius and aligning with the principle of least privilege.

### Description
- Updated the AWS deploy workflow `/.github/workflows/deploy-aws.yml` to introduce an `SSM_SECRET_ALLOWLIST` environment variable containing an explicit list of backend runtime secret names. 
- Replaced the previous `jq` filter that enumerated almost all `secrets` with a filter that selects only keys present in `SSM_SECRET_ALLOWLIST` before writing to SSM. 
- Preserved existing behavior for `REDIS_URL` validation, empty/placeholder secret skips, and routing between `/oxy/_shared/` and `/oxy/$APP/` parameter paths.

### Testing
- Ran a local `jq` proof-of-filter using a dummy secrets JSON to verify unrelated secrets like `DIGITALOCEAN_TOKEN` and `CLOUDFLARE_API_TOKEN` are excluded while allowlisted backend secrets remain included. 
- Parsed the modified workflow with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-aws.yml")'` to validate that the YAML remains syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5a4b44188323be4f1bf900068ba6)