### PR TITLE
fix(live): update the avatar LIVE badge instantly on go-live/go-offline

### DIFF
--- a/packages/frontend/lib/liveConfig.tsx
+++ b/packages/frontend/lib/liveConfig.tsx
@@ -130,6 +130,13 @@ const getPinnedPodcast: NonNullable<LiveConfig['getPinnedPodcast']> = async () =
 };
 
 export const liveConfig: LiveConfig = {
+  // Live-presence just changed for the local user (they started/stopped a room
+  // or stream). Invalidate the shared `['live-users']` query (see
+  // hooks/useLiveUsers.ts) so every avatar's LIVE badge updates instantly
+  // instead of waiting for the 60s background poll.
+  onRoomChanged: () => {
+    queryClient.invalidateQueries({ queryKey: ['live-users'] });
+  },
   httpClient: syraLinkedClient,
   socketUrl: SYRA_SOCKET_URL,
   useTheme: useLiveTheme,


### PR DESCRIPTION
## Bug

When a host starts a live (Syra) room/stream, their own avatar's LIVE badge did not update until the app was reloaded (it should be instant).

## Root cause

The avatar LIVE badge is driven by the shared React Query `['live-users']` in `hooks/useLiveUsers.ts` (polls every 60s). The `@syra.fm/live` engine already fires `config.onRoomChanged?.(roomId)` at every go-live / go-offline point (startRoom, stopRoom, deleteRoom, stream-started). But Mention's `liveConfig` object in `lib/liveConfig.tsx` did not provide `onRoomChanged`, so the signal was dropped and the badge only refreshed on the 60s poll or a reload.

## Fix

Wire `onRoomChanged` on `liveConfig` to invalidate the shared `['live-users']` query using the `queryClient` already imported in the file. Now a host's avatar shows/clears the LIVE badge the instant they start or stop.

Minimal diff: only the `onRoomChanged` addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)