### PR TITLE
fix(security): constrain federated banner media downloads

### DIFF
--- a/packages/backend/src/__tests__/connectors/identity.test.ts
+++ b/packages/backend/src/__tests__/connectors/identity.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../utils/oxyHelpers', () => ({
 
 vi.mock('../../services/mediaCache/cacheWorker', () => ({
   persistRemoteMediaForFederatedOwnerDetailed: mocks.persistRemoteMedia,
+  FEDERATED_BANNER_DOWNLOAD_POLICY: { allowedContentTypePrefixes: ['image/'], maxBytes: 10 * 1024 * 1024 },
 }));
 
 vi.mock('../../models/UserSettings', () => ({
@@ -141,6 +142,9 @@ describe('resolveOxyExternalUser', () => {
         actorUri: 'https://mastodon.social/users/alice',
         remoteHost: 'files.mastodon.social',
       }),
+      expect.objectContaining({
+        downloadPolicy: expect.objectContaining({ allowedContentTypePrefixes: ['image/'] }),
+      }),
     );
     expect(mocks.userSettingsUpdateOne).toHaveBeenCalledWith(
       { oxyUserId: 'oxy-resolved' },
@@ -166,6 +170,9 @@ describe('resolveOxyExternalUser', () => {
       'https://files.mastodon.social/banner.txt',
       'oxy-resolved',
       expect.objectContaining({ role: 'banner' }),
+      expect.objectContaining({
+        downloadPolicy: expect.objectContaining({ allowedContentTypePrefixes: ['image/'] }),
+      }),
     );
     expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
   });

--- a/packages/backend/src/__tests__/connectors/mirrorFederatedBanner.test.ts
+++ b/packages/backend/src/__tests__/connectors/mirrorFederatedBanner.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../services/mediaCache/cacheWorker', () => ({
   persistRemoteMediaForFederatedOwnerDetailed: mocks.persistRemoteMedia,
+  FEDERATED_BANNER_DOWNLOAD_POLICY: { allowedContentTypePrefixes: ['image/'], maxBytes: 10 * 1024 * 1024 },
 }));
 
 vi.mock('../../models/UserSettings', () => ({
@@ -59,6 +60,9 @@ describe('mirrorFederatedBanner', () => {
         role: 'banner',
         actorUri: 'https://mastodon.social/users/alice',
         remoteHost: 'files.mastodon.social',
+      }),
+      expect.objectContaining({
+        downloadPolicy: expect.objectContaining({ allowedContentTypePrefixes: ['image/'] }),
       }),
     );
     expect(mocks.userSettingsUpdateOne).toHaveBeenCalledWith(

--- a/packages/backend/src/__tests__/services/mediaCacheDurableFailure.test.ts
+++ b/packages/backend/src/__tests__/services/mediaCacheDurableFailure.test.ts
@@ -91,3 +91,49 @@ describe('durable federated media failure classification', () => {
     ).resolves.toMatchObject({ ok: false, reason: 'upstream-error', status: 410, permanent: true });
   });
 });
