### PR TITLE
Fix splash preset validation for inherited property names

### DIFF
--- a/packages/frontend/components/AppSplashScreen.tsx
+++ b/packages/frontend/components/AppSplashScreen.tsx
@@ -56,14 +56,17 @@ function parseHue(hslTriple: string | undefined): number | null {
  * when the preset's primary hue can't be parsed.
  */
 function buildDarkGradient(presetName: AppColorName): readonly [string, string] {
-    const hue = parseHue(APP_COLOR_PRESETS[presetName]?.dark['--primary']);
+    const hue = parseHue(APP_COLOR_PRESETS[presetName]?.dark?.['--primary']);
     if (hue === null) return FALLBACK_GRADIENT;
     return [`hsl(${hue} 60% 8%)`, DARK_STOP];
 }
 
 /** Validate an unknown value as a known preset name. */
 function isAppColorName(value: unknown): value is AppColorName {
-    return typeof value === 'string' && value in APP_COLOR_PRESETS;
+    return (
+        typeof value === 'string'
+        && Object.prototype.hasOwnProperty.call(APP_COLOR_PRESETS, value)
+    );
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Harden the splash screen theme parsing so malformed or adversarial persisted theme values (e.g. inherited object keys like `toString` / `__proto__`) cannot be treated as valid presets and crash the initial render.

### Description
- Use an own-property check (`Object.prototype.hasOwnProperty.call(APP_COLOR_PRESETS, value)`) instead of the `in` operator in `isAppColorName` so prototype keys are rejected. (file: `packages/frontend/components/AppSplashScreen.tsx`)
- Add defensive optional chaining when reading the preset dark primary token (`APP_COLOR_PRESETS[presetName]?.dark?.['--primary']`) so missing/invalid preset objects fall back safely. (file: `packages/frontend/components/AppSplashScreen.tsx`)

### Testing
- Ran `git diff --check` which passed with no whitespace errors. 
- Attempted `bun run --cwd packages/frontend typecheck` but it failed due to the `tsc` binary being unavailable (no installed dependencies). 
- `bun install` failed due to npm registry HTTP 403 responses, preventing dependency installation so typecheck and lint could not be executed. 
- Lint (`bun run --cwd packages/frontend lint`) could not run because the `expo` binary is not available without installing dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d450adec88323b4d11e5b989cb7d3)