### PR TITLE
feat(sidebar): use SDK ProfileButton for the account footer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.5",
         "@oxyhq/bloom": "^0.25.2",
-        "@oxyhq/services": "^13.0.3",
+        "@oxyhq/services": "^13.1.3",
         "@react-native/js-polyfills": "^0.86.0",
         "array.prototype.map": "^1.0.8",
         "react-native-worklets": "0.8.3",
@@ -298,7 +298,7 @@
   "overrides": {
     "@oxyhq/bloom": "^0.25.2",
     "@oxyhq/core": "^5.2.0",
-    "@oxyhq/services": "^13.0.3",
+    "@oxyhq/services": "^13.1.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
@@ -904,7 +904,7 @@
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.1", "", { "dependencies": { "@oxyhq/contracts": "^0.7.0", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-AiObs+A0+HkMsNCVfZuAaT6P0BOTq6oxKHwlgFUhRxIuPz0abO4SUBZyaszUQ5oJ0WgpTzx89fmLLdG1vjL+VQ=="],
 
-    "@oxyhq/services": ["@oxyhq/services@13.0.3", "", { "dependencies": { "@oxyhq/contracts": "0.7.0" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.16.0", "@oxyhq/core": "5.1.1", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": "^11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-document-picker": "~56.0.4", "expo-file-system": "~56.0.7", "expo-font": ">=13.0.0", "expo-haptics": "~56.0.3", "expo-image": ">=2.0.0", "expo-image-manipulator": "~56.0.3", "expo-linear-gradient": "~56.0.4", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-gesture-handler": "~2.31.2", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": "~5.8.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@expo/vector-icons", "@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-linear-gradient", "nativewind", "react-native-keyboard-controller", "react-native-qrcode-svg"] }, "sha512-JkVnNMv9nmkgyiLB8W4kiYKnqTeB6nWSEy8UUALcqoMKG9/a/BeSRPmozXlWK9CTfcTQE4s1Gw+a8whPQnkqGw=="],
+    "@oxyhq/services": ["@oxyhq/services@13.1.3", "", { "dependencies": { "@oxyhq/contracts": "0.7.0" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.16.0", "@oxyhq/core": "5.2.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": "^11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-document-picker": "~56.0.4", "expo-file-system": "~56.0.7", "expo-font": ">=13.0.0", "expo-haptics": "~56.0.3", "expo-image": ">=2.0.0", "expo-image-manipulator": "~56.0.3", "expo-linear-gradient": "~56.0.4", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-gesture-handler": "~2.31.2", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": "~5.8.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@expo/vector-icons", "@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-linear-gradient", "nativewind", "react-native-keyboard-controller", "react-native-qrcode-svg"] }, "sha512-8q6SbPmldHYOzNDYX9bp74ohQeD5FJQf2bhPgrsTAO/lxbehucLwDsrbDh7z5HHijxfw344FOOqdNc5okuk/8Q=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.5",
     "@oxyhq/bloom": "^0.25.2",
-    "@oxyhq/services": "^13.0.3",
+    "@oxyhq/services": "^13.1.3",
     "@react-native/js-polyfills": "^0.86.0",
     "array.prototype.map": "^1.0.8",
     "react-native-worklets": "0.8.3",
@@ -55,7 +55,7 @@
     "@react-native/metro-config": "0.85.3",
     "@oxyhq/bloom": "^0.25.2",
     "@oxyhq/core": "^5.2.0",
-    "@oxyhq/services": "^13.0.3",
+    "@oxyhq/services": "^13.1.3",
     "mongoose": "^8.17.0",
     "ioredis": "5.10.1",
     "lightningcss": "1.30.1",

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -19,19 +19,17 @@ import { Bookmark, BookmarkActive } from "@/assets/icons/bookmark-icon";
 import { Gear, GearActive } from "@/assets/icons/gear-icon";
 import { Search, SearchActive } from "@/assets/icons/search-icon";
 import { ComposeIcon } from "@/assets/icons/compose-icon";
-import { Ionicons } from "@expo/vector-icons";
 import { confirmDialog } from "@/utils/alerts";
 import { List, ListActive } from "@/assets/icons/list-icon";
 import { Video, VideoActive } from "@/assets/icons/video-icon";
 import { Hashtag, HashtagActive } from "@/assets/icons/hashtag-icon";
 import { AnalyticsIcon, AnalyticsIconActive } from "@/assets/icons/analytics-icon";
 import { useTheme, useBloomTheme } from '@oxyhq/bloom/theme';
-import { logger } from '@/lib/logger';
 import { useAppearanceStore } from '@/store/appearanceStore';
 import { Chat, ChatActive } from '@/assets/icons/chat-icon';
 import { Bell, BellActive } from '@/assets/icons/bell-icon';
 import { Agora, AgoraActive } from '@mention/agora-shared';
-import { useAuth } from '@oxyhq/services';
+import { useAuth, ProfileButton } from '@oxyhq/services';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { asViewStyle, type WebViewStyle } from '@/types/webStyles';
 
@@ -62,23 +60,19 @@ interface SideBarProps {
 export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
     const { t } = useTranslation();
     const router = useRouter();
-    const { user, signIn, signOut, isAuthenticated, isAuthResolved, isPrivateApiPending } = useAuth();
+    const { user, signIn } = useAuth();
     const theme = useTheme();
     const { resetTheme } = useBloomTheme();
     const resetAppearance = useAppearanceStore((state) => state.reset);
     const avatarUri = user?.avatar;
 
-    const handleSignOut = useCallback(async () => {
-        try {
-            await signOut();
-        } catch (error: unknown) {
-            logger.warn('Sign out failed', { error });
-        }
+    // ProfileButton owns the account switcher (switch/sign-out/sign-out-all live
+    // in the SDK). This fires just before the active identity changes so we can
+    // clear the previous account's scoped UI state (appearance + Bloom theme).
+    const handleBeforeSessionChange = useCallback(() => {
         resetAppearance();
         resetTheme();
-        onNavigate?.();
-        router.replace('/');
-    }, [signOut, onNavigate, router, resetAppearance, resetTheme]);
+    }, [resetAppearance, resetTheme]);
 
     // Every sidebar destination is a TAB ROOT (home, the current user's own
     // profile, explore, notifications, chat, agora, insights, saved, feeds,
@@ -98,12 +92,24 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
         router.push('/compose');
     }, [onNavigate, router]);
 
-    const handleSignIn = useCallback(() => {
+    // Adding another account (from the ProfileButton menu) and signing in while
+    // signed out both go through the same SDK sign-in flow.
+    const handleAddAccount = useCallback(() => {
         onNavigate?.();
         signIn().catch(() => {});
     }, [onNavigate, signIn]);
 
     const profileHandle = getNormalizedUserHandle(user);
+
+    const handleNavigateProfile = useCallback(() => {
+        if (profileHandle) {
+            handleNavPress(`/@${profileHandle}`);
+        }
+    }, [profileHandle, handleNavPress]);
+
+    const handleNavigateManage = useCallback(() => {
+        handleNavPress('/settings');
+    }, [handleNavPress]);
 
     const sideBarData = useMemo<Array<{ title: string; icon: React.ReactNode; iconActive: React.ReactNode; route?: Href; onPress?: () => void }>>(() => [
         {
@@ -187,7 +193,6 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
     const pathname = usePathname();
     const isSideBarVisible = useIsScreenNotMobile();
     const isExpanded = useIsSideBarExpanded();
-    const showAuthPlaceholder = !isAuthResolved || isPrivateApiPending || (isAuthenticated && !user);
 
     if (!asDrawer && !isSideBarVisible) return null;
 
@@ -244,43 +249,17 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
                     styles.footer,
                     { alignItems: showExpanded ? 'flex-start' : 'center' },
                 ]}>
-                    {/* Auth-sensitive footer. Three states:
-                        1. UNDETERMINED (`!isAuthResolved`): cold-boot session restore
-                           has not concluded, so `user`/`isAuthenticated` are not yet a
-                           reliable answer. Render a neutral skeleton of the same
-                           footprint as a SideBarItem so the column does not shift and
-                           we never flash the "Sign In" item before snapping to authed.
-                        2. AUTHED (`user`): show Sign Out.
-                        3. ANON (resolved, no user): show Sign In.
-                        Gating on the SAME reactive condition as the profile row above
-                        (truthy `user`) keeps the two in agreement. */}
-                    {showAuthPlaceholder ? (
-                        <View
-                            className={showExpanded ? 'w-full self-stretch px-4' : 'self-center px-3'}
-                            style={styles.footerSkeleton}
-                        >
-                            <View className="bg-muted rounded-full w-6 h-6" />
-                            {showExpanded && (
-                                <View className="bg-muted rounded-full h-3.5 flex-1 ml-3 mr-6" />
-                            )}
-                        </View>
-                    ) : isAuthenticated ? (
-                        <SideBarItem
-                            isActive={false}
-                            icon={<Ionicons name="log-out-outline" size={20} color={theme.colors.text} />}
-                            text={t('sidebar.signOut')}
-                            isExpanded={showExpanded}
-                            onPress={handleSignOut}
-                        />
-                    ) : (
-                        <SideBarItem
-                            isActive={false}
-                            icon={<Ionicons name="log-in-outline" size={20} color={theme.colors.text} />}
-                            text={t('sidebar.signIn')}
-                            isExpanded={showExpanded}
-                            onPress={handleSignIn}
-                        />
-                    )}
+                    {/* Account trigger. ProfileButton owns all three auth states
+                        (undetermined skeleton, signed-in row + account switcher,
+                        signed-out "Sign in") and the device-account switcher menu
+                        (switch / add account / sign out / sign out all). */}
+                    <ProfileButton
+                        expanded={showExpanded}
+                        onNavigateManage={handleNavigateManage}
+                        onNavigateProfile={handleNavigateProfile}
+                        onAddAccount={handleAddAccount}
+                        onBeforeSessionChange={handleBeforeSessionChange}
+                    />
                 </View>
             </View>
         </View>
@@ -342,14 +321,5 @@ const styles = StyleSheet.create({
         justifyContent: 'flex-end',
         width: '100%',
         marginTop: 'auto',
-    },
-    // Neutral placeholder for the auth-resolving window. Mirrors SideBarItem's
-    // footprint (icon row: py-2.5 = 10px vertical + 24px icon, mb-1.5 = 6px)
-    // so swapping to the real Sign-in/Sign-out item causes no layout shift.
-    footerSkeleton: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        paddingVertical: 10,
-        marginBottom: 6,
     },
 });


### PR DESCRIPTION
## Summary
Replaces the hand-rolled Sign In / Sign Out / auth-skeleton footer in the Mention sidebar with `ProfileButton` from `@oxyhq/services`. `ProfileButton` owns all three auth states (undetermined skeleton, signed-in row + device-account switcher, signed-out "Sign in") and the switch / add-account / sign-out / sign-out-all menu, so the local `showAuthPlaceholder` / `handleSignIn` / `handleSignOut` footer logic, the `footerSkeleton` style, and the now-unused `Ionicons` / `logger` imports are removed (clean cut).

## Footer JSX
```tsx
<ProfileButton
    expanded={showExpanded}
    onNavigateManage={handleNavigateManage}   // -> router.navigate('/settings')
    onNavigateProfile={handleNavigateProfile} // -> /@<getNormalizedUserHandle(user)>
    onAddAccount={handleAddAccount}           // -> useAuth().signIn()
    onBeforeSessionChange={handleBeforeSessionChange} // reset appearance + Bloom theme on identity change
/>
```
- Collapsed mode keeps the footer `View`'s `alignItems: showExpanded ? 'flex-start' : 'center'` so the avatar-only trigger centers.
- The separate "Profile" nav item in the items list is left untouched (out of scope).
- Avatar/name are rendered by `ProfileButton` itself via the app-wide `ImageResolverProvider` (registered at `app/_layout.tsx`).

## SDK bump
Bumps `@oxyhq/services` `^13.0.3` -> `^13.1.3` (dependency + overrides, lockfile in the same commit). `13.1.3` adds `ProfileButton` and fixes two consumer-side tsc regressions in the SDK that were fixed upstream during this work:
- `ProfileMenu` `ActionRow.icon` typed to the `MaterialCommunityIcons` glyph union (was `string`).
- `NotificationsScreen` invalid glyph `megaphone` -> `bullhorn`.

## Verification
- `bun run typecheck` (frontend): passes (3 allow-listed external livekit-client errors ignored).
- `bun run build:frontend`: web export succeeds (`Exported: dist`, 11 bundles).
- `bun install --frozen-lockfile`: green (lockfile resolves `@oxyhq/services@13.1.3` with concrete `@oxyhq/contracts 0.7.0`, no `workspace:*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)