### PR TITLE
fix(atproto): mirror Bluesky media + avatars to Oxy S3 like the fediverse

### DIFF
--- a/packages/backend/src/__tests__/connectors/atproto/postMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/postMapper.test.ts
@@ -68,6 +68,8 @@ const ACTOR: NormalizedExternalActor = {
   network: 'atproto',
   externalId: DID,
   handle: 'alice.bsky.social',
+  federatedUsername: 'alice.bsky.social@bsky.social',
+  instanceDomain: 'bsky.social',
   oxyUserId: 'oxy-alice',
 };
 
@@ -172,14 +174,25 @@ describe('importAuthorFeed', () => {
         oxyUserId: 'oxy-alice',
         federation: expect.objectContaining({ activityId: atUri('a'), actorUri: DID }),
         visibility: 'public',
+        // The imported post is stamped with the actor's INSTANCE domain
+        // (`bsky.social`), not the bare full handle (`alice.bsky.social`),
+        // matching the AP `Post.instanceDomain = actor host` convention.
+        instanceDomain: 'bsky.social',
         skipNotifications: true,
         skipSocketEmit: true,
         skipFederationDelivery: true,
         createdAt: new Date('2024-01-01T00:00:00.000Z'),
       }),
     );
-    // Media materialization ran for the imported post.
+    // Media materialization ran for the imported post, scoped to the resolved
+    // Oxy owner — so its remote bsky CDN media mirrors into Oxy S3 (not proxied).
     expect(mocks.materialize).toHaveBeenCalledTimes(1);
+    expect(mocks.materialize).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      'oxy-alice',
+      expect.objectContaining({ activityId: atUri('a'), actorUri: DID }),
+    );
   });
 
   it('returns empty without creating when the actor has no resolved Oxy user', async () => {

--- a/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
@@ -61,6 +61,10 @@ describe('mapProfileToNormalizedActor', () => {
       network: 'atproto',
       externalId: DID,
       handle: 'alice.bsky.social',
+      // The canonical `local@domain` Oxy username + the handle's parent domain —
+      // exactly what oxy-api's `PUT /users/resolve` binds for an atproto actor.
+      federatedUsername: 'alice.bsky.social@bsky.social',
+      instanceDomain: 'bsky.social',
       displayName: 'Alice',
       avatarUrl: PROFILE.avatar,
       bannerUrl: PROFILE.banner,
@@ -69,6 +73,12 @@ describe('mapProfileToNormalizedActor', () => {
       followingCount: 7,
       postsCount: 99,
     });
+  });
+
+  it('derives the instance domain from a bare custom-domain handle', () => {
+    const actor = mapProfileToNormalizedActor({ ...PROFILE, handle: 'example.com' });
+    expect(actor?.federatedUsername).toBe('example.com@example.com');
+    expect(actor?.instanceDomain).toBe('example.com');
   });
 
   it('returns null when did or handle is missing', () => {
@@ -96,6 +106,19 @@ describe('fetchAndUpsertAtprotoProfile', () => {
         }),
       }),
       expect.objectContaining({ upsert: true }),
+    );
+    // Oxy resolution is handed the canonical federated identity (`handle@domain`
+    // username + instance domain) — the exact shape oxy-api's username↔domain
+    // binding requires for a `did:` actor. Passing the bare handle here would
+    // make `PUT /users/resolve` 400 → no oxyUserId → no posts and proxied media.
+    expect(mocks.resolveOxyExternalUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalId: DID,
+        federatedUsername: 'alice.bsky.social@bsky.social',
+        instanceDomain: 'bsky.social',
+        avatarUrl: PROFILE.avatar,
+        bannerUrl: PROFILE.banner,
+      }),
     );
     // Oxy user resolved + stamped (the upsert returned no prior oxyUserId).
     expect(mocks.updateOne).toHaveBeenCalledWith({ _id: 'fa1' }, { $set: { oxyUserId: 'oxy-alice' } });

