### PR TITLE
fix(atproto-bridge): correct DID-vs-handle resolution + scope collection reads (review findings)

### DIFF
--- a/packages/backend/src/__tests__/connectors/atproto/bridge/identityService.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/bridge/identityService.test.ts
@@ -11,6 +11,7 @@ import { buildUserDid } from '../../../../services/mtn/mentionDid';
 
 const mockResolveOxyUser = vi.fn();
 const mockResolveDid = vi.fn();
+const mockGetUserById = vi.fn();
 
 vi.mock('../../../../connectors/activitypub/constants', async () => {
   const actual = await vi.importActual<typeof import('../../../../connectors/activitypub/constants')>(
@@ -20,11 +21,15 @@ vi.mock('../../../../connectors/activitypub/constants', async () => {
 });
 
 vi.mock('../../../../utils/oxyHelpers', () => ({
-  getServiceOxyClient: () => ({ resolveDid: (...a: unknown[]) => mockResolveDid(...a) }),
+  getServiceOxyClient: () => ({
+    resolveDid: (...a: unknown[]) => mockResolveDid(...a),
+    getUserById: (...a: unknown[]) => mockGetUserById(...a),
+  }),
 }));
 
 import {
   getAtprotoIdentity,
+  getAtprotoIdentityByOxyUserId,
   buildBridgeDidDocumentView,
   bridgeHandle,
   bridgePdsEndpoint,
@@ -59,6 +64,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockResolveOxyUser.mockResolvedValue({ id: OWNER, username: 'alice' });
   mockResolveDid.mockResolvedValue(canonicalDoc());
+  mockGetUserById.mockResolvedValue({ id: OWNER, username: 'alice' });
 });
 
 describe('bridge handle / pds endpoint', () => {
@@ -89,6 +95,31 @@ describe('getAtprotoIdentity', () => {
   });
 });
 
+describe('getAtprotoIdentityByOxyUserId', () => {
+  it('derives the handle from the user\'s CURRENT username (never the raw id)', async () => {
+    const identity = await getAtprotoIdentityByOxyUserId(OWNER);
+    expect(identity).toMatchObject({
+      did: buildUserDid(OWNER),
+      oxyUserId: OWNER,
+      handle: bridgeHandle('alice'),
+      pdsEndpoint: bridgePdsEndpoint(),
+    });
+    expect(mockGetUserById).toHaveBeenCalledWith(OWNER);
+    // The by-id path resolves the username from Oxy, not from the by-handle path.
+    expect(mockResolveOxyUser).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the id resolves to no Oxy user', async () => {
+    mockGetUserById.mockRejectedValueOnce(new Error('not found'));
+    expect(await getAtprotoIdentityByOxyUserId(OWNER)).toBeNull();
+  });
+
+  it('returns null when the resolved user carries no username', async () => {
+    mockGetUserById.mockResolvedValueOnce({ id: OWNER });
+    expect(await getAtprotoIdentityByOxyUserId(OWNER)).toBeNull();
+  });
+});
+
 describe('buildBridgeDidDocumentView', () => {
   it('augments the canonical Oxy DID doc with the #atproto_pds service + at:// aka', async () => {
     const doc = await buildBridgeDidDocumentView('alice');
@@ -113,6 +144,27 @@ describe('buildBridgeDidDocumentView', () => {
     const view = await buildBridgeDidDocumentView('alice');
     const pdsEntries = view?.service.filter((s) => s.id === ATPROTO_PDS_SERVICE_ID) ?? [];
     expect(pdsEntries).toHaveLength(1);
+  });
+
+  it('handles a sparse DID doc that omits alsoKnownAs / service (no crash)', async () => {
+    // `alsoKnownAs` and `service` are OPTIONAL in a W3C DID document; a resolver
+    // may return a doc that omits them. The view must default both to empty and
+    // still attach the bridge handle + #atproto_pds entry.
+    const sparse = canonicalDoc();
+    delete (sparse as Partial<DidDocument>).alsoKnownAs;
+    delete (sparse as Partial<DidDocument>).service;
+    mockResolveDid.mockResolvedValueOnce(sparse);
+
+    const view = await buildBridgeDidDocumentView('alice');
+    expect(view).not.toBeNull();
+    expect(view?.alsoKnownAs).toEqual([`at://${bridgeHandle('alice')}`]);
+    expect(view?.service).toEqual([
+      {
+        id: ATPROTO_PDS_SERVICE_ID,
+        type: ATPROTO_PDS_SERVICE_TYPE,
+        serviceEndpoint: bridgePdsEndpoint(),
+      },
+    ]);
   });
 
   it('returns null when the canonical Oxy DID document cannot be resolved', async () => {

--- a/packages/backend/src/__tests__/connectors/atproto/bridge/repoReadService.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/bridge/repoReadService.test.ts
@@ -160,6 +160,22 @@ describe('listRecords', () => {
     const page = await listRecords(OWNER, 'app.bsky.feed.post');
     expect(page.records.map((r) => r.rkey)).toEqual(['ok']);
   });
+
+  it('reads ONLY the requested collection + tombstones (not every feed collection)', async () => {
+    mockLedger([]);
+    await listRecords(OWNER, 'app.bsky.feed.like');
+    const query = mockFind.mock.calls[0]?.[0] as {
+      oxyUserId: string;
+      verified: boolean;
+      $or: Array<Record<string, unknown>>;
+    };
+    expect(query.oxyUserId).toBe(OWNER);
+    expect(query.verified).toBe(true);
+    expect(query.$or).toEqual([
+      { nsid: MENTION_LIKE_COLLECTION },
+      { nsid: MENTION_TOMBSTONE_COLLECTION },
+    ]);
+  });
 });
 
 describe('getRecord', () => {
@@ -169,6 +185,40 @@ describe('getRecord', () => {
     ]);
     const record = await getRecord(OWNER, 'app.bsky.feed.post', 'p1');
     expect(record?.value).toMatchObject({ text: 'hi' });
+  });
+
+  it('queries ONLY the requested rkey + tombstones (targeted, not a full scan)', async () => {
+    mockLedger([
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'p1', record: postRecord('hi'), createdAt: '2026-06-30T01:00:00.000Z' }),
+    ]);
+    await getRecord(OWNER, 'app.bsky.feed.post', 'p1');
+    const query = mockFind.mock.calls[0]?.[0] as {
+      oxyUserId: string;
+      verified: boolean;
+      $or: Array<Record<string, unknown>>;
+    };
+    expect(query.oxyUserId).toBe(OWNER);
+    expect(query.verified).toBe(true);
+    // The feed-collection clause is narrowed to the single rkey; tombstones are
+    // still read in full (they delete by subject, not by their own rkey).
+    expect(query.$or).toEqual([
+      { nsid: MENTION_POST_COLLECTION, rkey: 'p1' },
+      { nsid: MENTION_TOMBSTONE_COLLECTION },
+    ]);
+  });
+
+  it('applies LWW for the requested rkey (newest edit wins)', async () => {
+    mockLedger([
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'p1', record: postRecord('edited'), createdAt: '2026-06-30T02:00:00.000Z' }),
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'p1', record: postRecord('original'), createdAt: '2026-06-30T01:00:00.000Z' }),
+    ]);
+    const record = await getRecord(OWNER, 'app.bsky.feed.post', 'p1');
+    expect(record?.value).toMatchObject({ text: 'edited' });
+  });
+
+  it('returns null for an unknown / private collection without a ledger read', async () => {
+    expect(await getRecord(OWNER, 'app.mention.feed.bookmark', 'b1')).toBeNull();
+    expect(mockFind).not.toHaveBeenCalled();
   });
 
   it('returns null for a tombstoned record', async () => {

--- a/packages/backend/src/__tests__/connectors/atproto/bridge/routes.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/bridge/routes.test.ts
@@ -18,6 +18,7 @@ const mockListRecords = vi.fn();
 const mockGetRecord = vi.fn();
 const mockGetHead = vi.fn();
 const mockGetAtprotoIdentity = vi.fn();
+const mockGetAtprotoIdentityByOxyUserId = vi.fn();
 const mockBuildDidView = vi.fn();
 const mockResolveOxyUser = vi.fn();
 
@@ -47,6 +48,7 @@ vi.mock('../../../../services/mtn/MentionRepoLogService', () => ({
 
 vi.mock('../../../../connectors/atproto/bridge/identityService', () => ({
   getAtprotoIdentity: (...a: unknown[]) => mockGetAtprotoIdentity(...a),
+  getAtprotoIdentityByOxyUserId: (...a: unknown[]) => mockGetAtprotoIdentityByOxyUserId(...a),
   buildBridgeDidDocumentView: (...a: unknown[]) => mockBuildDidView(...a),
   bridgePdsEndpoint: () => 'https://mention.earth',
 }));
@@ -72,15 +74,18 @@ beforeAll(async () => {
   app.use('/.well-known', mod.wellKnownBridgeRouter);
 });
 
+const IDENTITY = {
+  did: OWNER_DID,
+  oxyUserId: OWNER,
+  handle: 'alice.mention.earth',
+  pdsEndpoint: 'https://mention.earth',
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockResolveOxyUser.mockResolvedValue({ id: OWNER, username: 'alice' });
-  mockGetAtprotoIdentity.mockResolvedValue({
-    did: OWNER_DID,
-    oxyUserId: OWNER,
-    handle: 'alice.mention.earth',
-    pdsEndpoint: 'https://mention.earth',
-  });
+  mockGetAtprotoIdentity.mockResolvedValue(IDENTITY);
+  mockGetAtprotoIdentityByOxyUserId.mockResolvedValue(IDENTITY);
 });
 
 describe('com.atproto.repo.listRecords', () => {
@@ -167,6 +172,38 @@ describe('com.atproto.repo.describeRepo', () => {
       handleIsCorrect: true,
     });
   });
+
+  it('resolves the handle from the OWNER ID, not by string-splitting a DID repo', async () => {
+    // Regression: a `did:web:oxy.so:u:<id>` repo contains dots (in `oxy.so`). The
+    // identity MUST be derived from the resolved owner id — never from
+    // `repo.split('.')[0]` (which would yield `did:web:oxy`).
+    const res = await request(app).get('/xrpc/com.atproto.repo.describeRepo').query({ repo: OWNER_DID });
+    expect(res.status).toBe(200);
+    expect(res.body.handle).toBe('alice.mention.earth');
+    expect(res.body.did).toBe(OWNER_DID);
+    // The by-id identity path was called with the already-resolved owner id.
+    expect(mockGetAtprotoIdentityByOxyUserId).toHaveBeenCalledWith(OWNER);
+    // The corrupted-username by-handle path was NOT taken.
+    expect(mockGetAtprotoIdentity).not.toHaveBeenCalled();
+  });
+
+  it('resolves a handle repo to the correct did/handle', async () => {
+    const res = await request(app)
+      .get('/xrpc/com.atproto.repo.describeRepo')
+      .query({ repo: 'alice.mention.earth' });
+    expect(res.status).toBe(200);
+    expect(res.body.handle).toBe('alice.mention.earth');
+    expect(res.body.did).toBe(OWNER_DID);
+    expect(mockResolveOxyUser).toHaveBeenCalledWith('alice');
+    expect(mockGetAtprotoIdentityByOxyUserId).toHaveBeenCalledWith(OWNER);
+  });
+
+  it('404s when the owner id maps to no identity', async () => {
+    mockGetAtprotoIdentityByOxyUserId.mockResolvedValueOnce(null);
+    const res = await request(app).get('/xrpc/com.atproto.repo.describeRepo').query({ repo: OWNER_DID });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('RepoNotFound');
+  });
 });
 
 describe('com.atproto.sync.getLatestCommit', () => {
@@ -231,5 +268,40 @@ describe('GET /.well-known/atproto-did', () => {
       .set('Host', 'alice.mention.earth');
     expect(res.status).toBe(200);
     expect(res.text).toBe(OWNER_DID);
+    expect(mockGetAtprotoIdentity).toHaveBeenCalledWith('alice');
+  });
+
+  it('strips the port before resolving the subdomain label', async () => {
+    const res = await request(app)
+      .get('/.well-known/atproto-did')
+      .set('Host', 'alice.mention.earth:8443');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe(OWNER_DID);
+    expect(mockGetAtprotoIdentity).toHaveBeenCalledWith('alice');
+  });
+
+  it('404s the apex domain (no subdomain → no user handle, never invents one)', async () => {
+    const res = await request(app)
+      .get('/.well-known/atproto-did')
+      .set('Host', 'mention.earth');
+    expect(res.status).toBe(404);
+    // The apex's first label (`mention`) must NOT be treated as a username.
+    expect(mockGetAtprotoIdentity).not.toHaveBeenCalled();
+  });
+
+  it('404s a host that is not under the bridge domain', async () => {
+    const res = await request(app)
+      .get('/.well-known/atproto-did')
+      .set('Host', 'alice.example.com');
+    expect(res.status).toBe(404);
+    expect(mockGetAtprotoIdentity).not.toHaveBeenCalled();
+  });
+
+  it('404s a nested subdomain under the bridge domain', async () => {
+    const res = await request(app)
+      .get('/.well-known/atproto-did')
+      .set('Host', 'a.b.mention.earth');
+    expect(res.status).toBe(404);
+    expect(mockGetAtprotoIdentity).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/connectors/atproto/bridge/identityService.ts
+++ b/packages/backend/src/connectors/atproto/bridge/identityService.ts
@@ -70,6 +70,20 @@ export function bridgeHandle(username: string): string {
 }
 
 /**
+ * Assemble the bridge identity facts from an already-resolved `(oxyUserId,
+ * username)` pair. The single builder both entry points funnel through so the
+ * DID / handle / PDS shape can never drift between the by-handle and by-id paths.
+ */
+function buildIdentity(oxyUserId: string, username: string): BridgeAtprotoIdentity {
+  return {
+    did: buildUserDid(oxyUserId),
+    oxyUserId,
+    handle: bridgeHandle(username),
+    pdsEndpoint: bridgePdsEndpoint(),
+  };
+}
+
+/**
  * Resolve a local username to its atproto bridge identity (Oxy DID + bridge
  * handle + PDS endpoint). Returns null when the username is not a local Oxy user.
  */
@@ -77,12 +91,33 @@ export async function getAtprotoIdentity(username: string): Promise<BridgeAtprot
   const user = await resolveOxyUser(username);
   const oxyUserId = user?.id ? String(user.id) : undefined;
   if (!oxyUserId) return null;
-  return {
-    did: buildUserDid(oxyUserId),
-    oxyUserId,
-    handle: bridgeHandle(username),
-    pdsEndpoint: bridgePdsEndpoint(),
-  };
+  return buildIdentity(oxyUserId, username);
+}
+
+/**
+ * Resolve a known Oxy user id to its atproto bridge identity. This is the inverse
+ * of {@link getAtprotoIdentity}: the caller already holds the canonical
+ * `oxyUserId` (e.g. parsed from the repo's `did:web`) and needs the bridge handle,
+ * which is derived from the user's CURRENT Oxy username — never re-parsed from the
+ * raw DID/handle string. Returns null when the id maps to no Oxy user (or the
+ * user record carries no username).
+ */
+export async function getAtprotoIdentityByOxyUserId(
+  oxyUserId: string,
+): Promise<BridgeAtprotoIdentity | null> {
+  let username: string | undefined;
+  try {
+    const user = await getServiceOxyClient().getUserById(oxyUserId);
+    username = user.username;
+  } catch (err) {
+    logger.warn('[atproto-bridge] failed to resolve Oxy user by id', {
+      oxyUserId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+  if (!username) return null;
+  return buildIdentity(oxyUserId, username);
 }
 
 /**
@@ -112,17 +147,23 @@ export async function buildBridgeDidDocumentView(username: string): Promise<DidD
     return null;
   }
 
+  // `alsoKnownAs` and `service` are OPTIONAL in a W3C DID document; a resolver
+  // may return a document that omits either array. Default a missing array to
+  // empty before augmenting so the bridge never crashes on a sparse DID doc.
+  const existingAka = canonical.alsoKnownAs ?? [];
+  const existingService = canonical.service ?? [];
+
   const akaHandle = `at://${identity.handle}`;
-  const alsoKnownAs = canonical.alsoKnownAs.includes(akaHandle)
-    ? [...canonical.alsoKnownAs]
-    : [...canonical.alsoKnownAs, akaHandle];
+  const alsoKnownAs = existingAka.includes(akaHandle)
+    ? [...existingAka]
+    : [...existingAka, akaHandle];
 
   // Augment (do not replace) the service array with the atproto PDS entry.
-  const hasPds = canonical.service.some((entry) => entry.id === ATPROTO_PDS_SERVICE_ID);
+  const hasPds = existingService.some((entry) => entry.id === ATPROTO_PDS_SERVICE_ID);
   const service = hasPds
-    ? canonical.service
+    ? [...existingService]
     : [
-        ...canonical.service,
+        ...existingService,
         {
           id: ATPROTO_PDS_SERVICE_ID,
           type: ATPROTO_PDS_SERVICE_TYPE,

--- a/packages/backend/src/connectors/atproto/bridge/index.ts
+++ b/packages/backend/src/connectors/atproto/bridge/index.ts
@@ -30,6 +30,7 @@
 
 export {
   getAtprotoIdentity,
+  getAtprotoIdentityByOxyUserId,
   buildBridgeDidDocumentView,
   bridgeHandle,
   bridgePdsEndpoint,

--- a/packages/backend/src/connectors/atproto/bridge/repoReadService.ts
+++ b/packages/backend/src/connectors/atproto/bridge/repoReadService.ts
@@ -23,9 +23,6 @@
 
 import {
   MtnUri,
-  MENTION_POST_COLLECTION,
-  MENTION_LIKE_COLLECTION,
-  MENTION_REPOST_COLLECTION,
   MENTION_TOMBSTONE_COLLECTION,
   mentionPostRecordSchema,
   mentionLikeRecordSchema,
@@ -87,25 +84,30 @@ interface LedgerRow {
 }
 
 /**
- * Read EVERY verified row for a user across the live feed collections + the
- * tombstone collection, newest-first. The materialization (LWW + tombstone
- * removal) is applied in memory because it spans collections (a tombstone in one
- * collection removes a key in another). Bounded by the per-user chain size; the
- * MTN chain is a single signer's append-only log, so this is a per-user scan, not
- * a global one.
+ * Read the verified rows needed to materialize ONE feed collection, newest-first:
+ * the requested `mtnCollection` itself PLUS the tombstone collection (a tombstone
+ * lives in its own collection but removes a key in the feed collection, so it must
+ * be read alongside). Scoping the `$in` to just these two — instead of every feed
+ * collection — avoids loading 4× the rows the materializer will keep. Bounded by
+ * the per-user chain size; the MTN chain is a single signer's append-only log, so
+ * this is a per-user scan, not a global one. An optional `rkey` narrows the read
+ * to a single key (the `getRecord` path) — the tombstone collection is still read
+ * in full because a deletion may target that key.
  */
-async function readLiveRows(oxyUserId: string): Promise<LedgerRow[]> {
+async function readLiveRows(
+  oxyUserId: string,
+  mtnCollection: string,
+  rkey?: string,
+): Promise<LedgerRow[]> {
+  // The feed-collection branch is the only one narrowed by rkey; tombstones are
+  // always read in full (they delete by `subject`, not by their own rkey).
+  const feedClause: Record<string, unknown> = { nsid: mtnCollection };
+  if (typeof rkey === 'string' && rkey.length > 0) feedClause.rkey = rkey;
+
   return MentionSignedRecord.find({
     oxyUserId,
     verified: true,
-    nsid: {
-      $in: [
-        MENTION_POST_COLLECTION,
-        MENTION_LIKE_COLLECTION,
-        MENTION_REPOST_COLLECTION,
-        MENTION_TOMBSTONE_COLLECTION,
-      ],
-    },
+    $or: [feedClause, { nsid: MENTION_TOMBSTONE_COLLECTION }],
   })
     .sort({ createdAt: -1, seq: -1 })
     .lean<LedgerRow[]>();
@@ -151,20 +153,19 @@ function translateRow(row: LedgerRow, bskyCollection: string): AtprotoRecordValu
 }
 
 /**
- * Materialize the CURRENT records of a single bsky collection for a user
- * (LWW per rkey, tombstones removed), newest-first, translated to atproto.
- *
- * This is the shared core both `listRecords` (paginated) and `getRecord`
- * (single) read from — one materialization, no drift.
+ * Reduce newest-first ledger `rows` into the live, translated records of one bsky
+ * collection: LWW per rkey (first row wins), tombstoned keys removed, malformed
+ * payloads skipped. This is the SINGLE materialization rule both the list path
+ * (full collection) and the single-get path (one rkey) run, so the two cannot
+ * drift. `rows` must already be scoped to `mtnCollection` + the tombstone
+ * collection and sorted newest-first; the reducer ignores any other `nsid`.
  */
-async function materializeCollection(
+function reduceLiveRecords(
+  rows: LedgerRow[],
   oxyUserId: string,
   bskyCollection: string,
-): Promise<BridgeRecord[]> {
-  const mtnCollection = BSKY_TO_MTN_COLLECTION[bskyCollection];
-  if (!mtnCollection) return [];
-
-  const rows = await readLiveRows(oxyUserId);
+  mtnCollection: string,
+): BridgeRecord[] {
   const tombstoned = collectTombstonedKeys(rows);
 
   const seen = new Set<string>();
@@ -193,6 +194,25 @@ async function materializeCollection(
     });
   }
   return out;
+}
+
+/**
+ * Materialize the CURRENT records of a single bsky collection for a user
+ * (LWW per rkey, tombstones removed), newest-first, translated to atproto.
+ *
+ * Reads ONLY the requested collection + tombstones (not every feed collection),
+ * then runs {@link reduceLiveRecords} — the shared rule `getRecord` also uses, so
+ * the list and single-get views cannot drift.
+ */
+async function materializeCollection(
+  oxyUserId: string,
+  bskyCollection: string,
+): Promise<BridgeRecord[]> {
+  const mtnCollection = BSKY_TO_MTN_COLLECTION[bskyCollection];
+  if (!mtnCollection) return [];
+
+  const rows = await readLiveRows(oxyUserId, mtnCollection);
+  return reduceLiveRecords(rows, oxyUserId, bskyCollection, mtnCollection);
 }
 
 /**
@@ -236,13 +256,23 @@ export async function listRecords(
  * `com.atproto.repo.getRecord` — resolve a single record by `(collection, rkey)`.
  * Returns null when the record does not exist, is tombstoned, is in a private
  * collection, or fails translation.
+ *
+ * Queries ONLY the requested key (plus the tombstone collection, which may delete
+ * it) instead of materializing the whole collection, then runs the SAME
+ * {@link reduceLiveRecords} rule the list path uses — an O(1)-target read with
+ * zero LWW/tombstone-logic drift. Multiple versions of the key (an edit) still
+ * collapse via LWW; the single live record (if any) is returned.
  */
 export async function getRecord(
   oxyUserId: string,
   bskyCollection: string,
   rkey: string,
 ): Promise<BridgeRecord | null> {
-  const records = await materializeCollection(oxyUserId, bskyCollection);
+  const mtnCollection = BSKY_TO_MTN_COLLECTION[bskyCollection];
+  if (!mtnCollection) return null;
+
+  const rows = await readLiveRows(oxyUserId, mtnCollection, rkey);
+  const records = reduceLiveRecords(rows, oxyUserId, bskyCollection, mtnCollection);
   return records.find((record) => record.rkey === rkey) ?? null;
 }
 

--- a/packages/backend/src/connectors/atproto/bridge/routes.ts
+++ b/packages/backend/src/connectors/atproto/bridge/routes.ts
@@ -28,6 +28,7 @@ import { ANY_DID_RE } from '../constants';
 import {
   ATPROTO_BRIDGE_ENABLED,
   BRIDGE_BSKY_COLLECTIONS,
+  BRIDGE_DOMAIN,
   type BridgeBskyCollection,
 } from './constants';
 import {
@@ -37,6 +38,7 @@ import {
 } from './repoReadService';
 import {
   getAtprotoIdentity,
+  getAtprotoIdentityByOxyUserId,
   buildBridgeDidDocumentView,
   bridgePdsEndpoint,
 } from './identityService';
@@ -183,17 +185,20 @@ router.get('/com.atproto.repo.describeRepo', async (req: Request, res: Response)
     const oxyUserId = await resolveRepoOwner(parsed.data.repo);
     if (!oxyUserId) return xrpcError(res, 404, 'RepoNotFound', 'repo not found');
 
-    // The repo param may be a DID or a handle; re-resolve the canonical identity
-    // facts by username so the response always carries the bridge handle + DID.
-    const username = parsed.data.repo.includes('.') ? parsed.data.repo.split('.')[0] : parsed.data.repo;
-    const identity = await getAtprotoIdentity(username);
+    // Derive the canonical identity facts from the ALREADY-RESOLVED owner id, not
+    // by string-splitting the raw repo param. The param may be a DID
+    // (`did:web:oxy.so:u:<id>`, where a naive `.split('.')` would corrupt the
+    // username) or a handle; both resolve to the same `oxyUserId`, and the bridge
+    // handle + DID are derived from the user's current Oxy username.
+    const identity = await getAtprotoIdentityByOxyUserId(oxyUserId);
+    if (!identity) return xrpcError(res, 404, 'RepoNotFound', 'repo not found');
 
     res.set('Cache-Control', 'public, max-age=60');
     return res.json({
-      did: identity?.did ?? `did:web:placeholder`,
-      handle: identity?.handle ?? username,
+      did: identity.did,
+      handle: identity.handle,
       collections: BRIDGE_DESCRIBE_COLLECTIONS,
-      handleIsCorrect: Boolean(identity),
+      handleIsCorrect: true,
     });
   } catch (err) {
     logger.error('[atproto-bridge] describeRepo failed', err);
@@ -251,6 +256,26 @@ router.get('/com.atproto.sync.getRepo', (_req: Request, res: Response) => {
 });
 
 /**
+ * Extract the bridge username from a request host. A valid bridge handle host is
+ * exactly `<username>.<bridge domain>` (a SINGLE subdomain label under the bridge
+ * domain). The apex domain itself (`<bridge domain>`, no subdomain) and any
+ * deeper / foreign host return null — the apex's first label is the registrable
+ * name, NOT a username, so blindly taking `host.split('.')[0]` would invent a
+ * bogus handle. The compare is case-insensitive and port-stripped.
+ */
+function bridgeUsernameFromHost(rawHost: string): string | null {
+  const host = rawHost.split(':')[0].toLowerCase();
+  const domain = BRIDGE_DOMAIN.toLowerCase();
+  const suffix = `.${domain}`;
+  if (!host.endsWith(suffix)) return null;
+
+  const username = host.slice(0, -suffix.length);
+  // Exactly one label: reject an empty label and any nested subdomain.
+  if (username.length === 0 || username.includes('.')) return null;
+  return username;
+}
+
+/**
  * GET /.well-known/atproto-did  (mounted at the `.well-known` level — see
  * `wellKnownBridgeRouter`). Resolves the requesting host's handle to the user's
  * Oxy DID. The handle is taken from the `Host` header (`<username>.<bridge
@@ -258,10 +283,11 @@ router.get('/com.atproto.sync.getRepo', (_req: Request, res: Response) => {
  * `https://<username>.<bridge domain>/.well-known/atproto-did` gets the DID.
  */
 async function atprotoDidHandler(req: Request, res: Response): Promise<Response> {
-  // The handle is the request host; the username is its first label.
+  // The handle is the request host; the username is the single subdomain label
+  // under the bridge domain. An apex-domain request carries no user handle.
   const host = (req.headers['x-forwarded-host'] as string | undefined) || req.headers.host || '';
-  const username = host.split(':')[0]?.split('.')[0] ?? '';
-  if (!username) return xrpcError(res, 400, 'InvalidRequest', 'no handle host');
+  const username = bridgeUsernameFromHost(host);
+  if (!username) return xrpcError(res, 404, 'NotFound', 'no handle host');
 
   try {
     const identity = await getAtprotoIdentity(username);


### PR DESCRIPTION
## Summary

Addresses 5 post-merge code-review findings from gemini-code-assist on PR #283 (atproto bridge), all in `packages/backend/src/connectors/atproto/bridge/`.

- **DID-vs-handle resolution (`routes.ts` `describeRepo`):** Was splitting the DID string via `repo.split('.')[0]` to derive the username. A `did:web:oxy.so:u:<id>` has dots in `oxy.so`, which corrupted the parsed username. Now resolves identity via the new `getAtprotoIdentityByOxyUserId` helper instead.
- **Scoped collection reads (`repoReadService.ts` `readLiveRows`):** Was loading all 4 MTN collections on every call. Now accepts the specific `mtnCollection` parameter and queries only that collection + tombstones.
- **Targeted `getRecord` query (`repoReadService.ts`):** Was materializing the entire collection to find one record. Now performs a targeted single-rkey query. Also shares the `reduceLiveRecords` LWW/tombstone reducer with `materializeCollection` to eliminate logic drift.
- **Subdomain validation (`routes.ts` `atprotoDidHandler`):** Added robust validation — only `<username>.<BRIDGE_DOMAIN>` is treated as a handle; apex, foreign, and nested hosts now return 404 instead of attempting resolution.
- **Sparse DID-doc safety (`identityService.ts` `buildBridgeDidDocumentView`):** Optional `alsoKnownAs` and `service` arrays now default to `[]` to prevent a crash on sparse/minimal DID documents.

## Test plan

- [x] `bun run build:backend` from repo root (shared-types → backend) — tsc EXIT 0, no errors
- [x] `cd packages/backend && bunx vitest run` — 107 files, 1082 tests, all green
- [x] `bun install --frozen-lockfile` — lockfile gate passed
- [x] Tests added/updated in all 3 bridge test files (`identityService.test.ts`, `repoReadService.test.ts`, `routes.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)