### PR TITLE
feat(search): unified cross-network search (Mastodon/Bluesky/local)

### DIFF
--- a/packages/frontend/app/(app)/search/index.tsx
+++ b/packages/frontend/app/(app)/search/index.tsx
@@ -34,6 +34,8 @@ import SEO from "@/components/SEO";
 import { ProfileCard, type ProfileCardData } from "@/components/ProfileCard";
 import { FeedCard, type FeedCardData } from "@/components/FeedCard";
 import { ListCard as ListCardComponent, type ListCardData } from "@/components/ListCard";
+import { ExternalActorCard } from "@/components/search/ExternalActorCard";
+import { useExternalActorResolve } from "@/hooks/useExternalActorResolve";
 import { Divider } from "@oxyhq/bloom/divider";
 import { EmptyState } from "@/components/common/EmptyState";
 import { SPACING } from "@/styles/spacing";
@@ -80,6 +82,17 @@ export default function SearchIndex() {
     // Search history state
     const [searchHistory, setSearchHistory] = useState<string[]>([]);
     const [isFocused, setIsFocused] = useState(true); // autoFocus starts focused
+
+    // Cross-network resolve — when the query looks like a remote handle
+    // (`@user@host`, `user.bsky.social`, `did:`, `at://`), resolve it to an
+    // external actor (Mastodon / Bluesky). Local `@username` queries never
+    // trigger this and stay on the existing Oxy people search below.
+    const {
+        actor: externalActor,
+        loading: externalLoading,
+        error: externalError,
+        isRemoteQuery,
+    } = useExternalActorResolve(query);
 
     // Load search history on mount
     useEffect(() => {
@@ -373,6 +386,39 @@ export default function SearchIndex() {
         return (results[activeTab]?.length || 0) > 0;
     }, [activeTab, results, hasResults]);
 
+    // The external (cross-network) result is a person, so it belongs on the
+    // "all" and "users" tabs only. It is shown whenever the query looks like a
+    // remote handle — independent of whether the LOCAL search returned anything.
+    const showExternalSection =
+        isRemoteQuery && (activeTab === "all" || activeTab === "users");
+    const hasExternalContent = showExternalSection && (externalLoading || externalError || Boolean(externalActor));
+
+    const renderExternalSection = () => {
+        if (!showExternalSection) return null;
+        return (
+            <View style={styles.section}>
+                {activeTab === "all" && (externalLoading || externalActor) ? (
+                    <Text className="text-xl font-bold text-foreground" style={{ paddingHorizontal: SPACING.base, paddingVertical: SPACING.md }}>
+                        {t("search.sections.fromOtherNetworks", "From other networks")}
+                    </Text>
+                ) : null}
+                {externalLoading ? (
+                    <View className="items-center justify-center" style={{ paddingVertical: SPACING.lg }}>
+                        <Loading className="text-primary" size="small" />
+                    </View>
+                ) : externalActor ? (
+                    <View style={styles.itemWrapper}>
+                        <ExternalActorCard actor={externalActor} />
+                    </View>
+                ) : externalError ? (
+                    <Text className="text-sm text-muted-foreground" style={{ paddingHorizontal: SPACING.base, paddingVertical: SPACING.sm }}>
+                        {t("search.external.error", "Couldn't reach that network. Try again.")}
+                    </Text>
+                ) : null}
+            </View>
+        );
+    };
+
     const renderSection = <T,>(title: string, items: T[], renderItem: (item: T) => React.ReactNode, showTitle: boolean) => {
         if (items.length === 0) return null;
         return (
@@ -459,13 +505,18 @@ export default function SearchIndex() {
                         keyboardShouldPersistTaps="handled"
                         keyboardDismissMode="on-drag"
                     >
+                        {/* Cross-network actor (Mastodon / Bluesky) — rendered above
+                            the local results and independent of the local-search
+                            loading state, since the resolve runs in parallel. */}
+                        {renderExternalSection()}
+
                         {loading && (
                             <View className="flex-1 items-center justify-center" style={{ minHeight: 300 }}>
                                 <Loading className="text-primary" size="large" />
                             </View>
                         )}
 
-                        {!loading && query.trim() && !currentTabHasResults && (
+                        {!loading && query.trim() && !currentTabHasResults && !hasExternalContent && (
                             <EmptyState
                                 title={t("search.noResults", "No results found")}
                                 subtitle={t("search.tryDifferent", "Try searching for something else")}

--- a/packages/frontend/components/search/ExternalActorCard.tsx
+++ b/packages/frontend/components/search/ExternalActorCard.tsx
@@ -1,0 +1,169 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { View, TouchableOpacity, StyleSheet, type GestureResponderEvent } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { show as toast } from '@oxyhq/bloom/toast';
+import { Avatar } from '@oxyhq/bloom/avatar';
+import { useTheme } from '@oxyhq/bloom/theme';
+import { useAuth } from '@oxyhq/services';
+import { getNormalizedUserHandle } from '@oxyhq/core';
+
+import { ThemedText } from '@/components/ThemedText';
+import { Button } from '@/components/ui/Button';
+import { FediverseIcon } from '@/assets/icons/fediverse-icon';
+import { displayNameOrHandle } from '@/utils/displayName';
+import { proxyExternalUrl } from '@/utils/imageUrlCache';
+import {
+  feedService,
+  type ExternalActorResolution,
+  type ExternalNetwork,
+} from '@/services/feedService';
+
+interface ExternalActorCardProps {
+  actor: ExternalActorResolution;
+}
+
+/** Human-readable label for a normalized network. */
+const NETWORK_LABEL: Record<ExternalNetwork, string> = {
+  activitypub: 'Mastodon',
+  atproto: 'Bluesky',
+};
+
+/** Keep a press on the Follow button from also opening the profile (web nested pressables). */
+function stopPropagation(event: GestureResponderEvent): void {
+  event.stopPropagation();
+}
+
+/**
+ * Cross-network external actor result card.
+ *
+ * Renders a remote actor resolved via `GET /federation/resolve` (Mastodon /
+ * Bluesky) as a normalized card: avatar, display name, fediverse-style handle, a
+ * network badge, and a Follow action. Following calls `POST /federation/follow`
+ * (protocol-dispatched on the backend) and, on success, routes into the existing
+ * federated-profile screen via the normalized Oxy handle.
+ */
+export function ExternalActorCard({ actor }: ExternalActorCardProps) {
+  const router = useRouter();
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const { isAuthenticated, showBottomSheet } = useAuth();
+
+  const [following, setFollowing] = useState(actor.followed);
+  const [pending, setPending] = useState(false);
+
+  const displayName = displayNameOrHandle(actor.displayName, `@${actor.handle}`);
+  const networkLabel = NETWORK_LABEL[actor.network];
+
+  // The avatar URL from a resolve is a REMOTE actor URL (Mastodon/Bluesky CDN) —
+  // route it through the media proxy so it loads on web and stays cached. Passing
+  // a full http URL to Bloom Avatar bypasses the file-id ImageResolver.
+  const avatarSource = useMemo(
+    () => (actor.avatarUrl ? proxyExternalUrl(actor.avatarUrl) : undefined),
+    [actor.avatarUrl],
+  );
+
+  // The route handle for the federated profile screen (resolves by Oxy handle:
+  // `user@domain` for ActivityPub via WebFinger, the bare handle for atproto).
+  const profileHandle = useMemo(
+    () =>
+      getNormalizedUserHandle({
+        username: actor.handle,
+        instance: undefined,
+        isFederated: true,
+      }) || actor.handle,
+    [actor.handle],
+  );
+
+  const openProfile = useCallback(() => {
+    if (!profileHandle) return;
+    router.push(`/@${profileHandle}`);
+  }, [router, profileHandle]);
+
+  const handleFollow = useCallback(async () => {
+    if (pending) return;
+    if (!isAuthenticated) {
+      showBottomSheet?.('OxyAuth');
+      return;
+    }
+    setPending(true);
+    try {
+      // Follow the actor's CANONICAL protocol id (AP actor URI / atproto DID).
+      const result = await feedService.followFederatedActor(actor.externalId);
+      if (result.success) {
+        setFollowing(true);
+        // Route into the existing federated-profile flow keyed by the Oxy user.
+        openProfile();
+      } else {
+        toast(
+          t('search.external.followFailed', { defaultValue: 'Could not follow this account' }),
+          { type: 'error' },
+        );
+      }
+    } catch {
+      toast(
+        t('search.external.followFailed', { defaultValue: 'Could not follow this account' }),
+        { type: 'error' },
+      );
+    } finally {
+      setPending(false);
+    }
+  }, [pending, isAuthenticated, showBottomSheet, actor.externalId, openProfile, t]);
+
+  return (
+    <TouchableOpacity
+      onPress={openProfile}
+      activeOpacity={0.7}
+      className="bg-card border-border w-full p-4 rounded-xl gap-3"
+      style={{ borderWidth: StyleSheet.hairlineWidth }}
+    >
+      <View className="flex-row items-center gap-3">
+        <Avatar source={avatarSource} name={displayName} size={48} />
+        <View className="flex-1 gap-1">
+          <ThemedText
+            className="text-base font-semibold"
+            style={{ lineHeight: 20 }}
+            numberOfLines={1}
+          >
+            {displayName}
+          </ThemedText>
+          <View className="flex-row items-center gap-1">
+            <FediverseIcon size={13} color={theme.colors.textSecondary} />
+            <ThemedText
+              className="text-muted-foreground text-sm"
+              style={{ lineHeight: 18 }}
+              numberOfLines={1}
+            >
+              @{actor.handle}
+            </ThemedText>
+          </View>
+          {/* Network badge — names the external network the actor lives on. */}
+          <View className="flex-row">
+            <View className="bg-secondary rounded-full px-2 py-0.5">
+              <ThemedText className="text-muted-foreground text-xs font-medium">
+                {networkLabel}
+              </ThemedText>
+            </View>
+          </View>
+        </View>
+        {/* Stop the press from bubbling to the card's profile-open handler so the
+            Follow button is independently tappable (matters on web, where nested
+            pressables both fire). */}
+        <View onStartShouldSetResponder={() => true} onTouchEnd={stopPropagation}>
+          <Button
+            variant={following ? 'secondary' : 'primary'}
+            size="small"
+            onPress={handleFollow}
+            disabled={following || pending}
+          >
+            {following
+              ? t('search.external.following', { defaultValue: 'Following' })
+              : pending
+                ? t('search.external.followingPending', { defaultValue: 'Following…' })
+                : t('search.external.follow', { defaultValue: 'Follow' })}
+          </Button>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}

--- a/packages/frontend/hooks/useExternalActorResolve.ts
+++ b/packages/frontend/hooks/useExternalActorResolve.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { feedService, type ExternalActorResolution } from '@/services/feedService';
+import { looksLikeRemoteHandle } from '@/utils/externalActor';
+
+/** Debounce window before a remote-handle query hits `GET /federation/resolve`. */
+const RESOLVE_DEBOUNCE_MS = 400;
+
+/** How long a successful resolution stays fresh (handle → actor is stable). */
+const RESOLVE_STALE_TIME = 5 * 60 * 1000;
+const RESOLVE_GC_TIME = 30 * 60 * 1000;
+
+export interface UseExternalActorResolveResult {
+  /** The resolved external actor, or null when the query resolves to nothing. */
+  actor: ExternalActorResolution | null;
+  /** True while a resolve request for a remote-looking query is in flight. */
+  loading: boolean;
+  /** True when the resolve request failed (network/server error, not a 404 miss). */
+  error: boolean;
+  /** Whether the (debounced) query looks like a remote handle worth resolving. */
+  isRemoteQuery: boolean;
+}
+
+/**
+ * Resolve a raw search query to a cross-network external actor.
+ *
+ * Debounces the query, and only calls `GET /federation/resolve` when the
+ * debounced value LOOKS like a remote handle (`@user@host`, `user.bsky.social`,
+ * `did:…`, `at://…`) — a bare local `@username` never triggers a resolve and
+ * stays entirely on the existing Oxy people search. Resolution, loading, error
+ * and caching are owned by React Query.
+ *
+ * A 404 miss ("not an external handle" / actor not found) surfaces as
+ * `actor: null` with `error: false`, so the UI simply shows no external card.
+ */
+export function useExternalActorResolve(rawQuery: string): UseExternalActorResolveResult {
+  // Value-debounce the raw query: the search box updates on every keystroke, but
+  // we only want to resolve once typing settles. This is the idiomatic place for
+  // an effect — subscribing to a changing input and a timer.
+  const [debounced, setDebounced] = useState('');
+  useEffect(() => {
+    const trimmed = rawQuery.trim();
+    const timeoutId = setTimeout(() => setDebounced(trimmed), RESOLVE_DEBOUNCE_MS);
+    return () => clearTimeout(timeoutId);
+  }, [rawQuery]);
+
+  const isRemoteQuery = useMemo(() => looksLikeRemoteHandle(debounced), [debounced]);
+
+  const query = useQuery<ExternalActorResolution | null>({
+    queryKey: ['federation', 'resolve', debounced],
+    queryFn: () => feedService.resolveExternalActor(debounced),
+    enabled: isRemoteQuery,
+    staleTime: RESOLVE_STALE_TIME,
+    gcTime: RESOLVE_GC_TIME,
+    retry: 1,
+  });
+
+  return {
+    actor: isRemoteQuery ? query.data ?? null : null,
+    loading: isRemoteQuery && query.isPending && query.fetchStatus !== 'idle',
+    error: isRemoteQuery && query.isError,
+    isRemoteQuery,
+  };
+}

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -872,7 +872,15 @@
       "feeds": "Feeds",
       "hashtags": "Hashtags",
       "lists": "Lists",
-      "saved": "Saved"
+      "saved": "Saved",
+      "fromOtherNetworks": "From other networks"
+    },
+    "external": {
+      "follow": "Follow",
+      "following": "Following",
+      "followingPending": "Following…",
+      "followFailed": "Could not follow this account",
+      "error": "Couldn't reach that network. Try again."
     }
   },
   "feeds": {

--- a/packages/frontend/services/feedService.ts
+++ b/packages/frontend/services/feedService.ts
@@ -18,10 +18,34 @@ import {
 // Feed responses may include slices for thread grouping
 type FeedServiceResponse = FeedResponse & Partial<Pick<SlicedFeedResponse, 'slices'>>;
 import { FeedFilters } from '../utils/feedUtils';
-import { authenticatedClient, publicClient } from '../utils/api';
+import { authenticatedClient, publicClient, isNotFoundError } from '../utils/api';
 import { oxyServices } from '@/lib/oxyServices';
 import { logger } from '@/lib/logger';
 import { normalizeApiError } from '@/utils/apiError';
+
+/** The network a resolved external actor belongs to (matches the backend `NetworkId`). */
+export type ExternalNetwork = 'activitypub' | 'atproto';
+
+/**
+ * A normalized cross-network actor returned by `GET /federation/resolve`.
+ * Mirrors the backend connectors route response shape exactly.
+ */
+export interface ExternalActorResolution {
+  /** The network that owns the actor. */
+  network: ExternalNetwork;
+  /** Canonical protocol id: an ActivityPub actor URI, or an atproto DID. Used as the follow target. */
+  externalId: string;
+  /** Fediverse-style handle (`user@domain` for ActivityPub; the atproto handle/DID otherwise). */
+  handle: string;
+  /** Canonical Oxy display name, when resolved. */
+  displayName?: string;
+  /** Actor avatar URL (a remote URL, proxied at render time). */
+  avatarUrl?: string;
+  /** The Oxy user this actor maps to, once minted — drives profile navigation. */
+  oxyUserId?: string;
+  /** Whether the current viewer already follows this actor. */
+  followed: boolean;
+}
 
 /**
  * In-flight dedup discriminator for the viewer's auth state.
@@ -661,16 +685,41 @@ class FeedService {
   }
 
   // ────────────────────────────────────────────────────────────
-  // Federation — ActivityPub follow/unfollow
+  // Cross-network connectors — resolve / follow / unfollow
   // ────────────────────────────────────────────────────────────
 
-  async followFederatedActor(actorUri: string): Promise<{ success: boolean; pending: boolean }> {
-    const response = await authenticatedClient.post<{ success: boolean; pending: boolean }>('/federation/follow', { actorUri });
+  /**
+   * Resolve a remote handle to a normalized external actor across networks
+   * (`GET /federation/resolve`). Returns `null` when the query is a local Oxy
+   * handle (404 "Not an external handle") or no actor was found — callers fall
+   * back to the existing local people search. Network errors propagate so React
+   * Query can surface a retryable error state.
+   */
+  async resolveExternalActor(handle: string): Promise<ExternalActorResolution | null> {
+    try {
+      const response = await authenticatedClient.get<ExternalActorResolution>('/federation/resolve', {
+        params: { handle },
+      });
+      return response.data ?? null;
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
+    }
+  }
+
+  /**
+   * Follow a remote actor across any network (`POST /federation/follow`,
+   * dispatched by the actor's protocol). `actorUri` is the actor's canonical
+   * protocol id (`externalId` from a resolve): an ActivityPub actor URI or an
+   * atproto DID. The response echoes the CANONICAL `actorUri` the system stored.
+   */
+  async followFederatedActor(actorUri: string): Promise<{ success: boolean; pending: boolean; actorUri: string }> {
+    const response = await authenticatedClient.post<{ success: boolean; pending: boolean; actorUri: string }>('/federation/follow', { actorUri });
     return response.data;
   }
 
-  async unfollowFederatedActor(actorUri: string): Promise<{ success: boolean }> {
-    const response = await authenticatedClient.post<{ success: boolean }>('/federation/unfollow', { actorUri });
+  async unfollowFederatedActor(actorUri: string): Promise<{ success: boolean; actorUri: string }> {
+    const response = await authenticatedClient.post<{ success: boolean; actorUri: string }>('/federation/unfollow', { actorUri });
     return response.data;
   }
 }

--- a/packages/frontend/utils/externalActor.ts
+++ b/packages/frontend/utils/externalActor.ts
@@ -1,0 +1,57 @@
+/**
+ * Frontend classifier for cross-network search queries.
+ *
+ * Mirrors the backend `classifyQuery` (`packages/backend/src/connectors/resolve.ts`)
+ * and the connector `matches()` shapes so the search box only fires a
+ * `GET /federation/resolve` request when a query actually looks like a REMOTE
+ * actor — never for a bare local `@username`, which the existing Oxy people
+ * search already handles. Keeping this purely client-side avoids a network round
+ * trip on every keystroke for local queries.
+ *
+ * Recognized remote shapes:
+ *  - `@user@host` / bare `user@domain`              → ActivityPub (Mastodon, …)
+ *  - `user.bsky.social` / any bare DNS handle       → atproto (Bluesky)
+ *  - `did:plc:…` / `did:web:…`                       → atproto
+ *  - `at://…`                                        → atproto
+ */
+
+/** A `did:plc:` or `did:web:` identifier. */
+const DID_RE = /^did:(?:plc|web):/;
+
+/** An `at://<authority>[/<collection>[/<rkey>]]` AT-URI. */
+const AT_URI_RE =
+  /^at:\/\/(did:(?:plc|web):[^/]+|[a-z0-9][a-z0-9.-]*\.[a-z]{2,})(?:\/([a-zA-Z0-9.]+)(?:\/([a-zA-Z0-9._~-]+))?)?$/i;
+
+/** A bare DNS handle (≥2 labels, alphabetic TLD): `alice.bsky.social`, `example.com`. */
+const HANDLE_RE =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i;
+
+/** True when `query` is a fediverse `user@host` acct (with or without a leading `@`). */
+function isFediverseAcct(query: string): boolean {
+  const cleaned = query.replace(/^@/, '');
+  const at = cleaned.indexOf('@');
+  if (at <= 0 || at === cleaned.length - 1) return false;
+  const domain = cleaned.slice(at + 1);
+  // The domain part must itself be a DNS name (≥2 labels) so a single trailing
+  // `@x` typo never resolves as an acct.
+  return HANDLE_RE.test(domain);
+}
+
+/** True when `query` is a bare atproto handle (a DNS name, no `@`, no scheme). */
+function isAtprotoHandle(query: string): boolean {
+  if (query.includes('@') || query.includes('://') || query.includes(' ')) return false;
+  return HANDLE_RE.test(query);
+}
+
+/**
+ * Whether a raw search query looks like a REMOTE actor handle the connectors can
+ * resolve. Only these queries are sent to `GET /federation/resolve`; a local
+ * `@username` / `username` returns false and stays on the existing people search.
+ */
+export function looksLikeRemoteHandle(raw: string): boolean {
+  const query = raw.trim();
+  if (!query) return false;
+  if (DID_RE.test(query) || AT_URI_RE.test(query)) return true;
+  if (isFediverseAcct(query)) return true;
+  return isAtprotoHandle(query);
+}


### PR DESCRIPTION
## Summary
- Adds unified cross-network search UI for Mastodon/Bluesky/local handles via `/federation/resolve` backend endpoint
- Pure frontend change — 3 new files (`externalActor.ts`, `useExternalActorResolve.ts`, `ExternalActorCard.tsx`) + 3 modified (`feedService.ts`, `search/index.tsx`, `en.json`)
- Backend endpoint already shipped separately

## Test plan
- [ ] Search for a Mastodon handle (e.g. `@user@mastodon.social`) and verify the ExternalActorCard renders
- [ ] Search for a Bluesky handle (e.g. `@user.bsky.social`) and verify resolution
- [ ] Search for a local handle and verify local results still appear
- [ ] Verify no regressions in existing search behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)