### PR TITLE
fix(thread): stamp threadId on self-thread root so feeds group it

### DIFF
--- a/packages/backend/src/__tests__/controllers/createThreadChain.test.ts
+++ b/packages/backend/src/__tests__/controllers/createThreadChain.test.ts
@@ -92,9 +92,11 @@ describe('createThread — sequential chain linkage', () => {
     const id0 = String(post0._id);
     const id1 = String(post1._id);
 
-    // Root post: no parent, no thread link.
+    // Root post: no parent, but it ANCHORS the thread on its own id so the whole
+    // self-thread (root included) shares one threadId — this is what lets
+    // ThreadSlicingService recognise the root and connect the slice.
     expect(post0.parentPostId).toBeUndefined();
-    expect(post0.threadId).toBeUndefined();
+    expect(post0.threadId).toBe(id0);
 
     // Post 1 chains onto post 0; thread root is post 0.
     expect(post1.parentPostId).toBe(id0);
@@ -103,6 +105,27 @@ describe('createThread — sequential chain linkage', () => {
     // Post 2 chains onto post 1 (NOT post 0 — the fan-out bug); thread root stays post 0.
     expect(post2.parentPostId).toBe(id1);
     expect(post2.threadId).toBe(id0);
+  });
+
+  it('leaves a single-post thread-mode call unlinked (no threadId on the lone root)', async () => {
+    const req = {
+      user: { id: 'author_1' },
+      body: {
+        mode: 'thread',
+        posts: [{ content: { text: 'Solo post' } }],
+      },
+    };
+
+    const { res, payload } = buildResponse();
+    await createThread(req as never, res as never);
+
+    expect(payload.status).toBe(201);
+    const posts = payload.value?.posts ?? [];
+    expect(posts).toHaveLength(1);
+
+    // A 1-post "thread" has no continuations to connect, so the root is NOT anchored.
+    expect(posts[0].parentPostId).toBeUndefined();
+    expect(posts[0].threadId).toBeUndefined();
   });
 
   it('does not link beast-mode posts (each post is independent)', async () => {

--- a/packages/backend/src/__tests__/scripts/backfillThreadRootThreadId.test.ts
+++ b/packages/backend/src/__tests__/scripts/backfillThreadRootThreadId.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+
+/**
+ * Offline, model-level tests for the self-thread root `threadId` backfill.
+ *
+ * `Post.aggregate` (candidate single-author thread groups) and `Post.find` (root
+ * existence/state/ownership lookup) are mocked with canned shapes, and
+ * `Post.bulkWrite` is captured. This exercises the REAL qualification guards
+ * (existence, native, top-level, not-already-stamped, ownership) and the per-root
+ * stamp WITHOUT depending on MongoDB's `$group` semantics (which the aggregation,
+ * not this script, owns). Mirrors `scripts/migrateThreadFanToChain.test.ts`.
+ */
+
+interface CapturedOp {
+  updateOne: { filter: { _id: mongoose.Types.ObjectId }; update: { $set: { threadId: string } } };
+}
+
+interface CandidateGroup {
+  _id: string;
+  count: number;
+  authors: string[];
+}
+
+interface RootRow {
+  _id: mongoose.Types.ObjectId;
+  oxyUserId?: string;
+  parentPostId?: string | null;
+  threadId?: string | null;
+  federation?: { activityId?: string };
+}
+
+const h = vi.hoisted(() => {
+  const state: {
+    candidates: CandidateGroup[];
+    roots: RootRow[];
+    capturedOps: CapturedOp[];
+  } = { candidates: [], roots: [], capturedOps: [] };
+
+  const aggregate = vi.fn(async () => state.candidates);
+
+  const find = vi.fn((query: Record<string, any>) => ({
+    lean: async () => {
+      const inClause = query?._id?.$in as mongoose.Types.ObjectId[] | undefined;
+      if (!Array.isArray(inClause)) return [];
+      const wanted = new Set(inClause.map((id) => id.toString()));
+      return state.roots.filter((r) => wanted.has(r._id.toString()));
+    },
+  }));
+
+  const bulkWrite = vi.fn(async (ops: CapturedOp[]) => {
+    state.capturedOps.push(...ops);
+    return { modifiedCount: ops.length };
+  });
+
+  return { state, aggregate, find, bulkWrite };
+});
+
+vi.mock('../../models/Post', () => ({
+  Post: { aggregate: h.aggregate, find: h.find, bulkWrite: h.bulkWrite },
+}));
+
+vi.mock('../../utils/database', () => ({
+  connectToDatabase: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.spyOn(mongoose, 'disconnect').mockResolvedValue(undefined as never);
+
+import backfillThreadRootThreadId from '../../scripts/backfillThreadRootThreadId';
+
+/**
+ * Build a candidate thread group plus its (optional) root row. `author` is the
+ * single continuation author the aggregation collected; the root defaults to the
+ * same author, native, top-level, with a null threadId (the broken-root shape).
+ */
+function makeThread(opts: {
+  author: string;
+  rootAuthor?: string;
+  rootThreadId?: string | null;
+  rootParentPostId?: string | null;
+  rootFederation?: { activityId?: string };
+  rootMissing?: boolean;
+  count?: number;
+}): { rootId: string; group: CandidateGroup; rootRow?: RootRow } {
+  const root = new mongoose.Types.ObjectId();
+  const rootId = root.toString();
+  const group: CandidateGroup = {
+    _id: rootId,
+    count: opts.count ?? 2,
+    authors: [opts.author],
+  };
+  const rootRow = opts.rootMissing
+    ? undefined
+    : {
+        _id: root,
+        oxyUserId: opts.rootAuthor ?? opts.author,
+        parentPostId: opts.rootParentPostId ?? null,
+        threadId: opts.rootThreadId ?? null,
+        federation: opts.rootFederation,
+      };
+  return { rootId, group, rootRow };
+}
+
+beforeEach(() => {
+  h.state.candidates = [];
+  h.state.roots = [];
+  h.state.capturedOps = [];
+  h.aggregate.mockClear();
+  h.find.mockClear();
+  h.bulkWrite.mockClear();
+});
+
+describe('backfillThreadRootThreadId', () => {
+  it('stamps threadId = root._id on a native single-author self-thread root with null threadId', async () => {
+    const { rootId, group, rootRow } = makeThread({ author: 'user-A' });
+    h.state.candidates = [group];
+    h.state.roots = rootRow ? [rootRow] : [];
+
+    await backfillThreadRootThreadId();
+
+    expect(h.state.capturedOps).toHaveLength(1);
+    const op = h.state.capturedOps[0];
+    expect(op.updateOne.filter._id.toString()).toBe(rootId);
+    expect(op.updateOne.update.$set.threadId).toBe(rootId);
+  });
+
+  it('is idempotent: a root that already carries a threadId is not re-stamped', async () => {
+    // Second-run state: the root was stamped on a prior run, so its threadId is set.
+    const { rootId, group, rootRow } = makeThread({ author: 'user-A' });
+    if (rootRow) rootRow.threadId = rootId;
+    h.state.candidates = [group];
+    h.state.roots = rootRow ? [rootRow] : [];
+
+    await backfillThreadRootThreadId();
+
+    expect(h.state.capturedOps).toHaveLength(0);
+  });
+
+  it('skips a thread whose continuations are by a different author than the root (reply tree)', async () => {
+    // The single continuation author is user-B, but the root belongs to user-A:
+    // a reply tree under someone else's post, NOT a self-thread.
+    const { group, rootRow } = makeThread({ author: 'user-B', rootAuthor: 'user-A' });
+    h.state.candidates = [group];
+    h.state.roots = rootRow ? [rootRow] : [];
+
+    await backfillThreadRootThreadId();
+
+    expect(h.state.capturedOps).toHaveLength(0);
+    expect(h.bulkWrite).not.toHaveBeenCalled();
+  });
+
+  it('skips a thread whose root is missing (cannot verify ownership)', async () => {
+    const { group } = makeThread({ author: 'user-A', rootMissing: true });
+    h.state.candidates = [group];
+    h.state.roots = [];
+
+    await backfillThreadRootThreadId();
+
+    expect(h.state.capturedOps).toHaveLength(0);
+  });
+
+  it('skips a federated root (federation.activityId present)', async () => {
+    const { group, rootRow } = makeThread({
+      author: 'user-A',
+      rootFederation: { activityId: 'https://remote.example/activities/1' },
+    });
+    h.state.candidates = [group];
+    h.state.roots = rootRow ? [rootRow] : [];
+
+    await backfillThreadRootThreadId();
+
+    expect(h.state.capturedOps).toHaveLength(0);
+  });
+
+  it('skips a root that is itself a reply (has a parentPostId)', async () => {
+    const { group, rootRow } = makeThread({ author: 'user-A', rootParentPostId: 'some-parent-id' });
+    h.state.candidates = [group];
+    h.state.roots = rootRow ? [rootRow] : [];
+
+    await backfillThreadRootThreadId();
+
+    expect(h.state.capturedOps).toHaveLength(0);
+  });
+
+  it('does nothing when there are no candidate threads', async () => {
+    h.state.candidates = [];
+
+    await backfillThreadRootThreadId();
+
+    expect(h.find).not.toHaveBeenCalled();
+    expect(h.bulkWrite).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing in DRY_RUN mode', async () => {
+    // DRY_RUN is read once at module load, so re-import the script with the env set.
+    vi.stubEnv('DRY_RUN', 'true');
+    vi.resetModules();
+    const { default: dryRunBackfill } = await import('../../scripts/backfillThreadRootThreadId');
+
+    const { group, rootRow } = makeThread({ author: 'user-A' });
+    h.state.candidates = [group];
+    h.state.roots = rootRow ? [rootRow] : [];
+
+    await dryRunBackfill();
+
+    expect(h.state.capturedOps).toHaveLength(0);
+    expect(h.bulkWrite).not.toHaveBeenCalled();
+
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+});

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -923,6 +923,17 @@ export const createThread = async (req: AuthRequest, res: Response) => {
         } : {})
       });
 
+      // Thread mode: the ROOT post (i === 0) anchors the thread on its OWN _id so
+      // the whole self-thread — root included — shares one threadId. This is what
+      // lets ThreadSlicingService recognise the root (threadId set, no
+      // parentPostId) and pull its same-author continuations into a single
+      // connected slice; without it the root never matches and the thread renders
+      // as loose posts. Mongoose assigns _id at construction, so it is available
+      // here. Single-post "threads" and beast mode stay unlinked.
+      if (mode === 'thread' && i === 0 && posts.length > 1) {
+        post.threadId = String(post._id);
+      }
+
       await post.save();
 
       if (pendingArticleDoc) {

--- a/packages/backend/src/scripts/backfillThreadRootThreadId.ts
+++ b/packages/backend/src/scripts/backfillThreadRootThreadId.ts
@@ -1,0 +1,269 @@
+/**
+ * One-shot repair: stamp `threadId = root._id` on existing native self-thread
+ * ROOTS that currently lack it.
+ *
+ * THE BUG (now fixed going forward in `createThread`): a compose thread's ROOT
+ * post (i === 0) was created with NO `threadId` — only the continuations (i > 0)
+ * received `threadId = <root id>`. `ThreadSlicingService.sliceFeed` groups a
+ * self-thread into one connected slice ONLY when it finds a thread ROOT matching
+ * `post.threadId && !post.parentPostId`, then pulls its same-author continuations
+ * via `fetchThreadChildren`. Because the root's `threadId` was null, the root
+ * never matched, no children were fetched, and the thread rendered as loose,
+ * ungrouped posts. The canonical correct shape (which the continuations and the
+ * native reply path already assume) is: EVERY member of a self-thread — INCLUDING
+ * the root — shares `threadId === root._id`. The root is the only member that was
+ * missing it.
+ *
+ * THE REPAIR: for each broken root, set `threadId = <its own _id>`. This is purely
+ * ADDITIVE and ROOT-ONLY — `parentPostId` and the continuations are NEVER touched.
+ *
+ * SAFETY — a non-null `threadId` does NOT uniquely identify a self-thread: the
+ * native reply path (`feed.controller.createReply`) ALSO stamps
+ * `threadId = parentPost.threadId ?? parentPost._id` on every reply, and the
+ * federated reply backfill stamps it too. Stamping the root of an arbitrary reply
+ * tree (e.g. "user B replied N times under user A's post") would wrongly fold an
+ * unrelated author's posts into a single connected slice. To touch ONLY genuine
+ * native self-thread roots, a root qualifies for the stamp iff ALL of the
+ * following hold:
+ *   1. SINGLE AUTHOR — every native member sharing its `threadId` has one
+ *      `oxyUserId` (a self-thread is authored entirely by the thread creator; this
+ *      excludes multi-user reply trees).
+ *   2. ROOT EXISTS — the post `_id === threadId` is present.
+ *   3. NATIVE — the root has no `federation.activityId` (the bug + forward fix are
+ *      native-`createThread`-only; federated threads are structured via inReplyTo).
+ *   4. TRUE TOP-LEVEL — the root has no `parentPostId` (it is the head of the
+ *      thread, not itself a reply).
+ *   5. NOT-ALREADY-STAMPED — the root's `threadId` is currently null/absent. A root
+ *      already carrying a `threadId` (e.g. a post created after the forward fix) is
+ *      left untouched. This is what makes the script IDEMPOTENT — a second run finds
+ *      every previously-stamped root non-null and skips it.
+ *   6. OWNERSHIP — the root's `oxyUserId` equals that single continuation author.
+ *      Excludes "user replied to someone else's post N times" — only a root authored
+ *      by the same person as its continuations is a real self-thread.
+ *
+ * Because feeds select top-level posts by `parentPostId` absence (NEVER by
+ * `threadId`), stamping the root's `threadId` keeps it in every feed unchanged; it
+ * only enables `ThreadSlicingService` to recognise the root and connect the slice,
+ * and (incidentally) improves `FeedRankingService` author-diversity dedup. Counts,
+ * content, `parentPostId`, and all continuations are deliberately left untouched.
+ *
+ * Runnable as a Fargate one-shot post-deploy (DRY_RUN first):
+ *   DRY_RUN=true bun packages/backend/dist/src/scripts/backfillThreadRootThreadId.js
+ *   bun packages/backend/dist/src/scripts/backfillThreadRootThreadId.js
+ */
+
+import mongoose from 'mongoose';
+import { Post } from '../models/Post';
+import { connectToDatabase } from '../utils/database';
+import { logger } from '../utils/logger';
+
+/** Root posts fetched per `$in` chunk when verifying ownership / current state. */
+const ROOT_FETCH_CHUNK_SIZE = 500;
+
+/** `threadId` stamp writes flushed per `bulkWrite` chunk. */
+const BULK_CHUNK_SIZE = 500;
+
+/** Candidate groups reported per progress line. */
+const PROGRESS_EVERY = 500;
+
+const DRY_RUN = process.env.DRY_RUN === 'true';
+
+/** A candidate single-author thread group from the aggregation. */
+interface CandidateThreadGroup {
+  /** The shared `threadId` (the root post's id, as a string). */
+  _id: string;
+  count: number;
+  authors: string[];
+}
+
+/** Minimal root-post projection used to qualify a stamp. */
+interface RootRow {
+  _id: mongoose.Types.ObjectId;
+  oxyUserId?: string;
+  parentPostId?: string | null;
+  threadId?: string | null;
+  federation?: { activityId?: string };
+}
+
+/**
+ * Find candidate threads: NATIVE members (no `federation.activityId`) carrying a
+ * non-null `threadId`, grouped by `threadId`, keeping only groups with EXACTLY ONE
+ * distinct author. Root existence/state/ownership is verified separately. Roots are
+ * NOT members of these groups when their own `threadId` is null (the broken case),
+ * so the group's author set reflects the continuations.
+ */
+function buildCandidatePipeline(): mongoose.PipelineStage[] {
+  return [
+    {
+      $match: {
+        threadId: { $ne: null },
+        // Native posts only — federated posts carry `federation.activityId`.
+        'federation.activityId': { $exists: false },
+      },
+    },
+    {
+      $group: {
+        _id: '$threadId',
+        count: { $sum: 1 },
+        authors: { $addToSet: '$oxyUserId' },
+      },
+    },
+    {
+      $match: {
+        // Exactly one distinct author (a second author would expose `authors.1`).
+        'authors.1': { $exists: false },
+      },
+    },
+  ];
+}
+
+/**
+ * Batch-fetch the root posts (`_id === threadId`) for the candidate threads and
+ * return a map of rootId string -> root projection. Threads whose root is absent
+ * from this map fail existence verification and are skipped.
+ */
+async function loadRoots(threadIds: string[]): Promise<Map<string, RootRow>> {
+  const rootById = new Map<string, RootRow>();
+  const validObjectIds = threadIds
+    .filter((id) => mongoose.Types.ObjectId.isValid(id))
+    .map((id) => new mongoose.Types.ObjectId(id));
+
+  for (let i = 0; i < validObjectIds.length; i += ROOT_FETCH_CHUNK_SIZE) {
+    const chunk = validObjectIds.slice(i, i + ROOT_FETCH_CHUNK_SIZE);
+    const roots = await Post.find(
+      { _id: { $in: chunk } },
+      { _id: 1, oxyUserId: 1, parentPostId: 1, threadId: 1, federation: 1 },
+    ).lean<RootRow[]>();
+    for (const root of roots) {
+      rootById.set(root._id.toString(), root);
+    }
+  }
+
+  return rootById;
+}
+
+async function backfillThreadRootThreadId(): Promise<void> {
+  const startedAt = Date.now();
+
+  await connectToDatabase();
+  logger.info(`[backfillThreadRootThreadId] connected to MongoDB; DRY_RUN=${DRY_RUN}`);
+
+  const candidates = await Post.aggregate<CandidateThreadGroup>(buildCandidatePipeline());
+  logger.info(
+    `[backfillThreadRootThreadId] ${candidates.length} candidate single-author native thread groups`,
+  );
+
+  if (candidates.length === 0) {
+    logger.info('[backfillThreadRootThreadId] nothing to do');
+    return;
+  }
+
+  const rootById = await loadRoots(candidates.map((c) => c._id));
+
+  let groupsScanned = 0;
+  let rootsStampedPlanned = 0;
+  let rootsStampedWritten = 0;
+  let skippedRootMissing = 0;
+  let skippedRootFederated = 0;
+  let skippedRootHasParent = 0;
+  let skippedRootAlreadyStamped = 0;
+  let skippedOwnership = 0;
+  let pendingOps: mongoose.AnyBulkWriteOperation<typeof Post>[] = [];
+
+  const flush = async (): Promise<void> => {
+    if (pendingOps.length === 0) return;
+    if (DRY_RUN) {
+      pendingOps = [];
+      return;
+    }
+    const result = await Post.bulkWrite(pendingOps, { ordered: false });
+    rootsStampedWritten += result.modifiedCount;
+    pendingOps = [];
+  };
+
+  for (const group of candidates) {
+    groupsScanned += 1;
+    const threadId = group._id;
+    const author = group.authors[0];
+
+    const root = rootById.get(threadId);
+
+    // The root (_id === threadId) must exist.
+    if (root === undefined) {
+      skippedRootMissing += 1;
+      continue;
+    }
+    // ...be native (federated threads are structured via inReplyTo, not threadId).
+    if (root.federation?.activityId !== undefined) {
+      skippedRootFederated += 1;
+      continue;
+    }
+    // ...be a true top-level post (the head of the thread, not itself a reply).
+    if (root.parentPostId !== null && root.parentPostId !== undefined) {
+      skippedRootHasParent += 1;
+      continue;
+    }
+    // ...currently lack a threadId (idempotency: a root already carrying one — e.g.
+    // a post created after the forward fix — is left untouched).
+    if (root.threadId !== null && root.threadId !== undefined) {
+      skippedRootAlreadyStamped += 1;
+      continue;
+    }
+    // ...and be authored by the SAME single author as its continuations (ownership:
+    // excludes reply trees where others replied under someone else's post).
+    if (root.oxyUserId !== author) {
+      skippedOwnership += 1;
+      continue;
+    }
+
+    rootsStampedPlanned += 1;
+    pendingOps.push({
+      updateOne: {
+        filter: { _id: root._id },
+        update: { $set: { threadId: root._id.toString() } },
+      },
+    });
+
+    if (pendingOps.length >= BULK_CHUNK_SIZE) {
+      await flush();
+    }
+
+    if (groupsScanned % PROGRESS_EVERY === 0) {
+      logger.info(
+        `[backfillThreadRootThreadId] progress: scanned ${groupsScanned}/${candidates.length} groups, roots stamped ${rootsStampedPlanned}`,
+      );
+    }
+  }
+
+  await flush();
+
+  const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+  logger.info(
+    `[backfillThreadRootThreadId] done${DRY_RUN ? ' (DRY_RUN — no writes)' : ''}: ` +
+      `candidate groups ${candidates.length}, ` +
+      `roots stamped ${DRY_RUN ? `${rootsStampedPlanned} (planned)` : `${rootsStampedWritten} written / ${rootsStampedPlanned} planned`}, ` +
+      `skipped (root missing) ${skippedRootMissing}, (federated) ${skippedRootFederated}, ` +
+      `(has parent) ${skippedRootHasParent}, (already stamped) ${skippedRootAlreadyStamped}, ` +
+      `(ownership) ${skippedOwnership} (${elapsedSeconds}s)`,
+  );
+}
+
+async function run(): Promise<void> {
+  try {
+    await backfillThreadRootThreadId();
+    await mongoose.disconnect();
+    // Exit explicitly: imported model/service modules may hold open handles
+    // (Redis/BullMQ singletons) that would otherwise keep the process alive.
+    process.exit(0);
+  } catch (error) {
+    logger.error('[backfillThreadRootThreadId] failed', error);
+    await mongoose.disconnect().catch(() => undefined);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  run();
+}
+
+export default backfillThreadRootThreadId;


### PR DESCRIPTION
## Summary

- `createThread` was building the thread root post with no `threadId` set, so `ThreadSlicingService` could never group it as a connected thread (the slicer requires root to match `threadId && !parentPostId`).
- Thread root now anchors itself by setting `threadId` to its own `_id` when the thread contains more than one post (multi-post thread mode).
- Adds `backfillThreadRootThreadId` one-shot script to stamp existing native single-author thread roots that were created without a `threadId` (ownership-gated, additive, idempotent, supports `DRY_RUN`).

## Test plan

- [ ] Unit tests for `createThreadChain` controller path (`packages/backend/src/__tests__/controllers/createThreadChain.test.ts`)
- [ ] Unit tests for the backfill script (`packages/backend/src/__tests__/scripts/backfillThreadRootThreadId.test.ts`)
- [ ] Compose a multi-post thread and verify it renders as a connected thread in the feed
- [ ] Run backfill script in `DRY_RUN=true` mode against prod to confirm expected root count before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)