### PR TITLE
fix(federation): mirror federated actor banner via service-token media path

### DIFF
--- a/packages/backend/src/__tests__/connectors/identity.test.ts
+++ b/packages/backend/src/__tests__/connectors/identity.test.ts
@@ -17,6 +17,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   makeServiceRequest: vi.fn(),
+  persistRemoteMedia: vi.fn(),
+  userSettingsUpdateOne: vi.fn(),
 }));
 
 vi.mock('../../utils/oxyHelpers', () => ({
@@ -25,12 +27,24 @@ vi.mock('../../utils/oxyHelpers', () => ({
   }),
 }));
 
+vi.mock('../../services/mediaCache/cacheWorker', () => ({
+  persistRemoteMediaForFederatedOwnerDetailed: mocks.persistRemoteMedia,
+}));
+
+vi.mock('../../models/UserSettings', () => ({
+  default: {
+    updateOne: mocks.userSettingsUpdateOne,
+  },
+}));
+
 import { resolveOxyExternalUser } from '../../connectors/identity';
 import type { NormalizedExternalActor } from '../../connectors/types';
 
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.makeServiceRequest.mockResolvedValue({ _id: 'oxy-resolved' });
+  mocks.persistRemoteMedia.mockResolvedValue({ ok: false, permanent: false, reason: 'disabled' });
+  mocks.userSettingsUpdateOne.mockResolvedValue({ acknowledged: true });
 });
 
 describe('resolveOxyExternalUser', () => {
@@ -98,5 +112,76 @@ describe('resolveOxyExternalUser', () => {
       instanceDomain: 'bsky.social',
     };
     expect(await resolveOxyExternalUser(actor)).toBeNull();
+  });
+
+  it('mirrors the actor banner as a public federated asset and stores its file id', async () => {
+    mocks.persistRemoteMedia.mockResolvedValue({
+      ok: true,
+      media: { oxyFileId: 'banner_file_1', contentType: 'image/png', sizeBytes: 1234 },
+    });
+    const actor: NormalizedExternalActor = {
+      network: 'activitypub',
+      externalId: 'https://mastodon.social/users/alice',
+      handle: 'alice@mastodon.social',
+      federatedUsername: 'alice@mastodon.social',
+      instanceDomain: 'mastodon.social',
+      bannerUrl: 'https://files.mastodon.social/banner.png',
+    };
+
+    await resolveOxyExternalUser(actor);
+
+    // The banner mirrors through the SAME service-token public-upload path as
+    // federated post media (`persistRemoteMediaForFederatedOwnerDetailed`), NOT
+    // the user-authenticated SDK `uploadProfileBanner` (which 401s here).
+    expect(mocks.persistRemoteMedia).toHaveBeenCalledWith(
+      'https://files.mastodon.social/banner.png',
+      'oxy-resolved',
+      expect.objectContaining({
+        role: 'banner',
+        actorUri: 'https://mastodon.social/users/alice',
+        remoteHost: 'files.mastodon.social',
+      }),
+    );
+    expect(mocks.userSettingsUpdateOne).toHaveBeenCalledWith(
+      { oxyUserId: 'oxy-resolved' },
+      { $set: { profileHeaderImage: 'banner_file_1' } },
+      { upsert: true },
+    );
+  });
+
+  it('does not store a profile header image when banner mirroring fails', async () => {
+    mocks.persistRemoteMedia.mockResolvedValue({ ok: false, permanent: true, reason: 'not-media' });
+    const actor: NormalizedExternalActor = {
+      network: 'activitypub',
+      externalId: 'https://mastodon.social/users/bob',
+      handle: 'bob@mastodon.social',
+      federatedUsername: 'bob@mastodon.social',
+      instanceDomain: 'mastodon.social',
+      bannerUrl: 'https://files.mastodon.social/banner.txt',
+    };
+
+    await resolveOxyExternalUser(actor);
+
+    expect(mocks.persistRemoteMedia).toHaveBeenCalledWith(
+      'https://files.mastodon.social/banner.txt',
+      'oxy-resolved',
+      expect.objectContaining({ role: 'banner' }),
+    );
+    expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('skips banner mirroring when the actor has no banner', async () => {
+    const actor: NormalizedExternalActor = {
+      network: 'activitypub',
+      externalId: 'https://mastodon.social/users/carol',
+      handle: 'carol@mastodon.social',
+      federatedUsername: 'carol@mastodon.social',
+      instanceDomain: 'mastodon.social',
+    };
+
+    await resolveOxyExternalUser(actor);
+
+    expect(mocks.persistRemoteMedia).not.toHaveBeenCalled();
+    expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/__tests__/services/federationService.test.ts
+++ b/packages/backend/src/__tests__/services/federationService.test.ts
@@ -28,7 +28,6 @@ const mocks = vi.hoisted(() => ({
   fetchUpstreamFollowingRedirects: vi.fn(),
   fetchUpstreamSingleHop: vi.fn(),
   userSettingsUpdateOne: vi.fn(),
-  uploadProfileBanner: vi.fn(),
 }));
 
 vi.mock('../../connectors/activitypub/crypto', () => ({
@@ -194,7 +193,6 @@ beforeEach(() => {
   mocks.recordAccess.mockResolvedValue(undefined);
   mocks.postCreatorCreate.mockResolvedValue({ _id: 'created_post_1' });
   mocks.makeServiceRequest.mockResolvedValue({ id: 'oxy_user_1' });
-  mocks.uploadProfileBanner.mockResolvedValue({ file: { id: 'banner_file_1' } });
   mocks.userSettingsUpdateOne.mockResolvedValue({ modifiedCount: 1 });
   mocks.fetchUpstreamFollowingRedirects.mockReset();
   // `signedFetch` is built on `fetchUpstreamSingleHop` (IP-pinned, no global
@@ -220,7 +218,6 @@ beforeEach(() => {
   );
   mocks.getServiceOxyClient.mockReturnValue({
     makeServiceRequest: mocks.makeServiceRequest,
-    uploadProfileBanner: mocks.uploadProfileBanner,
   });
 });
 
@@ -456,7 +453,7 @@ describe('federationService.fetchRemoteActor', () => {
     );
   });
 
-  it('downloads actor banners through the SSRF-safe media fetcher with content validation and a size cap', async () => {
+  it('mirrors the actor banner to a public federated asset and stores its file id', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url === 'https://remote.example/users/alice') {
         return jsonResponse({
@@ -465,7 +462,7 @@ describe('federationService.fetchRemoteActor', () => {
           preferredUsername: 'alice',
           name: 'Alice',
           inbox: 'https://remote.example/users/alice/inbox',
-          image: ['http://127.0.0.1/latest/meta-data', { url: 'https://remote.example/banner.jpg' }],
+          image: { url: 'https://remote.example/banner.jpg' },
         });
       }
 
@@ -473,27 +470,23 @@ describe('federationService.fetchRemoteActor', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const body = new PassThrough();
-    body.end(Buffer.from('fake-image-bytes'));
-    Object.assign(body, {
-      statusCode: 200,
-      headers: { 'content-type': 'image/jpeg' },
-    });
-    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue({
-      response: body,
-      finalUrl: 'http://127.0.0.1/latest/meta-data',
+    mocks.persistRemoteMedia.mockResolvedValue({
+      ok: true,
+      media: { oxyFileId: 'banner_file_1', contentType: 'image/jpeg', sizeBytes: 1234 },
     });
 
     await federationService.fetchRemoteActor('https://remote.example/users/alice');
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).not.toHaveBeenCalledWith('http://127.0.0.1/latest/meta-data');
-    expect(mocks.fetchUpstreamFollowingRedirects).toHaveBeenCalledWith(
-      'http://127.0.0.1/latest/meta-data',
-      {},
-      expect.any(AbortSignal),
+    // The banner is mirrored through the SAME service-token public-upload path as
+    // all other federated media (`persistRemoteMediaForFederatedOwnerDetailed` →
+    // `POST /assets/service/federation`), NOT the user-authenticated SDK
+    // `uploadProfileBanner` (which 401s on the service client). SSRF guarding +
+    // content validation now live inside that helper's `downloadToTempFile`.
+    expect(mocks.persistRemoteMedia).toHaveBeenCalledWith(
+      'https://remote.example/banner.jpg',
+      'oxy_user_1',
+      expect.objectContaining({ role: 'banner', remoteHost: 'remote.example' }),
     );
-    expect(mocks.uploadProfileBanner).toHaveBeenCalledTimes(1);
     expect(mocks.userSettingsUpdateOne).toHaveBeenCalledWith(
       { oxyUserId: 'oxy_user_1' },
       { $set: { profileHeaderImage: 'banner_file_1' } },
@@ -501,7 +494,7 @@ describe('federationService.fetchRemoteActor', () => {
     );
   });
 
-  it('rejects non-image actor banner responses before upload', async () => {
+  it('does not store a profile header image when banner mirroring fails', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url === 'https://remote.example/users/bob') {
         return jsonResponse({
@@ -517,25 +510,15 @@ describe('federationService.fetchRemoteActor', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const body = new PassThrough();
-    body.end(Buffer.from('not an image'));
-    Object.assign(body, {
-      statusCode: 200,
-      headers: { 'content-type': 'text/plain' },
-    });
-    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue({
-      response: body,
-      finalUrl: 'https://remote.example/banner.txt',
-    });
+    mocks.persistRemoteMedia.mockResolvedValue({ ok: false, reason: 'not-media', permanent: true });
 
     await federationService.fetchRemoteActor('https://remote.example/users/bob');
 
-    expect(mocks.fetchUpstreamFollowingRedirects).toHaveBeenCalledWith(
+    expect(mocks.persistRemoteMedia).toHaveBeenCalledWith(
       'https://remote.example/banner.txt',
-      {},
-      expect.any(AbortSignal),
+      'oxy_user_1',
+      expect.objectContaining({ role: 'banner' }),
     );
-    expect(mocks.uploadProfileBanner).not.toHaveBeenCalled();
     expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
   });
 

--- a/packages/backend/src/connectors/identity.ts
+++ b/packages/backend/src/connectors/identity.ts
@@ -1,9 +1,8 @@
 import { logger } from '../utils/logger';
 import { getServiceOxyClient } from '../utils/oxyHelpers';
 import UserSettings from '../models/UserSettings';
-import { contentTypeFamily, fetchUpstreamFollowingRedirects } from '../utils/safeUpstreamFetch';
-import { isAllowedMediaType } from '../services/mediaCache/mediaTypes';
-import { readBoundedResponseBody } from './shared/httpBody';
+import { persistRemoteMediaForFederatedOwnerDetailed } from '../services/mediaCache/cacheWorker';
+import { isAbsoluteHttpUrl, getRemoteHost } from './shared/url';
 import type { NormalizedExternalActor } from './types';
 
 /**
@@ -19,12 +18,6 @@ import type { NormalizedExternalActor } from './types';
  * returned id.
  */
 
-/** Bounded timeout for the remote banner fetch (matches the prior inline value). */
-const REMOTE_BANNER_FETCH_TIMEOUT_MS = 10000;
-
-/** Maximum bytes accepted for a remote federated actor banner image. */
-const ACTOR_BANNER_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
-
 /**
  * Resolve/mint the Oxy user a normalized external actor maps to.
  *
@@ -32,9 +25,9 @@ const ACTOR_BANNER_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
  * profile changes (avatar, name, bio) stay synced — creating the user when it
  * does not exist. Returns the resolved Oxy user id, or `null` when Oxy is
  * unreachable / returns no id (callers must then skip, never persisting an
- * orphan). After resolution, the actor's banner is mirrored into Oxy through the
- * shared SSRF-safe upstream fetcher (best-effort; failures are logged, not
- * propagated).
+ * orphan). After resolution, the actor's banner is mirrored into a durable,
+ * public Oxy asset via the SAME service-token media path as federated post media
+ * (best-effort; failures are logged, not propagated).
  *
  * @param actor the normalized external actor.
  * @param opts.forceAvatarRefresh when true, tell Oxy to re-download and replace
@@ -68,35 +61,40 @@ export async function resolveOxyExternalUser(
     const oxyId = String(oxyUser?._id || oxyUser?.id || '');
     if (!oxyId) return null;
 
-    // Download and upload the remote banner to Oxy (same pattern as avatar), but
-    // only through the shared SSRF-safe upstream fetcher: it validates the
-    // original URL and every redirect hop, pins DNS, and applies timeouts.
-    if (actor.bannerUrl) {
-      try {
-        const deadline = AbortSignal.timeout(REMOTE_BANNER_FETCH_TIMEOUT_MS);
-        const { response: imgRes } = await fetchUpstreamFollowingRedirects(actor.bannerUrl, {}, deadline);
-        if ((imgRes.statusCode ?? 0) >= 200 && (imgRes.statusCode ?? 0) < 300) {
-          const contentType = contentTypeFamily(imgRes.headers);
-          if (!contentType.startsWith('image/') || !isAllowedMediaType(contentType)) {
-            imgRes.destroy();
-            throw new Error(`remote banner content-type not allowed: ${contentType || 'unknown'}`);
-          }
-          const buffer = await readBoundedResponseBody(imgRes, ACTOR_BANNER_MAX_BYTES);
-          const blob = new Blob([buffer], { type: contentType });
-          const asset = await oxyClient.uploadProfileBanner(blob, oxyId);
-          const fileId = asset?.file?.id;
-          if (fileId) {
-            await UserSettings.updateOne(
-              { oxyUserId: oxyId },
-              { $set: { profileHeaderImage: fileId } },
-              { upsert: true },
-            );
-          }
-        } else {
-          imgRes.destroy();
-        }
-      } catch (bannerErr) {
-        logger.debug(`Failed to sync banner for ${actor.externalId}:`, bannerErr);
+    // Mirror the remote banner into a durable, PUBLIC Oxy asset, then store its
+    // file id in Mention's per-user `UserSettings.profileHeaderImage` (the same
+    // field a LOCAL user's banner uses, read back by the profile-design
+    // endpoint). This reuses the canonical federated-media path
+    // (`persistRemoteMediaForFederatedOwnerDetailed` →
+    // `POST /assets/service/federation`): SSRF-safe download → streamed upload as
+    // a public, CDN-reachable file owned by the resolved federated user — the
+    // SAME service-token flow that already mirrors federated post media and the
+    // avatar (downloaded server-side by oxy-api). It deliberately does NOT use the
+    // SDK's `uploadProfileBanner`, which routes through the USER-authenticated
+    // `POST /assets/upload` and is rejected `401 UNAUTHORIZED` on the service
+    // client, so the banner was never stored.
+    if (actor.bannerUrl && isAbsoluteHttpUrl(actor.bannerUrl)) {
+      const result = await persistRemoteMediaForFederatedOwnerDetailed(actor.bannerUrl, oxyId, {
+        role: 'banner',
+        actorUri: actor.externalId,
+        remoteHost: getRemoteHost(actor.bannerUrl),
+      });
+      if (result.ok) {
+        await UserSettings.updateOne(
+          { oxyUserId: oxyId },
+          { $set: { profileHeaderImage: result.media.oxyFileId } },
+          { upsert: true },
+        );
+      } else if (!result.permanent) {
+        // Surface transient failures (bad service credential, upstream 5xx,
+        // upload rejection) at `warn` — a silent `debug` previously hid a total
+        // outage where 0 federated banners were ever stored. Permanently
+        // unavailable banners (dead/oversized/non-image) are expected and stay
+        // quiet, mirroring `materializeFederatedMedia`.
+        logger.warn(`Failed to mirror banner for ${actor.externalId}`, {
+          reason: result.reason,
+          remoteHost: getRemoteHost(actor.bannerUrl),
+        });
       }
     }
 


### PR DESCRIPTION
## Problem
Federated (Mastodon + Bluesky) actors sync their **avatar** but never their **header/banner**. Verified against prod: of **15,654** federated actors with a remote banner + linked Oxy user, **0** had `UserSettings.profileHeaderImage`.

## Root cause (prod-verified)
The banner write hit oxy-api's **user-authenticated** `POST /assets/upload` via `uploadProfileBanner()` — but it was called on the **service client** (`getServiceOxyClient()`), which only carries a service token → **401 `UNAUTHORIZED` every time**. The error was swallowed at `logger.debug`. The avatar works because oxy-api downloads it server-side inside `PUT /users/resolve`.

## Fix
Replace the bespoke fetch+upload block in the shared identity bridge (`connectors/identity.ts` `resolveOxyExternalUser`) with the **canonical** `persistRemoteMediaForFederatedOwnerDetailed()` helper that post-media mirroring already uses (service-token `POST /assets/service/federation` → **public** Oxy S3 asset, SSRF-safe download internally). Store the returned file id in `UserSettings.profileHeaderImage`, exactly like local banners.

- Fixes **both networks at once** — the bridge is shared by ActivityPub + atproto; `actor.bannerUrl` is set by both connectors.
- Aligns with #284's "mirror like the fediverse" pattern (same helper, same `ok`/`permanent`/`reason` handling).
- Removes now-dead constants/imports; banner failures now log at **warn** so this class of error is visible.

## Verification
- Prod E2E (real actor): persist → `cloud.oxy.so/<id>` 302 public + `?variant=thumb` 200, identical to avatars/local banners.
- `bun run build` (tsc) green; full backend suite **106 files / 1041 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)