### PR TITLE
fix(web): static dark boot canvas in global.css — kills the white flash without the worker

### DIFF
--- a/packages/frontend/global.css
+++ b/packages/frontend/global.css
@@ -73,6 +73,15 @@
 
 html, body, #root {
   font-family: 'Inter', 'Inter-Regular', sans-serif;
+  /* Pre-hydration dark canvas. Bloom applies the real theme (the `.dark` class +
+     `--background` var) at RUNTIME from BloomThemeProvider, so before the JS
+     bundle runs there is no themed background and the first paint would be white.
+     This render-blocking rule (global.css ships as a <link rel=stylesheet> in the
+     head, before the deferred bundle) paints the boot canvas the same dark as the
+     always-dark AppSplashScreen (#0B0B0F, matching the native splash), killing the
+     white flash with no worker/JS. The app's own `bg-background` covers it once
+     mounted. This is the Expo analog of the Vite apps' static `<html class="dark">`. */
+  background-color: #0B0B0F;
 }
 
 /* Document-level scrolling. Expo / react-native-web automatically inject a


### PR DESCRIPTION
The white flash on reload happens because Bloom applies the theme (the `.dark` class + `--background` var) at **runtime** from `BloomThemeProvider` in `app/_layout.tsx` — so before the JS bundle runs there is no themed background and the first paint is white.

Fix: a plain `html, body, #root { background-color: #0B0B0F }` in `global.css`, which ships as a **render-blocking** `<link rel=stylesheet>` (before the `defer`red bundle) so the boot canvas paints the same dark as the always-dark `AppSplashScreen`. It's the Expo analog of the Vite Oxy apps' static `<html class="dark">`. **No Cloudflare worker, no JS, no build hack.**

Verified: the compiled render-blocking CSS contains `html,body,#root{background-color:#0b0b0f;…}`, and a real browser computes `html/body/#root` background as `rgb(11,11,15)`.

Also decouples the white-flash fix from the CF worker — the flash stays fixed even when Pages Functions is down (e.g. the free-plan daily limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
