### PR TITLE
feat(web): backend OG web-shell + runtime PWA manifest (prep to drop the CF worker)

### DIFF
--- a/docs/cloudflare-federation-origin-rules.md
+++ b/docs/cloudflare-federation-origin-rules.md
@@ -1,0 +1,82 @@
+# Cloudflare rules to serve federation + profile/post from the backend (no Worker)
+
+Goal: remove the CF Pages `_worker.js` entirely. These native Cloudflare rules on the
+**`mention.earth`** zone transparently route federation endpoints AND the profile/post
+pages to the backend (`api.mention.earth`), so no Pages Functions are needed. All are
+available on the **Free** plan.
+
+## Why the two rules (the ALB detail)
+The shared ALB routes to the Mention backend **by Host header** (`host_headers = ["api.mention.earth"]`,
+`oxy-infra/terraform-uswest2/app-services-realtime.tf:10`). So CF must send `Host: api.mention.earth`
+or the ALB won't route to the backend. But Mastodon signs its HTTP signatures over the **apex**
+host (`mention.earth`), and the backend verifies against `X-Forwarded-Host` (falling back to `Host`)
+— `packages/backend/src/connectors/activitypub/crypto.ts:266`. So we send `Host: api.mention.earth`
+(for ALB routing) **and** `X-Forwarded-Host: mention.earth` (for signature verification). This is
+exactly what the current worker does.
+
+---
+
+## Rule 1 — Origin Rule (Rules → Overrides / Origin Rules)
+**When incoming requests match** (Custom filter expression):
+```
+(http.request.uri.path eq "/ap") or
+(starts_with(http.request.uri.path, "/ap/")) or
+(http.request.uri.path eq "/.well-known/webfinger") or
+(http.request.uri.path eq "/.well-known/host-meta") or
+(http.request.uri.path eq "/.well-known/host-meta.json") or
+(http.request.uri.path eq "/.well-known/nodeinfo") or
+(http.request.uri.path eq "/.well-known/atproto-did") or
+(starts_with(http.request.uri.path, "/nodeinfo/")) or
+(starts_with(http.request.uri.path, "/xrpc/")) or
+(starts_with(http.request.uri.path, "/@")) or
+(starts_with(http.request.uri.path, "/p/"))
+```
+**Then (settings):**
+- **DNS record / Origin (Destination) override →** `api.mention.earth`
+- **Host Header →** rewrite to `api.mention.earth`
+- (Destination port 443 / preserve.)
+
+This makes CF fetch these paths from the backend ALB instead of Pages, transparently (same URL, no redirect).
+
+## Rule 2 — Transform Rule → Modify Request Header (Rules → Transform Rules → Modify Request Header)
+**When incoming requests match:** *(same expression as Rule 1 — or at minimum the federation paths; applying it to all matched paths is harmless)*
+**Then — Set static:**
+- Header name: `X-Forwarded-Host`
+- Value: `mention.earth`
+
+So the backend reconstructs the signed `host` line as `mention.earth` even though the ALB saw `Host: api.mention.earth`.
+
+---
+
+## What the backend now serves for these paths
+- `/ap/*`, webfinger, host-meta, nodeinfo, `/xrpc/*`, `/.well-known/atproto-did` → existing AP/bridge routes (unchanged; they already worked when the worker proxied them).
+- `/@:username` (+ sub-tabs) → new web-shell handler: AP `Accept` → 302 to `/ap/users/:username`; browser/crawler → SPA `index.html` with profile OG injected.
+- `/p/:id` → new web-shell handler: SPA shell with post OG injected.
+- Everything else (home, feed, settings, all static assets) → still served by CF Pages (static). No backend, no Functions.
+
+## Switch order (IMPORTANT — do not break federation)
+1. Deploy the backend web-shell handler + the runtime PWA manifest (code — done separately).
+2. Add Rule 1 + Rule 2 in the CF dashboard.
+3. **Test** (below) — federation + OG now flow through the backend via the Origin Rule (which bypasses the Pages worker for those paths).
+4. Only once green: delete `packages/frontend/public/_worker.js` + `_routes.json` and redeploy the frontend. Frontend is now pure static → can drop to the Free plan.
+
+## Test plan (after Rule 1 + 2 are live)
+```
+# federation: webfinger + actor (proxied to backend, no redirect)
+curl -s "https://mention.earth/.well-known/webfinger?resource=acct:nate@mention.earth" | head
+curl -s -H 'Accept: application/activity+json' "https://mention.earth/ap/users/nate" | head -c 200
+# profile OG (browser) + AP discovery (302)
+curl -s "https://mention.earth/@nate" | grep -o 'og:title[^>]*'
+curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' -H 'Accept: application/activity+json' "https://mention.earth/@nate"
+# post OG
+curl -s "https://mention.earth/p/<id>" | grep -o 'og:title[^>]*'
+# home still static (no backend, no OG)
+curl -s "https://mention.earth/" | grep -c og:title   # -> 0
+# Mastodon inbox POST signature verifies — confirm by following a Mention user from a Mastodon account.
+```
+
+## Caveat to watch when applying
+CF Pages custom domains + an Origin Rule overriding to an **external** origin (the ALB) is a slightly
+unusual combo. If Rule 1 doesn't take effect on the Pages-backed apex, the fallback is a Cloudflare
+**Configuration/Page Rule "Resolve Override"** to `api.mention.earth` for the same paths (same idea).
+Verify with the webfinger/actor curls above right after adding the rules.

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -64,6 +64,7 @@ import entityFollowRoutes from './src/routes/entity-follow.routes';
 import mediaRoutes from './src/routes/media';
 import recommendationsRoutes from './src/routes/recommendations';
 import mtnNodesRoutes from './src/routes/mtn-nodes.routes';
