### PR TITLE
feat(mtn): node registration + bidirectional sync (ingest re-verify + witness + project), B3

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -69,6 +69,7 @@ import entityFollowRoutes from './src/routes/entity-follow.routes';
 import adminRoutes from './src/routes/admin';
 import mediaRoutes from './src/routes/media';
 import recommendationsRoutes from './src/routes/recommendations';
+import mtnNodesRoutes from './src/routes/mtn-nodes.routes';
 
 // Federation (ActivityPub) — network connectors. Importing the connectors index
 // instantiates the enabled connectors and registers the connector registry as
@@ -776,6 +777,7 @@ publicApiRouter.use("/feeds", optionalAuth, customFeedsRoutes); // Public feed d
 publicApiRouter.use("/rooms", optionalAuth, roomsRoutes); // Public room discovery; write routes enforce auth internally
 publicApiRouter.use("/recommendations", optionalAuth, recommendationsRoutes); // Cross-app profile recommendations (personalized when authed)
 publicApiRouter.use("/starter-packs", optionalAuth, starterPacksRoutes); // Public read/discovery + shared pack links; write routes enforce auth internally
+publicApiRouter.use("/mtn/nodes", optionalAuth, mtnNodesRoutes); // MTN user-node registry: authed me/managed routes enforce auth internally; ingest-notify is a public 202 hint
 
 // Authenticated API routes (require authentication)
 const authenticatedApiRouter = express.Router();
@@ -1003,6 +1005,16 @@ function startSchedulers(): void {
   } catch (error) {
     logger.warn("Failed to start federation job scheduler", error);
   }
