### PR TITLE
Fix unbounded poke history endpoints

### DIFF
--- a/packages/backend/src/models/Poke.ts
+++ b/packages/backend/src/models/Poke.ts
@@ -25,5 +25,7 @@ const PokeSchema = new Schema({
 PokeSchema.index({ pokerId: 1, pokedId: 1 }, { unique: true });
 // Fetch pokes received by a user
 PokeSchema.index({ pokedId: 1, createdAt: -1 });
+// Fetch pokes sent by a user
+PokeSchema.index({ pokerId: 1, createdAt: -1 });
 
 export default mongoose.model<IPoke>("Poke", PokeSchema);

--- a/packages/backend/src/routes/pokes.ts
+++ b/packages/backend/src/routes/pokes.ts
@@ -8,17 +8,62 @@ import type { User } from '@oxyhq/core';
 
 const router = Router();
 
+const POKE_PAGE_DEFAULT_LIMIT = 50;
+const POKE_PAGE_MAX_LIMIT = 100;
+const POKE_LOOKUP_CONCURRENCY = 8;
+const MAX_OXY_USER_ID_LENGTH = 128;
+const SUGGESTION_LIMIT = 20;
+const SUGGESTION_CANDIDATE_LIMIT = 200;
+
+function normalizeOxyUserId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_OXY_USER_ID_LENGTH) return null;
+  return trimmed;
+}
+
+function parsePageLimit(value: unknown): number {
+  if (typeof value !== 'string') return POKE_PAGE_DEFAULT_LIMIT;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return POKE_PAGE_DEFAULT_LIMIT;
+  return Math.min(parsed, POKE_PAGE_MAX_LIMIT);
+}
+
+function parseCursor(value: unknown): Date | null {
+  if (typeof value !== 'string' || !value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
 /** Resolve an array of Oxy user IDs into profile objects (best-effort). */
 async function resolveUsers(ids: string[]): Promise<Map<string, User>> {
+  const uniqueIds = [...new Set(ids.map(normalizeOxyUserId).filter((id): id is string => !!id))];
   const map = new Map<string, User>();
-  await Promise.all(
-    ids.map(async (id) => {
-      try {
-        const user = await oxy.getUserById(id);
-        if (user) map.set(id, user);
-      } catch { /* skip unresolvable */ }
-    }),
-  );
+
+  const bulkGetUsers = (oxy as { getUsersByIds?: (ids: string[]) => Promise<User[]> }).getUsersByIds;
+  if (typeof bulkGetUsers === 'function') {
+    try {
+      const users = await bulkGetUsers.call(oxy, uniqueIds);
+      for (const user of users) {
+        if (user?.id) map.set(user.id, user);
+      }
+      return map;
+    } catch {
+      // Fall back to bounded single-user lookups below.
+    }
+  }
+
+  for (let i = 0; i < uniqueIds.length; i += POKE_LOOKUP_CONCURRENCY) {
+    const batch = uniqueIds.slice(i, i + POKE_LOOKUP_CONCURRENCY);
+    await Promise.all(
+      batch.map(async (id) => {
+        try {
+          const user = await oxy.getUserById(id);
+          if (user) map.set(id, user);
+        } catch { /* skip unresolvable */ }
+      }),
+    );
+  }
   return map;
 }
 
@@ -44,23 +89,32 @@ function extractUsersFromResult(result: unknown, key: 'followers' | 'following')
   return Array.isArray(list) ? list.filter((user): user is User => isRecord(user) && typeof user.id === 'string') : [];
 }
 
-const POKES_LIMIT = 100;
-
 router.get('/received', async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ message: 'Unauthorized' });
 
