### PR TITLE
perf(web): scope the CF worker to federation + profile/post via _routes.json

### DIFF
--- a/packages/frontend/public/_routes.json
+++ b/packages/frontend/public/_routes.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "include": [
+    "/ap",
+    "/ap/*",
+    "/.well-known/*",
+    "/nodeinfo/*",
+    "/xrpc/*",
+    "/@*",
+    "/p/*"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
The Advanced-Mode `_worker.js` runs on **every** request → Pages Functions invocations = all site traffic, which is what exceeded the free daily limit. This `_routes.json` scopes the worker to only the paths that need it: federation (`/ap`, `/ap/*`, `/.well-known/*`, `/nodeinfo/*`, `/xrpc/*`), profile-URL AP discovery + OG (`/@*`), and post OG (`/p/*`). Home / feed / settings / all static assets now bypass the worker → served straight from Pages, no Functions invocation. White flash unaffected (static in global.css).

🤖 Generated with [Claude Code](https://claude.com/claude-code)