+import webShellRoutes from './src/routes/webShell.routes';
 
 // Federation (ActivityPub) — network connectors. Importing the connectors index
 // instantiates the enabled connectors and registers the connector registry as
@@ -919,6 +920,16 @@ app.use('/media', mediaRoutes);
 
 // Mount public and authenticated API routers
 app.use("/", publicApiRouter);
+
+// --- Public web shell with OpenGraph (PUBLIC, no auth) ---
+// Serves the SPA shell HTML with per-request OG tags for `/@handle` and `/p/:id`
+// (the `bskyweb` model — replaces the retired CF Pages `_worker.js` OG injection).
+// Mounted LAST among the public routes and BEFORE the authenticated router so
+// anonymous browsers/crawlers reach it — the auth router's oxy.auth() middleware
+// would otherwise reject these public page loads. Its RegExp routes (`/@…`, `/p/…`)
+// do not collide with any API/federation mount.
+app.use("/", webShellRoutes);
+
 app.use("/", oxy.auth(), authenticatedApiRouter);
 
 // Global error handler — must be the LAST middleware registered.

--- a/packages/backend/src/__tests__/webShellRenderer.test.ts
+++ b/packages/backend/src/__tests__/webShellRenderer.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import type { HydratedPost } from '@mention/shared-types';
+import {
+  escapeHtml,
+  buildOgMetaHtml,
+  renderShellWithOg,
+  mapProfileOg,
+  mapPostOg,
+  OgData,
+} from '../services/webShellRenderer';
+
+const SHELL =
+  '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Mention</title>' +
+  '<link rel="icon" href="/favicon.ico" /></head><body><div id="root"></div>' +
+  '<script src="/_expo/static/js/web/entry.js" defer></script></body></html>';
+
+describe('escapeHtml', () => {
+  it('escapes the dangerous set (& < > ")', () => {
+    expect(escapeHtml('a & b < c > d "e"')).toBe('a &amp; b &lt; c &gt; d &quot;e&quot;');
+  });
+
+  it('does not escape safe characters', () => {
+    expect(escapeHtml("O'Brien — 5$")).toBe("O'Brien — 5$");
+  });
+});
+
+describe('buildOgMetaHtml', () => {
+  const og: OgData = {
+    title: 'Nate (@nate) on Mention',
+    description: 'hello <world> & "friends"',
+    image: 'https://cloud.oxy.so/abc?variant=thumb',
+    url: 'https://mention.earth/@nate',
+    type: 'profile',
+  };
+
+  it('emits all OG/Twitter tags with escaped values', () => {
+    const html = buildOgMetaHtml(og);
+    expect(html).toContain('<meta property="og:type" content="profile">');
+    expect(html).toContain('<meta property="og:site_name" content="Mention">');
+    expect(html).toContain('<meta property="og:url" content="https://mention.earth/@nate">');
+    expect(html).toContain('<meta property="og:title" content="Nate (@nate) on Mention">');
+    expect(html).toContain('<meta name="twitter:card" content="summary_large_image">');
+    // description is escaped everywhere it appears
+    expect(html).toContain('content="hello &lt;world&gt; &amp; &quot;friends&quot;"');
+    expect(html).not.toContain('hello <world>');
+  });
+
+  it('emits image tags only when an image is present', () => {
+    const withImage = buildOgMetaHtml(og);
+    expect(withImage).toContain('<meta property="og:image" content="https://cloud.oxy.so/abc?variant=thumb">');
+    expect(withImage).toContain('<meta name="twitter:image" content="https://cloud.oxy.so/abc?variant=thumb">');
+
+    const noImage = buildOgMetaHtml({ ...og, image: undefined });
+    expect(noImage).not.toContain('og:image');
+    expect(noImage).not.toContain('twitter:image');
+  });
+});
+
+describe('renderShellWithOg', () => {
+  const og: OgData = {
+    title: 'Nate (@nate) on Mention',
+    description: 'bio',
+    url: 'https://mention.earth/@nate',
+    type: 'profile',
+  };
+
+  it('replaces the existing <title> and injects the meta before </head>', () => {
+    const html = renderShellWithOg(SHELL, og);
+    expect(html).toContain('<title>Nate (@nate) on Mention</title>');
+    expect(html).not.toContain('<title>Mention</title>');
+    // the whole OG block is injected inside <head>, ending right before </head>
+    expect(html).toContain('<meta property="og:title" content="Nate (@nate) on Mention">');
+    expect(html).toContain('<meta name="description" content="bio"></head>');
+    expect(html.indexOf('og:title')).toBeLessThan(html.indexOf('</head>'));
+    // exactly one title tag remains
+    expect(html.match(/<title>/g)?.length).toBe(1);
+  });
+
+  it('returns the shell verbatim when og is null', () => {
+    expect(renderShellWithOg(SHELL, null)).toBe(SHELL);
+  });
+
+  it('does not treat a $ in the title as a replace back-reference', () => {
+    const html = renderShellWithOg(SHELL, { ...og, title: 'Deal $5 & $1' });
+    expect(html).toContain('<title>Deal $5 &amp; $1</title>');
+  });
+});
+
+describe('mapProfileOg', () => {
+  it('builds the display-name title and profile url', () => {
+    const og = mapProfileOg({ username: 'nate', name: { displayName: 'Nate' }, bio: 'hi there' });
+    expect(og).not.toBeNull();
+    expect(og?.title).toBe('Nate (@nate) on Mention');
+    expect(og?.description).toBe('hi there');
+    expect(og?.url).toBe('https://mention.earth/@nate');
+    expect(og?.type).toBe('profile');
+  });
+
+  it('falls back to the handle title when there is no display name', () => {
+    expect(mapProfileOg({ username: 'nate' })?.title).toBe('@nate on Mention');
+  });
+
+  it('passes through an absolute avatar URL and resolves a bare file id via the CDN helper', () => {
+    expect(mapProfileOg({ username: 'a', avatar: 'https://remote.example/x.png' })?.image).toBe(
+      'https://remote.example/x.png',
+    );
+    expect(mapProfileOg({ username: 'a', avatar: 'file123' })?.image).toBe(
+      'https://cloud.oxy.so/file123?variant=thumb',
+    );
+  });
+
+  it('omits the image when there is no avatar', () => {
+    expect(mapProfileOg({ username: 'a' })?.image).toBeUndefined();
+  });
+
+  it('returns null for an unknown handle (no username)', () => {
+    expect(mapProfileOg(null)).toBeNull();
+    expect(mapProfileOg({})).toBeNull();
+  });
+
+  it('prefers bio over description and trims', () => {
+    expect(mapProfileOg({ username: 'a', bio: '  b  ', description: 'd' })?.description).toBe('b');
+    expect(mapProfileOg({ username: 'a', description: '  d  ' })?.description).toBe('d');
+  });
+});
+
+describe('mapPostOg', () => {
+  const base = {
+    id: 'p1',
+    user: { id: 'u1', handle: 'nate', displayName: 'Nate', avatarUrl: 'https://cdn/a.png' },
+    content: { text: 'hello world' },
+  } as unknown as HydratedPost;
+
+  it('builds the author title, sliced description, and post url', () => {
+    const og = mapPostOg(base, 'p1');
+    expect(og.title).toBe('Nate on Mention');
+    expect(og.description).toBe('hello world');
+    expect(og.url).toBe('https://mention.earth/p/p1');
+    expect(og.type).toBe('article');
+    // no media/linkPreview → falls back to author avatar
+    expect(og.image).toBe('https://cdn/a.png');
+  });
+
+  it('falls back to @handle when the author has no display name', () => {
+    const post = { ...base, user: { ...base.user, displayName: undefined } } as HydratedPost;
+    expect(mapPostOg(post, 'p1').title).toBe('@nate on Mention');
+  });
+
+  it('truncates the description to 200 characters', () => {
+    const post = { ...base, content: { text: 'x'.repeat(500) } } as HydratedPost;
+    expect(mapPostOg(post, 'p1').description).toHaveLength(200);
+  });
+
+  it('prefers media url over thumb/poster/linkPreview/avatar', () => {
+    const post = {
+      ...base,
+      content: { text: 't', media: [{ id: 'm', type: 'image', url: 'https://m/u.jpg', thumbUrl: 'https://m/t.jpg' }] },
+      linkPreview: { url: 'https://l', image: 'https://l/i.jpg' },
+    } as unknown as HydratedPost;
+    expect(mapPostOg(post, 'p1').image).toBe('https://m/u.jpg');
+  });
+
+  it('uses the link-preview image when there is no media', () => {
+    const post = {
+      ...base,
+      content: { text: 't' },
+      linkPreview: { url: 'https://l', image: 'https://l/i.jpg' },
+    } as unknown as HydratedPost;
+    expect(mapPostOg(post, 'p1').image).toBe('https://l/i.jpg');
+  });
+});