--- a/packages/backend/src/__tests__/connectors/identity.test.ts
+++ b/packages/backend/src/__tests__/connectors/identity.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Network-neutral identity bridge (`resolveOxyExternalUser`) — asserts the EXACT
+ * `PUT /users/resolve` body sent to oxy-api for each protocol.
+ *
+ * Regression guard: oxy-api binds the federated `username` to `domain` (the
+ * username domain after `@` MUST equal `domain`) and requires a `local@domain`
+ * username. A Bluesky actor's bare DNS handle (`alice.bsky.social`) is NOT a
+ * valid federated username — sending it (and a guessed domain) made
+ * `PUT /users/resolve` 400, so the actor never resolved to an Oxy user, no posts
+ * imported, and the only media that ever surfaced was hot-loaded through
+ * `/media/proxy`. The connector now supplies the canonical `federatedUsername`
+ * (`<handle>@<instance-domain>`) and `instanceDomain`, which this bridge passes
+ * through verbatim.
+ */
+
+const mocks = vi.hoisted(() => ({
+  makeServiceRequest: vi.fn(),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    makeServiceRequest: mocks.makeServiceRequest,
+  }),
+}));
+
+import { resolveOxyExternalUser } from '../../connectors/identity';
+import type { NormalizedExternalActor } from '../../connectors/types';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.makeServiceRequest.mockResolvedValue({ _id: 'oxy-resolved' });
+});
+
+describe('resolveOxyExternalUser', () => {
+  it('sends the canonical handle@domain username + instance domain for an atproto (did:) actor', async () => {
+    const actor: NormalizedExternalActor = {
+      network: 'atproto',
+      externalId: 'did:plc:ewvi7nxzyoun6zhxrhs64oiz',
+      handle: 'alice.bsky.social',
+      federatedUsername: 'alice.bsky.social@bsky.social',
+      instanceDomain: 'bsky.social',
+      displayName: 'Alice',
+      avatarUrl: 'https://cdn.bsky.app/img/avatar/plain/did/cid@jpeg',
+      bio: 'hello from bluesky',
+    };
+
+    const oxyId = await resolveOxyExternalUser(actor);
+
+    expect(oxyId).toBe('oxy-resolved');
+    expect(mocks.makeServiceRequest).toHaveBeenCalledWith('PUT', '/users/resolve', {
+      type: 'federated',
+      // The canonical Oxy username — NOT the bare handle, which oxy-api rejects.
+      username: 'alice.bsky.social@bsky.social',
+      // The DID is stored verbatim as the dedup key (oxy-api skips host binding).
+      actorUri: 'did:plc:ewvi7nxzyoun6zhxrhs64oiz',
+      // The instance domain — equals the username domain, so the binding holds.
+      domain: 'bsky.social',
+      displayName: 'Alice',
+      avatar: 'https://cdn.bsky.app/img/avatar/plain/did/cid@jpeg',
+      bio: 'hello from bluesky',
+      refresh: false,
+      forceAvatarRefresh: false,
+    });
+  });
+
+  it('passes the AP acct through as both username and (via instanceDomain) domain', async () => {
+    const actor: NormalizedExternalActor = {
+      network: 'activitypub',
+      externalId: 'https://mastodon.social/users/alice',
+      handle: 'alice@mastodon.social',
+      federatedUsername: 'alice@mastodon.social',
+      instanceDomain: 'mastodon.social',
+      displayName: 'Alice',
+      avatarUrl: 'https://files.mastodon.social/avatar.png',
+    };
+
+    await resolveOxyExternalUser(actor, { forceAvatarRefresh: true });
+
+    expect(mocks.makeServiceRequest).toHaveBeenCalledWith('PUT', '/users/resolve', expect.objectContaining({
+      type: 'federated',
+      username: 'alice@mastodon.social',
+      actorUri: 'https://mastodon.social/users/alice',
+      domain: 'mastodon.social',
+      refresh: true,
+      forceAvatarRefresh: true,
+    }));
+  });
+
+  it('returns null (caller skips, no orphan) when Oxy returns no id', async () => {
+    mocks.makeServiceRequest.mockResolvedValue(null);
+    const actor: NormalizedExternalActor = {
+      network: 'atproto',
+      externalId: 'did:plc:ewvi7nxzyoun6zhxrhs64oiz',
+      handle: 'alice.bsky.social',
+      federatedUsername: 'alice.bsky.social@bsky.social',
+      instanceDomain: 'bsky.social',
+    };
+    expect(await resolveOxyExternalUser(actor)).toBeNull();
+  });
+});

