### PR TITLE
feat(thread): show replies across the whole self-thread spine on /p/[id]

### DIFF
--- a/packages/backend/src/__tests__/controllers/getRepliesFeedSpine.test.ts
+++ b/packages/backend/src/__tests__/controllers/getRepliesFeedSpine.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+
+/**
+ * Unit coverage for {@link FeedController.getRepliesFeed}'s self-thread spine
+ * expansion (Bluesky-style replies).
+ *
+ * When the parent post is a self-thread ROOT (`threadId === <its own id>`), the
+ * replies feed must surface external replies to ANY node of the OP's continuation
+ * spine (root … cN), not just the root's direct children — while EXCLUDING the OP's
+ * own continuations (those are rendered as the connected spine on the client). For
+ * any other parent the query is the single-parent match, unchanged.
+ *
+ * The controller pulls in the server bootstrap + hydration/Oxy layers; stub those so
+ * the test stays pure and never touches a DB or the network. `Post.findById`/
+ * `Post.find` are spied so we can assert on the EXACT Mongo query the controller
+ * builds.
+ */
+vi.mock('../../../server', () => ({
+  oxy: {},
+  io: { of: () => ({ emit: vi.fn() }) },
+  notificationsNamespace: { emit: vi.fn() },
+  roomsNamespace: { emit: vi.fn() },
+}));
+
+vi.mock('../../services/PostHydrationService', () => ({
+  // Passthrough hydration — the query shape we assert on is built before hydration,
+  // so return the documents unchanged (they already carry `id` + `user.id`).
+  postHydrationService: { hydratePosts: vi.fn(async (objs: object[]) => objs) },
+  resolveUserSummaries: vi.fn(async () => new Map()),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createScopedOxyClient: vi.fn(() => ({})),
+}));
+
+import { Post } from '../../models/Post';
+import { feedController } from '../../controllers/feed.controller';
+
+const ROOT_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const C1_ID = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+const C2_ID = 'cccccccccccccccccccccccc';
+const PLAIN_ID = 'dddddddddddddddddddddddd';
+const OP_USER = 'op_user_1';
+
+type AnyQuery = Record<string, unknown>;
+
+/**
+ * A minimal chainable Mongoose-query stub: every chain method returns itself and
+ * `.lean()` resolves to the supplied result, matching the
+ * `.select().sort().limit().maxTimeMS().lean()` call shape the controller uses.
+ */
+function chain(result: unknown) {
+  const q: Record<string, unknown> = {};
+  for (const method of ['select', 'sort', 'limit', 'maxTimeMS']) {
+    q[method] = vi.fn(() => q);
+  }
+  q.lean = vi.fn(() => Promise.resolve(result));
+  return q;
+}
+
+function buildResponse() {
+  const payload: { value?: unknown; status?: number } = {};
+  const res = {
+    status(code: number) {
+      payload.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      payload.value = body;
+      return this;
+    },
+  };
+  return { res, payload };
+}
+
+/**
+ * Wire `Post.findById` to return `parent` and route the two distinct `Post.find`
+ * calls (spine query vs. replies query) by inspecting the filter: the spine query is
+ * the only one carrying a `threadId` clause. Returns the captured find filters.
+ */
+function stubModel(parent: AnyQuery | null) {
+  const replyDocs = [{ _id: 'r1', id: 'r1', user: { id: 'other_user' } }];
+  const continuationDocs = [{ _id: C1_ID }, { _id: C2_ID }];
+  const findFilters: AnyQuery[] = [];
+
+  vi.spyOn(Post, 'findById').mockImplementation(((): unknown => chain(parent)) as never);
+  vi.spyOn(Post, 'find').mockImplementation(((filter: AnyQuery): unknown => {
+    findFilters.push(filter);
+    if (filter && 'threadId' in filter) return chain(continuationDocs);
+    return chain(replyDocs);
+  }) as never);
+
+  return { findFilters, replyDocs };
+}
+
+describe('getRepliesFeed — self-thread spine expansion', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('expands a self-thread root into its whole spine and excludes the OP continuations', async () => {
+    const { findFilters } = stubModel({ _id: ROOT_ID, threadId: ROOT_ID, oxyUserId: OP_USER });
+
+    const req = { query: {}, params: { parentId: ROOT_ID } };
+    const { res, payload } = buildResponse();
+    await feedController.getRepliesFeed(req as never, res as never);
+
+    // The spine query was issued (single source of truth, keyed by threadId).
+    const spineFilter = findFilters.find((f) => 'threadId' in f);
+    expect(spineFilter).toBeDefined();
+    expect(spineFilter?.threadId).toBe(ROOT_ID);
+    expect(spineFilter?.oxyUserId).toBe(OP_USER);
+
+    // The replies query matches replies to the ROOT and every continuation …
+    const repliesFilter = findFilters.find((f) => !('threadId' in f));
+    expect(repliesFilter?.parentPostId).toEqual({ $in: [ROOT_ID, C1_ID, C2_ID] });
+
+    // … while excluding the OP's own continuations by id (they render as the spine).
+    const idClause = repliesFilter?._id as { $nin?: mongoose.Types.ObjectId[] };
+    expect(idClause?.$nin?.map(String)).toEqual([C1_ID, C2_ID]);
+
+    // Response shape unchanged.
+    expect((payload.value as { items: unknown[] }).items).toHaveLength(1);
+  });
+
+  it('merges the pagination cursor with the continuation exclusion on _id', async () => {
+    const { findFilters } = stubModel({ _id: ROOT_ID, threadId: ROOT_ID, oxyUserId: OP_USER });
+
+    const cursorId = new mongoose.Types.ObjectId();
+    const req = { query: { cursor: String(cursorId) }, params: { parentId: ROOT_ID } };
+    const { res } = buildResponse();
+    await feedController.getRepliesFeed(req as never, res as never);
+
+    const repliesFilter = findFilters.find((f) => !('threadId' in f));
+    const idClause = repliesFilter?._id as { $nin?: mongoose.Types.ObjectId[]; $lt?: mongoose.Types.ObjectId };
+    expect(idClause?.$nin?.map(String)).toEqual([C1_ID, C2_ID]);
+    expect(String(idClause?.$lt)).toBe(String(cursorId));
+  });
+
+  it('leaves a non-root parent as a single-parent query (no spine, no _id exclusion)', async () => {
+    // A reply / mid-thread continuation: threadId points at the ROOT, not itself.
+    const { findFilters } = stubModel({ _id: PLAIN_ID, threadId: ROOT_ID, oxyUserId: OP_USER });
+
+    const req = { query: {}, params: { parentId: PLAIN_ID } };
+    const { res } = buildResponse();
+    await feedController.getRepliesFeed(req as never, res as never);
+
+    // No spine query was issued.
+    expect(findFilters.some((f) => 'threadId' in f)).toBe(false);
+
+    const repliesFilter = findFilters.find((f) => !('threadId' in f));
+    expect(repliesFilter?.parentPostId).toBe(PLAIN_ID);
+    expect(repliesFilter?._id).toBeUndefined();
+  });
+
+  it('treats a parent with no threadId as a plain post (single-parent query)', async () => {
+    const { findFilters } = stubModel({ _id: PLAIN_ID, oxyUserId: OP_USER });
+
+    const req = { query: {}, params: { parentId: PLAIN_ID } };
+    const { res } = buildResponse();
+    await feedController.getRepliesFeed(req as never, res as never);
+
+    expect(findFilters.some((f) => 'threadId' in f)).toBe(false);
+    const repliesFilter = findFilters.find((f) => !('threadId' in f));
+    expect(repliesFilter?.parentPostId).toBe(PLAIN_ID);
+    expect(repliesFilter?._id).toBeUndefined();
+  });
+});

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -1854,6 +1854,39 @@ class FeedController {
    */
   // Debug method removed for production
 
+  /**
+   * Resolve the ordered self-thread continuation documents for a self-thread root.
+   *
+   * Single source of truth for the spine query shared by BOTH
+   * {@link getThreadContinuations} (renders the connected spine on the post-detail
+   * screen) and {@link getRepliesFeed} (expands a root into its whole spine so
+   * external replies to ANY spine node surface — Bluesky behavior). The match shape
+   * mirrors ThreadSlicingService.fetchThreadChildren: every post in this thread by
+   * the SAME author that hangs off the chain (`parentPostId` present), public +
+   * published, in chronological (= thread) order, capped at
+   * MAX_THREAD_CONTINUATION_DEPTH.
+   *
+   * Returns the lean documents (not just ids) so the continuation endpoint hydrates
+   * them in a single query, while the replies feed maps them to ids — avoiding the
+   * extra round-trip an id-only helper would force on `getThreadContinuations`. The
+   * caller must already have verified `root` is a self-thread root
+   * (`root.threadId === String(root._id)`).
+   */
+  private getSelfThreadContinuations(root: Pick<IPost, 'oxyUserId' | 'threadId'>) {
+    return Post.find({
+      threadId: String(root.threadId),
+      oxyUserId: root.oxyUserId,
+      parentPostId: { $ne: null, $exists: true },
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+    })
+      .select(this.FEED_FIELDS)
+      .sort({ createdAt: 1 })
+      .limit(MAX_THREAD_CONTINUATION_DEPTH)
+      .maxTimeMS(FEED_CONSTANTS.QUERY_TIMEOUT_MS)
+      .lean();
+  }
+
   async getRepliesFeed(req: AuthRequest, res: Response) {
     try {
       const nestedFilters = req.query.filters as ParsedQs | undefined;
@@ -1869,15 +1902,47 @@ class FeedController {
       const sort = req.query.sort as string | undefined;
       const cursor = req.query.cursor as string | undefined;
 
+      // Detect whether the parent is a self-thread ROOT. A self-thread root anchors
+      // its own id as `threadId` (see createThread); for such a post the replies feed
+      // must surface external replies to ANY node of the OP's continuation spine
+      // (root … cN) — Bluesky behavior — not just the root's direct children. The
+      // findById is guarded on a valid ObjectId so a non-ObjectId parentId (and any
+      // non-root post) simply skips spine expansion and keeps the single-parent query.
+      const parent = mongoose.isValidObjectId(parentId)
+        ? await Post.findById(parentId)
+          .select('_id oxyUserId threadId')
+          .maxTimeMS(FEED_CONSTANTS.QUERY_TIMEOUT_MS)
+          .lean()
+        : null;
+      const isSelfThreadRoot = !!parent?.threadId && String(parent.threadId) === String(parent._id);
+
+      // The OP's own continuations are rendered as the connected spine on the client,
+      // so they must NOT also appear as replies. Each continuation hangs off another
+      // spine node (c1.parentPostId === root, c2.parentPostId === c1, …) and would
+      // otherwise match the expanded parent filter, so exclude them by id. The root
+      // has no parentPostId and can never appear as a reply.
+      const continuationIds = isSelfThreadRoot && parent
+        ? (await this.getSelfThreadContinuations(parent)).map((c) => String(c._id))
+        : [];
+
       const query: QueryFilter<IPost> = {
-        parentPostId: String(parentId),
+        parentPostId: continuationIds.length > 0
+          ? { $in: [String(parentId), ...continuationIds] }
+          : String(parentId),
         visibility: PostVisibility.PUBLIC,
         status: 'published',
       };
 
+      const idConditions: { $nin?: mongoose.Types.ObjectId[]; $lt?: mongoose.Types.ObjectId } = {};
+      if (continuationIds.length > 0) {
+        idConditions.$nin = continuationIds.map((cid) => new mongoose.Types.ObjectId(cid));
+      }
       if (cursor) {
         const cursorId = parseFeedCursor(cursor);
-        if (cursorId) query._id = { $lt: cursorId };
+        if (cursorId) idConditions.$lt = cursorId;
+      }
+      if (idConditions.$nin || idConditions.$lt) {
+        query._id = idConditions;
       }
 
       const feedFieldsProject = Object.fromEntries(
@@ -1987,21 +2052,10 @@ class FeedController {
         return res.json({ items: [] });
       }
 
-      // Identical query shape to ThreadSlicingService.fetchThreadChildren: every
-      // post in this thread by the SAME author that hangs off the chain
-      // (parentPostId present), in chronological (= thread) order.
-      const continuations = await Post.find({
-        threadId: String(root.threadId),
-        oxyUserId: root.oxyUserId,
-        parentPostId: { $ne: null, $exists: true },
-        visibility: PostVisibility.PUBLIC,
-        status: 'published',
-      })
-        .select(this.FEED_FIELDS)
-        .sort({ createdAt: 1 })
-        .limit(MAX_THREAD_CONTINUATION_DEPTH)
-        .maxTimeMS(FEED_CONSTANTS.QUERY_TIMEOUT_MS)
-        .lean();
+      // Single source of truth for the spine query (shared with getRepliesFeed,
+      // which expands a root into this same spine to surface external replies to
+      // any node). Identical match shape to ThreadSlicingService.fetchThreadChildren.
+      const continuations = await this.getSelfThreadContinuations(root);
 
       if (continuations.length === 0) {
         return res.json({ items: [] });

--- a/packages/frontend/app/(app)/p/[id].tsx
+++ b/packages/frontend/app/(app)/p/[id].tsx
@@ -82,12 +82,8 @@ const PostDetailScreen: React.FC = () => {
     const [error, setError] = useState<string | null>(null);
     const [repliesReloadKey, setRepliesReloadKey] = useState(0);
 
-    // The TAIL of the OP's self-thread — the last continuation (cN). When the
-    // focused post is a self-thread root, replies and the compose-reply prompt
-    // attach to the tail (Bluesky behavior): the replies feed then queries the
-    // tail's children and so never re-renders the spine continuations as replies
-    // (c1, a direct child of the root, would otherwise duplicate). Undefined for
-    // a non-thread post.
+    // The TAIL of the OP's self-thread — the last continuation (cN). Undefined for
+    // a non-thread post (no continuation spine).
     const threadTailId = continuations.length > 0
         ? String(continuations[continuations.length - 1].id)
         : undefined;
@@ -95,20 +91,31 @@ const PostDetailScreen: React.FC = () => {
     // A boost (`type:'boost'`) is its OWN post with an empty body whose content is
     // the original it boosted — so `/p/<boostId>` renders as the booster's post
     // with the original embedded as a nested sub-card (the same way the feed row
-    // renders a boost). A boost has no direct replies of its own; replies attach
-    // to the original, so the replies thread below targets the original's id. For
-    // a self-thread root, replies attach to the thread tail; otherwise they attach
-    // to the focused post itself.
-    const replyTargetId = post?.boost?.originalPost?.id
+    // renders a boost). A boost has no replies of its own; replies attach to the
+    // original, so both reply targets below resolve to the original's id.
+    const boostOriginalId = post?.boost?.originalPost?.id
         ? String(post.boost.originalPost.id)
-        : (threadTailId ?? String(id));
+        : undefined;
+
+    // Target that drives the REPLIES FEED query: the focused post itself (the
+    // self-thread ROOT when this is a thread). The backend expands a self-thread
+    // root into its whole continuation spine and returns external replies to ANY
+    // spine node (root … cN), EXCLUDING the OP's own continuations — so this must be
+    // the root, NOT the tail. For a non-thread post the root IS the focused post.
+    const repliesQueryTargetId = boostOriginalId ?? String(id);
+
+    // Target a NEW reply attaches to: the thread TAIL (cN) when this is a self-thread
+    // (Bluesky — reply to the latest thread post), else the focused post. Because the
+    // spine-aware replies feed includes the tail's children, a reply composed here
+    // surfaces in the replies list.
+    const composeReplyTargetId = boostOriginalId ?? (threadTailId ?? String(id));
 
     // Memoize filters for replies feed
     const feedFilters = useMemo(() => ({
-        postId: replyTargetId,
-        parentPostId: replyTargetId,
+        postId: repliesQueryTargetId,
+        parentPostId: repliesQueryTargetId,
         sort: SORT_TO_API[sortOrder],
-    }), [replyTargetId, sortOrder]);
+    }), [repliesQueryTargetId, sortOrder]);
 
     const openReplyPreferences = useCallback(() => {
         setBottomSheetContent(<ReplyPreferencesSheet />);
@@ -116,9 +123,10 @@ const PostDetailScreen: React.FC = () => {
     }, [setBottomSheetContent, openBottomSheet]);
 
     const handleOpenReply = useCallback(() => {
-        // Replies attach to the original, never to the boost record.
-        if (replyTargetId) router.push(`/compose?replyToPostId=${replyTargetId}`);
-    }, [replyTargetId]);
+        // A new reply attaches to the thread tail (or the focused post / boost
+        // original), never to the boost record itself.
+        if (composeReplyTargetId) router.push(`/compose?replyToPostId=${composeReplyTargetId}`);
+    }, [composeReplyTargetId]);
 
     // Load the post. When the feed already cached it, the post is rendered
     // synchronously above (`cachedPost`) and this effect only revalidates it in
@@ -166,8 +174,8 @@ const PostDetailScreen: React.FC = () => {
         //   - a cycle (id already visited) breaks the walk;
         //   - the walk is capped at MAX_ANCESTOR_DEPTH hops.
         // Boosts have no `parentPostId`, so they yield an empty chain — the boost
-        // renders standalone with its original embedded (replies target the
-        // original via `replyTargetId`, unchanged).
+        // renders standalone with its original embedded (reply targets resolve to
+        // the original via `boostOriginalId`, unchanged).
         const loadAncestors = async (startParentId: string | undefined) => {
             if (!startParentId) {
                 if (!cancelled) setAncestors([]);
@@ -319,8 +327,9 @@ const PostDetailScreen: React.FC = () => {
                     so they connect flush with no separators. The LAST continuation
                     (the thread tail) closes the thread with `isThreadLastChild`,
                     keeping its bottom border to separate the tail from the compose
-                    prompt below. Replies attach to this tail (see `replyTargetId`),
-                    so the continuations never double up in the replies feed. */}
+                    prompt below. A new reply attaches to this tail (see
+                    `composeReplyTargetId`); the spine-aware replies feed excludes the
+                    OP continuations, so they never double up in the replies list. */}
                 {continuations.map((continuation, index) => {
                     const isLast = index === continuations.length - 1;
                     return (
@@ -428,7 +437,7 @@ const PostDetailScreen: React.FC = () => {
                         listHeaderComponent={listHeader}
                         hideHeader={true}
                         threaded={treeView}
-                        threadPostId={replyTargetId}
+                        threadPostId={repliesQueryTargetId}
                         contentContainerStyle={styles.feedContent}
                     />
                 )}


### PR DESCRIPTION
## Summary
- `getRepliesFeed` is now spine-aware: when the post is a self-thread root, it collects external replies to all spine nodes (root + OP continuations), excluding the OP's own continuation posts
- `getSelfThreadContinuations` shared helper encapsulates spine traversal for reuse
- Post-detail screen splits reply targets: replies feed queries the root (backend expands the spine), while the compose prompt targets the thread tail so replies thread correctly

## Test plan
- [ ] New unit test `getRepliesFeedSpine.test.ts` covers spine-aware reply aggregation
- [ ] Verify external replies to mid-spine posts appear on `/p/[root-id]`
- [ ] Verify OP's own continuations are excluded from the replies list
- [ ] Verify compose on post-detail still targets the thread tail (last spine node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)