### PR TITLE
chore(federation): rate-limit the banner backfill under oxy-api caps

### DIFF
--- a/packages/backend/src/__tests__/connectors/mirrorFederatedBanner.test.ts
+++ b/packages/backend/src/__tests__/connectors/mirrorFederatedBanner.test.ts
@@ -43,13 +43,13 @@ describe('mirrorFederatedBanner', () => {
       media: { oxyFileId: 'banner_file_1', contentType: 'image/png', sizeBytes: 1234 },
     });
 
-    const stored = await mirrorFederatedBanner(
+    const result = await mirrorFederatedBanner(
       'https://files.mastodon.social/banner.png',
       'oxy-user-1',
       'https://mastodon.social/users/alice',
     );
 
-    expect(stored).toBe(true);
+    expect(result).toEqual({ ok: true, permanent: false });
     // Goes through the SAME service-token public-upload path as federated post
     // media — NOT the user-authenticated SDK `uploadProfileBanner` (which 401s).
     expect(mocks.persistRemoteMedia).toHaveBeenCalledWith(
@@ -68,16 +68,17 @@ describe('mirrorFederatedBanner', () => {
     );
   });
 
-  it('warns and returns false on a transient mirror failure (no header stored)', async () => {
+  it('warns and reports a transient (retryable) failure (no header stored)', async () => {
     mocks.persistRemoteMedia.mockResolvedValue({ ok: false, permanent: false, reason: 'upstream-error' });
 
-    const stored = await mirrorFederatedBanner(
+    const result = await mirrorFederatedBanner(
       'https://files.mastodon.social/banner.png',
       'oxy-user-2',
       'https://mastodon.social/users/bob',
     );
 
-    expect(stored).toBe(false);
+    // `permanent: false` tells the backfill caller this is worth a retry.
+    expect(result).toEqual({ ok: false, permanent: false });
     expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
     expect(mocks.loggerWarn).toHaveBeenCalledWith(
       'Failed to mirror banner for https://mastodon.social/users/bob',
@@ -85,28 +86,30 @@ describe('mirrorFederatedBanner', () => {
     );
   });
 
-  it('stays quiet and returns false on a permanent mirror failure', async () => {
+  it('stays quiet and reports a permanent failure', async () => {
     mocks.persistRemoteMedia.mockResolvedValue({ ok: false, permanent: true, reason: 'not-media' });
 
-    const stored = await mirrorFederatedBanner(
+    const result = await mirrorFederatedBanner(
       'https://files.mastodon.social/banner.txt',
       'oxy-user-3',
       'https://mastodon.social/users/carol',
     );
 
-    expect(stored).toBe(false);
+    // `permanent: true` tells the backfill caller NOT to retry.
+    expect(result).toEqual({ ok: false, permanent: true });
     expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
     expect(mocks.loggerWarn).not.toHaveBeenCalled();
   });
 
-  it('guards a non-http url without touching the media path', async () => {
-    const stored = await mirrorFederatedBanner(
+  it('guards a non-http url as a permanent failure without touching the media path', async () => {
+    const result = await mirrorFederatedBanner(
       'data:image/png;base64,iVBORw0KGgo=',
       'oxy-user-4',
       'https://mastodon.social/users/dave',
     );
 
-    expect(stored).toBe(false);
+    // A non-http url will never become valid → permanent, no retry.
+    expect(result).toEqual({ ok: false, permanent: true });
     expect(mocks.persistRemoteMedia).not.toHaveBeenCalled();
     expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
     expect(mocks.loggerWarn).not.toHaveBeenCalled();

--- a/packages/backend/src/__tests__/scripts/backfillFederatedBanners.test.ts
+++ b/packages/backend/src/__tests__/scripts/backfillFederatedBanners.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+
+/**
+ * Offline tests for the federated-banner backfill.
+ *
+ * `connectToDatabase`/`mongoose.disconnect`, `FederatedActor`, `UserSettings`,
+ * and `mirrorFederatedBanner` are mocked so the REAL paging, idempotent skip,
+ * global rate gate, transient-retry/backoff, and permanent-`dead` classification
+ * run WITHOUT MongoDB or a network. Mirrors the in-package pattern from
+ * `scripts/backfillMtnRecords.test.ts`.
+ *
+ * Fake timers keep the rate-gate spacing (≥ 60000/rate ms between upload starts)
+ * and the exponential backoff (2s/6s) instant while still asserting the gate is a
+ * REAL cap: each `acquire()` and each `sleep()` is advanced deterministically.
+ */
+
+interface ActorRow {
+  _id: mongoose.Types.ObjectId;
+  uri: string;
+  headerUrl: string;
+  oxyUserId: string;
+}
+
+const h = vi.hoisted(() => {
+  const state: {
+    actors: ActorRow[];
+    // oxyUserIds whose UserSettings.profileHeaderImage is already set.
+    alreadySet: Set<string>;
+    // queued mirror results, consumed FIFO per call (keyed by oxyUserId).
+    mirrorResults: Map<string, Array<{ ok: boolean; permanent: boolean } | Error>>;
+  } = { actors: [], alreadySet: new Set(), mirrorResults: new Map() };
+
+  // FederatedActor.find — first cursor read returns the candidate page, a query
+  // carrying a `$gt` cursor clause returns empty so the paging loop terminates.
+  const actorFind = vi.fn((query: { _id?: { $gt?: unknown } }) => ({
+    sort: () => ({
+      limit: () => ({
+        lean: async () => (query._id?.$gt ? [] : state.actors),
+      }),
+    }),
+  }));
+
+  const actorCount = vi.fn(async () => state.actors.length);
+
+  const settingsFindOne = vi.fn((query: { oxyUserId: string }) => ({
+    lean: async () =>
+      state.alreadySet.has(query.oxyUserId) ? { profileHeaderImage: 'existing_file' } : null,
+  }));
+
+  const mirror = vi.fn(async (_url: string, oxyUserId: string) => {
+    const queue = state.mirrorResults.get(oxyUserId);
+    const next = queue?.shift();
+    if (next instanceof Error) throw next;
+    return next ?? { ok: true, permanent: false };
+  });
+
+  return { state, actorFind, actorCount, settingsFindOne, mirror };
+});
+
+vi.mock('../../utils/database', () => ({
+  connectToDatabase: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../models/FederatedActor', () => ({
+  FederatedActor: {
+    find: h.actorFind,
+    countDocuments: h.actorCount,
+  },
+}));
+
+vi.mock('../../models/UserSettings', () => ({
+  default: {
+    findOne: h.settingsFindOne,
+  },
+}));
+
+vi.mock('../../connectors/identity', () => ({
+  mirrorFederatedBanner: h.mirror,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('mongoose', async () => {
+  const actual = await vi.importActual<typeof import('mongoose')>('mongoose');
+  return {
+    ...actual,
+    default: { ...actual.default, disconnect: vi.fn(async () => undefined) },
+  };
+});
+
+import backfillFederatedBanners from '../../scripts/backfillFederatedBanners';
+
+function actor(oxyUserId: string): ActorRow {
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    uri: `https://mastodon.social/users/${oxyUserId}`,
+    headerUrl: `https://files.mastodon.social/${oxyUserId}.png`,
+    oxyUserId,
+  };
+}
+
+/**
+ * Run the backfill under fake timers, draining every pending timer (the rate-gate
+ * spacing + backoff sleeps) so the async chain completes deterministically.
+ */
+async function runBackfill(): Promise<void> {
+  const done = backfillFederatedBanners();
+  await vi.runAllTimersAsync();
+  await done;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  h.state.actors = [];
+  h.state.alreadySet = new Set();
+  h.state.mirrorResults = new Map();
+  delete process.env.BACKFILL_FORCE;
+  delete process.env.BACKFILL_CONCURRENCY;
+  delete process.env.BACKFILL_RATE_PER_MIN;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetModules();
+  vi.doUnmock('../../scripts/backfillFederatedBanners');
+});
+
+describe('backfillFederatedBanners', () => {
+  it('mirrors every un-set actor banner and stores it', async () => {
+    h.state.actors = [actor('u1'), actor('u2'), actor('u3')];
+
+    await runBackfill();
+
+    expect(h.mirror).toHaveBeenCalledTimes(3);
+    expect(h.mirror).toHaveBeenCalledWith(
+      'https://files.mastodon.social/u1.png',
+      'u1',
+      'https://mastodon.social/users/u1',
+    );
+  });
+
+  it('skips actors whose profile header image is already set (idempotent)', async () => {
+    h.state.actors = [actor('u1'), actor('u2')];
+    h.state.alreadySet.add('u1');
+
+    await runBackfill();
+
+    // u1 is skipped → only u2 is mirrored.
+    expect(h.mirror).toHaveBeenCalledTimes(1);
+    expect(h.mirror).toHaveBeenCalledWith(
+      'https://files.mastodon.social/u2.png',
+      'u2',
+      'https://mastodon.social/users/u2',
+    );
+  });
+
+  it('re-mirrors already-set actors under BACKFILL_FORCE', async () => {
+    // FORCE is read at module-load time, so re-import the script with the env var
+    // set to exercise the force path (the top-level mocks are preserved by
+    // re-registering them after the reset).
+    process.env.BACKFILL_FORCE = 'true';
+    h.state.actors = [actor('u1')];
+    h.state.alreadySet.add('u1');
+
+    vi.resetModules();
+    vi.doMock('../../utils/database', () => ({ connectToDatabase: vi.fn(async () => undefined) }));
+    vi.doMock('../../models/FederatedActor', () => ({
+      FederatedActor: { find: h.actorFind, countDocuments: h.actorCount },
+    }));
+    vi.doMock('../../models/UserSettings', () => ({ default: { findOne: h.settingsFindOne } }));
+    vi.doMock('../../connectors/identity', () => ({ mirrorFederatedBanner: h.mirror }));
+    vi.doMock('../../utils/logger', () => ({
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    }));
+    vi.doMock('mongoose', async () => {
+      const actual = await vi.importActual<typeof import('mongoose')>('mongoose');
+      return { ...actual, default: { ...actual.default, disconnect: vi.fn(async () => undefined) } };
+    });
+
+    const forced = (await import('../../scripts/backfillFederatedBanners')).default;
+    const done = forced();
+    await vi.runAllTimersAsync();
+    await done;
+
+    // FORCE bypasses the idempotent skip — the already-set actor is re-mirrored.
+    expect(h.settingsFindOne).not.toHaveBeenCalled();
+    expect(h.mirror).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient failure with backoff, then succeeds', async () => {
+    h.state.actors = [actor('u1')];
+    h.state.mirrorResults.set('u1', [
+      { ok: false, permanent: false },
+      { ok: false, permanent: false },
+      { ok: true, permanent: false },
+    ]);
+
+    await runBackfill();
+
+    // 3 attempts total (2 transient + 1 success) — each re-passed the rate gate.
+    expect(h.mirror).toHaveBeenCalledTimes(3);
+  });
+
+  it('counts a failure after exhausting all retry attempts', async () => {
+    h.state.actors = [actor('u1')];
+    h.state.mirrorResults.set('u1', [
+      { ok: false, permanent: false },
+      { ok: false, permanent: false },
+      { ok: false, permanent: false },
+    ]);
+
+    await runBackfill();
+
+    // MAX_ATTEMPTS = 3 → exactly 3 calls, no infinite retry.
+    expect(h.mirror).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT retry a permanent failure', async () => {
+    h.state.actors = [actor('u1')];
+    h.state.mirrorResults.set('u1', [{ ok: false, permanent: true }]);
+
+    await runBackfill();
+
+    expect(h.mirror).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a thrown error as transient, then succeeds', async () => {
+    h.state.actors = [actor('u1')];
+    h.state.mirrorResults.set('u1', [new Error('network blip'), { ok: true, permanent: false }]);
+
+    await runBackfill();
+
+    expect(h.mirror).toHaveBeenCalledTimes(2);
+  });
+
+  it('spaces upload starts by the rate-gate minimum interval (real cap)', async () => {
+    process.env.BACKFILL_RATE_PER_MIN = '30'; // 60000/30 = 2000ms between starts
+    process.env.BACKFILL_CONCURRENCY = '4'; // concurrency must NOT defeat the gate
+    h.state.actors = [actor('u1'), actor('u2'), actor('u3')];
+
+    const startTimes: number[] = [];
+    h.mirror.mockImplementation(async () => {
+      startTimes.push(Date.now());
+      return { ok: true, permanent: false };
+    });
+
+    await runBackfill();
+
+    expect(startTimes).toHaveLength(3);
+    // Despite concurrency 4, starts are ≥ 2000ms apart (the gate serializes them).
+    expect(startTimes[1] - startTimes[0]).toBeGreaterThanOrEqual(2000);
+    expect(startTimes[2] - startTimes[1]).toBeGreaterThanOrEqual(2000);
+  });
+});

--- a/packages/backend/src/connectors/identity.ts
+++ b/packages/backend/src/connectors/identity.ts
@@ -62,6 +62,9 @@ export async function resolveOxyExternalUser(
     if (!oxyId) return null;
 
     if (actor.bannerUrl) {
+      // Best-effort on the live path: the outcome (stored / transient / permanent)
+      // only matters to the one-shot backfill, which inspects the return to decide
+      // whether to retry. Failures here are already logged inside the helper.
       await mirrorFederatedBanner(actor.bannerUrl, oxyId, actor.externalId);
     }
 
@@ -86,22 +89,30 @@ export async function resolveOxyExternalUser(
  * `POST /assets/upload` and is rejected `401 UNAUTHORIZED` on the service client,
  * so the banner was never stored.
  *
- * Best-effort: returns `true` when the banner was stored, `false` otherwise
- * (non-http url, mirror failure, or transient/permanent persist failure).
- * Transient failures are surfaced at `warn`; permanently-unavailable banners
- * (dead/oversized/non-image) stay quiet, mirroring `materializeFederatedMedia`.
+ * Best-effort: returns `{ ok: true }` when the banner was stored, otherwise
+ * `{ ok: false, permanent }`. `permanent` distinguishes a transient failure
+ * (bad service credential, upstream 5xx, upload rejection — worth retrying) from
+ * a permanently-unavailable banner (dead/oversized/non-image — never retry), so
+ * the backfill caller can decide whether to back off and retry. A non-http url is
+ * `permanent: true` (it will never become valid). Transient failures are surfaced
+ * at `warn`; permanent ones stay quiet, mirroring `materializeFederatedMedia`.
  *
- * Shared by the live actor-resolution path (`resolveOxyExternalUser`) and the
- * one-shot `backfillFederatedBanners` script so both go through ONE
- * implementation.
+ * Shared by the live actor-resolution path (`resolveOxyExternalUser`, which
+ * ignores the result) and the one-shot `backfillFederatedBanners` script (which
+ * inspects `permanent` to drive retry) so both go through ONE implementation.
  */
+export interface MirrorBannerResult {
+  ok: boolean;
+  permanent: boolean;
+}
+
 export async function mirrorFederatedBanner(
   bannerUrl: string,
   oxyUserId: string,
   actorUri: string,
-): Promise<boolean> {
+): Promise<MirrorBannerResult> {
   if (!isAbsoluteHttpUrl(bannerUrl)) {
-    return false;
+    return { ok: false, permanent: true };
   }
 
   const remoteHost = getRemoteHost(bannerUrl);
@@ -117,7 +128,7 @@ export async function mirrorFederatedBanner(
       { $set: { profileHeaderImage: result.media.oxyFileId } },
       { upsert: true },
     );
-    return true;
+    return { ok: true, permanent: false };
   }
 
   if (!result.permanent) {
@@ -131,5 +142,5 @@ export async function mirrorFederatedBanner(
     });
   }
 
-  return false;
+  return { ok: false, permanent: result.permanent };
 }

--- a/packages/backend/src/scripts/backfillFederatedBanners.ts
+++ b/packages/backend/src/scripts/backfillFederatedBanners.ts
@@ -16,15 +16,28 @@
  * so a re-run only fills the gaps. Set `BACKFILL_FORCE=true` to re-mirror every
  * actor regardless (e.g. to refresh stale banners).
  *
- * Throttled with a bounded worker pool (default 6; `BACKFILL_CONCURRENCY`) so we
- * neither hammer remote instances nor the Oxy asset API. Logs progress plus a
- * final summary (processed / stored / skipped-already-set / failed) and is
+ * Throughput is bounded TWO ways so the run completes without tripping oxy-api's
+ * rate limits (which OOM'd + 429'd an earlier concurrency-6 run):
+ *   - a global rate gate (`BACKFILL_RATE_PER_MIN`, default 25) enforces a minimum
+ *     interval between upload *starts* across the whole worker pool. 25/min stays
+ *     under oxy-api's `POST /assets/service/federation` cap of 30 uploads/min and
+ *     well under the global per-IP 1000-req/15-min limiter.
+ *   - a bounded worker pool (`BACKFILL_CONCURRENCY`, default 1) caps how many
+ *     mirrors hold a banner buffer at once (the prior OOM was concurrency 6).
+ * With the rate gate doing the real throttling, concurrency 1 is plenty.
+ *
+ * Transient mirror failures (network blip, 429) are retried up to 3 attempts with
+ * exponential backoff (each retry re-passes the rate gate); permanent failures
+ * (remote 404/410, non-image) are NOT retried and counted separately as `dead`.
+ *
+ * Logs progress plus a final summary
+ * (processed / stored / skipped-already-set / retried / failed / dead) and is
  * resumable via the idempotent skip check.
  *
  * Runnable as a Fargate one-shot post-deploy:
  *   bun packages/backend/dist/src/scripts/backfillFederatedBanners.js
  *   BACKFILL_FORCE=true bun packages/backend/dist/src/scripts/backfillFederatedBanners.js
- *   BACKFILL_CONCURRENCY=10 bun packages/backend/dist/src/scripts/backfillFederatedBanners.js
+ *   BACKFILL_RATE_PER_MIN=20 bun packages/backend/dist/src/scripts/backfillFederatedBanners.js
  */
 
 import mongoose from 'mongoose';
@@ -40,14 +53,56 @@ const PAGE_SIZE = 500;
 /** Re-mirror every actor's banner, even when one is already stored. */
 const FORCE = process.env.BACKFILL_FORCE === 'true';
 
+/** Retry attempts (incl. the first) for a transient (non-permanent) failure. */
+const MAX_ATTEMPTS = 3;
+
+/** Exponential backoff base; attempt N waits `BACKOFF_BASE_MS * 3^(N-1)` (2s, 6s, 18s). */
+const BACKOFF_BASE_MS = 2000;
+
 /**
- * Bounded fan-out of concurrent mirror operations. Each mirror is a remote
- * download + a service-token upload, so the cap keeps us from hammering remote
- * instances or the Oxy asset API.
+ * Bounded fan-out of concurrent mirror operations. With the rate gate enforcing
+ * the real throughput cap, this only bounds how many banner buffers are held in
+ * memory at once. Defaults to 1 (the prior concurrency-6 run OOM'd).
  */
 function getConcurrency(): number {
   const raw = Number.parseInt(process.env.BACKFILL_CONCURRENCY || '', 10);
-  return Number.isFinite(raw) && raw > 0 ? raw : 6;
+  return Number.isFinite(raw) && raw > 0 ? raw : 1;
+}
+
+/**
+ * Maximum upload *starts* per minute across the whole pool. Kept under oxy-api's
+ * 30/min federation-upload cap. Defaults to 25.
+ */
+function getRatePerMinute(): number {
+  const raw = Number.parseInt(process.env.BACKFILL_RATE_PER_MIN || '', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 25;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Global minimum-interval rate gate shared across the worker pool. `acquire()`
+ * resolves only once at least `minIntervalMs` has elapsed since the previous
+ * grant, so upload *starts* are spaced ≥ `60000 / ratePerMinute` ms apart
+ * regardless of concurrency. Serializing the reservation (each `acquire` advances
+ * `nextSlot` to `max(now, nextSlot) + minIntervalMs`) makes it a real cap rather
+ * than a per-worker sleep that would drift under parallelism.
+ */
+class RateGate {
+  private readonly minIntervalMs: number;
+  private nextSlot = 0;
+
+  constructor(ratePerMinute: number) {
+    this.minIntervalMs = 60000 / ratePerMinute;
+  }
+
+  async acquire(): Promise<void> {
+    const now = Date.now();
+    const slot = Math.max(now, this.nextSlot);
+    this.nextSlot = slot + this.minIntervalMs;
+    const waitMs = slot - now;
+    if (waitMs > 0) await sleep(waitMs);
+  }
 }
 
 interface FederatedActorRow {
@@ -61,16 +116,26 @@ interface BackfillCounters {
   processed: number;
   stored: number;
   skippedAlreadySet: number;
+  retried: number;
   failed: number;
+  dead: number;
 }
 
 /**
  * Mirror one actor's banner (unless its header image is already stored and we are
- * not forcing). Mutates `counters` in place — called concurrently within a
- * bounded pool, but each branch touches a distinct counter increment on the
- * single-threaded event loop, so no synchronization is needed.
+ * not forcing), passing the global rate gate before each attempt. Retries a
+ * transient failure up to `MAX_ATTEMPTS` with exponential backoff; a permanent
+ * failure (remote gone / non-image) is counted as `dead` and never retried.
+ *
+ * Mutates `counters` in place — called concurrently within a bounded pool, but
+ * each branch touches a distinct counter increment on the single-threaded event
+ * loop, so no synchronization is needed.
  */
-async function processActor(actor: FederatedActorRow, counters: BackfillCounters): Promise<void> {
+async function processActor(
+  actor: FederatedActorRow,
+  counters: BackfillCounters,
+  gate: RateGate,
+): Promise<void> {
   if (!FORCE) {
     const existing = await UserSettings.findOne(
       { oxyUserId: actor.oxyUserId },
@@ -82,18 +147,48 @@ async function processActor(actor: FederatedActorRow, counters: BackfillCounters
     }
   }
 
-  try {
-    const stored = await mirrorFederatedBanner(actor.headerUrl, actor.oxyUserId, actor.uri);
-    if (stored) {
-      counters.stored += 1;
-    } else {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    // Every attempt — first try and each retry — passes the global rate gate so
+    // backoff retries never burst past the upload cap.
+    await gate.acquire();
+
+    try {
+      const result = await mirrorFederatedBanner(actor.headerUrl, actor.oxyUserId, actor.uri);
+      if (result.ok) {
+        counters.stored += 1;
+        return;
+      }
+      if (result.permanent) {
+        // Remote 404/410, non-image, oversized, or a non-http url — retrying will
+        // never succeed. Count it as `dead` and stop.
+        counters.dead += 1;
+        return;
+      }
+      // Transient failure (network blip / 429 / upstream 5xx): back off and retry.
+      if (attempt < MAX_ATTEMPTS) {
+        counters.retried += 1;
+        await sleep(BACKOFF_BASE_MS * 3 ** (attempt - 1));
+        continue;
+      }
       counters.failed += 1;
+      return;
+    } catch (error) {
+      // A thrown error is treated as transient (the helper itself never throws on
+      // a classified permanent failure — it returns `permanent: true`).
+      if (attempt < MAX_ATTEMPTS) {
+        counters.retried += 1;
+        logger.warn(`[backfillFederatedBanners] mirror threw for ${actor.uri} (attempt ${attempt})`, {
+          reason: error instanceof Error ? error.message : 'unknown',
+        });
+        await sleep(BACKOFF_BASE_MS * 3 ** (attempt - 1));
+        continue;
+      }
+      counters.failed += 1;
+      logger.warn(`[backfillFederatedBanners] mirror threw for ${actor.uri} (final)`, {
+        reason: error instanceof Error ? error.message : 'unknown',
+      });
+      return;
     }
-  } catch (error) {
-    counters.failed += 1;
-    logger.warn(`[backfillFederatedBanners] mirror threw for ${actor.uri}`, {
-      reason: error instanceof Error ? error.message : 'unknown',
-    });
   }
 }
 
@@ -116,11 +211,13 @@ async function runPool<T>(items: T[], concurrency: number, worker: (item: T) => 
 async function backfillFederatedBanners(): Promise<void> {
   const startedAt = Date.now();
   const concurrency = getConcurrency();
+  const ratePerMinute = getRatePerMinute();
+  const gate = new RateGate(ratePerMinute);
 
   try {
     await connectToDatabase();
     logger.info(
-      `[backfillFederatedBanners] connected to MongoDB; FORCE=${FORCE}, concurrency=${concurrency}`,
+      `[backfillFederatedBanners] connected to MongoDB; FORCE=${FORCE}, concurrency=${concurrency}, rate=${ratePerMinute}/min`,
     );
 
     // Actors that advertise a banner AND are linked to an Oxy user (so the banner
@@ -145,7 +242,9 @@ async function backfillFederatedBanners(): Promise<void> {
       processed: 0,
       stored: 0,
       skippedAlreadySet: 0,
+      retried: 0,
       failed: 0,
+      dead: 0,
     };
     let lastId: mongoose.Types.ObjectId | null = null;
 
@@ -162,18 +261,18 @@ async function backfillFederatedBanners(): Promise<void> {
 
       if (page.length === 0) break;
 
-      await runPool(page, concurrency, (actor) => processActor(actor, counters));
+      await runPool(page, concurrency, (actor) => processActor(actor, counters, gate));
 
       counters.processed += page.length;
       lastId = page[page.length - 1]._id;
       logger.info(
-        `[backfillFederatedBanners] progress: processed ${counters.processed}/${totalCount}, stored ${counters.stored}, skipped-already-set ${counters.skippedAlreadySet}, failed ${counters.failed}`,
+        `[backfillFederatedBanners] progress: processed ${counters.processed}/${totalCount}, stored ${counters.stored}, skipped-already-set ${counters.skippedAlreadySet}, retried ${counters.retried}, failed ${counters.failed}, dead ${counters.dead}`,
       );
     }
 
     const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
     logger.info(
-      `[backfillFederatedBanners] done${FORCE ? ' (FORCE)' : ''}: processed ${counters.processed}, stored ${counters.stored}, skipped-already-set ${counters.skippedAlreadySet}, failed ${counters.failed} (${elapsedSeconds}s)`,
+      `[backfillFederatedBanners] done${FORCE ? ' (FORCE)' : ''}: processed ${counters.processed}, stored ${counters.stored}, skipped-already-set ${counters.skippedAlreadySet}, retried ${counters.retried}, failed ${counters.failed}, dead ${counters.dead} (${elapsedSeconds}s)`,
     );
 
     await mongoose.disconnect();


### PR DESCRIPTION
Follow-up to #287. The first backfill run (concurrency 6) tripped oxy-api rate limits hard (~3,500 HTTP 429: 30 uploads/min federation cap + 1000/15min global per-IP) and OOM'd. Per the user's decision, throttle the **client** so a one-shot completes cleanly — **no prod rate-limit change**.

- **RateGate** (shared across the worker pool) serializes upload starts ≥ `60000/rate` ms apart. New `BACKFILL_RATE_PER_MIN` (default **25**) stays under both caps. Backoff retries also pass the gate → no bursts.
- **Concurrency default 6 → 1** (overridable); keeps memory flat (the OOM was concurrency 6 holding multiple banner buffers).
- `mirrorFederatedBanner` now returns `{ ok, permanent }` so the backfill retries only **transient** failures (3 attempts, 2s/6s/18s backoff) and never retries **permanent** ones (remote 404/gone). The live path (`resolveOxyExternalUser`) ignores the result — no behaviour change.
- Summary adds `retried` + `dead`. Idempotent skip + `BACKFILL_FORCE` preserved.

## Verification
- tsc green; full backend suite **109 files / 1102 tests** green (incl. a fake-timer test proving concurrency can't defeat the rate cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)