--- a/packages/backend/src/__tests__/webShellRoutes.integration.test.ts
+++ b/packages/backend/src/__tests__/webShellRoutes.integration.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Mock the heavy deps BEFORE importing the router so the real PostHydrationService
+// (which imports the server entrypoint) never loads — keeps this a fast, isolated
+// route test. mongoose/redis/logger are already mocked in the global setup.
+vi.mock('../models/Post', () => ({ Post: { findById: vi.fn() } }));
+vi.mock('../services/PostHydrationService', () => ({
+  postHydrationService: { hydratePosts: vi.fn() },
+}));
+
+import webShellRoutes from '../routes/webShell.routes';
+import { Post } from '../models/Post';
+import { postHydrationService } from '../services/PostHydrationService';
+import type { HydratedPost } from '@mention/shared-types';
+
+const SHELL =
+  '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Mention</title></head>' +
+  '<body><div id="root"></div><script src="/_expo/static/js/web/entry.js" defer></script></body></html>';
+
+/** A 24-hex ObjectId so the route's `mongoose.isValidObjectId` guard passes. */
+const POST_ID = '507f1f77bcf86cd799439011';
+
+function makeApp() {
+  const app = express();
+  app.use('/', webShellRoutes);
+  return app;
+}
+
+/** Stub `global.fetch`: the shell fetch returns SHELL; the Oxy profile fetch returns `profile`. */
+function stubFetch(profile: { ok: boolean; body?: unknown }) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL) => {
+      const href = String(url);
+      if (href.includes('/profiles/username/')) {
+        return { ok: profile.ok, json: async () => profile.body } as Response;
+      }
+      return { ok: true, text: async () => SHELL } as unknown as Response;
+    }),
+  );
+}
+
+describe('webShell routes (integration)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('serves the shell with profile OG for a non-AP /@handle request', async () => {
+    stubFetch({ ok: true, body: { data: { username: 'nate', name: { displayName: 'Nate' }, bio: 'bio' } } });
+
+    const res = await request(makeApp()).get('/@nate');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.headers.vary).toContain('Accept');
+    expect(res.text).toContain('<meta property="og:title" content="Nate (@nate) on Mention">');
+    expect(res.text).toContain('<title>Nate (@nate) on Mention</title>');
+    expect(res.text).not.toContain('<title>Mention</title>');
+  });
+
+  it('302-redirects a local /@handle to the AP actor when Accept wants ActivityPub', async () => {
+    stubFetch({ ok: true, body: {} });
+
+    const res = await request(makeApp()).get('/@nate').set('Accept', 'application/activity+json');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://api.mention.earth/ap/users/nate');
+  });
+
+  it('does NOT AP-redirect a federated handle (@user@domain), serving the shell instead', async () => {
+    stubFetch({ ok: false });
+
+    const res = await request(makeApp())
+      .get('/@user@remote.social')
+      .set('Accept', 'application/ld+json');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  it('serves the shell with post OG for /p/:id', async () => {
+    stubFetch({ ok: false });
+    vi.mocked(Post.findById).mockReturnValue({
+      maxTimeMS: () => ({ lean: () => Promise.resolve({ _id: POST_ID, oxyUserId: 'u1', content: { text: 'hi there' } }) }),
+    } as unknown as ReturnType<typeof Post.findById>);
+    vi.mocked(postHydrationService.hydratePosts).mockResolvedValue([
+      {
+        id: POST_ID,
+        user: { id: 'u1', handle: 'nate', displayName: 'Nate', avatarUrl: 'https://cdn/a.png' },
+        content: { text: 'hi there' },
+      } as unknown as HydratedPost,
+    ]);
+
+    const res = await request(makeApp()).get(`/p/${POST_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.text).toContain('<meta property="og:title" content="Nate on Mention">');
+    expect(res.text).toContain(`<meta property="og:url" content="https://mention.earth/p/${POST_ID}">`);
+    expect(res.text).toContain('<meta property="og:image" content="https://cdn/a.png">');
+  });
+
+  it('fails open with a plain shell when the post is missing', async () => {
+    stubFetch({ ok: false });
+    vi.mocked(Post.findById).mockReturnValue({
+      maxTimeMS: () => ({ lean: () => Promise.resolve(null) }),
+    } as unknown as ReturnType<typeof Post.findById>);
+
+    const res = await request(makeApp()).get(`/p/${POST_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('<title>Mention</title>');
+    expect(res.text).not.toContain('og:title');
+  });
+});

--- a/packages/backend/src/routes/webShell.routes.ts
+++ b/packages/backend/src/routes/webShell.routes.ts
@@ -1,0 +1,207 @@
+/**
+ * Public web shell with per-request OpenGraph — the `bskyweb` model.
+ *
+ * A CF Origin Rule transparently routes `mention.earth/@*` and `mention.earth/p/*`
+ * to this backend. For those paths we serve the static SPA shell HTML with
+ * per-request OG/Twitter tags injected (so crawlers / link-unfurlers get a rich
+ * preview) while browsers still boot the SPA normally. This replaces the OG
+ * injection the retired Cloudflare Pages `_worker.js` used to do at the edge.
+ *
+ * The shell (Expo's single static `index.html`) is fetched ONCE from the frontend
+ * CDN and cached in-memory — it only changes on a frontend deploy. Root-relative
+ * asset refs in that HTML (`/_expo/static/...`) resolve against the apex, which
+ * CF still serves from Pages, so booting the SPA works unchanged.
+ *
+ * Everything here is PUBLIC (no auth) and fail-open: a slow/broken OG fetch or a
+ * missing entity serves the plain shell (no OG) rather than failing the page.
+ *
+ * AP content negotiation: a request for a LOCAL profile URL (`/@user`, single
+ * segment, no `@domain`, no sub-tab) that `Accept`s ActivityPub is 302-redirected
+ * to the canonical actor — a GET-only redirect, mirroring the worker. All other
+ * requests (browsers, crawlers, federated handles, sub-tabs) get the shell.
+ */
+import { Router, Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { Post } from '../models/Post';
+import { postHydrationService } from '../services/PostHydrationService';
+import { logger } from '../utils/logger';
+import {
+  OgData,
+  OxyProfileData,
+  mapPostOg,
+  mapProfileOg,
+  renderShellWithOg,
+} from '../services/webShellRenderer';
+
+/** Frontend CDN origin the static SPA shell is fetched from (NOT the apex — that would loop the Origin Rule). */
+const SHELL_ORIGIN = process.env.WEB_SHELL_ORIGIN || 'https://mention-frontend.pages.dev/';
+/** How long a fetched shell is trusted before a background refresh. */
+const SHELL_TTL_MS = 10 * 60 * 1000;
+/** Hard timeout for the shell fetch — a slow CDN must never block a page. */
+const SHELL_FETCH_TIMEOUT_MS = 5000;
+/** Hard timeout for the per-request OG data fetch. */
+const OG_FETCH_TIMEOUT_MS = 2500;
+
+/** Oxy API origin — canonical profiles live here. */
+const OXY_API_URL = process.env.OXY_API_URL || 'https://api.oxy.so';
+/** Backend origin that serves the canonical ActivityPub actor. */
+const API_ORIGIN = (process.env.MENTION_API_ORIGIN || 'https://api.mention.earth').replace(/\/+$/, '');
+const AP_ACTOR_BASE = `${API_ORIGIN}/ap/users/`;
+
+/** A LOCAL profile path: a single `@handle` segment with no second `@` and no sub-tab. */
+const LOCAL_PROFILE_RE = /^\/@([^/@]+)$/;
+
+/**
+ * Minimal valid HTML served only in the extreme edge case where the shell CDN is
+ * unreachable AND we have never cached a copy. It carries the OG tags (so
+ * crawlers still get a preview) and never 500s; browsers hitting this rare state
+ * simply reload once the CDN recovers.
+ */
+const FALLBACK_SHELL =
+  '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">' +
+  '<meta name="viewport" content="width=device-width, initial-scale=1"><title>Mention</title>' +
+  '</head><body><div id="root"></div></body></html>';
+
+interface ShellCache {
+  html: string;
+  fetchedAt: number;
+}
+
+let shellCache: ShellCache | null = null;
+let shellInFlight: Promise<string | null> | null = null;
+
+/** Fetch the static shell HTML with a hard timeout. Returns null on any failure (never throws). */
+async function fetchShellHtml(): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SHELL_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(SHELL_ORIGIN, {
+      headers: { Accept: 'text/html' },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      logger.warn(`[webShell] Shell fetch returned ${response.status}`);
+      return null;
+    }
+    return await response.text();
+  } catch (error) {
+    logger.warn('[webShell] Shell fetch failed', error);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Refresh the cached shell, de-duplicating concurrent refreshes into one fetch. */
+function refreshShell(): Promise<string | null> {
+  if (!shellInFlight) {
+    shellInFlight = fetchShellHtml()
+      .then((html) => {
+        if (html) shellCache = { html, fetchedAt: Date.now() };
+        return shellCache?.html ?? null;
+      })
+      .finally(() => {
+        shellInFlight = null;
+      });
+  }
+  return shellInFlight;
+}
+
+/**
+ * Return the SPA shell, aggressively cached. A fresh copy is served from memory;
+ * a stale copy is served immediately while a background refresh runs
+ * (stale-while-revalidate); a cold cache awaits the first successful fetch.
+ * Returns null only when there is no cache and the fetch failed.
+ */
+async function getShell(): Promise<string | null> {
+  if (shellCache && Date.now() - shellCache.fetchedAt < SHELL_TTL_MS) {
+    return shellCache.html;
+  }
+  if (shellCache) {
+    void refreshShell();
+    return shellCache.html;
+  }
+  return refreshShell();
+}
+
+/** Whether the `Accept` header asks for ActivityPub JSON (Mastodon may send `ld+json`). */
+function wantsActivityPub(accept: string | undefined): boolean {
+  if (!accept) return false;
+  const value = accept.toLowerCase();
+  return value.includes('activity+json') || value.includes('ld+json');
+}
+
+/** Fetch + map a profile's OG data from the Oxy API. Returns null on any failure. */
+async function fetchProfileOg(handle: string): Promise<OgData | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OG_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${OXY_API_URL}/profiles/username/${encodeURIComponent(handle)}`, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const json: { data?: OxyProfileData } = await response.json();
+    return mapProfileOg(json?.data);
+  } catch (error) {
+    logger.debug('[webShell] Profile OG fetch failed', error);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Hydrate + map a post's OG data in-process (same path as `GET /feed/item/:id`). Returns null on any failure. */
+async function fetchPostOg(id: string): Promise<OgData | null> {
+  try {
+    if (!mongoose.isValidObjectId(id)) return null;
+    const post = await Post.findById(id).maxTimeMS(OG_FETCH_TIMEOUT_MS).lean();
+    if (!post) return null;
+    // maxDepth:1 so boosts hydrate their original and link previews are included;
+    // the OG mapping itself only reads the post's own top-level fields.
+    const [hydrated] = await postHydrationService.hydratePosts([post], {
+      maxDepth: 1,
+      includeLinkMetadata: true,
+    });
+    if (!hydrated?.user) return null;
+    return mapPostOg(hydrated, id);
+  } catch (error) {
+    logger.debug('[webShell] Post OG fetch failed', error);
+    return null;
+  }
+}
+
+/** Serve the shell with OG injected, overriding the API no-store default for these public per-URL pages. */
+async function serveShell(res: Response, og: OgData | null): Promise<void> {
+  const shell = (await getShell()) ?? FALLBACK_SHELL;
+  res.status(200);
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, max-age=300');
+  res.send(renderShellWithOg(shell, og));
+}
+
+const router = Router();
+
+// Profile: `/@handle` plus sub-tabs (`/@handle/media`, `/@handle/followers`, …).
+// The captured group is the handle segment (`user` or `user@domain`).
+router.get(/^\/@([^/]+)(?:\/.*)?$/, async (req: Request, res: Response) => {
+  const handle = decodeURIComponent(req.params[0]);
+
+  // AP content negotiation — only for a LOCAL single-segment profile URL.
+  if (LOCAL_PROFILE_RE.test(req.path) && wantsActivityPub(req.headers.accept)) {
+    res.setHeader('Vary', 'Accept');
+    return res.redirect(302, AP_ACTOR_BASE + encodeURIComponent(handle));
+  }
+
+  res.setHeader('Vary', 'Accept');
+  const og = await fetchProfileOg(handle);
+  await serveShell(res, og);
+});
+
+// Post: `/p/<id>` (optional trailing slash). No AP case.
+router.get(/^\/p\/([^/]+)\/?$/, async (req: Request, res: Response) => {
+  const og = await fetchPostOg(req.params[0]);
+  await serveShell(res, og);
+});
+
+export default router;

--- a/packages/backend/src/services/webShellRenderer.ts
+++ b/packages/backend/src/services/webShellRenderer.ts
@@ -1,0 +1,170 @@
+/**
+ * Web-shell OpenGraph renderer — the `bskyweb` model, ported from the retired
+ * Cloudflare Pages `_worker.js`.
+ *
+ * These are the PURE, dependency-light building blocks: they map already-fetched
+ * profile / post data into an {@link OgData} record, render the OG/Twitter
+ * `<meta>` block, and splice it into a static SPA shell (replacing `<title>` and
+ * injecting the meta before `</head>`). They perform NO IO and NEVER import the
+ * server module / models, so they are unit-testable in isolation and can be
+ * called from the request path without pulling a heavy dependency graph.
+ *
+ * The IO layer (fetching the shell, the Oxy profile, and the hydrated post) lives
+ * in `routes/webShell.routes.ts`, which is the only caller of these functions.
+ */
+import { OxyServices } from '@oxyhq/core';
+import type { HydratedPost } from '@mention/shared-types';
+
+/** Normalized OG payload injected into a shell for one profile / post URL. */
+export interface OgData {
+  title: string;
+  description: string;
+  /** Absolute image URL; omitted entirely when the entity has no image. */
+  image?: string;
+  url: string;
+  /** OpenGraph object type (`profile` | `article`). */
+  type: string;
+}
+
+/** Canonical web origin used for `og:url` (the apex the SPA is served from). */
+const WEB_ORIGIN = (process.env.MENTION_WEB_ORIGIN || 'https://mention.earth').replace(/\/+$/, '');
+
+/** Oxy API origin — bare-file-id avatars resolve to their public CDN URL through the SDK. */
+const OXY_API_URL = process.env.OXY_API_URL || 'https://api.oxy.so';
+
+/**
+ * A bare, unauthenticated OxyServices instance used ONLY as the canonical
+ * `getFileDownloadUrl` chokepoint for building public CDN URLs from bare Oxy
+ * file ids (never hardcode `cloud.oxy.so`). It is intentionally separate from the
+ * service client in `utils/oxyHelpers` — that module transitively imports the
+ * server entrypoint, which would defeat this module's isolation. URL building
+ * needs no auth, so a plain client is both correct and test-safe.
+ */
+const cdnUrlClient = new OxyServices({ baseURL: OXY_API_URL });
+
+/** Shape of the Oxy `/profiles/username/<handle>` payload we read for OG. */
+export interface OxyProfileData {
+  username?: string;
+  name?: { displayName?: string };
+  avatar?: string;
+  bio?: string;
+  description?: string;
+}
+
+/**
+ * Escape a string for safe interpolation into HTML attribute / text contexts.
+ * Handles the minimum dangerous set (`& < > "`), matching the retired worker.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Render the OG/Twitter `<meta>` block for injection into `<head>`. Every dynamic
+ * value is HTML-escaped. `og:image`/`twitter:image` are emitted only when an
+ * image is present (a preview card without an image is still valid).
+ */
+export function buildOgMetaHtml(og: OgData): string {
+  const title = escapeHtml(og.title);
+  const description = escapeHtml(og.description);
+  const url = escapeHtml(og.url);
+  const type = escapeHtml(og.type);
+
+  let html =
+    `<meta property="og:type" content="${type}">` +
+    `<meta property="og:site_name" content="Mention">` +
+    `<meta property="og:url" content="${url}">` +
+    `<meta property="og:title" content="${title}">` +
+    `<meta property="og:description" content="${description}">` +
+    `<meta name="twitter:card" content="summary_large_image">` +
+    `<meta name="twitter:title" content="${title}">` +
+    `<meta name="twitter:description" content="${description}">` +
+    `<meta name="description" content="${description}">`;
+
+  if (og.image) {
+    const image = escapeHtml(og.image);
+    html +=
+      `<meta property="og:image" content="${image}">` +
+      `<meta name="twitter:image" content="${image}">`;
+  }
+
+  return html;
+}
+
+const TITLE_RE = /<title\b[^>]*>[\s\S]*?<\/title>/i;
+const HEAD_CLOSE_RE = /<\/head>/i;
+
+/**
+ * Splice OG data into a static SPA shell: replace the existing `<title>` and
+ * inject the OG/Twitter meta block immediately before `</head>`. When `og` is
+ * null the shell is returned verbatim (browsers still boot the SPA; crawlers
+ * simply see no rich preview). Function replacements are used so a `$` in the
+ * injected content is never interpreted as a `String.replace` back-reference.
+ */
+export function renderShellWithOg(shell: string, og: OgData | null): string {
+  if (!og) return shell;
+
+  const meta = buildOgMetaHtml(og);
+  const titleTag = `<title>${escapeHtml(og.title)}</title>`;
+
+  let html = shell;
+  html = TITLE_RE.test(html) ? html.replace(TITLE_RE, () => titleTag) : html;
+  html = HEAD_CLOSE_RE.test(html)
+    ? html.replace(HEAD_CLOSE_RE, () => `${meta}</head>`)
+    : meta + html;
+
+  return html;
+}
+
+/**
+ * Map an Oxy profile payload (`/profiles/username/<handle>`) into OG data. Works
+ * for local and federated handles — both resolve through the Oxy API. Returns
+ * null when the handle is unknown (no `username`).
+ */
+export function mapProfileOg(data: OxyProfileData | null | undefined): OgData | null {
+  if (!data?.username) return null;
+
+  const username = data.username;
+  const displayName = data.name?.displayName;
+  const avatar = data.avatar;
+
+  let image: string | undefined;
+  if (typeof avatar === 'string' && avatar.length > 0) {
+    // Federated avatars are absolute URLs; local avatars are bare Oxy file ids
+    // resolved to their public CDN URL through the canonical SDK helper.
+    image = /^https?:\/\//.test(avatar) ? avatar : cdnUrlClient.getFileDownloadUrl(avatar, 'thumb');
+  }
+
+  return {
+    title: displayName ? `${displayName} (@${username}) on Mention` : `@${username} on Mention`,
+    description: (data.bio || data.description || '').trim(),
+    image,
+    url: `${WEB_ORIGIN}/@${username}`,
+    type: 'profile',
+  };
+}
+
+/**
+ * Map a hydrated post into OG data. Media / poster / link-preview / avatar URLs
+ * are already absolute (resolved server-side during hydration).
+ */
+export function mapPostOg(post: HydratedPost, id: string): OgData {
+  const user = post.user;
+  const author = user.displayName || `@${user.handle}`;
+  const media = post.content?.media?.[0];
+
+  const image =
+    media?.url || media?.thumbUrl || media?.posterUrl || post.linkPreview?.image || user.avatarUrl || undefined;
+
+  return {
+    title: `${author} on Mention`,
+    description: (post.content?.text || '').trim().slice(0, 200),
+    image,
+    url: `${WEB_ORIGIN}/p/${id}`,
+    type: 'article',
+  };
+}

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -32,6 +32,7 @@ import { ImageResolverProvider } from '@oxyhq/bloom/image-resolver';
 // Components
 import AppSplashScreen from '@/components/AppSplashScreen';
 import { NotificationPermissionGate } from '@/components/NotificationPermissionGate';
+import { PwaHead } from '@/components/PwaHead';
 import { AppProviders } from '@/components/providers/AppProviders';
 import { Provider as PortalProvider, Outlet as PortalOutlet } from '@oxyhq/bloom/portal';
 
@@ -152,6 +153,10 @@ export default function RootLayout() {
 
   return (
     <ImageResolverProvider value={resolveImageSource}>
+      {/* WEB-only: inject the PWA manifest <link> + apple/theme metas into
+          document.head at runtime (installability + Web Share Target). Mounted at
+          the root so it is present on every page; renders nothing. No-op on native. */}
+      <PwaHead />
       <BloomThemeProvider
         defaultMode="system"
         defaultColorPreset="blue"

--- a/packages/frontend/components/PwaHead.tsx
+++ b/packages/frontend/components/PwaHead.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+/**
+ * Runtime PWA head injector (WEB ONLY).
+ *
+ * Expo's `output: "single"` web export ships a bare `index.html` — the
+ * `web.manifest` + `web.meta` declared in `app.config.js` are NOT wired into it,
+ * so the browser never sees the manifest link or the apple/theme metas. Without a
+ * live `<link rel="manifest">` there is no installable PWA and the Web Share
+ * Target (`/compose`) is dead.
+ *
+ * The browser evaluates PWA installability and the Share Target from the LIVE DOM,
+ * so injecting these tags into `document.head` at runtime is sufficient — no
+ * server/worker involvement is required. This mirrors exactly what the Cloudflare
+ * Pages worker's `PWA_HEAD` used to append; ownership now moves into the app so the
+ * worker can be retired.
+ *
+ * Mounted ONCE at the app root (present on every page). Renders nothing. The
+ * append is idempotent (guards on existing tags) so a stray remount can't
+ * duplicate anything. `document.head` mutation is a genuine external-system side
+ * effect, which is the legitimate use for `useEffect`.
+ */
+
+const MANIFEST_HREF = '/manifest.json';
+
+const PWA_META_TAGS: ReadonlyArray<{ name: string; content: string }> = [
+  { name: 'theme-color', content: '#0B0B0F' },
+  { name: 'apple-mobile-web-app-capable', content: 'yes' },
+  { name: 'apple-mobile-web-app-title', content: 'Mention' },
+  { name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent' },
+];
+
+export function PwaHead(): null {
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof document === 'undefined') return;
+
+    const head = document.head;
+    if (!head) return;
+
+    if (!head.querySelector('link[rel="manifest"]')) {
+      const link = document.createElement('link');
+      link.rel = 'manifest';
+      link.href = MANIFEST_HREF;
+      head.appendChild(link);
+    }
+
+    for (const { name, content } of PWA_META_TAGS) {
+      if (head.querySelector(`meta[name="${name}"]`)) continue;
+      const meta = document.createElement('meta');
+      meta.name = name;
+      meta.content = content;
+      head.appendChild(meta);
+    }
+  }, []);
+
+  return null;
+}
+
+export default PwaHead;


### PR DESCRIPTION
Prep to eliminate the CF Pages `_worker.js` entirely by moving its jobs to worker-free homes. **This PR does NOT delete the worker** — it stays until the CF Origin Rules are live (see `docs/cloudflare-federation-origin-rules.md`). Nothing about current routing changes; the new backend handler is dormant until an Origin Rule routes `/@*` + `/p/*` to the backend.

- **Backend** (bskyweb model): new public web-shell handler serves `/@handle` and `/p/:id` with per-request OG injected — fetches the SPA shell from `pages.dev` (cached, stale-while-revalidate), profile OG from the Oxy API, post OG in-process via `PostHydrationService`; AP content-neg 302 for `/@user`. Mounted before the auth router; fail-open; 23 tests.
- **Frontend**: `PwaHead` injects the manifest `<link>` + PWA metas into `document.head` at runtime (web-only, idempotent) — replaces the worker's `PWA_HEAD`. The browser reads the manifest from the live DOM, so install + Web Share Target work with no worker.
- **Docs**: exact CF Origin Rule + Transform Rule (`X-Forwarded-Host: mention.earth`) + switch order + test plan.

Worker's other job (federation proxy) → CF Origin Rules. Preboot dark bg → already in `global.css`. Once the rules are live + tested, `_worker.js` + `_routes.json` get deleted → frontend pure static → Free plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
