### PR TITLE
fix: bound received poke back lookup

### DIFF
--- a/packages/backend/src/routes/pokes.ts
+++ b/packages/backend/src/routes/pokes.ts
@@ -51,13 +51,13 @@ router.get('/received', async (req: AuthRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ message: 'Unauthorized' });
 
-    const [pokes, pokedBackDocs] = await Promise.all([
-      Poke.find({ pokedId: userId }).sort({ createdAt: -1 }).limit(POKES_LIMIT).lean(),
-      Poke.find({ pokerId: userId }).select('pokedId').lean(),
-    ]);
+    const pokes = await Poke.find({ pokedId: userId }).sort({ createdAt: -1 }).limit(POKES_LIMIT).lean();
+    const pokerIds = pokes.map((p) => p.pokerId);
+    const pokedBackDocs = pokerIds.length > 0
+      ? await Poke.find({ pokerId: userId, pokedId: { $in: pokerIds } }).select('pokedId').lean()
+      : [];
 
     const pokedBackSet = new Set(pokedBackDocs.map((p) => p.pokedId));
-    const pokerIds = pokes.map((p) => p.pokerId);
     const profiles = await resolveUsers(pokerIds);
 
     const items = pokes.flatMap((p) => {


### PR DESCRIPTION
### Motivation
- Prevent an unbounded read of all outgoing `Poke` documents in the `GET /pokes/received` endpoint which allowed an authenticated user to cause large DB reads and memory allocation by accumulating many outgoing pokes.

### Description
- Change `packages/backend/src/routes/pokes.ts` so the handler first loads the bounded received-pokes page (`limit: POKES_LIMIT`), derives the page's `pokerIds`, and then queries outgoing pokes constrained to `pokedId: { $in: pokerIds }` to build the `pokedBack` set while preserving the existing response shape.

### Testing
- Ran `git diff --check` which passed; running `bun run build:backend` failed due to a TypeScript deprecation setting in the workspace TS config (requires `ignoreDeprecations`), and `cd packages/backend && bun run test` could not run because `vitest` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5bdfffb08323aca3da8988da7f79)