### PR TITLE
feat(agora): stream a Syra podcast episode into a live room

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,7 +114,7 @@
         "@oxyhq/core": "^5.4.3",
         "@oxyhq/protocol": "^0.1.1",
         "@socket.io/redis-adapter": "^8.3.0",
-        "@syra.fm/sdk": "^0.3.0",
+        "@syra.fm/sdk": "^0.4.0",
         "@types/compression": "^1.8.1",
         "@types/multer": "^2.1.0",
         "ai": "^6.0.134",
@@ -1106,7 +1106,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@syra.fm/sdk": ["@syra.fm/sdk@0.3.0", "", { "dependencies": { "zod": "^3.25.76" } }, "sha512-ItDSe/ykNwkSeGVNct0a3RV5WzqEUo7oIfYFqcU3FvvoKMFndSv9wdk9PmWlml893orQj/ovICTC84qOqG/pqg=="],
+    "@syra.fm/sdk": ["@syra.fm/sdk@0.4.0", "", { "dependencies": { "zod": "^3.25.76" } }, "sha512-9Lf4oGrtssmnC/6QdizJzA2UDdqAOCTPAZWpXQc8UJpxHHksQfSocmAQUn5fe/kgSXHehZnyTdcbYrDo0I+xpQ=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 

--- a/docs/superpowers/specs/2026-07-03-live-room-podcast-stream-design.md
+++ b/docs/superpowers/specs/2026-07-03-live-room-podcast-stream-design.md
@@ -1,0 +1,126 @@
+# Live-room podcast streaming — design
+
+**Date:** 2026-07-03
+**Status:** Approved (design) — pending user review of this spec
+**Scope:** Let a live-room host search a Syra podcast, pick an episode, and stream that episode's audio into the room, reusing the existing LiveKit URL-ingress stream path and the existing Syra podcast search already used on profiles.
+
+## Goal
+
+In the live-room host controls (Stream Setup), add a **Podcast** mode. The host searches Syra podcast shows, drills into a show's episodes, and taps an episode to start streaming its audio into the room. All listeners hear it via the existing LiveKit ingress; the existing stream "now playing" card renders the episode metadata.
+
+## Why this shape (evidence)
+
+A "stream" in this system is fundamentally **an audio URL fed to a LiveKit URL ingress** (`packages/backend/src/routes/rooms.routes.ts:1136` `POST /:id/stream` → `createRoomUrlIngress`). To play a podcast, we must supply an episode's audio URL as that `url`.
+
+Verified against the live Syra API (`https://api.syra.fm`):
+
+- `GET /api/podcasts/search?q=` → podcast **shows** (already proxied by Mention `GET /profile/media/search?type=podcast`, `packages/backend/src/routes/profileMedia.ts:79`).
+- `GET /api/podcasts/:id` → show detail, **no inline episodes** (`episodeCount`, `feedUrl`, `persons` only).
+- `GET /api/podcasts/:id/episodes` → **public**, returns episodes each carrying:
+  - `enclosureUrl` — a direct audio file, e.g. `https://api.fastcast.ai/audio/<guid>.mp3`
+  - `enclosureType` — `audio/mpeg`
+  - `duration` (seconds), `pubDate`, `image`, `title`
+  - `hls` — an array, **empty** for the sampled episodes → do NOT rely on it; use `enclosureUrl`.
+
+The `@syra.fm/sdk` (v0.3.0) **strips episodes** from `getPodcast` and has no episodes method (`node_modules/@syra.fm/sdk/src/client.ts:106` comment). The SDK source is ours: `~/Oxy/Syra/packages/sdk`. Per the fix-upstream rule, we extend the SDK rather than hand-roll raw Syra HTTP inside Mention.
+
+The `enclosureUrl` (`http`/`https`) passes the existing `POST /:id/stream` URL validation and feeds the ingress unchanged.
+
+## Decisions locked
+
+1. **Granularity:** host picks a **specific episode** (search show → episode list → tap episode). A show has no single audio URL, so episode selection is required, not optional.
+2. **UI placement:** a new **"Podcast" tab** inside `StreamConfigPanel` ("Stream Setup"), alongside the existing **Stream URL** / **External App** tabs. Host-only (the panel is already host-gated).
+3. **URL resolution:** **backend resolves.** The client sends `{ syraPodcastId, episodeId }`; the Mention backend resolves the `enclosureUrl` + title/artwork from Syra and starts the ingress. Matches the existing "never trust the client for Syra data" pattern (`sanitizePodcast`/`resolvePodcastContent`, `utils/syraPodcast.ts`) and avoids trusting a client-supplied media URL.
+
+## Architecture — layers & changes
+
+### Layer 1 — Syra SDK (`~/Oxy/Syra/packages/sdk`) — fix upstream
+
+Add episode support to the public-catalog SDK.
+
+- **`schema.ts`** — new `episodeSummarySchema` + `EpisodeSummary` type. Fields the consumers need (tolerantly strips the rest, like the other schemas):
+  `{ id, podcastId, title, description?, enclosureUrl, enclosureType?, duration?, image?, imageSizes?, imageSourceUrl?, pubDate? }`.
+  `enclosureUrl` is required — rows without it are unplayable and dropped.
+- **`client.ts`** — new interface method + impl:
+  `getPodcastEpisodes(podcastId: string, options?: { limit?: number; offset?: number }): Promise<SearchPage<EpisodeSummary>>` → `GET /api/podcasts/:id/episodes?limit=&offset=`. Rows validated with `safeParse`; invalid/enclosure-less rows skipped. Derive `hasMore` from returned length vs requested `limit` (the episodes response carries no `pagination` object — mirror how `searchPodcasts` builds its `SearchPage`).
+  Add an `episodeImageUrl(ep, size?)` helper mirroring `podcastArtworkUrl` (resolve `image`/`imageSizes`/`imageSourceUrl` → absolute URL).
+- **`index.ts`** — export `EpisodeSummary` (+ schema if others are exported).
+- **`client.test.ts`** — add a `getPodcastEpisodes` test mirroring existing tests (mock fetch, assert URL, validation, hasMore).
+- **Publish:** bump SDK version, commit + push Syra, `bun publish` (via the `publish` skill: pack + inspect + verify propagation with a clean external install + import). Then bump `@syra.fm/sdk` in Mention backend `package.json` + `bun install` (lockfile in the same commit).
+
+### Layer 2 — Mention backend
+
+**`packages/backend/src/utils/syraPodcast.ts`** — add server-side resolvers (denormalize from Syra, never trust client):
+
+- `listPodcastEpisodes(podcastId, { offset }) → { items: EpisodeListItem[]; hasMore; offset }` for the picker. `EpisodeListItem = { episodeId, title, durationSec?, publishedAt?, artworkUrl? }` — **no audio URL leaked to the picker** (it's not needed there and stays server-owned).
+- `resolvePodcastEpisode(podcastId, episodeId) → { audioUrl, title, artworkUrl?, durationSec? } | null`. Scans `getPodcastEpisodes` pages to find `episodeId`; returns `null` when not found. `audioUrl = enclosureUrl`.
+
+**`packages/backend/src/routes/profileMedia.ts`** — add (router already `requireAuth`, mounted at `/api/profile/media`, `server.ts:806`):
+
+- `GET /podcasts/:id/episodes?offset=` → `sendPaginated(res, items, { hasMore, offset, limit })` using `listPodcastEpisodes`. Same auth/proxy rationale as the existing `/search` (avoids browser CORS, keeps Syra base URL server-owned).
+
+**`packages/backend/src/routes/rooms.routes.ts`** — extract + add:
+
+- **Refactor:** pull the ingress-start body of `POST /:id/stream` (`:1174`–`:1207`: `ensureLiveKitRoomForRoom` → `createIngressReplacingExisting`/`createRoomUrlIngress` → `cleanupPreviousIngressAfterReplacement` → persist fields → `emitStreamStarted` → response) into a shared internal `startUrlIngress(room, id, { url, title, image, description }, res, userId)`. `POST /:id/stream` calls it after its existing url/manager/live validation. No behavior change to the existing route.
+- **New route** `POST /:id/stream/podcast`, body `{ syraPodcastId, episodeId }`:
+  1. auth → `sendForbiddenUnlessRoomManager` → `room.status === LIVE` (identical gates to `POST /:id/stream`).
+  2. `resolvePodcastEpisode(syraPodcastId, episodeId)`; `404`/`400` if unresolvable.
+  3. call `startUrlIngress(room, id, { url: audioUrl, title, image: artworkUrl, description: undefined }, res, userId)`.
+  Response shape identical to `POST /:id/stream` (`{ message, ingressId, url }`).
+
+Note: `streamImage` for URL streams is a `cloud.oxy.so` URL; here it's the Syra absolute artwork URL. The stream card renders `room.streamImage` as a remote image — an external Syra URL renders directly. Confirm the card path during implementation; if it must be a proxied/cdn URL, resolve accordingly (no new per-app helper).
+
+### Layer 3 — agora-shared (`packages/agora-shared/src`)
+
+**`services/spacesService.ts`** — add methods on the `createAgoraService` client (same `httpClient`/base as `/rooms`; `/profile/media` is reachable on the same Mention API base):
+
+- `searchPodcasts(query, offset?) → { items: PodcastResult[]; hasMore; offset }` via `GET /profile/media/search?type=podcast&q=&offset=`. `PodcastResult = { syraPodcastId, title, author?, artworkUrl? }`.
+- `getPodcastEpisodes(syraPodcastId, offset?) → { items: EpisodeListItem[]; hasMore; offset }` via `GET /profile/media/podcasts/:id/episodes?offset=`.
+- `startPodcastStream(roomId, { syraPodcastId, episodeId }) → { ingressId; url } | null` via `POST /rooms/:id/stream/podcast`, parsed with the existing `ZStartStreamResponse` (reuse; response shape is identical).
+
+**New component `components/PodcastStreamPicker.tsx`** — self-contained (uses `useAgoraConfig()` for `httpClient`/`agoraService`, `useTheme`, `toast`, `AvatarComponent`; NO `@/utils/api` import so it works in both apps). Two-level view driven by local state:
+
+- **Show search:** debounced (350ms) query input → `agoraService.searchPodcasts` → list of show rows (artwork + title + author). Infinite scroll via `offset`/`hasMore`.
+- **Episode list:** tapping a show → `agoraService.getPodcastEpisodes` → episode rows (title + duration + date). Back affordance to the show list. Infinite scroll.
+- **Select:** tapping an episode calls `props.onSelectEpisode(syraPodcastId, episodeId)`. The picker owns no stream/room logic.
+
+**`components/StreamConfigPanel.tsx`** — integrate the tab:
+
+- `type StreamMode = 'url' | 'rtmp' | 'podcast'`. Add a third **Podcast** tab (mic/podcast icon) to `modeSelector`.
+- When `mode === 'podcast'`: render `<PodcastStreamPicker onSelectEpisode={handleStartPodcast} />` in place of the URL/RTMP body, and **hide** the manual "Stream Info (optional)" section and the footer Start button (metadata is resolved server-side; the episode tap is the action).
+- `handleStartPodcast(syraPodcastId, episodeId)`: `if (!(await ensureRoomLive())) return;` → `agoraService.startPodcastStream(roomId, { syraPodcastId, episodeId })` → on success `toast.success('Stream started')`, `onStreamStarted()`, `onClose()`; on failure `toast.error(...)`. Mirrors `handleStartUrlStream`.
+
+## Data flow
+
+1. Host taps **Stream** (bottom bar, host-only) → `StreamConfigPanel` → **Podcast** tab.
+2. Query → `agoraService.searchPodcasts` → `GET /profile/media/search?type=podcast` → Syra `searchPodcasts`.
+3. Tap show → `agoraService.getPodcastEpisodes` → `GET /profile/media/podcasts/:id/episodes` → SDK `getPodcastEpisodes` → Syra `/api/podcasts/:id/episodes`.
+4. Tap episode → `ensureRoomLive()` → `agoraService.startPodcastStream` → `POST /rooms/:id/stream/podcast`.
+5. Backend `resolvePodcastEpisode` → `enclosureUrl` + metadata → `startUrlIngress` (LiveKit URL ingress) → persist `activeStreamUrl/streamTitle/streamImage` → `emitStreamStarted`.
+6. `activeStream` socket event (`useRoomConnection.ts:86`) → the existing stream card (`LiveRoomSheet.tsx`) renders the episode as "now playing". Stop uses the existing `DELETE /:id/stream`.
+
+## Error handling
+
+- Search/episode fetch fail-soft → empty list + toast (mirrors existing agoraService `console.warn` + empty returns).
+- `startPodcastStream`: `403` non-manager, `400` room-not-live, `404`/`400` episode unresolvable, LiveKit errors via existing `sendLiveKitIngressError`. Client shows `toast.error` on any non-success.
+- SDK `getPodcastEpisodes`: invalid rows dropped, not thrown.
+
+## Testing
+
+- **SDK:** `client.test.ts` — `getPodcastEpisodes` (mock fetch: URL, schema validation, enclosure-less rows dropped, hasMore).
+- **Backend:** unit-test `resolvePodcastEpisode`/`listPodcastEpisodes` (mock `syraClient`); route test for `POST /:id/stream/podcast` (manager gate, live gate, resolution → ingress call) and `GET /podcasts/:id/episodes`. Run from `packages/backend` (`cd packages/backend && bun run test`) — note Mention CI does not run vitest, so run the suite locally before merge.
+- **Manual (required):** agora web, real foregrounded tab — search a podcast, pick an episode, confirm audio ingests into the room and the stream card shows the episode. Jest does not exercise LiveKit/render.
+
+## Sequencing (per publish + fix-upstream rules)
+
+1. Syra SDK: extend → build + test → commit/push Syra → `bun publish` (publish skill) → verify propagation.
+2. Mention backend: bump `@syra.fm/sdk` + `bun install` (lockfile same commit) → add resolvers, `/podcasts/:id/episodes`, `startUrlIngress` refactor, `POST /:id/stream/podcast`.
+3. agora-shared: service methods, `PodcastStreamPicker`, `StreamConfigPanel` tab.
+4. `test-build` → push (batch backend + frontend; single push).
+
+## Out of scope (YAGNI)
+
+- No podcast subscribe/follow, no "play show" concept, no episode queue/playlist, no seek/scrubbing (ingress plays the file through).
+- No new audio player — reuses LiveKit ingress + the existing stream card.
+- No HLS handling (empty in samples); revisit only if a show provides `hls`.
+- Bluesky/atproto untouched.

--- a/docs/superpowers/specs/2026-07-03-live-room-podcast-stream-design.md
+++ b/docs/superpowers/specs/2026-07-03-live-room-podcast-stream-design.md
@@ -16,11 +16,12 @@ Verified against the live Syra API (`https://api.syra.fm`):
 
 - `GET /api/podcasts/search?q=` → podcast **shows** (already proxied by Mention `GET /profile/media/search?type=podcast`, `packages/backend/src/routes/profileMedia.ts:79`).
 - `GET /api/podcasts/:id` → show detail, **no inline episodes** (`episodeCount`, `feedUrl`, `persons` only).
-- `GET /api/podcasts/:id/episodes` → **public**, returns episodes each carrying:
+- `GET /api/podcasts/:id/episodes` → **public**, `{ data: Episode[], total, page, limit }`. Each episode carries:
   - `enclosureUrl` — a direct audio file, e.g. `https://api.fastcast.ai/audio/<guid>.mp3`
   - `enclosureType` — `audio/mpeg`
   - `duration` (seconds), `pubDate`, `image`, `title`
   - `hls` — an array, **empty** for the sampled episodes → do NOT rely on it; use `enclosureUrl`.
+- `GET /api/episodes/:id` → **public**, `{ data: { episode, persons } }` — a single episode by id with the same `enclosureUrl`. Enables **O(1)** resolution at stream-start (no page scan).
 
 The `@syra.fm/sdk` (v0.3.0) **strips episodes** from `getPodcast` and has no episodes method (`node_modules/@syra.fm/sdk/src/client.ts:106` comment). The SDK source is ours: `~/Oxy/Syra/packages/sdk`. Per the fix-upstream rule, we extend the SDK rather than hand-roll raw Syra HTTP inside Mention.
 
@@ -41,19 +42,20 @@ Add episode support to the public-catalog SDK.
 - **`schema.ts`** — new `episodeSummarySchema` + `EpisodeSummary` type. Fields the consumers need (tolerantly strips the rest, like the other schemas):
   `{ id, podcastId, title, description?, enclosureUrl, enclosureType?, duration?, image?, imageSizes?, imageSourceUrl?, pubDate? }`.
   `enclosureUrl` is required — rows without it are unplayable and dropped.
-- **`client.ts`** — new interface method + impl:
-  `getPodcastEpisodes(podcastId: string, options?: { limit?: number; offset?: number }): Promise<SearchPage<EpisodeSummary>>` → `GET /api/podcasts/:id/episodes?limit=&offset=`. Rows validated with `safeParse`; invalid/enclosure-less rows skipped. Derive `hasMore` from returned length vs requested `limit` (the episodes response carries no `pagination` object — mirror how `searchPodcasts` builds its `SearchPage`).
-  Add an `episodeImageUrl(ep, size?)` helper mirroring `podcastArtworkUrl` (resolve `image`/`imageSizes`/`imageSourceUrl` → absolute URL).
+- **`client.ts`** — two new interface methods + impls:
+  - `getPodcastEpisodes(podcastId, options?: { limit?; offset? }): Promise<SearchPage<EpisodeSummary>>` → `GET /api/podcasts/:id/episodes?limit=&offset=`. Response is `{ data: Episode[], total, page, limit }`; rows validated with `safeParse` (invalid/enclosure-less skipped); `hasMore = page * limit < total`. Powers the picker's episode list.
+  - `getEpisode(episodeId): Promise<EpisodeSummary>` → `GET /api/episodes/:id`, parse `json?.data?.episode` (mirrors `getPodcast`'s `json?.data?.podcast`). Powers O(1) stream-start resolution.
+  - Add an `episodeImageUrl(ep, size?)` helper mirroring `podcastArtworkUrl` (resolve `image`/`imageSizes`/`imageSourceUrl` → absolute URL).
 - **`index.ts`** — export `EpisodeSummary` (+ schema if others are exported).
-- **`client.test.ts`** — add a `getPodcastEpisodes` test mirroring existing tests (mock fetch, assert URL, validation, hasMore).
+- **`client.test.ts`** — add `getPodcastEpisodes` + `getEpisode` tests mirroring existing tests (mock fetch, assert URL, validation, hasMore / `data.episode` unwrap).
 - **Publish:** bump SDK version, commit + push Syra, `bun publish` (via the `publish` skill: pack + inspect + verify propagation with a clean external install + import). Then bump `@syra.fm/sdk` in Mention backend `package.json` + `bun install` (lockfile in the same commit).
 
 ### Layer 2 — Mention backend
 
 **`packages/backend/src/utils/syraPodcast.ts`** — add server-side resolvers (denormalize from Syra, never trust client):
 
-- `listPodcastEpisodes(podcastId, { offset }) → { items: EpisodeListItem[]; hasMore; offset }` for the picker. `EpisodeListItem = { episodeId, title, durationSec?, publishedAt?, artworkUrl? }` — **no audio URL leaked to the picker** (it's not needed there and stays server-owned).
-- `resolvePodcastEpisode(podcastId, episodeId) → { audioUrl, title, artworkUrl?, durationSec? } | null`. Scans `getPodcastEpisodes` pages to find `episodeId`; returns `null` when not found. `audioUrl = enclosureUrl`.
+- `listPodcastEpisodes(podcastId, { offset }) → { items: EpisodeListItem[]; hasMore; offset }` via SDK `getPodcastEpisodes`, for the picker. `EpisodeListItem = { episodeId, title, durationSec?, publishedAt?, artworkUrl? }` — **no audio URL leaked to the picker** (it's not needed there and stays server-owned).
+- `resolvePodcastEpisode(episodeId, expectedPodcastId?) → { audioUrl, title, artworkUrl?, durationSec? } | null` via SDK `getEpisode` (**O(1)**, no page scan). When `expectedPodcastId` is passed, cross-check `episode.podcastId` and return `null` on mismatch. `audioUrl = enclosureUrl`.
 
 **`packages/backend/src/routes/profileMedia.ts`** — add (router already `requireAuth`, mounted at `/api/profile/media`, `server.ts:806`):
 
@@ -64,7 +66,7 @@ Add episode support to the public-catalog SDK.
 - **Refactor:** pull the ingress-start body of `POST /:id/stream` (`:1174`–`:1207`: `ensureLiveKitRoomForRoom` → `createIngressReplacingExisting`/`createRoomUrlIngress` → `cleanupPreviousIngressAfterReplacement` → persist fields → `emitStreamStarted` → response) into a shared internal `startUrlIngress(room, id, { url, title, image, description }, res, userId)`. `POST /:id/stream` calls it after its existing url/manager/live validation. No behavior change to the existing route.
 - **New route** `POST /:id/stream/podcast`, body `{ syraPodcastId, episodeId }`:
   1. auth → `sendForbiddenUnlessRoomManager` → `room.status === LIVE` (identical gates to `POST /:id/stream`).
-  2. `resolvePodcastEpisode(syraPodcastId, episodeId)`; `404`/`400` if unresolvable.
+  2. `resolvePodcastEpisode(episodeId, syraPodcastId)`; `404`/`400` if unresolvable or podcast-id mismatch.
   3. call `startUrlIngress(room, id, { url: audioUrl, title, image: artworkUrl, description: undefined }, res, userId)`.
   Response shape identical to `POST /:id/stream` (`{ message, ingressId, url }`).
 
@@ -107,7 +109,7 @@ Note: `streamImage` for URL streams is a `cloud.oxy.so` URL; here it's the Syra 
 
 ## Testing
 
-- **SDK:** `client.test.ts` — `getPodcastEpisodes` (mock fetch: URL, schema validation, enclosure-less rows dropped, hasMore).
+- **SDK:** `client.test.ts` — `getPodcastEpisodes` (URL, schema validation, enclosure-less rows dropped, `hasMore` from `total`) + `getEpisode` (`data.episode` unwrap, validation).
 - **Backend:** unit-test `resolvePodcastEpisode`/`listPodcastEpisodes` (mock `syraClient`); route test for `POST /:id/stream/podcast` (manager gate, live gate, resolution → ingress call) and `GET /podcasts/:id/episodes`. Run from `packages/backend` (`cd packages/backend && bun run test`) — note Mention CI does not run vitest, so run the suite locally before merge.
 - **Manual (required):** agora web, real foregrounded tab — search a podcast, pick an episode, confirm audio ingests into the room and the stream card shows the episode. Jest does not exercise LiveKit/render.
 

--- a/docs/superpowers/specs/2026-07-03-live-room-podcast-stream-design.md
+++ b/docs/superpowers/specs/2026-07-03-live-room-podcast-stream-design.md
@@ -43,7 +43,7 @@ Add episode support to the public-catalog SDK.
   `{ id, podcastId, title, description?, enclosureUrl, enclosureType?, duration?, image?, imageSizes?, imageSourceUrl?, pubDate? }`.
   `enclosureUrl` is required — rows without it are unplayable and dropped.
 - **`client.ts`** — two new interface methods + impls:
-  - `getPodcastEpisodes(podcastId, options?: { limit?; offset? }): Promise<SearchPage<EpisodeSummary>>` → `GET /api/podcasts/:id/episodes?limit=&offset=`. Response is `{ data: Episode[], total, page, limit }`; rows validated with `safeParse` (invalid/enclosure-less skipped); `hasMore = page * limit < total`. Powers the picker's episode list.
+  - `getPodcastEpisodes(podcastId, options?: { limit?; offset? }): Promise<SearchPage<EpisodeSummary>>` → the real endpoint is **page-based** (`GET /api/podcasts/:id/episodes?page=&limit=`, response `{ data: Episode[], total, page, limit }`). The SDK keeps its `SearchPage` **offset-based** for uniformity with `searchPodcasts`: it converts `page = floor(offset/limit) + 1`, validates rows with `safeParse` (invalid/enclosure-less skipped), and returns `{ items, hasMore: page * limit < total, offset, limit }`. Callers (picker + Mention layer) stay offset-based; the page translation is hidden here. Powers the picker's episode list.
   - `getEpisode(episodeId): Promise<EpisodeSummary>` → `GET /api/episodes/:id`, parse `json?.data?.episode` (mirrors `getPodcast`'s `json?.data?.podcast`). Powers O(1) stream-start resolution.
   - Add an `episodeImageUrl(ep, size?)` helper mirroring `podcastArtworkUrl` (resolve `image`/`imageSizes`/`imageSourceUrl` → absolute URL).
 - **`index.ts`** — export `EpisodeSummary` (+ schema if others are exported).

--- a/packages/agora-shared/src/components/PodcastStreamPicker.tsx
+++ b/packages/agora-shared/src/components/PodcastStreamPicker.tsx
@@ -1,0 +1,424 @@
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+  FlatList,
+  ActivityIndicator,
+} from 'react-native';
+import type { ViewStyle } from 'react-native';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+
+import { useAgoraConfig } from '../context/AgoraConfigContext';
+import type { AgoraTheme } from '../types';
+import type { PodcastResult, EpisodeListItem } from '../services/spacesService';
+
+const SEARCH_DEBOUNCE_MS = 350;
+
+type AvatarComponentType = React.ComponentType<{
+  size: number;
+  source?: string;
+  shape?: string;
+  style?: ViewStyle;
+}>;
+
+interface PodcastStreamPickerProps {
+  onSelectEpisode: (syraPodcastId: string, episodeId: string) => void;
+}
+
+function formatDuration(seconds?: number): string {
+  if (!seconds || seconds <= 0) return '';
+  const total = Math.floor(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  const paddedSecs = String(secs).padStart(2, '0');
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${paddedSecs}`;
+  }
+  return `${minutes}:${paddedSecs}`;
+}
+
+function formatDate(iso?: string): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+const ShowRow = memo(function ShowRow({
+  show,
+  theme,
+  AvatarComponent,
+  onSelect,
+}: {
+  show: PodcastResult;
+  theme: AgoraTheme;
+  AvatarComponent: AvatarComponentType;
+  onSelect: (show: PodcastResult) => void;
+}) {
+  return (
+    <TouchableOpacity style={styles.row} activeOpacity={0.7} onPress={() => onSelect(show)}>
+      <AvatarComponent size={44} source={show.artworkUrl} shape="squircle" />
+      <View style={styles.rowText}>
+        <Text style={[styles.rowTitle, { color: theme.colors.text }]} numberOfLines={1}>
+          {show.title}
+        </Text>
+        {!!show.author && (
+          <Text style={[styles.rowSubtitle, { color: theme.colors.textSecondary }]} numberOfLines={1}>
+            {show.author}
+          </Text>
+        )}
+      </View>
+      <MaterialCommunityIcons name="chevron-right" size={22} color={theme.colors.textSecondary} />
+    </TouchableOpacity>
+  );
+});
+
+const EpisodeRow = memo(function EpisodeRow({
+  episode,
+  theme,
+  AvatarComponent,
+  onSelect,
+}: {
+  episode: EpisodeListItem;
+  theme: AgoraTheme;
+  AvatarComponent: AvatarComponentType;
+  onSelect: (episode: EpisodeListItem) => void;
+}) {
+  const meta = [formatDuration(episode.durationSec), formatDate(episode.publishedAt)]
+    .filter(Boolean)
+    .join('  ·  ');
+
+  return (
+    <TouchableOpacity style={styles.row} activeOpacity={0.7} onPress={() => onSelect(episode)}>
+      <AvatarComponent size={44} source={episode.artworkUrl} shape="squircle" />
+      <View style={styles.rowText}>
+        <Text style={[styles.rowTitle, { color: theme.colors.text }]} numberOfLines={2}>
+          {episode.title}
+        </Text>
+        {!!meta && (
+          <Text style={[styles.rowSubtitle, { color: theme.colors.textSecondary }]} numberOfLines={1}>
+            {meta}
+          </Text>
+        )}
+      </View>
+      <MaterialCommunityIcons name="play-circle" size={26} color={theme.colors.primary} />
+    </TouchableOpacity>
+  );
+});
+
+/**
+ * Self-contained two-level podcast picker for the live-room stream setup. Level 1
+ * is a debounced Syra show search; tapping a show drills into Level 2, its episode
+ * list. Tapping an episode reports `(syraPodcastId, episodeId)` to the parent — the
+ * picker owns NO room/stream logic. Ships inside agora-shared, so it depends only
+ * on `useAgoraConfig()` injection and never imports from a host app (`@/`).
+ */
+export function PodcastStreamPicker({ onSelectEpisode }: PodcastStreamPickerProps) {
+  const { useTheme, agoraService, AvatarComponent } = useAgoraConfig();
+  const theme = useTheme();
+
+  // Level 1 — show search
+  const [query, setQuery] = useState('');
+  const [shows, setShows] = useState<PodcastResult[]>([]);
+  const [showsNextOffset, setShowsNextOffset] = useState(0);
+  const [showsHasMore, setShowsHasMore] = useState(false);
+  const [showsLoading, setShowsLoading] = useState(false);
+  const [showsLoadingMore, setShowsLoadingMore] = useState(false);
+  const showsSeqRef = useRef(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Level 2 — episode list
+  const [selectedShow, setSelectedShow] = useState<PodcastResult | null>(null);
+  const [episodes, setEpisodes] = useState<EpisodeListItem[]>([]);
+  const [episodesNextOffset, setEpisodesNextOffset] = useState(0);
+  const [episodesHasMore, setEpisodesHasMore] = useState(false);
+  const [episodesLoading, setEpisodesLoading] = useState(false);
+  const [episodesLoadingMore, setEpisodesLoadingMore] = useState(false);
+  const episodesSeqRef = useRef(0);
+
+  const runSearch = useCallback(
+    async (rawQuery: string, offset: number) => {
+      const trimmed = rawQuery.trim();
+      if (!trimmed) {
+        showsSeqRef.current += 1;
+        setShows([]);
+        setShowsHasMore(false);
+        setShowsNextOffset(0);
+        setShowsLoading(false);
+        setShowsLoadingMore(false);
+        return;
+      }
+      const seq = offset === 0 ? (showsSeqRef.current += 1) : showsSeqRef.current;
+      if (offset === 0) setShowsLoading(true);
+      else setShowsLoadingMore(true);
+
+      const result = await agoraService.searchPodcasts(trimmed, offset);
+      if (seq !== showsSeqRef.current) return; // superseded by a newer query
+
+      setShows((prev) => (offset === 0 ? result.items : [...prev, ...result.items]));
+      setShowsHasMore(result.hasMore);
+      setShowsNextOffset(result.offset + result.items.length);
+      setShowsLoading(false);
+      setShowsLoadingMore(false);
+    },
+    [agoraService],
+  );
+
+  const handleQueryChange = useCallback(
+    (text: string) => {
+      setQuery(text);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      // Show the spinner for the debounce window so a fresh query never briefly
+      // renders the "No podcasts found" empty state before the request fires.
+      if (text.trim()) setShowsLoading(true);
+      debounceRef.current = setTimeout(() => {
+        runSearch(text, 0);
+      }, SEARCH_DEBOUNCE_MS);
+    },
+    [runSearch],
+  );
+
+  const handleClearQuery = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setQuery('');
+    runSearch('', 0);
+  }, [runSearch]);
+
+  const handleShowsEndReached = useCallback(() => {
+    if (showsLoading || showsLoadingMore || !showsHasMore) return;
+    runSearch(query, showsNextOffset);
+  }, [showsLoading, showsLoadingMore, showsHasMore, runSearch, query, showsNextOffset]);
+
+  const loadEpisodes = useCallback(
+    async (syraPodcastId: string, offset: number) => {
+      const seq = offset === 0 ? (episodesSeqRef.current += 1) : episodesSeqRef.current;
+      if (offset === 0) setEpisodesLoading(true);
+      else setEpisodesLoadingMore(true);
+
+      const result = await agoraService.getPodcastEpisodes(syraPodcastId, offset);
+      if (seq !== episodesSeqRef.current) return; // superseded by a newer show
+
+      setEpisodes((prev) => (offset === 0 ? result.items : [...prev, ...result.items]));
+      setEpisodesHasMore(result.hasMore);
+      setEpisodesNextOffset(result.offset + result.items.length);
+      setEpisodesLoading(false);
+      setEpisodesLoadingMore(false);
+    },
+    [agoraService],
+  );
+
+  const handleSelectShow = useCallback(
+    (show: PodcastResult) => {
+      episodesSeqRef.current += 1;
+      setSelectedShow(show);
+      setEpisodes([]);
+      setEpisodesHasMore(false);
+      setEpisodesNextOffset(0);
+      loadEpisodes(show.syraPodcastId, 0);
+    },
+    [loadEpisodes],
+  );
+
+  const handleBack = useCallback(() => {
+    episodesSeqRef.current += 1;
+    setSelectedShow(null);
+    setEpisodes([]);
+    setEpisodesHasMore(false);
+    setEpisodesNextOffset(0);
+    setEpisodesLoading(false);
+    setEpisodesLoadingMore(false);
+  }, []);
+
+  const handleEpisodesEndReached = useCallback(() => {
+    if (!selectedShow || episodesLoading || episodesLoadingMore || !episodesHasMore) return;
+    loadEpisodes(selectedShow.syraPodcastId, episodesNextOffset);
+  }, [selectedShow, episodesLoading, episodesLoadingMore, episodesHasMore, loadEpisodes, episodesNextOffset]);
+
+  const handleSelectEpisode = useCallback(
+    (episode: EpisodeListItem) => {
+      if (!selectedShow) return;
+      onSelectEpisode(selectedShow.syraPodcastId, episode.episodeId);
+    },
+    [selectedShow, onSelectEpisode],
+  );
+
+  // Cancel any pending debounced search when the picker unmounts.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const hasQuery = query.trim().length > 0;
+
+  if (selectedShow) {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity style={styles.backHeader} activeOpacity={0.7} onPress={handleBack} hitSlop={8}>
+          <MaterialCommunityIcons name="chevron-left" size={24} color={theme.colors.text} />
+          <Text style={[styles.backTitle, { color: theme.colors.text }]} numberOfLines={1}>
+            {selectedShow.title}
+          </Text>
+        </TouchableOpacity>
+
+        {episodesLoading ? (
+          <View style={styles.stateBox}>
+            <ActivityIndicator size="small" color={theme.colors.primary} />
+          </View>
+        ) : episodes.length === 0 ? (
+          <View style={styles.stateBox}>
+            <MaterialCommunityIcons name="playlist-remove" size={32} color={theme.colors.textSecondary} />
+            <Text style={[styles.stateText, { color: theme.colors.textSecondary }]}>No episodes found</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={episodes}
+            keyExtractor={(item) => item.episodeId}
+            renderItem={({ item }) => (
+              <EpisodeRow
+                episode={item}
+                theme={theme}
+                AvatarComponent={AvatarComponent}
+                onSelect={handleSelectEpisode}
+              />
+            )}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+            onEndReached={handleEpisodesEndReached}
+            onEndReachedThreshold={0.4}
+            contentContainerStyle={styles.listContent}
+            ListFooterComponent={
+              episodesLoadingMore ? (
+                <View style={styles.footerLoader}>
+                  <ActivityIndicator size="small" color={theme.colors.primary} />
+                </View>
+              ) : null
+            }
+          />
+        )}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.searchWrap}>
+        <View style={[styles.searchRow, { backgroundColor: `${theme.colors.card}80`, borderColor: theme.colors.border }]}>
+          <MaterialCommunityIcons name="magnify" size={18} color={theme.colors.textSecondary} />
+          <TextInput
+            style={[styles.searchInput, { color: theme.colors.text }]}
+            placeholder="Search podcasts"
+            placeholderTextColor={theme.colors.textSecondary}
+            value={query}
+            onChangeText={handleQueryChange}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="search"
+          />
+          {query.length > 0 && (
+            <TouchableOpacity onPress={handleClearQuery} hitSlop={8}>
+              <MaterialCommunityIcons name="close-circle" size={18} color={theme.colors.textSecondary} />
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+
+      {!hasQuery ? (
+        <View style={styles.stateBox}>
+          <MaterialCommunityIcons name="podcast" size={32} color={theme.colors.textSecondary} />
+          <Text style={[styles.stateText, { color: theme.colors.textSecondary }]}>
+            Search for a podcast to stream
+          </Text>
+        </View>
+      ) : showsLoading ? (
+        <View style={styles.stateBox}>
+          <ActivityIndicator size="small" color={theme.colors.primary} />
+        </View>
+      ) : shows.length === 0 ? (
+        <View style={styles.stateBox}>
+          <MaterialCommunityIcons name="magnify-close" size={32} color={theme.colors.textSecondary} />
+          <Text style={[styles.stateText, { color: theme.colors.textSecondary }]}>No podcasts found</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={shows}
+          keyExtractor={(item) => item.syraPodcastId}
+          renderItem={({ item }) => (
+            <ShowRow show={item} theme={theme} AvatarComponent={AvatarComponent} onSelect={handleSelectShow} />
+          )}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          onEndReached={handleShowsEndReached}
+          onEndReachedThreshold={0.4}
+          contentContainerStyle={styles.listContent}
+          ListFooterComponent={
+            showsLoadingMore ? (
+              <View style={styles.footerLoader}>
+                <ActivityIndicator size="small" color={theme.colors.primary} />
+              </View>
+            ) : null
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  searchWrap: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    padding: 0,
+  },
+  backHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    paddingHorizontal: 12,
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  backTitle: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  listContent: { paddingBottom: 24 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  rowText: { flex: 1, gap: 2 },
+  rowTitle: { fontSize: 15, fontWeight: '600' },
+  rowSubtitle: { fontSize: 13 },
+  stateBox: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 40,
+  },
+  stateText: { fontSize: 14 },
+  footerLoader: { paddingVertical: 16 },
+});

--- a/packages/agora-shared/src/components/StreamConfigPanel.tsx
+++ b/packages/agora-shared/src/components/StreamConfigPanel.tsx
@@ -15,6 +15,7 @@ import * as ImagePicker from 'expo-image-picker';
 
 import { useAgoraConfig } from '../context/AgoraConfigContext';
 import { PanelHeader } from './PanelHeader';
+import { PodcastStreamPicker } from './PodcastStreamPicker';
 
 interface StreamConfigPanelProps {
   roomId: string;
@@ -26,7 +27,7 @@ interface StreamConfigPanelProps {
   onStreamStarted: () => void;
 }
 
-type StreamMode = 'url' | 'rtmp';
+type StreamMode = 'url' | 'rtmp' | 'podcast';
 
 type NativeFormDataFile = {
   uri: string;
@@ -167,6 +168,27 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     }
   };
 
+  const handleStartPodcast = async (syraPodcastId: string, episodeId: string) => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      if (!(await ensureRoomLive())) return;
+      const result = await agoraService.startPodcastStream(roomId, { syraPodcastId, episodeId });
+      if (result) {
+        toast.success('Stream started');
+        resetState();
+        onStreamStarted();
+        onClose();
+      } else {
+        toast.error('Failed to start stream');
+      }
+    } catch {
+      toast.error('Failed to start stream');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const generatingRef = useRef(false);
 
   const generateKey = async () => {
@@ -251,41 +273,57 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     <View style={styles.container}>
       <PanelHeader title="Stream Setup" theme={theme} onBack={onClose} />
 
+      <View style={styles.modeSelector}>
+        <TouchableOpacity
+          style={[
+            styles.modeTab,
+            { borderColor: theme.colors.border },
+            mode === 'url' && { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
+          ]}
+          onPress={() => setMode('url')}
+        >
+          <MaterialCommunityIcons name="link" size={16} color={mode === 'url' ? '#FFFFFF' : theme.colors.text} />
+          <Text style={[styles.modeTabText, { color: mode === 'url' ? '#FFFFFF' : theme.colors.text }]}>
+            Stream URL
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.modeTab,
+            { borderColor: theme.colors.border },
+            mode === 'rtmp' && { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
+          ]}
+          onPress={() => setMode('rtmp')}
+        >
+          <MaterialCommunityIcons name="key" size={16} color={mode === 'rtmp' ? '#FFFFFF' : theme.colors.text} />
+          <Text style={[styles.modeTabText, { color: mode === 'rtmp' ? '#FFFFFF' : theme.colors.text }]}>
+            External App
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.modeTab,
+            { borderColor: theme.colors.border },
+            mode === 'podcast' && { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
+          ]}
+          onPress={() => setMode('podcast')}
+        >
+          <MaterialCommunityIcons name="podcast" size={16} color={mode === 'podcast' ? '#FFFFFF' : theme.colors.text} />
+          <Text style={[styles.modeTabText, { color: mode === 'podcast' ? '#FFFFFF' : theme.colors.text }]}>
+            Podcast
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {mode === 'podcast' ? (
+        <PodcastStreamPicker onSelectEpisode={handleStartPodcast} />
+      ) : (
       <ScrollView
         style={{ flex: 1 }}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
-        <View style={styles.modeSelector}>
-          <TouchableOpacity
-            style={[
-              styles.modeTab,
-              { borderColor: theme.colors.border },
-              mode === 'url' && { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
-            ]}
-            onPress={() => setMode('url')}
-          >
-            <MaterialCommunityIcons name="link" size={16} color={mode === 'url' ? '#FFFFFF' : theme.colors.text} />
-            <Text style={[styles.modeTabText, { color: mode === 'url' ? '#FFFFFF' : theme.colors.text }]}>
-              Stream URL
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[
-              styles.modeTab,
-              { borderColor: theme.colors.border },
-              mode === 'rtmp' && { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
-            ]}
-            onPress={() => setMode('rtmp')}
-          >
-            <MaterialCommunityIcons name="key" size={16} color={mode === 'rtmp' ? '#FFFFFF' : theme.colors.text} />
-            <Text style={[styles.modeTabText, { color: mode === 'rtmp' ? '#FFFFFF' : theme.colors.text }]}>
-              External App
-            </Text>
-          </TouchableOpacity>
-        </View>
-
         {mode === 'url' && (
           <View style={styles.section}>
             <TextInput
@@ -463,6 +501,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
           )}
         </View>
       </ScrollView>
+      )}
     </View>
   );
 }

--- a/packages/agora-shared/src/index.ts
+++ b/packages/agora-shared/src/index.ts
@@ -61,6 +61,8 @@ export {
   createAgoraService,
   type AgoraServiceInstance,
   type CreateRoomData,
+  type PodcastResult,
+  type EpisodeListItem,
 } from './services/spacesService';
 export { RoomSocketService } from './services/spaceSocketService';
 export {

--- a/packages/agora-shared/src/services/spacesService.ts
+++ b/packages/agora-shared/src/services/spacesService.ts
@@ -22,6 +22,32 @@ export interface StreamMetadataUpdate extends Record<string, unknown> {
   description?: string;
 }
 
+/** A Syra podcast show, as proxied by Mention `GET /profile/media/search?type=podcast`. */
+export interface PodcastResult {
+  syraPodcastId: string;
+  title: string;
+  author?: string;
+  artworkUrl?: string;
+}
+
+/**
+ * A single episode row for the picker. Deliberately carries NO audio URL — the
+ * enclosure stays server-owned and is resolved at stream-start by the backend.
+ */
+export interface EpisodeListItem {
+  episodeId: string;
+  title: string;
+  durationSec?: number;
+  publishedAt?: string;
+  artworkUrl?: string;
+}
+
+interface PaginatedResult<T> {
+  items: T[];
+  hasMore: boolean;
+  offset: number;
+}
+
 interface RecordingResponse {
   recording: Recording;
   playbackUrl: string;
@@ -29,6 +55,47 @@ interface RecordingResponse {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function readPaginationMeta(data: Record<string, unknown>, requestedOffset: number): { hasMore: boolean; offset: number } {
+  const pagination = isRecord(data.pagination) ? data.pagination : {};
+  return {
+    hasMore: pagination.hasMore === true,
+    offset: typeof pagination.offset === 'number' ? pagination.offset : requestedOffset,
+  };
+}
+
+function parsePodcastSearchResponse(data: Record<string, unknown>, requestedOffset: number): PaginatedResult<PodcastResult> {
+  const raw = Array.isArray(data.data) ? data.data : [];
+  const items: PodcastResult[] = [];
+  for (const entry of raw) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.syraPodcastId !== 'string' || typeof entry.title !== 'string') continue;
+    items.push({
+      syraPodcastId: entry.syraPodcastId,
+      title: entry.title,
+      author: typeof entry.author === 'string' ? entry.author : undefined,
+      artworkUrl: typeof entry.artworkUrl === 'string' ? entry.artworkUrl : undefined,
+    });
+  }
+  return { items, ...readPaginationMeta(data, requestedOffset) };
+}
+
+function parseEpisodeListResponse(data: Record<string, unknown>, requestedOffset: number): PaginatedResult<EpisodeListItem> {
+  const raw = Array.isArray(data.data) ? data.data : [];
+  const items: EpisodeListItem[] = [];
+  for (const entry of raw) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.episodeId !== 'string' || typeof entry.title !== 'string') continue;
+    items.push({
+      episodeId: entry.episodeId,
+      title: entry.title,
+      durationSec: typeof entry.durationSec === 'number' ? entry.durationSec : undefined,
+      publishedAt: typeof entry.publishedAt === 'string' ? entry.publishedAt : undefined,
+      artworkUrl: typeof entry.artworkUrl === 'string' ? entry.artworkUrl : undefined,
+    });
+  }
+  return { items, ...readPaginationMeta(data, requestedOffset) };
 }
 
 function parseRecordingResponse(value: unknown): RecordingResponse | null {
@@ -192,6 +259,49 @@ export function createAgoraService(httpClient: HttpClient) {
       } catch (error) {
         console.warn("Failed to stop stream", error);
         return false;
+      }
+    },
+
+    // --- Podcast streaming (Syra catalog → LiveKit URL ingress) ---
+
+    async searchPodcasts(query: string, offset = 0): Promise<PaginatedResult<PodcastResult>> {
+      try {
+        const res = await httpClient.get('/profile/media/search', {
+          params: { type: 'podcast', q: query, offset: String(offset) },
+        });
+        return parsePodcastSearchResponse(res.data, offset);
+      } catch (error) {
+        console.warn("Failed to search podcasts", error);
+        return { items: [], hasMore: false, offset };
+      }
+    },
+
+    async getPodcastEpisodes(syraPodcastId: string, offset = 0): Promise<PaginatedResult<EpisodeListItem>> {
+      if (!syraPodcastId) return { items: [], hasMore: false, offset };
+      try {
+        const res = await httpClient.get(`/profile/media/podcasts/${syraPodcastId}/episodes`, {
+          params: { offset: String(offset) },
+        });
+        return parseEpisodeListResponse(res.data, offset);
+      } catch (error) {
+        console.warn("Failed to fetch podcast episodes", error);
+        return { items: [], hasMore: false, offset };
+      }
+    },
+
+    async startPodcastStream(roomId: string, body: { syraPodcastId: string; episodeId: string }): Promise<{ ingressId: string; url: string } | null> {
+      if (!roomId) return null;
+      try {
+        const res = await httpClient.post(`/rooms/${roomId}/stream/podcast`, body);
+        const parsed = ZStartStreamResponse.safeParse(res.data);
+        if (!parsed.success) {
+          console.warn('[agora] Invalid startPodcastStream response:', parsed.error.issues[0]);
+          return null;
+        }
+        return parsed.data;
+      } catch (error) {
+        console.warn("Failed to start podcast stream", error);
+        return null;
       }
     },
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
     "@oxyhq/core": "^5.4.3",
     "@oxyhq/protocol": "^0.1.1",
     "@socket.io/redis-adapter": "^8.3.0",
-    "@syra.fm/sdk": "^0.3.0",
+    "@syra.fm/sdk": "^0.4.0",
     "@types/compression": "^1.8.1",
     "@types/multer": "^2.1.0",
     "ai": "^6.0.134",

--- a/packages/backend/src/__tests__/routes/roomStreamPodcast.test.ts
+++ b/packages/backend/src/__tests__/routes/roomStreamPodcast.test.ts
@@ -1,0 +1,193 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResolvedPodcastEpisode } from '../../utils/syraPodcast';
+
+/**
+ * Route-level coverage for `POST /rooms/:id/stream/podcast`. Exercises the REAL
+ * handler (and the shared `startUrlIngressForRoom` helper it delegates to)
+ * against mocked LiveKit + Syra + Room-model boundaries, asserting the manager
+ * gate, the live gate, the unresolved-episode 404, and that a resolved episode
+ * drives the URL-ingress path with the server-resolved audio URL + metadata.
+ */
+
+const TEST_USER = 'host-1';
+
+// LiveKit ingress boundary — the helper's only external I/O on the happy path.
+vi.mock('../../utils/livekit', () => ({
+  generateRoomToken: vi.fn(),
+  generateBroadcastToken: vi.fn(),
+  createLiveKitRoomForRoom: vi.fn(),
+  ensureLiveKitRoomForRoom: vi.fn().mockResolvedValue(undefined),
+  deleteLiveKitRoomForRoom: vi.fn(),
+  createRoomUrlIngress: vi.fn().mockResolvedValue({ ingressId: 'ingress-xyz', url: '' }),
+  createRoomRtmpIngress: vi.fn(),
+  deleteIngress: vi.fn().mockResolvedValue(undefined),
+  startRoomRecording: vi.fn(),
+  stopRoomRecording: vi.fn(),
+}));
+
+vi.mock('../../utils/livekitErrors', () => ({
+  mapLiveKitIngressError: vi.fn(() => ({
+    statusCode: 502,
+    message: 'LiveKit error',
+    code: 'INGRESS_FAILED',
+    liveKit: { status: 502, code: 'INGRESS_FAILED', message: 'LiveKit error' },
+  })),
+  shouldRetryIngressAfterDeletingExisting: vi.fn(() => false),
+}));
+
+// Syra episode resolution — the unit under mock control for each test case.
+vi.mock('../../utils/syraPodcast', () => ({
+  resolvePodcastEpisode: vi.fn(),
+}));
+
+// Room model: keep the real enums (RoomStatus/OwnerType/...) but replace the
+// Mongoose model with a controllable findById.
+vi.mock('../../models/Room', async () => {
+  const actual = await vi.importActual<typeof import('../../models/Room')>('../../models/Room');
+  return {
+    ...actual,
+    default: { findById: vi.fn() },
+  };
+});
+
+// Unrelated boundaries pulled in by other routes in the same module — stub so
+// the module imports cleanly without loading AWS / image / socket internals.
+vi.mock('../../models/House', () => ({ default: { findById: vi.fn() }, HouseMemberRole: { ADMIN: 'admin' } }));
+vi.mock('../../middleware/admin', () => ({ isAdmin: vi.fn(() => false) }));
+vi.mock('../../models/Recording', () => ({ default: {}, RecordingStatus: {}, RecordingAccess: {} }));
+vi.mock('../../utils/spaces', () => ({
+  getRecordingObjectKey: vi.fn(),
+  uploadObject: vi.fn(),
+  deleteObject: vi.fn(),
+  getAgoraRoomImageKey: vi.fn(),
+}));
+vi.mock('../../utils/imageProcessor', () => ({ processImage: vi.fn() }));
+vi.mock('../../utils/socket', () => ({ emitLiveRoomsUpdated: vi.fn() }));
+
+import Room, { RoomStatus, OwnerType } from '../../models/Room';
+import { createRoomUrlIngress, ensureLiveKitRoomForRoom } from '../../utils/livekit';
+import { resolvePodcastEpisode } from '../../utils/syraPodcast';
+import roomsRouter from '../../routes/rooms.routes';
+
+const findById = vi.mocked(Room.findById);
+const resolveEpisode = vi.mocked(resolvePodcastEpisode);
+const createUrlIngress = vi.mocked(createRoomUrlIngress);
+const ensureRoom = vi.mocked(ensureLiveKitRoomForRoom);
+
+/** A minimal Room document with a spyable `save`. Overrides win. */
+function makeRoom(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'room-1',
+    host: TEST_USER,
+    ownerType: OwnerType.PROFILE,
+    status: RoomStatus.LIVE,
+    maxParticipants: 100,
+    activeIngressId: undefined as string | undefined,
+    activeStreamUrl: undefined as string | undefined,
+    rtmpUrl: undefined as string | undefined,
+    rtmpStreamKey: undefined as string | undefined,
+    streamTitle: undefined as string | undefined,
+    streamImage: undefined as string | undefined,
+    streamDescription: undefined as string | undefined,
+    save: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (req as express.Request & { user?: { id: string } }).user = { id: TEST_USER };
+  next();
+});
+app.use('/rooms', roomsRouter);
+
+const RESOLVED: ResolvedPodcastEpisode = {
+  audioUrl: 'https://api.fastcast.ai/audio/ep-1.mp3',
+  title: 'Episode One',
+  artworkUrl: 'https://cdn.syra.fm/art/ep-1.jpg',
+  durationSec: 120,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /rooms/:id/stream/podcast', () => {
+  it('rejects a non-manager with 403 and never resolves the episode', async () => {
+    findById.mockResolvedValue(makeRoom({ host: 'someone-else' }));
+
+    const res = await request(app)
+      .post('/rooms/room-1/stream/podcast')
+      .send({ syraPodcastId: 'show-1', episodeId: 'ep-1' });
+
+    expect(res.status).toBe(403);
+    expect(resolveEpisode).not.toHaveBeenCalled();
+    expect(createUrlIngress).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 400 when the room is not live', async () => {
+    findById.mockResolvedValue(makeRoom({ status: RoomStatus.SCHEDULED }));
+
+    const res = await request(app)
+      .post('/rooms/room-1/stream/podcast')
+      .send({ syraPodcastId: 'show-1', episodeId: 'ep-1' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Room must be live to add a stream');
+    expect(resolveEpisode).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 400 when episodeId is missing', async () => {
+    const res = await request(app).post('/rooms/room-1/stream/podcast').send({ syraPodcastId: 'show-1' });
+
+    expect(res.status).toBe(400);
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the episode cannot be resolved', async () => {
+    findById.mockResolvedValue(makeRoom());
+    resolveEpisode.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/rooms/room-1/stream/podcast')
+      .send({ syraPodcastId: 'show-1', episodeId: 'missing' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Podcast episode not found');
+    expect(resolveEpisode).toHaveBeenCalledWith('missing', 'show-1');
+    expect(createUrlIngress).not.toHaveBeenCalled();
+  });
+
+  it('starts a URL ingress from the server-resolved episode audio + metadata', async () => {
+    const room = makeRoom();
+    findById.mockResolvedValue(room);
+    resolveEpisode.mockResolvedValue(RESOLVED);
+
+    const res = await request(app)
+      .post('/rooms/room-1/stream/podcast')
+      .send({ syraPodcastId: 'show-1', episodeId: 'ep-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      message: 'Stream started successfully',
+      ingressId: 'ingress-xyz',
+      url: 'https://api.fastcast.ai/audio/ep-1.mp3',
+    });
+
+    expect(resolveEpisode).toHaveBeenCalledWith('ep-1', 'show-1');
+    expect(ensureRoom).toHaveBeenCalledWith('room-1', 100);
+    expect(createUrlIngress).toHaveBeenCalledWith('room-1', 'https://api.fastcast.ai/audio/ep-1.mp3');
+
+    expect(room.save).toHaveBeenCalledTimes(1);
+    expect(room.activeIngressId).toBe('ingress-xyz');
+    expect(room.activeStreamUrl).toBe('https://api.fastcast.ai/audio/ep-1.mp3');
+    expect(room.streamTitle).toBe('Episode One');
+    expect(room.streamImage).toBe('https://cdn.syra.fm/art/ep-1.jpg');
+    expect(room.streamDescription).toBeUndefined();
+    expect(room.rtmpUrl).toBeUndefined();
+    expect(room.rtmpStreamKey).toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/utils/syraPodcast.test.ts
+++ b/packages/backend/src/__tests__/utils/syraPodcast.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EpisodeSummary, SearchPage } from '@syra.fm/sdk';
+
+/**
+ * Unit coverage for the server-side Syra episode resolvers. The `@syra.fm/sdk`
+ * factory is mocked so the REAL `listPodcastEpisodes` / `resolvePodcastEpisode`
+ * run against a controllable stub client — the same instance the module assigns
+ * to `syraClient`. Asserts the denormalization (never trusting the client), the
+ * podcast-id cross-check, the throw-becomes-null contract, and — critically —
+ * that the picker list NEVER leaks a playable audio URL.
+ */
+
+vi.mock('@syra.fm/sdk', () => ({
+  createSyraClient: vi.fn(() => ({
+    getEpisode: vi.fn(),
+    getPodcastEpisodes: vi.fn(),
+    episodeImageUrl: vi.fn(),
+  })),
+}));
+
+import { syraClient, listPodcastEpisodes, resolvePodcastEpisode } from '../../utils/syraPodcast';
+
+const getEpisode = vi.mocked(syraClient.getEpisode);
+const getPodcastEpisodes = vi.mocked(syraClient.getPodcastEpisodes);
+const episodeImageUrl = vi.mocked(syraClient.episodeImageUrl);
+
+/** Build a full episode-summary fixture; overrides win over the defaults. */
+function makeEpisode(overrides: Partial<EpisodeSummary> = {}): EpisodeSummary {
+  return {
+    id: 'ep-1',
+    podcastId: 'show-1',
+    title: 'Episode One',
+    enclosureUrl: 'https://api.fastcast.ai/audio/ep-1.mp3',
+    enclosureType: 'audio/mpeg',
+    duration: 3600,
+    pubDate: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolvePodcastEpisode', () => {
+  it('denormalizes a resolved episode into its playable form', async () => {
+    getEpisode.mockResolvedValue(makeEpisode());
+    episodeImageUrl.mockReturnValue('https://cdn.syra.fm/art/ep-1.jpg');
+
+    const result = await resolvePodcastEpisode('ep-1', 'show-1');
+
+    expect(getEpisode).toHaveBeenCalledWith('ep-1');
+    expect(result).toEqual({
+      audioUrl: 'https://api.fastcast.ai/audio/ep-1.mp3',
+      title: 'Episode One',
+      artworkUrl: 'https://cdn.syra.fm/art/ep-1.jpg',
+      durationSec: 3600,
+    });
+  });
+
+  it('returns null when the episode belongs to a different show', async () => {
+    getEpisode.mockResolvedValue(makeEpisode({ podcastId: 'other-show' }));
+
+    const result = await resolvePodcastEpisode('ep-1', 'show-1');
+
+    expect(result).toBeNull();
+  });
+
+  it('resolves without cross-check when no expected podcast id is passed', async () => {
+    getEpisode.mockResolvedValue(makeEpisode({ podcastId: 'whatever' }));
+    episodeImageUrl.mockReturnValue(undefined);
+
+    const result = await resolvePodcastEpisode('ep-1');
+
+    expect(result).toEqual({
+      audioUrl: 'https://api.fastcast.ai/audio/ep-1.mp3',
+      title: 'Episode One',
+      artworkUrl: undefined,
+      durationSec: 3600,
+    });
+  });
+
+  it('returns null (never throws) when the SDK cannot resolve the episode', async () => {
+    getEpisode.mockRejectedValue(new Error('not found'));
+
+    await expect(resolvePodcastEpisode('missing', 'show-1')).resolves.toBeNull();
+  });
+});
+
+describe('listPodcastEpisodes', () => {
+  it('maps each episode to a picker row and passes pagination through', async () => {
+    const page: SearchPage<EpisodeSummary> = {
+      items: [makeEpisode()],
+      hasMore: true,
+      offset: 20,
+      limit: 20,
+    };
+    getPodcastEpisodes.mockResolvedValue(page);
+    episodeImageUrl.mockReturnValue('https://cdn.syra.fm/art/ep-1.jpg');
+
+    const result = await listPodcastEpisodes('show-1', { offset: 20 });
+
+    expect(getPodcastEpisodes).toHaveBeenCalledWith('show-1', { offset: 20 });
+    expect(result).toEqual({
+      items: [
+        {
+          episodeId: 'ep-1',
+          title: 'Episode One',
+          durationSec: 3600,
+          publishedAt: '2026-07-01T00:00:00.000Z',
+          artworkUrl: 'https://cdn.syra.fm/art/ep-1.jpg',
+        },
+      ],
+      hasMore: true,
+      offset: 20,
+      limit: 20,
+    });
+  });
+
+  it('never leaks a playable audio URL to the picker row', async () => {
+    getPodcastEpisodes.mockResolvedValue({
+      items: [makeEpisode()],
+      hasMore: false,
+      offset: 0,
+      limit: 20,
+    });
+    episodeImageUrl.mockReturnValue(undefined);
+
+    const { items } = await listPodcastEpisodes('show-1');
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).not.toHaveProperty('audioUrl');
+    expect(items[0]).not.toHaveProperty('enclosureUrl');
+    expect(Object.values(items[0])).not.toContain('https://api.fastcast.ai/audio/ep-1.mp3');
+  });
+});

--- a/packages/backend/src/routes/profileMedia.ts
+++ b/packages/backend/src/routes/profileMedia.ts
@@ -1,6 +1,6 @@
 import { Router, Response } from 'express';
 import { requireOxyAuth as requireAuth, type OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
-import { syraClient } from '../utils/syraPodcast';
+import { syraClient, listPodcastEpisodes } from '../utils/syraPodcast';
 import { sendErrorResponse } from '../utils/apiHelpers';
 import { sendPaginated } from '../utils/apiResponse';
 import { logger } from '../utils/logger';
@@ -93,6 +93,47 @@ router.get('/search', async (req: AuthRequest, res: Response) => {
   } catch (err) {
     logger.error('[ProfileMedia] Error searching Syra catalog:', { userId: req.user?.id, error: err });
     return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to search profile media');
+  }
+});
+
+/**
+ * GET /api/profile/media/podcasts/:id/episodes?offset=
+ * List a Syra podcast show's episodes for the episode picker, proxied server-side
+ * for the same reason as `/search` (avoids browser CORS, keeps the Syra base URL
+ * server-owned). Paginated for infinite scroll: `offset` advances through the
+ * show's episodes in SDK-sized pages, and `hasMore` comes from the Syra backend,
+ * not the page's row count (invalid/enclosure-less rows are dropped by the SDK,
+ * so a page can be short while more episodes remain). The playable audio URL is
+ * intentionally NOT surfaced here — it is resolved server-side only at
+ * stream-start (see `POST /rooms/:id/stream/podcast`).
+ */
+router.get('/podcasts/:id/episodes', async (req: AuthRequest, res: Response) => {
+  try {
+    const rawId = req.params.id;
+    const id = typeof rawId === 'string' ? rawId.trim() : '';
+    if (!id) {
+      return sendErrorResponse(res, 400, 'Bad Request', 'Missing podcast id');
+    }
+
+    // Zero-based page offset for infinite scroll. Absent or malformed values
+    // start from the first page rather than erroring a scroll.
+    const rawOffset = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0;
+    const offset = Number.isInteger(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+
+    const page = await listPodcastEpisodes(id, { offset });
+
+    return sendPaginated(res, page.items, {
+      hasMore: page.hasMore,
+      offset: page.offset,
+      limit: page.limit,
+    });
+  } catch (err) {
+    logger.error('[ProfileMedia] Error listing Syra podcast episodes:', {
+      userId: req.user?.id,
+      podcastId: req.params.id,
+      error: err,
+    });
+    return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to list podcast episodes');
   }
 });
 

--- a/packages/backend/src/routes/rooms.routes.ts
+++ b/packages/backend/src/routes/rooms.routes.ts
@@ -25,6 +25,7 @@ import Recording, { IRecording, RecordingStatus, RecordingAccess } from '../mode
 import { getRecordingObjectKey, uploadObject, deleteObject, getAgoraRoomImageKey } from '../utils/spaces';
 import { processImage } from '../utils/imageProcessor';
 import { emitLiveRoomsUpdated } from '../utils/socket';
+import { resolvePodcastEpisode } from '../utils/syraPodcast';
 
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 const uploadMiddleware = multer({
@@ -191,6 +192,61 @@ async function cleanupPreviousIngressAfterReplacement(roomId: string, result: In
     await deleteIngress(result.previousIngressId);
     logger.info(`Replaced previous ingress for room ${roomId}: ${result.previousIngressId}`);
   }
+}
+
+/**
+ * Start (or replace) a LiveKit URL ingress for a live room and respond to the
+ * request. Shared by `POST /:id/stream` (host-supplied audio URL) and
+ * `POST /:id/stream/podcast` (Syra episode audio URL) so both surfaces drive the
+ * exact same ingress lifecycle + persistence + socket broadcast + response shape.
+ *
+ * Callers MUST perform their own auth / manager / `RoomStatus.LIVE` validation
+ * and pass an already-validated `meta.url`; this helper owns only the ingress +
+ * persistence half. On a LiveKit failure it responds via
+ * {@link sendLiveKitIngressError} and returns without persisting. `meta.title` /
+ * `meta.image` / `meta.description` are stored verbatim (callers normalize) and
+ * the RTMP fields are cleared, since starting a URL ingress switches the room out
+ * of RTMP mode.
+ */
+async function startUrlIngressForRoom(
+  room: IRoom,
+  id: string,
+  meta: { url: string; title?: string; image?: string; description?: string },
+  res: Response,
+  userId: string,
+): Promise<void> {
+  let ingressResult: IngressReplacementResult;
+  try {
+    await ensureLiveKitRoomForRoom(id, room.maxParticipants);
+    ingressResult = await createIngressReplacingExisting(room, id, () =>
+      createRoomUrlIngress(id, meta.url)
+    );
+    await cleanupPreviousIngressAfterReplacement(id, ingressResult);
+  } catch (liveKitError) {
+    sendLiveKitIngressError(res, liveKitError, 'create-url-ingress', { roomId: id, userId });
+    return;
+  }
+
+  // Persist ingress info + metadata (clear RTMP fields if switching modes)
+  room.activeIngressId = ingressResult.ingress.ingressId;
+  room.activeStreamUrl = meta.url;
+  room.rtmpUrl = undefined;
+  room.rtmpStreamKey = undefined;
+  room.streamTitle = meta.title;
+  room.streamImage = meta.image;
+  room.streamDescription = meta.description;
+  await room.save();
+
+  logger.info(`Live stream started in room ${id}: ${meta.url}`);
+
+  // Notify participants via socket (no URL -- only metadata)
+  emitStreamStarted(id, room);
+
+  res.json({
+    message: 'Stream started successfully',
+    ingressId: ingressResult.ingress.ingressId,
+    url: meta.url,
+  });
 }
 
 // --- Recording auto-stop timers (1 hour max) ---
@@ -1171,42 +1227,96 @@ router.post('/:id/stream', async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'Room must be live to add a stream' });
     }
 
-    let ingressResult: IngressReplacementResult;
-    try {
-      await ensureLiveKitRoomForRoom(String(id), room.maxParticipants);
-      ingressResult = await createIngressReplacingExisting(room, String(id), () =>
-        createRoomUrlIngress(String(id), trimmedUrl)
-      );
-      await cleanupPreviousIngressAfterReplacement(String(id), ingressResult);
-    } catch (liveKitError) {
-      return sendLiveKitIngressError(res, liveKitError, 'create-url-ingress', {
-        roomId: String(id),
-        userId,
-      });
-    }
-
-    // Persist ingress info + metadata (clear RTMP fields if switching modes)
-    room.activeIngressId = ingressResult.ingress.ingressId;
-    room.activeStreamUrl = trimmedUrl;
-    room.rtmpUrl = undefined;
-    room.rtmpStreamKey = undefined;
-    room.streamTitle = title ? String(title).trim() : undefined;
-    room.streamImage = image ? String(image).trim() : undefined;
-    room.streamDescription = description ? String(description).trim() : undefined;
-    await room.save();
-
-    logger.info(`Live stream started in room ${id}: ${trimmedUrl}`);
-
-    // Notify participants via socket (no URL -- only metadata)
-    emitStreamStarted(String(id), room);
-
-    res.json({
-      message: 'Stream started successfully',
-      ingressId: ingressResult.ingress.ingressId,
-      url: trimmedUrl,
-    });
+    await startUrlIngressForRoom(
+      room,
+      String(id),
+      {
+        url: trimmedUrl,
+        title: title ? String(title).trim() : undefined,
+        image: image ? String(image).trim() : undefined,
+        description: description ? String(description).trim() : undefined,
+      },
+      res,
+      userId,
+    );
   } catch (error) {
     logger.error('Error starting stream:', { userId: req.user?.id, roomId: req.params.id, error });
+    res.status(500).json({
+      message: 'Error starting stream',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * Start streaming a Syra podcast episode into the room (room manager only)
+ * POST /api/rooms/:id/stream/podcast
+ * Body: { syraPodcastId?: string, episodeId: string }
+ *
+ * Rate limiting is handled by the global Oxy limiter (`createOxyRateLimit`,
+ * `app.use(rateLimiter)` in server.ts) that fronts every route — like the sibling
+ * `/:id/stream` routes, this handler carries no per-route limiter of its own.
+ *
+ * The client sends only the episode reference — never a media URL. The backend
+ * resolves the episode's playable `enclosureUrl` + metadata server-side from the
+ * Syra catalog (O(1) by-id lookup) and feeds it into the SAME LiveKit URL ingress
+ * path as `POST /:id/stream`. When `syraPodcastId` is supplied it is cross-checked
+ * against the resolved episode's show to reject a mismatched pairing.
+ */
+router.post('/:id/stream/podcast', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    const { id } = req.params;
+    const { syraPodcastId, episodeId } = req.body ?? {};
+
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    if (typeof episodeId !== 'string' || !episodeId.trim()) {
+      return res.status(400).json({ message: 'episodeId is required' });
+    }
+
+    if (syraPodcastId !== undefined && typeof syraPodcastId !== 'string') {
+      return res.status(400).json({ message: 'syraPodcastId must be a string' });
+    }
+
+    const trimmedEpisodeId = episodeId.trim();
+    const trimmedPodcastId =
+      typeof syraPodcastId === 'string' && syraPodcastId.trim() ? syraPodcastId.trim() : undefined;
+
+    const room = await Room.findById(id);
+    if (!room) {
+      return res.status(404).json({ message: 'Room not found' });
+    }
+
+    if (!(await sendForbiddenUnlessRoomManager(room, userId, res, 'Only a room manager can add a live stream'))) {
+      return;
+    }
+
+    if (room.status !== RoomStatus.LIVE) {
+      return res.status(400).json({ message: 'Room must be live to add a stream' });
+    }
+
+    const resolved = await resolvePodcastEpisode(trimmedEpisodeId, trimmedPodcastId);
+    if (!resolved) {
+      return res.status(404).json({ message: 'Podcast episode not found' });
+    }
+
+    await startUrlIngressForRoom(
+      room,
+      String(id),
+      {
+        url: resolved.audioUrl,
+        title: resolved.title,
+        image: resolved.artworkUrl,
+        description: undefined,
+      },
+      res,
+      userId,
+    );
+  } catch (error) {
+    logger.error('Error starting podcast stream:', { userId: req.user?.id, roomId: req.params.id, error });
     res.status(500).json({
       message: 'Error starting stream',
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/packages/backend/src/utils/syraPodcast.ts
+++ b/packages/backend/src/utils/syraPodcast.ts
@@ -1,6 +1,7 @@
 import { createSyraClient } from '@syra.fm/sdk';
 import type { PostPodcastContent } from '@mention/shared-types';
 import { config } from '../config';
+import { logger } from './logger';
 
 /**
  * The single shared Syra catalog client. Every backend path that resolves Syra
@@ -39,4 +40,88 @@ export const resolvePodcastContent = async (id: string): Promise<PostPodcastCont
     artworkUrl: syraClient.podcastArtworkUrl(show),
     showUrl: syraClient.podcastUrl(id),
   };
+};
+
+/**
+ * One row in the episode picker. Deliberately carries NO audio URL: the picker
+ * only needs enough to render + select a row, and the playable `enclosureUrl`
+ * stays server-owned so a client can never hand us an arbitrary media URL to
+ * ingest (see {@link resolvePodcastEpisode}). `episodeId` is the opaque handle
+ * the client sends back at stream-start.
+ */
+export interface PodcastEpisodeListItem {
+  episodeId: string;
+  title: string;
+  durationSec?: number;
+  publishedAt?: string;
+  artworkUrl?: string;
+}
+
+/**
+ * List a Syra podcast show's episodes for the picker, denormalized from the Syra
+ * catalog (never the client). Each {@link EpisodeSummary} is mapped to a
+ * {@link PodcastEpisodeListItem} — WITHOUT its `enclosureUrl`, which is resolved
+ * server-side only at stream-start. Pagination stays offset-based for parity
+ * with the profile-media search: the SDK's page-based endpoint is hidden behind
+ * its uniform `SearchPage`, so callers advance `offset` by `limit` (never by
+ * `items.length`). Propagates SDK errors; callers own the drop-vs-500 policy.
+ */
+export const listPodcastEpisodes = async (
+  podcastId: string,
+  opts?: { offset?: number },
+): Promise<{ items: PodcastEpisodeListItem[]; hasMore: boolean; offset: number; limit: number }> => {
+  const page = await syraClient.getPodcastEpisodes(podcastId, { offset: opts?.offset });
+
+  const items: PodcastEpisodeListItem[] = page.items.map((ep) => ({
+    episodeId: ep.id,
+    title: ep.title,
+    durationSec: ep.duration,
+    publishedAt: ep.pubDate,
+    artworkUrl: syraClient.episodeImageUrl(ep),
+  }));
+
+  return { items, hasMore: page.hasMore, offset: page.offset, limit: page.limit };
+};
+
+/**
+ * The server-resolved playable form of a podcast episode. `audioUrl` is the
+ * Syra `enclosureUrl` (a direct audio file) fed straight into the LiveKit URL
+ * ingress; the remaining fields denormalize the "now playing" card metadata.
+ */
+export interface ResolvedPodcastEpisode {
+  audioUrl: string;
+  title: string;
+  artworkUrl?: string;
+  durationSec?: number;
+}
+
+/**
+ * Resolve a single Syra episode by id into its playable {@link
+ * ResolvedPodcastEpisode}, denormalized from the Syra catalog — the client never
+ * supplies the audio URL. This is an O(1) by-id lookup (no page scan). When
+ * `expectedPodcastId` is provided, the resolved episode's `podcastId` must match
+ * it, else `null` is returned (guards against pairing an episode id with a
+ * mismatched show). Returns `null` — never throws — when the SDK cannot resolve
+ * the episode (e.g. not found); the caller owns the 404 so a missing episode is
+ * indistinguishable from a mismatched one at the transport layer.
+ */
+export const resolvePodcastEpisode = async (
+  episodeId: string,
+  expectedPodcastId?: string,
+): Promise<ResolvedPodcastEpisode | null> => {
+  try {
+    const episode = await syraClient.getEpisode(episodeId);
+    if (expectedPodcastId && episode.podcastId !== expectedPodcastId) {
+      return null;
+    }
+    return {
+      audioUrl: episode.enclosureUrl,
+      title: episode.title,
+      artworkUrl: syraClient.episodeImageUrl(episode),
+      durationSec: episode.duration,
+    };
+  } catch (err) {
+    logger.warn('[SyraPodcast] Failed to resolve episode', { episodeId, expectedPodcastId, error: err });
+    return null;
+  }
 };


### PR DESCRIPTION
Host can search Syra podcasts in the live-room **Stream Setup** panel, drill into a show's episodes, and tap one to ingest its audio into the room via the existing LiveKit URL ingress. The existing "now playing" stream card renders the episode.

## Layers
- **`@syra.fm/sdk` 0.4.0** (already published) — new `getPodcastEpisodes`, `getEpisode`, `episodeImageUrl`, `EpisodeSummary`. Fix-upstream: extended the SDK rather than calling Syra HTTP directly.
- **Backend** — `listPodcastEpisodes` + `resolvePodcastEpisode` (server-owned audio URL, never trusts the client; O(1) by-id resolution); `GET /profile/media/podcasts/:id/episodes`; `POST /rooms/:id/stream/podcast` reusing an extracted `startUrlIngressForRoom` helper (existing `/stream` route behaviour unchanged).
- **agora-shared** — `searchPodcasts` / `getPodcastEpisodes` / `startPodcastStream` service methods; self-contained `PodcastStreamPicker`; **Podcast** tab in `StreamConfigPanel` (host-only).

## Verification (against current main)
- backend `bun run build` clean; agora-shared typecheck clean (only pre-existing LiveRoomContext NativeWind gotcha).
- backend suite: **1517 tests pass** (incl. new `resolvePodcastEpisode` / `listPodcastEpisodes` / `POST /stream/podcast` route tests).

Design: `docs/superpowers/specs/2026-07-03-live-room-podcast-stream-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)