--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -157,6 +157,10 @@ class ActivityPubConnector implements NetworkConnector {
       network: 'activitypub',
       externalId: actor.uri,
       handle: actor.acct,
+      // For AP the acct IS the canonical `user@domain` Oxy username, and the
+      // stored `domain` is its instance host.
+      federatedUsername: actor.acct,
+      instanceDomain: actor.domain,
       // Display names are owned by the Oxy API (`name.displayName`); a federated
       // actor row carries no local name copy.
       avatarUrl: actor.avatarUrl,

--- a/packages/backend/src/connectors/activitypub/actor.service.ts
+++ b/packages/backend/src/connectors/activitypub/actor.service.ts
@@ -299,6 +299,10 @@ export class ActorService {
             network: 'activitypub',
             externalId: actor.id,
             handle: acct,
+            // For AP the acct IS the canonical `user@domain` Oxy username, and
+            // `domain` is its instance host — both already verified above.
+            federatedUsername: acct,
+            instanceDomain: domain,
             displayName: decodeEntities(actor.name || username),
             avatarUrl,
             bannerUrl: headerUrl,

--- a/packages/backend/src/connectors/atproto/post.mapper.ts
+++ b/packages/backend/src/connectors/atproto/post.mapper.ts
@@ -286,7 +286,10 @@ export async function importAuthorFeed(
     logger.warn(`[atproto] importAuthorFeed called for ${did} without a resolved Oxy user; skipping (no orphan)`);
     return { posts: [] };
   }
-  const instanceDomain = actor.handle;
+  // Stamp the actor's instance domain (e.g. `bsky.social`) on imported posts —
+  // matching the AP convention (`Post.instanceDomain` = the actor's host), not
+  // the bare full handle.
+  const instanceDomain = actor.instanceDomain;
 
   let feed: AtprotoAuthorFeed;
   try {

--- a/packages/backend/src/connectors/atproto/profile.mapper.ts
+++ b/packages/backend/src/connectors/atproto/profile.mapper.ts
@@ -24,11 +24,25 @@ export interface AtprotoProfileView {
   postsCount?: number;
 }
 
-/** Split an atproto handle (a DNS name) into a display username + instance domain. */
-function splitHandle(handle: string): { username: string; domain: string } {
+/**
+ * Split an atproto handle (a DNS name) into its display username, instance
+ * domain, and the canonical `local@domain` username Oxy stores it under.
+ *
+ * A Bluesky handle is a bare DNS name. Its instance domain is the handle minus
+ * its first label — but ONLY when that leaves a real ≥2-label domain:
+ *   - `alice.bsky.social` (3 labels) → instance `bsky.social`.
+ *   - `example.com` (a 2-label apex custom domain) is its OWN instance — stripping
+ *     would leave the bare TLD `com`, so the full handle stays the domain.
+ * The federated Oxy username is `<handle>@<instance-domain>`
+ * (`alice.bsky.social@bsky.social`, `example.com@example.com`) — the exact form
+ * oxy-api's `PUT /users/resolve` binds (username domain must equal `domain`).
+ */
+function splitHandle(handle: string): { username: string; domain: string; federatedUsername: string } {
   const dot = handle.indexOf('.');
-  if (dot <= 0) return { username: handle, domain: handle };
-  return { username: handle, domain: handle.slice(dot + 1) };
+  // Strip the first label only if the remainder is still a multi-label domain.
+  const parent = dot > 0 ? handle.slice(dot + 1) : handle;
+  const domain = parent.includes('.') ? parent : handle;
+  return { username: handle, domain, federatedUsername: `${handle}@${domain}` };
 }
 
 /** Map a getProfile response to the network-neutral actor shape (pure). */
@@ -37,10 +51,15 @@ export function mapProfileToNormalizedActor(profile: AtprotoProfileView): Normal
   const handle = typeof profile.handle === 'string' ? profile.handle : '';
   if (!did || !handle) return null;
 
+  const { domain, federatedUsername } = splitHandle(handle);
   return {
     network: 'atproto',
     externalId: did,
     handle,
+    // A DID carries no host, so the Oxy identity is keyed on the handle's parent
+    // domain. These are what the shared identity bridge sends to oxy-api.
+    federatedUsername,
+    instanceDomain: domain,
     displayName: profile.displayName || undefined,
     avatarUrl: profile.avatar || undefined,
     bannerUrl: profile.banner || undefined,

--- a/packages/backend/src/connectors/identity.ts
+++ b/packages/backend/src/connectors/identity.ts
@@ -26,29 +26,6 @@ const REMOTE_BANNER_FETCH_TIMEOUT_MS = 10000;
 const ACTOR_BANNER_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
 
 /**
- * Derive the federated user's instance domain from the normalized actor. AP
- * handles are `user@domain`; otherwise fall back to the host of the protocol id.
- * Reproduces the prior `domainFromAcct(acct) || actorHost` value for AP actors.
- *
- * For atproto the handle is itself a bare DNS name (e.g. `alice.bsky.social`) and
- * the protocol id is a `did:` (which has no URL host), so neither the `@` split
- * nor the URL host yields a domain — fall back to the handle (the domain).
- */
-function deriveDomain(actor: NormalizedExternalActor): string {
-  const at = actor.handle.lastIndexOf('@');
-  if (at > 0 && at < actor.handle.length - 1) {
-    return actor.handle.slice(at + 1).toLowerCase();
-  }
-  try {
-    const host = new URL(actor.externalId).hostname.toLowerCase();
-    if (host) return host;
-  } catch {
-    // Unparseable protocol id (e.g. a DID) — fall through to the handle.
-  }
-  return actor.handle.toLowerCase();
-}
-
-/**
  * Resolve/mint the Oxy user a normalized external actor maps to.
  *
  * Upserts the federated user via `PUT /users/resolve` (service-token scoped) so
@@ -70,12 +47,15 @@ export async function resolveOxyExternalUser(
   const forceAvatarRefresh = opts.forceAvatarRefresh ?? false;
   try {
     const oxyClient = getServiceOxyClient();
-    const domain = deriveDomain(actor);
+    // The connector owns deriving the canonical `local@domain` username and the
+    // instance domain for its protocol, so this bridge stays protocol-agnostic:
+    // it never has to guess a domain out of a bare atproto handle or a hostless
+    // DID. oxy-api binds the two (username domain must equal `domain`).
     const oxyUser: { _id?: string; id?: string } | null = await oxyClient.makeServiceRequest('PUT', '/users/resolve', {
       type: 'federated',
-      username: actor.handle,
+      username: actor.federatedUsername,
       actorUri: actor.externalId,
-      domain,
+      domain: actor.instanceDomain,
       displayName: actor.displayName,
       avatar: actor.avatarUrl,
       bio: actor.bio,

--- a/packages/backend/src/connectors/types.ts
+++ b/packages/backend/src/connectors/types.ts
@@ -27,6 +27,22 @@ export interface NormalizedExternalActor {
   externalId: string;
   /** Fediverse-style handle (`user@domain` for AP; the atproto handle/DID otherwise). */
   handle: string;
+  /**
+   * The canonical `local@domain` username this actor is stored under in Oxy — the
+   * exact value passed to `PUT /users/resolve`. Each connector derives it for its
+   * own protocol so the shared identity bridge never has to guess: AP uses the
+   * acct (`user@domain`); atproto synthesizes `<handle>@<instance-domain>` (e.g.
+   * `alice.bsky.social@bsky.social`). It MUST equal `instanceDomain` after the
+   * `@` so oxy-api's username↔domain binding holds.
+   */
+  federatedUsername: string;
+  /**
+   * The instance/origin domain this actor's identity belongs to — the `domain`
+   * passed to `PUT /users/resolve` and stamped on imported `Post.instanceDomain`.
+   * AP: the actor host (e.g. `mastodon.social`); atproto: the handle's parent
+   * domain (e.g. `bsky.social`), since a DID carries no host.
+   */
+  instanceDomain: string;
   displayName?: string;
   avatarUrl?: string;
   bannerUrl?: string;


### PR DESCRIPTION
## Summary
- Fixes Bluesky (atproto) federated actors never resolving to an Oxy user because the connector sent oxy-api a bare handle instead of the required `local@domain` format
- Adds `federatedUsername` and `instanceDomain` canonical fields to `NormalizedExternalActor`; each connector populates its own protocol's identity; `resolveOxyExternalUser` passes them verbatim to oxy-api
- Deletes the `deriveDomain` guesser — AP behavior is byte-identical; atproto actors now resolve, so post images/video, avatars, and banners mirror to Oxy S3 instead of being hot-loaded through `/media/proxy`
- New `identity.test.ts` + updated mapper tests cover the canonical-identity contract

## Test plan
- [ ] `bunx tsc --noEmit` in packages/backend → exit 0
- [ ] `bun run test --run` in packages/backend → 106 files / 1038 tests passing
- [ ] `bun install --frozen-lockfile` at repo root → passes (no dep changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)