### PR TITLE
chore(sdk): drop dead auth.<apex> config after device-first bump

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -23,8 +23,6 @@ API_URL_SOCKET=ws://localhost:3000
 # ── Oxy platform (auth + API) ────────────────────────────────────────
 # Oxy API base. Prod default: https://api.oxy.so
 EXPO_PUBLIC_OXY_BASE_URL=http://localhost:3001
-# Oxy auth host. Prod default: https://auth.oxy.so
-EXPO_PUBLIC_OXY_AUTH_URL=http://localhost:3002
 
 # ── Public web origin ────────────────────────────────────────────────
 # Origin used to build shareable deep links (posts, trends, rooms).

--- a/packages/frontend/config.ts
+++ b/packages/frontend/config.ts
@@ -31,10 +31,6 @@ export const OXY_BASE_URL =
   process.env.EXPO_PUBLIC_OXY_BASE_URL ||
   (process.env.NODE_ENV === 'production' ? 'https://api.oxy.so' : 'http://localhost:3001');
 
-export const OXY_AUTH_URL =
-  process.env.EXPO_PUBLIC_OXY_AUTH_URL ||
-  (process.env.NODE_ENV === 'production' ? 'https://auth.oxy.so' : 'http://localhost:3002');
-
 // Mention's registered Oxy OAuth client id (ApplicationCredential publicKey).
 // Required by @oxyhq/services for the cross-app device sign-in flow. Public and
 // safe to commit; overridable per-environment via EXPO_PUBLIC_OXY_CLIENT_ID.

--- a/packages/frontend/lib/oxyServices.ts
+++ b/packages/frontend/lib/oxyServices.ts
@@ -2,12 +2,13 @@ import { OxyServices } from '@oxyhq/core';
 import { OXY_BASE_URL } from '@/config';
 
 /**
- * Shared OxyServices instance for use throughout the app
- * This is the same instance that's passed to OxyProvider in _layout.tsx
+ * Shared OxyServices instance for use throughout the app.
+ * This is the same instance that's passed to OxyProvider in AppProviders.
  *
- * authWebUrl is intentionally omitted so the SDK auto-detects the first-party
- * IdP at auth.<apex> (e.g. auth.mention.earth) from window.location. This keeps
- * cross-domain session restore first-party on Safari/Firefox and works on
- * preview deployments without hardcoding a host.
+ * Only baseURL (the Oxy API) is needed. Session restore is device-first and
+ * owned entirely by OxyProvider's cold boot: on the first cross-apex visit it
+ * runs a bootstrap hop to the Oxy API, then persists a per-origin rotating
+ * refresh token so subsequent reloads stay signed in offline. There is no
+ * per-apex auth.<apex> iframe/CNAME anymore, so no authWebUrl is configured.
  */
 export const oxyServices = new OxyServices({ baseURL: OXY_BASE_URL });


### PR DESCRIPTION
Small follow-up to the merged wave-2 device-first SDK bump (#325).

The wave-2 SDK's device-first cold boot restores sessions via a bootstrap hop to the Oxy API + a per-origin rotating refresh token — there is no per-apex `auth.<apex>` iframe/CNAME anymore. This removes the leftover config that only existed to feed that removed flow:

- Remove the `OXY_AUTH_URL` export from `config.ts` (defined but never consumed anywhere — verified repo-wide) and its `EXPO_PUBLIC_OXY_AUTH_URL` line in `.env.example`.
- Rewrite the stale `lib/oxyServices.ts` doc comment, which described the removed `authWebUrl` auto-detect of `auth.<apex>`, to reflect the device-first flow (baseURL = Oxy API; `OxyProvider` cold boot owns the bootstrap hop + per-origin refresh persistence).

No behavior change — purely dead-config/comment cleanup. Frontend typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)