### PR TITLE
refactor(rooms): rename Agora identifiers → live-rooms (@syra.fm/live 0.2.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/netinfo": "^12.0.1",
         "@shopify/flash-list": "2.3.2",
-        "@syra.fm/live": "^0.1.1",
+        "@syra.fm/live": "^0.2.0",
         "@tanstack/query-async-storage-persister": "^5.101.1",
         "@tanstack/react-query": "^5.100.0",
         "@tanstack/react-query-persist-client": "^5.101.0",
@@ -1022,7 +1022,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@syra.fm/live": ["@syra.fm/live@0.1.1", "", { "peerDependencies": { "@expo/vector-icons": "^15.0.2", "@livekit/react-native": "^2.11.1", "@oxyhq/core": "^5.2.1", "@oxyhq/services": "^13.1.7", "expo-audio": "~56.0.12", "expo-blur": "~56.0.3", "expo-image-picker": "~56.0.18", "livekit-client": "^2.20.0", "react": "^19.2.3", "react-native": "^0.85.3", "react-native-reanimated": "^4.3.1", "react-native-safe-area-context": "^5.7.0", "react-native-svg": "15.15.4", "socket.io-client": "^4.8.1", "sonner-native": "^0.21.1", "zod": "^3.25.76" } }, "sha512-dACNzTjr4ZbEh4CCv01sKGI/FcFfKGK8nr9OfrtzAKOcFOmBAa9sgJ44f3iAlT0J8FYEaOaWlRq611+n7HG2IQ=="],
+    "@syra.fm/live": ["@syra.fm/live@0.2.0", "", { "peerDependencies": { "@expo/vector-icons": "^15.0.2", "@livekit/react-native": "^2.11.1", "@oxyhq/core": "^5.2.1", "@oxyhq/services": "^13.1.7", "expo-audio": "~56.0.12", "expo-blur": "~56.0.3", "expo-image-picker": "~56.0.18", "livekit-client": "^2.20.0", "react": "^19.2.3", "react-native": "^0.85.3", "react-native-reanimated": "^4.3.1", "react-native-safe-area-context": "^5.7.0", "react-native-svg": "15.15.4", "socket.io-client": "^4.8.1", "sonner-native": "^0.21.1", "zod": "^3.25.76" } }, "sha512-oqhi0fx07mwj7G4iBj7QnwMsNS03e2aJyHo+Z7WA4HmSF4JueAfofHTEglgv1nX7gumk0va+DDaOyqVfEWddQg=="],
 
     "@syra.fm/sdk": ["@syra.fm/sdk@0.4.0", "", { "dependencies": { "zod": "^3.25.76" } }, "sha512-9Lf4oGrtssmnC/6QdizJzA2UDdqAOCTPAZWpXQc8UJpxHHksQfSocmAQUn5fe/kgSXHehZnyTdcbYrDo0I+xpQ=="],
 

--- a/packages/frontend/app/(app)/live-rooms/[id].tsx
+++ b/packages/frontend/app/(app)/live-rooms/[id].tsx
@@ -27,7 +27,7 @@ import { useTheme, type Theme } from '@oxyhq/bloom/theme';
 import { useRoomUsers, getDisplayName, getAvatarUrl } from '@/hooks/useRoomUsers';
 import { useUserById } from '@/hooks/useCachedUser';
 import { useLiveRoom } from '@/context/LiveRoomContext';
-import { roomsService } from '@/lib/agoraConfig';
+import { roomsService } from '@/lib/liveConfig';
 import type { Room } from '@syra.fm/live';
 import { useAuth } from '@oxyhq/services';
 import { useTranslation } from 'react-i18next';

--- a/packages/frontend/app/(app)/live-rooms/index.tsx
+++ b/packages/frontend/app/(app)/live-rooms/index.tsx
@@ -14,7 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@oxyhq/services';
 
 import { ThemedText } from '@/components/ThemedText';
-import { Agora as LiveRoomsIcon } from '@syra.fm/live';
+import { LiveRoomsIcon } from '@syra.fm/live';
 import { Header } from '@/components/Header';
 import { EmptyState } from '@/components/common/EmptyState';
 import RoomCard from '@/components/RoomCard';
@@ -23,7 +23,7 @@ import SEO from '@/components/SEO';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useRoomUsers } from '@/hooks/useRoomUsers';
 import { useLiveRoom } from '@/context/LiveRoomContext';
-import { roomsService } from '@/lib/agoraConfig';
+import { roomsService } from '@/lib/liveConfig';
 import type { Room } from '@syra.fm/live';
 import { logger } from '@/lib/logger';
 import { BottomSheetContext } from '@/context/BottomSheetContext';

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -28,7 +28,7 @@ import { useTheme, useBloomTheme } from '@oxyhq/bloom/theme';
 import { useAppearanceStore } from '@/store/appearanceStore';
 import { Chat, ChatActive } from '@/assets/icons/chat-icon';
 import { Bell, BellActive } from '@/assets/icons/bell-icon';