+
+const FEDERATED_BANNER_DOWNLOAD_POLICY = { allowedContentTypePrefixes: ['image/'], maxBytes: 10 * 1024 * 1024 };
+
+describe('durable federated banner media policy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects video banners before upload or poster extraction', async () => {
+    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue(
+      upstreamResponse(200, { 'content-type': 'video/mp4', 'content-length': String(11 * 1024 * 1024) }),
+    );
+    const { persistRemoteMediaForFederatedOwnerDetailed } = await import(
+      '../../services/mediaCache/cacheWorker'
+    );
+
+    await expect(
+      persistRemoteMediaForFederatedOwnerDetailed(
+        'https://remote.example/banner.mp4',
+        'oxy_user',
+        { role: 'banner' },
+        { downloadPolicy: FEDERATED_BANNER_DOWNLOAD_POLICY },
+      ),
+    ).resolves.toMatchObject({ ok: false, reason: 'not-media' });
+    expect(mocks.uploadFederatedMedia).not.toHaveBeenCalled();
+  });
+
+  it('applies the 10 MiB banner cap even for image content', async () => {
+    mocks.fetchUpstreamFollowingRedirects.mockResolvedValue(
+      upstreamResponse(200, { 'content-type': 'image/jpeg', 'content-length': String(11 * 1024 * 1024) }),
+    );
+    const { persistRemoteMediaForFederatedOwnerDetailed } = await import(
+      '../../services/mediaCache/cacheWorker'
+    );
+
+    await expect(
+      persistRemoteMediaForFederatedOwnerDetailed(
+        'https://remote.example/banner.jpg',
+        'oxy_user',
+        { role: 'banner' },
+        { downloadPolicy: FEDERATED_BANNER_DOWNLOAD_POLICY },
+      ),
+    ).resolves.toMatchObject({ ok: false, reason: 'too-large' });
+    expect(mocks.uploadFederatedMedia).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/connectors/identity.ts
+++ b/packages/backend/src/connectors/identity.ts
@@ -1,7 +1,10 @@
 import { logger } from '../utils/logger';
 import { getServiceOxyClient } from '../utils/oxyHelpers';
 import UserSettings from '../models/UserSettings';
-import { persistRemoteMediaForFederatedOwnerDetailed } from '../services/mediaCache/cacheWorker';
+import {
+  FEDERATED_BANNER_DOWNLOAD_POLICY,
+  persistRemoteMediaForFederatedOwnerDetailed,
+} from '../services/mediaCache/cacheWorker';
 import { isAbsoluteHttpUrl, getRemoteHost } from './shared/url';
 import type { NormalizedExternalActor } from './types';
 
@@ -116,11 +119,16 @@ export async function mirrorFederatedBanner(
   }
 
   const remoteHost = getRemoteHost(bannerUrl);
-  const result = await persistRemoteMediaForFederatedOwnerDetailed(bannerUrl, oxyUserId, {
-    role: 'banner',
-    actorUri,
-    remoteHost,
-  });
+  const result = await persistRemoteMediaForFederatedOwnerDetailed(
+    bannerUrl,
+    oxyUserId,
+    {
+      role: 'banner',
+      actorUri,
+      remoteHost,
+    },
+    { downloadPolicy: FEDERATED_BANNER_DOWNLOAD_POLICY },
+  );
 
   if (result.ok) {
     await UserSettings.updateOne(

--- a/packages/backend/src/services/mediaCache/cacheWorker.ts
+++ b/packages/backend/src/services/mediaCache/cacheWorker.ts
@@ -60,12 +60,31 @@ type DownloadOutcome =
 
 type MediaUploader = (source: CachedMediaSource) => Promise<UploadedAsset>;
 
+interface DownloadPolicy {
+  allowedContentTypePrefixes?: readonly string[];
+  maxBytes?: number;
+}
+
+export interface PersistFederatedMediaOptions {
+  downloadPolicy?: DownloadPolicy;
+}
+
+export const FEDERATED_BANNER_MAX_BYTES = 10 * 1024 * 1024;
+export const FEDERATED_BANNER_DOWNLOAD_POLICY: DownloadPolicy = {
+  allowedContentTypePrefixes: ['image/'],
+  maxBytes: FEDERATED_BANNER_MAX_BYTES,
+};
+
 /**
  * Stream a remote media body to a local temp file, enforcing the per-type size
  * cap. Never buffers the whole body in memory. The caller owns cleanup of the
  * temp directory (passed in) in its `finally`.
  */
-async function downloadToTempFile(remoteUrl: string, dir: string): Promise<DownloadOutcome> {
+async function downloadToTempFile(
+  remoteUrl: string,
+  dir: string,
+  policy: DownloadPolicy = {},
+): Promise<DownloadOutcome> {
   const abortController = new AbortController();
   let response: IncomingMessage | null = null;
 
@@ -91,7 +110,11 @@ async function downloadToTempFile(remoteUrl: string, dir: string): Promise<Downl
   }
 
   const contentType = contentTypeFamily(response.headers);
-  if (!isCacheableMediaType(contentType)) {
+  const allowedByGenericPolicy = isCacheableMediaType(contentType);
+  const allowedByCallerPolicy = policy.allowedContentTypePrefixes
+    ? policy.allowedContentTypePrefixes.some((prefix) => contentType.startsWith(prefix))
+    : true;
+  if (!allowedByGenericPolicy || !allowedByCallerPolicy) {
     response.destroy();
     logger.info('[MediaCache] Worker skipping non-cacheable media type', {
       contentType: contentType || 'unknown',
@@ -99,7 +122,7 @@ async function downloadToTempFile(remoteUrl: string, dir: string): Promise<Downl
     return { ok: false, reason: 'not-media' };
   }
 
-  const maxBytes = maxBytesForType(contentType);
+  const maxBytes = Math.min(maxBytesForType(contentType), policy.maxBytes ?? Number.POSITIVE_INFINITY);
 
   // Reject over-large declared bodies up front (streamed bytes are capped too).
   const declared = Number(response.headers['content-length']);
@@ -328,6 +351,7 @@ export async function persistRemoteMediaForFederatedOwnerDetailed(
   remoteUrl: string,
   ownerUserId: string,
   metadata?: Record<string, unknown>,
+  options: PersistFederatedMediaOptions = {},
 ): Promise<PersistFederatedMediaResult> {
   if (!isMediaCacheEnabled()) {
     logger.debug('[MediaCache] Durable federation upload skipped — media writes disabled');
@@ -336,7 +360,7 @@ export async function persistRemoteMediaForFederatedOwnerDetailed(
 
   const dir = await mkdtemp(join(tmpdir(), TEMP_DIR_PREFIX));
   try {
-    const outcome = await downloadToTempFile(remoteUrl, dir);
+    const outcome = await downloadToTempFile(remoteUrl, dir, options.downloadPolicy);
     if (!outcome.ok) {
       return {
         ok: false,


### PR DESCRIPTION
### Motivation
- Prevent an unauthenticated federated actor from causing large downloads/uploads (video/audio) when Mention mirrors actor banners, which created a DoS/cost vector. 

### Description
- Add a caller-configurable download policy and a banner-specific policy (`FEDERATED_BANNER_DOWNLOAD_POLICY`) that restricts banners to `image/*` and caps them at 10 MiB. 
- Extend `persistRemoteMediaForFederatedOwnerDetailed` to accept `options.downloadPolicy` and thread that policy into the download step so callers can enforce stricter rules. 
- Change `downloadToTempFile` to accept an optional `policy` and enforce both allowed content-type prefixes and an effective max-bytes limit (min of generic per-type cap and caller cap). 
- Apply the banner policy from the identity bridge (`mirrorFederatedBanner` / `resolveOxyExternalUser`) so `UserSettings.profileHeaderImage` is only populated after an image-only, size-limited download succeeds, and add/adjust unit tests to cover video-banner rejection and over-10MiB image rejection.

### Testing
- Ran the focused Vitest suite for the changes with: `bun run --cwd packages/backend vitest run src/__tests__/connectors/mirrorFederatedBanner.test.ts src/__tests__/connectors/identity.test.ts src/__tests__/services/mediaCacheDurableFailure.test.ts --reporter verbose`, and all tests in those files passed. 
- Ran TypeScript check: `bun run --cwd packages/backend tsc --noEmit`, which surfaced pre-existing repository-wide typing errors unrelated to this change (the compile run failed for unrelated files), so the behavioral unit tests remain the primary verification for this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4459c750a0832382c2a6843c244bf3)