### PR TITLE
fix(federation): reliable post language capture + language-feed filtering + backfill

### DIFF
--- a/packages/backend/src/__tests__/backfillPostLanguages.test.ts
+++ b/packages/backend/src/__tests__/backfillPostLanguages.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+
+/**
+ * Offline, model-level test for the version-gated language backfill.
+ *
+ * `Post.find` (the ascending `_id` page cursor) and `Post.bulkWrite` are mocked
+ * over a small in-memory store, so the REAL selection filter, idempotency, and
+ * write shape run WITHOUT MongoDB — mirroring the in-package convention from
+ * `scripts/backfillThreadRootThreadId.test.ts` / `scripts/backfillFederatedBanners.test.ts`
+ * (the repo has no `mongodb-memory-server` and globally mocks mongoose). The REAL
+ * `BaselineContentClassifier` (pure/synchronous) derives the languages so the
+ * test validates genuine detection, not a stub.
+ */
+
+interface StoredPost {
+  _id: mongoose.Types.ObjectId;
+  content?: { text?: string };
+  hashtags?: string[];
+  federation?: { sensitive?: boolean } | null;
+  postClassification?: { languages?: string[]; version?: number };
+  language?: string;
+}
+
+interface CapturedOp {
+  updateOne: { filter: { _id: mongoose.Types.ObjectId }; update: { $set: Record<string, unknown> } };
+}
+
+const h = vi.hoisted(() => {
+  const state: { posts: StoredPost[] } = { posts: [] };
+  return { state, find: vi.fn(), bulkWrite: vi.fn() };
+});
+
+vi.mock('../models/Post', () => ({
+  Post: { find: h.find, bulkWrite: h.bulkWrite },
+}));
+
+import { BASELINE_CLASSIFIER_VERSION } from '../services/BaselineContentClassifier';
+import { backfillPostLanguages } from '../scripts/backfillPostLanguages';
+
+/**
+ * Mirror the backfill's selection filter: a post qualifies when its canonical
+ * `postClassification.languages` array is missing/empty OR it was classified
+ * before the current baseline version.
+ */
+function matchesFilter(p: StoredPost): boolean {
+  const langs = p.postClassification?.languages;
+  const langsMissingOrEmpty = langs == null || (Array.isArray(langs) && langs.length === 0);
+  const version = p.postClassification?.version;
+  const versionStale = typeof version === 'number' && version < BASELINE_CLASSIFIER_VERSION;
+  return langsMissingOrEmpty || versionStale;
+}
+
+beforeEach(() => {
+  h.state.posts = [];
+  h.find.mockReset();
+  h.bulkWrite.mockReset();
+
+  h.find.mockImplementation((query: { _id?: { $gt?: mongoose.Types.ObjectId } }) => ({
+    sort: () => ({
+      limit: (n: number) => ({
+        lean: async () => {
+          const gt = query._id?.$gt;
+          return h.state.posts
+            .filter((p) => (!gt || p._id.toString() > gt.toString()) && matchesFilter(p))
+            .sort((a, b) => a._id.toString().localeCompare(b._id.toString()))
+            .slice(0, n);
+        },
+      }),
+    }),
+  }));
+
+  h.bulkWrite.mockImplementation(async (ops: CapturedOp[]) => {
+    for (const op of ops) {
+      const target = h.state.posts.find((p) => p._id.toString() === op.updateOne.filter._id.toString());
+      if (!target) continue;
+      const set = op.updateOne.update.$set;
+      target.postClassification = {
+        ...target.postClassification,
+        languages: set['postClassification.languages'] as string[] | undefined,
+        version: set['postClassification.version'] as number | undefined,
+      };
+      target.language = set.language as string | undefined;
+    }
+    return { modifiedCount: ops.length };
+  });
+});
+
+describe('backfillPostLanguages', () => {
+  it('derives languages for a post missing them and is idempotent', async () => {
+    const id = new mongoose.Types.ObjectId();
+    // A pre-multilanguage doc: stale classifier version, no languages array.
+    h.state.posts = [
+      {
+        _id: id,
+        content: { text: 'Hola, ¿cómo estás hoy amigo?' },
+        postClassification: { version: 1 },
+      },
+    ];
+
+    const first = await backfillPostLanguages({ batchSize: 100 });
+    expect(first.updated).toBeGreaterThanOrEqual(1);
+
+    const after = h.state.posts.find((p) => p._id.equals(id));
+    expect(after?.postClassification?.languages?.length).toBeGreaterThanOrEqual(1);
+    expect(after?.postClassification?.version).toBe(BASELINE_CLASSIFIER_VERSION);
+    expect(after?.language).toBe(after?.postClassification?.languages?.[0]);
+
+    // Second run finds nothing new (idempotent).
+    const second = await backfillPostLanguages({ batchSize: 100 });
+    expect(second.updated).toBe(0);
+  });
+
+  it('does not write when dryRun is set, but still reports what it would update', async () => {
+    h.state.posts = [
+      {
+        _id: new mongoose.Types.ObjectId(),
+        content: { text: 'This is a clearly English sentence for detection.' },
+        postClassification: { version: 1 },
+      },
+    ];
+
+    const result = await backfillPostLanguages({ dryRun: true });
+
+    expect(result.updated).toBeGreaterThanOrEqual(1);
+    expect(h.bulkWrite).not.toHaveBeenCalled();
+    expect(h.state.posts[0].postClassification?.languages).toBeUndefined();
+  });
+
+  it('skips posts with no derivable language without fabricating one', async () => {
+    h.state.posts = [
+      {
+        _id: new mongoose.Types.ObjectId(),
+        content: { text: 'hi' }, // too short to detect
+        postClassification: { version: 1 },
+      },
+    ];
+
+    const result = await backfillPostLanguages({ batchSize: 100 });
+
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(h.bulkWrite).not.toHaveBeenCalled();
+    expect(h.state.posts[0].postClassification?.languages).toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/filterByLanguage.test.ts
+++ b/packages/backend/src/__tests__/filterByLanguage.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import type { FeedPostSlice, HydratedPost } from '@mention/shared-types';
+import { filterByLanguage } from '../mtn/feed/tuners/filterByLanguage';
+import type { TunerContext } from '../mtn/feed/FeedTuner';
+
+/**
+ * `filterByLanguage` matches on the canonical `postClassification.languages`
+ * array (surfaced via hydrated `metadata.languages`) with ANY-OVERLAP semantics:
+ * a bilingual post passes as long as one of its languages is preferred, and a
+ * post with no declared language passes through (permissive, never hard-excludes).
+ */
+const slice = (languages?: string[]): FeedPostSlice => ({
+  _sliceKey: 'k',
+  isIncompleteThread: false,
+  items: [
+    {
+      post: { metadata: { languages } } as unknown as HydratedPost,
+      isThreadParent: false,
+      isThreadChild: false,
+      isThreadLastChild: false,
+    },
+  ],
+});
+
+const ctx = (languages: string[]): TunerContext => ({ preferences: { languages } });
+
+describe('filterByLanguage', () => {
+  it('passes posts whose languages array overlaps the preference', () => {
+    const out = filterByLanguage([slice(['es', 'en'])], ctx(['en']));
+    expect(out).toHaveLength(1);
+  });
+
+  it('drops posts with no overlap', () => {
+    const out = filterByLanguage([slice(['fr'])], ctx(['en'])); // no overlap
+    expect(out).toHaveLength(0);
+  });
+
+  it('passes posts with no language set (permissive)', () => {
+    const out = filterByLanguage([slice(undefined)], ctx(['en']));
+    expect(out).toHaveLength(1);
+  });
+
+  it('passes everything when no language preference is set', () => {
+    const out = filterByLanguage([slice(['fr'])], ctx([]));
+    expect(out).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/__tests__/postLanguageDefault.test.ts
+++ b/packages/backend/src/__tests__/postLanguageDefault.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { Post } from '../models/Post';
+
+/**
+ * The top-level `post.language` (ActivityPub protocol field) must reflect the
+ * REAL primary language of the post — the classifier's `languages[0]`, or nothing
+ * when no language could be declared/detected. It must NOT be silently defaulted
+ * to `'en'`, which mislabels every language-less/undetectable post as English and
+ * poisons language-based feed filtering + recommendation.
+ *
+ * These instantiate real Post documents (no DB) and assert the schema default.
+ */
+describe('Post.language default', () => {
+  it('is undefined (not "en") when no language is provided', () => {
+    const doc = new Post({ content: { text: 'hi' } });
+    expect(doc.language).toBeUndefined();
+  });
+
+  it('keeps an explicitly set language', () => {
+    const doc = new Post({ content: { text: 'hola' }, language: 'es' });
+    expect(doc.language).toBe('es');
+  });
+});

--- a/packages/backend/src/models/Post.ts
+++ b/packages/backend/src/models/Post.ts
@@ -408,7 +408,7 @@ const PostSchema = new Schema<IPost>({
   visibility: { type: String, enum: Object.values(PostVisibility), default: PostVisibility.PUBLIC, index: true },
   isEdited: { type: Boolean, default: false },
   editHistory: [{ type: String }],
-  language: { type: String, default: 'en', index: true },
+  language: { type: String, index: true },
   tags: [{ type: String }],
   mentions: [{ type: String, index: true }],
   hashtags: [{ type: String, index: true }],

--- a/packages/backend/src/mtn/feed/tuners/filterByLanguage.ts
+++ b/packages/backend/src/mtn/feed/tuners/filterByLanguage.ts
@@ -2,8 +2,9 @@ import { FeedPostSlice } from '@mention/shared-types';
 import { TunerContext } from '../FeedTuner';
 
 /**
- * Filter slices to only include preferred languages.
- * If no language preferences set, passes through all slices.
+ * Filter slices to preferred languages using the canonical
+ * `postClassification.languages` array (surfaced via hydrated metadata).
+ * Any-overlap match; posts with no declared language pass through.
  */
 export function filterByLanguage(slices: FeedPostSlice[], ctx: TunerContext): FeedPostSlice[] {
   const langs = ctx.preferences.languages;
@@ -12,12 +13,11 @@ export function filterByLanguage(slices: FeedPostSlice[], ctx: TunerContext): Fe
   const langSet = new Set(langs.map((l) => l.toLowerCase()));
 
   return slices.filter((slice) => {
-    // Check the anchor post's language
     const anchorPost = slice.items[0]?.post;
     if (!anchorPost) return true;
-    const postLang = (anchorPost.metadata as any)?.language?.toLowerCase();
-    // Pass through posts with no language set
-    if (!postLang) return true;
-    return langSet.has(postLang);
+    const postLangs = anchorPost.metadata?.languages;
+    // Pass through posts with no language set.
+    if (!postLangs || postLangs.length === 0) return true;
+    return postLangs.some((l) => langSet.has(l.toLowerCase()));
   });
 }

--- a/packages/backend/src/routes/search.ts
+++ b/packages/backend/src/routes/search.ts
@@ -226,9 +226,11 @@ router.get("/", async (req: AuthRequest, res: Response) => {
         }
       }
 
-      // Language filter
+      // Language filter — match the canonical multi-language array (multikey
+      // index). Mongo matches an array field by element equality, so the scalar
+      // matches any post whose `postClassification.languages` contains it.
       if (language && typeof language === 'string') {
-        filter.language = language;
+        filter['postClassification.languages'] = language;
       }
 
       // Cursor-based pagination

--- a/packages/backend/src/scripts/backfillPostLanguages.ts
+++ b/packages/backend/src/scripts/backfillPostLanguages.ts
@@ -1,0 +1,184 @@
+/**
+ * One-shot corpus backfill: derive `postClassification.languages` (+ the
+ * top-level primary `post.language`) for posts that predate multi-language
+ * classification.
+ *
+ * Language-based feed filtering/recommendation reads the canonical
+ * `postClassification.languages` array. Posts created before v4 of the Stage-A
+ * baseline (or before the multi-language field existed) either lack that array or
+ * carry a stale `postClassification.version`, so they never match a viewer's
+ * language preference. This re-runs the deterministic {@link baselineContentClassifier}
+ * over those posts and writes the derived array + primary.
+ *
+ * It re-derives from the post's own `content.text` / `hashtags` (NOT the stored
+ * `post.language`, which used to be defaulted to `'en'` — reusing it would
+ * propagate that bad default). Posts whose text is too short/undetectable are
+ * left untouched rather than fabricating a language.
+ *
+ * Idempotent (writing the array + current version removes a post from the
+ * selection filter, so a re-run only fills gaps), batched via a stable ascending
+ * `_id` page cursor, and fail-soft (a single post's classify failure is logged at
+ * warn and skipped — never aborts the run). Supports `--dry-run` (report what it
+ * would update, write nothing).
+ *
+ * Runnable as a Fargate one-shot post-deploy:
+ *   bun packages/backend/dist/src/scripts/backfillPostLanguages.js
+ *   bun packages/backend/dist/src/scripts/backfillPostLanguages.js --dry-run
+ */
+
+import mongoose from 'mongoose';
+import { Post } from '../models/Post';
+import { baselineContentClassifier, BASELINE_CLASSIFIER_VERSION } from '../services/BaselineContentClassifier';
+import { logger } from '../utils/logger';
+
+/** Posts scanned per page (stable ascending `_id` cursor pagination). */
+const DEFAULT_PAGE_SIZE = 500;
+
+/** Update writes flushed per bulkWrite chunk. */
+const BULK_CHUNK_SIZE = 500;
+
+export interface BackfillPostLanguagesResult {
+  scanned: number;
+  updated: number;
+}
+
+/** Minimal projected shape the classifier needs. */
+interface PostLanguageRow {
+  _id: mongoose.Types.ObjectId;
+  content?: { text?: string };
+  hashtags?: string[];
+  federation?: { sensitive?: boolean } | null;
+}
+
+/**
+ * Re-classify and backfill languages over the qualifying corpus. Operates on the
+ * `Post` model only — the caller owns the Mongo connection lifecycle — so it is
+ * unit-testable with a mocked model and reusable from an in-process caller.
+ */
+export async function backfillPostLanguages(
+  opts: { batchSize?: number; dryRun?: boolean } = {},
+): Promise<BackfillPostLanguagesResult> {
+  const pageSize = opts.batchSize ?? DEFAULT_PAGE_SIZE;
+  const dryRun = opts.dryRun ?? false;
+
+  // Posts whose canonical multi-language array is absent/empty, or that were
+  // classified before the current baseline version. Setting the array + version
+  // removes a post from this filter, so the ascending `_id` cursor never revisits
+  // a completed post and a re-run only fills remaining gaps.
+  const baseFilter: Record<string, unknown> = {
+    $or: [
+      { 'postClassification.languages': { $in: [null, []] } },
+      { 'postClassification.languages': { $exists: false } },
+      { 'postClassification.version': { $lt: BASELINE_CLASSIFIER_VERSION } },
+    ],
+  };
+
+  let scanned = 0;
+  let updated = 0;
+  let lastId: mongoose.Types.ObjectId | null = null;
+  let pendingOps: mongoose.AnyBulkWriteOperation<typeof Post>[] = [];
+
+  const flush = async (): Promise<void> => {
+    if (pendingOps.length === 0 || dryRun) {
+      pendingOps = [];
+      return;
+    }
+    await Post.bulkWrite(pendingOps, { ordered: false });
+    pendingOps = [];
+  };
+
+  for (;;) {
+    const pageFilter: Record<string, unknown> = { ...baseFilter };
+    if (lastId) {
+      pageFilter._id = { $gt: lastId };
+    }
+
+    const page = await Post.find(pageFilter, {
+      _id: 1,
+      'content.text': 1,
+      hashtags: 1,
+      federation: 1,
+    })
+      .sort({ _id: 1 })
+      .limit(pageSize)
+      .lean<PostLanguageRow[]>();
+
+    if (page.length === 0) break;
+
+    for (const post of page) {
+      scanned += 1;
+      try {
+        const signals = baselineContentClassifier.classify({
+          text: post.content?.text,
+          hashtags: post.hashtags,
+          sensitive: post.federation?.sensitive,
+          isFederated: post.federation != null,
+        });
+        // No derivable language (too short / undetectable): leave it for a later
+        // run rather than fabricating one. Never write an empty array.
+        if (signals.languages.length === 0) continue;
+
+        updated += 1;
+        if (dryRun) continue;
+
+        pendingOps.push({
+          updateOne: {
+            filter: { _id: post._id },
+            update: {
+              $set: {
+                'postClassification.languages': signals.languages,
+                'postClassification.version': signals.version,
+                language: signals.languages[0],
+              },
+            },
+          },
+        });
+
+        if (pendingOps.length >= BULK_CHUNK_SIZE) {
+          await flush();
+        }
+      } catch (error) {
+        logger.warn('[backfillPostLanguages] classify failed for post; skipping', {
+          id: String(post._id),
+          reason: error instanceof Error ? error.message : 'unknown',
+        });
+      }
+    }
+
+    lastId = page[page.length - 1]._id;
+    logger.info(`[backfillPostLanguages] progress: scanned ${scanned}, updated ${updated}`);
+  }
+
+  await flush();
+
+  return { scanned, updated };
+}
+
+async function main(): Promise<void> {
+  const startedAt = Date.now();
+  const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/mention';
+  const dbName = `mention-${process.env.NODE_ENV || 'development'}`;
+  const dryRun = process.argv.includes('--dry-run');
+
+  try {
+    await mongoose.connect(mongoUri, { dbName });
+    logger.info(`[backfillPostLanguages] connected to MongoDB (${dbName}); DRY_RUN=${dryRun}`);
+
+    const result = await backfillPostLanguages({ dryRun });
+
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    logger.info(
+      `[backfillPostLanguages] done${dryRun ? ' (DRY_RUN — no writes)' : ''}: scanned ${result.scanned}, updated ${result.updated} (${elapsedSeconds}s)`,
+    );
+
+    await mongoose.disconnect();
+  } catch (error) {
+    logger.error('[backfillPostLanguages] failed', error);
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -27,6 +27,11 @@ interface RawPost {
   oxyUserId?: string;
   content?: Partial<PostContent>;
   metadata?: Partial<PostMetadata>;
+  /**
+   * Stage-A classification subdoc. Only the canonical multi-language array is
+   * read during hydration (surfaced to the DTO as `metadata.languages`).
+   */
+  postClassification?: { languages?: string[] };
   stats?: {
     likesCount?: number;
     downvotesCount?: number;
@@ -1178,6 +1183,7 @@ export class PostHydrationService {
       isSensitive: Boolean(post.metadata?.isSensitive),
       isThread: Boolean(post.threadId),
       language: post.language || undefined,
+      languages: post.postClassification?.languages ?? undefined,
       // Only include tags/hashtags if needed (can be large arrays)
       tags: includeFullMetadata && Array.isArray(post.tags) && post.tags.length > 0 ? post.tags : undefined,
       mentions: includeFullMetadata && Array.isArray(post.mentions) && post.mentions.length > 0 ? post.mentions.filter((m): m is string => typeof m === 'string') : undefined,

--- a/packages/backend/src/utils/feedQueryBuilder.ts
+++ b/packages/backend/src/utils/feedQueryBuilder.ts
@@ -192,7 +192,10 @@ export class FeedQueryBuilder {
       query['metadata.isSensitive'] = { $ne: true };
     }
     if (filters.language) {
-      query.language = filters.language;
+      // Match the canonical multi-language array (multikey index): Mongo matches an
+      // array field by element equality, so the scalar matches any post whose
+      // `postClassification.languages` contains it.
+      query['postClassification.languages'] = filters.language;
     }
     if (filters.dateFrom) {
       const dateFrom = typeof filters.dateFrom === 'string' || filters.dateFrom instanceof Date 

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -561,7 +561,18 @@ export interface PostMetadataState {
   isSensitive?: boolean;
   hideEngagementCounts?: boolean;
   isThread?: boolean;
+  /**
+   * Top-level ActivityPub primary language (`postClassification.languages[0]`).
+   * Absent when no language could be determined.
+   */
   language?: string;
+  /**
+   * ALL detected/declared ISO 639-1 languages (primary first), from the canonical
+   * `postClassification.languages` array. Consumers doing language-match (e.g. the
+   * feed language tuner) read this array with any-overlap semantics; the single
+   * {@link PostMetadataState.language} is the protocol-facing primary.
+   */
+  languages?: string[];
   tags?: string[];
   mentions?: string[];
   hashtags?: string[];


### PR DESCRIPTION
## Summary
- **BUG1** — `e22a920b`: Stop defaulting `post.language` to `'en'` when the language is actually unknown. Federated/native posts with undetected language no longer get silently mislabeled as English, which was polluting language-based ranking and search.
- **BUG2** — `c607b65e`: Unify feed language filtering onto the canonical `postClassification.languages` array (the multi-language, ANY-OVERLAP field) instead of the stale single top-level `language` field, so language-scoped feeds (ForYou, Explore, language-match candidate sources) match posts correctly across all declared/detected languages.
- **BUG3** — `6a2c62a9`: Add a version-gated backfill script (`backfillPostLanguages.ts`) to repair the existing corpus — only touches posts whose `postClassification` predates the current baseline classifier version. Intended to be run as a Fargate one-shot after deploy.

## Test plan
- [x] `bun run build` (shared-types + backend + mcp) — green
- [x] `cd packages/backend && bun run test` — 113 test files / 1123 tests passed, no failures
- [ ] Post-deploy: run `backfillPostLanguages.ts` as a Fargate one-shot to repair existing corpus

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>