-import { Agora as LiveRoomsIcon, AgoraActive as LiveRoomsIconActive } from '@syra.fm/live';
+import { LiveRoomsIcon, LiveRoomsIconActive } from '@syra.fm/live';
 import { useAuth, ProfileButton } from '@oxyhq/services';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { asViewStyle, type WebViewStyle } from '@/types/webStyles';

--- a/packages/frontend/components/providers/AppProviders.tsx
+++ b/packages/frontend/components/providers/AppProviders.tsx
@@ -14,7 +14,7 @@ import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-c
 import { StatusBar } from 'expo-status-bar';
 import { OxyProvider } from '@oxyhq/services';
 import { OxyServices } from '@oxyhq/core';
-import { AgoraProvider, LiveRoomProvider } from '@syra.fm/live';
+import { LiveConfigProvider, LiveRoomProvider } from '@syra.fm/live';
 import { AppErrorBoundary } from '@/components/AppErrorBoundary';
 import { BottomSheetProvider } from '@/context/BottomSheetContext';
 import { HomeRefreshProvider } from '@/context/HomeRefreshContext';
@@ -24,7 +24,7 @@ import { ToastOutlet } from '@oxyhq/bloom/toast';
 import { ConfirmPromptProvider } from '@/components/common/ConfirmPrompt';
 import { FediverseInfoDialogProvider } from '@/components/Fediverse/FediverseInfoDialog';
 import i18n from '@/lib/i18n';
-import { agoraConfig } from '@/lib/agoraConfig';
+import { liveConfig } from '@/lib/liveConfig';
 import { createScopedLogger } from '@/lib/logger';
 
 const logger = createScopedLogger('AppProviders');
