### PR TITLE
fix: enforce profile privacy in friends-of-friends feed

### DIFF
--- a/packages/backend/src/__tests__/socialSources.test.ts
+++ b/packages/backend/src/__tests__/socialSources.test.ts
@@ -14,6 +14,7 @@ let findRouter: (match: Record<string, unknown>) => unknown[] = () => [];
 let likeAggregateResult: Array<Record<string, unknown>> = [];
 let entityFollowDistinct: string[] = [];
 let starterPackDoc: Record<string, unknown> | null = null;
+let userSettingsRows: Array<{ oxyUserId: string; privacy?: { profileVisibility?: string } }> = [];
 
 function chainable(result: unknown[]) {
   const chain = {
@@ -54,6 +55,13 @@ vi.mock('../models/StarterPack', () => ({
   },
 }));
 
+vi.mock('../models/UserSettings', () => ({
+  default: {
+    findOne: vi.fn(() => ({ lean: () => Promise.resolve(null) })),
+    find: vi.fn(() => ({ lean: () => Promise.resolve(userSettingsRows) })),
+  },
+}));
+
 import { mutualsSource } from '../mtn/feed/engine/sources/userSources';
 import {
   friendsEngagedSource,
@@ -79,6 +87,7 @@ beforeEach(() => {
   likeAggregateResult = [];
   entityFollowDistinct = [];
   starterPackDoc = null;
+  userSettingsRows = [];
   vi.clearAllMocks();
 });
 
@@ -250,14 +259,28 @@ describe('onThisDay source', () => {
 });
 
 describe('friendsOfFriends source', () => {
-  it('queries ctx.fofIds with PUBLIC-only visibility', async () => {
+  it('queries profile-visible ctx.fofIds with PUBLIC-only visibility', async () => {
+    userSettingsRows = [
+      { oxyUserId: 'x2', privacy: { profileVisibility: 'private' } },
+      { oxyUserId: 'x3', privacy: { profileVisibility: 'followers_only' } },
+    ];
     findRouter = () => [makePost(12)];
-    const ctx: FeedEngineContext = { currentUserId: 'viewer', fofIds: ['x1', 'x2'] };
+    const ctx: FeedEngineContext = { currentUserId: 'viewer', followingIds: ['x3'], fofIds: ['x1', 'x2', 'x3'] };
     const posts = await friendsOfFriendsSource.gather(ctx, {}, 30);
     expect(posts.map((p) => String(p._id))).toEqual([oid(12).toString()]);
     const match = findCalls[0];
-    expect(match.oxyUserId).toEqual({ $in: ['x1', 'x2'] });
+    expect(match.oxyUserId).toEqual({ $in: ['x1', 'x3'] });
     expect(match.visibility).toBe(PostVisibility.PUBLIC);
+  });
+
+  it('returns [] when all FoF author profiles deny access', async () => {
+    userSettingsRows = [
+      { oxyUserId: 'x1', privacy: { profileVisibility: 'private' } },
+      { oxyUserId: 'x2', privacy: { profileVisibility: 'followers_only' } },
+    ];
+    const posts = await friendsOfFriendsSource.gather({ currentUserId: 'viewer', fofIds: ['x1', 'x2'] }, {}, 30);
+    expect(posts).toEqual([]);
+    expect(findCalls).toHaveLength(0);
   });
 
   it('returns [] when ctx.fofIds is empty', async () => {

--- a/packages/backend/src/mtn/feed/engine/sources/socialSources.ts
+++ b/packages/backend/src/mtn/feed/engine/sources/socialSources.ts
@@ -15,10 +15,12 @@ import { Post } from '../../../../models/Post';
 import Like from '../../../../models/Like';
 import { EntityFollow } from '../../../../models/EntityFollow';
 import { StarterPack } from '../../../../models/StarterPack';
+import UserSettings from '../../../../models/UserSettings';
 import { FEED_FIELDS } from '../../FeedAPI';
 import { ChronoCursor } from '../../CursorBuilder';
 import { DISCOVERY_SAFE_MATCH } from '../../feedSafety';
 import { logger } from '../../../../utils/logger';
+import { ProfileVisibility, requiresAccessCheck } from '../../../../utils/privacyHelpers';
 import type { CandidatePost, FeedEngineContext, SourceModule } from '../types';
 
 /**
@@ -48,6 +50,29 @@ async function fetchPostsByIds(ids: mongoose.Types.ObjectId[]): Promise<Candidat
     .lean()) as unknown as CandidatePost[];
   const order = new Map(ids.map((id, i) => [String(id), i]));
   return posts.sort((a, b) => (order.get(String(a._id)) ?? 0) - (order.get(String(b._id)) ?? 0));
+}
+
+/** Filter author ids through the same profile-visibility gate used by profile feeds. */
+async function filterProfileVisibleAuthorIds(ctx: FeedEngineContext, authorIds: string[]): Promise<string[]> {
+  const uniqueAuthorIds = Array.from(new Set(authorIds.filter((id) => typeof id === 'string' && id.length > 0)));
+  if (uniqueAuthorIds.length === 0) return [];
+
+  const followAuthorizedIds = new Set([ctx.currentUserId, ...(ctx.followingIds ?? [])].filter(Boolean));
+  const settings = await UserSettings.find(
+    { oxyUserId: { $in: uniqueAuthorIds } },
+    { oxyUserId: 1, 'privacy.profileVisibility': 1 },
+  ).lean();
+  const visibilityByAuthor = new Map(
+    settings.map((row) => [
+      row.oxyUserId,
+      row.privacy?.profileVisibility ?? ProfileVisibility.PUBLIC,
+    ]),
+  );
+
+  return uniqueAuthorIds.filter((authorId) => {
+    const visibility = visibilityByAuthor.get(authorId) ?? ProfileVisibility.PUBLIC;
+    return !requiresAccessCheck(visibility) || followAuthorizedIds.has(authorId);
+  });
 }
 
 /** Standard engagement composite (mirrors the discovery aggregations). */
@@ -510,19 +535,19 @@ export const topRepliesSource: SourceModule = {
  * viewer does not) — social-graph expansion. `ctx.fofIds` is populated by the
  * controller (via the Oxy follows-of-follows endpoint, guarded optional call)
  * ONLY for the Friends-of-Friends feed; returns `[]` when it is empty (any other
- * context, or a viewer whose network yields none). PUBLIC-only — FoF authors are
- * NOT the viewer's followers, so followers-only posts are excluded.
+ * context, or a viewer whose network yields none). PUBLIC-only, and excludes
+ * authors whose profile privacy would deny the viewer's normal profile access.
  */
 export const friendsOfFriendsSource: SourceModule = {
   id: 'friendsOfFriends',
   kind: 'source',
   userComposable: false,
   gather: async (ctx, _params, cap) => {
-    const fofIds = ctx.fofIds ?? [];
-    if (fofIds.length === 0) return [];
+    const visibleFofIds = await filterProfileVisibleAuthorIds(ctx, ctx.fofIds ?? []);
+    if (visibleFofIds.length === 0) return [];
 
     return fetchChrono(
-      { oxyUserId: { $in: fofIds }, visibility: PostVisibility.PUBLIC, status: 'published' },
+      { oxyUserId: { $in: visibleFofIds }, visibility: PostVisibility.PUBLIC, status: 'published' },
       ctx.cursor,
       cap,
     );


### PR DESCRIPTION
### Motivation

- Prevent a privacy bypass where the Friends-of-Friends (FoF) feed could surface posts from authors whose profile visibility is `private` or `followers_only` simply because their id appeared in the viewer's FoF set. 
- The bump of `@oxyhq/core` activated the FoF id population path and made this gap exploitable; the feed must gate authors by the same profile-visibility rules used by profile feeds.

### Description

- Added `filterProfileVisibleAuthorIds(ctx, authorIds)` which resolves `UserSettings.privacy.profileVisibility` for candidate author ids and returns only those the viewer may normally see (public profiles or authors the viewer is authorized to view via self/following). 
- Import `UserSettings` and `ProfileVisibility`/`requiresAccessCheck` from `privacyHelpers` and apply the filter before any Post query in the FoF source. 
- Updated `friendsOfFriendsSource` to query posts only for the filtered author id set while preserving `visibility: PostVisibility.PUBLIC` and `status: 'published'` constraints. 
- Added unit test coverage in `packages/backend/src/__tests__/socialSources.test.ts` to assert the visibility filtering and the short-circuit path when no FoF author remains visible.

### Testing

- Ran the focused unit tests: `cd packages/backend && bun run test src/__tests__/socialSources.test.ts` which passed (1 file, 22 tests). 
- Attempted full backend build: `cd packages/backend && bun run build`; TypeScript build failed due to a pre-existing `bullmq`/`ioredis` typing mismatch in queue files unrelated to this change (reported but not modified by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46f26d84fc8323b91969a692c6b7a0)