### PR TITLE
fix(deps): pin mongoose to ^8.17.0 — Bun 1.3.14 boot crash (bson isBuildingSnapshot)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -133,7 +133,7 @@
         "jsonwebtoken": "^9.0.3",
         "jwt-decode": "^4.0.0",
         "livekit-server-sdk": "^2.15.0",
-        "mongoose": "^9.3.1",
+        "mongoose": "^8.17.0",
         "multer": "^2.1.1",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -311,7 +311,7 @@
     "lightningcss": "1.30.1",
     "lightningcss-linux-x64-gnu": "1.30.1",
     "lightningcss-linux-x64-musl": "1.30.1",
-    "mongoose": "9.3.1",
+    "mongoose": "^8.17.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.85.3",
@@ -1274,7 +1274,7 @@
 
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
-    "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
+    "@types/whatwg-url": ["@types/whatwg-url@11.0.5", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -1526,7 +1526,7 @@
 
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
-    "bson": ["bson@7.3.1", "", {}, "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag=="],
+    "bson": ["bson@6.10.4", "", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -2410,7 +2410,7 @@
 
     "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
 
-    "kareem": ["kareem@3.2.0", "", {}, "sha512-VS8MWZz/cT+SqBCpVfNN4zoVz5VskR3N4+sTmUXme55e9avQHntpwpNq0yjnosISXqwJ3AQVjlbI4Dyzv//JtA=="],
+    "kareem": ["kareem@2.6.3", "", {}, "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -2606,17 +2606,17 @@
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
-    "mongodb": ["mongodb@7.1.1", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.1.1", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w=="],
+    "mongodb": ["mongodb@6.20.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^6.10.4", "mongodb-connection-string-url": "^3.0.2" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.1.0 || ^2.0.0", "gcp-metadata": "^5.2.0", "kerberos": "^2.0.1", "mongodb-client-encryption": ">=6.0.0 <7", "snappy": "^7.3.2", "socks": "^2.7.1" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ=="],
 
-    "mongodb-connection-string-url": ["mongodb-connection-string-url@7.0.1", "", { "dependencies": { "@types/whatwg-url": "^13.0.0", "whatwg-url": "^14.1.0" } }, "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ=="],
+    "mongodb-connection-string-url": ["mongodb-connection-string-url@3.0.2", "", { "dependencies": { "@types/whatwg-url": "^11.0.2", "whatwg-url": "^14.1.0 || ^13.0.0" } }, "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA=="],
 
-    "mongoose": ["mongoose@9.3.1", "", { "dependencies": { "kareem": "3.2.0", "mongodb": "~7.1", "mpath": "0.9.0", "mquery": "6.0.0", "ms": "2.1.3", "sift": "17.1.3" } }, "sha512-58DuQti+LlRS74/UfWN4F3wZsC0Yr1dgTWZ2Wd3/TuSvm6rIdyAjDWbx2xGyuBooqJYdAWotVv4mQgVdivh+3Q=="],
+    "mongoose": ["mongoose@8.24.1", "", { "dependencies": { "bson": "^6.10.4", "kareem": "2.6.3", "mongodb": "~6.20.0", "mpath": "0.9.0", "mquery": "5.0.0", "ms": "2.1.3", "sift": "17.1.3" } }, "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA=="],
 
     "moo": ["moo@0.5.3", "", {}, "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA=="],
 
     "mpath": ["mpath@0.9.0", "", {}, "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="],
 
-    "mquery": ["mquery@6.0.0", "", {}, "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw=="],
+    "mquery": ["mquery@5.0.0", "", { "dependencies": { "debug": "4.x" } }, "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -3761,6 +3761,8 @@
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "mquery/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "multer/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@oxyhq/bloom": "^0.25.0",
     "@oxyhq/core": "^5.2.0",
     "@oxyhq/services": "^13.0.3",
-    "mongoose": "9.3.1",
+    "mongoose": "^8.17.0",
     "ioredis": "5.10.1",
     "lightningcss": "1.30.1",
     "lightningcss-linux-x64-gnu": "1.30.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -47,7 +47,7 @@
     "jsonwebtoken": "^9.0.3",
     "jwt-decode": "^4.0.0",
     "livekit-server-sdk": "^2.15.0",
-    "mongoose": "^9.3.1",
+    "mongoose": "^8.17.0",
     "multer": "^2.1.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -17,7 +17,7 @@ import {
   PostContent,
   HydratedPost,
 } from '@mention/shared-types';
-import mongoose, { QueryFilter } from 'mongoose';
+import mongoose, { FilterQuery } from 'mongoose';
 import { IPost } from '../models/Post';
 import { IAccountList } from '../models/AccountList';
 import { io } from '../../server';
@@ -448,7 +448,7 @@ class FeedController {
       }
 
       // Build query
-      let query: QueryFilter<IPost>;
+      let query: FilterQuery<IPost>;
       if (feedType === 'saved' && savedPostIds.length > 0) {
         // For saved posts, use a simple query that only filters by saved post IDs
         // Don't filter by visibility - users should be able to see their saved posts regardless of visibility
@@ -767,7 +767,7 @@ class FeedController {
       // Handle Likes feed separately (posts the user liked)
       if (type === 'likes') {
         // Paginate likes by Like document _id (chronological like order)
-        const likeQuery: QueryFilter<ILike> = { userId };
+        const likeQuery: FilterQuery<ILike> = { userId };
         const cursorId = parseFeedCursor(cursor);
         if (cursorId) {
           likeQuery._id = { $lt: cursorId };
@@ -1984,7 +1984,7 @@ class FeedController {
         ? (await this.getSelfThreadContinuations(parent)).map((c) => String(c._id))
         : [];
 
-      const query: QueryFilter<IPost> = {
+      const query: FilterQuery<IPost> = {
         parentPostId: continuationIds.length > 0
           ? { $in: [String(parentId), ...continuationIds] }
           : String(parentId),

--- a/packages/backend/src/routes/admin/broadcasts.routes.ts
+++ b/packages/backend/src/routes/admin/broadcasts.routes.ts
@@ -1,5 +1,5 @@
 import { Router, Response } from 'express';
-import type { QueryFilter } from 'mongoose';
+import type { FilterQuery } from 'mongoose';
 import Room, {
   RoomStatus,
   RoomType,
@@ -134,7 +134,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
   try {
     const { status, limit = '20', cursor } = req.query;
 
-    const query: QueryFilter<IRoom> = {
+    const query: FilterQuery<IRoom> = {
       ownerType: OwnerType.AGORA,
       type: RoomType.BROADCAST,
       broadcastKind: BroadcastKind.AGORA,

--- a/packages/backend/src/services/ContentAffinityService.ts
+++ b/packages/backend/src/services/ContentAffinityService.ts
@@ -49,7 +49,7 @@
  * to empty on error so a single failing query never sinks the whole computation.
  */
 
-import type { QueryFilter } from 'mongoose';
+import type { FilterQuery } from 'mongoose';
 import { PostType, MtnConfig, isVideoSurface } from '@mention/shared-types';
 import Like from '../models/Like';
 import { Post, type IPost } from '../models/Post';
@@ -736,7 +736,7 @@ export class ContentAffinityService {
     kind: 'reply' | 'boost',
   ): Promise<string[]> {
     try {
-      const match: QueryFilter<IPost> =
+      const match: FilterQuery<IPost> =
         kind === 'boost'
           ? {
             oxyUserId: viewerId,

--- a/packages/backend/src/services/UserPreferenceService.ts
+++ b/packages/backend/src/services/UserPreferenceService.ts
@@ -667,7 +667,7 @@ export class UserPreferenceService {
    * Get user behavior data (lean). `null` when the viewer has none yet.
    */
   async getUserBehavior(userId: string): Promise<IUserBehavior | null> {
-    return await UserBehavior.findOne({ oxyUserId: userId }).lean();
+    return await UserBehavior.findOne({ oxyUserId: userId }).lean<IUserBehavior>();
   }
 
   /**


### PR DESCRIPTION
## Incident
**Every mention ECS deploy since the mongoose 9 bump crash-loops at boot (exit 1).** Prod stays up only on the old image. Reproduced locally under Bun 1.3.14:
```
import('mongoose') → NotImplementedError: node:v8 isBuildingSnapshot is not yet implemented in Bun
  at node_modules/bson/lib/bson.cjs → mongodb → mongoose → server boot
```
`bson 7.3.1` (via `mongoose ^9.3.1 → mongodb 7.1.1`) calls `v8.startupSnapshot.isBuildingSnapshot()` at module load, which **Bun 1.3.14 — the latest published Bun — does not implement.** Bun can't be upgraded past 1.3.14. The old (healthy) prod image runs mongoose 8 / bson 6, which boots fine under the same Bun.

## Fix
Downgrade the Mongo stack to the last Bun-compatible major: **mongoose `^8.17.0`** (resolves mongoose 8.24.1 → mongodb 6.20.0 → **bson 6.10.4**). The root `overrides.mongoose` pin (which forced 9.3.1 regardless of the workspace dep) is lowered too — **both must move together on any future mongoose bump.**

Mongoose 9→8 source adjustments (no behaviour change): `QueryFilter<T>` → `FilterQuery<T>` (renamed export; 6 usages) and one `.lean<IUserBehavior>()` projection.

## Verification
- **Decisive boot test:** `import('mongoose')` → **`IMPORT OK, mongoose 8.24.1`** (was the crash).
- `bun run build` (tsc, all packages) green.
- Full backend suite **107 files / 1067 tests** green.

Unblocks ALL mention deploys (the banner fix #285 and everything merged today go live with this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)