### PR TITLE
feat(connectors): AT Protocol (Bluesky) connector + unified cross-network resolve

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -77,7 +77,7 @@ import recommendationsRoutes from './src/routes/recommendations';
 import './src/connectors';
 import webfingerRoutes from './src/connectors/activitypub/routes/wellKnown.routes';
 import federationRoutes from './src/connectors/activitypub/routes/ap.routes';
-import federationApiRoutes from './src/routes/federation.api.routes';
+import federationApiRoutes from './src/connectors/connectors.routes';
 
 // MTN Protocol
 import { registerAllFeeds } from './src/mtn/feed/registerFeeds';

--- a/packages/backend/src/__tests__/connectors/atproto/atprotoConnector.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/atprotoConnector.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * AtprotoConnector contract: subject matching, the follow → local subscription
+ * (`direction:'outbound', status:'accepted', network:'atproto'`) + backfill, and
+ * the no-orphan guard on `fetchPosts`. All network + persistence collaborators
+ * are mocked.
+ */
+
+const mocks = vi.hoisted(() => ({
+  resolveIdentity: vi.fn(),
+  fetchAndUpsertAtprotoProfile: vi.fn(),
+  importAuthorFeed: vi.fn(),
+  resolveOxyExternalUser: vi.fn(),
+  followUpsert: vi.fn(),
+  followDelete: vi.fn(),
+}));
+
+vi.mock('../../../connectors/atproto/identityResolver', () => ({
+  resolveIdentity: mocks.resolveIdentity,
+}));
+
+vi.mock('../../../connectors/atproto/profile.mapper', () => ({
+  fetchAndUpsertAtprotoProfile: mocks.fetchAndUpsertAtprotoProfile,
+}));
+
+vi.mock('../../../connectors/atproto/post.mapper', () => ({
+  importAuthorFeed: mocks.importAuthorFeed,
+}));
+
+vi.mock('../../../connectors/identity', () => ({
+  resolveOxyExternalUser: mocks.resolveOxyExternalUser,
+}));
+
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: {
+    findOneAndUpdate: mocks.followUpsert,
+    deleteOne: mocks.followDelete,
+  },
+}));
+
+import { atprotoConnector } from '../../../connectors/atproto/AtprotoConnector';
+
+const DID = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveIdentity.mockResolvedValue({ did: DID, handle: 'alice.bsky.social' });
+  mocks.fetchAndUpsertAtprotoProfile.mockResolvedValue({
+    network: 'atproto',
+    externalId: DID,
+    handle: 'alice.bsky.social',
+    oxyUserId: 'oxy-alice',
+  });
+  mocks.importAuthorFeed.mockResolvedValue({ posts: [], cursor: undefined });
+  mocks.followUpsert.mockResolvedValue({ _id: 'ff1' });
+  mocks.followDelete.mockResolvedValue({ deletedCount: 1 });
+});
+
+describe('AtprotoConnector.matches', () => {
+  it('claims DIDs, AT-URIs and bare handles, never fediverse accts or URLs', () => {
+    expect(atprotoConnector.matches(DID)).toBe(true);
+    expect(atprotoConnector.matches('at://did:plc:x/app.bsky.feed.post/y')).toBe(true);
+    expect(atprotoConnector.matches('alice.bsky.social')).toBe(true);
+    expect(atprotoConnector.matches('@alice@mastodon.social')).toBe(false);
+    expect(atprotoConnector.matches('https://mastodon.social/users/alice')).toBe(false);
+  });
+});
+
+describe('AtprotoConnector.deliver', () => {
+  it('records a local subscription on follow.add and backfills the feed', async () => {
+    await atprotoConnector.deliver({
+      kind: 'follow.add',
+      localOxyUserId: 'viewer-1',
+      localUsername: 'viewer',
+      targetActorUri: DID,
+    });
+
+    expect(mocks.followUpsert).toHaveBeenCalledWith(
+      { localUserId: 'viewer-1', remoteActorUri: DID, direction: 'outbound' },
+      { $set: { status: 'accepted', network: 'atproto' } },
+      expect.objectContaining({ upsert: true }),
+    );
+    expect(mocks.importAuthorFeed).toHaveBeenCalled();
+  });
+
+  it('removes the local subscription on follow.remove', async () => {
+    await atprotoConnector.deliver({
+      kind: 'follow.remove',
+      localOxyUserId: 'viewer-1',
+      localUsername: 'viewer',
+      targetActorUri: DID,
+    });
+
+    expect(mocks.followDelete).toHaveBeenCalledWith({
+      localUserId: 'viewer-1',
+      remoteActorUri: DID,
+      direction: 'outbound',
+    });
+  });
+
+  it('is a no-op on post.create (no outbound publish in C2)', async () => {
+    await expect(
+      atprotoConnector.deliver({
+        kind: 'post.create',
+        post: { _id: 'p1', content: { text: 'hi' }, visibility: 'public', createdAt: '2024-01-01T00:00:00.000Z' },
+        actorOxyUserId: 'viewer-1',
+        actorUsername: 'viewer',
+      }),
+    ).resolves.toBeUndefined();
+    expect(mocks.followUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('AtprotoConnector.fetchPosts', () => {
+  it('skips the backfill (no orphan) when the actor has no resolved Oxy user', async () => {
+    mocks.fetchAndUpsertAtprotoProfile.mockResolvedValue({
+      network: 'atproto',
+      externalId: DID,
+      handle: 'alice.bsky.social',
+      oxyUserId: undefined,
+    });
+
+    const result = await atprotoConnector.fetchPosts(DID);
+
+    expect(result).toEqual({ posts: [] });
+    expect(mocks.importAuthorFeed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/atproto/classification.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/classification.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Cross-network query classification + atproto subject predicates.
+ *
+ * `classifyQuery` (unified resolve) must route fediverse `user@host` accts to
+ * ActivityPub, bare DNS handles / DIDs / AT-URIs to atproto, and bare local
+ * usernames to the local Oxy profile path — without touching the network.
+ */
+
+import { classifyQuery } from '../../../connectors/resolve';
+import { isAtUri, isAtprotoHandle, isDid } from '../../../connectors/atproto/constants';
+
+describe('atproto subject predicates', () => {
+  it('recognises did:plc and did:web identifiers', () => {
+    expect(isDid('did:plc:ewvi7nxzyoun6zhxrhs64oiz')).toBe(true);
+    expect(isDid('did:web:example.com')).toBe(true);
+    expect(isDid('did:web:example.com:user:alice')).toBe(true);
+    expect(isDid('alice.bsky.social')).toBe(false);
+    expect(isDid('https://mastodon.social/users/alice')).toBe(false);
+  });
+
+  it('recognises AT-URIs', () => {
+    expect(isAtUri('at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/app.bsky.feed.post/3k')).toBe(true);
+    expect(isAtUri('at://alice.bsky.social/app.bsky.feed.post/3k')).toBe(true);
+    expect(isAtUri('at://did:plc:ewvi7nxzyoun6zhxrhs64oiz')).toBe(true);
+    expect(isAtUri('https://bsky.app/profile/alice')).toBe(false);
+  });
+
+  it('recognises bare atproto handles but never @-accts or URLs', () => {
+    expect(isAtprotoHandle('alice.bsky.social')).toBe(true);
+    expect(isAtprotoHandle('example.com')).toBe(true);
+    // A fediverse acct (has @) is NOT an atproto handle.
+    expect(isAtprotoHandle('alice@mastodon.social')).toBe(false);
+    expect(isAtprotoHandle('@alice@mastodon.social')).toBe(false);
+    // A bare local username (single label, no dot) is NOT a handle.
+    expect(isAtprotoHandle('alice')).toBe(false);
+    // A URL is NOT a handle.
+    expect(isAtprotoHandle('https://example.com')).toBe(false);
+  });
+});
+
+describe('classifyQuery', () => {
+  it('classifies fediverse accts as activitypub', () => {
+    expect(classifyQuery('@alice@mastodon.social')).toBe('activitypub');
+    expect(classifyQuery('alice@mastodon.social')).toBe('activitypub');
+    expect(classifyQuery('acct:alice@mastodon.social')).toBe('activitypub');
+  });
+
+  it('classifies handles, DIDs and AT-URIs as atproto', () => {
+    expect(classifyQuery('alice.bsky.social')).toBe('atproto');
+    expect(classifyQuery('example.com')).toBe('atproto');
+    expect(classifyQuery('did:plc:ewvi7nxzyoun6zhxrhs64oiz')).toBe('atproto');
+    expect(classifyQuery('did:web:example.com')).toBe('atproto');
+    expect(classifyQuery('at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/app.bsky.feed.post/3k')).toBe('atproto');
+  });
+
+  it('classifies bare usernames as local', () => {
+    expect(classifyQuery('@alice')).toBe('local');
+    expect(classifyQuery('alice')).toBe('local');
+    expect(classifyQuery('')).toBe('local');
+  });
+});

--- a/packages/backend/src/__tests__/connectors/atproto/identityResolver.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/identityResolver.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * atproto identity resolution: handle → DID (AppView, then well-known / DNS
+ * fallbacks) and DID → DID document (PLC directory / did:web `did.json`).
+ * The SSRF-safe transport is mocked; these tests assert the resolution logic +
+ * the exact URLs each DID method resolves at.
+ */
+
+const mocks = vi.hoisted(() => ({
+  xrpcGet: vi.fn(),
+  safeGetJson: vi.fn(),
+  safeGetText: vi.fn(),
+  resolveTxt: vi.fn(),
+}));
+
+vi.mock('../../../connectors/atproto/xrpcClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../connectors/atproto/xrpcClient')>();
+  return {
+    ...actual,
+    xrpcGet: mocks.xrpcGet,
+    safeGetJson: mocks.safeGetJson,
+    safeGetText: mocks.safeGetText,
+  };
+});
+
+vi.mock('node:dns/promises', () => ({ resolveTxt: mocks.resolveTxt }));
+
+import {
+  handleFromDidDocument,
+  pdsEndpointFromDidDocument,
+  resolveDidDocument,
+  resolveHandleToDid,
+  resolveIdentity,
+} from '../../../connectors/atproto/identityResolver';
+
+const DID = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveTxt.mockRejectedValue(new Error('no txt'));
+  mocks.safeGetText.mockRejectedValue(new Error('no well-known'));
+});
+
+describe('resolveHandleToDid', () => {
+  it('resolves a handle via the AppView resolveHandle query', async () => {
+    mocks.xrpcGet.mockResolvedValue({ did: DID });
+
+    const did = await resolveHandleToDid('alice.bsky.social');
+
+    expect(did).toBe(DID);
+    expect(mocks.xrpcGet).toHaveBeenCalledWith(
+      'public.api.bsky.app',
+      'com.atproto.identity.resolveHandle',
+      { handle: 'alice.bsky.social' },
+    );
+  });
+
+  it('falls back to the .well-known/atproto-did document', async () => {
+    mocks.xrpcGet.mockRejectedValue(new Error('appview down'));
+    mocks.safeGetText.mockResolvedValue(DID);
+
+    const did = await resolveHandleToDid('custom.example');
+
+    expect(did).toBe(DID);
+    expect(mocks.safeGetText).toHaveBeenCalledWith('https://custom.example/.well-known/atproto-did');
+  });
+
+  it('falls back to the _atproto DNS TXT record', async () => {
+    mocks.xrpcGet.mockRejectedValue(new Error('appview down'));
+    mocks.resolveTxt.mockResolvedValue([[`did=${DID}`]]);
+
+    const did = await resolveHandleToDid('dns.example');
+
+    expect(did).toBe(DID);
+    expect(mocks.resolveTxt).toHaveBeenCalledWith('_atproto.dns.example');
+  });
+
+  it('returns null when no method yields a DID', async () => {
+    mocks.xrpcGet.mockResolvedValue({});
+    const did = await resolveHandleToDid('ghost.example');
+    expect(did).toBeNull();
+  });
+});
+
+describe('resolveDidDocument', () => {
+  it('resolves a did:plc document from the PLC directory', async () => {
+    mocks.safeGetJson.mockResolvedValue({ id: DID });
+
+    const doc = await resolveDidDocument(DID);
+
+    expect(doc).toEqual({ id: DID });
+    expect(mocks.safeGetJson).toHaveBeenCalledWith(`https://plc.directory/${DID}`);
+  });
+
+  it('resolves a did:web document from the well-known location', async () => {
+    mocks.safeGetJson.mockResolvedValue({ id: 'did:web:example.com' });
+
+    await resolveDidDocument('did:web:example.com');
+
+    expect(mocks.safeGetJson).toHaveBeenCalledWith('https://example.com/.well-known/did.json');
+  });
+
+  it('resolves a path-scoped did:web document', async () => {
+    mocks.safeGetJson.mockResolvedValue({ id: 'did:web:example.com:user:alice' });
+
+    await resolveDidDocument('did:web:example.com:user:alice');
+
+    expect(mocks.safeGetJson).toHaveBeenCalledWith('https://example.com/user/alice/did.json');
+  });
+
+  it('returns null for an unsupported DID method', async () => {
+    const doc = await resolveDidDocument('did:key:zabc');
+    expect(doc).toBeNull();
+    expect(mocks.safeGetJson).not.toHaveBeenCalled();
+  });
+});
+
+describe('DID document field extraction', () => {
+  it('reads the handle from alsoKnownAs and the PDS service endpoint', () => {
+    const doc = {
+      id: DID,
+      alsoKnownAs: ['at://alice.bsky.social'],
+      service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }],
+    };
+    expect(handleFromDidDocument(doc)).toBe('alice.bsky.social');
+    expect(pdsEndpointFromDidDocument(doc)).toBe('https://pds.example');
+  });
+});
+
+describe('resolveIdentity', () => {
+  it('resolves a handle to a full identity (DID + verified handle + PDS)', async () => {
+    mocks.xrpcGet.mockResolvedValue({ did: DID });
+    mocks.safeGetJson.mockResolvedValue({
+      id: DID,
+      alsoKnownAs: ['at://alice.bsky.social'],
+      service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }],
+    });
+
+    const identity = await resolveIdentity('alice.bsky.social');
+
+    expect(identity).toEqual({ did: DID, handle: 'alice.bsky.social', pdsEndpoint: 'https://pds.example' });
+  });
+
+  it('resolves a DID input without re-resolving the handle', async () => {
+    mocks.safeGetJson.mockResolvedValue({ id: DID, alsoKnownAs: ['at://alice.bsky.social'] });
+
+    const identity = await resolveIdentity(DID);
+
+    expect(mocks.xrpcGet).not.toHaveBeenCalled();
+    expect(identity).toMatchObject({ did: DID, handle: 'alice.bsky.social' });
+  });
+});

--- a/packages/backend/src/__tests__/connectors/atproto/postMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/postMapper.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * atproto post mapping + import.
+ *
+ *  - `mapPostViewToNormalizedPost`: `app.bsky.feed.post` PostView → normalized
+ *    post (AT-URI provenance, bsky.app web URL, reply parent, embed media,
+ *    richtext hashtags, langs, adult self-labels), with the actor-match guard.
+ *  - `importAuthorFeed`: getAuthorFeed → dedup on the AT-URI → import the new
+ *    posts via `getPostCreator().create`, skipping reposts. The XRPC fetch, the
+ *    Post model, the post creator, and media materialization are mocked.
+ */
+
+const mocks = vi.hoisted(() => ({
+  xrpcGet: vi.fn(),
+  postFind: vi.fn(),
+  create: vi.fn(),
+  materialize: vi.fn(),
+}));
+
+vi.mock('../../../connectors/atproto/xrpcClient', () => ({ xrpcGet: mocks.xrpcGet }));
+
+vi.mock('../../../models/Post', () => ({
+  POST_CLASSIFICATION_PENDING: 'pending',
+  Post: { find: mocks.postFind },
+}));
+
+vi.mock('../../../services/serviceRegistry', () => ({
+  getPostCreator: () => ({ create: mocks.create }),
+  registerPostCreator: vi.fn(),
+  registerPostFederator: vi.fn(),
+  getPostFederator: vi.fn(),
+}));
+
+vi.mock('../../../connectors/shared/federatedMedia', () => ({
+  materializeFederatedMedia: mocks.materialize,
+}));
+
+import {
+  importAuthorFeed,
+  mapPostViewToNormalizedPost,
+} from '../../../connectors/atproto/post.mapper';
+import type { NormalizedExternalActor } from '../../../connectors/types';
+
+const DID = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz';
+
+function atUri(rkey: string): string {
+  return `at://${DID}/app.bsky.feed.post/${rkey}`;
+}
+
+function postView(rkey: string, text: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    uri: atUri(rkey),
+    cid: 'cid',
+    author: { did: DID, handle: 'alice.bsky.social' },
+    record: {
+      $type: 'app.bsky.feed.post',
+      text,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      ...(extra.record as Record<string, unknown> | undefined),
+    },
+    embed: extra.embed,
+    indexedAt: '2024-01-01T00:00:00.000Z',
+  };
+}
+
+const ACTOR: NormalizedExternalActor = {
+  network: 'atproto',
+  externalId: DID,
+  handle: 'alice.bsky.social',
+  oxyUserId: 'oxy-alice',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.postFind.mockReturnValue({ select: () => ({ lean: async () => [] }) });
+  mocks.create.mockResolvedValue({ _id: 'created1' });
+  mocks.materialize.mockImplementation(async (media: unknown, attachments: unknown) => ({ media, attachments }));
+});
+
+describe('mapPostViewToNormalizedPost', () => {
+  it('maps a feed post to the normalized provenance shape', () => {
+    const post = mapPostViewToNormalizedPost(postView('abc', 'hello bluesky'), DID);
+
+    expect(post).toMatchObject({
+      network: 'atproto',
+      activityId: atUri('abc'),
+      actorUri: DID,
+      url: 'https://bsky.app/profile/alice.bsky.social/post/abc',
+      text: 'hello bluesky',
+    });
+  });
+
+  it('extracts reply parent, langs, hashtags, image media and adult labels', () => {
+    const post = mapPostViewToNormalizedPost(
+      postView('rich', 'tagged', {
+        record: {
+          $type: 'app.bsky.feed.post',
+          text: 'tagged',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          reply: { parent: { uri: 'at://did:plc:other/app.bsky.feed.post/parent' } },
+          langs: ['en-US', 'es'],
+          tags: ['atproto'],
+          facets: [{ features: [{ $type: 'app.bsky.richtext.facet#tag', tag: '#bluesky' }] }],
+          labels: { values: [{ val: 'porn' }] },
+        },
+        embed: {
+          $type: 'app.bsky.embed.images#view',
+          images: [{ thumb: 'https://cdn/thumb.jpg', fullsize: 'https://cdn/full.jpg', alt: 'a' }],
+        },
+      }),
+      DID,
+    );
+
+    expect(post?.inReplyTo).toBe('at://did:plc:other/app.bsky.feed.post/parent');
+    expect(post?.language).toBe('en');
+    expect(post?.languages).toEqual(['en', 'es']);
+    expect(post?.hashtags).toEqual(expect.arrayContaining(['atproto', 'bluesky']));
+    expect(post?.sensitive).toBe(true);
+    expect(post?.media).toEqual([{ id: 'https://cdn/full.jpg', type: 'image', remoteUrl: 'https://cdn/full.jpg' }]);
+  });
+
+  it('extracts video playlist media from a video embed view', () => {
+    const post = mapPostViewToNormalizedPost(
+      postView('vid', 'a video', {
+        embed: { $type: 'app.bsky.embed.video#view', playlist: 'https://cdn/playlist.m3u8', thumbnail: 'https://cdn/thumb.jpg' },
+      }),
+      DID,
+    );
+    expect(post?.media).toEqual([{ id: 'https://cdn/playlist.m3u8', type: 'video', remoteUrl: 'https://cdn/playlist.m3u8' }]);
+  });
+
+  it('rejects a non-feed-post record, a wrong author, and a non-AT-URI', () => {
+    // Wrong collection (a like, not a post).
+    expect(
+      mapPostViewToNormalizedPost(
+        { uri: `at://${DID}/app.bsky.feed.like/x`, author: { did: DID }, record: { $type: 'app.bsky.feed.like' } },
+        DID,
+      ),
+    ).toBeNull();
+    // Author does not match the synced actor.
+    expect(mapPostViewToNormalizedPost(postView('x', 'forged'), 'did:plc:someoneelse000000000000')).toBeNull();
+    // Not an AT-URI.
+    expect(mapPostViewToNormalizedPost({ uri: 'https://bsky.app/x', author: { did: DID } }, DID)).toBeNull();
+  });
+});
+
+describe('importAuthorFeed', () => {
+  it('imports new posts, dedups on the AT-URI, and skips reposts', async () => {
+    mocks.xrpcGet.mockResolvedValue({
+      cursor: 'next-cursor',
+      feed: [
+        { post: postView('a', 'fresh post') },
+        // A repost carries a `reason` — skipped in C2.
+        { post: postView('b', 'reposted'), reason: { $type: 'app.bsky.feed.defs#reasonRepost' } },
+        // Already imported (returned by the dedup query) — skipped.
+        { post: postView('c', 'already here') },
+      ],
+    });
+    mocks.postFind.mockReturnValue({
+      select: () => ({ lean: async () => [{ federation: { activityId: atUri('c') } }] }),
+    });
+
+    const result = await importAuthorFeed(ACTOR);
+
+    expect(result.cursor).toBe('next-cursor');
+    expect(result.posts.map((p) => p.activityId)).toEqual([atUri('a')]);
+    // Exactly one create (post 'a'); 'b' skipped (repost), 'c' skipped (dedup).
+    expect(mocks.create).toHaveBeenCalledTimes(1);
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oxyUserId: 'oxy-alice',
+        federation: expect.objectContaining({ activityId: atUri('a'), actorUri: DID }),
+        visibility: 'public',
+        skipNotifications: true,
+        skipSocketEmit: true,
+        skipFederationDelivery: true,
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      }),
+    );
+    // Media materialization ran for the imported post.
+    expect(mocks.materialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty without creating when the actor has no resolved Oxy user', async () => {
+    const result = await importAuthorFeed({ ...ACTOR, oxyUserId: undefined });
+    expect(result.posts).toEqual([]);
+    expect(mocks.xrpcGet).not.toHaveBeenCalled();
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * atproto profile mapping: `app.bsky.actor.getProfile` → normalized actor →
+ * `FederatedActor` upsert (`protocol:'atproto'`) → Oxy identity resolution.
+ * Verifies the no-orphan fail-soft contract: when Oxy cannot resolve the actor's
+ * `did:` (oxy-api dependency), the actor returns WITHOUT an `oxyUserId` and never
+ * throws.
+ */
+
+const mocks = vi.hoisted(() => ({
+  xrpcGet: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+  updateOne: vi.fn(),
+  resolveOxyExternalUser: vi.fn(),
+}));
+
+vi.mock('../../../connectors/atproto/xrpcClient', () => ({ xrpcGet: mocks.xrpcGet }));
+
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    findOneAndUpdate: mocks.findOneAndUpdate,
+    updateOne: mocks.updateOne,
+  },
+}));
+
+vi.mock('../../../connectors/identity', () => ({
+  resolveOxyExternalUser: mocks.resolveOxyExternalUser,
+}));
+
+import {
+  fetchAndUpsertAtprotoProfile,
+  mapProfileToNormalizedActor,
+} from '../../../connectors/atproto/profile.mapper';
+
+const DID = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz';
+
+const PROFILE = {
+  did: DID,
+  handle: 'alice.bsky.social',
+  displayName: 'Alice',
+  description: 'hello from bluesky',
+  avatar: 'https://cdn.bsky.app/img/avatar/plain/did/cid@jpeg',
+  banner: 'https://cdn.bsky.app/img/banner/plain/did/cid@jpeg',
+  followersCount: 12,
+  followsCount: 7,
+  postsCount: 99,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.findOneAndUpdate.mockResolvedValue({ _id: 'fa1', oxyUserId: undefined });
+  mocks.updateOne.mockResolvedValue({ modifiedCount: 1 });
+  mocks.resolveOxyExternalUser.mockResolvedValue('oxy-alice');
+});
+
+describe('mapProfileToNormalizedActor', () => {
+  it('maps a getProfile response to the network-neutral actor shape', () => {
+    const actor = mapProfileToNormalizedActor(PROFILE);
+    expect(actor).toEqual({
+      network: 'atproto',
+      externalId: DID,
+      handle: 'alice.bsky.social',
+      displayName: 'Alice',
+      avatarUrl: PROFILE.avatar,
+      bannerUrl: PROFILE.banner,
+      bio: 'hello from bluesky',
+      followersCount: 12,
+      followingCount: 7,
+      postsCount: 99,
+    });
+  });
+
+  it('returns null when did or handle is missing', () => {
+    expect(mapProfileToNormalizedActor({ handle: 'a.b' })).toBeNull();
+    expect(mapProfileToNormalizedActor({ did: DID })).toBeNull();
+  });
+});
+
+describe('fetchAndUpsertAtprotoProfile', () => {
+  it('upserts the FederatedActor (atproto) and stamps the resolved Oxy user', async () => {
+    mocks.xrpcGet.mockResolvedValue(PROFILE);
+
+    const actor = await fetchAndUpsertAtprotoProfile(DID);
+
+    expect(mocks.xrpcGet).toHaveBeenCalledWith('public.api.bsky.app', 'app.bsky.actor.getProfile', { actor: DID });
+    // Upsert keyed on the DID, carrying protocol + externalId + handle acct.
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledWith(
+      { uri: DID },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          protocol: 'atproto',
+          uri: DID,
+          externalId: DID,
+          acct: 'alice.bsky.social',
+          headerUrl: PROFILE.banner,
+        }),
+      }),
+      expect.objectContaining({ upsert: true }),
+    );
+    // Oxy user resolved + stamped (the upsert returned no prior oxyUserId).
+    expect(mocks.updateOne).toHaveBeenCalledWith({ _id: 'fa1' }, { $set: { oxyUserId: 'oxy-alice' } });
+    expect(actor?.oxyUserId).toBe('oxy-alice');
+  });
+
+  it('fails soft (no oxyUserId, no throw, no stamp) when Oxy cannot resolve the did:', async () => {
+    mocks.xrpcGet.mockResolvedValue(PROFILE);
+    mocks.resolveOxyExternalUser.mockResolvedValue(null);
+
+    const actor = await fetchAndUpsertAtprotoProfile(DID);
+
+    expect(actor).not.toBeNull();
+    expect(actor?.oxyUserId).toBeUndefined();
+    expect(mocks.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the profile cannot be fetched', async () => {
+    mocks.xrpcGet.mockRejectedValue(new Error('not found'));
+    const actor = await fetchAndUpsertAtprotoProfile('ghost.example');
+    expect(actor).toBeNull();
+  });
+});

