### PR TITLE
feat(mtn): blob read-side via sha256 reverse lookup + node-blob ingest mirror (core 5.2.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -109,7 +109,7 @@
         "@mention/shared-types": "file:../shared-types",
         "@napi-rs/image": "^1.12.0",
         "@oxyhq/contracts": "^0.7.0",
-        "@oxyhq/core": "^5.1.1",
+        "@oxyhq/core": "^5.2.0",
         "@oxyhq/protocol": "^0.1.1",
         "@socket.io/redis-adapter": "^8.3.0",
         "@syra.fm/sdk": "^0.3.0",
@@ -299,7 +299,7 @@
   },
   "overrides": {
     "@oxyhq/bloom": "^0.25.0",
-    "@oxyhq/core": "^5.1.1",
+    "@oxyhq/core": "^5.2.0",
     "@oxyhq/services": "^13.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native/babel-preset": "0.85.3",
@@ -904,7 +904,7 @@
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.7.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-2apYWhEMSb5ZalpiYLbD1nQ6Gm40xvqQe0EJ4HhKrnDAbFPhq6WwfOWQJUhEZiS/6ccAIu948dVjyFbXr6c0Rw=="],
 
-    "@oxyhq/core": ["@oxyhq/core@5.1.1", "", { "dependencies": { "@oxyhq/contracts": "^0.7.0", "@oxyhq/protocol": "^0.1.1", "bip39": "^3.1.0", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.5", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^7.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-2vl60oTsVk9a3J9nK3u8a/HCPNC1KTHQ+UvdgoSUaxyvemyonUcC1kU8J5m+WZadGKMC0eTaM7W1WdsqX4c49A=="],
+    "@oxyhq/core": ["@oxyhq/core@5.2.0", "", { "dependencies": { "@oxyhq/contracts": "^0.7.0", "@oxyhq/protocol": "^0.1.1", "bip39": "^3.1.0", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.5", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^7.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-vtdbvqYO+qbOzLjfRgvyCHFXJN7WzKQdL6UyA2RljvuW/6Fvq1Pk3greRJjpBFda3BaqFJvjZD45VeEoaA5ygQ=="],
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.1", "", { "dependencies": { "@oxyhq/contracts": "^0.7.0", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-AiObs+A0+HkMsNCVfZuAaT6P0BOTq6oxKHwlgFUhRxIuPz0abO4SUBZyaszUQ5oJ0WgpTzx89fmLLdG1vjL+VQ=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
     "@oxyhq/bloom": "^0.25.0",
-    "@oxyhq/core": "^5.1.1",
+    "@oxyhq/core": "^5.2.0",
     "@oxyhq/services": "^13.0.3",
     "mongoose": "9.3.1",
     "ioredis": "5.10.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,7 +23,7 @@
     "@mention/shared-types": "file:../shared-types",
     "@napi-rs/image": "^1.12.0",
     "@oxyhq/contracts": "^0.7.0",
-    "@oxyhq/core": "^5.1.1",
+    "@oxyhq/core": "^5.2.0",
     "@oxyhq/protocol": "^0.1.1",
     "@socket.io/redis-adapter": "^8.3.0",
     "@syra.fm/sdk": "^0.3.0",

--- a/packages/backend/src/__tests__/services/mtn/mentionNodeSync.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/mentionNodeSync.test.ts
@@ -42,6 +42,10 @@ vi.mock('@oxyhq/protocol/node', () => ({
     head = (...a: unknown[]) => mockHead(...a);
     log = (...a: unknown[]) => mockLog(...a);
     pushRecords = vi.fn();
+    // Content-addressed blob fetcher (used by the materialize media mirror). These
+    // test records carry no embed, so it is never invoked, but the mock mirrors the
+    // real client surface.
+    getBlob = vi.fn(async () => null);
   },
 }));
 vi.mock('@oxyhq/protocol', async () => {

--- a/packages/backend/src/__tests__/services/mtn/mtnNodeBlobMirror.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/mtnNodeBlobMirror.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import type { MentionPostRecord } from '@mention/shared-types';
+
+/**
+ * MTN node-blob mirror tests — `mirrorNodeBlobsForRecord` pulls a record's
+ * not-yet-resolvable content-addressed media blobs from the node and uploads them
+ * to Oxy S3 via the durable federated-media path. The Oxy reverse lookup, the
+ * federated-media upload, and the media-cache enable flag are mocked so the REAL
+ * mirror logic (existence pre-check, candidate bounding, node fetch, upload) runs
+ * without any network or real upstream. Temp files are written to the OS tmpdir
+ * and cleaned up by the helper itself.
+ */
+
+// Service-scoped Oxy client: the reverse `sha256 → fileId` existence pre-check.
+const oxyMock = vi.hoisted(() => ({
+  getServiceAssetMetadataBySha256: vi.fn<
+    (sha256s: string[]) => Promise<
+      Array<{ sha256: string; id: string; mime: string; size: number; status: 'active' | 'trash'; url?: string }>
+    >
+  >(),
+}));
+vi.mock('../../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => oxyMock,
+}));
+
+// Durable federated-media upload + the write-side enable flag.
+const storeMock = vi.hoisted(() => ({
+  isMediaCacheEnabled: vi.fn<() => boolean>(),
+  uploadFederatedMedia: vi.fn<
+    (source: { filePath: string; contentType: string; ownerUserId: string; sizeBytes?: number }) => Promise<{
+      oxyFileId: string;
+    }>
+  >(),
+}));
+vi.mock('../../../services/mediaCache/oxyMediaStore', () => ({
+  isMediaCacheEnabled: storeMock.isMediaCacheEnabled,
+  uploadFederatedMedia: storeMock.uploadFederatedMedia,
+}));
+
+import { mirrorNodeBlobsForRecord, type NodeBlobFetcher } from '../../../services/mtn/mtnNodeBlobMirror';
+
+const OWNER = '650000000000000000000abc';
+
+/** Build a post record carrying a media embed with the given blob items. */
+function makeRecord(
+  items: Array<{ sha256: string; mediaType: 'image' | 'video' | 'gif'; mime?: string; size?: number; alt?: string }>,
+): MentionPostRecord {
+  return {
+    text: 'a post with media',
+    createdAt: new Date().toISOString(),
+    embed: {
+      type: 'media',
+      items: items.map((b) => ({
+        blob: {
+          sha256: b.sha256,
+          mediaType: b.mediaType,
+          ...(b.mime ? { mime: b.mime } : {}),
+          ...(typeof b.size === 'number' ? { size: b.size } : {}),
+        },
+        ...(b.alt ? { alt: b.alt } : {}),
+      })),
+    },
+  };
+}
+
+beforeEach(() => {
+  oxyMock.getServiceAssetMetadataBySha256.mockReset();
+  oxyMock.getServiceAssetMetadataBySha256.mockResolvedValue([]); // default: nothing already in S3
+  storeMock.isMediaCacheEnabled.mockReset();
+  storeMock.isMediaCacheEnabled.mockReturnValue(true); // default: write side enabled
+  storeMock.uploadFederatedMedia.mockReset();
+  storeMock.uploadFederatedMedia.mockResolvedValue({ oxyFileId: 'file-new' });
+});
+
+describe('mirrorNodeBlobsForRecord', () => {
+  it('fetches an unresolved blob from the node and uploads it (becomes resolvable)', async () => {
+    const bytes = Buffer.from('fake-image-bytes');
+    const getBlob = vi.fn<NodeBlobFetcher>().mockResolvedValue(bytes);
+
+    await mirrorNodeBlobsForRecord(
+      makeRecord([{ sha256: 'sha-img', mediaType: 'image', mime: 'image/png', size: bytes.length }]),
+      OWNER,
+      getBlob,
+    );
+
+    // The node was asked for the blob bytes by content address.
+    expect(getBlob).toHaveBeenCalledTimes(1);
+    expect(getBlob).toHaveBeenCalledWith('sha-img');
+
+    // The bytes were uploaded as a durable federated asset owned by the author,
+    // with the blob's declared content type.
+    expect(storeMock.uploadFederatedMedia).toHaveBeenCalledTimes(1);
+    const source = storeMock.uploadFederatedMedia.mock.calls[0][0];
+    expect(source.ownerUserId).toBe(OWNER);
+    expect(source.contentType).toBe('image/png');
+    expect(source.sizeBytes).toBe(bytes.length);
+    expect(typeof source.filePath).toBe('string');
+  });
+
+  it('is a clean no-op when the federated-media write side is disabled', async () => {
+    storeMock.isMediaCacheEnabled.mockReturnValue(false);
+    const getBlob = vi.fn<NodeBlobFetcher>();
+
+    await mirrorNodeBlobsForRecord(makeRecord([{ sha256: 'sha-x', mediaType: 'image' }]), OWNER, getBlob);
+
+    // No existence check, no node fetch, no upload.
+    expect(oxyMock.getServiceAssetMetadataBySha256).not.toHaveBeenCalled();
+    expect(getBlob).not.toHaveBeenCalled();
+    expect(storeMock.uploadFederatedMedia).not.toHaveBeenCalled();
+  });
+
+  it('skips a blob already resolvable in our S3 (idempotent — no re-fetch/re-upload)', async () => {
+    oxyMock.getServiceAssetMetadataBySha256.mockResolvedValue([
+      { sha256: 'sha-have', id: 'file-have', mime: 'image/png', size: 10, status: 'active' },
+    ]);
+    const getBlob = vi.fn<NodeBlobFetcher>().mockResolvedValue(Buffer.from('x'));
+
+    await mirrorNodeBlobsForRecord(makeRecord([{ sha256: 'sha-have', mediaType: 'image' }]), OWNER, getBlob);
+
+    expect(getBlob).not.toHaveBeenCalled();
+    expect(storeMock.uploadFederatedMedia).not.toHaveBeenCalled();
+  });
+
+  it('mirrors only the unresolved blobs in a mixed record', async () => {
+    oxyMock.getServiceAssetMetadataBySha256.mockResolvedValue([
+      { sha256: 'sha-have', id: 'file-have', mime: 'image/png', size: 10, status: 'active' },
+    ]);
+    const getBlob = vi.fn<NodeBlobFetcher>().mockResolvedValue(Buffer.from('bytes'));
+
+    await mirrorNodeBlobsForRecord(
+      makeRecord([
+        { sha256: 'sha-have', mediaType: 'image' },
+        { sha256: 'sha-need', mediaType: 'video', mime: 'video/mp4' },
+      ]),
+      OWNER,
+      getBlob,
+    );
+
+    expect(getBlob).toHaveBeenCalledTimes(1);
+    expect(getBlob).toHaveBeenCalledWith('sha-need');
+    expect(storeMock.uploadFederatedMedia).toHaveBeenCalledTimes(1);
+    expect(storeMock.uploadFederatedMedia.mock.calls[0][0].contentType).toBe('video/mp4');
+  });
+
+  it('does not upload when the node has no bytes for the blob (getBlob → null)', async () => {
+    const getBlob = vi.fn<NodeBlobFetcher>().mockResolvedValue(null);
+
+    await mirrorNodeBlobsForRecord(makeRecord([{ sha256: 'sha-gone', mediaType: 'image' }]), OWNER, getBlob);
+
+    expect(getBlob).toHaveBeenCalledWith('sha-gone');
+    expect(storeMock.uploadFederatedMedia).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a per-kind content type when the blob carries no mime', async () => {
+    const getBlob = vi.fn<NodeBlobFetcher>().mockResolvedValue(Buffer.from('gif-bytes'));
+
+    await mirrorNodeBlobsForRecord(makeRecord([{ sha256: 'sha-gif', mediaType: 'gif' }]), OWNER, getBlob);
+
+    expect(storeMock.uploadFederatedMedia).toHaveBeenCalledTimes(1);
+    expect(storeMock.uploadFederatedMedia.mock.calls[0][0].contentType).toBe('image/gif');
+  });
+
+  it('never uses a disallowed mime (e.g. SVG) as the upload content type', async () => {
+    const getBlob = vi.fn<NodeBlobFetcher>().mockResolvedValue(Buffer.from('img'));
+
+    await mirrorNodeBlobsForRecord(
+      makeRecord([{ sha256: 'sha-svg', mediaType: 'image', mime: 'image/svg+xml' }]),
+      OWNER,
+      getBlob,
+    );
+
+    // image/svg+xml is rejected by the media-type policy, so the per-kind default
+    // (image/jpeg) is used instead — never the dangerous SVG content type.
+    expect(storeMock.uploadFederatedMedia).toHaveBeenCalledTimes(1);
+    expect(storeMock.uploadFederatedMedia.mock.calls[0][0].contentType).toBe('image/jpeg');
+  });
+
+  it('never throws when the upload fails (fail-soft per blob)', async () => {
+    const getBlob = vi.fn<NodeBlobFetcher>().mockResolvedValue(Buffer.from('x'));
+    storeMock.uploadFederatedMedia.mockRejectedValue(new Error('upload boom'));
+
+    await expect(
+      mirrorNodeBlobsForRecord(makeRecord([{ sha256: 'sha-img', mediaType: 'image' }]), OWNER, getBlob),
+    ).resolves.toBeUndefined();
+  });
+
+  it('never throws when the node fetch fails (fail-soft per blob)', async () => {
+    const getBlob = vi.fn<NodeBlobFetcher>().mockRejectedValue(new Error('node down'));
+
+    await expect(
+      mirrorNodeBlobsForRecord(makeRecord([{ sha256: 'sha-img', mediaType: 'image' }]), OWNER, getBlob),
+    ).resolves.toBeUndefined();
+    expect(storeMock.uploadFederatedMedia).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for a record with no embed', async () => {
+    const getBlob = vi.fn<NodeBlobFetcher>();
+    const record: MentionPostRecord = { text: 'no media', createdAt: new Date().toISOString() };
+
+    await mirrorNodeBlobsForRecord(record, OWNER, getBlob);
+
+    expect(oxyMock.getServiceAssetMetadataBySha256).not.toHaveBeenCalled();
+    expect(getBlob).not.toHaveBeenCalled();
+    expect(storeMock.uploadFederatedMedia).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/services/mtn/postMaterializer.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/postMaterializer.test.ts
@@ -100,6 +100,20 @@ vi.mock('../../../models/Post', () => ({
 vi.mock('../../../models/Like', () => ({ default: h.Like }));
 vi.mock('../../../models/Bookmark', () => ({ default: h.Bookmark }));
 
+// Mock the service-scoped Oxy client so the read-side blob resolver's REVERSE
+// lookup (`getServiceAssetMetadataBySha256`, sha256 → fileId) is fully
+// controllable and performs no real I/O. Hoisted so it predates the import.
+const oxyMock = vi.hoisted(() => ({
+  getServiceAssetMetadataBySha256: vi.fn<
+    (sha256s: string[]) => Promise<
+      Array<{ sha256: string; id: string; mime: string; size: number; status: 'active' | 'trash'; url?: string }>
+    >
+  >(),
+}));
+vi.mock('../../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => oxyMock,
+}));
+
 import { projectRecord } from '../../../services/mtn/PostMaterializer';
 import { buildUserDid } from '../../../services/mtn/mentionDid';
 import { baselineContentClassifier } from '../../../services/BaselineContentClassifier';
@@ -158,6 +172,10 @@ beforeEach(() => {
   h.Like.findByIdAndDelete.mockClear();
   h.Bookmark.findByIdAndUpdate.mockClear();
   h.Bookmark.findByIdAndDelete.mockClear();
+  // Default: no blob resolves (records without embeds are unaffected). Tests that
+  // exercise the resolver override this per-case.
+  oxyMock.getServiceAssetMetadataBySha256.mockReset();
+  oxyMock.getServiceAssetMetadataBySha256.mockResolvedValue([]);
 });
 
 describe('projectRecord — post', () => {
@@ -274,17 +292,83 @@ describe('projectRecord — post', () => {
     expect(content.media).toEqual([{ id: 'file-abc', type: 'image' }]);
   });
 
-  it('READ-SIDE DEFERRED: a record that CARRIES a blob embed never writes content.media', async () => {
-    // The write side now emits content-addressed blob refs, but the read side
-    // cannot turn a bare sha256 back into a servable fileId/URL (no reverse
-    // upstream index). The materializer must NOT write content.media from the
-    // embed — for a NEW post that means no media key at all (no fake URLs), and
-    // for an existing post the fileId media is preserved (other test below).
+  it('READ-SIDE: resolves a blob embed (sha256) → fileId MediaItem via reverse lookup', async () => {
+    // The write side emits content-addressed blob refs; the read side resolves
+    // each sha256 back to its live Oxy fileId and writes a native content.media
+    // MediaItem, so the post renders through the normal CDN path.
+    oxyMock.getServiceAssetMetadataBySha256.mockResolvedValue([
+      { sha256: 'sha-img', id: 'file-img', mime: 'image/png', size: 42, status: 'active' },
+      { sha256: 'sha-vid', id: 'file-vid', mime: 'video/mp4', size: 99, status: 'active' },
+    ]);
+
     const recordWithEmbed = {
       ...postRecord,
       embed: {
         type: 'media',
-        items: [{ blob: { sha256: 'sha-from-chain', mediaType: 'image', mime: 'image/png', size: 42 } }],
+        items: [
+          { blob: { sha256: 'sha-img', mediaType: 'image', mime: 'image/png', size: 42 }, alt: 'a cat' },
+          { blob: { sha256: 'sha-vid', mediaType: 'video', mime: 'video/mp4', size: 99 } },
+        ],
+      },
+    };
+
+    const result = await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, recordWithEmbed));
+    expect(result).toEqual({ ok: true, kind: 'post', id: POST_RKEY });
+
+    // The reverse lookup is called once with the embed's distinct sha256s.
+    expect(oxyMock.getServiceAssetMetadataBySha256).toHaveBeenCalledTimes(1);
+    expect(oxyMock.getServiceAssetMetadataBySha256).toHaveBeenCalledWith(['sha-img', 'sha-vid']);
+
+    const doc = h.posts.get(POST_RKEY);
+    const content = doc?.content as { text: string; media: Array<{ id: string; type: string; alt?: string }> };
+    expect(content.text).toBe(postRecord.text);
+    // Each blob became a fileId MediaItem (id = resolved fileId, type = mediaType),
+    // order + alt preserved.
+    expect(content.media).toEqual([
+      { id: 'file-img', type: 'image', alt: 'a cat' },
+      { id: 'file-vid', type: 'video' },
+    ]);
+  });
+
+  it('READ-SIDE FAIL-SOFT: an unresolvable sha256 is dropped (no fake URL)', async () => {
+    // Only one of two blobs resolves; the other (unknown/trashed) is omitted by
+    // the upstream batch. The materializer drops it rather than inventing a URL.
+    oxyMock.getServiceAssetMetadataBySha256.mockResolvedValue([
+      { sha256: 'sha-ok', id: 'file-ok', mime: 'image/jpeg', size: 10, status: 'active' },
+      // sha-trash present but trashed → not renderable, treated as unresolvable.
+      { sha256: 'sha-trash', id: 'file-trash', mime: 'image/jpeg', size: 11, status: 'trash' },
+      // sha-missing simply absent from the response.
+    ]);
+
+    const recordWithEmbed = {
+      ...postRecord,
+      embed: {
+        type: 'media',
+        items: [
+          { blob: { sha256: 'sha-ok', mediaType: 'image' } },
+          { blob: { sha256: 'sha-trash', mediaType: 'image' } },
+          { blob: { sha256: 'sha-missing', mediaType: 'image' } },
+        ],
+      },
+    };
+
+    const result = await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, recordWithEmbed));
+    expect(result.ok).toBe(true);
+
+    const doc = h.posts.get(POST_RKEY);
+    const content = doc?.content as { media: Array<{ id: string; type: string }> };
+    // Only the single resolvable, active blob survived.
+    expect(content.media).toEqual([{ id: 'file-ok', type: 'image' }]);
+  });
+
+  it('READ-SIDE FAIL-SOFT: a reverse-lookup error never aborts projection (no media written)', async () => {
+    oxyMock.getServiceAssetMetadataBySha256.mockRejectedValue(new Error('403 forbidden: files:read'));
+
+    const recordWithEmbed = {
+      ...postRecord,
+      embed: {
+        type: 'media',
+        items: [{ blob: { sha256: 'sha-x', mediaType: 'image' } }],
       },
     };
 
@@ -294,8 +378,37 @@ describe('projectRecord — post', () => {
     const doc = h.posts.get(POST_RKEY);
     const content = doc?.content as { text: string; media?: unknown };
     expect(content.text).toBe(postRecord.text);
-    // No media materialized from the blob embed (deferred read side, no fake URL).
+    // Lookup failed → no media materialized, no throw.
     expect(content.media).toBeUndefined();
+  });
+
+  it('READ-SIDE ZERO-REGRESSION: an empty resolution preserves existing fileId media', async () => {
+    // Existing post already carries fileId media. The incoming record carries a
+    // blob embed whose sha256 does NOT resolve → resolver returns [] → the upsert
+    // must NOT write content.media, so the existing media survives.
+    h.posts.set(POST_RKEY, {
+      _id: POST_RKEY,
+      oxyUserId: SUBJECT_OXY_ID,
+      content: { text: 'original', media: [{ id: 'file-existing', type: 'image' }] },
+    });
+    oxyMock.getServiceAssetMetadataBySha256.mockResolvedValue([]); // nothing resolves
+
+    const recordWithEmbed = {
+      ...postRecord,
+      embed: {
+        type: 'media',
+        items: [{ blob: { sha256: 'sha-unresolved', mediaType: 'image' } }],
+      },
+    };
+
+    const result = await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, recordWithEmbed));
+    expect(result.ok).toBe(true);
+
+    const doc = h.posts.get(POST_RKEY);
+    const content = doc?.content as { text: string; media: Array<{ id: string; type: string }> };
+    expect(content.text).toBe(postRecord.text);
+    // Existing fileId media preserved (resolver returned nothing → no write).
+    expect(content.media).toEqual([{ id: 'file-existing', type: 'image' }]);
   });
 
   it('rejects an invalid inner record with reason invalid_record', async () => {

--- a/packages/backend/src/services/mtn/MentionNodeSyncService.ts
+++ b/packages/backend/src/services/mtn/MentionNodeSyncService.ts
@@ -55,21 +55,33 @@
  * unconfigured (dev/pre-prod) witnessing is skipped (logged once) but ingest
  * still proceeds.
  *
- * ## DEFERRED — blob / media sync
+ * ## Blob / media sync
  *
- * A node serves blobs by `sha256`, but Mention has NO reverse `sha256 → fileId`/
- * `url` resolver yet (the same gap that deferred the blob-ref READ side in PR
- * #280). So for an ingested post record whose `embed` carries blob refs, the
- * RECORD + text + thread structure + likes + reposts are materialized fully now;
- * the media BYTES are deferred — `PostMaterializer.resolveEmbedToMedia` is a no-op
- * until the upstream reverse content-address index lands. No fake URL is invented;
- * an existing post's fileId media survives re-projection.
+ * A node serves media bytes by `sha256` (content address); Mention's feed renders
+ * by Oxy `fileId`. For an ingested post record whose `embed` carries blob refs,
+ * the blobs are MIRRORED into Oxy S3 (owned by the record's author) BEFORE
+ * materialization via {@link mirrorNodeBlobsForRecord} — it pulls each
+ * not-yet-resolvable blob's bytes from the node (`NodeClient.getBlob`) and uploads
+ * them through the existing durable federated-media path. After mirroring, the
+ * read-side resolver (`PostMaterializer.resolveEmbedToMedia`) turns each `sha256`
+ * back into a servable `fileId` via the reverse content-address lookup, so the
+ * post renders byte-identically to native media. The mirror is bounded,
+ * background-only, fail-soft, idempotent, and gated on the federated-media write
+ * flag — a blob the node cannot serve (or that fails to mirror) simply yields a
+ * text-only render until a later run; no fake URL is invented.
  */
 
 import { canonicalize, computeRecordId, signMessage } from '@oxyhq/protocol';
 import { NodeClient, type NodeFetch } from '@oxyhq/protocol/node';
 import { safeFetch } from '@oxyhq/core/server';
-import { signedRecordEnvelopeSchema, type SignedRecordEnvelope } from '@oxyhq/contracts';
+import {
+  signedRecordEnvelopeSchema,
+  type SignedRecordEnvelope,
+} from '@oxyhq/contracts';
+import {
+  MENTION_POST_COLLECTION,
+  mentionPostRecordSchema,
+} from '@mention/shared-types';
 import MentionUserNode from '../../models/MentionUserNode';
 import MentionSignedRecord from '../../models/MentionSignedRecord';
 import MentionNodeIngestWitness from '../../models/MentionNodeIngestWitness';
@@ -77,6 +89,8 @@ import { logger } from '../../utils/logger';
 import { getHead, getPublicLogSince } from './MentionRepoLogService';
 import { verifyAndStoreRecord } from './MentionRecordService';
 import { projectRecord } from './PostMaterializer';
+import { mirrorNodeBlobsForRecord, type NodeBlobFetcher } from './mtnNodeBlobMirror';
+import { parseUserDid } from './mentionDid';
 import {
   getMentionCustodialPrivateKey,
   getMentionCustodialPublicKey,
@@ -176,12 +190,33 @@ async function witnessRecord(oxyUserId: string, recordId: string, ingestedAt: nu
 }
 
 /**
+ * Best-effort mirror of an ingested POST record's content-addressed media blobs
+ * from the node into Oxy S3, so the materializer's reverse `sha256 → fileId`
+ * resolver can render them. Runs BEFORE {@link materialize} so the blobs are
+ * resolvable on the first projection. A non-post record, a record without an
+ * embed, or any mirror failure is a clean no-op (the mirror itself never throws).
+ */
+async function mirrorBlobs(envelope: SignedRecordEnvelope, getBlob: NodeBlobFetcher): Promise<void> {
+  if (envelope.collection !== MENTION_POST_COLLECTION) return;
+  const parsed = mentionPostRecordSchema.safeParse(envelope.record);
+  if (!parsed.success || !parsed.data.embed) return;
+  // The subject DID owns the mirrored assets; the materializer resolves the same
+  // owner from the envelope, so reuse the envelope's subject as the oxyUserId.
+  const ownerOxyUserId = parseUserDid(envelope.subject);
+  if (!ownerOxyUserId) return;
+  await mirrorNodeBlobsForRecord(parsed.data, ownerOxyUserId, getBlob);
+}
+
+/**
  * Materialize a verified+stored record into the feed-readable store. Best-effort
  * and non-throwing (the materializer itself never throws); a projection failure
- * is logged but never aborts the ingest run.
+ * is logged but never aborts the ingest run. For a post record carrying media
+ * blobs, the node bytes are mirrored into Oxy S3 FIRST (see {@link mirrorBlobs})
+ * so the post's media resolves on this projection.
  */
-async function materialize(envelope: SignedRecordEnvelope): Promise<void> {
+async function materialize(envelope: SignedRecordEnvelope, getBlob: NodeBlobFetcher): Promise<void> {
   try {
+    await mirrorBlobs(envelope, getBlob);
     const result = await projectRecord(envelope);
     if (!result.ok) {
       logger.debug('MentionNodeSync: projectRecord skipped an ingested record', {
@@ -267,14 +302,19 @@ async function storeForkMirror(env: SignedRecordEnvelope, oxyUserId: string, rec
  * returned {@link IngestOutcome}. `verifyAndStoreRecord` does the heavy lifting
  * (re-verify + atomic append + head advance); its rejection reason routes the
  * record to LWW-skip, fork-preserve, or hard-reject. On any persisted record the
- * envelope is materialized into the feed store + counter-signed.
+ * envelope is materialized into the feed store + counter-signed; `getBlob` lets
+ * the materialize step mirror a post's content-addressed media from the node.
  */
-async function ingestEnvelope(env: SignedRecordEnvelope, oxyUserId: string): Promise<IngestOutcome> {
+async function ingestEnvelope(
+  env: SignedRecordEnvelope,
+  oxyUserId: string,
+  getBlob: NodeBlobFetcher,
+): Promise<IngestOutcome> {
   const result = await verifyAndStoreRecord(env);
 
   if (result.ok) {
     const recordId = result.recordId;
-    await materialize(env);
+    await materialize(env, getBlob);
     await witnessRecord(oxyUserId, recordId, Date.now());
     return { kind: 'appended', seq: typeof result.seq === 'number' ? result.seq : -1, recordId };
   }
@@ -291,7 +331,7 @@ async function ingestEnvelope(env: SignedRecordEnvelope, oxyUserId: string): Pro
         if (incomingWinsLww({ issuedAt: env.issuedAt, recordId }, existing)) {
           const stored = await storeForkMirror(env, oxyUserId, recordId);
           if (stored) {
-            await materialize(env);
+            await materialize(env, getBlob);
             await witnessRecord(oxyUserId, recordId, Date.now());
             logger.info('MentionNodeSync: LWW tiebreak adopted incoming record', {
               oxyUserId,
@@ -315,7 +355,7 @@ async function ingestEnvelope(env: SignedRecordEnvelope, oxyUserId: string): Pro
       const recordId = await computeRecordId(env);
       const stored = await storeForkMirror(env, oxyUserId, recordId);
       if (stored) {
-        await materialize(env);
+        await materialize(env, getBlob);
         await witnessRecord(oxyUserId, recordId, Date.now());
       }
       logger.warn('MentionNodeSync: detected a chain fork; preserved both branches', {
@@ -360,6 +400,10 @@ export async function ingestFromNode(oxyUserId: string): Promise<void> {
     }
 
     const client = makeNodeClient(node.endpoint);
+    // The content-addressed blob fetcher for the materialize step's media mirror.
+    // Bound here so the (untrusted, SSRF-guarded) node transport stays the one
+    // place that talks to the node.
+    const getBlob: NodeBlobFetcher = (sha256) => client.getBlob(sha256);
 
     // Compare the node's head against Mention's local head. When Mention is
     // already at or ahead of the node, there is nothing to pull — stamp the time.
@@ -411,7 +455,7 @@ export async function ingestFromNode(oxyUserId: string): Promise<void> {
           continue;
         }
 
-        const outcome = await ingestEnvelope(env, oxyUserId);
+        const outcome = await ingestEnvelope(env, oxyUserId, getBlob);
         if (outcome.kind === 'appended') {
           cursor = outcome.seq >= 0 ? outcome.seq : cursor;
         } else if (outcome.kind === 'fork') {

--- a/packages/backend/src/services/mtn/PostMaterializer.ts
+++ b/packages/backend/src/services/mtn/PostMaterializer.ts
@@ -16,24 +16,30 @@
  *    the same row (no duplicates, stable classification). Re-runs are safe.
  *  - ZERO-REGRESSION — a post upsert uses a FIELD-SCOPED `$set` of only the fields
  *    the record owns (text, reply, tags, langs, sources, location, …). It NEVER
- *    replaces the whole document, so re-projecting an existing post that already
- *    carries `content.media` fileId items KEEPS that media untouched. The
- *    authoritative native write path is unchanged; media rendering stays
- *    byte-identical (this module never touches `mediaResolver`).
- *  - READ-SIDE BLOB DEFERRED — `record.embed` now CARRIES content-addressed blob
+ *    replaces the whole document, and it only writes `content.media` when the
+ *    embed RESOLVES to ≥1 renderable item (see below), so re-projecting an
+ *    existing post whose `content.media` fileId items would not re-resolve KEEPS
+ *    that media untouched. The authoritative native write path is unchanged; media
+ *    rendering stays byte-identical (URLs are resolved by the existing
+ *    `mediaResolver` at hydration time, exactly as for native fileId media).
+ *  - READ-SIDE BLOB RESOLUTION — `record.embed` carries content-addressed blob
  *    refs (the WRITE side populates `embed[].blob.sha256` via the service SDK).
- *    The READ side cannot turn a bare `sha256` back into a servable URL yet: the
- *    Oxy CDN addresses media by `fileId` (`cloud.oxy.so/<fileId>`), and the only
- *    content-addressing endpoint is the FORWARD `fileId → sha256` lookup
- *    (`/assets/service/by-ids`) — there is NO reverse `sha256 → fileId`/`→ url`
- *    index upstream. A true content-addressed render path therefore needs a new
- *    upstream oxy-api endpoint and lands in a later phase. For the B2 round-trip
- *    (Mention's own records re-projected onto the SAME `rkey` post) this is moot:
- *    the post row already carries its `fileId` `content.media`, and the
- *    field-scoped `$set` below deliberately PRESERVES it. {@link
- *    resolveEmbedToMedia} stays the seam; it returns `[]` so the materializer
- *    NEVER writes `content.media` from a record (so it cannot clobber existing
- *    fileId media to empty). No fake URLs are ever invented.
+ *    The READ side turns each bare `sha256` back into a servable native MediaItem
+ *    with the REVERSE content-address lookup `getServiceAssetMetadataBySha256`
+ *    (core 5.2.0, `POST /assets/service/by-sha256`) — the inverse of the FORWARD
+ *    `fileId → sha256` lookup the write side uses. {@link resolveEmbedToMedia}
+ *    maps each resolvable blob to `{ id: <resolved Oxy fileId>, type, alt? }`, so
+ *    the materialized post's `content.media` renders through the EXISTING
+ *    `getFileDownloadUrl` CDN path EXACTLY like a normal fileId post. FAIL-SOFT: a
+ *    `sha256` with no live asset in our S3 is dropped (the upstream omits
+ *    unknown/trashed hashes), so a record whose blobs are not yet mirrored yields
+ *    fewer/zero items and never a fake URL. ZERO-REGRESSION GUARD: the post upsert
+ *    only writes `content.media` when the resolver produced ≥1 item; an empty
+ *    resolution leaves the field untouched, so the B2 round-trip (Mention's own
+ *    records re-projected onto the SAME `rkey`) keeps its existing fileId media.
+ *    This path matters for records INGESTED from a node whose blobs are
+ *    content-addressed (the node-blob mirror in `MentionNodeSyncService` makes
+ *    those blobs resolvable by `sha256` first).
  *  - NEVER THROWS — any failure (bad subject DID, invalid inner record, DB error)
  *    is wrapped and returned as `{ ok: false, reason }` so the backfill/ingest
  *    caller can log and continue. Validation runs FIRST: the inner `record` is
@@ -60,12 +66,14 @@ import {
   type MentionTombstoneRecord,
   type MentionBookmarkRecord,
   type MtnMediaEmbed,
+  type MediaItem,
 } from '@mention/shared-types';
 import { PostType, PostVisibility } from '@mention/shared-types';
 import { Post, POST_CLASSIFICATION_PENDING } from '../../models/Post';
 import Like from '../../models/Like';
 import Bookmark from '../../models/Bookmark';
 import { logger } from '../../utils/logger';
+import { getServiceOxyClient } from '../../utils/oxyHelpers';
 import { parseUserDid } from './mentionDid';
 import { baselineContentClassifier } from '../BaselineContentClassifier';
 
@@ -82,24 +90,82 @@ export type ProjectResult =
   | { ok: false; reason: string };
 
 /**
- * Resolve a record `embed` (content-addressed blob refs) to the native
- * `content.media` MediaItem shape.
+ * Resolve a record `embed` (content-addressed blob refs) to native
+ * `content.media` MediaItems by REVERSE content-address lookup.
  *
- * READ-SIDE SEAM — DEFERRED: the WRITE side now emits real `embed[].blob.sha256`,
- * but turning a bare `sha256` back into a renderable MediaItem (a servable
- * `fileId`/URL) requires a REVERSE content-address lookup (`sha256 → fileId`/
- * `→ url`) that the Oxy CDN/oxy-api/core do NOT expose — core 5.1.0 ships only
- * the FORWARD `fileId → sha256` lookup (`/assets/service/by-ids`). Until that
- * upstream endpoint lands, this returns `[]` for ANY embed — the materializer
- * therefore NEVER writes `content.media` from a record, which also guarantees it
- * cannot clobber an existing post's fileId media to empty (the B2 round-trip
- * keeps the post's own fileId media). No fake/guessed URL is ever produced.
+ * Each `embed.items[].blob.sha256` is batch-resolved through the service-scoped
+ * SDK's `getServiceAssetMetadataBySha256` (core 5.2.0, `POST
+ * /assets/service/by-sha256`) — the inverse of the write side's forward
+ * `fileId → sha256` lookup. Every blob that resolves to a LIVE (`status:'active'`)
+ * asset becomes a `MediaItem` whose `id` is the resolved Oxy `fileId` and whose
+ * `type` is the lexicon `mediaType` (the two enums are identical), preserving the
+ * embed's order and `alt` text. The materialized post's `content.media` then
+ * renders through the EXISTING `getFileDownloadUrl`/`mediaResolver` CDN path
+ * exactly like a normal fileId post — no new render path, no fake URL.
+ *
+ * FAIL-SOFT — NEVER THROWS:
+ *  - No embed / empty items → `[]` (the caller then leaves `content.media`
+ *    untouched, preserving any existing fileId media).
+ *  - A `sha256` with no live asset in our S3 (unknown/trashed — the upstream
+ *    omits these from the batch) is simply DROPPED, never placeholdered with a
+ *    guessed URL. A record whose blobs are not yet mirrored yields fewer/zero
+ *    items rather than failing.
+ *  - Any lookup error (e.g. a `files:read`-scope 403 on the federation
+ *    credential) is logged and yields `[]`, so a media-resolution failure can
+ *    never abort projection.
  */
-function resolveEmbedToMedia(_embed: MtnMediaEmbed | undefined): [] {
-  // Replace with sha256 → fileId resolution once the upstream reverse
-  // content-address endpoint exists, then map each resolved file to a MediaItem
-  // ({ id, type }). Intentionally a no-op today (see the READ-SIDE SEAM note).
-  return [];
+async function resolveEmbedToMedia(embed: MtnMediaEmbed | undefined): Promise<MediaItem[]> {
+  if (!embed || !Array.isArray(embed.items) || embed.items.length === 0) {
+    return [];
+  }
+
+  // Collect the distinct content addresses to resolve (preserve item order for
+  // the output; the lookup itself is order-independent and deduped).
+  const sha256s = Array.from(
+    new Set(
+      embed.items
+        .map((item) => item.blob?.sha256)
+        .filter((sha): sha is string => typeof sha === 'string' && sha.length > 0),
+    ),
+  );
+  if (sha256s.length === 0) {
+    return [];
+  }
+
+  try {
+    const metadata = await getServiceOxyClient().getServiceAssetMetadataBySha256(sha256s);
+    // sha256 → live fileId. Only `active` assets are renderable; a `trash` asset
+    // is dropped (treated as unresolvable) rather than linked to a dead file.
+    const fileIdBySha = new Map<string, string>();
+    for (const entry of metadata) {
+      if (entry.status === 'active' && typeof entry.id === 'string' && entry.id.length > 0) {
+        fileIdBySha.set(entry.sha256, entry.id);
+      }
+    }
+
+    const media: MediaItem[] = [];
+    for (const item of embed.items) {
+      const sha = item.blob?.sha256;
+      if (typeof sha !== 'string' || sha.length === 0) continue;
+      const fileId = fileIdBySha.get(sha);
+      // Unresolvable blob (not in our S3 / trashed): drop it — no fake URL.
+      if (!fileId) continue;
+      const resolved: MediaItem = { id: fileId, type: item.blob.mediaType };
+      if (typeof item.alt === 'string' && item.alt.length > 0) {
+        resolved.alt = item.alt;
+      }
+      media.push(resolved);
+    }
+    return media;
+  } catch (error) {
+    // Best-effort: a failed reverse lookup must never abort projection. Leave the
+    // post's existing media untouched (the caller skips the empty write).
+    logger.warn('PostMaterializer: resolveEmbedToMedia failed; projecting without record media', {
+      sha256Count: sha256s.length,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
 }
 
 /**
@@ -175,9 +241,11 @@ function buildClassificationFields(record: MentionPostRecord): Record<string, un
 
 /**
  * Project an `app.mention.feed.post` record into a `Post` row, upserted by
- * `_id = rkey`. Only the fields the record OWNS are `$set` (text/reply/tags/…);
- * `content.media` is never written here (BLOB DEFERRED), so an existing post's
- * fileId media survives re-projection.
+ * `_id = rkey`. Only the fields the record OWNS are `$set` (text/reply/tags/…).
+ * `content.media` is written ONLY when the record's content-addressed `embed`
+ * RESOLVES to ≥1 live MediaItem ({@link resolveEmbedToMedia}); an empty
+ * resolution leaves the field untouched, so an existing post's fileId media
+ * survives re-projection (zero-regression guard).
  */
 async function projectPost(
   rkey: string,
@@ -197,8 +265,6 @@ async function projectPost(
 
   const tags = Array.isArray(record.tags) ? [...record.tags] : [];
 
-  // `content.*` paths the record owns. NOTE: `content.media` is intentionally
-  // ABSENT (BLOB DEFERRED) so an upsert never clobbers existing fileId media.
   const set: Record<string, unknown> = {
     oxyUserId,
     type: PostType.TEXT,
@@ -211,6 +277,15 @@ async function projectPost(
 
   if (record.langs?.[0]) {
     set.language = record.langs[0];
+  }
+
+  // `content.media`: reverse-resolve the content-addressed blob embed to native
+  // fileId MediaItems. Only set the path when ≥1 blob resolved — an empty result
+  // (no embed, or blobs not yet in our S3) is intentionally OMITTED so the upsert
+  // never clobbers an existing post's fileId media to empty.
+  const media = await resolveEmbedToMedia(record.embed);
+  if (media.length > 0) {
+    set['content.media'] = media;
   }
 
   // `content.sources`: map the record's source links to the native shape.

--- a/packages/backend/src/services/mtn/mentionNodes.constants.ts
+++ b/packages/backend/src/services/mtn/mentionNodes.constants.ts
@@ -59,6 +59,32 @@ export const MENTION_NODE_INGEST_FETCH_TIMEOUT_MS = 8_000;
 /** Max bytes read from a single `/oxy/log` response before the stream is cut. */
 export const MENTION_NODE_INGEST_MAX_BYTES = 2 * 1024 * 1024; // 2 MiB
 
+/* -------------------------------------------------------------------------- */
+/*  Node-blob mirror (content-addressed media bytes node → Oxy S3)            */
+/* -------------------------------------------------------------------------- */
+
+const BYTES_PER_MIB = 1024 * 1024;
+
+/**
+ * Max media items per ingested post record we will attempt to mirror from the
+ * node. Bounds the per-record fetch+upload work so a single hostile/oversized
+ * record can never balloon a background ingest run. A normal post carries a
+ * handful of media items; this is a generous ceiling.
+ */
+export const MENTION_NODE_BLOB_MIRROR_MAX_ITEMS = 8;
+
+/**
+ * Max bytes of a single blob we will pull from a node and mirror into Oxy S3.
+ * Matches the federated media cache's video ceiling so node-sourced video is
+ * treated identically to ActivityPub video. A blob whose advertised `size` (or
+ * fetched byte length) exceeds this is skipped (left unresolvable → no media,
+ * never a partial/oversized upload).
+ */
+export const MENTION_NODE_BLOB_MIRROR_MAX_BYTES = 200 * BYTES_PER_MIB;
+
+/** Time-to-first-byte deadline for a single `getBlob` fetch from a node. */
+export const MENTION_NODE_BLOB_FETCH_TIMEOUT_MS = 15_000;
+
 /** Records pushed per export batch (bounds the outbound working set). */
 export const MENTION_NODE_EXPORT_BATCH = 100;
 

--- a/packages/backend/src/services/mtn/mtnNodeBlobMirror.ts
+++ b/packages/backend/src/services/mtn/mtnNodeBlobMirror.ts
@@ -1,0 +1,250 @@
+/**
+ * MTN node-blob mirror — makes a content-addressed media blob from an INGESTED
+ * record resolvable in Oxy S3.
+ *
+ * A `mention-node` serves media bytes by `sha256` (content address). Mention's
+ * feed renders by Oxy `fileId` (`cloud.oxy.so/<fileId>`), and the read-side
+ * resolver ({@link import('./PostMaterializer').resolveEmbedToMedia}) turns a
+ * blob `sha256` back into a `fileId` via the REVERSE lookup
+ * `getServiceAssetMetadataBySha256`. That lookup only finds a blob that already
+ * lives in OUR S3. For a record ingested from a node whose blobs are
+ * content-addressed (not yet in our S3), this module pulls the bytes from the
+ * node ONCE and mirrors them into Oxy S3 — owned by the record's author — via the
+ * EXISTING durable federated-media upload path. After mirroring, the SAME bytes
+ * (identical `sha256`) are resolvable, so the resolver produces a fileId and the
+ * post renders byte-identically to native media. No new render path; no fake URL.
+ *
+ * ## Invariants
+ *  - BACKGROUND-ONLY: runs exclusively in the node ingest worker
+ *    (`MentionNodeSyncService`), NEVER on a request/read path. A down/slow node
+ *    only leaves media unmirrored (the post renders text-only until a later run);
+ *    it never slows a reader.
+ *  - BOUNDED: at most {@link MENTION_NODE_BLOB_MIRROR_MAX_ITEMS} blobs per record,
+ *    each ≤ {@link MENTION_NODE_BLOB_MIRROR_MAX_BYTES}. A single record can never
+ *    balloon a run.
+ *  - FAIL-SOFT — NEVER THROWS: every step (existence check, node fetch, temp-file
+ *    write, upload) is best-effort per blob. Any failure is logged and that blob
+ *    is left unresolvable (no media materialized for it) — projection still
+ *    succeeds with whatever resolved.
+ *  - IDEMPOTENT: a blob already present in our S3 (active asset) is skipped before
+ *    any fetch, so re-ingesting a record never re-uploads. Oxy dedupes by `sha256`
+ *    upstream, so even a race converges to one asset.
+ *  - GATED: when the federated-media write side is disabled
+ *    (`FEDERATION_MEDIA_CACHE_WRITE_ENABLED` ≠ `'true'`) this is a clean no-op — no
+ *    node fetch, no temp files, no upload traffic.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { MentionPostRecord, MtnEmbedMediaItem } from '@mention/shared-types';
+import { getServiceOxyClient } from '../../utils/oxyHelpers';
+import { logger } from '../../utils/logger';
+import { isMediaCacheEnabled, uploadFederatedMedia } from '../mediaCache/oxyMediaStore';
+import { isAllowedMediaType } from '../mediaCache/mediaTypes';
+import {
+  MENTION_NODE_BLOB_MIRROR_MAX_ITEMS,
+  MENTION_NODE_BLOB_MIRROR_MAX_BYTES,
+} from './mentionNodes.constants';
+
+/** Fetch a content-addressed blob's bytes by `sha256`; `null` when the node has none. */
+export type NodeBlobFetcher = (sha256: string) => Promise<Buffer | null>;
+
+/** Per-`mediaType` fallback content-type when the blob ref carries no `mime`. */
+const DEFAULT_CONTENT_TYPE: Record<MtnEmbedMediaItem['blob']['mediaType'], string> = {
+  image: 'image/jpeg',
+  video: 'video/mp4',
+  gif: 'image/gif',
+};
+
+/** Temp-dir prefix for node-blob mirror downloads (under the OS tmpdir). */
+const TEMP_DIR_PREFIX = 'mtn-node-blob-';
+
+/** The Oxy asset metadata `app` tag so mirrored node blobs are attributable. */
+const MIRROR_OXY_APP = 'mention-node-blob-mirror' as const;
+
+/**
+ * Resolve the content-type to send for a blob: its declared `mime` when present
+ * AND policy-allowed (image/video/audio family, never SVG), else the per-kind
+ * default. Returns `null` when even the default is somehow disallowed (never
+ * happens for the three media kinds, but keeps the contract total).
+ */
+function resolveContentType(blob: MtnEmbedMediaItem['blob']): string | null {
+  if (typeof blob.mime === 'string' && blob.mime.length > 0) {
+    const family = blob.mime.split(';')[0].trim().toLowerCase();
+    if (isAllowedMediaType(family)) return family;
+  }
+  const fallback = DEFAULT_CONTENT_TYPE[blob.mediaType];
+  return isAllowedMediaType(fallback) ? fallback : null;
+}
+
+/**
+ * The distinct, in-bounds blobs of a post record that are candidates for
+ * mirroring: deduped by `sha256`, capped at {@link
+ * MENTION_NODE_BLOB_MIRROR_MAX_ITEMS}, with any blob whose advertised `size`
+ * already exceeds {@link MENTION_NODE_BLOB_MIRROR_MAX_BYTES} dropped up front
+ * (before any fetch).
+ */
+function candidateBlobs(record: MentionPostRecord): MtnEmbedMediaItem['blob'][] {
+  const items = record.embed?.items;
+  if (!Array.isArray(items) || items.length === 0) return [];
+
+  const seen = new Set<string>();
+  const out: MtnEmbedMediaItem['blob'][] = [];
+  for (const item of items) {
+    const blob = item?.blob;
+    if (!blob || typeof blob.sha256 !== 'string' || blob.sha256.length === 0) continue;
+    if (seen.has(blob.sha256)) continue;
+    // Drop an over-cap blob before fetching its bytes.
+    if (typeof blob.size === 'number' && Number.isFinite(blob.size) && blob.size > MENTION_NODE_BLOB_MIRROR_MAX_BYTES) {
+      continue;
+    }
+    seen.add(blob.sha256);
+    out.push(blob);
+    if (out.length >= MENTION_NODE_BLOB_MIRROR_MAX_ITEMS) break;
+  }
+  return out;
+}
+
+/**
+ * The subset of `sha256s` that are NOT already resolvable as a LIVE asset in our
+ * S3. Done with ONE batched reverse lookup so an already-mirrored record makes a
+ * single call and fetches nothing. A lookup failure is treated as "all
+ * unresolved" so a transient error never blocks a first mirror (Oxy dedupes by
+ * `sha256`, so a redundant upload is harmless).
+ */
+async function unresolvedSha256s(sha256s: string[]): Promise<Set<string>> {
+  const unresolved = new Set(sha256s);
+  if (sha256s.length === 0) return unresolved;
+  try {
+    const metadata = await getServiceOxyClient().getServiceAssetMetadataBySha256(sha256s);
+    for (const entry of metadata) {
+      if (entry.status === 'active' && typeof entry.sha256 === 'string') {
+        unresolved.delete(entry.sha256);
+      }
+    }
+  } catch (error) {
+    logger.debug('mtnNodeBlobMirror: existence pre-check failed; treating all blobs as unresolved', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return unresolved;
+}
+
+/**
+ * Fetch one blob's bytes from the node and mirror them into Oxy S3 owned by
+ * `ownerOxyUserId`. Best-effort: returns silently on any miss/failure (logged at
+ * debug/warn) — NEVER throws.
+ */
+async function mirrorOneBlob(
+  blob: MtnEmbedMediaItem['blob'],
+  ownerOxyUserId: string,
+  getBlob: NodeBlobFetcher,
+): Promise<void> {
+  const contentType = resolveContentType(blob);
+  if (!contentType) {
+    logger.debug('mtnNodeBlobMirror: skipping blob with disallowed content type', {
+      sha256: blob.sha256,
+      mediaType: blob.mediaType,
+    });
+    return;
+  }
+
+  let bytes: Buffer | null;
+  try {
+    bytes = await getBlob(blob.sha256);
+  } catch (error) {
+    logger.debug('mtnNodeBlobMirror: node getBlob failed (non-fatal)', {
+      sha256: blob.sha256,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  if (!bytes || bytes.length === 0) {
+    // The node does not (yet) hold these bytes — leave the blob unresolvable.
+    return;
+  }
+  // Enforce the byte cap against the ACTUAL fetched length (the advertised `size`
+  // was only a hint and was checked earlier as a fast-path).
+  if (bytes.length > MENTION_NODE_BLOB_MIRROR_MAX_BYTES) {
+    logger.debug('mtnNodeBlobMirror: blob exceeds max bytes; skipping', {
+      sha256: blob.sha256,
+      bytes: bytes.length,
+    });
+    return;
+  }
+
+  const dir = await mkdtemp(join(tmpdir(), TEMP_DIR_PREFIX)).catch(() => null);
+  if (!dir) {
+    logger.warn('mtnNodeBlobMirror: failed to create temp dir; skipping blob', { sha256: blob.sha256 });
+    return;
+  }
+  try {
+    const filePath = join(dir, blob.sha256);
+    await writeFile(filePath, bytes);
+    await uploadFederatedMedia({
+      filePath,
+      contentType,
+      sizeBytes: bytes.length,
+      ownerUserId: ownerOxyUserId,
+      metadata: { app: MIRROR_OXY_APP, sha256: blob.sha256, mediaType: blob.mediaType },
+    });
+    logger.debug('mtnNodeBlobMirror: mirrored node blob into Oxy S3', {
+      sha256: blob.sha256,
+      ownerOxyUserId,
+      bytes: bytes.length,
+      contentType,
+    });
+  } catch (error) {
+    // A disabled write side, a 403, or any upload failure must never abort ingest.
+    logger.warn('mtnNodeBlobMirror: failed to mirror node blob (non-fatal)', {
+      sha256: blob.sha256,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+/**
+ * Mirror the not-yet-resolvable media blobs of an ingested post record from the
+ * node into Oxy S3, so the read-side resolver can later turn each `sha256` into a
+ * servable `fileId`. Bounded, background-only, fail-soft, idempotent, gated.
+ *
+ * @param record   The verified post record being ingested.
+ * @param ownerOxyUserId The record author's oxyUserId — the owner of the mirrored
+ *                       assets in Oxy S3.
+ * @param getBlob  The node's content-addressed blob fetcher (`NodeClient.getBlob`).
+ */
+export async function mirrorNodeBlobsForRecord(
+  record: MentionPostRecord,
+  ownerOxyUserId: string,
+  getBlob: NodeBlobFetcher,
+): Promise<void> {
+  // Gate: when the federated-media write side is off, do nothing at all (no node
+  // fetch, no temp files) — exactly like the rest of the durable media path.
+  if (!isMediaCacheEnabled()) return;
+
+  const blobs = candidateBlobs(record);
+  if (blobs.length === 0) return;
+
+  try {
+    const unresolved = await unresolvedSha256s(blobs.map((b) => b.sha256));
+    const toMirror = blobs.filter((b) => unresolved.has(b.sha256));
+    if (toMirror.length === 0) return; // every blob already in our S3 (idempotent)
+
+    // Sequential: ingest is already bounded + background, and serial keeps node /
+    // upload pressure modest (a node is untrusted, possibly slow, transport).
+    for (const blob of toMirror) {
+      await mirrorOneBlob(blob, ownerOxyUserId, getBlob);
+    }
+  } catch (error) {
+    // Defensive: the per-blob path already swallows its errors, but never let a
+    // programming error here escape into the ingest worker.
+    logger.warn('mtnNodeBlobMirror: mirrorNodeBlobsForRecord encountered an error (non-fatal)', {
+      ownerOxyUserId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds sha256-based reverse lookup for blob read-side in the MTN feed layer
- Implements `mtnNodeBlobMirror` service for node-blob ingest mirroring
- Updates `MentionNodeSyncService`, `PostMaterializer`, and `mentionNodes.constants` to support core 5.2.0 blob protocol

## Test plan
- [ ] `postMaterializer.test.ts` — verify post materialization with blob read-side
- [ ] `mentionNodeSync.test.ts` — verify node sync service with updated blob handling
- [ ] `mtnNodeBlobMirror.test.ts` — verify node-blob ingest mirror service

🤖 Generated with [Claude Code](https://claude.com/claude-code)