### PR TITLE
chore(federation): backfill existing federated actor banners + extract mirror helper

### DIFF
--- a/packages/backend/src/__tests__/connectors/mirrorFederatedBanner.test.ts
+++ b/packages/backend/src/__tests__/connectors/mirrorFederatedBanner.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `mirrorFederatedBanner` — the extracted, network-neutral banner-mirror helper
+ * shared by the live actor-resolution path (`resolveOxyExternalUser`) and the
+ * one-shot `backfillFederatedBanners` script. Asserts it goes through the SAME
+ * service-token public-upload path as federated post media
+ * (`persistRemoteMediaForFederatedOwnerDetailed`) and writes
+ * `UserSettings.profileHeaderImage` only on success.
+ */
+
+const mocks = vi.hoisted(() => ({
+  persistRemoteMedia: vi.fn(),
+  userSettingsUpdateOne: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock('../../services/mediaCache/cacheWorker', () => ({
+  persistRemoteMediaForFederatedOwnerDetailed: mocks.persistRemoteMedia,
+}));
+
+vi.mock('../../models/UserSettings', () => ({
+  default: {
+    updateOne: mocks.userSettingsUpdateOne,
+  },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: mocks.loggerWarn, error: vi.fn(), debug: vi.fn() },
+}));
+
+import { mirrorFederatedBanner } from '../../connectors/identity';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.userSettingsUpdateOne.mockResolvedValue({ acknowledged: true });
+});
+
+describe('mirrorFederatedBanner', () => {
+  it('mirrors the banner and stores its file id on success', async () => {
+    mocks.persistRemoteMedia.mockResolvedValue({
+      ok: true,
+      media: { oxyFileId: 'banner_file_1', contentType: 'image/png', sizeBytes: 1234 },
+    });
+
+    const stored = await mirrorFederatedBanner(
+      'https://files.mastodon.social/banner.png',
+      'oxy-user-1',
+      'https://mastodon.social/users/alice',
+    );
+
+    expect(stored).toBe(true);
+    // Goes through the SAME service-token public-upload path as federated post
+    // media — NOT the user-authenticated SDK `uploadProfileBanner` (which 401s).
+    expect(mocks.persistRemoteMedia).toHaveBeenCalledWith(
+      'https://files.mastodon.social/banner.png',
+      'oxy-user-1',
+      expect.objectContaining({
+        role: 'banner',
+        actorUri: 'https://mastodon.social/users/alice',
+        remoteHost: 'files.mastodon.social',
+      }),
+    );
+    expect(mocks.userSettingsUpdateOne).toHaveBeenCalledWith(
+      { oxyUserId: 'oxy-user-1' },
+      { $set: { profileHeaderImage: 'banner_file_1' } },
+      { upsert: true },
+    );
+  });
+
+  it('warns and returns false on a transient mirror failure (no header stored)', async () => {
+    mocks.persistRemoteMedia.mockResolvedValue({ ok: false, permanent: false, reason: 'upstream-error' });
+
+    const stored = await mirrorFederatedBanner(
+      'https://files.mastodon.social/banner.png',
+      'oxy-user-2',
+      'https://mastodon.social/users/bob',
+    );
+
+    expect(stored).toBe(false);
+    expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      'Failed to mirror banner for https://mastodon.social/users/bob',
+      expect.objectContaining({ reason: 'upstream-error', remoteHost: 'files.mastodon.social' }),
+    );
+  });
+
+  it('stays quiet and returns false on a permanent mirror failure', async () => {
+    mocks.persistRemoteMedia.mockResolvedValue({ ok: false, permanent: true, reason: 'not-media' });
+
+    const stored = await mirrorFederatedBanner(
+      'https://files.mastodon.social/banner.txt',
+      'oxy-user-3',
+      'https://mastodon.social/users/carol',
+    );
+
+    expect(stored).toBe(false);
+    expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('guards a non-http url without touching the media path', async () => {
+    const stored = await mirrorFederatedBanner(
+      'data:image/png;base64,iVBORw0KGgo=',
+      'oxy-user-4',
+      'https://mastodon.social/users/dave',
+    );
+
+    expect(stored).toBe(false);
+    expect(mocks.persistRemoteMedia).not.toHaveBeenCalled();
+    expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/connectors/identity.ts
+++ b/packages/backend/src/connectors/identity.ts
@@ -61,41 +61,8 @@ export async function resolveOxyExternalUser(
     const oxyId = String(oxyUser?._id || oxyUser?.id || '');
     if (!oxyId) return null;
 
-    // Mirror the remote banner into a durable, PUBLIC Oxy asset, then store its
-    // file id in Mention's per-user `UserSettings.profileHeaderImage` (the same
-    // field a LOCAL user's banner uses, read back by the profile-design
-    // endpoint). This reuses the canonical federated-media path
-    // (`persistRemoteMediaForFederatedOwnerDetailed` →
-    // `POST /assets/service/federation`): SSRF-safe download → streamed upload as
-    // a public, CDN-reachable file owned by the resolved federated user — the
-    // SAME service-token flow that already mirrors federated post media and the
-    // avatar (downloaded server-side by oxy-api). It deliberately does NOT use the
-    // SDK's `uploadProfileBanner`, which routes through the USER-authenticated
-    // `POST /assets/upload` and is rejected `401 UNAUTHORIZED` on the service
-    // client, so the banner was never stored.
-    if (actor.bannerUrl && isAbsoluteHttpUrl(actor.bannerUrl)) {
-      const result = await persistRemoteMediaForFederatedOwnerDetailed(actor.bannerUrl, oxyId, {
-        role: 'banner',
-        actorUri: actor.externalId,
-        remoteHost: getRemoteHost(actor.bannerUrl),
-      });
-      if (result.ok) {
-        await UserSettings.updateOne(
-          { oxyUserId: oxyId },
-          { $set: { profileHeaderImage: result.media.oxyFileId } },
-          { upsert: true },
-        );
-      } else if (!result.permanent) {
-        // Surface transient failures (bad service credential, upstream 5xx,
-        // upload rejection) at `warn` — a silent `debug` previously hid a total
-        // outage where 0 federated banners were ever stored. Permanently
-        // unavailable banners (dead/oversized/non-image) are expected and stay
-        // quiet, mirroring `materializeFederatedMedia`.
-        logger.warn(`Failed to mirror banner for ${actor.externalId}`, {
-          reason: result.reason,
-          remoteHost: getRemoteHost(actor.bannerUrl),
-        });
-      }
+    if (actor.bannerUrl) {
+      await mirrorFederatedBanner(actor.bannerUrl, oxyId, actor.externalId);
     }
 
     return oxyId;
@@ -103,4 +70,66 @@ export async function resolveOxyExternalUser(
     logger.warn(`Failed to resolve Oxy user for ${actor.externalId}:`, resolveErr);
     return null;
   }
+}
+
+/**
+ * Mirror a federated actor's remote banner into a durable, PUBLIC Oxy asset, then
+ * store its file id in Mention's per-user `UserSettings.profileHeaderImage` (the
+ * same field a LOCAL user's banner uses, read back by the profile-design
+ * endpoint). This reuses the canonical federated-media path
+ * (`persistRemoteMediaForFederatedOwnerDetailed` →
+ * `POST /assets/service/federation`): SSRF-safe download → streamed upload as a
+ * public, CDN-reachable file owned by the resolved federated user — the SAME
+ * service-token flow that already mirrors federated post media and the avatar
+ * (downloaded server-side by oxy-api). It deliberately does NOT use the SDK's
+ * `uploadProfileBanner`, which routes through the USER-authenticated
+ * `POST /assets/upload` and is rejected `401 UNAUTHORIZED` on the service client,
+ * so the banner was never stored.
+ *
+ * Best-effort: returns `true` when the banner was stored, `false` otherwise
+ * (non-http url, mirror failure, or transient/permanent persist failure).
+ * Transient failures are surfaced at `warn`; permanently-unavailable banners
+ * (dead/oversized/non-image) stay quiet, mirroring `materializeFederatedMedia`.
+ *
+ * Shared by the live actor-resolution path (`resolveOxyExternalUser`) and the
+ * one-shot `backfillFederatedBanners` script so both go through ONE
+ * implementation.
+ */
+export async function mirrorFederatedBanner(
+  bannerUrl: string,
+  oxyUserId: string,
+  actorUri: string,
+): Promise<boolean> {
+  if (!isAbsoluteHttpUrl(bannerUrl)) {
+    return false;
+  }
+
+  const remoteHost = getRemoteHost(bannerUrl);
+  const result = await persistRemoteMediaForFederatedOwnerDetailed(bannerUrl, oxyUserId, {
+    role: 'banner',
+    actorUri,
+    remoteHost,
+  });
+
+  if (result.ok) {
+    await UserSettings.updateOne(
+      { oxyUserId },
+      { $set: { profileHeaderImage: result.media.oxyFileId } },
+      { upsert: true },
+    );
+    return true;
+  }
+
+  if (!result.permanent) {
+    // Surface transient failures (bad service credential, upstream 5xx, upload
+    // rejection) at `warn` — a silent `debug` previously hid a total outage where
+    // 0 federated banners were ever stored. Permanently unavailable banners
+    // (dead/oversized/non-image) are expected and stay quiet.
+    logger.warn(`Failed to mirror banner for ${actorUri}`, {
+      reason: result.reason,
+      remoteHost,
+    });
+  }
+
+  return false;
 }

--- a/packages/backend/src/scripts/backfillFederatedBanners.ts
+++ b/packages/backend/src/scripts/backfillFederatedBanners.ts
@@ -1,0 +1,196 @@
+/**
+ * One-shot backfill: mirror header/banner images for ALREADY-imported federated
+ * actors.
+ *
+ * #285 wired `resolveOxyExternalUser` to mirror a federated actor's banner into a
+ * durable, PUBLIC Oxy asset (service-token media path) and store the file id on
+ * `UserSettings.profileHeaderImage` — but only NEW actor resolutions get a banner
+ * from then on. The ~15k EXISTING federated actors never re-resolve, so their
+ * profiles stay banner-less until this runs.
+ *
+ * This script walks every `FederatedActor` that advertises a `headerUrl` and is
+ * already linked to an Oxy user (`oxyUserId` set), and mirrors that banner
+ * through the SAME `mirrorFederatedBanner` helper the live path uses (banner-only:
+ * no full re-resolve, no re-PUT of `/users/resolve`). It is idempotent — by
+ * default it SKIPS actors whose `UserSettings.profileHeaderImage` is already set,
+ * so a re-run only fills the gaps. Set `BACKFILL_FORCE=true` to re-mirror every
+ * actor regardless (e.g. to refresh stale banners).
+ *
+ * Throttled with a bounded worker pool (default 6; `BACKFILL_CONCURRENCY`) so we
+ * neither hammer remote instances nor the Oxy asset API. Logs progress plus a
+ * final summary (processed / stored / skipped-already-set / failed) and is
+ * resumable via the idempotent skip check.
+ *
+ * Runnable as a Fargate one-shot post-deploy:
+ *   bun packages/backend/dist/src/scripts/backfillFederatedBanners.js
+ *   BACKFILL_FORCE=true bun packages/backend/dist/src/scripts/backfillFederatedBanners.js
+ *   BACKFILL_CONCURRENCY=10 bun packages/backend/dist/src/scripts/backfillFederatedBanners.js
+ */
+
+import mongoose from 'mongoose';
+import { connectToDatabase } from '../utils/database';
+import { FederatedActor } from '../models/FederatedActor';
+import UserSettings from '../models/UserSettings';
+import { mirrorFederatedBanner } from '../connectors/identity';
+import { logger } from '../utils/logger';
+
+/** Actors scanned per page (stable ascending `_id` cursor pagination). */
+const PAGE_SIZE = 500;
+
+/** Re-mirror every actor's banner, even when one is already stored. */
+const FORCE = process.env.BACKFILL_FORCE === 'true';
+
+/**
+ * Bounded fan-out of concurrent mirror operations. Each mirror is a remote
+ * download + a service-token upload, so the cap keeps us from hammering remote
+ * instances or the Oxy asset API.
+ */
+function getConcurrency(): number {
+  const raw = Number.parseInt(process.env.BACKFILL_CONCURRENCY || '', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 6;
+}
+
+interface FederatedActorRow {
+  _id: mongoose.Types.ObjectId;
+  uri: string;
+  headerUrl: string;
+  oxyUserId: string;
+}
+
+interface BackfillCounters {
+  processed: number;
+  stored: number;
+  skippedAlreadySet: number;
+  failed: number;
+}
+
+/**
+ * Mirror one actor's banner (unless its header image is already stored and we are
+ * not forcing). Mutates `counters` in place — called concurrently within a
+ * bounded pool, but each branch touches a distinct counter increment on the
+ * single-threaded event loop, so no synchronization is needed.
+ */
+async function processActor(actor: FederatedActorRow, counters: BackfillCounters): Promise<void> {
+  if (!FORCE) {
+    const existing = await UserSettings.findOne(
+      { oxyUserId: actor.oxyUserId },
+      { profileHeaderImage: 1 },
+    ).lean<{ profileHeaderImage?: string } | null>();
+    if (existing?.profileHeaderImage) {
+      counters.skippedAlreadySet += 1;
+      return;
+    }
+  }
+
+  try {
+    const stored = await mirrorFederatedBanner(actor.headerUrl, actor.oxyUserId, actor.uri);
+    if (stored) {
+      counters.stored += 1;
+    } else {
+      counters.failed += 1;
+    }
+  } catch (error) {
+    counters.failed += 1;
+    logger.warn(`[backfillFederatedBanners] mirror threw for ${actor.uri}`, {
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+  }
+}
+
+/**
+ * Run `worker` over `items` with at most `concurrency` in flight at once.
+ */
+async function runPool<T>(items: T[], concurrency: number, worker: (item: T) => Promise<void>): Promise<void> {
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      await worker(items[index]);
+    }
+  });
+  await Promise.all(runners);
+}
+
+async function backfillFederatedBanners(): Promise<void> {
+  const startedAt = Date.now();
+  const concurrency = getConcurrency();
+
+  try {
+    await connectToDatabase();
+    logger.info(
+      `[backfillFederatedBanners] connected to MongoDB; FORCE=${FORCE}, concurrency=${concurrency}`,
+    );
+
+    // Actors that advertise a banner AND are linked to an Oxy user (so the banner
+    // has an owner to upload it under). `oxyUserId` is sparse-indexed; the set is
+    // immutable for this run (we only write `UserSettings`, never the actor), so
+    // the ascending `_id` cursor never revisits a row.
+    const baseFilter: Record<string, unknown> = {
+      headerUrl: { $type: 'string', $ne: '' },
+      oxyUserId: { $type: 'string', $ne: '' },
+    };
+
+    const totalCount = await FederatedActor.countDocuments(baseFilter);
+    logger.info(`[backfillFederatedBanners] ${totalCount} federated actors with a banner to scan`);
+
+    if (totalCount === 0) {
+      logger.info('[backfillFederatedBanners] nothing to do');
+      await mongoose.disconnect();
+      return;
+    }
+
+    const counters: BackfillCounters = {
+      processed: 0,
+      stored: 0,
+      skippedAlreadySet: 0,
+      failed: 0,
+    };
+    let lastId: mongoose.Types.ObjectId | null = null;
+
+    for (;;) {
+      const pageFilter: Record<string, unknown> = { ...baseFilter };
+      if (lastId) {
+        pageFilter._id = { $gt: lastId };
+      }
+
+      const page = await FederatedActor.find(pageFilter, { _id: 1, uri: 1, headerUrl: 1, oxyUserId: 1 })
+        .sort({ _id: 1 })
+        .limit(PAGE_SIZE)
+        .lean<FederatedActorRow[]>();
+
+      if (page.length === 0) break;
+
+      await runPool(page, concurrency, (actor) => processActor(actor, counters));
+
+      counters.processed += page.length;
+      lastId = page[page.length - 1]._id;
+      logger.info(
+        `[backfillFederatedBanners] progress: processed ${counters.processed}/${totalCount}, stored ${counters.stored}, skipped-already-set ${counters.skippedAlreadySet}, failed ${counters.failed}`,
+      );
+    }
+
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    logger.info(
+      `[backfillFederatedBanners] done${FORCE ? ' (FORCE)' : ''}: processed ${counters.processed}, stored ${counters.stored}, skipped-already-set ${counters.skippedAlreadySet}, failed ${counters.failed} (${elapsedSeconds}s)`,
+    );
+
+    await mongoose.disconnect();
+  } catch (error) {
+    logger.error('[backfillFederatedBanners] failed', error);
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  backfillFederatedBanners()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error('[backfillFederatedBanners] unhandled failure', error);
+      process.exit(1);
+    });
+}
+
+export default backfillFederatedBanners;


### PR DESCRIPTION
Follow-up to #285. #285 fixed banner sync for **newly-resolved** federated actors; the **~15,654 already-resolved** actors stay banner-less until they happen to re-resolve. This adds a one-shot backfill to populate them now.

## Reuse-first refactor
Extract the banner-mirror logic from `resolveOxyExternalUser` into an exported `mirrorFederatedBanner(bannerUrl, oxyUserId, actorUri)` helper (pure extraction — behaviour identical to #285). The live resolution path and the backfill share **one** implementation; no duplicated logic.

## Backfill script `scripts/backfillFederatedBanners.ts`
- Queries `FederatedActor` with a remote `headerUrl` + linked `oxyUserId`.
- **Idempotent:** skips rows whose `UserSettings.profileHeaderImage` is already set (`BACKFILL_FORCE=true` overrides).
- Bounded worker pool (`BACKFILL_CONCURRENCY`, default 6) so we don't hammer remote instances / the Oxy asset API.
- Counters + summary; `_id` cursor, resumable. Shared `connectToDatabase`, graceful exit.
- One-shot Fargate: `bun packages/backend/dist/src/scripts/backfillFederatedBanners.js`.

## Verification
- `bun run build` green; `dist/.../backfillFederatedBanners.js` produced.
- Full backend suite **108 files / 1071 tests** green (4 new helper tests + #285 identity tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)