### PR TITLE
feat(atproto-bridge): route apex xrpc + atproto-did to backend (be-discovery edge)

### DIFF
--- a/packages/frontend/public/_worker.js
+++ b/packages/frontend/public/_worker.js
@@ -8,25 +8,67 @@
  * deployed dir (Advanced Mode). This file lives in `public/` so `expo export`
  * copies it to `dist/_worker.js`.
  *
- * Purpose: ActivityPub content negotiation for LOCAL profile URLs. The fediverse
- * discovers a Mention profile two ways:
- *  - by acct handle (`@user@mention.earth`) → webfinger → actor (already works).
- *  - by profile URL (`https://mention.earth/@user`) → the server must return the
- *    AP actor (or HTML linking to it). The Expo SPA only serves `index.html`, so
- *    URL-based discovery was failing for LOCAL profiles.
+ * This worker owns the apex (`mention.earth`) edge. It has two jobs:
  *
- * When a fediverse server requests a LOCAL profile URL with an ActivityPub
- * `Accept` header, we 302-redirect to the canonical actor at
- * `api.mention.earth/ap/users/<username>`. Every other request (human browsers,
- * federated profiles, all other routes) is served from static assets via
- * `env.ASSETS.fetch`, which also honors the `_redirects` SPA fallback.
+ * 1. ActivityPub content negotiation for LOCAL profile URLs. The fediverse
+ *    discovers a Mention profile two ways:
+ *     - by acct handle (`@user@mention.earth`) → webfinger → actor (already works).
+ *     - by profile URL (`https://mention.earth/@user`) → the server must return the
+ *       AP actor (or HTML linking to it). The Expo SPA only serves `index.html`, so
+ *       URL-based discovery was failing for LOCAL profiles. When a fediverse server
+ *       requests a LOCAL profile URL with an ActivityPub `Accept` header, we
+ *       302-redirect to the canonical actor at `api.mention.earth/ap/users/<user>`.
+ *
+ * 2. AT Protocol BE-DISCOVERED bridge edge. The atproto bridge's read surface and
+ *    handle resolution are served by the BACKEND (`api.mention.earth`), but the
+ *    canonical contract advertises the apex host (`mention.earth`):
+ *     - the user DID-document advertises `#atproto_pds` serviceEndpoint
+ *       `https://mention.earth` (apex), so a foreign Bluesky AppView issues its
+ *       `com.atproto.repo.*` / `com.atproto.sync.*` XRPC calls against
+ *       `https://mention.earth/xrpc/*`.
+ *     - apex handle resolution (`https://mention.earth/.well-known/atproto-did`)
+ *       and the Relay `requestCrawl` host both resolve to this apex.
+ *    The apex is served by THIS Cloudflare Pages worker, but the bridge handlers
+ *    live on the backend. So for those apex paths we PROXY (origin-fetch, not a
+ *    302) to `https://api.mention.earth`, preserving method + headers + body so
+ *    POST XRPC calls survive. The original `Host` is forwarded as
+ *    `X-Forwarded-Host` (the backend's atproto-did handler reads it).
+ *
+ * Everything else (human browsers, federated profiles, all other routes) is served
+ * from static assets via `env.ASSETS.fetch`, which also honors the `_redirects`
+ * SPA fallback (`/*  /index.html  200`). That SPA rewrite is exactly why the bridge
+ * paths MUST be intercepted here first — otherwise `/xrpc/*` would be rewritten to
+ * `index.html` and the AppView would get HTML instead of XRPC JSON.
+ *
+ * SAFE TO SHIP BEFORE GO-LIVE: while `ATPROTO_BRIDGE_ENABLED=false` the backend
+ * bridge routes 404, so this forwarding just relays a 404 — no behavior change for
+ * users. It only starts serving real data once the backend flag is flipped.
+ *
+ * NOTE — wildcard handle hosts are NOT handled here. atproto ALSO resolves a handle
+ * via `https://<user>.mention.earth/.well-known/atproto-did`. That is a DIFFERENT
+ * host (`<user>.mention.earth`), which this Pages project does not receive unless
+ * `*.mention.earth` is explicitly routed to the backend at the DNS/CF layer. That
+ * is an infra step, not worker code — see the go-live runbook.
  */
 
 /** Canonical ActivityPub actor base for local users. */
 const ACTOR_BASE = 'https://api.mention.earth/ap/users/';
 
+/** Backend origin that serves the atproto bridge XRPC + apex handle resolution. */
+const BACKEND_ORIGIN = 'https://api.mention.earth';
+
 /** Local profile path: a single segment after `@`, with no second `@`. */
 const LOCAL_PROFILE_PATH = /^\/@([^/@]+)$/;
+
+/**
+ * Apex paths owned by the atproto bridge that must be proxied to the backend.
+ * The bridge serves only `com.atproto.*` XRPC, but forwarding the whole `/xrpc/`
+ * prefix is correct: any unsupported XRPC method simply 404s at the backend. The
+ * apex `.well-known/atproto-did` is the apex-host handle-resolution endpoint.
+ */
+function isBridgeBackendPath(pathname) {
+  return pathname === '/.well-known/atproto-did' || pathname.startsWith('/xrpc/');
+}
 
 /**
  * Whether the `Accept` header asks for ActivityPub JSON. Mastodon may send
@@ -39,10 +81,42 @@ function wantsActivityPub(accept) {
   return value.includes('activity+json') || value.includes('ld+json');
 }
 
+/**
+ * Proxy an apex bridge request to the backend origin, preserving the method,
+ * headers, and body so POST XRPC calls work. The path + query string are kept
+ * verbatim; only the origin changes (`mention.earth` → `api.mention.earth`). The
+ * original apex host is forwarded as `X-Forwarded-Host` because the backend's
+ * `.well-known/atproto-did` handler reads it to derive the handle.
+ */
+function proxyToBackend(request) {
+  const incoming = new URL(request.url);
+  const target = new URL(incoming.pathname + incoming.search, BACKEND_ORIGIN);
+
+  const headers = new Headers(request.headers);
+  headers.set('X-Forwarded-Host', incoming.host);
+  headers.set('X-Forwarded-Proto', 'https');
+
+  // `duplex: 'half'` is required by the Fetch standard when forwarding a request
+  // that may carry a streaming body (POST XRPC); harmless for bodyless GETs.
+  return fetch(target.toString(), {
+    method: request.method,
+    headers,
+    body: request.body,
+    redirect: 'manual',
+    duplex: 'half',
+  });
+}
+
 export default {
   async fetch(request, env) {
     const { pathname } = new URL(request.url);
 
+    // 1. atproto bridge apex paths → proxy to the backend (preserve method/body).
+    if (isBridgeBackendPath(pathname)) {
+      return proxyToBackend(request);
+    }
+
+    // 2. ActivityPub content negotiation for local profile URLs.
     const match = pathname.match(LOCAL_PROFILE_PATH);
     if (match && wantsActivityPub(request.headers.get('Accept'))) {
       const username = match[1];
@@ -56,7 +130,7 @@ export default {
       });
     }
 
-    // Serve the static export (and the `_redirects` SPA fallback) for everything
+    // 3. Serve the static export (and the `_redirects` SPA fallback) for everything
     // else: human browsers, federated profiles, and all other routes.
     return env.ASSETS.fetch(request);
   },


### PR DESCRIPTION
## Summary

- The CF Pages apex worker (`packages/frontend/public/_worker.js`) now intercepts `/.well-known/atproto-did` and `/xrpc/*` requests before they fall through to the SPA static-asset rewrite that would return `index.html` instead of XRPC JSON.
- Those requests are proxied (origin-fetch, not a redirect) to `https://api.mention.earth`, preserving method, headers, and body so POST XRPC calls survive intact. The original apex host is forwarded as `X-Forwarded-Host` because the backend's handle-resolution handler reads it to derive the handle.
- The existing `/@user` ActivityPub content-negotiation 302 and the default `env.ASSETS.fetch` static-asset fall-through are completely unchanged.

## Why

The atproto bridge's read surface (`com.atproto.repo.*` / `com.atproto.sync.*` XRPC) and apex handle resolution (`/.well-known/atproto-did`) are contractually served at the apex host `mention.earth`, but the handlers live on `api.mention.earth`. Without this worker intercept, the SPA `_redirects` rule (`/* /index.html 200`) would swallow every XRPC call and return HTML — the bridge would be unfetchable from foreign Bluesky AppViews.

## Safe pre-go-live

While `ATPROTO_BRIDGE_ENABLED=false` (current prod state), the backend bridge routes return 404. This worker just relays that 404. No behavior change for users or existing federation until the backend flag is flipped.

## Out of scope — wildcard handle hosts

atproto ALSO resolves a handle via `https://<user>.mention.earth/.well-known/atproto-did`. That is a **different host** (`<user>.mention.earth`) that this Cloudflare Pages project does not receive traffic for unless `*.mention.earth` is explicitly routed to the backend at the DNS/CF layer. That is an **infra/DNS step**, not worker code — see the go-live runbook.

## Test plan

- [ ] `node --check packages/frontend/public/_worker.js` passes (syntax gate)
- [ ] 13/13 behavioral routing assertions pass (atproto-did proxy + X-Forwarded-Host, GET /xrpc path+query, POST /xrpc method+body+duplex, /@user AP 302 unchanged, human profile + arbitrary routes + webfinger + bare `/xrpc` all fall through to static assets)
- [ ] `bun run build:frontend` succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)