--- a/packages/backend/src/__tests__/routes/federationFollowsDisplayName.test.ts
+++ b/packages/backend/src/__tests__/routes/federationFollowsDisplayName.test.ts
@@ -18,9 +18,10 @@ const { followFind, actorFind, getUsersByIds } = vi.hoisted(() => ({
   getUsersByIds: vi.fn(),
 }));
 
-// The route module imports the server entrypoint transitively (FederationService,
-// PostHydrationService); stub the heavy/circular deps so it can be imported in
-// isolation — same pattern as profileDesign.test.ts.
+// The route module imports the server entrypoint and the connector registry
+// transitively (ActivityPub + atproto connectors, PostHydrationService); stub the
+// heavy/circular deps so it can be imported in isolation — same pattern as
+// profileDesign.test.ts.
 vi.mock('../../../server', () => ({ oxy: {} }));
 
 vi.mock('@oxyhq/core/server', () => ({
@@ -28,6 +29,18 @@ vi.mock('@oxyhq/core/server', () => ({
 }));
 
 vi.mock('../../connectors/activitypub/constants', () => ({ FEDERATION_ENABLED: true }));
+vi.mock('../../connectors/atproto/constants', () => ({ ATPROTO_ENABLED: false }));
+
+// The connector registry + resolve classifier pull the full connector graph;
+// these list-only routes never invoke them, so stub them out.
+vi.mock('../../connectors/index', () => ({
+  connectorRegistry: {
+    list: () => [],
+    connectorFor: () => undefined,
+    resolve: vi.fn(async () => null),
+  },
+}));
+vi.mock('../../connectors/resolve', () => ({ classifyQuery: vi.fn(() => 'activitypub') }));
 
 vi.mock('../../middleware/rateLimiter', () => ({
   apiRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
@@ -61,7 +74,7 @@ vi.mock('../../models/FederatedActor', () => ({
   default: { find: (...args: unknown[]) => leanable(actorFind(...args)) },
 }));
 
-import federationApiRoutes from '../../routes/federation.api.routes';
+import federationApiRoutes from '../../connectors/connectors.routes';
 
 interface FollowResult {
   actorUri: string;

--- a/packages/backend/src/connectors/ConnectorRegistry.ts
+++ b/packages/backend/src/connectors/ConnectorRegistry.ts
@@ -55,9 +55,22 @@ export class ConnectorRegistry implements PostFederator {
     return this.connectors.find((connector) => connector.matches(subject));
   }
 
-  /** Resolve a handle through the connector that claims it. */
+  /**
+   * Resolve a handle/URI/DID through the FIRST enabled connector that claims it,
+   * returning a normalized actor with its Oxy user (`oxyUserId`) resolved. The
+   * connector's own `resolve` usually mints the identity while upserting; this
+   * runs `mapIdentity` as a fallback so the returned actor always carries an
+   * `oxyUserId` when one could be resolved.
+   */
   async resolve(handle: string): Promise<NormalizedExternalActor | null> {
     const connector = this.connectorFor(handle);
-    return connector ? connector.resolve(handle) : null;
+    if (!connector) return null;
+    const actor = await connector.resolve(handle);
+    if (!actor) return null;
+    if (!actor.oxyUserId) {
+      const oxyUserId = await connector.mapIdentity(actor);
+      if (oxyUserId) return { ...actor, oxyUserId };
+    }
+    return actor;
   }
 }

--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -115,9 +115,18 @@ class ActivityPubConnector implements NetworkConnector {
       case 'post.create':
         await followService.federateNewPost(event.post, event.actorOxyUserId, event.actorUsername);
         break;
+      case 'follow.add':
+        // Sends a Follow activity + records the outbound FederatedFollow. The
+        // `{ success, pending }` it returns is surfaced by the route via the
+        // actor's `manuallyApprovesFollowers` flag (route reads it post-deliver).
+        await followService.sendFollow(event.localOxyUserId, event.localUsername, event.targetActorUri);
+        break;
+      case 'follow.remove':
+        await followService.sendUndoFollow(event.localOxyUserId, event.localUsername, event.targetActorUri);
+        break;
       default: {
-        const exhaustive: never = event.kind;
-        throw new Error(`ActivityPubConnector: unhandled local event ${String(exhaustive)}`);
+        const exhaustive: never = event;
+        throw new Error(`ActivityPubConnector: unhandled local event ${JSON.stringify(exhaustive)}`);
       }
     }
   }

--- a/packages/backend/src/connectors/activitypub/actor.service.ts
+++ b/packages/backend/src/connectors/activitypub/actor.service.ts
@@ -250,6 +250,10 @@ export class ActorService {
       const headerUrl = firstStringUrl(actor.image);
 
       const update: Partial<IFederatedActor> = {
+        protocol: 'activitypub',
+        // For ActivityPub the stable protocol id IS the actor URI, so externalId
+        // mirrors `uri` (atproto rows carry the DID here instead).
+        externalId: actor.id,
         uri: actor.id,
         username,
         domain,

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -409,15 +409,20 @@ export class FollowService {
     // remote POST.
     await FederatedFollow.deleteOne({ _id: follow._id });
 
+    // `inboxUrl` is schema-optional (atproto actors have none); an AP actor we
+    // are sending Undo(Follow) to always has one. When neither inbox is known the
+    // local follow is already removed — just skip the outbound delivery.
     const targetInbox = actor.sharedInboxUrl ?? actor.inboxUrl;
-    void this.deliverActivity(activity, targetInbox, localOxyUserId, localUsername)
-      .then((delivered) => {
-        if (!delivered) return this.queueDelivery(activity, targetInbox, localOxyUserId);
-      })
-      .catch((err) => {
-        const message = err instanceof Error ? err.message : String(err);
-        logger.warn(`[FedSync] background undo-follow delivery failed for ${remoteActorUri}: ${message}`);
-      });
+    if (targetInbox) {
+      void this.deliverActivity(activity, targetInbox, localOxyUserId, localUsername)
+        .then((delivered) => {
+          if (!delivered) return this.queueDelivery(activity, targetInbox, localOxyUserId);
+        })
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(`[FedSync] background undo-follow delivery failed for ${remoteActorUri}: ${message}`);
+        });
+    }
 
     return true;
   }
@@ -433,6 +438,13 @@ export class FollowService {
   ): Promise<void> {
     const actor = await FederatedActor.findOne({ uri: remoteActorUri }).lean();
     if (!actor) return;
+    // `inboxUrl` is schema-optional (atproto actors have none); an AP actor we
+    // are sending Accept(Follow) to always has one. Guard so the absent case is
+    // a logged no-op instead of delivering to `undefined`.
+    if (!actor.inboxUrl) {
+      logger.warn(`[FedSync] cannot send Accept(Follow) to ${remoteActorUri}: actor has no inboxUrl`);
+      return;
+    }
 
     const localActorUri = actorUrl(localUsername);
 

--- a/packages/backend/src/connectors/atproto/AtprotoConnector.ts
+++ b/packages/backend/src/connectors/atproto/AtprotoConnector.ts
@@ -1,0 +1,161 @@
+import { logger } from '../../utils/logger';
+import FederatedFollow from '../../models/FederatedFollow';
+import { resolveOxyExternalUser } from '../identity';
+import type {
+  FetchPostsOptions,
+  FetchPostsResult,
+  LocalNetworkEvent,
+  NetworkConnector,
+  NetworkId,
+  NormalizedExternalActor,
+  ReceiveContext,
+} from '../types';
+import {
+  ATPROTO_ENABLED,
+  isAtUri,
+  isAtprotoHandle,
+  isDid,
+} from './constants';
+import { resolveIdentity } from './identityResolver';
+import { fetchAndUpsertAtprotoProfile } from './profile.mapper';
+import { importAuthorFeed } from './post.mapper';
+
+/**
+ * The AT Protocol (Bluesky) network connector — READ / DISCOVERY only (C2/C3).
+ *
+ * It resolves Bluesky handles/DIDs, mirrors profiles into `FederatedActor`
+ * (`protocol:'atproto'`) + the shared Oxy identity bridge, and backfills an
+ * actor's posts as native `Post` rows (deduped on the AT-URI) through the SAME
+ * `getPostCreator().create` path ActivityPub uses.
+ *
+ * Outbound is intentionally minimal: `deliver({kind:'follow.add'})` records a
+ * LOCAL subscription (no Follow is written to the atproto network) and triggers a
+ * post backfill; `post.create` is a no-op until the C4 bridge (see
+ * `bridge.seam.ts`). The connector NEVER uses `@atproto/api`; every network read
+ * goes through the SSRF-safe XRPC client.
+ */
+class AtprotoConnector implements NetworkConnector {
+  readonly id: NetworkId = 'atproto';
+
+  get enabled(): boolean {
+    return ATPROTO_ENABLED;
+  }
+
+  /** True for an atproto DID, an AT-URI, or a bare handle (DNS name, no `@`). */
+  matches(subject: string): boolean {
+    const value = subject.trim();
+    return isDid(value) || isAtUri(value) || isAtprotoHandle(value);
+  }
+
+  /**
+   * Resolve a handle / DID / AT-URI to a normalized actor (handle→DID, then
+   * `app.bsky.actor.getProfile`), upserting the `FederatedActor` row and the
+   * Oxy identity it maps to.
+   */
+  async resolve(handle: string): Promise<NormalizedExternalActor | null> {
+    const value = handle.trim();
+    // Resolve to a DID first (handles, DIDs, and AT-URI authorities all funnel
+    // through identity resolution); getProfile then accepts the DID.
+    const identity = await resolveIdentity(this.toIdentityInput(value));
+    if (!identity) return null;
+    return this.fetchProfile(identity.did);
+  }
+
+  /** Fetch + normalize an atproto profile by its DID (or handle). */
+  fetchProfile(externalId: string): Promise<NormalizedExternalActor | null> {
+    return fetchAndUpsertAtprotoProfile(externalId);
+  }
+
+  /**
+   * Backfill an actor's recent posts. Resolves/refreshes the actor (so its Oxy
+   * user is known — no orphan posts), then imports `app.bsky.feed.getAuthorFeed`.
+   */
+  async fetchPosts(externalId: string, opts: FetchPostsOptions = {}): Promise<FetchPostsResult> {
+    const actor = await fetchAndUpsertAtprotoProfile(externalId);
+    if (!actor) return { posts: [] };
+    if (!actor.oxyUserId) {
+      logger.warn(`[atproto] fetchPosts: ${externalId} has no resolved Oxy user; skipping backfill`);
+      return { posts: [] };
+    }
+    const { posts, cursor } = await importAuthorFeed(actor, { limit: opts.limit, cursor: opts.cursor });
+    return { posts, cursor };
+  }
+
+  /** Deliver a local domain event. */
+  async deliver(event: LocalNetworkEvent): Promise<void> {
+    switch (event.kind) {
+      case 'post.create':
+        // C2: Mention does NOT publish into the atproto network yet — outbound
+        // post delivery is the C4 bridge (`bridge.seam.ts`). No-op for now.
+        return;
+      case 'follow.add':
+        await this.followActor(event.localOxyUserId, event.targetActorUri);
+        return;
+      case 'follow.remove':
+        await this.unfollowActor(event.localOxyUserId, event.targetActorUri);
+        return;
+      default: {
+        const exhaustive: never = event;
+        throw new Error(`AtprotoConnector: unhandled local event ${JSON.stringify(exhaustive)}`);
+      }
+    }
+  }
+
+  /** atproto has no inbound push transport in C2 — discovery is pull-only. */
+  async receive(_payload: unknown, _ctx: ReceiveContext): Promise<void> {
+    // No-op: there is no signed atproto inbox to process. Posts arrive via the
+    // pull-based `fetchPosts` backfill, not an inbound delivery.
+  }
+
+  /** Resolve/mint the Oxy user this atproto actor maps to. */
+  mapIdentity(actor: NormalizedExternalActor): Promise<string | null> {
+    return resolveOxyExternalUser(actor);
+  }
+
+  /**
+   * Record a LOCAL subscription to an atproto actor and backfill its posts. No
+   * Follow is delivered to the atproto network in C2 (that is the C4 bridge); the
+   * subscription merges the actor's posts into the viewer's feed exactly like the
+   * ActivityPub `/federation/following` path.
+   */
+  private async followActor(localOxyUserId: string, targetDid: string): Promise<void> {
+    // Resolve the actor first so `targetDid` is canonical (a handle/AT-URI is
+    // normalized to its DID) and its Oxy user is minted before the backfill.
+    const actor = await this.resolve(targetDid);
+    const canonicalDid = actor?.externalId ?? targetDid;
+
+    await FederatedFollow.findOneAndUpdate(
+      { localUserId: localOxyUserId, remoteActorUri: canonicalDid, direction: 'outbound' },
+      { $set: { status: 'accepted', network: 'atproto' } },
+      { upsert: true, returnDocument: 'after' },
+    );
+
+    // Backfill the followed actor's recent posts in the background.
+    if (actor?.oxyUserId) {
+      void importAuthorFeed(actor, { limit: 20 }).catch((err) => {
+        logger.warn(`[atproto] follow backfill failed for ${canonicalDid}`, err);
+      });
+    }
+  }
+
+  /** Remove the local subscription to an atproto actor. */
+  private async unfollowActor(localOxyUserId: string, targetDid: string): Promise<void> {
+    await FederatedFollow.deleteOne({
+      localUserId: localOxyUserId,
+      remoteActorUri: targetDid,
+      direction: 'outbound',
+    });
+  }
+
+  /** Strip an `at://<authority>/...` to its authority so identity resolution works. */
+  private toIdentityInput(subject: string): string {
+    if (isAtUri(subject)) {
+      const authority = subject.slice('at://'.length).split('/')[0];
+      return authority || subject;
+    }
+    return subject;
+  }
+}
+
+export const atprotoConnector = new AtprotoConnector();
+export default atprotoConnector;

--- a/packages/backend/src/connectors/atproto/bridge.seam.ts
+++ b/packages/backend/src/connectors/atproto/bridge.seam.ts
@@ -1,0 +1,61 @@
+import type { LocalPostEventPayload } from '../types';
+
+/**
+ * Typed seam for the FULL Bluesky bridge (Phase C4 — NOT implemented here).
+ *
+ * C2/C3 are read/discovery only: Mention reads Bluesky profiles and posts through
+ * the public AppView and records follows as local subscriptions. Going the other
+ * direction — publishing Mention content INTO the atproto network and being
+ * discovered BY Bluesky — is the C4 bridge. This file documents that future
+ * surface as throwing stubs so the wiring is explicit and the connector's
+ * `deliver` can reference it without any partial implementation leaking out.
+ *
+ * The atproto bridge is feasible because Oxy identities are `did:web` and atproto
+ * accepts `did:web`. The C4 work is:
+ *
+ *  1. OUTBOUND publish — turn a local post into an `app.bsky.feed.post` record and
+ *     `com.atproto.repo.createRecord` it to a Personal Data Server (PDS) the user
+ *     authorizes, signed by their Oxy `did:web` identity. Requires a PDS session
+ *     / app-password (or a Mention-hosted repo) and the user's PDS endpoint
+ *     (already surfaced by `identityResolver.resolveIdentity().pdsEndpoint`).
+ *
+ *  2. BE-DISCOVERED — serve `/.well-known/atproto-did` on the user's domain, list
+ *     atproto verification methods in the Oxy DID document, host the repo's
+ *     `com.atproto.sync.*` endpoints, and register with a Relay so AppViews index
+ *     the content.
+ *
+ *  3. A periodic `atproto:refresh-followed` job to keep followed actors' feeds
+ *     fresh (the inbound counterpart of outbound delivery).
+ */
+
+/** Marker thrown by the unimplemented C4 outbound stubs. */
+export class AtprotoBridgeNotImplementedError extends Error {
+  constructor(operation: string) {
+    super(`atproto outbound bridge not implemented (C4): ${operation}`);
+    this.name = 'AtprotoBridgeNotImplementedError';
+  }
+}
+
+/**
+ * C4 STUB — publish a local post to the author's PDS as an `app.bsky.feed.post`
+ * record via `com.atproto.repo.createRecord`, signed by their Oxy `did:web`.
+ * Not implemented in C2/C3.
+ */
+export function publishPostToPds(
+  _post: LocalPostEventPayload,
+  _authorOxyUserId: string,
+): Promise<never> {
+  throw new AtprotoBridgeNotImplementedError('publishPostToPds');
+}
+
+/**
+ * C4 STUB — deliver a Follow into the atproto network (write an
+ * `app.bsky.graph.follow` record to the follower's PDS). The C2 `deliver` records
+ * a local subscription instead; this is the real outbound edge. Not implemented.
+ */
+export function publishFollowToPds(
+  _followerOxyUserId: string,
+  _targetDid: string,
+): Promise<never> {
+  throw new AtprotoBridgeNotImplementedError('publishFollowToPds');
+}

--- a/packages/backend/src/connectors/atproto/constants.ts
+++ b/packages/backend/src/connectors/atproto/constants.ts
@@ -1,0 +1,87 @@
+/**
+ * AT Protocol (Bluesky) connector constants.
+ *
+ * Read/discovery only (Phase C2): the connector talks to the public Bluesky
+ * AppView for profiles/feeds and resolves identities through PLC / did:web /
+ * handle resolution. All host/identity strings and the classification regexes a
+ * caller needs to recognise atproto subjects live here.
+ */
+
+/**
+ * Master gate for the atproto connector. OFF by default — the connector is only
+ * instantiated and registered when `ATPROTO_ENABLED === 'true'`, mirroring the
+ * `FEDERATION_ENABLED` gate for ActivityPub but defaulting closed because the
+ * read/discovery path is still being rolled out.
+ */
+export const ATPROTO_ENABLED = process.env.ATPROTO_ENABLED === 'true';
+
+/**
+ * Bluesky's public AppView host. Read XRPC queries (`app.bsky.actor.getProfile`,
+ * `app.bsky.feed.getAuthorFeed`, `com.atproto.identity.resolveHandle`) hit this
+ * fixed, trusted host. Overridable for a self-hosted AppView.
+ */
+export const PUBLIC_APPVIEW = process.env.ATPROTO_APPVIEW || 'public.api.bsky.app';
+
+/**
+ * The PLC directory host that serves `did:plc:` DID documents
+ * (`https://plc.directory/<did>`). Overridable for a mirror.
+ */
+export const PLC_DIRECTORY = process.env.ATPROTO_PLC_DIRECTORY || 'plc.directory';
+
+/** Bluesky's web app origin — the canonical web URL for a post / profile. */
+export const BSKY_APP_ORIGIN = 'https://bsky.app';
+
+/** The atproto record collection that holds a feed post. */
+export const POST_COLLECTION = 'app.bsky.feed.post';
+
+/**
+ * A `did:plc:` identifier: the literal prefix followed by 24 base32-sortable
+ * characters (lowercase `a-z` + digits `2-7`).
+ */
+export const DID_PLC_RE = /^did:plc:[a-z2-7]{24}$/;
+
+/**
+ * A `did:web:` identifier: the prefix followed by a percent-encoded host
+ * (optionally `:`-separated path segments, with `%3A` encoding a port).
+ */
+export const DID_WEB_RE = /^did:web:[a-zA-Z0-9._%-]+(?::[a-zA-Z0-9._%-]+)*$/;
+
+/** Any supported atproto DID method (`did:plc:` or `did:web:`). */
+export const ANY_DID_RE = /^did:(?:plc|web):/;
+
+/**
+ * An AT-URI: `at://<authority>/<collection>/<rkey>` where the authority is a DID
+ * or a handle, the collection is an NSID, and the rkey is a record key. The
+ * collection + rkey are optional so a bare `at://<authority>` also matches.
+ */
+export const AT_URI_RE =
+  /^at:\/\/(did:(?:plc|web):[^/]+|[a-z0-9][a-z0-9.-]*\.[a-z]{2,})(?:\/([a-zA-Z0-9.]+)(?:\/([a-zA-Z0-9._~-]+))?)?$/i;
+
+/**
+ * An atproto handle: a DNS domain name (≥2 labels, e.g. `alice.bsky.social` or a
+ * custom domain `example.com`). Deliberately excludes anything containing `@`
+ * (that is a fediverse `user@host` acct, owned by the ActivityPub connector) or a
+ * URL scheme. The TLD label must be alphabetic so a bare IP / numeric form never
+ * matches.
+ */
+export const HANDLE_RE =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i;
+
+/** True when `subject` is a supported atproto DID. */
+export function isDid(subject: string): boolean {
+  return ANY_DID_RE.test(subject);
+}
+
+/** True when `subject` is an AT-URI. */
+export function isAtUri(subject: string): boolean {
+  return AT_URI_RE.test(subject);
+}
+
+/**
+ * True when `subject` looks like an atproto handle (a bare DNS name with no `@`
+ * and no URL scheme). `*.bsky.social` and any other registrable domain qualify.
+ */
+export function isAtprotoHandle(subject: string): boolean {
+  if (subject.includes('@') || subject.includes('://') || subject.includes(' ')) return false;
+  return HANDLE_RE.test(subject);
+}

--- a/packages/backend/src/connectors/atproto/identityResolver.ts
+++ b/packages/backend/src/connectors/atproto/identityResolver.ts
@@ -1,0 +1,148 @@
+import { resolveTxt } from 'node:dns/promises';
+import { logger } from '../../utils/logger';
+import { safeGetJson, safeGetText, xrpcGet, XrpcError } from './xrpcClient';
+import { ANY_DID_RE, DID_PLC_RE, PLC_DIRECTORY, PUBLIC_APPVIEW } from './constants';
+
+/**
+ * AT Protocol identity resolution (handle ↔ DID ↔ DID document).
+ *
+ * atproto identities are anchored by a DID (`did:plc:` or `did:web:`); the
+ * human-facing handle is a mutable DNS name that points BACK at the DID. This
+ * module turns either form into the other and reads the DID document (which
+ * lists the verified handle and the user's PDS service endpoint, needed later by
+ * the C4 outbound bridge). Every network read goes through the SSRF-safe XRPC
+ * client.
+ */
+
+/** The subset of an atproto DID document this connector reads. */
+export interface AtprotoDidDocument {
+  id?: string;
+  alsoKnownAs?: string[];
+  service?: Array<{ id?: string; type?: string; serviceEndpoint?: string }>;
+  verificationMethod?: Array<{ id?: string; type?: string; publicKeyMultibase?: string }>;
+}
+
+/** A fully resolved atproto identity. */
+export interface ResolvedAtprotoIdentity {
+  /** The stable DID (`did:plc:...` / `did:web:...`). */
+  did: string;
+  /** The verified handle (from the DID doc / input), or the DID when unknown. */
+  handle: string;
+  /** The user's Personal Data Server endpoint, when the DID doc advertises one. */
+  pdsEndpoint?: string;
+}
+
+/**
+ * Resolve a handle to its DID.
+ *
+ * Primary: the AppView `com.atproto.identity.resolveHandle` query. Fallbacks
+ * (handle's own domain authority): `https://<handle>/.well-known/atproto-did`
+ * and the `_atproto.<handle>` DNS TXT record. Returns null when no method yields
+ * a DID.
+ */
+export async function resolveHandleToDid(handle: string): Promise<string | null> {
+  // 1. AppView resolveHandle (the common path).
+  try {
+    const res = await xrpcGet<{ did?: string }>(PUBLIC_APPVIEW, 'com.atproto.identity.resolveHandle', { handle });
+    if (res?.did && ANY_DID_RE.test(res.did)) return res.did;
+  } catch (err) {
+    logger.debug(`[atproto] resolveHandle AppView failed for ${handle}`, err);
+  }
+
+  // 2. HTTPS well-known on the handle's own domain (SSRF-safe).
+  try {
+    const did = await safeGetText(`https://${handle}/.well-known/atproto-did`);
+    if (ANY_DID_RE.test(did)) return did;
+  } catch (err) {
+    logger.debug(`[atproto] .well-known/atproto-did failed for ${handle}`, err);
+  }
+
+  // 3. DNS TXT `_atproto.<handle>` — value is `did=<did>`.
+  try {
+    const records = await resolveTxt(`_atproto.${handle}`);
+    for (const chunks of records) {
+      const value = chunks.join('').trim();
+      const match = value.match(/^did=(.+)$/);
+      if (match && ANY_DID_RE.test(match[1])) return match[1];
+    }
+  } catch (err) {
+    logger.debug(`[atproto] _atproto DNS TXT failed for ${handle}`, err);
+  }
+
+  return null;
+}
+
+/** Convert a `did:web:` identifier to the `did.json` URL it resolves at. */
+function didWebToDocumentUrl(did: string): string | null {
+  const methodId = did.slice('did:web:'.length);
+  if (!methodId) return null;
+  const parts = methodId.split(':').map((segment) => {
+    try {
+      return decodeURIComponent(segment);
+    } catch {
+      return segment;
+    }
+  });
+  const host = parts[0];
+  if (!host) return null;
+  // No path segments → the well-known location; otherwise a path-scoped doc.
+  const path = parts.length > 1 ? `/${parts.slice(1).join('/')}/did.json` : '/.well-known/did.json';
+  return `https://${host}${path}`;
+}
+
+/**
+ * Fetch the DID document for a `did:plc:` (via the PLC directory) or `did:web:`
+ * (via its `did.json`). Returns null for unsupported methods or on failure.
+ */
+export async function resolveDidDocument(did: string): Promise<AtprotoDidDocument | null> {
+  try {
+    if (DID_PLC_RE.test(did)) {
+      return await safeGetJson<AtprotoDidDocument>(`https://${PLC_DIRECTORY}/${did}`);
+    }
+    if (did.startsWith('did:web:')) {
+      const url = didWebToDocumentUrl(did);
+      if (!url) return null;
+      return await safeGetJson<AtprotoDidDocument>(url);
+    }
+  } catch (err) {
+    if (err instanceof XrpcError) {
+      logger.debug(`[atproto] DID document resolution failed for ${did}: ${err.message}`);
+    } else {
+      logger.debug(`[atproto] DID document resolution error for ${did}`, err);
+    }
+  }
+  return null;
+}
+
+/** Extract the verified handle from a DID document's `alsoKnownAs` (`at://<handle>`). */
+export function handleFromDidDocument(doc: AtprotoDidDocument): string | undefined {
+  const aka = doc.alsoKnownAs?.find((value) => value.startsWith('at://'));
+  return aka ? aka.slice('at://'.length) : undefined;
+}
+
+/** Extract the PDS service endpoint (`#atproto_pds`) from a DID document. */
+export function pdsEndpointFromDidDocument(doc: AtprotoDidDocument): string | undefined {
+  const service = doc.service?.find(
+    (entry) => entry.id === '#atproto_pds' || entry.type === 'AtprotoPersonalDataServer',
+  );
+  return service?.serviceEndpoint;
+}
+
+/**
+ * Resolve a handle OR a DID into a full {@link ResolvedAtprotoIdentity}.
+ *
+ * Determines the DID (the input when already a DID, else handle→DID), then
+ * best-effort resolves the DID document to recover the verified handle and PDS
+ * endpoint. DID-document failure is non-fatal: discovery still succeeds with the
+ * DID and the input/derived handle.
+ */
+export async function resolveIdentity(handleOrDid: string): Promise<ResolvedAtprotoIdentity | null> {
+  const isDidInput = ANY_DID_RE.test(handleOrDid);
+  const did = isDidInput ? handleOrDid : await resolveHandleToDid(handleOrDid);
+  if (!did) return null;
+
+  const doc = await resolveDidDocument(did);
+  const handle = (doc && handleFromDidDocument(doc)) || (isDidInput ? did : handleOrDid);
+  const pdsEndpoint = doc ? pdsEndpointFromDidDocument(doc) : undefined;
+  return { did, handle, pdsEndpoint };
+}

--- a/packages/backend/src/connectors/atproto/post.mapper.ts
+++ b/packages/backend/src/connectors/atproto/post.mapper.ts
@@ -1,0 +1,333 @@
+import { PostVisibility } from '@mention/shared-types';
+import { logger } from '../../utils/logger';
+import { Post } from '../../models/Post';
+import { getPostCreator } from '../../services/serviceRegistry';
+import { materializeFederatedMedia, type ExtractedMediaItem, type ExtractedMediaAttachment } from '../shared/federatedMedia';
+import type { NormalizedExternalActor, NormalizedExternalMedia, NormalizedExternalPost } from '../types';
+import { xrpcGet } from './xrpcClient';
+import { BSKY_APP_ORIGIN, POST_COLLECTION, PUBLIC_APPVIEW } from './constants';
+
+/**
+ * Maps Bluesky `app.bsky.feed.post` records (from `app.bsky.feed.getAuthorFeed`)
+ * into native `Post` rows via the SAME `getPostCreator().create({...})` path the
+ * ActivityPub ingest uses, deduped on `Post.federation.activityId` (the AT-URI),
+ * with remote media mirrored to Oxy S3 by the shared `materializeFederatedMedia`.
+ */
+
+/** Adult/sensitive self-label values that flip a post's content warning on. */
+const ADULT_LABEL_VALUES = new Set(['porn', 'nudity', 'sexual', 'graphic-media']);
+
+/** Clamp self-asserted future timestamps (atproto `createdAt` is author-supplied). */
+const MAX_FUTURE_SKEW_MS = 60 * 60 * 1000; // 1 hour
+
+// --- getAuthorFeed response shape (only the fields this connector reads) ---
+
+interface AtprotoFacetFeature {
+  $type?: string;
+  tag?: string;
+  uri?: string;
+  did?: string;
+}
+interface AtprotoFacet {
+  features?: AtprotoFacetFeature[];
+}
+interface AtprotoReplyRef {
+  uri?: string;
+  cid?: string;
+}
+interface AtprotoPostRecord {
+  $type?: string;
+  text?: string;
+  createdAt?: string;
+  reply?: { root?: AtprotoReplyRef; parent?: AtprotoReplyRef };
+  facets?: AtprotoFacet[];
+  langs?: string[];
+  tags?: string[];
+  labels?: { values?: Array<{ val?: string }> };
+}
+interface AtprotoEmbedImage {
+  thumb?: string;
+  fullsize?: string;
+  alt?: string;
+}
+interface AtprotoEmbedView {
+  $type?: string;
+  images?: AtprotoEmbedImage[];
+  playlist?: string;
+  thumbnail?: string;
+  media?: AtprotoEmbedView;
+}
+interface AtprotoPostView {
+  uri?: string;
+  cid?: string;
+  author?: { did?: string; handle?: string };
+  record?: AtprotoPostRecord;
+  embed?: AtprotoEmbedView;
+  indexedAt?: string;
+}
+interface AtprotoFeedItem {
+  post?: AtprotoPostView;
+  /** Present on reposts (`#reasonRepost`) — those are skipped in C2. */
+  reason?: unknown;
+}
+interface AtprotoAuthorFeed {
+  feed?: AtprotoFeedItem[];
+  cursor?: string;
+}
+
+/** Parse an AT-URI `at://<authority>/<collection>/<rkey>` into its parts. */
+function parseAtUri(uri: string): { authority: string; collection: string; rkey: string } | null {
+  const match = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/([^/]+)$/);
+  if (!match) return null;
+  return { authority: match[1], collection: match[2], rkey: match[3] };
+}
+
+/** Parse an atproto `createdAt`, rejecting NaN and clamping far-future dates. */
+function parseCreatedAt(value: unknown): Date | undefined {
+  if (typeof value !== 'string') return undefined;
+  const date = new Date(value);
+  const ms = date.getTime();
+  if (Number.isNaN(ms)) return undefined;
+  if (ms > Date.now() + MAX_FUTURE_SKEW_MS) return undefined;
+  return date;
+}
+
+/** Extract hashtags from richtext `#tag` facets and the record-level `tags`. */
+function extractHashtags(record: AtprotoPostRecord): string[] {
+  const tags = new Set<string>();
+  for (const tag of record.tags ?? []) {
+    if (typeof tag === 'string' && tag.trim()) tags.add(tag.trim().replace(/^#/, '').toLowerCase());
+  }
+  for (const facet of record.facets ?? []) {
+    for (const feature of facet.features ?? []) {
+      if (feature?.$type === 'app.bsky.richtext.facet#tag' && typeof feature.tag === 'string' && feature.tag.trim()) {
+        tags.add(feature.tag.trim().replace(/^#/, '').toLowerCase());
+      }
+    }
+  }
+  return Array.from(tags);
+}
+
+/** Normalize `record.langs` to ISO 639-1 primary subtags (deduped, capped at 3). */
+function normalizeLangs(langs: unknown): string[] {
+  if (!Array.isArray(langs)) return [];
+  const out: string[] = [];
+  for (const lang of langs) {
+    if (typeof lang !== 'string') continue;
+    const code = lang.trim().toLowerCase().split('-')[0];
+    if (code && !out.includes(code)) out.push(code);
+    if (out.length >= 3) break;
+  }
+  return out;
+}
+
+/** True when the post carries an adult self-label. */
+function hasAdultLabel(record: AtprotoPostRecord): boolean {
+  const values = record.labels?.values;
+  if (!Array.isArray(values)) return false;
+  return values.some((entry) => typeof entry?.val === 'string' && ADULT_LABEL_VALUES.has(entry.val));
+}
+
+/**
+ * Extract playable media from a hydrated embed VIEW. Bluesky returns full CDN
+ * URLs in `app.bsky.embed.images#view` (`fullsize`) and
+ * `app.bsky.embed.video#view` (`playlist`, an HLS manifest); `recordWithMedia`
+ * nests its media under `.media`.
+ */
+function extractMediaFromEmbed(embed: AtprotoEmbedView | undefined): NormalizedExternalMedia[] {
+  const out: NormalizedExternalMedia[] = [];
+  const collect = (view: AtprotoEmbedView | undefined): void => {
+    if (!view) return;
+    switch (view.$type) {
+      case 'app.bsky.embed.images#view':
+        for (const image of view.images ?? []) {
+          const url = image?.fullsize || image?.thumb;
+          if (typeof url === 'string' && url) out.push({ id: url, type: 'image', remoteUrl: url });
+        }
+        break;
+      case 'app.bsky.embed.video#view': {
+        const url = view.playlist || view.thumbnail;
+        if (typeof url === 'string' && url) out.push({ id: url, type: 'video', remoteUrl: url });
+        break;
+      }
+      case 'app.bsky.embed.recordWithMedia#view':
+        collect(view.media);
+        break;
+      default:
+        break;
+    }
+  };
+  collect(embed);
+  return out;
+}
+
+/**
+ * Map a single `app.bsky.feed.post` PostView into a network-neutral post.
+ *
+ * Returns null for anything that is not an `app.bsky.feed.post` authored by
+ * `expectedAuthorDid` (the synced actor) — mirroring the ActivityPub
+ * actor-match guard so an author feed cannot smuggle in another actor's post.
+ */
+export function mapPostViewToNormalizedPost(
+  postView: AtprotoPostView | undefined,
+  expectedAuthorDid: string,
+): NormalizedExternalPost | null {
+  if (!postView || typeof postView.uri !== 'string') return null;
+  const parsed = parseAtUri(postView.uri);
+  if (!parsed || parsed.collection !== POST_COLLECTION) return null;
+
+  const did = postView.author?.did;
+  if (typeof did !== 'string' || did !== expectedAuthorDid) return null;
+
+  const record = postView.record;
+  if (!record || record.$type !== POST_COLLECTION) return null;
+
+  const handle = typeof postView.author?.handle === 'string' ? postView.author.handle : undefined;
+  const profileRef = handle || did;
+  const url = `${BSKY_APP_ORIGIN}/profile/${profileRef}/post/${parsed.rkey}`;
+  const langs = normalizeLangs(record.langs);
+  const media = extractMediaFromEmbed(postView.embed);
+  const inReplyTo = typeof record.reply?.parent?.uri === 'string' ? record.reply.parent.uri : undefined;
+
+  return {
+    network: 'atproto',
+    activityId: postView.uri,
+    actorUri: did,
+    url,
+    inReplyTo,
+    sensitive: hasAdultLabel(record),
+    authorOxyUserId: undefined,
+    text: typeof record.text === 'string' ? record.text : '',
+    media: media.length > 0 ? media : undefined,
+    hashtags: extractHashtags(record),
+    language: langs[0],
+    languages: langs.length > 0 ? langs : undefined,
+    createdAt: parseCreatedAt(record.createdAt),
+  };
+}
+
+/** True for a MongoDB duplicate-key (E11000) error — a concurrent import race. */
+function isDuplicateKeyError(err: unknown): boolean {
+  return Boolean(err && typeof err === 'object' && (err as { code?: number }).code === 11000);
+}
+
+/**
+ * Persist a normalized atproto post as a native `Post` via the shared creation
+ * path, after mirroring its media to Oxy S3. Returns true on a fresh insert,
+ * false when it already existed (dedup race) or creation failed.
+ */
+async function createPostFromNormalized(
+  post: NormalizedExternalPost,
+  ownerOxyUserId: string,
+  did: string,
+  instanceDomain: string,
+): Promise<boolean> {
+  const media: ExtractedMediaItem[] = (post.media ?? []).map((item) => ({ id: item.id, type: item.type }));
+  const attachments: ExtractedMediaAttachment[] = (post.media ?? []).map((item) => ({
+    type: 'media',
+    id: item.id,
+    mediaType: item.type,
+  }));
+
+  const materialized = await materializeFederatedMedia(media, attachments, ownerOxyUserId, {
+    activityId: post.activityId,
+    actorUri: did,
+  });
+
+  try {
+    await getPostCreator().create({
+      oxyUserId: ownerOxyUserId,
+      federation: {
+        activityId: post.activityId,
+        actorUri: did,
+        inReplyTo: post.inReplyTo,
+        url: post.url,
+        sensitive: post.sensitive ?? false,
+      },
+      content: {
+        text: post.text,
+        media: materialized.media.length > 0 ? materialized.media : undefined,
+        attachments: materialized.attachments.length > 0 ? materialized.attachments : undefined,
+      },
+      visibility: PostVisibility.PUBLIC,
+      hashtags: post.hashtags,
+      language: post.language,
+      languages: post.languages,
+      instanceDomain,
+      status: 'published',
+      metadata: { isSensitive: post.sensitive === true },
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+      ...(post.createdAt ? { createdAt: post.createdAt, updatedAt: post.createdAt } : {}),
+    });
+    return true;
+  } catch (err) {
+    if (isDuplicateKeyError(err)) return false;
+    logger.warn(`[atproto] failed to import post ${post.activityId}`, err);
+    return false;
+  }
+}
+
+/**
+ * Fetch `app.bsky.feed.getAuthorFeed` for the resolved atproto `actor`, map each
+ * original `app.bsky.feed.post` to a native `Post`, dedup on the AT-URI, and
+ * import the new ones. Reposts (items carrying a `reason`) are skipped in C2.
+ *
+ * The actor MUST already carry a resolved `oxyUserId` (no orphan posts).
+ */
+export async function importAuthorFeed(
+  actor: NormalizedExternalActor,
+  opts: { limit?: number; cursor?: string } = {},
+): Promise<{ posts: NormalizedExternalPost[]; cursor?: string }> {
+  const did = actor.externalId;
+  const ownerOxyUserId = actor.oxyUserId;
+  if (!ownerOxyUserId) {
+    logger.warn(`[atproto] importAuthorFeed called for ${did} without a resolved Oxy user; skipping (no orphan)`);
+    return { posts: [] };
+  }
+  const instanceDomain = actor.handle;
+
+  let feed: AtprotoAuthorFeed;
+  try {
+    feed = await xrpcGet<AtprotoAuthorFeed>(PUBLIC_APPVIEW, 'app.bsky.feed.getAuthorFeed', {
+      actor: did,
+      limit: opts.limit ?? 20,
+      cursor: opts.cursor,
+    });
+  } catch (err) {
+    logger.debug(`[atproto] getAuthorFeed failed for ${did}`, err);
+    return { posts: [] };
+  }
+
+  const items = Array.isArray(feed?.feed) ? feed.feed : [];
+  const normalized: NormalizedExternalPost[] = [];
+  for (const item of items) {
+    if (item?.reason) continue; // skip reposts in C2
+    const mapped = mapPostViewToNormalizedPost(item.post, did);
+    if (mapped) normalized.push({ ...mapped, authorOxyUserId: ownerOxyUserId });
+  }
+
+  if (normalized.length === 0) return { posts: [], cursor: feed?.cursor };
+
+  // Dedup against AT-URIs already imported (the unique sparse
+  // `federation.activityId` index is the backstop for concurrent races).
+  const atUris = normalized.map((post) => post.activityId);
+  const existingDocs = await Post.find({ 'federation.activityId': { $in: atUris } })
+    .select('federation.activityId')
+    .lean();
+  const seen = new Set<string>();
+  for (const doc of existingDocs) {
+    const id = (doc as { federation?: { activityId?: string } }).federation?.activityId;
+    if (id) seen.add(id);
+  }
+
+  const imported: NormalizedExternalPost[] = [];
+  for (const post of normalized) {
+    if (seen.has(post.activityId)) continue;
+    const created = await createPostFromNormalized(post, ownerOxyUserId, did, instanceDomain);
+    if (created) imported.push(post);
+  }
+
+  return { posts: imported, cursor: feed?.cursor };
+}

--- a/packages/backend/src/connectors/atproto/profile.mapper.ts
+++ b/packages/backend/src/connectors/atproto/profile.mapper.ts
@@ -1,0 +1,133 @@
+import { logger } from '../../utils/logger';
+import FederatedActor, { IFederatedActor } from '../../models/FederatedActor';
+import { resolveOxyExternalUser } from '../identity';
+import type { NormalizedExternalActor } from '../types';
+import { xrpcGet } from './xrpcClient';
+import { PUBLIC_APPVIEW } from './constants';
+
+/**
+ * Maps an `app.bsky.actor.getProfile` response into a network-neutral actor,
+ * upserts the backing `FederatedActor` row (`protocol:'atproto'`), and mints /
+ * stamps the Oxy user it maps to through the shared identity bridge.
+ */
+
+/** The subset of `app.bsky.actor.defs#profileViewDetailed` this connector reads. */
+export interface AtprotoProfileView {
+  did?: string;
+  handle?: string;
+  displayName?: string;
+  description?: string;
+  avatar?: string;
+  banner?: string;
+  followersCount?: number;
+  followsCount?: number;
+  postsCount?: number;
+}
+
+/** Split an atproto handle (a DNS name) into a display username + instance domain. */
+function splitHandle(handle: string): { username: string; domain: string } {
+  const dot = handle.indexOf('.');
+  if (dot <= 0) return { username: handle, domain: handle };
+  return { username: handle, domain: handle.slice(dot + 1) };
+}
+
+/** Map a getProfile response to the network-neutral actor shape (pure). */
+export function mapProfileToNormalizedActor(profile: AtprotoProfileView): NormalizedExternalActor | null {
+  const did = typeof profile.did === 'string' ? profile.did : '';
+  const handle = typeof profile.handle === 'string' ? profile.handle : '';
+  if (!did || !handle) return null;
+
+  return {
+    network: 'atproto',
+    externalId: did,
+    handle,
+    displayName: profile.displayName || undefined,
+    avatarUrl: profile.avatar || undefined,
+    bannerUrl: profile.banner || undefined,
+    bio: profile.description || undefined,
+    followersCount: typeof profile.followersCount === 'number' ? profile.followersCount : undefined,
+    followingCount: typeof profile.followsCount === 'number' ? profile.followsCount : undefined,
+    postsCount: typeof profile.postsCount === 'number' ? profile.postsCount : undefined,
+  };
+}
+
+/**
+ * Upsert the `FederatedActor` row for a normalized atproto actor and resolve its
+ * Oxy user. Returns the actor with `oxyUserId` populated when Oxy resolved it.
+ *
+ * Fails soft: if `resolveOxyExternalUser` returns null (e.g. oxy-api does not yet
+ * accept a `did:` `actorUri`), the actor row is still upserted but `oxyUserId`
+ * stays undefined — callers MUST NOT import posts for an unresolved author (no
+ * orphan posts), exactly like the ActivityPub no-orphan invariant.
+ */
+export async function upsertAtprotoActor(actor: NormalizedExternalActor): Promise<NormalizedExternalActor> {
+  const did = actor.externalId;
+  const { username, domain } = splitHandle(actor.handle);
+
+  let fedActor: IFederatedActor | null = null;
+  try {
+    fedActor = await FederatedActor.findOneAndUpdate(
+      { uri: did },
+      {
+        $set: {
+          protocol: 'atproto',
+          uri: did,
+          externalId: did,
+          username,
+          domain,
+          acct: actor.handle,
+          summary: actor.bio ?? '',
+          avatarUrl: actor.avatarUrl,
+          headerUrl: actor.bannerUrl,
+          type: 'Person',
+          followersCount: actor.followersCount ?? 0,
+          followingCount: actor.followingCount ?? 0,
+          postsCount: actor.postsCount ?? 0,
+          lastFetchedAt: new Date(),
+        },
+      },
+      { upsert: true, returnDocument: 'after', lean: true },
+    ) as IFederatedActor | null;
+  } catch (err) {
+    // A rare unique-key collision (a handle reassigned across DIDs) must not
+    // abort discovery — log and continue with no stamped row.
+    logger.warn(`[atproto] failed to upsert FederatedActor for ${did}`, err);
+  }
+
+  const existingOxyId = fedActor?.oxyUserId ?? undefined;
+  const oxyId = await resolveOxyExternalUser({ ...actor, oxyUserId: existingOxyId });
+  if (!oxyId) {
+    // Hard runtime dependency: oxy-api `PUT /users/resolve` must accept a `did:`
+    // actorUri. Until it does this returns null — fail soft (no throw, no orphan).
+    logger.warn(`[atproto] Oxy user unresolved for ${did}; importing skipped until oxy-api accepts did: actorUri`);
+    return { ...actor, oxyUserId: undefined };
+  }
+
+  if (fedActor && fedActor.oxyUserId !== oxyId) {
+    await FederatedActor.updateOne({ _id: fedActor._id }, { $set: { oxyUserId: oxyId } });
+  }
+  return { ...actor, oxyUserId: oxyId };
+}
+
+/**
+ * Fetch a Bluesky profile (`app.bsky.actor.getProfile`), normalize it, upsert the
+ * `FederatedActor`, and resolve its Oxy user. `actor` may be a handle or a DID.
+ * Returns null when the profile cannot be fetched / mapped.
+ */
+export async function fetchAndUpsertAtprotoProfile(actor: string): Promise<NormalizedExternalActor | null> {
+  let profile: AtprotoProfileView;
+  try {
+    profile = await xrpcGet<AtprotoProfileView>(PUBLIC_APPVIEW, 'app.bsky.actor.getProfile', { actor });
+  } catch (err) {
+    logger.debug(`[atproto] getProfile failed for ${actor}`, err);
+    return null;
+  }
+
+  const normalized = mapProfileToNormalizedActor(profile);
+  if (!normalized) {
+    logger.debug(`[atproto] getProfile for ${actor} returned an unmappable profile`);
+    return null;
+  }
+
+  return upsertAtprotoActor(normalized);
+}

--- a/packages/backend/src/connectors/atproto/xrpcClient.ts
+++ b/packages/backend/src/connectors/atproto/xrpcClient.ts
@@ -1,0 +1,104 @@
+import { fetchUpstreamSingleHop } from '../../utils/safeUpstreamFetch';
+import { readBoundedResponseBody } from '../shared/httpBody';
+
+/**
+ * Thin, SSRF-safe XRPC client for the AT Protocol.
+ *
+ * The atproto connector NEVER uses `@atproto/api`. Every outbound GET — AppView
+ * XRPC queries, PLC directory lookups, did:web `did.json`, `.well-known`
+ * documents — goes through the same IP-pinned single-hop fetch the federation
+ * media proxy and signed ActivityPub fetches use (`fetchUpstreamSingleHop`):
+ *
+ *  - the URL is validated by `assertSafePublicUrl` (DNS resolution + private /
+ *    reserved-range denylist) and the TCP connection is PINNED to the validated
+ *    IP, closing the DNS-rebind TOCTOU window;
+ *  - the response body is read with a hard byte cap so a hostile remote cannot
+ *    make us buffer an unbounded payload;
+ *  - a time-to-first-byte deadline abandons slow/dead hosts.
+ *
+ * Redirects are NOT followed (XRPC / PLC / did:web endpoints answer directly);
+ * a 3xx is surfaced as a non-2xx error.
+ */
+
+/** Time-to-first-byte + overall read deadline for an atproto GET. */
+const XRPC_TIMEOUT_MS = 8_000;
+
+/** Maximum JSON document size accepted from any atproto endpoint (2 MiB). */
+const MAX_JSON_BYTES = 2 * 1024 * 1024;
+
+/** Maximum text document size (e.g. `.well-known/atproto-did`) — DIDs are short. */
+const MAX_TEXT_BYTES = 4 * 1024;
+
+/** User-Agent presented to atproto hosts. */
+const USER_AGENT = 'Mention/atproto-connector (+https://mention.earth)';
+
+/** A failed atproto GET (non-2xx upstream, transport error, or invalid body). */
+export class XrpcError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'XrpcError';
+    this.status = status;
+  }
+}
+
+/** Query-string parameter values an XRPC endpoint accepts. */
+export type XrpcParams = Record<string, string | number | boolean | undefined>;
+
+/** Build the absolute XRPC URL for `host`/`nsid` with `params` query-encoded. */
+export function buildXrpcUrl(host: string, nsid: string, params: XrpcParams = {}): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    search.set(key, String(value));
+  }
+  const qs = search.toString();
+  return `https://${host}/xrpc/${nsid}${qs ? `?${qs}` : ''}`;
+}
+
+/** Common bounded GET used for both JSON and text reads. */
+async function safeGet(
+  url: string,
+  accept: string,
+  maxBytes: number,
+): Promise<Buffer> {
+  const deadline = AbortSignal.timeout(XRPC_TIMEOUT_MS);
+  const { response, status } = await fetchUpstreamSingleHop(url, {
+    headers: { 'User-Agent': USER_AGENT, Accept: accept },
+    signal: deadline,
+    headersTimeoutMs: XRPC_TIMEOUT_MS,
+  });
+
+  if (status < 200 || status >= 300) {
+    response.destroy();
+    throw new XrpcError(`atproto GET ${url} returned ${status}`, status);
+  }
+
+  const buffer = await readBoundedResponseBody(response, maxBytes);
+  return Buffer.from(buffer);
+}
+
+/** Fetch + parse a JSON document from `url`. Throws {@link XrpcError} on failure. */
+export async function safeGetJson<T = unknown>(url: string): Promise<T> {
+  const buffer = await safeGet(url, 'application/json', MAX_JSON_BYTES);
+  try {
+    return JSON.parse(buffer.toString('utf8')) as T;
+  } catch {
+    throw new XrpcError(`atproto GET ${url} returned invalid JSON`);
+  }
+}
+
+/** Fetch a short text document (e.g. `.well-known/atproto-did`), trimmed. */
+export async function safeGetText(url: string): Promise<string> {
+  const buffer = await safeGet(url, 'text/plain', MAX_TEXT_BYTES);
+  return buffer.toString('utf8').trim();
+}
+
+/**
+ * Perform an XRPC query: `GET https://{host}/xrpc/{nsid}?{params}` and parse the
+ * JSON response. Throws {@link XrpcError} on any non-2xx / transport / parse
+ * failure so callers can fail soft.
+ */
+export function xrpcGet<T = unknown>(host: string, nsid: string, params: XrpcParams = {}): Promise<T> {
+  return safeGetJson<T>(buildXrpcUrl(host, nsid, params));
+}

--- a/packages/backend/src/connectors/connectors.routes.ts
+++ b/packages/backend/src/connectors/connectors.routes.ts
@@ -4,36 +4,56 @@ import { getRequiredOxyUserId, type OxyAuthRequest as AuthRequest } from '@oxyhq
 import type { User as OxyUser } from '@oxyhq/core';
 import { PostVisibility } from '@mention/shared-types';
 import { logger } from '../utils/logger';
-import { activityPubConnector, isPermanentlyUnavailableOutboxReason } from '../connectors/activitypub/ActivityPubConnector';
+import { activityPubConnector, isPermanentlyUnavailableOutboxReason } from './activitypub/ActivityPubConnector';
 import FederatedActor from '../models/FederatedActor';
 import FederatedFollow from '../models/FederatedFollow';
 import { Post } from '../models/Post';
-import { FEDERATION_ENABLED } from '../connectors/activitypub/constants';
+import { FEDERATION_ENABLED } from './activitypub/constants';
+import { ATPROTO_ENABLED } from './atproto/constants';
+import { connectorRegistry } from './index';
+import { classifyQuery } from './resolve';
+import type { NetworkConnector } from './types';
 import { postHydrationService } from '../services/PostHydrationService';
 import { createScopedOxyClient, getServiceOxyClient } from '../utils/oxyHelpers';
 import { apiRateLimiter } from '../middleware/rateLimiter';
 
+/**
+ * Cross-network connector API (mounted at `/federation`, URL kept stable for the
+ * frontend). Generalized from the ActivityPub-only `federation.api.routes`:
+ * follow / unfollow now dispatch to the connector that owns the target's
+ * protocol, `/resolve` performs unified cross-network handle resolution, and the
+ * `actor/posts` empty-state sync dispatches by `FederatedActor.protocol`. The
+ * `following`/`followers` list queries are already protocol-agnostic.
+ */
 const router = Router();
 
-// Rate-limit all federation API routes (200 req/min per user or IP)
+// Rate-limit all connector API routes (200 req/min per user or IP)
 router.use(apiRateLimiter);
 
 // --- Zod schemas ---
 
-const actorUriSchema = z.object({
-  actorUri: z.string().url('Invalid actorUri'),
+// `actorUri` is a protocol id: an http(s) ActivityPub actor URI OR an atproto
+// DID (`did:plc:` / `did:web:`). `.url()` would reject DIDs, so accept any
+// bounded non-empty string and let connector dispatch validate the shape.
+const actorRefSchema = z.object({
+  actorUri: z.string().min(1).max(2048),
 });
 
 const actorPostsQuerySchema = z.object({
-  uri: z.string().url('Invalid uri parameter'),
+  // Same as above: a stored actor `uri` is an AP actor URI OR an atproto DID.
+  uri: z.string().min(1).max(2048),
   cursor: z.string().datetime({ offset: true }).optional(),
+});
+
+const resolveQuerySchema = z.object({
+  handle: z.string().min(1).max(512),
 });
 
 // --- Helpers ---
 
-/** Guard: return 404 if federation is disabled. */
-function requireFederation(res: Response): boolean {
-  if (!FEDERATION_ENABLED) {
+/** Guard: return 404 if NO external network is enabled. */
+function requireAnyConnector(res: Response): boolean {
+  if (!FEDERATION_ENABLED && !ATPROTO_ENABLED) {
     res.status(404).json({ error: 'Federation disabled' });
     return false;
   }
@@ -45,8 +65,7 @@ function requireFederation(res: Response): boolean {
  *
  * Identity resolution is owned entirely by `@oxyhq/core/server`
  * (`getRequiredOxyUserId`, which throws when unauthenticated). This wrapper only
- * translates that into an HTTP 401 — these routes are mounted under `optionalAuth`,
- * so the federation availability check (404) must run before this auth check.
+ * translates that into an HTTP 401 — these routes are mounted under `optionalAuth`.
  */
 function resolveUserOr401(req: AuthRequest, res: Response): string | null {
   try {
@@ -55,6 +74,20 @@ function resolveUserOr401(req: AuthRequest, res: Response): string | null {
     res.status(401).json({ error: 'Unauthorized' });
     return null;
   }
+}
+
+/**
+ * Resolve the connector that owns a follow/unfollow target. Prefers the stored
+ * `FederatedActor.protocol` (authoritative once an actor is known), falling back
+ * to shape-based `matches` (an http URI → ActivityPub, a DID → atproto).
+ */
+async function resolveTargetConnector(target: string): Promise<NetworkConnector | undefined> {
+  const stored = await FederatedActor.findOne({ uri: target }).select('protocol').lean();
+  if (stored?.protocol) {
+    const byProtocol = connectorRegistry.list().find((connector) => connector.id === stored.protocol);
+    if (byProtocol) return byProtocol;
+  }
+  return connectorRegistry.connectorFor(target);
 }
 
 function hasUnavailableCurrentOutbox(actor: { outboxUrl?: string; outboxBackfill?: { outboxUrl?: string; status?: string } }): boolean {
@@ -109,32 +142,96 @@ async function resolveActorDisplayNamesByUri(
 }
 
 // --- Routes ---
-// Note: Profile search/lookup is handled by OxyHQServices (/profiles/search, /profiles/resolve).
-// These routes handle Mention-specific federation operations (follows, posts).
+// Note: Local profile search/lookup is handled by OxyHQServices
+// (/profiles/search, /profiles/resolve). These routes handle cross-network
+// federation operations (resolve, follows, posts).
+
+/**
+ * GET /federation/resolve?handle=...
+ *
+ * Unified cross-network handle resolution. Classifies the query (ActivityPub /
+ * atproto / local), dispatches to the connector that owns it, and returns a
+ * normalized actor card with the Oxy user it maps to plus the viewer's follow
+ * state. Local Oxy handles are out of scope here (resolved by Oxy `/profiles`).
+ */
+router.get('/resolve', async (req: AuthRequest, res: Response) => {
+  if (!requireAnyConnector(res)) return;
+
+  const parsed = resolveQuerySchema.safeParse(req.query);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
+
+  const network = classifyQuery(parsed.data.handle);
+  if (network === 'local') {
+    return res.status(404).json({ error: 'Not an external handle' });
+  }
+
+  try {
+    const actor = await connectorRegistry.resolve(parsed.data.handle);
+    if (!actor) return res.status(404).json({ error: 'Actor not found' });
+
+    // Follow state for the (optional) viewer — keyed on the actor's protocol id.
+    let followed = false;
+    const viewerId = req.user?.id;
+    if (viewerId) {
+      const follow = await FederatedFollow.findOne({
+        localUserId: viewerId,
+        remoteActorUri: actor.externalId,
+        direction: 'outbound',
+        status: { $in: ['accepted', 'pending'] },
+      }).lean();
+      followed = Boolean(follow);
+    }
+
+    return res.json({
+      network: actor.network,
+      externalId: actor.externalId,
+      handle: actor.handle,
+      displayName: actor.displayName,
+      avatarUrl: actor.avatarUrl,
+      oxyUserId: actor.oxyUserId,
+      followed,
+    });
+  } catch (err) {
+    logger.error('Federation resolve error:', err);
+    return res.status(500).json({ error: 'Resolve failed' });
+  }
+});
 
 /**
  * POST /federation/follow
- * Follow a remote fediverse actor.
+ * Follow a remote actor (ActivityPub or atproto), dispatched by protocol.
  */
 router.post('/follow', async (req: AuthRequest, res: Response) => {
-  if (!requireFederation(res)) return;
+  if (!requireAnyConnector(res)) return;
   const userId = resolveUserOr401(req, res);
   if (!userId) return;
 
-  const parsed = actorUriSchema.safeParse(req.body);
+  const parsed = actorRefSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
 
   try {
+    const connector = await resolveTargetConnector(parsed.data.actorUri);
+    if (!connector) return res.status(404).json({ error: 'Unsupported or unknown actor' });
+
     const { oxy } = require('../../server.js');
     const user = await oxy.getUserById(userId);
     if (!user?.username) return res.status(404).json({ error: 'User not found' });
 
-    const result = await activityPubConnector.sendFollow(userId, user.username, parsed.data.actorUri);
-    return res.json({
-      success: result.success,
-      pending: result.pending,
-      actorUri: parsed.data.actorUri,
+    await connector.deliver({
+      kind: 'follow.add',
+      localOxyUserId: userId,
+      localUsername: user.username,
+      targetActorUri: parsed.data.actorUri,
     });
+
+    // `pending` reflects whether the target manually approves followers (an
+    // ActivityPub locked account); atproto actors never do, so this is false.
+    const actor = await FederatedActor.findOne({ uri: parsed.data.actorUri })
+      .select('manuallyApprovesFollowers')
+      .lean();
+    const pending = actor?.manuallyApprovesFollowers === true;
+
+    return res.json({ success: true, pending, actorUri: parsed.data.actorUri });
   } catch (err) {
     logger.error('Federation follow error:', err);
     return res.status(500).json({ error: 'Follow failed' });
@@ -143,23 +240,32 @@ router.post('/follow', async (req: AuthRequest, res: Response) => {
 
 /**
  * POST /federation/unfollow
- * Unfollow a remote fediverse actor.
+ * Unfollow a remote actor (ActivityPub or atproto), dispatched by protocol.
  */
 router.post('/unfollow', async (req: AuthRequest, res: Response) => {
-  if (!requireFederation(res)) return;
+  if (!requireAnyConnector(res)) return;
   const userId = resolveUserOr401(req, res);
   if (!userId) return;
 
-  const parsed = actorUriSchema.safeParse(req.body);
+  const parsed = actorRefSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
 
   try {
+    const connector = await resolveTargetConnector(parsed.data.actorUri);
+    if (!connector) return res.status(404).json({ error: 'Unsupported or unknown actor' });
+
     const { oxy } = require('../../server.js');
     const user = await oxy.getUserById(userId);
     if (!user?.username) return res.status(404).json({ error: 'User not found' });
 
-    const success = await activityPubConnector.sendUndoFollow(userId, user.username, parsed.data.actorUri);
-    return res.json({ success, actorUri: parsed.data.actorUri });
+    await connector.deliver({
+      kind: 'follow.remove',
+      localOxyUserId: userId,
+      localUsername: user.username,
+      targetActorUri: parsed.data.actorUri,
+    });
+
+    return res.json({ success: true, actorUri: parsed.data.actorUri });
   } catch (err) {
     logger.error('Federation unfollow error:', err);
     return res.status(500).json({ error: 'Unfollow failed' });
@@ -168,10 +274,10 @@ router.post('/unfollow', async (req: AuthRequest, res: Response) => {
 
 /**
  * GET /federation/following
- * List remote accounts the current user follows.
+ * List remote accounts the current user follows (any network).
  */
 router.get('/following', async (req: AuthRequest, res: Response) => {
-  if (!requireFederation(res)) return;
+  if (!requireAnyConnector(res)) return;
   const userId = resolveUserOr401(req, res);
   if (!userId) return;
 
@@ -192,6 +298,7 @@ router.get('/following', async (req: AuthRequest, res: Response) => {
       const handleFallback = actor ? `@${actor.acct}` : f.remoteActorUri;
       return {
         actorUri: f.remoteActorUri,
+        network: actor?.protocol ?? f.network ?? 'activitypub',
         handle: actor?.username || 'unknown',
         instance: actor?.domain || 'unknown',
         fullHandle: handleFallback,
@@ -214,7 +321,7 @@ router.get('/following', async (req: AuthRequest, res: Response) => {
  * List remote accounts following the current user.
  */
 router.get('/followers', async (req: AuthRequest, res: Response) => {
-  if (!requireFederation(res)) return;
+  if (!requireAnyConnector(res)) return;
   const userId = resolveUserOr401(req, res);
   if (!userId) return;
 
@@ -235,6 +342,7 @@ router.get('/followers', async (req: AuthRequest, res: Response) => {
       const handleFallback = actor ? `@${actor.acct}` : f.remoteActorUri;
       return {
         actorUri: f.remoteActorUri,
+        network: actor?.protocol ?? f.network ?? 'activitypub',
         handle: actor?.username || 'unknown',
         instance: actor?.domain || 'unknown',
         fullHandle: handleFallback,
@@ -252,10 +360,11 @@ router.get('/followers', async (req: AuthRequest, res: Response) => {
 
 /**
  * GET /federation/actor/posts?uri=...&cursor=...
- * Get posts from a federated actor stored locally.
+ * Get posts from a federated actor stored locally (any network). The empty-state
+ * background sync dispatches by the actor's protocol.
  */
 router.get('/actor/posts', async (req: AuthRequest, res: Response) => {
-  if (!requireFederation(res)) return;
+  if (!requireAnyConnector(res)) return;
 
   const parsed = actorPostsQuerySchema.safeParse(req.query);
   if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
@@ -282,30 +391,48 @@ router.get('/actor/posts', async (req: AuthRequest, res: Response) => {
       .limit(limit + 1)
       .lean();
 
-    // If no local posts and no cursor (first page), trigger async sync
-    if (posts.length === 0 && !parsed.data.cursor && actor.outboxUrl) {
-      if (hasUnavailableCurrentOutbox(actor)) {
-        return res.json({ posts: [], hasMore: false, syncing: false, syncUnavailable: true });
+    // If no local posts and no cursor (first page), trigger an async backfill
+    // dispatched by the actor's network.
+    if (posts.length === 0 && !parsed.data.cursor) {
+      if (actor.protocol === 'atproto') {
+        if (actor.externalId) {
+          const connector = connectorRegistry.connectorFor(actor.externalId);
+          if (connector) {
+            connector.fetchPosts(actor.externalId, { limit }).catch((err) => {
+              logger.warn('Background atproto author-feed sync failed:', err);
+            });
+            return res.json({ posts: [], hasMore: false, syncing: true });
+          }
+        }
+        return res.json({ posts: [], hasMore: false });
       }
 
-      // Fire-and-forget: sync in background, return syncing flag to client
-      activityPubConnector.syncOutboxPostsDetailed(actor, limit)
-        .then(async (result) => {
-          if (isPermanentlyUnavailableOutboxReason(result.reason)) {
-            await activityPubConnector.markOutboxBackfillUnavailable(actor, result.reason);
-          }
-        })
-        .catch((err) => {
-          logger.warn('Background outbox sync failed:', err);
-        });
-      return res.json({ posts: [], hasMore: false, syncing: true });
+      // ActivityPub outbox backfill.
+      if (actor.outboxUrl) {
+        if (hasUnavailableCurrentOutbox(actor)) {
+          return res.json({ posts: [], hasMore: false, syncing: false, syncUnavailable: true });
+        }
+
+        // Fire-and-forget: sync in background, return syncing flag to client
+        activityPubConnector.syncOutboxPostsDetailed(actor, limit)
+          .then(async (result) => {
+            if (isPermanentlyUnavailableOutboxReason(result.reason)) {
+              await activityPubConnector.markOutboxBackfillUnavailable(actor, result.reason);
+            }
+          })
+          .catch((err) => {
+            logger.warn('Background outbox sync failed:', err);
+          });
+        return res.json({ posts: [], hasMore: false, syncing: true });
+      }
     }
 
     const hasMore = posts.length > limit;
     const sliced = hasMore ? posts.slice(0, limit) : posts;
     const nextCursor = hasMore ? sliced[sliced.length - 1].createdAt : undefined;
 
-    // Hydrate posts so they render identically to native posts
+    // Hydrate posts so they render identically to native posts. maxDepth:1 is
+    // REQUIRED so federated boosts (empty body, hydrated via boostOf) render.
     const hydrated = await postHydrationService.hydratePosts(sliced, {
       viewerId: req.user?.id,
       oxyClient: createScopedOxyClient(req),

--- a/packages/backend/src/connectors/identity.ts
+++ b/packages/backend/src/connectors/identity.ts
@@ -29,6 +29,10 @@ const ACTOR_BANNER_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
  * Derive the federated user's instance domain from the normalized actor. AP
  * handles are `user@domain`; otherwise fall back to the host of the protocol id.
  * Reproduces the prior `domainFromAcct(acct) || actorHost` value for AP actors.
+ *
+ * For atproto the handle is itself a bare DNS name (e.g. `alice.bsky.social`) and
+ * the protocol id is a `did:` (which has no URL host), so neither the `@` split
+ * nor the URL host yields a domain — fall back to the handle (the domain).
  */
 function deriveDomain(actor: NormalizedExternalActor): string {
   const at = actor.handle.lastIndexOf('@');
@@ -36,10 +40,12 @@ function deriveDomain(actor: NormalizedExternalActor): string {
     return actor.handle.slice(at + 1).toLowerCase();
   }
   try {
-    return new URL(actor.externalId).hostname.toLowerCase();
+    const host = new URL(actor.externalId).hostname.toLowerCase();
+    if (host) return host;
   } catch {
-    return actor.handle.toLowerCase();
+    // Unparseable protocol id (e.g. a DID) — fall through to the handle.
   }
+  return actor.handle.toLowerCase();
 }
 
 /**

--- a/packages/backend/src/connectors/index.ts
+++ b/packages/backend/src/connectors/index.ts
@@ -3,6 +3,8 @@ import type { NetworkConnector } from './types';
 import { ConnectorRegistry } from './ConnectorRegistry';
 import { activityPubConnector } from './activitypub/ActivityPubConnector';
 import { FEDERATION_ENABLED } from './activitypub/constants';
+import { atprotoConnector } from './atproto/AtprotoConnector';
+import { ATPROTO_ENABLED } from './atproto/constants';
 
 /**
  * Network-connector bootstrap.
@@ -21,12 +23,20 @@ import { FEDERATION_ENABLED } from './activitypub/constants';
  *
  * Connectors gate on their own env flags:
  *  - ActivityPub  → `FEDERATION_ENABLED` (default on; `false` disables).
- *  - atproto      → added in a later phase (its own gate).
+ *  - atproto      → `ATPROTO_ENABLED` (default OFF; `true` enables Bluesky read).
+ *
+ * Order matters for `connectorFor`/`resolve`: ActivityPub is registered first so
+ * a fediverse `@user@host` acct is claimed by it, and the atproto connector
+ * claims the remaining shapes (bare handles / DIDs / AT-URIs).
  */
 const connectors: NetworkConnector[] = [];
 
 if (FEDERATION_ENABLED) {
   connectors.push(activityPubConnector);
+}
+
+if (ATPROTO_ENABLED) {
+  connectors.push(atprotoConnector);
 }
 
 export const connectorRegistry = new ConnectorRegistry(connectors);

--- a/packages/backend/src/connectors/resolve.ts
+++ b/packages/backend/src/connectors/resolve.ts
@@ -1,0 +1,35 @@
+import { normalizeFederatedAcct } from './activitypub/helpers';
+import { isAtUri, isAtprotoHandle, isDid } from './atproto/constants';
+
+/**
+ * Network classification for a unified cross-network resolve.
+ *
+ * Maps a raw search query to the network that owns it WITHOUT touching the
+ * network (pure, synchronous). The `/federation/resolve` route uses this to
+ * short-circuit local Oxy handles and to know which family a subject belongs to;
+ * the actual fetch is dispatched through the connector registry (whose
+ * `connectorFor` uses each connector's `matches`).
+ *
+ *  - `@user@host` / bare `user@domain`               → activitypub
+ *  - `*.bsky.social` / bare domain / did:* / at://    → atproto
+ *  - `@username` / bare local username                → local (Oxy profile)
+ */
+export type QueryNetwork = 'activitypub' | 'atproto' | 'local';
+
+/** Classify a resolve query into the network that owns it. */
+export function classifyQuery(raw: string): QueryNetwork {
+  const query = raw.trim();
+  if (!query) return 'local';
+
+  // atproto: a DID or an AT-URI is unambiguous.
+  if (isDid(query) || isAtUri(query)) return 'atproto';
+
+  // ActivityPub: a fediverse `user@host` acct (with or without a leading `@`).
+  if (normalizeFederatedAcct(query)) return 'activitypub';
+
+  // atproto: a bare handle is a DNS name (≥2 labels, no `@`, no scheme).
+  if (isAtprotoHandle(query)) return 'atproto';
+
+  // Everything else (`@alice`, `alice`) is a local Oxy username.
+  return 'local';
+}

--- a/packages/backend/src/connectors/types.ts
+++ b/packages/backend/src/connectors/types.ts
@@ -94,8 +94,9 @@ export interface LocalPostEventPayload {
 
 /**
  * A local domain event handed to connectors for outbound delivery. Discriminated
- * by `kind`; starts with `post.create` (a new local post to federate) and grows
- * as more outbound flows (likes, reposts, follows, deletes) are wired.
+ * by `kind`; starts with `post.create` (a new local post to federate) and the
+ * follow lifecycle, and grows as more outbound flows (likes, reposts, deletes)
+ * are wired.
  */
 export type LocalNetworkEvent =
   | {
@@ -103,6 +104,18 @@ export type LocalNetworkEvent =
       post: LocalPostEventPayload;
       actorOxyUserId: string;
       actorUsername: string;
+    }
+  | {
+      kind: 'follow.add';
+      localOxyUserId: string;
+      localUsername: string;
+      targetActorUri: string;
+    }
+  | {
+      kind: 'follow.remove';
+      localOxyUserId: string;
+      localUsername: string;
+      targetActorUri: string;
     };
 
 /** Context passed alongside an inbound payload to {@link NetworkConnector.receive}. */

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -49,6 +49,8 @@ import { threadSlicingService } from '../services/ThreadSlicingService';
 import FederatedActor, { IFederatedActor } from '../models/FederatedActor';
 import { activityPubConnector, isPermanentlyUnavailableOutboxReason } from '../connectors/activitypub/ActivityPubConnector';
 import { FEDERATION_ENABLED } from '../connectors/activitypub/constants';
+import { ATPROTO_ENABLED } from '../connectors/atproto/constants';
+import { connectorRegistry } from '../connectors';
 import {
   isWithinOutboxSyncCooldown,
   shouldForceUntrackedOutboxSync,
@@ -869,7 +871,7 @@ class FeedController {
       // The only request-path work is a single cheap indexed DB lookup
       // (`FederatedActor.findOne`) to decide whether to mark the feed pending.
       let fedSyncPending = false;
-      if (posts.length === 0 && !cursor && FEDERATION_ENABLED) {
+      if (posts.length === 0 && !cursor && (FEDERATION_ENABLED || ATPROTO_ENABLED)) {
         const syncUserId = userId;
         const cachedActor = await FederatedActor.findOne({ oxyUserId: syncUserId })
           .lean<IFederatedActor>();
@@ -969,10 +971,25 @@ class FeedController {
    * caller (the work runs detached).
    */
   private runFederatedProfileSyncInBackground(syncUserId: string, cachedActor?: IFederatedActor): void {
-    if (!FEDERATION_ENABLED) return;
+    if (!FEDERATION_ENABLED && !ATPROTO_ENABLED) return;
 
     void (async () => {
       try {
+        // Dispatch by the cached actor's network. atproto profiles backfill
+        // through the atproto connector's pull-based author feed (no AP outbox
+        // dance); the rest of this method is the ActivityPub outbox flow.
+        if (cachedActor?.protocol === 'atproto') {
+          if (cachedActor.externalId) {
+            const connector = connectorRegistry.connectorFor(cachedActor.externalId);
+            if (connector) {
+              await connector.fetchPosts(cachedActor.externalId, { limit: this.FED_OUTBOX_SYNC_LIMIT });
+            }
+          }
+          return;
+        }
+
+        if (!FEDERATION_ENABLED) return;
+
         let actor: IFederatedActor | null = cachedActor ?? null;
         let refreshedActorForSync = false;
         let oxyIdentity:

--- a/packages/backend/src/models/FederatedActor.ts
+++ b/packages/backend/src/models/FederatedActor.ts
@@ -22,14 +22,34 @@ export interface FederatedOutboxBackfillState {
 }
 
 export interface IFederatedActor extends Document {
+  /**
+   * The external network this actor belongs to. ActivityPub (Mastodon/fediverse)
+   * actors default here; atproto (Bluesky) actors carry `'atproto'`. Lets every
+   * protocol-agnostic query (`/federation/*` follow/post routes, the profile-sync
+   * dispatcher) route an actor to the connector that owns it.
+   */
+  protocol: 'activitypub' | 'atproto';
   uri: string;
+  /**
+   * Stable protocol id, distinct from the web-facing `uri`. For atproto this is
+   * the actor's DID (`did:plc:...` / `did:web:...`); for ActivityPub it equals
+   * `uri` (the actor URI). Sparse-unique so a DID maps to exactly one row.
+   */
+  externalId?: string;
   username: string;
   domain: string;
   acct: string;
   summary?: string;
   avatarUrl?: string;
   headerUrl?: string;
-  inboxUrl: string;
+  /**
+   * ActivityPub inbox URL. REQUIRED in practice for AP actors (every AP ingest
+   * path sets it), but optional on the schema because atproto actors have no AP
+   * inbox — they are read/discovered through the AppView, never delivered to over
+   * ActivityPub. AP delivery code reads `sharedInboxUrl ?? inboxUrl` and guards
+   * the absent case.
+   */
+  inboxUrl?: string;
   outboxUrl?: string;
   sharedInboxUrl?: string;
   followersUrl?: string;
@@ -58,14 +78,16 @@ export interface IFederatedActor extends Document {
 }
 
 const FederatedActorSchema = new Schema<IFederatedActor>({
+  protocol: { type: String, enum: ['activitypub', 'atproto'], default: 'activitypub', index: true },
   uri: { type: String, required: true, unique: true, index: true },
+  externalId: { type: String, index: { unique: true, sparse: true } },
   username: { type: String, required: true },
   domain: { type: String, required: true, index: true },
   acct: { type: String, required: true, unique: true, index: true },
   summary: { type: String },
   avatarUrl: { type: String },
   headerUrl: { type: String },
-  inboxUrl: { type: String, required: true },
+  inboxUrl: { type: String },
   outboxUrl: { type: String },
   sharedInboxUrl: { type: String },
   followersUrl: { type: String },

--- a/packages/backend/src/models/FederatedFollow.ts
+++ b/packages/backend/src/models/FederatedFollow.ts
@@ -2,12 +2,20 @@ import mongoose, { Document, Schema } from 'mongoose';
 
 export type FollowDirection = 'outbound' | 'inbound';
 export type FollowStatus = 'pending' | 'accepted' | 'rejected';
+export type FollowNetwork = 'activitypub' | 'atproto';
 
 export interface IFederatedFollow extends Document {
   localUserId: string;
   remoteActorUri: string;
   direction: FollowDirection;
   status: FollowStatus;
+  /**
+   * The external network this follow edge targets. Defaults to ActivityPub
+   * (every existing row); atproto follows are recorded as a local subscription
+   * (`direction:'outbound', status:'accepted', network:'atproto'`) that backfills
+   * the actor's posts without delivering a Follow over the wire.
+   */
+  network: FollowNetwork;
   activityId?: string;
   createdAt: Date;
   updatedAt: Date;
@@ -18,6 +26,7 @@ const FederatedFollowSchema = new Schema<IFederatedFollow>({
   remoteActorUri: { type: String, required: true, index: true },
   direction: { type: String, required: true, enum: ['outbound', 'inbound'], index: true },
   status: { type: String, default: 'pending', enum: ['pending', 'accepted', 'rejected'], index: true },
+  network: { type: String, enum: ['activitypub', 'atproto'], default: 'activitypub' },
   activityId: { type: String },
 }, {
   timestamps: true,


### PR DESCRIPTION
Adds AtprotoConnector (read/discovery) over a thin SSRF-safe XRPC client (no @atproto/api): handle/DID resolution, profile + getAuthorFeed mapping into FederatedActor(protocol:atproto)/Post.federation via the shared media mirror. Gated by ATPROTO_ENABLED (off). 915 tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->