@@ -63,7 +63,7 @@ export const AppProviders = memo(function AppProviders({
             queryClient={queryClient}
           >
             <I18nextProvider i18n={i18n}>
-              <AgoraProvider config={agoraConfig}>
+              <LiveConfigProvider config={liveConfig}>
                 <LiveRoomProvider>
                   <BottomSheetProvider>
                     <MenuProvider>
@@ -83,7 +83,7 @@ export const AppProviders = memo(function AppProviders({
                     </MenuProvider>
                   </BottomSheetProvider>
                 </LiveRoomProvider>
-              </AgoraProvider>
+              </LiveConfigProvider>
             </I18nextProvider>
           </OxyProvider>
         </KeyboardProvider>

--- a/packages/frontend/components/widgets/LiveRoomsWidget.tsx
+++ b/packages/frontend/components/widgets/LiveRoomsWidget.tsx
@@ -16,7 +16,7 @@ import { useUserById } from '@/hooks/useCachedUser';
 import { useWidgetItemMenu } from '@/hooks/useWidgetItemMenu';
 import { shareLink } from '@/utils/shareLink';
 import { WEB_BASE_URL } from '@/config';
-import { Agora as LiveRoomsIcon } from '@syra.fm/live';
+import { LiveRoomsIcon } from '@syra.fm/live';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 
 const MAX_ROOMS_DISPLAYED = 3;

--- a/packages/frontend/lib/liveConfig.tsx
+++ b/packages/frontend/lib/liveConfig.tsx
@@ -1,5 +1,5 @@
-import type { AgoraConfig, AgoraTheme, UserEntity } from '@syra.fm/live';
-import { createAgoraService } from '@syra.fm/live';
+import type { LiveConfig, LiveTheme, UserEntity } from '@syra.fm/live';
+import { createRoomsService } from '@syra.fm/live';
 import type { ComponentType } from 'react';
 import type { ViewStyle } from 'react-native';
 import { queryKeys } from '@oxyhq/services';
@@ -50,40 +50,40 @@ const syraRoomsClient = {
 };
 
 /**
- * The one live-rooms service — the engine's `createAgoraService` bound to the
+ * The one live-rooms service — the engine's `createRoomsService` bound to the
  * Syra client above. Exposed at module scope so non-React callers (Zustand
  * stores) and screens can reuse it without re-instantiating a client. React
- * components can equivalently read `useAgoraConfig().agoraService`.
+ * components can equivalently read `useLiveConfig().roomsService`.
  */
-export const roomsService = createAgoraService(syraRoomsClient);
+export const roomsService = createRoomsService(syraRoomsClient);
 
-const useAgoraTheme = (): AgoraTheme => {
+const useLiveTheme = (): LiveTheme => {
   const theme = useBloomTheme();
   return {
     isDark: theme.isDark,
-    colors: { ...theme.colors } as AgoraTheme['colors'],
+    colors: { ...theme.colors } as LiveTheme['colors'],
   };
 };
 
-interface AgoraAvatarProps {
+interface LiveAvatarProps {
   size: number;
   source?: string;
   shape?: string;
   style?: ViewStyle;
 }
 
-const AgoraAvatar: ComponentType<AgoraAvatarProps> = ({ shape, ...rest }) => {
+const LiveAvatar: ComponentType<LiveAvatarProps> = ({ shape, ...rest }) => {
   const safeShape: 'circle' | 'squircle' | undefined =
     shape === 'squircle' ? 'squircle' : shape === 'circle' ? 'circle' : undefined;
   return <Avatar {...rest} shape={safeShape} />;
 };
 
 /**
- * Cache-first user fetch for Agora — reads/writes the shared React Query cache.
- * Returns the cached user when fresh, otherwise runs the caller's loader and
- * primes the cache via `fetchQuery`.
+ * Cache-first user fetch for live rooms — reads/writes the shared React Query
+ * cache. Returns the cached user when fresh, otherwise runs the caller's loader
+ * and primes the cache via `fetchQuery`.
  */
-const ensureUserById: AgoraConfig['ensureUserById'] = (id, loader) =>
+const ensureUserById: LiveConfig['ensureUserById'] = (id, loader) =>
   queryClient.fetchQuery<UserEntity | null | undefined>({
     queryKey: queryKeys.users.detail(id),
     queryFn: () => loader(id),
@@ -92,10 +92,10 @@ const ensureUserById: AgoraConfig['ensureUserById'] = (id, loader) =>
 
 /**
  * Localize the shared live-room UI via Mention's i18n instance. `i18n.t` is
- * stable and resolves keys flat (see `lib/i18n.ts`); the agora-shared components
+ * stable and resolves keys flat (see `lib/i18n.ts`); the live-room components
  * only ask for plain strings, so `String()` collapses i18next's wide return type.
  */
-const translate: NonNullable<AgoraConfig['t']> = (key, options) => String(i18n.t(key, options));
+const translate: NonNullable<LiveConfig['t']> = (key, options) => String(i18n.t(key, options));
 
 /**
  * Resolve the viewer's pinned Syra podcast from their profile media so the
@@ -103,7 +103,7 @@ const translate: NonNullable<AgoraConfig['t']> = (key, options) => String(i18n.t
  * store (loading it once if cold); returns `null` when the viewer has no pinned
  * podcast (or has a pinned song instead).
  */
-const getPinnedPodcast: NonNullable<AgoraConfig['getPinnedPodcast']> = async () => {
+const getPinnedPodcast: NonNullable<LiveConfig['getPinnedPodcast']> = async () => {
   const store = useAppearanceStore.getState();
   let settings = store.mySettings;
   if (!settings) {
@@ -115,17 +115,17 @@ const getPinnedPodcast: NonNullable<AgoraConfig['getPinnedPodcast']> = async () 
   return { syraPodcastId: media.syraPodcastId, title: media.title, artworkUrl: media.artworkUrl };
 };
 
-export const agoraConfig: AgoraConfig = {
+export const liveConfig: LiveConfig = {
   httpClient: syraRoomsClient,
   socketUrl: SYRA_SOCKET_URL,
-  useTheme: useAgoraTheme,
+  useTheme: useLiveTheme,
   t: translate,
   getPinnedPodcast,
   useUserById,
   ensureUserById,
   getCachedFileDownloadUrl,
   getCachedFileDownloadUrlSync,
-  AvatarComponent: AgoraAvatar,
+  AvatarComponent: LiveAvatar,
   toast: Object.assign(
     (message: string) => show(message),
     {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -56,7 +56,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^12.0.1",
     "@shopify/flash-list": "2.3.2",
-    "@syra.fm/live": "^0.1.1",
+    "@syra.fm/live": "^0.2.0",
     "@tanstack/query-async-storage-persister": "^5.101.1",
     "@tanstack/react-query": "^5.100.0",
     "@tanstack/react-query-persist-client": "^5.101.0",

--- a/packages/frontend/stores/liveRoomsStore.ts
+++ b/packages/frontend/stores/liveRoomsStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { roomsService } from '@/lib/agoraConfig';
+import { roomsService } from '@/lib/liveConfig';
 import type { Room } from '@syra.fm/live';
 import { createScopedLogger } from '@/lib/logger';
 

--- a/packages/frontend/utils/shareLink.ts
+++ b/packages/frontend/utils/shareLink.ts
@@ -23,7 +23,7 @@ interface ShareLinkOptions {
  * - native: RN `Share.share`
  * - web: `navigator.share` when available, otherwise copy to clipboard + toast
  *
- * Mirrors the app's existing share behavior (`usePostShare`, agora room share).
+ * Mirrors the app's existing share behavior (`usePostShare`, live room share).
  */
 export async function shareLink({
   title,


### PR DESCRIPTION
Mention frontend rename of the leftover Agora identifiers (agoraConfig→liveConfig, AgoraProvider→LiveConfigProvider, createAgoraService→createRoomsService, Agora icons→LiveRoomsIcon, etc.) consuming @syra.fm/live 0.2.0. Pure rename, typecheck clean. 🤖 Generated with Claude Code