### PR TITLE
fix(connectors): allSettled fan-out isolation, AP cursor pagination, consolidate FederatedActor externalId

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/activityPubConnector.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/activityPubConnector.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ActivityPubConnector.fetchPosts must forward the incoming opaque cursor as
+ * `startPageUrl` to `outboxSyncService.syncOutboxPostsDetailed`, so pagination
+ * advances instead of re-fetching the first page every call. The returned cursor
+ * is `result.nextCursor?.url`.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getOrFetchActor: vi.fn(),
+  syncOutboxPostsDetailed: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/actor.service', () => ({
+  actorService: {
+    getOrFetchActor: mocks.getOrFetchActor,
+    resolveWebFinger: vi.fn(),
+    fetchRemoteActor: vi.fn(),
+    refreshActorInBackground: vi.fn(),
+    fetchPublicKey: vi.fn(),
+  },
+}));
+
+vi.mock('../../../connectors/activitypub/outbox.service', () => ({
+  outboxSyncService: {
+    syncOutboxPostsDetailed: mocks.syncOutboxPostsDetailed,
+    syncOutboxPosts: vi.fn(),
+    markOutboxBackfillUnavailable: vi.fn(),
+  },
+  // Runtime values re-exported by ActivityPubConnector at module eval.
+  isPermanentlyUnavailableOutboxReason: vi.fn().mockReturnValue(false),
+  PERMANENTLY_UNAVAILABLE_OUTBOX_REASONS: [],
+}));
+
+vi.mock('../../../connectors/activitypub/follow.service', () => ({
+  followService: {},
+}));
+
+vi.mock('../../../connectors/activitypub/inbox.service', () => ({
+  inboxProcessingService: { processInboxActivity: vi.fn() },
+}));
+
+vi.mock('../../../connectors/identity', () => ({
+  resolveOxyExternalUser: vi.fn(),
+}));
+
+import { activityPubConnector } from '../../../connectors/activitypub/ActivityPubConnector';
+
+const ACTOR_URI = 'https://mastodon.social/users/alice';
+const OUTBOX_URL = 'https://mastodon.social/users/alice/outbox';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getOrFetchActor.mockResolvedValue({ uri: ACTOR_URI, acct: 'alice@mastodon.social', outboxUrl: OUTBOX_URL });
+  mocks.syncOutboxPostsDetailed.mockResolvedValue({
+    syncedCount: 20,
+    shouldStampCooldown: false,
+    nextCursor: { url: `${OUTBOX_URL}?page=2`, itemOffset: 0 },
+  });
+});
+
+describe('ActivityPubConnector.fetchPosts', () => {
+  it('forwards the incoming cursor as startPageUrl and returns the next cursor url', async () => {
+    const result = await activityPubConnector.fetchPosts(ACTOR_URI, {
+      limit: 30,
+      cursor: `${OUTBOX_URL}?page=1`,
+    });
+
+    expect(mocks.syncOutboxPostsDetailed).toHaveBeenCalledWith(
+      expect.objectContaining({ outboxUrl: OUTBOX_URL }),
+      { limit: 30, startPageUrl: `${OUTBOX_URL}?page=1` },
+    );
+    expect(result).toEqual({ posts: [], cursor: `${OUTBOX_URL}?page=2` });
+  });
+
+  it('passes startPageUrl: undefined (first page) when no cursor is supplied', async () => {
+    await activityPubConnector.fetchPosts(ACTOR_URI);
+
+    expect(mocks.syncOutboxPostsDetailed).toHaveBeenCalledWith(
+      expect.objectContaining({ outboxUrl: OUTBOX_URL }),
+      { limit: 20, startPageUrl: undefined },
+    );
+  });
+
+  it('returns no posts and never syncs when the actor has no outbox URL', async () => {
+    mocks.getOrFetchActor.mockResolvedValue({ uri: ACTOR_URI, acct: 'alice@mastodon.social' });
+
+    const result = await activityPubConnector.fetchPosts(ACTOR_URI, { cursor: 'x' });
+
+    expect(result).toEqual({ posts: [] });
+    expect(mocks.syncOutboxPostsDetailed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
@@ -84,14 +84,13 @@ describe('fetchAndUpsertAtprotoProfile', () => {
     const actor = await fetchAndUpsertAtprotoProfile(DID);
 
     expect(mocks.xrpcGet).toHaveBeenCalledWith('public.api.bsky.app', 'app.bsky.actor.getProfile', { actor: DID });
-    // Upsert keyed on the DID, carrying protocol + externalId + handle acct.
+    // Upsert keyed on the DID, carrying protocol + uri (the DID) + handle acct.
     expect(mocks.findOneAndUpdate).toHaveBeenCalledWith(
       { uri: DID },
       expect.objectContaining({
         $set: expect.objectContaining({
           protocol: 'atproto',
           uri: DID,
-          externalId: DID,
           acct: 'alice.bsky.social',
           headerUrl: PROFILE.banner,
         }),

--- a/packages/backend/src/__tests__/connectors/connectorRegistry.test.ts
+++ b/packages/backend/src/__tests__/connectors/connectorRegistry.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ConnectorRegistry fan-out isolation: `federateNewPost` must attempt delivery to
+ * EVERY enabled connector even when one throws (best-effort outbound federation),
+ * resolve once all are attempted, and log each rejection with the connector id.
+ */
+
+const mocks = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    error: mocks.loggerError,
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { ConnectorRegistry } from '../../connectors/ConnectorRegistry';
+import type {
+  NetworkConnector,
+  NetworkId,
+  LocalPostEventPayload,
+} from '../../connectors/types';
+
+/** A minimal fake connector with overridable, spy-able `deliver`. */
+function makeConnector(
+  id: NetworkId,
+  deliver: NetworkConnector['deliver'],
+  enabled = true,
+): NetworkConnector {
+  return {
+    id,
+    enabled,
+    matches: vi.fn().mockReturnValue(false),
+    resolve: vi.fn().mockResolvedValue(null),
+    fetchProfile: vi.fn().mockResolvedValue(null),
+    fetchPosts: vi.fn().mockResolvedValue({ posts: [] }),
+    deliver,
+    receive: vi.fn().mockResolvedValue(undefined),
+    mapIdentity: vi.fn().mockResolvedValue(null),
+  };
+}
+
+const POST: LocalPostEventPayload = {
+  _id: 'p1',
+  content: { text: 'hello' },
+  visibility: 'public',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ConnectorRegistry.federateNewPost', () => {
+  it('still delivers to the other connectors when one connector rejects, and resolves', async () => {
+    const okDeliver = vi.fn().mockResolvedValue(undefined);
+    const failDeliver = vi.fn().mockRejectedValue(new Error('transient AP network error'));
+    const otherOkDeliver = vi.fn().mockResolvedValue(undefined);
+
+    const registry = new ConnectorRegistry([
+      makeConnector('activitypub', failDeliver),
+      makeConnector('atproto', okDeliver),
+      // A second healthy connector after the failing one proves the fan-out is
+      // not short-circuited by the earlier rejection (Promise.allSettled).
+      makeConnector('atproto', otherOkDeliver),
+    ]);
+
+    await expect(
+      registry.federateNewPost(POST, 'oxy-1', 'alice'),
+    ).resolves.toBeUndefined();
+
+    expect(failDeliver).toHaveBeenCalledTimes(1);
+    expect(okDeliver).toHaveBeenCalledTimes(1);
+    expect(otherOkDeliver).toHaveBeenCalledTimes(1);
+    for (const deliver of [failDeliver, okDeliver, otherOkDeliver]) {
+      expect(deliver).toHaveBeenCalledWith({
+        kind: 'post.create',
+        post: POST,
+        actorOxyUserId: 'oxy-1',
+        actorUsername: 'alice',
+      });
+    }
+  });
+
+  it('logs each rejected connector with its id, not silently swallowing', async () => {
+    const reason = new Error('boom');
+    const registry = new ConnectorRegistry([
+      makeConnector('activitypub', vi.fn().mockRejectedValue(reason)),
+      makeConnector('atproto', vi.fn().mockResolvedValue(undefined)),
+    ]);
+
+    await registry.federateNewPost(POST, 'oxy-1', 'alice');
+
+    expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.stringContaining('"activitypub"'),
+      reason,
+    );
+  });
+
+  it('skips disabled connectors entirely', async () => {
+    const enabledDeliver = vi.fn().mockResolvedValue(undefined);
+    const disabledDeliver = vi.fn().mockResolvedValue(undefined);
+
+    const registry = new ConnectorRegistry([
+      makeConnector('activitypub', enabledDeliver, true),
+      makeConnector('atproto', disabledDeliver, false),
+    ]);
+
+    await registry.federateNewPost(POST, 'oxy-1', 'alice');
+
+    expect(enabledDeliver).toHaveBeenCalledTimes(1);
+    expect(disabledDeliver).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/connectors/ConnectorRegistry.ts
+++ b/packages/backend/src/connectors/ConnectorRegistry.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import type { PostFederator } from '../services/serviceRegistry';
 import type {
   NetworkConnector,
@@ -31,14 +32,20 @@ export class ConnectorRegistry implements PostFederator {
    * Federate a newly created local post outbound to every enabled connector.
    * Each connector decides what delivery means for its network (ActivityPub
    * delivers to remote followers; future connectors write their own records).
-   * One connector's failure does not abort the others.
+   *
+   * Delivery is fanned out with `Promise.allSettled` so one connector's failure
+   * (e.g. a transient ActivityPub network error) does NOT abort delivery to the
+   * others and does NOT propagate back to `PostCreationService` — the local post
+   * is already persisted; outbound federation is best-effort. Each rejected
+   * connector is logged with its id; the method resolves once every connector has
+   * been attempted.
    */
   async federateNewPost(
     post: LocalPostEventPayload,
     senderOxyUserId: string,
     senderUsername: string,
   ): Promise<void> {
-    await Promise.all(
+    const results = await Promise.allSettled(
       this.connectors.map((connector) =>
         connector.deliver({
           kind: 'post.create',
@@ -48,6 +55,14 @@ export class ConnectorRegistry implements PostFederator {
         }),
       ),
     );
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        logger.error(
+          `[connectors] federateNewPost delivery failed for connector "${this.connectors[index].id}":`,
+          result.reason,
+        );
+      }
+    });
   }
 
   /** The connector that owns `subject` (a handle / URI / DID), if any. */

--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -105,7 +105,14 @@ class ActivityPubConnector implements NetworkConnector {
   async fetchPosts(externalId: string, opts: FetchPostsOptions = {}): Promise<FetchPostsResult> {
     const actor = await actorService.getOrFetchActor(externalId);
     if (!actor?.outboxUrl) return { posts: [] };
-    const result = await outboxSyncService.syncOutboxPostsDetailed(actor, opts.limit ?? 20);
+    // Forward the incoming opaque cursor as `startPageUrl` so pagination advances:
+    // `fetchPosts` returns `result.nextCursor?.url`, and `syncOutboxPostsDetailed`
+    // resumes at `startPageUrl` (validated same-origin against the outbox). Absent
+    // cursor → first page.
+    const result = await outboxSyncService.syncOutboxPostsDetailed(actor, {
+      limit: opts.limit ?? 20,
+      startPageUrl: opts.cursor,
+    });
     return { posts: [], cursor: result.nextCursor?.url };
   }
 

--- a/packages/backend/src/connectors/activitypub/actor.service.ts
+++ b/packages/backend/src/connectors/activitypub/actor.service.ts
@@ -251,9 +251,6 @@ export class ActorService {
 
       const update: Partial<IFederatedActor> = {
         protocol: 'activitypub',
-        // For ActivityPub the stable protocol id IS the actor URI, so externalId
-        // mirrors `uri` (atproto rows carry the DID here instead).
-        externalId: actor.id,
         uri: actor.id,
         username,
         domain,

--- a/packages/backend/src/connectors/atproto/profile.mapper.ts
+++ b/packages/backend/src/connectors/atproto/profile.mapper.ts
@@ -72,7 +72,6 @@ export async function upsertAtprotoActor(actor: NormalizedExternalActor): Promis
         $set: {
           protocol: 'atproto',
           uri: did,
-          externalId: did,
           username,
           domain,
           acct: actor.handle,

--- a/packages/backend/src/connectors/connectors.routes.ts
+++ b/packages/backend/src/connectors/connectors.routes.ts
@@ -395,10 +395,10 @@ router.get('/actor/posts', async (req: AuthRequest, res: Response) => {
     // dispatched by the actor's network.
     if (posts.length === 0 && !parsed.data.cursor) {
       if (actor.protocol === 'atproto') {
-        if (actor.externalId) {
-          const connector = connectorRegistry.connectorFor(actor.externalId);
+        if (actor.uri) {
+          const connector = connectorRegistry.connectorFor(actor.uri);
           if (connector) {
-            connector.fetchPosts(actor.externalId, { limit }).catch((err) => {
+            connector.fetchPosts(actor.uri, { limit }).catch((err) => {
               logger.warn('Background atproto author-feed sync failed:', err);
             });
             return res.json({ posts: [], hasMore: false, syncing: true });

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -979,10 +979,10 @@ class FeedController {
         // through the atproto connector's pull-based author feed (no AP outbox
         // dance); the rest of this method is the ActivityPub outbox flow.
         if (cachedActor?.protocol === 'atproto') {
-          if (cachedActor.externalId) {
-            const connector = connectorRegistry.connectorFor(cachedActor.externalId);
+          if (cachedActor.uri) {
+            const connector = connectorRegistry.connectorFor(cachedActor.uri);
             if (connector) {
-              await connector.fetchPosts(cachedActor.externalId, { limit: this.FED_OUTBOX_SYNC_LIMIT });
+              await connector.fetchPosts(cachedActor.uri, { limit: this.FED_OUTBOX_SYNC_LIMIT });
             }
           }
           return;

--- a/packages/backend/src/models/FederatedActor.ts
+++ b/packages/backend/src/models/FederatedActor.ts
@@ -29,13 +29,13 @@ export interface IFederatedActor extends Document {
    * dispatcher) route an actor to the connector that owns it.
    */
   protocol: 'activitypub' | 'atproto';
-  uri: string;
   /**
-   * Stable protocol id, distinct from the web-facing `uri`. For atproto this is
-   * the actor's DID (`did:plc:...` / `did:web:...`); for ActivityPub it equals
-   * `uri` (the actor URI). Sparse-unique so a DID maps to exactly one row.
+   * The actor's stable protocol id and unique key. For ActivityPub this is the
+   * actor URI; for atproto it is the actor's DID (`did:plc:...` / `did:web:...`).
+   * Both connectors key their upserts on `uri`, and protocol-agnostic queries
+   * (the `connectorFor` dispatch, follow records) resolve actors through it.
    */
-  externalId?: string;
+  uri: string;
   username: string;
   domain: string;
   acct: string;
@@ -80,7 +80,6 @@ export interface IFederatedActor extends Document {
 const FederatedActorSchema = new Schema<IFederatedActor>({
   protocol: { type: String, enum: ['activitypub', 'atproto'], default: 'activitypub', index: true },
   uri: { type: String, required: true, unique: true, index: true },
-  externalId: { type: String, index: { unique: true, sparse: true } },
   username: { type: String, required: true },
   domain: { type: String, required: true, index: true },
   acct: { type: String, required: true, unique: true, index: true },


### PR DESCRIPTION
## Summary
- Isolation via `allSettled` fan-out so a single connector failure doesn't abort the rest
- ActivityPub cursor pagination fixed
- `FederatedActor.externalId` consolidation

## Test plan
- [x] tsc --noEmit: exit 0
- [x] 921 backend tests passed (92 files)
- [x] Lockfile gate: bun install --frozen-lockfile passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)