### PR TITLE
Fix atproto bridge exposure of non-public posts

### DIFF
--- a/packages/backend/src/__tests__/connectors/atproto/bridge/repoReadService.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/bridge/repoReadService.test.ts
@@ -17,9 +17,14 @@ import { buildUserDid } from '../../../../services/mtn/mentionDid';
  */
 
 const mockFind = vi.fn();
+const mockPostFind = vi.fn();
 
 vi.mock('../../../../models/MentionSignedRecord', () => ({
   default: { find: (...a: unknown[]) => mockFind(...a) },
+}));
+
+vi.mock('../../../../models/Post', () => ({
+  Post: { find: (...a: unknown[]) => mockPostFind(...a) },
 }));
 
 import { listRecords, getRecord } from '../../../../connectors/atproto/bridge/repoReadService';
@@ -66,6 +71,13 @@ function postRecord(text: string): Record<string, unknown> {
 function mockLedger(rows: ReturnType<typeof row>[]): void {
   mockFind.mockReturnValue({
     sort: () => ({ lean: () => Promise.resolve(rows) }),
+  });
+  mockPublicPosts(rows.filter((r) => r.nsid === MENTION_POST_COLLECTION).map((r) => r.rkey));
+}
+
+function mockPublicPosts(postIds: string[]): void {
+  mockPostFind.mockReturnValue({
+    lean: () => Promise.resolve(postIds.map((_id) => ({ _id }))),
   });
 }
 
@@ -125,6 +137,28 @@ describe('listRecords', () => {
     const likes = await listRecords(OWNER, 'app.bsky.feed.like');
     expect(likes.records).toHaveLength(1);
     expect(likes.records[0].value.$type).toBe('app.bsky.feed.like');
+  });
+
+  it('filters draft and non-public post records through the authoritative Post document', async () => {
+    mockLedger([
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'published-public', record: postRecord('safe'), createdAt: '2026-06-30T03:00:00.000Z' }),
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'draft-public', record: postRecord('draft secret'), createdAt: '2026-06-30T02:00:00.000Z' }),
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'published-private', record: postRecord('private secret'), createdAt: '2026-06-30T01:00:00.000Z' }),
+    ]);
+    mockPublicPosts(['published-public']);
+
+    const page = await listRecords(OWNER, 'app.bsky.feed.post');
+
+    expect(page.records.map((record) => record.rkey)).toEqual(['published-public']);
+    expect(mockPostFind).toHaveBeenCalledWith(
+      {
+        _id: { $in: ['published-public', 'draft-public', 'published-private'] },
+        oxyUserId: OWNER,
+        status: 'published',
+        visibility: 'public',
+      },
+      { _id: 1 },
+    );
   });
 
   it('returns an empty page for an unknown / private collection', async () => {
@@ -214,6 +248,15 @@ describe('getRecord', () => {
     ]);
     const record = await getRecord(OWNER, 'app.bsky.feed.post', 'p1');
     expect(record?.value).toMatchObject({ text: 'edited' });
+  });
+
+  it('returns null when the authoritative Post document is draft or non-public', async () => {
+    mockLedger([
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'p1', record: postRecord('secret'), createdAt: '2026-06-30T01:00:00.000Z' }),
+    ]);
+    mockPublicPosts([]);
+
+    expect(await getRecord(OWNER, 'app.bsky.feed.post', 'p1')).toBeNull();
   });
 
   it('returns null for an unknown / private collection without a ledger read', async () => {

--- a/packages/backend/src/__tests__/services/mtn/mentionRecordService.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/mentionRecordService.test.ts
@@ -254,6 +254,8 @@ describe('MentionRecordEmitter dual-write gate', () => {
       oxyUserId: SUBJECT_OXY_ID,
       federation: undefined,
       content: { text: 'native post', sources: [], media: [] },
+      visibility: 'public',
+      status: 'published',
       hashtags: ['mtn'],
       language: 'en',
       createdAt: new Date().toISOString(),
@@ -265,5 +267,31 @@ describe('MentionRecordEmitter dual-write gate', () => {
     expect(stored.collection).toBe(MENTION_POST_COLLECTION);
     expect(stored.rkey).toBe('local-post-1');
     expect(stored.record).toMatchObject({ text: 'native post', tags: ['mtn'], langs: ['en'] });
+  });
+
+  it('does NOT emit public bridge records for draft or non-public LOCAL posts', async () => {
+    const draftPost = {
+      _id: 'draft-post-1',
+      oxyUserId: SUBJECT_OXY_ID,
+      federation: undefined,
+      content: { text: 'draft secret', sources: [], media: [] },
+      visibility: 'public',
+      status: 'draft',
+      createdAt: new Date().toISOString(),
+    } as unknown as Parameters<typeof emitPostCreated>[0];
+    const privatePost = {
+      _id: 'private-post-1',
+      oxyUserId: SUBJECT_OXY_ID,
+      federation: undefined,
+      content: { text: 'private secret', sources: [], media: [] },
+      visibility: 'private',
+      status: 'published',
+      createdAt: new Date().toISOString(),
+    } as unknown as Parameters<typeof emitPostCreated>[0];
+
+    await emitPostCreated(draftPost);
+    await emitPostCreated(privatePost);
+
+    expect(memoryStore.rows).toHaveLength(0);
   });
 });

--- a/packages/backend/src/connectors/atproto/bridge/repoReadService.ts
+++ b/packages/backend/src/connectors/atproto/bridge/repoReadService.ts
@@ -28,9 +28,11 @@ import {
   mentionLikeRecordSchema,
   mentionRepostRecordSchema,
   mentionTombstoneRecordSchema,
+  PostVisibility,
 } from '@mention/shared-types';
 import type { SignedRecordEnvelope } from '@oxyhq/contracts';
 import MentionSignedRecord from '../../../models/MentionSignedRecord';
+import { Post } from '../../../models/Post';
 import { buildUserDid } from '../../../services/mtn/mentionDid';
 import { logger } from '../../../utils/logger';
 import {
@@ -204,6 +206,26 @@ function reduceLiveRecords(
  * then runs {@link reduceLiveRecords} — the shared rule `getRecord` also uses, so
  * the list and single-get views cannot drift.
  */
+async function filterPublicPublishedPosts(
+  oxyUserId: string,
+  records: BridgeRecord[],
+): Promise<BridgeRecord[]> {
+  if (records.length === 0) return records;
+
+  const postIds = records.map((record) => record.rkey);
+  const publicPosts = await Post.find(
+    {
+      _id: { $in: postIds },
+      oxyUserId,
+      status: 'published',
+      visibility: PostVisibility.PUBLIC,
+    },
+    { _id: 1 },
+  ).lean<Array<{ _id: unknown }>>();
+  const publicPostIds = new Set(publicPosts.map((post) => String(post._id)));
+  return records.filter((record) => publicPostIds.has(record.rkey));
+}
+
 async function materializeCollection(
   oxyUserId: string,
   bskyCollection: string,
@@ -212,7 +234,10 @@ async function materializeCollection(
   if (!mtnCollection) return [];
 
   const rows = await readLiveRows(oxyUserId, mtnCollection);
-  return reduceLiveRecords(rows, oxyUserId, bskyCollection, mtnCollection);
+  const records = reduceLiveRecords(rows, oxyUserId, bskyCollection, mtnCollection);
+  return bskyCollection === BSKY_POST_COLLECTION
+    ? filterPublicPublishedPosts(oxyUserId, records)
+    : records;
 }
 
 /**
@@ -272,7 +297,10 @@ export async function getRecord(
   if (!mtnCollection) return null;
 
   const rows = await readLiveRows(oxyUserId, mtnCollection, rkey);
-  const records = reduceLiveRecords(rows, oxyUserId, bskyCollection, mtnCollection);
+  const liveRecords = reduceLiveRecords(rows, oxyUserId, bskyCollection, mtnCollection);
+  const records = bskyCollection === BSKY_POST_COLLECTION
+    ? await filterPublicPublishedPosts(oxyUserId, liveRecords)
+    : liveRecords;
   return records.find((record) => record.rkey === rkey) ?? null;
 }
 

--- a/packages/backend/src/scripts/backfill-mtn-records.ts
+++ b/packages/backend/src/scripts/backfill-mtn-records.ts
@@ -10,6 +10,8 @@
  * SCOPE: `app.mention.feed.post` records only. A post QUALIFIES iff:
  *   - it is LOCAL-authored: `federation == null && oxyUserId` set (federated
  *     posts belong to the origin instance and never emit a Mention record), and
+ *   - it is published and public (draft/private posts must never appear on the
+ *     public atproto bridge), and
  *   - it is NOT a boost (`type: 'boost'` / `boostOf` set) — boosts are
  *     `app.mention.feed.repost` records, a different collection, intentionally
  *     out of scope here so this backfill stays idempotent (a boost would never
@@ -42,7 +44,7 @@
 import mongoose from 'mongoose';
 import { Post, type IPost } from '../models/Post';
 import MentionSignedRecord from '../models/MentionSignedRecord';
-import { MENTION_POST_COLLECTION } from '@mention/shared-types';
+import { MENTION_POST_COLLECTION, PostVisibility } from '@mention/shared-types';
 import { connectToDatabase } from '../utils/database';
 import { logger } from '../utils/logger';
 import { isMentionRecordSigningEnabled } from '../services/mtn/mentionRecordEnv';
@@ -120,6 +122,8 @@ async function backfillMtnRecords(): Promise<void> {
   const candidateFilter: Record<string, unknown> = {
     'federation.activityId': { $exists: false },
     oxyUserId: { $exists: true, $ne: null },
+    status: 'published',
+    visibility: PostVisibility.PUBLIC,
     boostOf: { $exists: false },
   };
 

--- a/packages/backend/src/services/mtn/MentionRecordEmitter.ts
+++ b/packages/backend/src/services/mtn/MentionRecordEmitter.ts
@@ -18,6 +18,7 @@
 
 import type { IPost } from '../../models/Post';
 import {
+  PostVisibility,
   MENTION_POST_COLLECTION,
   MENTION_LIKE_COLLECTION,
   MENTION_REPOST_COLLECTION,
@@ -44,6 +45,11 @@ import {
 /** True when a post is authored by a LOCAL Mention user (eligible to emit). */
 function isLocalAuthored(post: Pick<IPost, 'federation' | 'oxyUserId'>): post is Pick<IPost, 'federation' | 'oxyUserId'> & { oxyUserId: string } {
   return post.federation == null && typeof post.oxyUserId === 'string' && post.oxyUserId.length > 0;
+}
+
+/** True when a post is safe to publish to public MTN/atproto read surfaces. */
+function isPublicPublishedPost(post: Pick<IPost, 'status' | 'visibility'>): boolean {
+  return (post.status ?? 'published') === 'published' && post.visibility === PostVisibility.PUBLIC;
 }
 
 /**
@@ -83,7 +89,7 @@ export async function emitPostCreated(
   post: IPost,
   options: { reply?: ReplyContext; facets?: MtnFacet[] } = {},
 ): Promise<void> {
-  if (!isLocalAuthored(post)) return;
+  if (!isLocalAuthored(post) || !isPublicPublishedPost(post)) return;
   const authorOxyUserId = post.oxyUserId;
   await isolate('emitPostCreated', async () => {
     // Resolve the post's media to content-addressed blob refs (fileId → sha256).


### PR DESCRIPTION
### Motivation
- The apex worker began proxying `/xrpc/*` to the backend bridge which materializes MTN ledger rows, and emitted ledger records could contain draft or non-public post text that should not be publicly exposed. 
- The bridge read path and backfill/emitter logic lacked an authoritative gate to exclude non-public/draft posts, enabling unauthenticated reads of sensitive content once the bridge is enabled.

### Description
- Add server-side filtering so the bridge `listRecords` and `getRecord` paths only return post records that the authoritative `Post` document marks as `status: 'published'` and `visibility: PostVisibility.PUBLIC` (implemented as `filterPublicPublishedPosts` in `repoReadService.ts`).
- Prevent emission of MTN `app.mention.feed.post` records for local posts that are drafts or non-public by gating `emitPostCreated` on published + public (`MentionRecordEmitter.ts`).
- Narrow the one-shot backfill (`backfill-mtn-records.ts`) to only consider local posts that are `status: 'published'` and `visibility: PostVisibility.PUBLIC` so historical non-public posts are not appended into the public ledger.
- Add regression tests covering (a) that the bridge read filters out draft/private records and (b) that the emitter does not write records for draft/private local posts (`repoReadService.test.ts`, `mentionRecordService.test.ts`).

### Testing
- Ran the focused backend tests: `cd packages/backend && bun run test src/__tests__/connectors/atproto/bridge/repoReadService.test.ts src/__tests__/services/mtn/mentionRecordService.test.ts src/__tests__/scripts/backfillMtnRecords.test.ts`, and the test suite passed (3 test files, 28 tests total).
- Attempted a full backend build with `bun run build:backend`, which surfaced pre-existing, unrelated TypeScript typing errors elsewhere in the repo (mongoose/BullMQ/ioredis type issues); these build failures are outside the scope of this change and did not affect the focused tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4470be62c8832394888dc5e0eb837a)