### PR TITLE
refactor(embeds): simplify parser, memoize feed-path parse, centralize embed gate

### DIFF
--- a/packages/frontend/components/Post/Attachments/ExternalEmbedPlayer.native.tsx
+++ b/packages/frontend/components/Post/Attachments/ExternalEmbedPlayer.native.tsx
@@ -60,6 +60,9 @@ export function ExternalEmbedPlayer({
     [params.type, width, thumb],
   );
 
+  // Stable source object so the WebView isn't handed a new `{ uri }` each render.
+  const webViewSource = useMemo(() => ({ uri: params.playerUri }), [params.playerUri]);
+
   const viewRef = useAnimatedRef<Animated.View>();
   const frameCallback = useFrameCallback(() => {
     const measurement = measure(viewRef);
@@ -113,7 +116,7 @@ export function ExternalEmbedPlayer({
     <Animated.View ref={viewRef} collapsable={false} style={[{ width: '100%' }, aspect, styles.surface]}>
       {active ? (
         <WebView
-          source={{ uri: params.playerUri }}
+          source={webViewSource}
           javaScriptEnabled
           allowsInlineMediaPlayback
           mediaPlaybackRequiresUserAction={false}

--- a/packages/frontend/components/Post/Attachments/PostAttachmentExternalEmbed.tsx
+++ b/packages/frontend/components/Post/Attachments/PostAttachmentExternalEmbed.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { StyleSheet, Text, View, type ViewStyle } from 'react-native';
 import { Image } from 'expo-image';
 import { useDialogControl } from '@oxyhq/bloom/dialog';
-import { parseEmbedPlayerFromUrl } from '@/utils/embedPlayer';
+import { parseEmbedPlayerFromUrl, canEmbed } from '@/utils/embedPlayer';
 import { proxyExternalUrl } from '@/utils/imageUrlCache';
 import { useExternalEmbedsStore } from '@/stores/externalEmbedsStore';
 import { ExternalEmbedPlayer } from './ExternalEmbedPlayer';
@@ -66,7 +66,7 @@ const PostAttachmentExternalEmbed: React.FC<PostAttachmentExternalEmbedProps> = 
   const onDeactivate = useCallback(() => setActive(false), []);
 
   // Unsupported provider or a hidden one → fall back to the static link card.
-  if (!params || pref === 'hide') {
+  if (!canEmbed(params, pref)) {
     return (
       <PostAttachmentLink
         url={url}

--- a/packages/frontend/components/Post/PostAttachmentsRow.tsx
+++ b/packages/frontend/components/Post/PostAttachmentsRow.tsx
@@ -32,7 +32,7 @@ import {
   PostAttachmentEvent,
   PostAttachmentRoom,
 } from './Attachments';
-import { parseEmbedPlayerFromUrl } from '@/utils/embedPlayer';
+import { parseEmbedPlayerFromUrl, canEmbed, type EmbedPlayerParams } from '@/utils/embedPlayer';
 import { useExternalEmbedsStore } from '@/stores/externalEmbedsStore';
 
 // Runtime media reference. The server now resolves final URLs (`url`, `thumbUrl`,
@@ -78,7 +78,7 @@ type AttachmentItem =
   | { type: 'event' }
   | { type: 'room' }
   | { type: 'podcast' }
-  | { type: 'link'; url: string; title?: string; description?: string; image?: string; siteName?: string }
+  | { type: 'link'; url: string; title?: string; description?: string; image?: string; siteName?: string; embedParams?: EmbedPlayerParams }
   | { type: 'video'; mediaId: string; src: string; poster?: string }
   | { type: 'gif'; mediaId: string; src: string }
   | { type: 'image'; mediaId: string; src: string; fullSrc: string; mediaType: 'image' | 'gif'; alt?: string };
@@ -171,6 +171,9 @@ const PostAttachmentsRow: React.FC<Props> = React.memo(({
           description: linkMetadata.description,
           image: linkMetadata.image,
           siteName: linkMetadata.siteName,
+          // Parse the embed provider once here (memoized on `linkMetadata`) so
+          // the render loop doesn't run `new URL()` + regex on every frame.
+          embedParams: parseEmbedPlayerFromUrl(linkMetadata.url),
         }
       : null;
     const mediaById = new Map<string, MediaObj>();
@@ -563,9 +566,10 @@ const PostAttachmentsRow: React.FC<Props> = React.memo(({
         if (item.type === 'link') {
           // Embeddable provider URL (and not hidden by the viewer) → render the
           // inline external player as the post's primary media. Otherwise keep
-          // the static link-preview card.
-          const embedParams = parseEmbedPlayerFromUrl(item.url);
-          if (embedParams && embedPrefs[embedParams.source] !== 'hide') {
+          // the static link-preview card. The parse is precomputed on the item;
+          // the pref read stays in render so the decision reacts to pref changes.
+          const embedPref = item.embedParams ? embedPrefs[item.embedParams.source] : undefined;
+          if (canEmbed(item.embedParams, embedPref)) {
             return (
               <PostAttachmentExternalEmbed
                 key={`embed-${idx}`}

--- a/packages/frontend/stores/externalEmbedsStore.ts
+++ b/packages/frontend/stores/externalEmbedsStore.ts
@@ -31,6 +31,11 @@ const logger = createScopedLogger('externalEmbedsStore');
 
 const CACHE_KEY = '@mention_external_embeds';
 
+// `hydrate` fires twice across the auth transition (`canFetch` false→true). The
+// AsyncStorage cache only seeds the initial state, so read it at most once; the
+// authoritative server fetch still runs when `canFetch` becomes true.
+let cacheRead = false;
+
 interface ExternalEmbedsState {
   prefs: ExternalEmbedsSettings;
   /** True once the first hydrate (cache + optional server fetch) has settled. */
@@ -56,13 +61,17 @@ export const useExternalEmbedsStore = create<ExternalEmbedsState>((set, get) => 
 
   async hydrate(canFetch: boolean) {
     // 1. Cache first — fast, offline-safe, and correct for anonymous viewers.
-    try {
-      const cached = await AsyncStorage.getItem(CACHE_KEY);
-      if (cached) {
-        set({ prefs: JSON.parse(cached) as ExternalEmbedsSettings });
+    //    Guarded so the duplicate hydrate on the auth transition doesn't re-read.
+    if (!cacheRead) {
+      cacheRead = true;
+      try {
+        const cached = await AsyncStorage.getItem(CACHE_KEY);
+        if (cached) {
+          set({ prefs: JSON.parse(cached) as ExternalEmbedsSettings });
+        }
+      } catch (error) {
+        logger.debug('Failed to read cached external-embed prefs', { error });
       }
-    } catch (error) {
-      logger.debug('Failed to read cached external-embed prefs', { error });
     }
 
     // 2. Server is authoritative — but only reachable once the private API is up.
@@ -101,11 +110,10 @@ export const useExternalEmbedsStore = create<ExternalEmbedsState>((set, get) => 
 
     try {
       await authenticatedClient.put('/profile/settings', { externalEmbeds: patch });
-      try {
-        await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(next));
-      } catch (error) {
+      // Best-effort cache write — it doesn't gate the mutation, so don't await it.
+      void AsyncStorage.setItem(CACHE_KEY, JSON.stringify(next)).catch((error) => {
         logger.debug('Failed to cache external-embed prefs', { error });
-      }
+      });
     } catch (error) {
       logger.error('Failed to persist external-embed prefs', { error });
       set({ prefs: previous });

--- a/packages/frontend/utils/embedPlayer.ts
+++ b/packages/frontend/utils/embedPlayer.ts
@@ -14,7 +14,7 @@
 
 import { Platform } from 'react-native';
 import { Dimensions } from 'react-native';
-import type { EmbedPlayerSource, EmbedPlayerType } from '@mention/shared-types';
+import type { EmbedPlayerSource, EmbedPlayerType, ExternalEmbedPref } from '@mention/shared-types';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -31,12 +31,7 @@ export interface EmbedPlayerParams {
   playerUri: string;
   isGif?: boolean;
   source: EmbedPlayerSource;
-  metaUri?: string;
   hideDetails?: boolean;
-  dimensions?: {
-    height: number;
-    width: number;
-  };
 }
 
 const giphyRegex = /media(?:[0-4]\.giphy\.com|\.giphy\.com)/i;
@@ -118,45 +113,28 @@ export function parseEmbedPlayerFromUrl(url: string): EmbedPlayerParams | undefi
     }
   }
 
-  // spotify
+  // spotify — the path segment (playlist/album/track/episode/show) names the
+  // embed kind and is reused verbatim in the embed path; `track`/`episode`/`show`
+  // all render as `spotify_song`.
   if (urlp.hostname === 'open.spotify.com') {
     const [, typeOrLocale, idOrType, id] = urlp.pathname.split('/');
 
     if (idOrType) {
-      if (typeOrLocale === 'playlist' || idOrType === 'playlist') {
-        return {
-          type: 'spotify_playlist',
-          source: 'spotify',
-          playerUri: `https://open.spotify.com/embed/playlist/${id ?? idOrType}`,
-        };
-      }
-      if (typeOrLocale === 'album' || idOrType === 'album') {
-        return {
-          type: 'spotify_album',
-          source: 'spotify',
-          playerUri: `https://open.spotify.com/embed/album/${id ?? idOrType}`,
-        };
-      }
-      if (typeOrLocale === 'track' || idOrType === 'track') {
-        return {
-          type: 'spotify_song',
-          source: 'spotify',
-          playerUri: `https://open.spotify.com/embed/track/${id ?? idOrType}`,
-        };
-      }
-      if (typeOrLocale === 'episode' || idOrType === 'episode') {
-        return {
-          type: 'spotify_song',
-          source: 'spotify',
-          playerUri: `https://open.spotify.com/embed/episode/${id ?? idOrType}`,
-        };
-      }
-      if (typeOrLocale === 'show' || idOrType === 'show') {
-        return {
-          type: 'spotify_song',
-          source: 'spotify',
-          playerUri: `https://open.spotify.com/embed/show/${id ?? idOrType}`,
-        };
+      const spotifyEmbedTypes: Record<string, EmbedPlayerType> = {
+        playlist: 'spotify_playlist',
+        album: 'spotify_album',
+        track: 'spotify_song',
+        episode: 'spotify_song',
+        show: 'spotify_song',
+      };
+      for (const [segment, type] of Object.entries(spotifyEmbedTypes)) {
+        if (typeOrLocale === segment || idOrType === segment) {
+          return {
+            type,
+            source: 'spotify',
+            playerUri: `https://open.spotify.com/embed/${segment}/${id ?? idOrType}`,
+          };
+        }
       }
     }
   }
@@ -249,7 +227,6 @@ export function parseEmbedPlayerFromUrl(url: string): EmbedPlayerParams | undefi
           source: 'giphy',
           isGif: true,
           hideDetails: true,
-          metaUri: `https://giphy.com/gifs/${gifId}`,
           playerUri: `https://i.giphy.com/media/${gifId}/200.webp`,
         };
       }
@@ -268,7 +245,6 @@ export function parseEmbedPlayerFromUrl(url: string): EmbedPlayerParams | undefi
           source: 'giphy',
           isGif: true,
           hideDetails: true,
-          metaUri: `https://giphy.com/gifs/${trackingOrId}`,
           playerUri: `https://i.giphy.com/media/${trackingOrId}/200.webp`,
         };
       } else if (filename && gifFilenameRegex.test(filename)) {
@@ -277,35 +253,26 @@ export function parseEmbedPlayerFromUrl(url: string): EmbedPlayerParams | undefi
           source: 'giphy',
           isGif: true,
           hideDetails: true,
-          metaUri: `https://giphy.com/gifs/${idOrFilename}`,
           playerUri: `https://i.giphy.com/media/${idOrFilename}/200.webp`,
         };
       }
     }
   }
 
-  // i.giphy.com direct media links (may end in .webp, not just .gif)
+  // i.giphy.com direct media links (may end in .webp, not just .gif). The path
+  // is either `/media/<file>` or a bare `/<file>`; the gif id is the filename
+  // stem in both cases.
   if (urlp.hostname === 'i.giphy.com' || urlp.hostname === 'www.i.giphy.com') {
     const [, mediaOrFilename, filename] = urlp.pathname.split('/');
+    const gifSegment = mediaOrFilename === 'media' && filename ? filename : mediaOrFilename;
 
-    if (mediaOrFilename === 'media' && filename) {
-      const gifId = filename.split('.')[0];
+    if (gifSegment) {
+      const gifId = gifSegment.split('.')[0];
       return {
         type: 'giphy_gif',
         source: 'giphy',
         isGif: true,
         hideDetails: true,
-        metaUri: `https://giphy.com/gifs/${gifId}`,
-        playerUri: `https://i.giphy.com/media/${gifId}/200.webp`,
-      };
-    } else if (mediaOrFilename) {
-      const gifId = mediaOrFilename.split('.')[0];
-      return {
-        type: 'giphy_gif',
-        source: 'giphy',
-        isGif: true,
-        hideDetails: true,
-        metaUri: `https://giphy.com/gifs/${gifId}`,
         playerUri: `https://i.giphy.com/media/${gifId}/200.webp`,
       };
     }
@@ -449,3 +416,15 @@ export function getPlayerAspect({
       return { aspectRatio: 16 / 9 };
   }
 }
+
+/**
+ * The single embed-vs-link predicate: a URL renders its inline external player
+ * when it maps to a supported provider (`params` parsed) AND the viewer hasn't
+ * hidden that provider (`pref !== 'hide'`). The attachment row's decision and
+ * the embed wrapper's internal guard both route through here so the rule lives
+ * in one place.
+ */
+export const canEmbed = (
+  params: EmbedPlayerParams | undefined,
+  pref: ExternalEmbedPref | undefined,
+): params is EmbedPlayerParams => !!params && pref !== 'hide';


### PR DESCRIPTION
Pure quality cleanups to the External Media Preferences feature (#267). **No behavior change** — every parse, predicate, and persisted state is identical; only structure and render efficiency change. Frontend typecheck is clean (only the 3 pre-existing allow-listed `livekit-client` errors); `bun.lock` is unchanged.

## Changes

**`utils/embedPlayer.ts`**
1. Removed dead `EmbedPlayerParams` fields `metaUri` (only ever written, never read) and `dimensions` (never set or read). Grep-confirmed nothing references them.
2. Deduped the `i.giphy.com` handler — the two near-identical branches now compute the gif id once (`/media/<file>` or bare `/<file>`) and return a single object.
3. Table-drove the 5 Spotify branches into a `{ playlist, album, track, episode, show } → EmbedPlayerType` map iterated in the original order; same match rule (`typeOrLocale === seg || idOrType === seg`), same `playerUri` (`embed/${seg}/${id ?? idOrType}`).
8. Added one shared predicate `canEmbed(params, pref): params is EmbedPlayerParams` (`!!params && pref !== 'hide'`).

**`components/Post/PostAttachmentsRow.tsx`**
4. `parseEmbedPlayerFromUrl` now runs inside the memoized attachment builder (keyed on `linkMetadata`) and is stored on the link item, so the feed render loop no longer runs `new URL()` + regex every frame. The pref read stays in render so the embed-vs-link decision still reacts to preference changes.
8. Decision routed through `canEmbed`.

**`components/Post/Attachments/PostAttachmentExternalEmbed.tsx`**
8. Internal `!params || pref === 'hide'` guard replaced with `!canEmbed(params, pref)` — the rule now lives in one place. The `PostAttachmentLink` fallback is unchanged.

**`components/Post/Attachments/ExternalEmbedPlayer.native.tsx`**
5. Memoized the WebView `source` object (`useMemo(() => ({ uri: params.playerUri }), [params.playerUri])`).

**`stores/externalEmbedsStore.ts`**
6. `hydrate()` reads the AsyncStorage cache at most once across the `canUsePrivateApi` false→true transition (module guard flag); the authoritative server fetch still runs when `canFetch` becomes true. Resulting state unchanged.
7. The post-PUT cache write in `setManyPrefs` is now non-blocking (`void … .catch(logger.debug)`); the PUT stays awaited and the optimistic update + rollback are untouched.

## Out of scope (left as-is)
`setPref`, the settings-store/hydration architecture, the `externalEmbeds?` wire type in `usePrivacySettings.ts`, and all backend files.

Refs #267