### PR TITLE
fix(federation): show a federated author's real handle, never a neutral placeholder

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationFederatedRepair.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationFederatedRepair.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PostActorSummary } from '@mention/shared-types';
+
+/**
+ * Regression harness for the "federated author renders without its real handle"
+ * bug. A federated (e.g. Mastodon) post whose author could not be resolved from
+ * Oxy degrades to {@link degradedActorSummary} (empty handle, "Unknown user").
+ * For a LOCAL author that neutral placeholder is the best we can do, but a
+ * FEDERATED author's canonical `username@domain` is knowable WITHOUT Oxy from
+ * Mention's own FederatedActor record — so `repairFederatedFallbackSummaries`
+ * upgrades the degraded summary to the real, tappable handle instead of leaving
+ * a nameless "Unknown user". This also closes the earlier ghost-handle variant
+ * where the fallback used the raw Mongo id as the handle.
+ */
+
+const { federatedActorFind } = vi.hoisted(() => ({
+  federatedActorFind: vi.fn(),
+}));
+
+// PostHydrationService touches these at module load — stub them so importing the
+// module never starts the server, hits the network, or opens Redis/Mongo.
+vi.mock('../../../server', () => ({
+  oxy: {
+    getUserById: vi.fn(),
+    getUserFollowing: vi.fn(async () => []),
+    getUserFollowers: vi.fn(async () => []),
+  },
+}));
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    getUsersByIds: vi.fn(async () => []),
+    getLinkPreviews: vi.fn(async () => ({})),
+    getFileDownloadUrl: (id: string) => id,
+  }),
+}));
+vi.mock('../../utils/privacyHelpers', () => ({
+  getBlockedUserIds: vi.fn(async () => []),
+  getRestrictedUserIds: vi.fn(async () => []),
+  extractFollowingIds: vi.fn(() => []),
+  extractFollowersIds: vi.fn(() => []),
+}));
+
+function chainable(rows: unknown[]) {
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.lean = async () => rows;
+  return q;
+}
+
+vi.mock('../../models/Post', () => ({ Post: { find: () => chainable([]), findOne: () => chainable([]) } }));
+vi.mock('../../models/Poll', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/Like', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/Bookmark', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/UserSettings', () => ({ UserSettings: { find: () => chainable([]), findOne: () => chainable([]) } }));
+vi.mock('../../services/userSummaryCache', () => ({ mget: vi.fn(async () => new Map()), mset: vi.fn(async () => undefined) }));
+
+vi.mock('../../models/FederatedActor', () => ({
+  FederatedActor: { find: (...args: unknown[]) => ({ select: () => ({ lean: () => federatedActorFind(...args) }) }) },
+  default: { find: (...args: unknown[]) => ({ select: () => ({ lean: () => federatedActorFind(...args) }) }) },
+}));
+
+import { repairFederatedFallbackSummaries, degradedActorSummary } from '../../services/PostHydrationService';
+
+const FED_ID = '6a38fbdd272930c46a785b1f';
+
+describe('repairFederatedFallbackSummaries', () => {
+  beforeEach(() => {
+    federatedActorFind.mockReset();
+  });
+
+  it('upgrades a degraded (empty-handle) federated author to the FederatedActor handle', async () => {
+    federatedActorFind.mockResolvedValue([
+      { oxyUserId: FED_ID, acct: 'kaleidotrope@mastodon.online', username: 'kaleidotrope', domain: 'mastodon.online', name: 'Kaleidotrope' },
+    ]);
+
+    const summaries = new Map<string, PostActorSummary>([[FED_ID, degradedActorSummary(FED_ID)]]);
+    await repairFederatedFallbackSummaries(summaries, new Set([FED_ID]));
+
+    const repaired = summaries.get(FED_ID);
+    expect(repaired?.handle).toBe('kaleidotrope@mastodon.online');
+    expect(repaired?.handle).not.toBe('');
+    expect(repaired?.handle).not.toBe(FED_ID);
+    expect(repaired?.isFederated).toBe(true);
+    expect(repaired?.instance).toBe('mastodon.online');
+    expect(repaired?.displayName).toBe('Kaleidotrope');
+  });
+
+  it('also repairs a legacy raw-id fallback (handle === oxyUserId)', async () => {
+    federatedActorFind.mockResolvedValue([
+      { oxyUserId: FED_ID, acct: 'kaleidotrope@mastodon.online', domain: 'mastodon.online' },
+    ]);
+
+    const summaries = new Map<string, PostActorSummary>([[FED_ID, { id: FED_ID, handle: FED_ID, displayName: FED_ID }]]);
+    await repairFederatedFallbackSummaries(summaries, new Set([FED_ID]));
+
+    expect(summaries.get(FED_ID)?.handle).toBe('kaleidotrope@mastodon.online');
+  });
+
+  it('derives username@domain when acct is absent, and omits displayName rather than "Unknown user"', async () => {
+    federatedActorFind.mockResolvedValue([
+      { oxyUserId: FED_ID, username: 'kaleidotrope', domain: 'mastodon.online' },
+    ]);
+
+    const summaries = new Map<string, PostActorSummary>([[FED_ID, degradedActorSummary(FED_ID)]]);
+    await repairFederatedFallbackSummaries(summaries, new Set([FED_ID]));
+
+    const repaired = summaries.get(FED_ID);
+    expect(repaired?.handle).toBe('kaleidotrope@mastodon.online');
+    expect(repaired?.displayName).toBeUndefined();
+  });
+
+  it('leaves a properly-resolved federated author untouched and never queries', async () => {
+    const good: PostActorSummary = {
+      id: FED_ID,
+      handle: 'kaleidotrope@mastodon.online',
+      displayName: 'Kaleidotrope',
+      isFederated: true,
+      instance: 'mastodon.online',
+    };
+    const summaries = new Map<string, PostActorSummary>([[FED_ID, { ...good }]]);
+    await repairFederatedFallbackSummaries(summaries, new Set([FED_ID]));
+
+    expect(federatedActorFind).not.toHaveBeenCalled();
+    expect(summaries.get(FED_ID)).toEqual(good);
+  });
+
+  it('is a no-op with no federated authors', async () => {
+    const summaries = new Map<string, PostActorSummary>();
+    await repairFederatedFallbackSummaries(summaries, new Set());
+    expect(federatedActorFind).not.toHaveBeenCalled();
+  });
+
+  it('never fails hydration when the FederatedActor lookup throws (stays degraded)', async () => {
+    federatedActorFind.mockRejectedValue(new Error('db down'));
+
+    const summaries = new Map<string, PostActorSummary>([[FED_ID, degradedActorSummary(FED_ID)]]);
+    await expect(repairFederatedFallbackSummaries(summaries, new Set([FED_ID]))).resolves.toBeUndefined();
+    expect(summaries.get(FED_ID)?.handle).toBe('');
+  });
+});

--- a/packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts
+++ b/packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts
@@ -44,6 +44,10 @@ vi.mock('../../models/Post', () => ({
 // PostHydrationService; mocking it keeps this a pure unit test of the slicer.
 vi.mock('../../services/PostHydrationService', () => ({
   resolveUserSummaries: (...args: unknown[]) => resolveUserSummaries(...args),
+  // Federated fallback repair is a separate, DB-backed boundary exercised in its
+  // own suite (postHydrationFederatedRepair.test.ts). Stub it here so this stays
+  // a pure unit test of the slicer (parents in these cases are local).
+  repairFederatedFallbackSummaries: vi.fn(async () => undefined),
 }));
 
 import { threadSlicingService } from '../../services/ThreadSlicingService';

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -63,7 +63,7 @@ const MAX_ALT_TEXT_LENGTH = config.posts.maxAltTextLength;
 const mapActorSummary = (
   userId: string,
   summary: PostActorSummary | undefined,
-): { id: string; displayName?: string; handle: string; avatar?: string; verified: boolean } => {
+): { id: string; displayName?: string; handle: string; avatar?: string; verified: boolean; isFederated?: boolean; instance?: string } => {
   const actor = summary ?? degradedActorSummary(userId);
   return {
     id: actor.id,
@@ -72,6 +72,10 @@ const mapActorSummary = (
     handle: actor.handle,
     avatar: actor.avatarUrl,
     verified: Boolean(actor.isVerified),
+    // Federation context so the client builds a `username@domain` profile link
+    // for a federated liker/booster instead of a bare/local handle.
+    isFederated: actor.isFederated,
+    instance: actor.instance,
   };
 };
 

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -4,6 +4,7 @@ import { Post } from '../models/Post';
 import Poll from '../models/Poll';
 import Like from '../models/Like';
 import Bookmark from '../models/Bookmark';
+import { FederatedActor } from '../models/FederatedActor';
 import { UserSettings } from '../models/UserSettings';
 import { oxy as defaultOxyClient } from '../../server';
 import { getServiceOxyClient } from '../utils/oxyHelpers';
@@ -285,6 +286,72 @@ export async function resolveUserSummaries(userIds: string[]): Promise<Map<strin
   }
 
   return resolved;
+}
+
+/**
+ * Repair FEDERATED author summaries that degraded to {@link degradedActorSummary}
+ * (empty handle, "Unknown user") because Oxy resolution failed transiently.
+ *
+ * Unlike a local author, a federated author's canonical `username@domain` is
+ * knowable WITHOUT Oxy: Mention's own {@link FederatedActor} record carries
+ * `acct`. Repairing from it lets a federated post show its REAL, tappable handle
+ * (`/@username@domain` → WebFinger-resolved profile) instead of a neutral
+ * "Unknown user" whenever Oxy is momentarily unreachable (or in the brief window
+ * right after the federation bridge creates the Oxy user).
+ *
+ * Mutates `summaries` in place. Batched (a single query), scoped to the ids that
+ * actually degraded, and best-effort — a lookup failure leaves the degraded
+ * summary untouched rather than failing hydration. Shared by feed hydration
+ * ({@link PostHydrationService.buildUserMap}) and reply-context author
+ * resolution ({@link ThreadSlicingService}).
+ */
+export async function repairFederatedFallbackSummaries(
+  summaries: Map<string, PostActorSummary>,
+  federatedAuthorIds: Set<string>,
+): Promise<void> {
+  const needsRepair: string[] = [];
+  for (const authorId of federatedAuthorIds) {
+    const summary = summaries.get(authorId);
+    // The degraded summary has an empty handle; `handle === authorId` guards any
+    // legacy raw-id summary. Either is the placeholder we want to replace.
+    if (!summary || isFallbackUserSummary(summary) || summary.handle === authorId) {
+      needsRepair.push(authorId);
+    }
+  }
+  if (needsRepair.length === 0) return;
+
+  let actors: Array<{ oxyUserId?: string; acct?: string; username?: string; domain?: string; name?: string }>;
+  try {
+    actors = await FederatedActor.find({ oxyUserId: { $in: needsRepair } })
+      .select('oxyUserId acct username domain name')
+      .lean();
+  } catch (error) {
+    logger.warn('[PostHydration] Federated author repair lookup failed', {
+      count: needsRepair.length,
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+    return;
+  }
+
+  for (const actor of actors) {
+    const oxyUserId = actor.oxyUserId ? String(actor.oxyUserId) : '';
+    if (!oxyUserId) continue;
+    const handle = actor.acct
+      || (actor.username && actor.domain ? `${actor.username}@${actor.domain}` : '');
+    if (!handle) continue;
+    const existing = summaries.get(oxyUserId);
+    summaries.set(oxyUserId, {
+      id: oxyUserId,
+      handle,
+      // Prefer the federated actor's own display name; leave undefined (never the
+      // raw id / "Unknown user") so the renderer falls back to the real handle.
+      displayName: actor.name?.trim() || undefined,
+      avatarUrl: existing?.avatarUrl,
+      isVerified: existing?.isVerified ?? false,
+      isFederated: true,
+      instance: actor.domain || undefined,
+    });
+  }
 }
 
 export class PostHydrationService {
@@ -842,6 +909,19 @@ export class PostHydrationService {
     for (const [userId, value] of resolved) {
       userMap.set(userId, value.summary);
     }
+
+    // A FEDERATED author whose Oxy resolution degraded (empty handle, "Unknown
+    // user") still has a knowable canonical handle in Mention's own
+    // FederatedActor record. Repair those so a federated post shows its real
+    // `@username@domain` (tappable) instead of a neutral "Unknown user".
+    const federatedAuthorIds = new Set<string>();
+    for (const { post } of nodes) {
+      if (post?.federation && post?.oxyUserId) {
+        federatedAuthorIds.add(String(post.oxyUserId));
+      }
+    }
+    await repairFederatedFallbackSummaries(userMap, federatedAuthorIds);
+
     return userMap;
   }
 

--- a/packages/backend/src/services/ThreadSlicingService.ts
+++ b/packages/backend/src/services/ThreadSlicingService.ts
@@ -17,7 +17,7 @@ import {
 } from '@mention/shared-types';
 import { Post } from '../models/Post';
 import { logger } from '../utils/logger';
-import { resolveUserSummaries } from './PostHydrationService';
+import { resolveUserSummaries, repairFederatedFallbackSummaries } from './PostHydrationService';
 
 export interface ThreadSlicingOptions {
   enableThreadGrouping: boolean;
@@ -293,6 +293,9 @@ class ThreadSlicingService {
     postById: Map<string, RawPost>,
   ): Promise<Map<string, PostActorSummary>> {
     const authorIds = new Set<string>();
+    // Federated parent authors — so a degraded "Replying to @Unknown user"
+    // header is repaired to the real `@username@domain` handle.
+    const federatedAuthorIds = new Set<string>();
 
     for (const post of posts) {
       if (!post.parentPostId) continue;
@@ -300,6 +303,9 @@ class ThreadSlicingService {
       const authorId = parent?.oxyUserId ? String(parent.oxyUserId) : '';
       if (authorId) {
         authorIds.add(authorId);
+        if (parent?.federation) {
+          federatedAuthorIds.add(authorId);
+        }
       }
     }
 
@@ -312,6 +318,7 @@ class ThreadSlicingService {
     for (const [userId, value] of resolved) {
       summaries.set(userId, value.summary);
     }
+    await repairFederatedFallbackSummaries(summaries, federatedAuthorIds);
     return summaries;
   }
 }

--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -303,15 +303,26 @@ const PostItem: React.FC<PostItemProps> = ({
         }
     }, [router, viewPostId, isTappable, feedDescriptor, isNested, isThreadUnit, threadRootId]);
 
+    // Canonical profile handle for the author. Built from the full actor so a
+    // federated actor resolves to `username@domain` (via isFederated + instance)
+    // rather than a bare local-part. Display AND navigation both use this single
+    // value so they can never diverge. Empty for a degraded/unresolvable author
+    // (empty handle) → no `@handle` shown and no tappable link.
+    const authorHandle = useMemo(
+        () =>
+            getNormalizedUserHandle({
+                handle: viewPost.user?.handle,
+                isFederated: viewPost.user?.isFederated,
+                instance: viewPost.user?.instance,
+            }) ?? undefined,
+        [viewPost.user?.handle, viewPost.user?.isFederated, viewPost.user?.instance],
+    );
+
     const goToUser = useCallback(() => {
-        const handle = getNormalizedUserHandle({
-            handle: viewPost.user?.handle,
-            username: viewPost.user?.handle,
-        });
-        if (handle) {
-            router.push(`/@${handle}`);
+        if (authorHandle) {
+            router.push(`/@${authorHandle}`);
         }
-    }, [router, viewPost.user?.handle]);
+    }, [router, authorHandle]);
 
     // "Reposted by X" row → the BOOSTER's profile. Stop propagation so it doesn't
     // also trigger the outer container press (which opens the ORIGINAL post detail).
@@ -319,12 +330,13 @@ const PostItem: React.FC<PostItemProps> = ({
         event?.stopPropagation?.();
         const handle = getNormalizedUserHandle({
             handle: repostedBy?.handle,
-            username: repostedBy?.handle,
+            isFederated: repostedBy?.isFederated,
+            instance: repostedBy?.instance,
         });
         if (handle) {
             router.push(`/@${handle}`);
         }
-    }, [router, repostedBy?.handle]);
+    }, [router, repostedBy?.handle, repostedBy?.isFederated, repostedBy?.instance]);
 
     // Pass the originating feed descriptor as the engagement `source` so the
     // backend can attribute a like/save/boost to the surface it happened on
@@ -644,7 +656,7 @@ const PostItem: React.FC<PostItemProps> = ({
 
     const replyContextHandle = replyContextAuthor?.handle || replyContextAuthor?.displayName;
 
-    const postAuthor = displayNameOrHandle(viewPost.user.displayName, `@${viewPost.user.handle}`);
+    const postAuthor = displayNameOrHandle(viewPost.user.displayName, `@${authorHandle ?? viewPost.user.handle}`);
     const postTextSummary = content.text
         ? content.text.length > 80
             ? content.text.substring(0, 80) + '...'
@@ -786,7 +798,7 @@ const PostItem: React.FC<PostItemProps> = ({
                     <PostHeader
                         user={{
                             displayName: viewPost.user.displayName,
-                            handle: viewPost.user.handle || '',
+                            handle: authorHandle || viewPost.user.handle || '',
                             verified: viewPost.user.isVerified,
                             isFederated: viewPost.user.isFederated,
                             instance: viewPost.user.instance,

--- a/packages/frontend/components/Post/EngagementListSheet.tsx
+++ b/packages/frontend/components/Post/EngagementListSheet.tsx
@@ -21,6 +21,8 @@ interface User {
   handle: string;
   avatar?: string;
   verified: boolean;
+  isFederated?: boolean;
+  instance?: string;
 }
 
 interface EngagementListSheetProps {
@@ -74,9 +76,13 @@ const EngagementListSheet: React.FC<EngagementListSheetProps> = ({ postId, type,
     }
   }, [hasMore, nextCursor, loadingMore, loadUsers]);
 
-  const handleUserPress = useCallback((handle: string) => {
+  const handleUserPress = useCallback((user: User) => {
     onClose();
-    const profileHandle = getNormalizedUserHandle({ handle });
+    const profileHandle = getNormalizedUserHandle({
+      handle: user.handle,
+      isFederated: user.isFederated,
+      instance: user.instance,
+    });
     if (profileHandle) {
       router.push(`/@${profileHandle}`);
     }
@@ -90,7 +96,7 @@ const EngagementListSheet: React.FC<EngagementListSheetProps> = ({ postId, type,
       <TouchableOpacity
         className="flex-row items-center px-4 py-3"
         style={{ borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: 'transparent' }}
-        onPress={() => handleUserPress(item.handle)}
+        onPress={() => handleUserPress(item)}
       >
         <Avatar source={item.avatar} size={50} style={{ marginRight: 12 }} />
         <View className="flex-1">


### PR DESCRIPTION
## Summary

Federated post authors were rendering with a neutral placeholder handle instead of their real fediverse handle, and tapping the author link 404'd.

**Concrete case:** Mastodon author `kaleidotrope@mastodon.online` (Oxy `_id 6a38fbdd272930c46a785b1f`) rendered as `@6a38fbdd…` in the feed. Tapping it linked to a local `/@6a38fbdd…` route, which 404'd — there is no local user with that handle.

Builds on `1301f07b` (never render a raw `oxyUserId` as a ghost `@handle`), extending the fix to cover degraded federated author summaries specifically.

- **Backend root cause:** `PostHydrationService` could produce a degraded author summary for a federated actor (falling back to the raw Oxy user id as the handle) when the summary wasn't fully hydrated from the actor's `FederatedActor` record. Added `repairFederatedFallbackSummaries`, wired into `buildUserMap`, which re-derives the real federated handle (`username@instance`) from `FederatedActor` for any summary that degraded to an id-shaped placeholder. `ThreadSlicingService` reply-context parents and `posts.controller.ts`'s `mapActorSummary` now carry `isFederated`/`instance` so the frontend has enough signal to render and link correctly.
- **Frontend fix:** `PostItem.tsx` and `EngagementListSheet.tsx` now use the federated-aware handle/link contract — a federated author displays their real `username@instance` handle and links out appropriately, instead of falling back to a local `/@<id>` route that can never resolve.

## Test plan

- [x] `bunx vitest run` (from `packages/backend`) on the touched suites — **57/57 passed** across 11 test files: `postHydrationFederatedRepair.test.ts` (new), `postHydration/*`, `threadSlicing/*`, `getRepliesFeedSpine.test.ts`, `followingFeed.test.ts`, `exploreFeed.test.ts`, `forYouFeedPipeline.test.ts`, `federationFollowsDisplayName.test.ts`
- [x] `bunx tsc --noEmit` in both `packages/backend` and `packages/frontend` — zero errors in any of the 6 touched files (`PostHydrationService.ts`, `ThreadSlicingService.ts`, `posts.controller.ts`, `PostItem.tsx`, `EngagementListSheet.tsx`, plus the new/updated tests). Remaining tsc errors on both packages are pre-existing and unrelated (feed-preset/ranking-signal symbols on backend, `agora-shared` livekit-client types on frontend) — confirmed absent from this branch's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)