+
+  // MTN Node Scheduler (B3 bidirectional node sync: leader-gated liveness probes
+  // + ingest of pull nodes / export to push nodes). Background only — NEVER on a
+  // request path; the feed/hydration hot path never queries a node.
+  try {
+    const { mentionNodeScheduler } = require("./src/services/mtn/MentionNodeScheduler");
+    mentionNodeScheduler.start();
+  } catch (error) {
+    logger.warn("Failed to start MTN node scheduler", error);
+  }
 }
 
 /**
@@ -1055,6 +1067,13 @@ function stopSchedulers(): void {
     federationJobScheduler.stop();
   } catch (error) {
     logger.warn("Failed to stop federation job scheduler", error);
+  }
+
+  try {
+    const { mentionNodeScheduler } = require("./src/services/mtn/MentionNodeScheduler");
+    mentionNodeScheduler.stop();
+  } catch (error) {
+    logger.warn("Failed to stop MTN node scheduler", error);
   }
 }
 

--- a/packages/backend/src/__tests__/services/mtn/mentionNodeRegistry.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/mentionNodeRegistry.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  verifyEnvelopeSignature,
+  isAuthorizedKey,
+  type RecordStore,
+  type ChainHead,
+} from '@oxyhq/protocol';
+import type { SignedRecordEnvelope } from '@oxyhq/contracts';
+
+/**
+ * MTN Protocol — B3 node REGISTRATION (MentionNodeRegistryService).
+ *
+ * Exercises:
+ *  - `materializeNodeFromRecord` projects a signed `app.mention.node` record's
+ *    payload into the `MentionUserNode` cache (active, self-hosted), validating +
+ *    normalising the endpoint and firing a background probe;
+ *  - a malformed payload (bad endpoint / non-hex key) is a non-throwing no-op;
+ *  - `provisionManagedVault` custodial-signs an `app.mention.node` record through
+ *    the REAL protocol engine (in-memory store + resolver), then materializes the
+ *    cache as `managed:true, controller:'oxy'` and flags the operator;
+ *  - `provisionManagedVault` fails closed when the custodial key or the managed
+ *    base URL is unconfigured;
+ *  - `probeLiveness` flips the badge from a mocked `safeFetch` result.
+ *
+ * The real `@oxyhq/protocol` engine runs against an in-memory `RecordStore` (so
+ * the managed record genuinely signs + verifies + appends without Mongo); the
+ * `MentionUserNode` model + `safeFetch` are mocked.
+ */
+
+// --- A fixed custodial secp256k1 keypair the resolver authorizes (issuer ===
+//     MENTION_DID). `signEnvelope` derives `publicKey` = CUSTODIAL_PUBLIC. ---
+const CUSTODIAL_PRIVATE = 'd6bd0dbca0e4e37f4329e615cde35d1990ff6650d5b88a58c470d6d393cc6584';
+const CUSTODIAL_PUBLIC =
+  '04d5c06b76d56858b73655c4cc03594cc17e60d1a1607e14b98387bf5dcc62282a66ad2e1eb60b96fb854f1c303b1d50a7eebbcb06ea7151f69b0e2cbc436f43a6';
+const MENTION_DID = 'did:web:mention.earth';
+const SUBJECT_OXY_ID = '650000000000000000000abc';
+const SUBJECT_DID = `did:web:oxy.so:u:${SUBJECT_OXY_ID}`;
+const MANAGED_BASE = 'https://nodes.mention.earth';
+
+// --- In-memory RecordStore (the protocol `RecordStore` contract). -------------
+interface MemoryStore extends RecordStore {
+  rows: Array<{ env: SignedRecordEnvelope; recordId: string }>;
+  heads: Map<string, ChainHead>;
+}
+
+const { memoryStore, resolveDid, nodeModel, safeFetchMock } = vi.hoisted(() => {
+  const rows: Array<{ env: SignedRecordEnvelope; recordId: string }> = [];
+  const heads = new Map<string, ChainHead>();
+  const store: MemoryStore = {
+    rows,
+    heads,
+    async getHead(subject) {
+      return heads.get(subject) ?? null;
+    },
+    async append(subject, env, recordId) {
+      rows.push({ env, recordId });
+      heads.set(subject, {
+        headRecordId: recordId,
+        seq: env.seq as number,
+        recordCount: (heads.get(subject)?.recordCount ?? 0) + 1,
+      });
+      return { ok: true, recordId, seq: env.seq as number };
+    },
+    async getLogSince(subject, sinceSeq, limit) {
+      return rows
+        .filter((r) => r.env.subject === subject && (r.env.seq ?? -1) > sinceSeq)
+        .sort((a, b) => (a.env.seq ?? 0) - (b.env.seq ?? 0))
+        .slice(0, limit)
+        .map((r) => r.env);
+    },
+    async resolveCursorSeq(subject, recordId) {
+      const row = rows.find((r) => r.env.subject === subject && r.recordId === recordId);
+      return typeof row?.env.seq === 'number' ? row.env.seq : null;
+    },
+    async materializeCurrent(subject, collection, rkey) {
+      const matches = rows.filter(
+        (r) => r.env.subject === subject && r.env.collection === collection && r.env.rkey === rkey,
+      );
+      return matches.length ? matches[matches.length - 1].env : null;
+    },
+    async latestIssuedAtForKey(subject, env) {
+      if (env.version === 2 && (typeof env.collection !== 'string' || typeof env.rkey !== 'string')) {
+        return null;
+      }
+      const matches = rows.filter(
+        (r) => r.env.subject === subject && r.env.collection === env.collection && r.env.rkey === env.rkey,
+      );
+      const latest = matches[matches.length - 1];
+      return typeof latest?.env.issuedAt === 'number' ? latest.env.issuedAt : null;
+    },
+  };
+
+  const resolveDidMock = vi.fn(async () => ({ verificationMethod: [] as Array<{ publicKeyHex: string }> }));
+
+  // In-memory MentionUserNode model: only the statics the registry touches.
+  const cache = new Map<string, Record<string, unknown>>();
+  const model = {
+    cache,
+    findOneAndUpdate: vi.fn(
+      async (
+        filter: { oxyUserId: string },
+        update: { $set?: Record<string, unknown>; $setOnInsert?: Record<string, unknown> },
+      ) => {
+        const existing = cache.get(filter.oxyUserId) ?? {};
+        const doc = { ...existing, ...(update.$setOnInsert ?? {}), ...(update.$set ?? {}) };
+        cache.set(filter.oxyUserId, doc);
+        return doc;
+      },
+    ),
+    findOne: vi.fn((filter: { oxyUserId: string }) => ({
+      select: () => ({ lean: async () => cache.get(filter.oxyUserId) ?? null }),
+      lean: async () => cache.get(filter.oxyUserId) ?? null,
+    })),
+    updateOne: vi.fn(async () => ({ modifiedCount: 1 })),
+    find: vi.fn(() => ({
+      sort: () => ({ limit: () => ({ select: () => ({ lean: async () => [] }) }) }),
+    })),
+  };
+
+  const safeFetch = vi.fn(async () => ({
+    status: 200,
+    headers: {},
+    response: { destroy: () => undefined },
+    finalUrl: '',
+  }));
+
+  return { memoryStore: store, resolveDid: resolveDidMock, nodeModel: model, safeFetchMock: safeFetch };
+});
+
+// --- Mocks -------------------------------------------------------------------
+vi.mock('../../../services/mtn/MentionRecordStore', () => ({
+  mentionRecordStore: memoryStore,
+}));
+vi.mock('../../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({ resolveDid }),
+}));
+vi.mock('../../../models/MentionUserNode', () => ({
+  __esModule: true,
+  default: nodeModel,
+  MentionUserNode: nodeModel,
+}));
+vi.mock('@oxyhq/core/server', () => ({
+  safeFetch: safeFetchMock,
+}));
+
+import {
+  materializeNodeFromRecord,
+  provisionManagedVault,
+  probeLiveness,
+} from '../../../services/mtn/MentionNodeRegistryService';
+import { clearVerificationMethodCache } from '../../../services/mtn/mentionVerificationResolver';
+import { MENTION_NODE_COLLECTION, MENTION_NODE_RKEY } from '../../../services/mtn/mentionNodes.constants';
+
+const NODE_ENDPOINT = 'https://node.example.com';
+const NODE_PUBLIC_KEY = 'ab'.repeat(33); // 66 hex chars — a valid secp256k1 key
+
+/** The update arg (`{ $set, $unset, ... }`) of a Mongo-static mock's last call. */
+type MongoUpdate = { $set?: Record<string, unknown>; $unset?: Record<string, unknown> };
+function lastUpdate(mock: { mock: { calls: unknown[][] } }): MongoUpdate {
+  const calls = mock.mock.calls;
+  const last = calls[calls.length - 1];
+  return (last?.[1] ?? {}) as MongoUpdate;
+}
+/** The `$set` of a Mongo-static mock's last call (asserted present). */
+function lastSet(mock: { mock: { calls: unknown[][] } }): Record<string, unknown> {
+  const set = lastUpdate(mock).$set;
+  expect(set).toBeDefined();
+  return set as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  process.env.MENTION_DID = MENTION_DID;
+  process.env.MENTION_PRIVATE_KEY = CUSTODIAL_PRIVATE;
+  process.env.MENTION_PUBLIC_KEY = CUSTODIAL_PUBLIC;
+  process.env.MENTION_NODE_BASE_URL = MANAGED_BASE;
+  memoryStore.rows.length = 0;
+  memoryStore.heads.clear();
+  nodeModel.cache.clear();
+  nodeModel.findOneAndUpdate.mockClear();
+  nodeModel.updateOne.mockClear();
+  safeFetchMock.mockClear();
+  resolveDid.mockClear();
+  clearVerificationMethodCache();
+});
+
+afterEach(() => {
+  delete process.env.MENTION_DID;
+  delete process.env.MENTION_PRIVATE_KEY;
+  delete process.env.MENTION_PUBLIC_KEY;
+  delete process.env.MENTION_NODE_BASE_URL;
+  delete process.env.MENTION_NODE_PUBLIC_KEY;
+});
+
+describe('MentionNodeRegistryService.materializeNodeFromRecord', () => {
+  it('projects a signed app.mention.node record payload into the cache as an active self-hosted node', async () => {
+    const node = await materializeNodeFromRecord(SUBJECT_OXY_ID, {
+      endpoint: NODE_ENDPOINT,
+      nodePublicKey: NODE_PUBLIC_KEY,
+    });
+
+    expect(node).not.toBeNull();
+    expect(lastSet(nodeModel.findOneAndUpdate)).toMatchObject({
+      endpoint: NODE_ENDPOINT,
+      nodePublicKey: NODE_PUBLIC_KEY,
+      mode: 'pull',
+      managed: false,
+      controller: 'self',
+      status: 'active',
+    });
+  });
+
+  it('honors an explicit push mode + nodeDid from the record', async () => {
+    await materializeNodeFromRecord(SUBJECT_OXY_ID, {
+      endpoint: `${NODE_ENDPOINT}/`,
+      nodePublicKey: NODE_PUBLIC_KEY,
+      mode: 'push',
+      nodeDid: 'did:web:node.example.com',
+    });
+    const set = lastSet(nodeModel.findOneAndUpdate);
+    // Trailing slash is normalised off the endpoint.
+    expect(set.endpoint).toBe(NODE_ENDPOINT);
+    expect(set.mode).toBe('push');
+    expect(set.nodeDid).toBe('did:web:node.example.com');
+  });
+
+  it('is a non-throwing no-op for a non-HTTPS endpoint', async () => {
+    const node = await materializeNodeFromRecord(SUBJECT_OXY_ID, {
+      endpoint: 'http://insecure.example.com',
+      nodePublicKey: NODE_PUBLIC_KEY,
+    });
+    expect(node).toBeNull();
+    expect(nodeModel.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('is a non-throwing no-op for a non-hex node public key', async () => {
+    const node = await materializeNodeFromRecord(SUBJECT_OXY_ID, {
+      endpoint: NODE_ENDPOINT,
+      nodePublicKey: 'not-a-hex-key',
+    });
+    expect(node).toBeNull();
+    expect(nodeModel.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('MentionNodeRegistryService.provisionManagedVault', () => {
+  it('custodial-signs a verifiable app.mention.node record and materializes a managed vault', async () => {
+    const result = await provisionManagedVault(SUBJECT_OXY_ID);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Exactly one signed record was appended to the subject's chain (genesis).
+    expect(memoryStore.rows).toHaveLength(1);
+    const stored = memoryStore.rows[0].env;
+    expect(stored.version).toBe(2);
+    expect(stored.subject).toBe(SUBJECT_DID);
+    expect(stored.issuer).toBe(MENTION_DID);
+    expect(stored.collection).toBe(MENTION_NODE_COLLECTION);
+    expect(stored.rkey).toBe(MENTION_NODE_RKEY);
+    expect(stored.seq).toBe(0);
+    expect(stored.publicKey).toBe(CUSTODIAL_PUBLIC);
+    expect(stored.record).toMatchObject({
+      endpoint: `${MANAGED_BASE}/u/${SUBJECT_OXY_ID}`,
+      mode: 'pull',
+      managed: true,
+    });
+
+    // The record genuinely verifies + is authorized for the custodial issuer.
+    expect(await verifyEnvelopeSignature(stored)).toBe(true);
+    const { mentionVerificationResolver } = await import('../../../services/mtn/mentionVerificationResolver');
+    const resolved = await mentionVerificationResolver.resolve(stored.subject);
+    expect(isAuthorizedKey(resolved, stored).ok).toBe(true);
+
+    // The cache was materialized as a Mention-operated managed node.
+    expect(lastSet(nodeModel.findOneAndUpdate)).toMatchObject({
+      managed: true,
+      controller: 'oxy',
+      status: 'active',
+    });
+  });
+
+  it('fails closed (custodial_key_unconfigured) when the custodial key is unset', async () => {
+    delete process.env.MENTION_PRIVATE_KEY;
+    const result = await provisionManagedVault(SUBJECT_OXY_ID);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('custodial_key_unconfigured');
+    expect(memoryStore.rows).toHaveLength(0);
+  });
+
+  it('fails closed (managed_endpoint_unconfigured) when MENTION_NODE_BASE_URL is unset', async () => {
+    delete process.env.MENTION_NODE_BASE_URL;
+    const result = await provisionManagedVault(SUBJECT_OXY_ID);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('managed_endpoint_unconfigured');
+    expect(memoryStore.rows).toHaveLength(0);
+  });
+});
+
+describe('MentionNodeRegistryService.probeLiveness', () => {
+  it('flips a node to active on a 2xx well-known probe', async () => {
+    nodeModel.cache.set(SUBJECT_OXY_ID, { oxyUserId: SUBJECT_OXY_ID, endpoint: NODE_ENDPOINT, status: 'unreachable' });
+
+    await probeLiveness(SUBJECT_OXY_ID);
+
+    expect(safeFetchMock).toHaveBeenCalledWith(
+      `${NODE_ENDPOINT}/.well-known/oxy-node.json`,
+      expect.objectContaining({ maxRedirects: 1 }),
+    );
+    const update = lastUpdate(nodeModel.updateOne);
+    expect(update.$set).toMatchObject({ status: 'active' });
+    expect(update.$unset).toEqual({ lastError: '' });
+  });
+
+  it('marks a node unreachable + records lastError when the probe throws', async () => {
+    nodeModel.cache.set(SUBJECT_OXY_ID, { oxyUserId: SUBJECT_OXY_ID, endpoint: NODE_ENDPOINT, status: 'active' });
+    safeFetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    await probeLiveness(SUBJECT_OXY_ID);
+
+    const set = lastSet(nodeModel.updateOne);
+    expect(set.status).toBe('unreachable');
+    expect(set.lastError).toContain('ECONNREFUSED');
+  });
+});

--- a/packages/backend/src/__tests__/services/mtn/mentionNodeScheduler.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/mentionNodeScheduler.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import path from 'path';
+
+/**
+ * MTN Protocol — B3 node scheduler (MentionNodeScheduler) + read-path invariant.
+ *
+ *  - The scheduler runs the liveness + sync sweeps ONLY in the background (on a
+ *    deferred timer), never inline; `start()`/`stop()` are idempotent and cancel
+ *    pending first-ticks.
+ *  - The sync sweep routes `pull` nodes to ingest and `push` nodes to export.
+ *  - READ INVARIANT (static guard): NO feed / hydration / controller code on the
+ *    hot read path references `MentionUserNode`, the node endpoints, or the node
+ *    sync/registry services. All node I/O is background-only.
+ */
+
+const mockSweepLiveness = vi.fn();
+const mockIngest = vi.fn();
+const mockExport = vi.fn();
+const mockNodeFind = vi.fn();
+
+vi.mock('../../../services/mtn/MentionNodeRegistryService', () => ({
+  sweepNodeLiveness: (...a: unknown[]) => mockSweepLiveness(...a),
+}));
+vi.mock('../../../services/mtn/MentionNodeSyncService', () => ({
+  ingestFromNode: (...a: unknown[]) => mockIngest(...a),
+  exportToNode: (...a: unknown[]) => mockExport(...a),
+}));
+vi.mock('../../../models/MentionUserNode', () => ({
+  __esModule: true,
+  default: { find: (...a: unknown[]) => mockNodeFind(...a) },
+}));
+
+import { MentionNodeScheduler } from '../../../services/mtn/MentionNodeScheduler';
+
+function findLean(rows: unknown) {
+  return { sort: () => ({ limit: () => ({ select: () => ({ lean: () => Promise.resolve(rows) }) }) }) };
+}
+
+describe('MentionNodeScheduler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockSweepLiveness.mockResolvedValue(undefined);
+    mockIngest.mockResolvedValue(undefined);
+    mockExport.mockResolvedValue(undefined);
+    mockNodeFind.mockReturnValue(findLean([]));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does NOT run any sweep synchronously on start (background only)', () => {
+    const scheduler = new MentionNodeScheduler();
+    scheduler.start();
+    // Nothing fired yet — both sweeps are deferred behind a startup timer.
+    expect(mockSweepLiveness).not.toHaveBeenCalled();
+    expect(mockNodeFind).not.toHaveBeenCalled();
+    scheduler.stop();
+  });
+
+  it('runs the liveness + sync sweeps after their startup delay', async () => {
+    mockNodeFind.mockReturnValue(
+      findLean([
+        { oxyUserId: 'u-pull', mode: 'pull' },
+        { oxyUserId: 'u-push', mode: 'push' },
+      ]),
+    );
+    const scheduler = new MentionNodeScheduler();
+    scheduler.start();
+
+    // Advance past both startup delays (liveness 60s, sync 90s) and flush the
+    // async sweep bodies.
+    await vi.advanceTimersByTimeAsync(95_000);
+
+    expect(mockSweepLiveness).toHaveBeenCalled();
+    // pull → ingest, push → export.
+    expect(mockIngest).toHaveBeenCalledWith('u-pull');
+    expect(mockExport).toHaveBeenCalledWith('u-push');
+    scheduler.stop();
+  });
+
+  it('stop() cancels pending first-ticks so no sweep runs after stop', async () => {
+    const scheduler = new MentionNodeScheduler();
+    scheduler.start();
+    scheduler.stop();
+
+    await vi.advanceTimersByTimeAsync(200_000);
+
+    expect(mockSweepLiveness).not.toHaveBeenCalled();
+    expect(mockIngest).not.toHaveBeenCalled();
+    expect(mockExport).not.toHaveBeenCalled();
+  });
+
+  it('start() is idempotent (a second start does not double-schedule)', async () => {
+    const scheduler = new MentionNodeScheduler();
+    scheduler.start();
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(95_000);
+
+    // Only ONE liveness sweep fired despite two start() calls.
+    expect(mockSweepLiveness).toHaveBeenCalledTimes(1);
+    scheduler.stop();
+  });
+});
+
+describe('Read-path invariant — feeds/hydration never touch a node', () => {
+  // Hot read-path modules: anything a feed/hydration request executes. None may
+  // reference the node model, node endpoints, or the node services.
+  const HOT_PATH_DIRS = ['src/mtn/feed', 'src/controllers', 'src/services'];
+  // The node layer itself is the ONLY place node I/O is allowed — exclude it.
+  const NODE_LAYER = path.normalize('src/services/mtn');
+  const FORBIDDEN = [
+    'MentionUserNode',
+    'MentionNodeSyncService',
+    'MentionNodeRegistryService',
+    'MentionNodeScheduler',
+    'ingestFromNode',
+    'exportToNode',
+    'oxy-node.json',
+  ];
+
+  function walk(dir: string): string[] {
+    const abs = path.resolve(__dirname, '../../../../', dir);
+    let entries: string[];
+    try {
+      entries = readdirSync(abs);
+    } catch {
+      return [];
+    }
+    const files: string[] = [];
+    for (const entry of entries) {
+      const full = path.join(abs, entry);
+      const rel = path.relative(path.resolve(__dirname, '../../../../'), full);
+      // The node layer (src/services/mtn) is the allowed home of node I/O.
+      if (path.normalize(rel).startsWith(NODE_LAYER)) continue;
+      if (statSync(full).isDirectory()) {
+        files.push(...walk(rel));
+      } else if (full.endsWith('.ts') && !full.endsWith('.test.ts')) {
+        files.push(full);
+      }
+    }
+    return files;
+  }
+
+  it('no hot-path module references a node model / endpoint / sync service', () => {
+    const offenders: string[] = [];
+    for (const dir of HOT_PATH_DIRS) {
+      for (const file of walk(dir)) {
+        const content = readFileSync(file, 'utf8');
+        for (const token of FORBIDDEN) {
+          if (content.includes(token)) {
+            offenders.push(`${path.basename(file)} references "${token}"`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/backend/src/__tests__/services/mtn/mentionNodeSync.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/mentionNodeSync.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * MTN Protocol — B3 node→Mention INGEST (MentionNodeSyncService.ingestFromNode).
+ *
+ * Pulls a user's authentic signed chain back from their node (a MOCKED
+ * `NodeClient`) and mirrors it into Mention's local store. These tests lock the
+ * trust + conflict model + the Mention-specific materialization step:
+ *
+ *  - every record is RE-VERIFIED via `MentionRecordService.verifyAndStoreRecord`,
+ *    then materialized via `PostMaterializer.projectRecord`, then COUNTER-SIGNED
+ *    into a witness, and the cursor advances;
+ *  - a BAD-SIGNATURE record (verifyAndStoreRecord → bad_signature) is rejected:
+ *    NOT projected, NOT witnessed, cursor not advanced, `lastError` stamped;
+ *  - a caught-up node is a no-op (no log fetch);
+ *  - LWW keeps the existing higher-`issuedAt` record (skips the loser);
+ *  - witnessing is skipped cleanly when the custodial key is unset (ingest still
+ *    proceeds);
+ *  - an unreachable node leaves state stale WITHOUT throwing.
+ *
+ * `NodeClient`, every model, `verifyAndStoreRecord`, `projectRecord`, the repo-log
+ * head, the signer, and the logger are mocked — no DB, no network. The real
+ * `@oxyhq/contracts` envelope schema validates crafted envelopes.
+ */
+
+const mockHead = vi.fn();
+const mockLog = vi.fn();
+const mockVerifyAndStore = vi.fn();
+const mockProjectRecord = vi.fn();
+const mockGetHead = vi.fn();
+const mockSignMessage = vi.fn();
+const mockComputeRecordId = vi.fn();
+const mockNodeFindOne = vi.fn();
+const mockNodeUpdateOne = vi.fn();
+const mockSignedRecordFindOne = vi.fn();
+const mockSignedRecordCreate = vi.fn();
+const mockWitnessCreate = vi.fn();
+
+// NodeClient is mocked to a stub that returns the canned head/log responses.
+vi.mock('@oxyhq/protocol/node', () => ({
+  NodeClient: class {
+    head = (...a: unknown[]) => mockHead(...a);
+    log = (...a: unknown[]) => mockLog(...a);
+    pushRecords = vi.fn();
+  },
+}));
+vi.mock('@oxyhq/protocol', async () => {
+  const actual = await vi.importActual<typeof import('@oxyhq/protocol')>('@oxyhq/protocol');
+  return {
+    ...actual,
+    computeRecordId: (...a: unknown[]) => mockComputeRecordId(...a),
+    signMessage: (...a: unknown[]) => mockSignMessage(...a),
+  };
+});
+vi.mock('@oxyhq/core/server', () => ({ safeFetch: vi.fn() }));
+vi.mock('../../../services/mtn/MentionRecordService', () => ({
+  verifyAndStoreRecord: (...a: unknown[]) => mockVerifyAndStore(...a),
+}));
+vi.mock('../../../services/mtn/PostMaterializer', () => ({
+  projectRecord: (...a: unknown[]) => mockProjectRecord(...a),
+}));
+vi.mock('../../../services/mtn/MentionRepoLogService', () => ({
+  getHead: (...a: unknown[]) => mockGetHead(...a),
+  getPublicLogSince: vi.fn(async () => []),
+}));
+vi.mock('../../../models/MentionUserNode', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...a: unknown[]) => mockNodeFindOne(...a),
+    updateOne: (...a: unknown[]) => mockNodeUpdateOne(...a),
+  },
+}));
+vi.mock('../../../models/MentionSignedRecord', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...a: unknown[]) => mockSignedRecordFindOne(...a),
+    create: (...a: unknown[]) => mockSignedRecordCreate(...a),
+  },
+}));
+vi.mock('../../../models/MentionNodeIngestWitness', () => ({
+  __esModule: true,
+  default: { create: (...a: unknown[]) => mockWitnessCreate(...a) },
+}));
+
+import { ingestFromNode } from '../../../services/mtn/MentionNodeSyncService';
+
+const OXY_USER_ID = '650000000000000000000abc';
+const SUBJECT_DID = `did:web:oxy.so:u:${OXY_USER_ID}`;
+const PUBLIC_KEY = 'ab'.repeat(33);
+
+/** A well-formed v2 envelope that passes the real contract schema. */
+function envelope(seq: number, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 2,
+    type: 'app_record',
+    subject: SUBJECT_DID,
+    issuer: SUBJECT_DID,
+    record: { text: `post ${seq}`, createdAt: new Date(1_700_000_000_000 + seq).toISOString() },
+    issuedAt: 1_700_000_000_000 + seq,
+    seq,
+    prev: seq === 0 ? null : `p${seq}`.padEnd(64, '0'),
+    collection: 'app.mention.feed.post',
+    rkey: `650000000000000000000${(seq + 100).toString().padStart(3, '0')}`,
+    publicKey: PUBLIC_KEY,
+    alg: 'ES256K-DER-SHA256',
+    signature: 'deadbeef',
+    ...overrides,
+  };
+}
+
+/** Chainable `.select().lean()`. */
+function selectLean(value: unknown) {
+  return { select: () => ({ lean: () => Promise.resolve(value) }) };
+}
+/** Chainable `.sort().lean()`. */
+function sortLean(value: unknown) {
+  return { sort: () => ({ lean: () => Promise.resolve(value) }) };
+}
+
+/** The update arg (`{ $set, $unset, ... }`) of a Mongo-static mock's last call. */
+function lastUpdate(mock: { mock: { calls: unknown[][] } }): {
+  $set?: Record<string, unknown>;
+  $unset?: Record<string, unknown>;
+} {
+  const { calls } = mock.mock;
+  const last = calls[calls.length - 1];
+  return (last?.[1] ?? {}) as { $set?: Record<string, unknown>; $unset?: Record<string, unknown> };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.MENTION_PRIVATE_KEY = 'aa'.repeat(32);
+  process.env.MENTION_PUBLIC_KEY = PUBLIC_KEY;
+
+  mockNodeFindOne.mockReturnValue(selectLean({ endpoint: 'https://node.example.com', cursor: undefined }));
+  mockGetHead.mockResolvedValue(null); // local head -1
+  mockNodeUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  mockSignedRecordFindOne.mockReturnValue(sortLean(null));
+  mockSignedRecordCreate.mockResolvedValue({});
+  mockWitnessCreate.mockResolvedValue({});
+  mockSignMessage.mockResolvedValue('witness-sig');
+  mockProjectRecord.mockResolvedValue({ ok: true, kind: 'post', id: 'r' });
+  mockComputeRecordId.mockImplementation(async (env: { seq?: number }) => `rid-${env.seq}`);
+  mockVerifyAndStore.mockImplementation(async (env: { seq?: number }) => ({
+    ok: true,
+    recordId: `rid-${env.seq}`,
+    seq: env.seq,
+  }));
+});
+
+afterEach(() => {
+  delete process.env.MENTION_PRIVATE_KEY;
+  delete process.env.MENTION_PUBLIC_KEY;
+});
+
+describe('ingestFromNode — happy path', () => {
+  it('re-verifies + materializes + witnesses each record and advances the cursor', async () => {
+    mockHead.mockResolvedValueOnce({ seq: 2, headRecordId: 'h', recordCount: 3 });
+    mockLog.mockResolvedValueOnce({ records: [envelope(0), envelope(1), envelope(2)], count: 3, head: null });
+
+    await ingestFromNode(OXY_USER_ID);
+
+    // EVERY record was re-verified through the chain engine chokepoint.
+    expect(mockVerifyAndStore).toHaveBeenCalledTimes(3);
+    // EVERY verified record was materialized into the feed-readable store.
+    expect(mockProjectRecord).toHaveBeenCalledTimes(3);
+    // EVERY ingested record was counter-signed into the witness ledger.
+    expect(mockWitnessCreate).toHaveBeenCalledTimes(3);
+
+    // Cursor advanced to the node head (2) + lastSyncedAt stamped + error cleared.
+    const update = lastUpdate(mockNodeUpdateOne);
+    expect(update.$set).toMatchObject({ cursor: 2 });
+    expect(update.$set?.lastSyncedAt).toBeInstanceOf(Date);
+    expect(update.$unset).toEqual({ lastError: '' });
+  });
+
+  it('is a caught-up no-op (no log fetch) when the node head is not ahead', async () => {
+    mockGetHead.mockResolvedValueOnce({ seq: 5, headRecordId: 'h', recordCount: 6 });
+    mockHead.mockResolvedValueOnce({ seq: 5, headRecordId: 'h', recordCount: 6 });
+
+    await ingestFromNode(OXY_USER_ID);
+
+    expect(mockLog).not.toHaveBeenCalled();
+    expect(mockVerifyAndStore).not.toHaveBeenCalled();
+    expect(mockProjectRecord).not.toHaveBeenCalled();
+    const update = mockNodeUpdateOne.mock.calls[0];
+    expect(update[1].$set).toMatchObject({ cursor: 5 });
+  });
+});
+
+describe('ingestFromNode — bad-signature rejection', () => {
+  it('rejects a record whose signature does not verify; never projects or witnesses it', async () => {
+    mockHead.mockResolvedValueOnce({ seq: 0, headRecordId: 'h', recordCount: 1 });
+    mockLog.mockResolvedValueOnce({ records: [envelope(0)], count: 1, head: null });
+    mockVerifyAndStore.mockResolvedValueOnce({ ok: false, reason: 'bad_signature' });
+
+    await ingestFromNode(OXY_USER_ID);
+
+    // It WAS re-verified (the trust boundary ran) but rejected.
+    expect(mockVerifyAndStore).toHaveBeenCalledTimes(1);
+    expect(mockProjectRecord).not.toHaveBeenCalled(); // not materialized
+    expect(mockWitnessCreate).not.toHaveBeenCalled(); // not witnessed
+    expect(mockSignedRecordCreate).not.toHaveBeenCalled(); // no fork mirror
+    const update = mockNodeUpdateOne.mock.calls[0];
+    expect(update[1].$set.lastError).toContain('rejected:bad_signature');
+  });
+
+  it('rejects a record forged with a key that is not a current verification method', async () => {
+    mockHead.mockResolvedValueOnce({ seq: 0, headRecordId: 'h', recordCount: 1 });
+    mockLog.mockResolvedValueOnce({ records: [envelope(0)], count: 1, head: null });
+    mockVerifyAndStore.mockResolvedValueOnce({
+      ok: false,
+      reason: 'public_key_not_a_current_verification_method',
+    });
+
+    await ingestFromNode(OXY_USER_ID);
+
+    expect(mockProjectRecord).not.toHaveBeenCalled();
+    expect(mockWitnessCreate).not.toHaveBeenCalled();
+    const update = mockNodeUpdateOne.mock.calls[0];
+    expect(update[1].$set.lastError).toContain('rejected:public_key_not_a_current_verification_method');
+  });
+
+  it('rejects a malformed envelope that fails the contract schema', async () => {
+    mockHead.mockResolvedValueOnce({ seq: 0, headRecordId: 'h', recordCount: 1 });
+    mockLog.mockResolvedValueOnce({ records: [{ not: 'an envelope' }], count: 1, head: null });
+
+    await ingestFromNode(OXY_USER_ID);
+
+    expect(mockVerifyAndStore).not.toHaveBeenCalled(); // never reached the engine
+    expect(mockProjectRecord).not.toHaveBeenCalled();
+    const update = mockNodeUpdateOne.mock.calls[0];
+    expect(update[1].$set.lastError).toContain('rejected:invalid_envelope');
+  });
+});
+
+describe('ingestFromNode — last-writer-wins', () => {
+  it('keeps the existing higher-issuedAt record and skips the incoming loser', async () => {
+    mockHead.mockResolvedValueOnce({ seq: 1, headRecordId: 'h', recordCount: 2 });
+    mockLog.mockResolvedValueOnce({ records: [envelope(1)], count: 1, head: null });
+    mockVerifyAndStore.mockResolvedValueOnce({ ok: false, reason: 'stale_issued_at' });
+    // The existing materialized value for the key has a STRICTLY higher issuedAt.
+    mockSignedRecordFindOne.mockReturnValueOnce(
+      sortLean({ recordId: 'rid-existing', envelope: { issuedAt: 1_700_000_000_999 } }),
+    );
+
+    await ingestFromNode(OXY_USER_ID);
+
+    expect(mockSignedRecordCreate).not.toHaveBeenCalled(); // loser NOT stored
+    expect(mockProjectRecord).not.toHaveBeenCalled(); // not materialized
+    expect(mockWitnessCreate).not.toHaveBeenCalled();
+    // Clean skip → cursor stamped, lastError cleared.
+    expect(mockNodeUpdateOne.mock.calls[0][1].$unset).toEqual({ lastError: '' });
+  });
+});
+
+describe('ingestFromNode — counter-sign witness', () => {
+  it('skips witnessing cleanly when the custodial key is unset, but still ingests + materializes', async () => {
+    delete process.env.MENTION_PRIVATE_KEY;
+    delete process.env.MENTION_PUBLIC_KEY;
+    mockHead.mockResolvedValueOnce({ seq: 0, headRecordId: 'h', recordCount: 1 });
+    mockLog.mockResolvedValueOnce({ records: [envelope(0)], count: 1, head: null });
+
+    await ingestFromNode(OXY_USER_ID);
+
+    expect(mockSignMessage).not.toHaveBeenCalled();
+    expect(mockWitnessCreate).not.toHaveBeenCalled();
+    // Ingest + materialization still happened; the cursor moved.
+    expect(mockVerifyAndStore).toHaveBeenCalledTimes(1);
+    expect(mockProjectRecord).toHaveBeenCalledTimes(1);
+    expect(lastUpdate(mockNodeUpdateOne).$set).toMatchObject({ cursor: 0 });
+  });
+});
+
+describe('ingestFromNode — resilience', () => {
+  it('leaves state stale WITHOUT throwing when the node is unreachable', async () => {
+    mockHead.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    await expect(ingestFromNode(OXY_USER_ID)).resolves.toBeUndefined();
+
+    expect(mockVerifyAndStore).not.toHaveBeenCalled();
+    expect(mockProjectRecord).not.toHaveBeenCalled();
+    expect(mockNodeUpdateOne.mock.calls[0][1].$set.lastError).toContain('ECONNREFUSED');
+  });
+
+  it('no-ops when the user has no registered node', async () => {
+    mockNodeFindOne.mockReturnValueOnce(selectLean(null));
+
+    await ingestFromNode(OXY_USER_ID);
+
+    expect(mockHead).not.toHaveBeenCalled();
+    expect(mockNodeUpdateOne).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/models/MentionNodeIngestWitness.ts
+++ b/packages/backend/src/models/MentionNodeIngestWitness.ts
@@ -1,0 +1,65 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+/**
+ * MentionNodeIngestWitness (MTN Protocol — B3 node→Mention ingest)
+ *
+ * An append-only, Mention-COUNTER-SIGNED witness over each signed record Mention
+ * ingests from a user's personal data node. When the background ingest worker
+ * mirrors a record (content address `recordId`) from a node into Mention's
+ * `MentionSignedRecord` store, it ALSO produces a small `ES256K-DER-SHA256`
+ * signature over `canonicalize({ recordId, oxyUserId, ingestedAt })` using the
+ * Mention custodial key (`MENTION_PRIVATE_KEY`, the verification method of
+ * `MENTION_DID`).
+ *
+ * This MIRRORS oxy-api's `NodeIngestWitness` model, but it lives in MENTION's
+ * Mongo and is keyed by `oxyUserId` (the user's Oxy account id as a STRING)
+ * instead of an Oxy `userId` ObjectId — Mention has no `User` collection.
+ *
+ * ## Why a counter-sign
+ *
+ * The node holds the user's own signing key. If that key were ever stolen, an
+ * attacker could re-sign a DIFFERENT history and present it as authentic. This
+ * witness binds the FIRST recordId Mention ever saw at a given content address to
+ * a timestamp under Mention's independent key — an immutable, third-party
+ * attestation of "Mention observed this exact record at this time". A later
+ * silent rewrite can no longer claim the old content never existed.
+ *
+ * One witness per `recordId` (unique) — witnessing is idempotent, so a record
+ * re-pulled on a later sweep is never double-witnessed. The store is never
+ * mutated or deleted.
+ */
+export interface IMentionNodeIngestWitness extends Document {
+  /** The Oxy account id (string) whose chain the witnessed record belongs to. */
+  oxyUserId: string;
+  /** The content address (sha256 of the canonical signing input) Mention witnessed. */
+  recordId: string;
+  /** DER-encoded secp256k1 signature by the Mention custodial key over the witness input. */
+  witnessSignature: string;
+  /** When Mention first ingested + witnessed this recordId (ms epoch). */
+  ingestedAt: number;
+  createdAt: Date;
+}
+
+const MentionNodeIngestWitnessSchema = new Schema<IMentionNodeIngestWitness>(
+  {
+    oxyUserId: { type: String, required: true },
+    recordId: { type: String, required: true, unique: true },
+    witnessSignature: { type: String, required: true },
+    ingestedAt: { type: Number, required: true },
+  },
+  {
+    // Append-only: stamp createdAt, never updatedAt.
+    timestamps: { createdAt: true, updatedAt: false },
+    strict: true,
+    minimize: false,
+  },
+);
+
+// Per-user audit reads (newest first).
+MentionNodeIngestWitnessSchema.index({ oxyUserId: 1, createdAt: -1 });
+
+export const MentionNodeIngestWitness = mongoose.model<IMentionNodeIngestWitness>(
+  'MentionNodeIngestWitness',
+  MentionNodeIngestWitnessSchema,
+);
+export default MentionNodeIngestWitness;

--- a/packages/backend/src/models/MentionUserNode.ts
+++ b/packages/backend/src/models/MentionUserNode.ts
@@ -1,0 +1,127 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+/**
+ * MentionUserNode (MTN Protocol — B3 user nodes / decentralization)
+ *
+ * Operational cache of a user's registered personal data node (a `mention-node`
+ * — a DEPLOYMENT of `@oxyhq/node` with `appNamespace=app.mention`). The AUTHORITY
+ * for a node registration is a signed `app.mention.node` record on the user's
+ * hash chain (`collection: 'app.mention.node'`, `rkey: 'self'`, last-writer-wins)
+ * — this row is a denormalised, fast-to-read projection of that record plus the
+ * live liveness state Mention maintains in the background.
+ *
+ * This MIRRORS oxy-api's `UserNode` model, but it lives in MENTION's Mongo and is
+ * keyed by `oxyUserId` (the user's Oxy account id as a STRING) instead of an Oxy
+ * `userId` ObjectId — Mention has no `User` collection (exactly like
+ * `MentionSignedRecord`). Identity/signing is Oxy's; the storage is Mention's.
+ *
+ * ## The read-path invariant
+ *
+ * Nothing in a request's READ path ever touches a node. A node being down means
+ * this row is stale-but-instant, never slow. `status`/`lastSeenAt`/`lastError`/
+ * `cursor` are updated ONLY by background liveness probes and the ingest/export
+ * worker via `safeFetch` (SSRF-safe) — never inline in a request handler.
+ *
+ * One node per user (`oxyUserId` unique). Re-registration (a newer signed
+ * `app.mention.node` record) upserts this row in place.
+ */
+
+/** How Mention and the node move records: the node pulls (default), or Mention pushes. */
+export type MentionUserNodeMode = 'pull' | 'push';
+
+/**
+ * Who operates the node (managed vault):
+ *  - `self` — the user self-hosts the node (the default; registered by a
+ *    client-signed `app.mention.node` record the user published themselves).
+ *  - `oxy`  — Mention operates the node ON BEHALF of a non-technical user, using
+ *    the custodial key (`issuer = MENTION_DID`). Registered by a custodial-signed
+ *    `app.mention.node` record via `provisionManagedVault`.
+ */
+export type MentionUserNodeController = 'self' | 'oxy';
+
+/**
+ * Liveness state of the node:
+ *  - `active`      — last probe reached the node's `/.well-known/oxy-node.json`.
+ *  - `unreachable` — last probe failed (DNS/connect/timeout/non-2xx). The row is
+ *    still served from cache; only the badge changes.
+ *  - `revoked`     — the user removed the node registration. Excluded from the
+ *    liveness/ingest sweeps.
+ */
+export type MentionUserNodeStatus = 'active' | 'unreachable' | 'revoked';
+
+export interface IMentionUserNode extends Document {
+  /** The Oxy account id (string) that registered the node (one node per user). */
+  oxyUserId: string;
+  /** Optional DID the node advertises for itself (informational). */
+  nodeDid?: string;
+  /** The node's public HTTPS base URL (where its `/.well-known/oxy-node.json` lives). */
+  endpoint: string;
+  /** The node's secp256k1 public key (hex) — records it signs verify against this. */
+  nodePublicKey: string;
+  /** Transport direction. Defaults to `pull` (the node paces its own sync). */
+  mode: MentionUserNodeMode;
+  /**
+   * Whether Mention operates this node on the user's behalf (managed vault) vs.
+   * the user self-hosting it. A managed node is `managed:true, controller:'oxy'`,
+   * registered by a custodial-signed `app.mention.node` record (issuer =
+   * `MENTION_DID`).
+   */
+  managed: boolean;
+  /**
+   * Operator of the node — `self` (user self-hosts) or `oxy` (managed vault).
+   * Defaults to `self`.
+   */
+  controller: MentionUserNodeController;
+  /** Liveness badge — maintained only by background probes, never a read handler. */
+  status: MentionUserNodeStatus;
+  /** Last time a probe reached the node successfully. */
+  lastSeenAt?: Date;
+  /** Last time a probe ran (success or failure). */
+  lastProbeAt?: Date;
+  /** Human-readable reason the last probe OR ingest failed (cleared on success). */
+  lastError?: string;
+  /**
+   * Last synced chain `seq` for the two-way sync — how far Mention has mirrored
+   * the node's authentic chain back in (the `seq` of Mention's local chain head
+   * after the last successful ingest). Advanced ONLY by the background worker.
+   */
+  cursor?: number;
+  /**
+   * Last time the ingest worker ran a pull for this node (success OR a caught-up
+   * no-op). Maintained only in the background — never a read handler.
+   */
+  lastSyncedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const MentionUserNodeSchema = new Schema<IMentionUserNode>(
+  {
+    oxyUserId: { type: String, required: true, unique: true },
+    nodeDid: { type: String },
+    endpoint: { type: String, required: true },
+    nodePublicKey: { type: String, required: true },
+    mode: { type: String, enum: ['pull', 'push'], required: true, default: 'pull' },
+    managed: { type: Boolean, required: true, default: false },
+    controller: { type: String, enum: ['self', 'oxy'], required: true, default: 'self' },
+    status: { type: String, enum: ['active', 'unreachable', 'revoked'], required: true, default: 'active' },
+    lastSeenAt: { type: Date },
+    lastProbeAt: { type: Date },
+    lastError: { type: String },
+    cursor: { type: Number },
+    lastSyncedAt: { type: Date },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: true },
+    strict: true,
+    minimize: false,
+  },
+);
+
+// Liveness/ingest sweeps scan by status (`active`/`unreachable`, never `revoked`).
+MentionUserNodeSchema.index({ status: 1 });
+// Ingest sweep picks the least-recently-synced `pull` nodes first.
+MentionUserNodeSchema.index({ status: 1, mode: 1, lastSyncedAt: 1 });
+
+export const MentionUserNode = mongoose.model<IMentionUserNode>('MentionUserNode', MentionUserNodeSchema);
+export default MentionUserNode;

--- a/packages/backend/src/routes/mtn-nodes.routes.ts
+++ b/packages/backend/src/routes/mtn-nodes.routes.ts
@@ -1,0 +1,159 @@
+/**
+ * MTN User-Node Routes (MTN Protocol — B3 user nodes)
+ *
+ * Mounted at `/mtn/nodes` (behind `optionalAuth`, which populates `req.user` for
+ * a valid session). The authed routes enforce auth INTERNALLY (`req.user?.id`),
+ * mirroring how `/federation` + `/starter-packs` are mounted in `server.ts`:
+ *  - `GET    /mtn/nodes/me`                  (auth) — the caller's node + status.
+ *  - `DELETE /mtn/nodes/me`                  (auth) — revoke the caller's node.
+ *  - `POST   /mtn/nodes/managed`             (auth) — provision a managed vault.
+ *  - `POST   /mtn/nodes/ingest/notify/:userId` (public) — a 202 ingest HINT.
+ *
+ * The owner id is ALWAYS resolved server-side from the session (never the body).
+ * Node REGISTRATION is not here — a node is registered by publishing a signed
+ * `app.mention.node` record onto the user's chain, which materializes the cache
+ * via `MentionNodeRegistryService`. These routes only read/revoke that cache and
+ * trigger background sync; NOTHING here ever fetches a node inline (revocation is
+ * a local cache write; the notify only schedules background work) — the read-path
+ * invariant holds.
+ */
+
+import { Router, Request, Response } from 'express';
+import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
+import { logger } from '../utils/logger';
+import {
+  getUserNode,
+  removeNode,
+  provisionManagedVault,
+} from '../services/mtn/MentionNodeRegistryService';
+import { ingestFromNode } from '../services/mtn/MentionNodeSyncService';
+import MentionUserNode, { type IMentionUserNode } from '../models/MentionUserNode';
+
+const router = Router();
+
+/** Public projection of a node row (drops Mongo internals). */
+function serializeNode(node: IMentionUserNode): Record<string, unknown> {
+  return {
+    nodeDid: node.nodeDid,
+    endpoint: node.endpoint,
+    nodePublicKey: node.nodePublicKey,
+    mode: node.mode,
+    managed: node.managed,
+    controller: node.controller,
+    status: node.status,
+    lastSeenAt: node.lastSeenAt,
+    lastProbeAt: node.lastProbeAt,
+    lastError: node.lastError,
+    cursor: node.cursor,
+    lastSyncedAt: node.lastSyncedAt,
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+  };
+}
+
+/** GET /mtn/nodes/me — the caller's registered node (or `{ node: null }`). */
+router.get('/me', async (req: AuthRequest, res: Response) => {
+  try {
+    const oxyUserId = req.user?.id;
+    if (!oxyUserId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const node = await getUserNode(oxyUserId);
+    return res.json({ node: node ? serializeNode(node) : null });
+  } catch (error) {
+    logger.error('GET /mtn/nodes/me failed', error);
+    return res.status(500).json({ message: 'Failed to load node' });
+  }
+});
+
+/** DELETE /mtn/nodes/me — revoke the caller's node registration. */
+router.delete('/me', async (req: AuthRequest, res: Response) => {
+  try {
+    const oxyUserId = req.user?.id;
+    if (!oxyUserId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const revoked = await removeNode(oxyUserId);
+    if (!revoked) {
+      return res.status(404).json({ message: 'No active node registration to revoke' });
+    }
+
+    return res.json({ success: true });
+  } catch (error) {
+    logger.error('DELETE /mtn/nodes/me failed', error);
+    return res.status(500).json({ message: 'Failed to revoke node' });
+  }
+});
+
+/**
+ * POST /mtn/nodes/managed — provision a Mention-operated MANAGED vault for the
+ * caller ("Create your vault"). The owner id is resolved from the session ONLY
+ * (the body is never read), Mention custodial-signs the node registration onto
+ * the caller's chain, and the materialized node is returned. Idempotent: an
+ * existing active managed vault is refreshed in place, not duplicated.
+ *
+ * A missing custodial key or unconfigured managed-node fleet is server config, so
+ * it answers 503 (try later) — never a silent broken vault.
+ */
+router.post('/managed', async (req: AuthRequest, res: Response) => {
+  try {
+    const oxyUserId = req.user?.id;
+    if (!oxyUserId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const result = await provisionManagedVault(oxyUserId);
+    if (!result.ok) {
+      switch (result.reason) {
+        case 'custodial_key_unconfigured':
+        case 'managed_endpoint_unconfigured':
+          return res.status(503).json({ message: 'Managed vaults are not available right now' });
+        default:
+          return res.status(500).json({ message: 'Failed to provision managed vault' });
+      }
+    }
+
+    return res.status(201).json({ node: serializeNode(result.node) });
+  } catch (error) {
+    logger.error('POST /mtn/nodes/managed failed', error);
+    return res.status(500).json({ message: 'Failed to provision managed vault' });
+  }
+});
+
+/**
+ * POST /mtn/nodes/ingest/notify/:userId — a HINT (no authority) that a user's
+ * node has new records. The target is resolved server-side from the path param
+ * ONLY; the request body is never read or trusted. If the named user has a
+ * registered (non-revoked) node, a background ingest is fired-and-forget (never
+ * awaited), then fully re-verified by the worker (a notify can never inject
+ * data). Always answers 202: it is a fire-and-forget hint, not a probe.
+ *
+ * Unauthenticated by design (it only re-pulls the user's OWN node and changes
+ * nothing without cryptographic verification). The global rate limiter +
+ * brute-force protection apply. The read path is untouched — this only schedules
+ * background work.
+ */
+router.post('/ingest/notify/:userId', async (req: Request, res: Response) => {
+  const { userId } = req.params;
+  // Bound the param so a junk id never reaches the DB; an Oxy account id is a
+  // short, opaque, alphanumeric string.
+  if (typeof userId === 'string' && /^[a-zA-Z0-9_-]{1,64}$/.test(userId)) {
+    void MentionUserNode.exists({ oxyUserId: userId, status: { $ne: 'revoked' } })
+      .then((hasNode) => {
+        if (hasNode) {
+          // Detached background ingest — NEVER awaited on the request path.
+          void ingestFromNode(userId);
+        }
+      })
+      .catch((error) => {
+        logger.debug('mtn/nodes ingest notify: existence check failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  }
+  return res.status(202).json({ accepted: true });
+});
+
+export default router;

--- a/packages/backend/src/services/mtn/MentionNodeRegistryService.ts
+++ b/packages/backend/src/services/mtn/MentionNodeRegistryService.ts
@@ -1,0 +1,465 @@
+/**
+ * Mention Node Registry Service (MTN Protocol — B3 user nodes)
+ *
+ * Materializes and maintains the operational {@link MentionUserNode} cache from
+ * the AUTHORITATIVE source — a user's signed `app.mention.node` record on their
+ * MTN hash chain (`collection: 'app.mention.node'`, `rkey: 'self'`). The signed
+ * record is verified + stored by the chain engine (`verifyAndStoreRecord`); this
+ * service projects its `record` payload into the fast cache and keeps the
+ * liveness badge current.
+ *
+ * A faithful port of oxy-api's `nodeRegistry.service.ts`, scoped to `app.mention.*`
+ * and keyed by `oxyUserId` (a string — Mention has no `User` collection).
+ *
+ * ## Absolute read-path invariant
+ *
+ * Every node fetch here goes through `@oxyhq/core/server`'s `safeFetch`
+ * (HTTPS-only, private-IP denylist, DNS-pinned, bounded redirects) and runs ONLY
+ * in the background — the post-registration probe (fire-and-forget) and the
+ * periodic sweep. No function in a request's read path ever awaits a node: a
+ * down node leaves the cache stale-but-instant. `probeLiveness` and
+ * `sweepNodeLiveness` NEVER throw into a caller.
+ */
+
+import type { UpdateQuery } from 'mongoose';
+import { z } from 'zod';
+import { signEnvelope, type SignedRecordSigningFields } from '@oxyhq/protocol';
+import { safeFetch } from '@oxyhq/core/server';
+import MentionUserNode, {
+  type IMentionUserNode,
+  type MentionUserNodeMode,
+  type MentionUserNodeController,
+} from '../../models/MentionUserNode';
+import { logger } from '../../utils/logger';
+import { buildUserDid } from './mentionDid';
+import { getHead } from './MentionRepoLogService';
+import { verifyAndStoreRecord } from './MentionRecordService';
+import {
+  getMentionCustodialIssuer,
+  getMentionCustodialPrivateKey,
+  getMentionCustodialPublicKey,
+} from './mentionRecordEnv';
+import {
+  MENTION_NODE_COLLECTION,
+  MENTION_NODE_RKEY,
+  MENTION_NODE_WELL_KNOWN_PATH,
+  MENTION_NODE_PROBE_TIMEOUT_MS,
+  MENTION_NODE_LAST_ERROR_MAX_LEN,
+  MENTION_NODE_LIVENESS_SWEEP_BATCH,
+  MENTION_NODE_BASE_URL_ENV,
+  MENTION_NODE_USER_PATH_PREFIX,
+  MENTION_NODE_PUBLIC_KEY_ENV,
+  MENTION_NODE_MANAGED_MODE,
+} from './mentionNodes.constants';
+
+/** The open envelope `type` Mention signs every v2 app record under (incl. node). */
+const MENTION_RECORD_TYPE = 'app_record';
+
+/** Retry budget for the multi-writer chain-head race when appending the node record. */
+const MAX_PROVISION_ATTEMPTS = 4;
+
+/**
+ * How a managed `app.mention.node` record was projected into the cache.
+ * Self-hosted registrations omit this (defaults below); the managed path passes it.
+ */
+export interface MaterializeNodeOptions {
+  /** Mention operates this node on the user's behalf (managed vault). Default `false`. */
+  managed?: boolean;
+  /** Operator of the node. Default `self`. */
+  controller?: MentionUserNodeController;
+}
+
+/**
+ * Shape of the `record` payload inside a signed `app.mention.node` envelope. Only
+ * these fields are projected into the cache; anything else is ignored.
+ */
+const nodeRecordSchema = z.object({
+  endpoint: z.string().trim().min(1),
+  nodePublicKey: z
+    .string()
+    .trim()
+    .regex(/^[0-9a-fA-F]{64,130}$/, 'nodePublicKey must be a secp256k1 hex key'),
+  mode: z.enum(['pull', 'push']).optional(),
+  nodeDid: z.string().trim().min(1).optional(),
+});
+
+/**
+ * Validate + normalise a node endpoint. Returns the canonical `origin + path`
+ * (trailing slash trimmed) only for a well-formed, credential-free HTTPS URL;
+ * `null` otherwise. The SSRF/private-IP check itself happens later in `safeFetch`
+ * at probe time — here we only reject endpoints that could never be a valid node.
+ */
+function normalizeHttpsEndpoint(raw: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'https:') return null;
+  if (url.username.length > 0 || url.password.length > 0) return null;
+  if (url.hostname.length === 0) return null;
+  const path = url.pathname.replace(/\/+$/, '');
+  return `${url.origin}${path}`;
+}
+
+/** The liveness manifest URL for a normalised node endpoint. */
+function wellKnownUrl(endpoint: string): string {
+  return `${endpoint}${MENTION_NODE_WELL_KNOWN_PATH}`;
+}
+
+/**
+ * Project a verified `app.mention.node` signed record into the
+ * {@link MentionUserNode} cache.
+ *
+ * Best-effort and non-throwing: the signed record is the source of truth and is
+ * already persisted on the chain by the caller; a malformed `record` payload
+ * (bad endpoint/key) simply skips materialization (logged) rather than failing.
+ * On success the row is upserted `active` and a liveness probe is fired WITHOUT
+ * being awaited.
+ *
+ * `options` records WHO operates the node: self-hosted by default, or
+ * `{ managed: true, controller: 'oxy' }` for a managed vault. Both flags are
+ * written every time so re-registering a self-hosted node over a previously
+ * managed one (or vice-versa) flips the operator deterministically.
+ */
+export async function materializeNodeFromRecord(
+  oxyUserId: string,
+  record: Record<string, unknown>,
+  options: MaterializeNodeOptions = {},
+): Promise<IMentionUserNode | null> {
+  const parsed = nodeRecordSchema.safeParse(record);
+  if (!parsed.success) {
+    logger.warn('MentionNodeRegistry: node record payload failed validation; skipping materialization', {
+      oxyUserId,
+    });
+    return null;
+  }
+
+  const endpoint = normalizeHttpsEndpoint(parsed.data.endpoint);
+  if (!endpoint) {
+    logger.warn('MentionNodeRegistry: node record endpoint is not a valid HTTPS URL; skipping materialization', {
+      oxyUserId,
+    });
+    return null;
+  }
+
+  const mode: MentionUserNodeMode = parsed.data.mode ?? 'pull';
+  const managed = options.managed ?? false;
+  const controller: MentionUserNodeController = options.controller ?? 'self';
+
+  try {
+    const node = await MentionUserNode.findOneAndUpdate(
+      { oxyUserId },
+      {
+        $set: {
+          endpoint,
+          nodePublicKey: parsed.data.nodePublicKey,
+          mode,
+          managed,
+          controller,
+          status: 'active',
+          ...(parsed.data.nodeDid ? { nodeDid: parsed.data.nodeDid } : {}),
+        },
+        $unset: { lastError: '' },
+        $setOnInsert: { oxyUserId },
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+
+    // Fire-and-forget liveness probe — NEVER awaited in the request path.
+    probeLiveness(oxyUserId).catch((err) =>
+      logger.debug('MentionNodeRegistry: post-registration liveness probe failed to schedule', {
+        oxyUserId,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+
+    return node;
+  } catch (err) {
+    logger.error('MentionNodeRegistry: failed to materialize node from signed record', {
+      oxyUserId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Background liveness probe for a single user's node. Fetches the node's
+ * `/.well-known/oxy-node.json` over `safeFetch` (SSRF-safe) and updates the
+ * cached badge: a 2xx → `active` + `lastSeenAt`; anything else (or a thrown
+ * fetch error) → `unreachable` + `lastError`. Never throws and never reads more
+ * than the response headers (the body is destroyed immediately). A `revoked`
+ * node is skipped.
+ */
+export async function probeLiveness(oxyUserId: string): Promise<void> {
+  try {
+    const node = await MentionUserNode.findOne({ oxyUserId, status: { $ne: 'revoked' } })
+      .select('endpoint')
+      .lean<{ endpoint: string } | null>();
+    if (!node) {
+      return;
+    }
+
+    const probeAt = new Date();
+    let update: UpdateQuery<IMentionUserNode>;
+
+    try {
+      const result = await safeFetch(wellKnownUrl(node.endpoint), {
+        headersTimeoutMs: MENTION_NODE_PROBE_TIMEOUT_MS,
+        maxRedirects: 1,
+      });
+      // Liveness only needs the status line — drop the body without reading it.
+      result.response.destroy();
+
+      if (result.status >= 200 && result.status < 300) {
+        update = {
+          $set: { status: 'active', lastSeenAt: probeAt, lastProbeAt: probeAt },
+          $unset: { lastError: '' },
+        };
+      } else {
+        update = {
+          $set: {
+            status: 'unreachable',
+            lastProbeAt: probeAt,
+            lastError: `node responded with HTTP ${result.status}`.slice(0, MENTION_NODE_LAST_ERROR_MAX_LEN),
+          },
+        };
+      }
+    } catch (fetchErr) {
+      const message = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+      update = {
+        $set: {
+          status: 'unreachable',
+          lastProbeAt: probeAt,
+          lastError: message.slice(0, MENTION_NODE_LAST_ERROR_MAX_LEN),
+        },
+      };
+      logger.debug('MentionNodeRegistry: node liveness probe failed', { oxyUserId, error: message });
+    }
+
+    await MentionUserNode.updateOne({ oxyUserId, status: { $ne: 'revoked' } }, update);
+  } catch (err) {
+    // A DB error during a background probe must never escape — log and move on.
+    logger.error('MentionNodeRegistry: node liveness probe encountered an error', {
+      oxyUserId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Re-probe a bounded batch of registered nodes (least-recently-probed first).
+ * Sequential to bound the outbound concurrency; each probe is independent and
+ * non-throwing. Called ONLY by the leader-gated background scheduler.
+ */
+export async function sweepNodeLiveness(): Promise<void> {
+  const nodes = await MentionUserNode.find({ status: { $in: ['active', 'unreachable'] } })
+    .sort({ lastProbeAt: 1 })
+    .limit(MENTION_NODE_LIVENESS_SWEEP_BATCH)
+    .select('oxyUserId')
+    .lean<Array<{ oxyUserId: string }>>();
+
+  for (const node of nodes) {
+    await probeLiveness(node.oxyUserId);
+  }
+}
+
+/** The cached node row for a user (any status), or `null`. */
+export async function getUserNode(oxyUserId: string): Promise<IMentionUserNode | null> {
+  return MentionUserNode.findOne({ oxyUserId }).lean<IMentionUserNode | null>();
+}
+
+/**
+ * Revoke a user's node registration (mark `revoked` so it leaves the liveness +
+ * ingest sweeps). Returns `true` when a non-revoked row was flipped.
+ *
+ * Operator-agnostic: it revokes a self-hosted node and a MANAGED vault
+ * identically — flipping `status` to `revoked` is the entire control-plane action.
+ *
+ * ## Managed-vault teardown seam (infra, out-of-band)
+ *
+ * For a managed vault (`managed:true, controller:'oxy'`) the underlying container
+ * + on-disk storage are an INFRASTRUCTURE concern, not an API concern. Revoking
+ * here is the durable, idempotent signal: a node-fleet reconciler tears down (or
+ * archives) the per-user volume by reconciling against
+ * `MentionUserNode.find({ managed: true, controller: 'oxy', status: 'revoked' })`.
+ * The API never reaches the node inline (the read-path invariant), so this stays
+ * a pure local DB write; the heavy teardown happens asynchronously in the fleet.
+ */
+export async function removeNode(oxyUserId: string): Promise<boolean> {
+  const result = await MentionUserNode.updateOne(
+    { oxyUserId, status: { $ne: 'revoked' } },
+    { $set: { status: 'revoked' }, $unset: { lastError: '' } },
+  );
+  return result.modifiedCount > 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Managed vault provisioning                                                */
+/* -------------------------------------------------------------------------- */
+
+/** Why {@link provisionManagedVault} could not provision a managed vault. */
+export type ManagedVaultFailureReason =
+  | 'custodial_key_unconfigured'
+  | 'managed_endpoint_unconfigured'
+  | 'provision_failed';
+
+/** Result of {@link provisionManagedVault} — the active row, or a clear reason. */
+export type ProvisionManagedVaultResult =
+  | { ok: true; node: IMentionUserNode }
+  | { ok: false; reason: ManagedVaultFailureReason };
+
+/** The managed node's signing public key: a dedicated fleet key, else the custodial key. */
+function resolveManagedNodePublicKey(): string | undefined {
+  return process.env[MENTION_NODE_PUBLIC_KEY_ENV] || getMentionCustodialPublicKey() || undefined;
+}
+
+/**
+ * Derive the managed-node endpoint for a user from `MENTION_NODE_BASE_URL`
+ * (`${base}/u/${oxyUserId}`), validated/normalised as a credential-free HTTPS URL.
+ * Returns `null` when the base is unset or not a usable HTTPS base — provisioning
+ * then fails closed rather than registering a junk endpoint.
+ */
+function resolveManagedEndpoint(oxyUserId: string): string | null {
+  const base = process.env[MENTION_NODE_BASE_URL_ENV];
+  if (!base) {
+    return null;
+  }
+  const trimmed = base.replace(/\/+$/, '');
+  return normalizeHttpsEndpoint(`${trimmed}${MENTION_NODE_USER_PATH_PREFIX}${oxyUserId}`);
+}
+
+/**
+ * Provision (or refresh) a Mention-operated MANAGED vault for `oxyUserId` — the
+ * "Create your vault" convenience for non-technical users.
+ *
+ * Mention custodial-signs an `app.mention.node` record onto the user's hash chain
+ * (issuer = `MENTION_DID`, signed by the Mention custodial key — the SAME
+ * mechanism as the dual-write provenance record), runs it through the shared
+ * {@link verifyAndStoreRecord} so it lands on the chain exactly like a self-signed
+ * node record, then materializes the {@link MentionUserNode} cache as
+ * `managed:true, controller:'oxy', status:'active'` and fires the async liveness
+ * probe.
+ *
+ * Fails closed: with no Mention custodial key (`custodial_key_unconfigured`) or
+ * no configured managed-node base URL (`managed_endpoint_unconfigured`) it
+ * returns a clear error instead of creating a broken vault.
+ *
+ * Idempotent: re-provisioning while an active managed vault already exists at the
+ * same endpoint is a no-op refresh (re-probe) — it does NOT append another chain
+ * record. The container/storage orchestration itself is INFRA (a node-fleet
+ * reconciler stands up the per-user volume off the active managed
+ * {@link MentionUserNode} row — DEFERRED, exactly like Oxy F5c); this layer only
+ * writes the cryptographic registration + the cache flag.
+ */
+export async function provisionManagedVault(oxyUserId: string): Promise<ProvisionManagedVaultResult> {
+  const issuer = getMentionCustodialIssuer();
+  const privateKey = getMentionCustodialPrivateKey();
+  const custodialPublicKey = getMentionCustodialPublicKey();
+  if (!issuer || !privateKey || !custodialPublicKey) {
+    logger.warn('MentionNodeRegistry: managed vault refused — Mention custodial key not configured', {
+      oxyUserId,
+    });
+    return { ok: false, reason: 'custodial_key_unconfigured' };
+  }
+
+  const endpoint = resolveManagedEndpoint(oxyUserId);
+  if (!endpoint) {
+    logger.warn('MentionNodeRegistry: managed vault refused — MENTION_NODE_BASE_URL unset or not a valid HTTPS base', {
+      oxyUserId,
+    });
+    return { ok: false, reason: 'managed_endpoint_unconfigured' };
+  }
+
+  const nodePublicKey = resolveManagedNodePublicKey();
+  if (!nodePublicKey) {
+    // Unreachable while `custodialPublicKey` is set, but keeps the result total.
+    return { ok: false, reason: 'custodial_key_unconfigured' };
+  }
+
+  // Idempotency: an already-active managed vault at this endpoint is a no-op
+  // refresh — re-probe, but do NOT grow the chain.
+  const existing = await getUserNode(oxyUserId);
+  if (
+    existing &&
+    existing.managed === true &&
+    existing.controller === 'oxy' &&
+    existing.status !== 'revoked' &&
+    existing.endpoint === endpoint
+  ) {
+    probeLiveness(oxyUserId).catch((err) =>
+      logger.debug('MentionNodeRegistry: managed vault refresh probe failed to schedule', {
+        oxyUserId,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return { ok: true, node: existing };
+  }
+
+  const subjectDid = buildUserDid(oxyUserId);
+  const record: Record<string, unknown> = {
+    endpoint,
+    nodePublicKey,
+    mode: MENTION_NODE_MANAGED_MODE,
+    managed: true,
+  };
+
+  let stored = false;
+  for (let attempt = 0; attempt < MAX_PROVISION_ATTEMPTS; attempt += 1) {
+    const head = await getHead(oxyUserId);
+    const seq = head ? head.seq + 1 : 0;
+    const prev = head ? head.headRecordId : null;
+
+    const fields: SignedRecordSigningFields = {
+      version: 2,
+      type: MENTION_RECORD_TYPE,
+      subject: subjectDid,
+      issuer,
+      record,
+      issuedAt: Date.now(),
+      seq,
+      prev,
+      collection: MENTION_NODE_COLLECTION,
+      rkey: MENTION_NODE_RKEY,
+    };
+    // Custodial-sign (issuer === MENTION_DID), then re-verify + store through the
+    // SAME engine the dual-write uses. The resolver authorizes the custodial key.
+    const envelope = await signEnvelope(fields, privateKey);
+    const result = await verifyAndStoreRecord(envelope);
+    if (result.ok) {
+      stored = true;
+      break;
+    }
+
+    // A concurrent writer advanced the chain head between our read and write —
+    // re-read the head and retry. Anything else is a hard failure.
+    if (result.reason === 'chain_conflict' || result.reason === 'bad_seq' || result.reason === 'chain_fork') {
+      continue;
+    }
+
+    logger.warn('MentionNodeRegistry: managed vault node record rejected', {
+      oxyUserId,
+      reason: result.reason,
+    });
+    return { ok: false, reason: 'provision_failed' };
+  }
+
+  if (!stored) {
+    logger.warn('MentionNodeRegistry: managed vault abandoned after chain-race retries', { oxyUserId });
+    return { ok: false, reason: 'provision_failed' };
+  }
+
+  // Project the just-signed record into the operational cache as a
+  // Mention-operated managed node (active) + fire the async liveness probe.
+  const node = await materializeNodeFromRecord(oxyUserId, record, { managed: true, controller: 'oxy' });
+  if (!node) {
+    logger.error('MentionNodeRegistry: managed vault chain record stored but cache materialization failed', {
+      oxyUserId,
+    });
+    return { ok: false, reason: 'provision_failed' };
+  }
+
+  return { ok: true, node };
+}

--- a/packages/backend/src/services/mtn/MentionNodeScheduler.ts
+++ b/packages/backend/src/services/mtn/MentionNodeScheduler.ts
@@ -1,0 +1,130 @@
+/**
+ * Mention Node Scheduler (MTN Protocol — B3 background node sync)
+ *
+ * The LEADER-GATED background driver for the two-way node sync. Registered in
+ * `server.ts`'s `startSchedulers()` alongside `FederationJobScheduler` /
+ * `FeedJobScheduler`, which `leaderElection` runs on exactly ONE task at a time —
+ * so the sweeps never multiply across the fleet.
+ *
+ * Two periodic in-process sweeps:
+ *  - LIVENESS — re-probe registered nodes (`sweepNodeLiveness`), updating the
+ *    cached `status` badge.
+ *  - SYNC — for each active node least-recently-synced first: `mode:'pull'`
+ *    nodes are INGESTED (`ingestFromNode`), `mode:'push'` nodes are EXPORTED
+ *    (`exportToNode`). Bounded batch per sweep.
+ *
+ * ## Absolute read-path invariant
+ *
+ * NOTHING here ever runs on a request path. Every tick is background, bounded,
+ * and self-isolating: a single node failing its probe/ingest/export is caught and
+ * recorded as `lastError`, never thrown. The feed/hydration hot path never queries
+ * {@link MentionUserNode} or a node endpoint.
+ */
+
+import MentionUserNode from '../../models/MentionUserNode';
+import { logger } from '../../utils/logger';
+import { sweepNodeLiveness } from './MentionNodeRegistryService';
+import { ingestFromNode, exportToNode } from './MentionNodeSyncService';
+import {
+  MENTION_NODE_LIVENESS_SWEEP_INTERVAL_MS,
+  MENTION_NODE_INGEST_SWEEP_INTERVAL_MS,
+  MENTION_NODE_INGEST_SWEEP_BATCH,
+  MENTION_NODE_LIVENESS_SWEEP_START_DELAY_MS,
+  MENTION_NODE_INGEST_SWEEP_START_DELAY_MS,
+} from './mentionNodes.constants';
+
+export class MentionNodeScheduler {
+  private livenessInterval: NodeJS.Timeout | null = null;
+  private syncInterval: NodeJS.Timeout | null = null;
+  private livenessStartTimeout: NodeJS.Timeout | null = null;
+  private syncStartTimeout: NodeJS.Timeout | null = null;
+  private isRunning = false;
+
+  /** Start the leader-gated liveness + sync sweeps. Idempotent. */
+  start(): void {
+    if (this.isRunning) return;
+    this.isRunning = true;
+
+    // Defer the first sweeps so boot is never contended; then run on a fixed
+    // cadence. Both first-ticks are tracked so stop() can cancel them.
+    this.livenessStartTimeout = setTimeout(() => {
+      this.livenessStartTimeout = null;
+      void this.runLivenessSweep();
+      this.livenessInterval = setInterval(() => {
+        void this.runLivenessSweep();
+      }, MENTION_NODE_LIVENESS_SWEEP_INTERVAL_MS);
+    }, MENTION_NODE_LIVENESS_SWEEP_START_DELAY_MS);
+
+    this.syncStartTimeout = setTimeout(() => {
+      this.syncStartTimeout = null;
+      void this.runSyncSweep();
+      this.syncInterval = setInterval(() => {
+        void this.runSyncSweep();
+      }, MENTION_NODE_INGEST_SWEEP_INTERVAL_MS);
+    }, MENTION_NODE_INGEST_SWEEP_START_DELAY_MS);
+
+    logger.info('MentionNodeScheduler started (leader-gated node liveness + sync sweeps)');
+  }
+
+  /** Stop all sweeps + cancel any pending first-ticks. Idempotent. */
+  stop(): void {
+    if (this.livenessInterval) {
+      clearInterval(this.livenessInterval);
+      this.livenessInterval = null;
+    }
+    if (this.syncInterval) {
+      clearInterval(this.syncInterval);
+      this.syncInterval = null;
+    }
+    if (this.livenessStartTimeout) {
+      clearTimeout(this.livenessStartTimeout);
+      this.livenessStartTimeout = null;
+    }
+    if (this.syncStartTimeout) {
+      clearTimeout(this.syncStartTimeout);
+      this.syncStartTimeout = null;
+    }
+    this.isRunning = false;
+    logger.info('MentionNodeScheduler stopped');
+  }
+
+  /** One liveness sweep tick — never throws into the timer. */
+  private async runLivenessSweep(): Promise<void> {
+    try {
+      await sweepNodeLiveness();
+    } catch (err) {
+      logger.warn('MentionNodeScheduler: liveness sweep failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * One sync sweep tick — ingest `pull` nodes, export `push` nodes, bounded and
+   * sequential. Each node is independent + non-throwing. Never throws into the
+   * timer.
+   */
+  private async runSyncSweep(): Promise<void> {
+    try {
+      const nodes = await MentionUserNode.find({ status: { $in: ['active', 'unreachable'] } })
+        .sort({ lastSyncedAt: 1 })
+        .limit(MENTION_NODE_INGEST_SWEEP_BATCH)
+        .select('oxyUserId mode')
+        .lean<Array<{ oxyUserId: string; mode: 'pull' | 'push' }>>();
+
+      for (const node of nodes) {
+        if (node.mode === 'push') {
+          await exportToNode(node.oxyUserId);
+        } else {
+          await ingestFromNode(node.oxyUserId);
+        }
+      }
+    } catch (err) {
+      logger.warn('MentionNodeScheduler: sync sweep failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+export const mentionNodeScheduler = new MentionNodeScheduler();

--- a/packages/backend/src/services/mtn/MentionNodeSyncService.ts
+++ b/packages/backend/src/services/mtn/MentionNodeSyncService.ts
@@ -1,0 +1,563 @@
+/**
+ * Mention Node Sync Service (MTN Protocol — B3 bidirectional node sync)
+ *
+ * The two-way sync between a user's personal data node (a `mention-node`) and
+ * Mention's fast local copy:
+ *
+ *  - INGEST ({@link ingestFromNode}): pulls a user's authentic signed-record
+ *    chain BACK from their node, re-verifies EVERY record, mirrors it into the
+ *    `MentionSignedRecord` ledger, materializes it into the feed-readable store
+ *    (`PostMaterializer.projectRecord`), and counter-signs a witness.
+ *  - EXPORT ({@link exportToNode}): pushes a user's new local PUBLIC records OUT
+ *    to their node (`NodeClient.pushRecords`).
+ *
+ * A faithful port of oxy-api's `nodeSync.service.ts`, scoped to `app.mention.*`,
+ * keyed by `oxyUserId` (a string), and EXTENDED with the materialization step
+ * (Mention is the feed-rendering app; Oxy is not).
+ *
+ * ## Absolute read-path invariant
+ *
+ * Every node fetch here goes through `@oxyhq/core/server`'s `safeFetch`
+ * (HTTPS-only, private-IP denylist, DNS-pinned, bounded redirects) and runs ONLY
+ * in the background scheduler. NOTHING in a request's read path ever calls this.
+ * A down/slow/malicious node leaves Mention's mirror STALE — never wrong and
+ * never slow. `ingestFromNode` / `exportToNode` NEVER throw into a caller; they
+ * log and record `lastError` on the {@link MentionUserNode} row. Ingest batches
+ * are bounded so a backfill never contends with the hot path.
+ *
+ * ## Trust model — verify everything, trust nothing the node says
+ *
+ * The node is untrusted transport. Every record it returns is independently
+ * re-verified with {@link verifyAndStoreRecord} (the SAME chain engine the
+ * dual-write uses): signature over the canonical input, recomputed `recordId`,
+ * current-verification-method / subject ownership, freshness, and v2 chain
+ * continuity. A record whose `publicKey` is not a current VM of THIS user's DID,
+ * or whose `subject` is not this user's DID, is rejected as forged/foreign — a
+ * node cannot inject a record the user did not sign.
+ *
+ * ## Conflict resolution
+ *
+ *  - **Linear append** (the normal case): a record that extends Mention's chain
+ *    head by one is appended atomically, advancing the head + the cursor.
+ *  - **Last-writer-wins per `(oxyUserId, nsid, rkey)`**: a record whose
+ *    `issuedAt` is not newer for that key (tiebreak: higher `recordId`) is the
+ *    loser — Mention keeps what it has and skips. Re-pulling an already-ingested
+ *    record is therefore idempotent.
+ *  - **Genuine fork**: a record authentically signed by the owner that conflicts
+ *    Mention's chain is ALSO preserved (a non-chained mirror row so the unique
+ *    `(oxyUserId, seq)` chain index is never violated) and wins materialization
+ *    for its key. Both branches persist; nothing is deleted; the fork is logged.
+ *
+ * ## Anti-rewrite counter-signature
+ *
+ * Every recordId Mention ingests is COUNTER-SIGNED with the Mention custodial key
+ * into an append-only {@link MentionNodeIngestWitness}. When the custodial key is
+ * unconfigured (dev/pre-prod) witnessing is skipped (logged once) but ingest
+ * still proceeds.
+ *
+ * ## DEFERRED — blob / media sync
+ *
+ * A node serves blobs by `sha256`, but Mention has NO reverse `sha256 → fileId`/
+ * `url` resolver yet (the same gap that deferred the blob-ref READ side in PR
+ * #280). So for an ingested post record whose `embed` carries blob refs, the
+ * RECORD + text + thread structure + likes + reposts are materialized fully now;
+ * the media BYTES are deferred — `PostMaterializer.resolveEmbedToMedia` is a no-op
+ * until the upstream reverse content-address index lands. No fake URL is invented;
+ * an existing post's fileId media survives re-projection.
+ */
+
+import { canonicalize, computeRecordId, signMessage } from '@oxyhq/protocol';
+import { NodeClient, type NodeFetch } from '@oxyhq/protocol/node';
+import { safeFetch } from '@oxyhq/core/server';
+import { signedRecordEnvelopeSchema, type SignedRecordEnvelope } from '@oxyhq/contracts';
+import MentionUserNode from '../../models/MentionUserNode';
+import MentionSignedRecord from '../../models/MentionSignedRecord';
+import MentionNodeIngestWitness from '../../models/MentionNodeIngestWitness';
+import { logger } from '../../utils/logger';
+import { getHead, getPublicLogSince } from './MentionRepoLogService';
+import { verifyAndStoreRecord } from './MentionRecordService';
+import { projectRecord } from './PostMaterializer';
+import {
+  getMentionCustodialPrivateKey,
+  getMentionCustodialPublicKey,
+} from './mentionRecordEnv';
+import {
+  MENTION_NODE_INGEST_BATCH,
+  MENTION_NODE_INGEST_MAX_ITERATIONS,
+  MENTION_NODE_INGEST_FETCH_TIMEOUT_MS,
+  MENTION_NODE_INGEST_MAX_BYTES,
+  MENTION_NODE_EXPORT_BATCH,
+  MENTION_NODE_EXPORT_MAX_ITERATIONS,
+  MENTION_NODE_LAST_ERROR_MAX_LEN,
+} from './mentionNodes.constants';
+
+/** True only once the missing-custodial-key warning has been logged (avoid spam). */
+let warnedMissingCustodialKey = false;
+
+/** The cached node fields the ingest worker needs. */
+interface IngestNode {
+  endpoint: string;
+  cursor?: number;
+}
+
+/** Per-record ingest outcome, used to drive cursor advance + loop control. */
+type IngestOutcome =
+  | { kind: 'appended'; seq: number; recordId: string }
+  | { kind: 'fork'; recordId: string }
+  | { kind: 'skipped' }
+  | { kind: 'stop'; reason: string };
+
+/**
+ * The injected transport for the protocol {@link NodeClient}: a thin adapter over
+ * `@oxyhq/core/server`'s `safeFetch` (HTTPS-only, DNS-pinned, private-IP
+ * denylist, bounded redirects). The client owns the bounded-body reads; this
+ * adapter only hands it the SSRF-safe streamed response. The read-path invariant
+ * still holds — this runs ONLY in the background scheduler.
+ */
+const nodeFetch: NodeFetch = async (url, init) => {
+  const result = await safeFetch(url, {
+    method: init.method,
+    ...(init.headers ? { headers: init.headers } : {}),
+    ...(init.body ? { body: init.body } : {}),
+    headersTimeoutMs: init.headersTimeoutMs,
+    maxRedirects: init.maxRedirects,
+  });
+  return {
+    status: result.status,
+    headers: result.headers,
+    body: result.response,
+    destroy: () => result.response.destroy(),
+  };
+};
+
+/** Build a {@link NodeClient} for a node endpoint with the ingest tunables. */
+function makeNodeClient(endpoint: string): NodeClient {
+  return new NodeClient({
+    baseUrl: endpoint,
+    fetch: nodeFetch,
+    headersTimeoutMs: MENTION_NODE_INGEST_FETCH_TIMEOUT_MS,
+    maxRedirects: 1,
+    logMaxBytes: MENTION_NODE_INGEST_MAX_BYTES,
+  });
+}
+
+/**
+ * Counter-sign an ingested recordId with the Mention custodial key and append it
+ * to the witness ledger (idempotent per recordId). Non-fatal and never throws: a
+ * missing custodial key skips witnessing (warned once); a duplicate is a no-op.
+ */
+async function witnessRecord(oxyUserId: string, recordId: string, ingestedAt: number): Promise<void> {
+  const privateKey = getMentionCustodialPrivateKey();
+  const publicKey = getMentionCustodialPublicKey();
+  if (!privateKey || !publicKey) {
+    if (!warnedMissingCustodialKey) {
+      warnedMissingCustodialKey = true;
+      logger.warn('MentionNodeSync: ingest counter-signing skipped — Mention custodial key not configured');
+    }
+    return;
+  }
+  try {
+    const witnessSignature = await signMessage(
+      canonicalize({ recordId, oxyUserId, ingestedAt }),
+      privateKey,
+    );
+    await MentionNodeIngestWitness.create({ oxyUserId, recordId, witnessSignature, ingestedAt });
+  } catch (err) {
+    // A duplicate recordId (E11000) means we already witnessed it — expected on a
+    // re-pull. Anything else is logged, never thrown (background-safe).
+    if (typeof err === 'object' && err !== null && (err as { code?: number }).code === 11000) {
+      return;
+    }
+    logger.warn('MentionNodeSync: ingest counter-signature failed (non-fatal)', {
+      oxyUserId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Materialize a verified+stored record into the feed-readable store. Best-effort
+ * and non-throwing (the materializer itself never throws); a projection failure
+ * is logged but never aborts the ingest run.
+ */
+async function materialize(envelope: SignedRecordEnvelope): Promise<void> {
+  try {
+    const result = await projectRecord(envelope);
+    if (!result.ok) {
+      logger.debug('MentionNodeSync: projectRecord skipped an ingested record', {
+        collection: envelope.collection,
+        rkey: envelope.rkey,
+        reason: result.reason,
+      });
+    }
+  } catch (err) {
+    logger.warn('MentionNodeSync: projectRecord threw (non-fatal)', {
+      collection: envelope.collection,
+      rkey: envelope.rkey,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * The current materialized record for an AtProto-style `(nsid, rkey)` key, as the
+ * minimal `{ issuedAt, recordId }` LWW needs. Reads Mention's own copy only.
+ */
+async function currentKeyValue(
+  oxyUserId: string,
+  nsid: string,
+  rkey: string,
+): Promise<{ issuedAt: number; recordId: string } | null> {
+  const row = await MentionSignedRecord.findOne({ oxyUserId, nsid, rkey, verified: true })
+    .sort({ createdAt: -1 })
+    .lean<{ recordId?: string; envelope?: { issuedAt?: number } } | null>();
+  if (!row || typeof row.envelope?.issuedAt !== 'number' || typeof row.recordId !== 'string') {
+    return null;
+  }
+  return { issuedAt: row.envelope.issuedAt, recordId: row.recordId };
+}
+
+/**
+ * Last-writer-wins decision: does the incoming record supersede the existing
+ * value for its key? Newer `issuedAt` wins; on an exact `issuedAt` tie the higher
+ * `recordId` (string compare) wins. No existing value → incoming always wins.
+ */
+function incomingWinsLww(
+  incoming: { issuedAt: number; recordId: string },
+  existing: { issuedAt: number; recordId: string } | null,
+): boolean {
+  if (!existing) return true;
+  if (incoming.issuedAt !== existing.issuedAt) return incoming.issuedAt > existing.issuedAt;
+  return incoming.recordId > existing.recordId;
+}
+
+/**
+ * Persist a forked / tie-breaking envelope as a NON-chained mirror row. It keeps
+ * the AtProto `(nsid, rkey)` materialization fields and `recordId` (so it becomes
+ * the current value for its key by `createdAt`) but deliberately carries NO `seq`
+ * — the authentic linear chain (and its unique `(oxyUserId, seq)` index) is left
+ * untouched, so both the existing chain row AND this fork branch persist. The
+ * unique `recordId` index makes a re-ingested fork idempotent.
+ */
+async function storeForkMirror(env: SignedRecordEnvelope, oxyUserId: string, recordId: string): Promise<boolean> {
+  try {
+    await MentionSignedRecord.create({
+      subjectDid: env.subject,
+      oxyUserId,
+      type: env.type,
+      envelope: env,
+      publicKey: env.publicKey,
+      verified: true,
+      // No `seq`/`prev` — intentionally off the linear chain (fork archive).
+      recordId,
+      nsid: env.version === 2 ? env.collection : undefined,
+      rkey: env.version === 2 ? env.rkey : undefined,
+    });
+    return true;
+  } catch (err) {
+    if (typeof err === 'object' && err !== null && (err as { code?: number }).code === 11000) {
+      return false; // already stored (idempotent re-pull)
+    }
+    throw err;
+  }
+}
+
+/**
+ * Verify + ingest a single envelope from the node. Drives the cursor/loop via the
+ * returned {@link IngestOutcome}. `verifyAndStoreRecord` does the heavy lifting
+ * (re-verify + atomic append + head advance); its rejection reason routes the
+ * record to LWW-skip, fork-preserve, or hard-reject. On any persisted record the
+ * envelope is materialized into the feed store + counter-signed.
+ */
+async function ingestEnvelope(env: SignedRecordEnvelope, oxyUserId: string): Promise<IngestOutcome> {
+  const result = await verifyAndStoreRecord(env);
+
+  if (result.ok) {
+    const recordId = result.recordId;
+    await materialize(env);
+    await witnessRecord(oxyUserId, recordId, Date.now());
+    return { kind: 'appended', seq: typeof result.seq === 'number' ? result.seq : -1, recordId };
+  }
+
+  switch (result.reason) {
+    case 'stale_issued_at': {
+      // LWW: incoming is not newer for its key — usually an idempotent re-pull.
+      // Only an exact-issuedAt tie with a higher recordId flips to incoming (a
+      // fork archive); otherwise Mention keeps what it has. Either way the linear
+      // chain cannot advance through a stale frontier record, so we stop.
+      if (env.version === 2 && env.collection && env.rkey) {
+        const recordId = await computeRecordId(env);
+        const existing = await currentKeyValue(oxyUserId, env.collection, env.rkey);
+        if (incomingWinsLww({ issuedAt: env.issuedAt, recordId }, existing)) {
+          const stored = await storeForkMirror(env, oxyUserId, recordId);
+          if (stored) {
+            await materialize(env);
+            await witnessRecord(oxyUserId, recordId, Date.now());
+            logger.info('MentionNodeSync: LWW tiebreak adopted incoming record', {
+              oxyUserId,
+              nsid: env.collection,
+              rkey: env.rkey,
+            });
+            return { kind: 'stop', reason: 'lww_tiebreak' };
+          }
+        }
+      }
+      return { kind: 'skipped' };
+    }
+
+    case 'chain_fork':
+    case 'bad_seq':
+    case 'chain_conflict': {
+      // A genuine fork: the record is authentically signed by the owner (signature
+      // + ownership + freshness all passed before the chain check) but conflicts
+      // Mention's chain. Preserve it append-only and let it win materialization
+      // for its key (it is strictly newer — `stale_issued_at` is handled above).
+      const recordId = await computeRecordId(env);
+      const stored = await storeForkMirror(env, oxyUserId, recordId);
+      if (stored) {
+        await materialize(env);
+        await witnessRecord(oxyUserId, recordId, Date.now());
+      }
+      logger.warn('MentionNodeSync: detected a chain fork; preserved both branches', {
+        oxyUserId,
+        reason: result.reason,
+        recordId,
+      });
+      return { kind: 'fork', recordId };
+    }
+
+    case 'chain_gap':
+      // Mention is missing intermediate records this one builds on — cannot append
+      // out of order. Stop and leave the mirror stale at the last good seq.
+      return { kind: 'stop', reason: 'chain_gap' };
+
+    default:
+      // Forged / foreign / malformed: subject_mismatch,
+      // public_key_not_a_current_verification_method, untrusted_issuer,
+      // bad_signature, invalid_envelope, issued_in_future. Reject and stop so a
+      // poisoned log entry can never advance the mirror.
+      logger.warn('MentionNodeSync: rejected a record', { oxyUserId, reason: result.reason });
+      return { kind: 'stop', reason: `rejected:${result.reason}` };
+  }
+}
+
+/**
+ * Ingest a user's chain from their registered node into Mention's local mirror.
+ *
+ * Background-safe: NEVER throws. A missing/revoked/unreachable node is a no-op
+ * (or records `lastError`) — the mirror simply stays as-is. On success the
+ * {@link MentionUserNode} cursor (= Mention's local head seq) and `lastSyncedAt`
+ * advance. Bounded iterations cap how much a single run ingests so a long backlog
+ * is caught up across several scheduled runs (the hot path is never contended).
+ */
+export async function ingestFromNode(oxyUserId: string): Promise<void> {
+  try {
+    const node = await MentionUserNode.findOne({ oxyUserId, status: { $ne: 'revoked' } })
+      .select('endpoint cursor')
+      .lean<IngestNode | null>();
+    if (!node) {
+      return; // no registered node — nothing to ingest
+    }
+
+    const client = makeNodeClient(node.endpoint);
+
+    // Compare the node's head against Mention's local head. When Mention is
+    // already at or ahead of the node, there is nothing to pull — stamp the time.
+    let remoteHeadSeq: number;
+    try {
+      const head = await client.head();
+      remoteHeadSeq = typeof head.seq === 'number' && Number.isFinite(head.seq) ? head.seq : -1;
+    } catch (err) {
+      await recordIngestError(oxyUserId, err);
+      return;
+    }
+
+    const localHead = await getHead(oxyUserId);
+    const localHeadSeq = localHead ? localHead.seq : -1;
+    // Never re-pull below our own head: start from the greater of the persisted
+    // cursor and the live local head (idempotent — avoids re-ingesting).
+    let cursor = Math.max(typeof node.cursor === 'number' ? node.cursor : -1, localHeadSeq);
+
+    if (remoteHeadSeq <= cursor) {
+      await markSynced(oxyUserId, cursor, true);
+      return;
+    }
+
+    let stopReason: string | null = null;
+
+    for (let iteration = 0; iteration < MENTION_NODE_INGEST_MAX_ITERATIONS && !stopReason; iteration += 1) {
+      let page: unknown[];
+      try {
+        page = (await client.log(cursor, MENTION_NODE_INGEST_BATCH)).records;
+      } catch (err) {
+        await recordIngestError(oxyUserId, err);
+        return;
+      }
+      if (page.length === 0) {
+        break; // caught up
+      }
+
+      for (const raw of page) {
+        const parsed = signedRecordEnvelopeSchema.safeParse(raw);
+        if (!parsed.success) {
+          stopReason = 'rejected:invalid_envelope';
+          logger.warn('MentionNodeSync: rejected a malformed envelope', { oxyUserId });
+          break;
+        }
+        const env = parsed.data;
+
+        // Already mirrored (below our advanced cursor)? Skip without re-work.
+        if (env.version === 2 && typeof env.seq === 'number' && env.seq <= cursor) {
+          continue;
+        }
+
+        const outcome = await ingestEnvelope(env, oxyUserId);
+        if (outcome.kind === 'appended') {
+          cursor = outcome.seq >= 0 ? outcome.seq : cursor;
+        } else if (outcome.kind === 'fork') {
+          stopReason = 'chain_fork';
+          break;
+        } else if (outcome.kind === 'stop') {
+          stopReason = outcome.reason;
+          break;
+        }
+        // 'skipped' → continue to the next record (LWW loser / idempotent).
+      }
+
+      // A short page means the node has no more records right now.
+      if (page.length < MENTION_NODE_INGEST_BATCH) {
+        break;
+      }
+    }
+
+    if (stopReason && stopReason !== 'lww_tiebreak') {
+      await MentionUserNode.updateOne(
+        { oxyUserId, status: { $ne: 'revoked' } },
+        { $set: { cursor, lastSyncedAt: new Date(), lastError: stopReason.slice(0, MENTION_NODE_LAST_ERROR_MAX_LEN) } },
+      );
+    } else {
+      await markSynced(oxyUserId, cursor, true);
+    }
+  } catch (err) {
+    // Background-safe: a programming/DB error must never escape the worker.
+    logger.error('MentionNodeSync: ingest encountered an error', {
+      oxyUserId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    await recordIngestError(oxyUserId, err).catch(() => undefined);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Export (Mention → node)                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Push a user's new local PUBLIC records OUT to their registered node.
+ *
+ * Background-safe: NEVER throws. Reads the user's PUBLIC signed-record log
+ * (`getPublicLogSince`, which excludes private bookmarks) from the node's last
+ * acknowledged `seq` and pushes it in bounded batches via `NodeClient.pushRecords`.
+ * The node independently re-verifies every pushed record (the same trust model in
+ * reverse), so a push can never corrupt a node; a node-side rejection is logged
+ * and the export stops at the last accepted record.
+ *
+ * Used by the scheduler for `mode:'push'` nodes; pull-mode nodes pace their own
+ * sync and are NOT exported to here.
+ */
+export async function exportToNode(oxyUserId: string): Promise<void> {
+  try {
+    const node = await MentionUserNode.findOne({ oxyUserId, status: { $ne: 'revoked' } })
+      .select('endpoint')
+      .lean<{ endpoint: string } | null>();
+    if (!node) {
+      return;
+    }
+
+    const client = makeNodeClient(node.endpoint);
+
+    // The node's head seq is the high-water mark of what it already has.
+    let remoteHeadSeq: number;
+    try {
+      const head = await client.head();
+      remoteHeadSeq = typeof head.seq === 'number' && Number.isFinite(head.seq) ? head.seq : -1;
+    } catch (err) {
+      await recordIngestError(oxyUserId, err);
+      return;
+    }
+
+    let cursor = remoteHeadSeq;
+
+    for (let iteration = 0; iteration < MENTION_NODE_EXPORT_MAX_ITERATIONS; iteration += 1) {
+      const batch = await getPublicLogSince(oxyUserId, cursor, MENTION_NODE_EXPORT_BATCH);
+      if (batch.length === 0) {
+        break; // node is caught up with our public log
+      }
+
+      let pushed: Awaited<ReturnType<NodeClient['pushRecords']>>;
+      try {
+        pushed = await client.pushRecords(batch);
+      } catch (err) {
+        await recordIngestError(oxyUserId, err);
+        return;
+      }
+
+      // Advance the cursor by the records the node accepted in order. A per-item
+      // rejection stops the export at the last accepted seq (logged); the next
+      // run retries from there.
+      let advanced = false;
+      for (let i = 0; i < batch.length; i += 1) {
+        const itemResult = pushed.results[i];
+        const envelope = batch[i];
+        if (itemResult?.ok && envelope.version === 2 && typeof envelope.seq === 'number') {
+          cursor = envelope.seq;
+          advanced = true;
+        } else if (itemResult && !itemResult.ok) {
+          logger.warn('MentionNodeSync: node rejected an exported record; stopping export', {
+            oxyUserId,
+            reason: itemResult.reason,
+          });
+          await markSynced(oxyUserId, cursor, false);
+          return;
+        }
+      }
+
+      if (!advanced || batch.length < MENTION_NODE_EXPORT_BATCH) {
+        break;
+      }
+    }
+
+    await markSynced(oxyUserId, cursor, true);
+  } catch (err) {
+    logger.error('MentionNodeSync: export encountered an error', {
+      oxyUserId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    await recordIngestError(oxyUserId, err).catch(() => undefined);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Cursor / error bookkeeping                                                */
+/* -------------------------------------------------------------------------- */
+
+/** Advance the cursor + stamp `lastSyncedAt`; clear `lastError` when requested. */
+async function markSynced(oxyUserId: string, cursor: number, clearError: boolean): Promise<void> {
+  await MentionUserNode.updateOne(
+    { oxyUserId, status: { $ne: 'revoked' } },
+    {
+      $set: { cursor, lastSyncedAt: new Date() },
+      ...(clearError ? { $unset: { lastError: '' } } : {}),
+    },
+  );
+}
+
+/** Record a non-throwing sync failure as `lastError` on the node row. */
+async function recordIngestError(oxyUserId: string, err: unknown): Promise<void> {
+  const message = err instanceof Error ? err.message : String(err);
+  logger.debug('MentionNodeSync: node fetch failed', { oxyUserId, error: message });
+  await MentionUserNode.updateOne(
+    { oxyUserId, status: { $ne: 'revoked' } },
+    { $set: { lastError: message.slice(0, MENTION_NODE_LAST_ERROR_MAX_LEN), lastSyncedAt: new Date() } },
+  );
+}

--- a/packages/backend/src/services/mtn/MentionRecordService.ts
+++ b/packages/backend/src/services/mtn/MentionRecordService.ts
@@ -33,6 +33,7 @@ import {
   verifyAndAppend,
   type SignedRecordSigningFields,
   type RejectionReason,
+  type AppendOutcome,
 } from '@oxyhq/protocol';
 import type { SignedRecordEnvelope } from '@oxyhq/contracts';
 import { logger } from '../../utils/logger';
@@ -148,4 +149,29 @@ export async function signAndAppend(
     reason: lastReason,
   });
   return { ok: false, reason: lastReason };
+}
+
+/**
+ * Re-verify a signed record (signed ELSEWHERE — on a user's node, or a
+ * custodial managed-vault record) and append it to its subject's chain.
+ *
+ * This is the INGEST chokepoint: it delegates to the app-agnostic
+ * `@oxyhq/protocol` engine with the SAME Mention store + resolver the dual-write
+ * uses, so a record pulled from an untrusted node is held to the identical trust
+ * boundary as a locally-signed one — the signature is re-checked over the
+ * canonical input, the `recordId` is recomputed, the signing key must be a
+ * CURRENT verification method of the subject's DID (self-issued) or the Mention
+ * custodial key (`issuer === MENTION_DID`), freshness is enforced, and v2 chain
+ * continuity is validated. A node can therefore never inject a record the user
+ * did not sign.
+ *
+ * Unlike {@link signAndAppend}, the caller supplies the ENVELOPE verbatim (it was
+ * signed elsewhere) — this function NEVER signs. The returned {@link AppendOutcome}
+ * carries the chain coordinates on success, or the {@link RejectionReason} the
+ * ingest worker routes to LWW-skip / fork-preserve / hard-reject.
+ *
+ * @param envelope The verbatim signed envelope to re-verify + append.
+ */
+export async function verifyAndStoreRecord(envelope: SignedRecordEnvelope): Promise<AppendOutcome> {
+  return verifyAndAppend(mentionRecordStore, mentionVerificationResolver, envelope);
 }

--- a/packages/backend/src/services/mtn/MentionRepoLogService.ts
+++ b/packages/backend/src/services/mtn/MentionRepoLogService.ts
@@ -1,0 +1,63 @@
+/**
+ * Mention Repo Log Service — the focused READ helpers over the MTN chain that the
+ * node-sync export side needs (the inbound ingest side re-verifies + appends via
+ * `MentionRecordService.verifyAndStoreRecord` + the `mentionRecordStore`).
+ *
+ * Mirrors oxy-api's `repoLog.service.ts` (`getHead` / `getPublicLogSince`),
+ * scoped to Mention's Mongo and keyed by `oxyUserId` (a string). The ONE
+ * difference from the store's raw `getLogSince` is the PUBLIC-collection
+ * allowlist: a node export/public log MUST exclude private collections
+ * (`app.mention.feed.bookmark`), so `getPublicLogSince` filters the ledger to
+ * {@link MENTION_NODE_PUBLIC_COLLECTIONS}. The raw store log (used internally by
+ * the protocol engine) is unchanged.
+ *
+ * Read-path note: these helpers are consumed ONLY by the background export worker
+ * (`MentionNodeSyncService.exportToNode`) — never by a request's read path. They
+ * read Mention's own Mongo (no node fetch).
+ */
+
+import type { SignedRecordEnvelope } from '@oxyhq/contracts';
+import type { ChainHead } from '@oxyhq/protocol';
+import MentionSignedRecord from '../../models/MentionSignedRecord';
+import { mentionRecordStore } from './MentionRecordStore';
+import { buildUserDid } from './mentionDid';
+import { MENTION_NODE_PUBLIC_COLLECTIONS } from './mentionNodes.constants';
+
+/** Default page size for the public-log read (matches the store's default). */
+export const DEFAULT_PUBLIC_LOG_LIMIT = 100;
+/** Hard ceiling so a single public-log call can never scan an unbounded slice. */
+const MAX_PUBLIC_LOG_LIMIT = 500;
+
+function clampLimit(limit: number): number {
+  return Math.max(1, Math.min(Math.trunc(limit) || DEFAULT_PUBLIC_LOG_LIMIT, MAX_PUBLIC_LOG_LIMIT));
+}
+
+/** The subject's chain head, or `null` when the user has no chain yet. */
+export async function getHead(oxyUserId: string): Promise<ChainHead | null> {
+  return mentionRecordStore.getHead(buildUserDid(oxyUserId));
+}
+
+/**
+ * The ordered slice of a user's PUBLIC signed-record log strictly after
+ * `sinceSeq`, capped at `limit`. Excludes private collections (bookmarks) via the
+ * {@link MENTION_NODE_PUBLIC_COLLECTIONS} allowlist — so a node export / public
+ * log never leaks them. Returns verbatim envelopes in `seq` order.
+ *
+ * Tombstones ARE public (a deletion is part of the public history), so a puller
+ * sees the record removal — only the bookmark collection is withheld.
+ */
+export async function getPublicLogSince(
+  oxyUserId: string,
+  sinceSeq: number,
+  limit: number = DEFAULT_PUBLIC_LOG_LIMIT,
+): Promise<SignedRecordEnvelope[]> {
+  const rows = await MentionSignedRecord.find({
+    oxyUserId,
+    seq: { $gt: sinceSeq },
+    nsid: { $in: MENTION_NODE_PUBLIC_COLLECTIONS },
+  })
+    .sort({ seq: 1 })
+    .limit(clampLimit(limit))
+    .lean<Array<{ envelope: SignedRecordEnvelope }>>();
+  return rows.map((row) => row.envelope);
+}

--- a/packages/backend/src/services/mtn/mentionNodes.constants.ts
+++ b/packages/backend/src/services/mtn/mentionNodes.constants.ts
@@ -1,0 +1,137 @@
+/**
+ * Mention user-node constants (MTN Protocol — B3 decentralization / personal
+ * data nodes).
+ *
+ * SINGLE SOURCE OF TRUTH for the tunables of node registration, the liveness
+ * probe, the background liveness sweep, and the node→Mention ingest. Nothing in
+ * the node services may hardcode these — import them here. A faithful port of
+ * oxy-api's `nodes.constants.ts`, scoped to the `app.mention.*` namespace (a
+ * `mention-node` is a DEPLOYMENT of `@oxyhq/node` with `appNamespace=app.mention`).
+ */
+
+import { MENTION_FEED_COLLECTIONS, MENTION_BOOKMARK_COLLECTION } from '@mention/shared-types';
+
+/**
+ * AtProto-style collection (NSID) carried by a signed `app.mention.node` record.
+ * The record's `rkey` is fixed to {@link MENTION_NODE_RKEY} so a user has exactly
+ * ONE active node registration (last-writer-wins on the chain's
+ * `(collection, rkey)` key).
+ */
+export const MENTION_NODE_COLLECTION = 'app.mention.node' as const;
+
+/** The single record key for a user's node registration (one node per user). */
+export const MENTION_NODE_RKEY = 'self' as const;
+
+/**
+ * The well-known liveness manifest a `mention-node` serves. The probe fetches
+ * this over HTTPS via `safeFetch`; a 2xx means the node is reachable. Matches the
+ * `@oxyhq/node` manifest path (the node base is app-agnostic).
+ */
+export const MENTION_NODE_WELL_KNOWN_PATH = '/.well-known/oxy-node.json' as const;
+
+/** Time-to-first-byte deadline for a liveness probe (kept short — background). */
+export const MENTION_NODE_PROBE_TIMEOUT_MS = 5_000;
+
+/** Max length of a stored `lastError` string (keeps the row bounded). */
+export const MENTION_NODE_LAST_ERROR_MAX_LEN = 300;
+
+/** Max nodes re-probed per sweep (bounds the background work). */
+export const MENTION_NODE_LIVENESS_SWEEP_BATCH = 100;
+
+/* -------------------------------------------------------------------------- */
+/*  Bidirectional sync (node → Mention ingest)                                */
+/* -------------------------------------------------------------------------- */
+
+/** Records pulled per `/oxy/log` page (bounds a single fetch's working set). */
+export const MENTION_NODE_INGEST_BATCH = 100;
+
+/**
+ * Hard cap on log pages processed in one `ingestFromNode` run. The batch × this
+ * bounds how many records a single ingest can append (`100 × 50 = 5000`) so a
+ * very long chain is caught up across several scheduled runs, never one
+ * unbounded loop — the read hot path is NEVER contended by a backfill.
+ */
+export const MENTION_NODE_INGEST_MAX_ITERATIONS = 50;
+
+/** Time-to-first-byte deadline for a node head/log fetch (kept short). */
+export const MENTION_NODE_INGEST_FETCH_TIMEOUT_MS = 8_000;
+
+/** Max bytes read from a single `/oxy/log` response before the stream is cut. */
+export const MENTION_NODE_INGEST_MAX_BYTES = 2 * 1024 * 1024; // 2 MiB
+
+/** Records pushed per export batch (bounds the outbound working set). */
+export const MENTION_NODE_EXPORT_BATCH = 100;
+
+/**
+ * Hard cap on export pages pushed in one `exportToNode` run. Bounds how many
+ * local records a single export pushes (`100 × 50 = 5000`) so a long backlog is
+ * drained across several scheduled runs, never one unbounded loop.
+ */
+export const MENTION_NODE_EXPORT_MAX_ITERATIONS = 50;
+
+/**
+ * The PUBLIC collections a node log / export includes. Bookmarks
+ * (`app.mention.feed.bookmark`) are PRIVATE — they are excluded so a public
+ * export/ingest never leaks them. Derived from the canonical feed-collection set
+ * minus the private bookmark collection, so a new public collection flows through
+ * here automatically.
+ */
+export const MENTION_NODE_PUBLIC_COLLECTIONS: readonly string[] = MENTION_FEED_COLLECTIONS.filter(
+  (collection) => collection !== MENTION_BOOKMARK_COLLECTION,
+);
+
+/* -------------------------------------------------------------------------- */
+/*  Background sweep intervals                                                 */
+/* -------------------------------------------------------------------------- */
+
+/** How often the background sweep re-probes registered nodes (leader-gated). */
+export const MENTION_NODE_LIVENESS_SWEEP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+
+/** How often the background sweep pulls `mode:'pull'` active nodes (leader-gated). */
+export const MENTION_NODE_INGEST_SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Max active `pull` nodes ingested per sweep (bounds the background work). */
+export const MENTION_NODE_INGEST_SWEEP_BATCH = 100;
+
+/**
+ * Delay after startup before the first liveness + ingest sweep ticks, so boot is
+ * never contended by a backfill. The ingest sweep is offset after the liveness
+ * sweep so the two never start in lockstep.
+ */
+export const MENTION_NODE_LIVENESS_SWEEP_START_DELAY_MS = 60 * 1000; // 1 minute
+export const MENTION_NODE_INGEST_SWEEP_START_DELAY_MS = 90 * 1000; // 1.5 minutes
+
+/* -------------------------------------------------------------------------- */
+/*  Managed vault (Mention operates a node on behalf of a user)               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Env var naming the HTTPS base URL of the Mention-operated managed-node fleet. A
+ * managed vault's endpoint is derived as
+ * `${MENTION_NODE_BASE_URL}${MENTION_NODE_USER_PATH_PREFIX}${oxyUserId}` (e.g.
+ * `https://nodes.mention.earth/u/<oxyUserId>`) — NEVER hardcoded. When unset (or
+ * not a valid credential-free HTTPS base) managed-vault provisioning FAILS
+ * CLOSED: a managed vault must have a real place to live, so Mention never
+ * creates a broken one.
+ */
+export const MENTION_NODE_BASE_URL_ENV = 'MENTION_NODE_BASE_URL';
+
+/** Per-user path segment appended under the managed-node base URL. */
+export const MENTION_NODE_USER_PATH_PREFIX = '/u/';
+
+/**
+ * Env var optionally overriding the managed node's signing public key (hex
+ * secp256k1). Mention operates a managed node with the CUSTODIAL key
+ * (`controller:'oxy'`), so this DEFAULTS to `MENTION_PUBLIC_KEY` when unset —
+ * records a managed node signs verify against the Mention custodial key exactly
+ * like any other custodial (`issuer = MENTION_DID`) record. Set it only when the
+ * managed fleet runs a dedicated keypair distinct from the custodial key.
+ */
+export const MENTION_NODE_PUBLIC_KEY_ENV = 'MENTION_NODE_PUBLIC_KEY';
+
+/**
+ * Transport mode for a managed vault. Mention operates both sides, but the node
+ * still PULLS its own chain (the node paces sync) — identical to the self-hosted
+ * default — so nothing in a read path ever waits on it.
+ */
+export const MENTION_NODE_MANAGED_MODE = 'pull' as const;


### PR DESCRIPTION
## Summary
- Self-hostable Mention node registration and bidirectional sync (MTN Protocol Fase B3)
- Ingest re-verify chokepoint via `verifyAndStoreRecord` in `MentionRecordService`
- Witness model (`MentionNodeIngestWitness`) + user-node model (`MentionUserNode`) for cross-node record tracking
- `MentionNodeRegistryService`, `MentionNodeSyncService`, `MentionNodeScheduler`, `MentionRepoLogService`
- REST routes at `mtn-nodes.routes.ts`, wired into `server.ts`
- 23 new tests (981 total, 99 files, all passing)

## Test plan
- [x] `bunx tsc --noEmit` → EXIT 0
- [x] `bun run test` → 981 passed, 0 failed (99 files)
- [x] `bun install --frozen-lockfile` → EXIT 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)