-    const [pokes, pokedBackDocs] = await Promise.all([
-      Poke.find({ pokedId: userId }).sort({ createdAt: -1 }).limit(POKES_LIMIT).lean(),
-      Poke.find({ pokerId: userId }).select('pokedId').lean(),
+    const limit = parsePageLimit(req.query.limit);
+    const cursor = parseCursor(req.query.cursor);
+    const receivedQuery = cursor ? { pokedId: userId, createdAt: { $lt: cursor } } : { pokedId: userId };
+
+    const pokes = await Poke.find(receivedQuery)
+      .sort({ createdAt: -1 })
+      .limit(limit + 1)
+      .lean();
+    const pagePokes = pokes.slice(0, limit);
+    const pokerIds = pagePokes.map((p) => p.pokerId);
+
+    const [profiles, pokedBackDocs] = await Promise.all([
+      resolveUsers(pokerIds),
+      pokerIds.length
+        ? Poke.find({ pokerId: userId, pokedId: { $in: pokerIds } }).select('pokedId').limit(pokerIds.length).lean()
+        : [],
     ]);
 
     const pokedBackSet = new Set(pokedBackDocs.map((p) => p.pokedId));
-    const pokerIds = pokes.map((p) => p.pokerId);
-    const profiles = await resolveUsers(pokerIds);
 
-    const items = pokes.flatMap((p) => {
+    const items = pagePokes.flatMap((p) => {
       const user = profiles.get(p.pokerId);
       return user
         ? [{
@@ -73,7 +127,8 @@ router.get('/received', async (req: AuthRequest, res: Response) => {
         : [];
     });
 
-    return res.json({ pokes: items });
+    const nextCursor = pokes.length > limit ? pagePokes.at(-1)?.createdAt?.toISOString() : undefined;
+    return res.json({ pokes: items, nextCursor });
   } catch (error) {
     logger.error('[Pokes] Error listing received pokes:', { userId: req.user?.id, error });
     return res.status(500).json({ message: 'Error listing received pokes' });
@@ -85,11 +140,19 @@ router.get('/sent', async (req: AuthRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ message: 'Unauthorized' });
 
-    const pokes = await Poke.find({ pokerId: userId }).sort({ createdAt: -1 }).limit(POKES_LIMIT).lean();
-    const pokedIds = pokes.map((p) => p.pokedId);
+    const limit = parsePageLimit(req.query.limit);
+    const cursor = parseCursor(req.query.cursor);
+    const sentQuery = cursor ? { pokerId: userId, createdAt: { $lt: cursor } } : { pokerId: userId };
+
+    const pokes = await Poke.find(sentQuery)
+      .sort({ createdAt: -1 })
+      .limit(limit + 1)
+      .lean();
+    const pagePokes = pokes.slice(0, limit);
+    const pokedIds = pagePokes.map((p) => p.pokedId);
     const profiles = await resolveUsers(pokedIds);
 
-    const items = pokes.flatMap((p) => {
+    const items = pagePokes.flatMap((p) => {
       const user = profiles.get(p.pokedId);
       return user
         ? [{
@@ -100,7 +163,8 @@ router.get('/sent', async (req: AuthRequest, res: Response) => {
         : [];
     });
 
-    return res.json({ pokes: items });
+    const nextCursor = pokes.length > limit ? pagePokes.at(-1)?.createdAt?.toISOString() : undefined;
+    return res.json({ pokes: items, nextCursor });
   } catch (error) {
     logger.error('[Pokes] Error listing sent pokes:', { userId: req.user?.id, error });
     return res.status(500).json({ message: 'Error listing sent pokes' });
@@ -113,23 +177,29 @@ router.get('/suggested', async (req: AuthRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ message: 'Unauthorized' });
 
-    // Fetch existing pokes, followers, and following in parallel
-    const [existingPokes, followersResult, followingResult] = await Promise.all([
-      Poke.find({ pokerId: userId }).select('pokedId').lean(),
+    const [followersResult, followingResult] = await Promise.all([
       oxy.getUserFollowers(userId).catch(() => []),
       oxy.getUserFollowing(userId).catch(() => []),
     ]);
-    const alreadyPokedIds = new Set(existingPokes.map((p) => p.pokedId));
 
     const followerIds = extractUsersFromResult(followersResult, 'followers').map((user) => user.id);
     const followingIds = extractUsersFromResult(followingResult, 'following').map((user) => user.id);
 
-    // Merge and deduplicate, excluding self and already-poked
+    // Merge and deduplicate before querying poke state; do not load the caller's full poke history.
     const candidateIds = [...new Set([...followerIds, ...followingIds])]
-      .filter((id) => id !== userId && !alreadyPokedIds.has(id));
+      .map(normalizeOxyUserId)
+      .filter((id): id is string => !!id && id !== userId)
+      .slice(0, SUGGESTION_CANDIDATE_LIMIT);
 
-    // Limit to 20 suggestions
-    const limitedIds = candidateIds.slice(0, 20);
+    const existingPokes = candidateIds.length
+      ? await Poke.find({ pokerId: userId, pokedId: { $in: candidateIds } })
+        .select('pokedId')
+        .limit(candidateIds.length)
+        .lean()
+      : [];
+    const alreadyPokedIds = new Set(existingPokes.map((p) => p.pokedId));
+
+    const limitedIds = candidateIds.filter((id) => !alreadyPokedIds.has(id)).slice(0, SUGGESTION_LIMIT);
     const profiles = await resolveUsers(limitedIds);
 
     const items = limitedIds.flatMap((id) => {
@@ -150,12 +220,13 @@ router.get('/:userId/status', async (req: AuthRequest, res: Response) => {
     const pokerId = req.user?.id;
     const { userId } = req.params;
     if (!pokerId) return res.status(401).json({ message: 'Unauthorized' });
-    if (!userId) return res.status(400).json({ message: 'userId is required' });
+    const normalizedUserId = normalizeOxyUserId(userId);
+    if (!normalizedUserId) return res.status(400).json({ message: 'Valid userId is required' });
 
-    const exists = await Poke.exists({ pokerId, pokedId: userId });
+    const exists = await Poke.exists({ pokerId, pokedId: normalizedUserId });
     return res.json({ poked: !!exists });
   } catch (error) {
-    logger.error('[Pokes] Error checking poke status:', { userId: req.user?.id, targetId: req.params.userId, error });
+    logger.error('[Pokes] Error checking poke status:', { userId: req.user?.id, targetId: normalizeOxyUserId(req.params.userId), error });
     return res.status(500).json({ message: 'Error checking poke status' });
   }
 });
@@ -166,19 +237,23 @@ router.post('/:userId', async (req: AuthRequest, res: Response) => {
     const pokerId = req.user?.id;
     const { userId } = req.params;
     if (!pokerId) return res.status(401).json({ message: 'Unauthorized' });
-    if (!userId) return res.status(400).json({ message: 'userId is required' });
-    if (userId === pokerId) return res.status(400).json({ message: 'Cannot poke yourself' });
+    const normalizedUserId = normalizeOxyUserId(userId);
+    if (!normalizedUserId) return res.status(400).json({ message: 'Valid userId is required' });
+    if (normalizedUserId === pokerId) return res.status(400).json({ message: 'Cannot poke yourself' });
+
+    const targetUser = await oxy.getUserById(normalizedUserId).catch(() => null);
+    if (!targetUser) return res.status(404).json({ message: 'User not found' });
 
     const result = await Poke.updateOne(
-      { pokerId, pokedId: userId },
-      { $setOnInsert: { pokerId, pokedId: userId } },
+      { pokerId, pokedId: normalizedUserId },
+      { $setOnInsert: { pokerId, pokedId: normalizedUserId } },
       { upsert: true }
     );
 
     // Only send notification when a new poke was created (not on duplicate)
     if (result.upsertedCount === 1) {
       await createNotification({
-        recipientId: String(userId),
+        recipientId: String(normalizedUserId),
         actorId: String(pokerId),
         type: 'poke',
         entityId: String(pokerId),
@@ -191,7 +266,7 @@ router.post('/:userId', async (req: AuthRequest, res: Response) => {
     if (isDuplicateKeyError(error)) {
       return res.json({ poked: true });
     }
-    logger.error('[Pokes] Error poking user:', { userId: req.user?.id, targetId: req.params.userId, error });
+    logger.error('[Pokes] Error poking user:', { userId: req.user?.id, targetId: normalizeOxyUserId(req.params.userId), error });
     return res.status(500).json({ message: 'Error poking user' });
   }
 });
@@ -202,12 +277,13 @@ router.delete('/:userId', async (req: AuthRequest, res: Response) => {
     const pokerId = req.user?.id;
     const { userId } = req.params;
     if (!pokerId) return res.status(401).json({ message: 'Unauthorized' });
-    if (!userId) return res.status(400).json({ message: 'userId is required' });
+    const normalizedUserId = normalizeOxyUserId(userId);
+    if (!normalizedUserId) return res.status(400).json({ message: 'Valid userId is required' });
 
-    await Poke.deleteOne({ pokerId, pokedId: userId });
+    await Poke.deleteOne({ pokerId, pokedId: normalizedUserId });
     return res.json({ poked: false });
   } catch (error) {
-    logger.error('[Pokes] Error undoing poke:', { userId: req.user?.id, targetId: req.params.userId, error });
+    logger.error('[Pokes] Error undoing poke:', { userId: req.user?.id, targetId: normalizeOxyUserId(req.params.userId), error });
     return res.status(500).json({ message: 'Error undoing poke' });
   }
 });


### PR DESCRIPTION
### Motivation
- Prevent resource-amplification abuse where listing endpoints load unbounded Poke rows and perform unbounded concurrent Oxy lookups causing DB and upstream bursts. 
- Harden poke creation to avoid storing arbitrary/invalid target IDs that enable amplification. 
- Keep existing functionality (received/sent/suggested/status/poke/unpoke) while bounding work per request.

### Description
- Add pagination and cursor support to `GET /pokes/received` and `GET /pokes/sent` with `limit` and `cursor` parsing and `nextCursor` in responses to avoid returning the full history. 
- Replace unbounded concurrent profile resolution with `resolveUsers` that deduplicates IDs, prefers a bulk `getUsersByIds` call when available, and otherwise performs bounded-concurrency single-user lookups. 
- Limit the suggested-pokes calculation to a capped candidate set and check poke state only for those candidates instead of loading the caller's entire sent history. 
- Validate and normalize Oxy user IDs (trim + max length), verify target existence on `POST /pokes/:userId`, and use the normalized IDs for create/delete/status queries. 
- Add a `pokerId` sent-history index to the `Poke` model for efficient paginated `sent` queries.

### Testing
- Ran `git diff --check` which reported no whitespace/index issues and succeeded. 
- Transpiled the modified route with `bun build packages/backend/src/routes/pokes.ts --target=node --no-bundle --outfile=/tmp/pokes.js` which completed successfully for the changed file. 
- Full backend TypeScript build and dependency install could not be completed in this environment due to registry `403` failures and existing TypeScript deprecation/type issues, so end-to-end type-check/build and test-suite runs were not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5be0d6608323a003a1e506685895)