### PR TITLE
feat(frontend): render handle when a user has no display name

### DIFF
--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -52,12 +52,13 @@ const MAX_ALT_TEXT_LENGTH = config.posts.maxAltTextLength;
 const mapActorSummary = (
   userId: string,
   summary: PostActorSummary | undefined,
-): { id: string; displayName: string; handle: string; avatar?: string; verified: boolean } => {
+): { id: string; displayName?: string; handle: string; avatar?: string; verified: boolean } => {
   if (!summary) {
-    return { id: userId, displayName: userId, handle: userId, avatar: undefined, verified: false };
+    return { id: userId, handle: userId, avatar: undefined, verified: false };
   }
   return {
     id: summary.id,
+    // May be absent — the client renders the (always-present) handle instead.
     displayName: summary.displayName,
     handle: summary.handle,
     avatar: summary.avatarUrl,

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -116,7 +116,10 @@ const DEFAULT_PRIVACY = {
  */
 function summaryFromOxyUser(userId: string, userData: OxyUser): CachedUserSummary {
   const username: string = String(userData?.username || userData?.handle || userId);
-  const displayName: string = userData.name.displayName;
+  // May be absent — the renderer falls back to the (always-present) handle. Do
+  // NOT synthesize a name from the handle here; the handle fallback lives once,
+  // client-side, on `PostActorSummary.handle`.
+  const displayName: string | undefined = userData.name?.displayName;
   const profileImage = (userData as { profileImage?: unknown }).profileImage;
   const rawAvatar: string | undefined = typeof userData?.avatar === 'string'
     ? userData.avatar
@@ -1548,7 +1551,9 @@ export class PostHydrationService {
     for (const mentionId of declaredMentionIds) {
       const mentionUser = mentionCache.get(mentionId);
       if (mentionUser) {
-        replacements.set(mentionId, `[@${mentionUser.displayName}](${mentionUser.handle})`);
+        // A mention with no display name renders as `@handle` — never `@undefined`.
+        const mentionLabel = mentionUser.displayName?.trim() || mentionUser.handle;
+        replacements.set(mentionId, `[@${mentionLabel}](${mentionUser.handle})`);
       }
     }
 

--- a/packages/frontend/app/(app)/[username]/connections.tsx
+++ b/packages/frontend/app/(app)/[username]/connections.tsx
@@ -382,7 +382,10 @@ function ConnectionsContent({
     const avatarSource = item?.avatar ?? item.profilePicture;
     const bio = item?.profile?.bio || item?.bio;
     const userId = String(item.id || item._id || item.userID || '');
-    if (!userId || !item.name?.displayName) return null;
+    if (!userId) return null;
+    // A real display name is the bold primary with the muted @handle below; with
+    // no display name the @handle becomes the bold primary, shown ONCE.
+    const hasName = !!item.name?.displayName?.trim();
 
     return (
       <View style={[styles.row, { borderBottomColor: theme.colors.border }]}>
@@ -394,11 +397,13 @@ function ConnectionsContent({
           <Avatar source={avatarSource || undefined} size={48} />
           <View className="ml-3 flex-1">
             <ThemedText className="font-semibold text-base text-foreground" numberOfLines={1}>
-              {item.name.displayName}
+              {hasName ? item.name?.displayName : `@${handle}`}
             </ThemedText>
-            <ThemedText className="pt-0.5 text-sm text-muted-foreground" numberOfLines={1}>
-              @{handle}
-            </ThemedText>
+            {hasName ? (
+              <ThemedText className="pt-0.5 text-sm text-muted-foreground" numberOfLines={1}>
+                @{handle}
+              </ThemedText>
+            ) : null}
             {bio ? (
               <ThemedText className="pt-1 text-sm leading-[18px] text-muted-foreground" numberOfLines={2}>
                 {bio}

--- a/packages/frontend/app/(app)/search/index.tsx
+++ b/packages/frontend/app/(app)/search/index.tsx
@@ -233,7 +233,7 @@ export default function SearchIndex() {
 
     const renderUserItem = useCallback((user: SearchUserResult) => {
         const username = user.username || user.handle || '';
-        if (!username || !user.name?.displayName) return null;
+        if (!username) return null;
         const isFederated = user.isFederated || user.type === 'federated';
         const instance = user.instance || user.federation?.domain;
 

--- a/packages/frontend/components/BoostScreen.tsx
+++ b/packages/frontend/components/BoostScreen.tsx
@@ -152,12 +152,11 @@ const BoostScreen: React.FC = () => {
                         <View className="flex-1">
                             <UserName
                                 name={originalPost.user.displayName}
+                                handle={originalPost.user.handle}
                                 verified={originalPost.user.verified}
                                 variant="small"
+                                style={{ handle: { fontSize: 13 } }}
                             />
-                            {originalPost.user.handle ? (
-                                <Text className="text-muted-foreground text-[13px]">@{originalPost.user.handle}</Text>
-                            ) : null}
                         </View>
                     </View>
                     <Text className="text-foreground text-[15px]" style={{ lineHeight: 20 }}>{originalPost.content}</Text>

--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -567,7 +567,7 @@ const PostItem: React.FC<PostItemProps> = ({
 
     const replyContextHandle = replyContextAuthor?.handle || replyContextAuthor?.displayName;
 
-    const postAuthor = viewPost.user.displayName;
+    const postAuthor = viewPost.user.displayName?.trim() || `@${viewPost.user.handle}`;
     const postTextSummary = content.text
         ? content.text.length > 80
             ? content.text.substring(0, 80) + '...'
@@ -602,7 +602,7 @@ const PostItem: React.FC<PostItemProps> = ({
                     <BoostIcon size={13} color={theme.colors.textSecondary} />
                 </View>
                 <Text className="text-muted-foreground text-[13px] font-semibold" numberOfLines={1}>
-                    {t('post.repostedBy', { defaultValue: 'Reposted by' })} {repostedBy.displayName}
+                    {t('post.repostedBy', { defaultValue: 'Reposted by' })} {repostedBy.displayName?.trim() || `@${repostedBy.handle}`}
                 </Text>
             </TouchableOpacity>,
         );

--- a/packages/frontend/components/MentionPicker.tsx
+++ b/packages/frontend/components/MentionPicker.tsx
@@ -17,7 +17,7 @@ import { logger } from '@/lib/logger';
 export interface MentionUser {
     id: string;
     username: string;
-    displayName: string;
+    displayName?: string;
     avatar?: string;
     verified?: boolean;
 }
@@ -62,14 +62,13 @@ const MentionPicker: React.FC<MentionPickerProps> = ({
                     verified?: boolean;
                 }) => {
                     const username = profile.username || profile.handle || '';
-                    const displayName = profile.name?.displayName;
-                    if (!username || !displayName) {
+                    if (!username) {
                         return [];
                     }
                     return [{
                         id: profile.id || profile._id || username,
                         username,
-                        displayName,
+                        displayName: profile.name?.displayName,
                         avatar: profile.avatar || profile.profilePicture || undefined,
                         verified: profile.verified || false,
                     }];
@@ -117,7 +116,12 @@ const MentionPicker: React.FC<MentionPickerProps> = ({
                     data={users}
                     keyExtractor={(item) => item.id}
                     keyboardShouldPersistTaps="handled"
-                    renderItem={({ item }) => (
+                    renderItem={({ item }) => {
+                        // A real display name is the bold primary with the muted
+                        // @handle below; with no display name the @handle becomes
+                        // the bold primary, shown ONCE.
+                        const hasName = !!item.displayName?.trim();
+                        return (
                         <TouchableOpacity
                             className="border-b-border"
                             style={styles.userItem}
@@ -137,22 +141,25 @@ const MentionPicker: React.FC<MentionPickerProps> = ({
                                         style={styles.userName}
                                         numberOfLines={1}
                                     >
-                                        {item.displayName}
+                                        {hasName ? item.displayName : `@${item.username}`}
                                     </Text>
                                     {item.verified && (
                                         <Text style={styles.verifiedBadge}>✓</Text>
                                     )}
                                 </View>
-                                <Text
-                                    className="text-muted-foreground"
-                                    style={styles.userHandle}
-                                    numberOfLines={1}
-                                >
-                                    @{item.username}
-                                </Text>
+                                {hasName ? (
+                                    <Text
+                                        className="text-muted-foreground"
+                                        style={styles.userHandle}
+                                        numberOfLines={1}
+                                    >
+                                        @{item.username}
+                                    </Text>
+                                ) : null}
                             </View>
                         </TouchableOpacity>
-                    )}
+                        );
+                    }}
                 />
             )}
         </View>

--- a/packages/frontend/components/MentionTextInput.tsx
+++ b/packages/frontend/components/MentionTextInput.tsx
@@ -161,7 +161,7 @@ const MentionTextInput = memo(forwardRef<MentionTextInputHandle, MentionTextInpu
             const newMention: MentionData = {
                 userId: user.id,
                 username: user.username,
-                displayName: user.displayName,
+                displayName: user.displayName?.trim() || user.username,
             };
 
             const updatedMentions = [...mentions, newMention];

--- a/packages/frontend/components/NotificationItem.tsx
+++ b/packages/frontend/components/NotificationItem.tsx
@@ -191,8 +191,11 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
                     setActorName(ensured.name.displayName);
                     setActorAvatar(ensured.avatar ?? undefined);
                 } else if (!cancelled) {
-                    actorCacheRef.current.set(String(id), { name: String(id), avatar: undefined });
-                    setActorName(String(id));
+                    // Could not resolve a profile — leave the name empty so the
+                    // title falls back to the actor handle (or a neutral label),
+                    // never the raw user id.
+                    actorCacheRef.current.set(String(id), { name: '', avatar: undefined });
+                    setActorName('');
                 }
             } catch {
                 // Fallback: keep id or existing
@@ -203,8 +206,15 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
         return () => { cancelled = true; };
     }, [actorName, notification.actorId, oxyServices]);
 
+    // Actor handle, used as the fallback label when no display name resolves —
+    // preferred over a generic word or the raw user id.
+    const actorHandle = useMemo(
+        () => notification.actorId_populated?.username || actorUsernameFrom(notification.actorId) || '',
+        [notification.actorId_populated, notification.actorId],
+    );
+
     const buildTitle = useCallback((type: string, name: string) => {
-        const display = name || transformedNotification.actorName || 'Someone';
+        const display = name || transformedNotification.actorName || (actorHandle ? `@${actorHandle}` : 'Someone');
         switch (type) {
             case 'like':
                 return t('notification.like', { actorName: display });
@@ -228,7 +238,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
             default:
                 return t('notification.like', { actorName: display });
         }
-    }, [t, transformedNotification.actorName]);
+    }, [t, transformedNotification.actorName, actorHandle]);
 
     const getNotificationIcon = (type: string): IoniconName => {
         switch (type) {

--- a/packages/frontend/components/Post/EngagementListSheet.tsx
+++ b/packages/frontend/components/Post/EngagementListSheet.tsx
@@ -16,7 +16,7 @@ import { getNormalizedUserHandle } from '@oxyhq/core';
 
 interface User {
   id: string;
-  displayName: string;
+  displayName?: string;
   handle: string;
   avatar?: string;
   verified: boolean;
@@ -82,6 +82,9 @@ const EngagementListSheet: React.FC<EngagementListSheetProps> = ({ postId, type,
   }, [onClose, router]);
 
   const renderUser = useCallback(({ item }: { item: User }) => {
+    // A real display name is the bold primary with the muted @handle below; with
+    // no display name the @handle becomes the bold primary, shown ONCE.
+    const hasName = !!item.displayName?.trim();
     return (
       <TouchableOpacity
         className="flex-row items-center px-4 py-3"
@@ -92,15 +95,17 @@ const EngagementListSheet: React.FC<EngagementListSheetProps> = ({ postId, type,
         <View className="flex-1">
           <View className="flex-row items-center">
             <Text className="text-foreground text-base font-semibold" numberOfLines={1}>
-              {item.displayName}
+              {hasName ? item.displayName : `@${item.handle}`}
             </Text>
             {item.verified && (
               <Ionicons name="checkmark-circle" size={16} color={theme.colors.primary} style={{ marginLeft: 4 }} />
             )}
           </View>
-          <Text className="text-muted-foreground text-sm mt-0.5" numberOfLines={1}>
-            @{item.handle}
-          </Text>
+          {hasName ? (
+            <Text className="text-muted-foreground text-sm mt-0.5" numberOfLines={1}>
+              @{item.handle}
+            </Text>
+          ) : null}
         </View>
         <Ionicons name="chevron-forward" size={20} color={theme.colors.textSecondary} />
       </TouchableOpacity>

--- a/packages/frontend/components/Post/PostHeader.tsx
+++ b/packages/frontend/components/Post/PostHeader.tsx
@@ -39,7 +39,7 @@ export const HEADER_CONTENT_GAP = 4;
 export const POST_CONTEXT_ROW_HEIGHT = 18;
 
 interface User {
-  displayName: string;
+  displayName?: string;
   handle: string;
   verified?: boolean;
   isFederated?: boolean;
@@ -104,6 +104,7 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   const theme = useTheme();
 
   const timeLabel = useMemo(() => formatTimeAgo(date || ''), [date]);
+  const hasDisplayName = !!user.displayName?.trim();
 
   // `contextTop` rows are the first children of the flex-1 content column, so the
   // name row is pushed down by each fixed-height context row plus the column gap.
@@ -125,15 +126,17 @@ const PostHeader: React.FC<PostHeaderProps> = ({
           <View className="flex-row items-end" style={{ gap: ROW_GAP }}>
             {/* Bluesky-style identity line: the display name takes the space it
                 needs (no width cap); the @handle gives way first (shrinks
-                aggressively); the trailing "\u00B7 time" never wraps and stays visible. */}
+                aggressively); the trailing "\u00B7 time" never wraps and stays visible.
+                With NO display name the @handle becomes the bold primary (rendered
+                ONCE here \u2014 the trailing muted handle is suppressed), never blank. */}
             <View className="flex-row items-end flex-shrink" style={{ minWidth: 0 }}>
               <UserName
-                name={user.displayName}
+                name={hasDisplayName ? user.displayName : (user.handle ? `@${user.handle}` : undefined)}
                 verified={user.verified}
                 onPress={onPressUser}
                 style={{ container: { flexShrink: 0 } }}
               />
-              {user.handle ? (
+              {hasDisplayName && user.handle ? (
                 <Text
                   className="text-muted-foreground text-[15px] leading-tight"
                   style={{ flexShrink: 10, minWidth: 0 }}

--- a/packages/frontend/components/Profile/FollowedByRow.tsx
+++ b/packages/frontend/components/Profile/FollowedByRow.tsx
@@ -31,7 +31,8 @@ export const FollowedByRow = memo(function FollowedByRow({ profileId, username }
       mutuals.map((mutual) => ({
         id: mutual.id,
         uri: mutual.avatar,
-        displayName: mutual.name.displayName,
+        // Fall back to the handle when a mutual has no display name.
+        displayName: mutual.name.displayName?.trim() || mutual.username,
         username: mutual.username,
       })),
     [mutuals],
@@ -43,8 +44,8 @@ export const FollowedByRow = memo(function FollowedByRow({ profileId, username }
     return null;
   }
 
-  const name1 = mutuals[0].name.displayName;
-  const name2 = mutuals[1]?.name.displayName;
+  const name1 = mutuals[0].name.displayName?.trim() || mutuals[0].username;
+  const name2 = mutuals[1] ? (mutuals[1].name.displayName?.trim() || mutuals[1].username) : undefined;
 
   let label: string;
   if (total === 1 || !name2) {

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -50,7 +50,7 @@ export type UserNameComponent = React.ComponentType<UserNameProps>;
 
 // Profile header props (shared between default and minimalist)
 export interface ProfileHeaderBaseProps {
-  displayName: string;
+  displayName?: string;
   username?: string;
   avatarUri?: string;
   verified?: boolean;

--- a/packages/frontend/components/ProfileCard.tsx
+++ b/packages/frontend/components/ProfileCard.tsx
@@ -17,7 +17,7 @@ export interface ProfileCardData {
   id: string;
   username: string;
   name: {
-    displayName: string;
+    displayName?: string;
   };
   avatar?: string | null;
   verified?: boolean;
@@ -45,6 +45,7 @@ export function ProfileCard({
   style,
 }: ProfileCardProps) {
   const router = useRouter();
+  const hasName = !!profile.name?.displayName?.trim();
 
   const handlePress = () => {
     if (onPress) {
@@ -73,19 +74,24 @@ export function ProfileCard({
           verified={profile.verified}
         />
         <View className="flex-1 gap-1">
+          {/* A real display name is the bold primary with the muted @handle below;
+              with no display name the @handle becomes the bold primary, shown
+              ONCE (the muted handle line is suppressed). */}
           <ThemedText
             className="text-base font-semibold"
             style={{ lineHeight: 20 }}
             numberOfLines={1}>
-            {profile.name.displayName}
+            {hasName ? profile.name.displayName : `@${profile.username}`}
           </ThemedText>
           <View className="flex-row items-center gap-1">
-            <ThemedText
-              className="text-muted-foreground text-sm"
-              style={{ lineHeight: 18 }}
-              numberOfLines={1}>
-              @{profile.username}
-            </ThemedText>
+            {hasName && (
+              <ThemedText
+                className="text-muted-foreground text-sm"
+                style={{ lineHeight: 18 }}
+                numberOfLines={1}>
+                @{profile.username}
+              </ThemedText>
+            )}
             {profile.isFederated && (
               <FediverseIcon size={13} className="text-muted-foreground" />
             )}

--- a/packages/frontend/components/UserName.tsx
+++ b/packages/frontend/components/UserName.tsx
@@ -30,12 +30,24 @@ const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated
     // Use a slightly larger nudge for larger fonts (e.g., header titles) to improve visual alignment.
     const baselineNudge = Math.round(effectiveFontSize >= 18 ? effectiveFontSize * 0.18 : effectiveFontSize * 0.06);
 
+    // Single source of truth for the "display name else handle, once" rule:
+    //  - a real display name owns the bold primary slot, with the muted `@handle`
+    //    line trailing below (as before);
+    //  - with NO display name the `@handle` takes the bold primary slot ONCE and
+    //    the separate muted handle line is suppressed (never blank, never doubled);
+    //  - with neither, nothing renders.
+    const hasName = !!name?.trim();
+    const primaryText = hasName ? name : (handle ? `@${handle}` : undefined);
+    const showHandleLine = hasName && !!handle;
+
     const inner = (
         <>
             <View className="gap-1" style={styles.nameRow}>
-                <Text className="text-foreground" style={nameStyle} numberOfLines={1} ellipsizeMode="tail">
-                    {name}
-                </Text>
+                {primaryText != null && (
+                    <Text className="text-foreground" style={nameStyle} numberOfLines={1} ellipsizeMode="tail">
+                        {primaryText}
+                    </Text>
+                )}
                 {verified && (
                     <VerifiedIcon size={iconSize} className={unifiedColors ? "text-foreground" : "text-primary"} style={{ transform: [{ translateY: baselineNudge }] }} />
                 )}
@@ -49,7 +61,7 @@ const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated
                     <AutomatedIcon size={iconSize} className="text-muted-foreground" style={{ transform: [{ translateY: baselineNudge }] }} />
                 )}
             </View>
-            {handle ? (
+            {showHandleLine ? (
                 isFederated ? (
                     <TouchableOpacity activeOpacity={0.7} onPress={handleCopyHandle}>
                         <Text className="text-muted-foreground" style={[styles.handle, style?.handle]} numberOfLines={1} ellipsizeMode="tail">

--- a/packages/frontend/services/feedService.ts
+++ b/packages/frontend/services/feedService.ts
@@ -57,7 +57,7 @@ interface FeedDataEnvelope {
 }
 
 interface PostEngagementUsersResponse {
-  users: Array<{ id: string; displayName: string; handle: string; avatar?: string; verified: boolean }>;
+  users: Array<{ id: string; displayName?: string; handle: string; avatar?: string; verified: boolean }>;
   hasMore: boolean;
   nextCursor?: string;
   totalCount: number;

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -480,7 +480,12 @@ export interface PostFilters {
 export interface PostActorSummary {
   id: string;
   handle: string;
-  displayName: string;
+  /**
+   * Canonical Oxy `name.displayName`. OPTIONAL: an actor may have no display
+   * name (the API may stop synthesizing one). Renderers MUST fall back to the
+   * (always-present) `handle` — never show a blank name or the handle twice.
+   */
+  displayName?: string;
   /**
    * Final, ready-to-render avatar URL resolved server-side — NOT a raw Oxy file
    * id or relative path.


### PR DESCRIPTION
## Summary

- `UserName` renders the handle in the primary slot when no display name is present — never a blank line, never a duplicated handle
- Post header, profile header, profile cards, engagement/follower lists, mentions, notifications, and search/connections all fall back to the `@handle` (or `@user@domain` for federated accounts)
- Removed hide-filters that previously dropped no-name users from lists — federated accounts with no display name now appear correctly
- `PostActorSummary.displayName` and related render types are now optional; `PostHydrationService` passes `displayName` through without synthesizing a fallback
- Stage 1 of the optional-`displayName` rollout; no visible change to the production UI yet (the Oxy API still synthesizes a `displayName` for every user)

## Test plan

- [ ] Backend: 862 vitest tests pass (`bun run test` in `packages/backend`)
- [ ] Frontend: 173 jest tests pass (`bun run test` in `packages/frontend`)
- [ ] Frontend typecheck clean except 3 pre-existing allow-listed `livekit-client` errors (`bun run typecheck` in `packages/frontend`)
- [ ] Lockfile gate: `bun install --frozen-lockfile` passes at repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->