### PR TITLE
fix(atproto): restrict bridge posts to public published

### DIFF
--- a/packages/backend/src/__tests__/connectors/atproto/bridge/repoReadService.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/bridge/repoReadService.test.ts
@@ -17,9 +17,14 @@ import { buildUserDid } from '../../../../services/mtn/mentionDid';
  */
 
 const mockFind = vi.fn();
+const mockPostFind = vi.fn();
 
 vi.mock('../../../../models/MentionSignedRecord', () => ({
   default: { find: (...a: unknown[]) => mockFind(...a) },
+}));
+
+vi.mock('../../../../models/Post', () => ({
+  Post: { find: (...a: unknown[]) => mockPostFind(...a) },
 }));
 
 import { listRecords, getRecord } from '../../../../connectors/atproto/bridge/repoReadService';
@@ -67,6 +72,12 @@ function mockLedger(rows: ReturnType<typeof row>[]): void {
   mockFind.mockReturnValue({
     sort: () => ({ lean: () => Promise.resolve(rows) }),
   });
+
+  mockPostFind.mockImplementation((query: { _id?: { $in?: string[] } }) => ({
+    select: () => ({
+      lean: () => Promise.resolve((query._id?.$in ?? []).map((_id) => ({ _id }))),
+    }),
+  }));
 }
 
 beforeEach(() => {
@@ -111,6 +122,29 @@ describe('listRecords', () => {
     const page = await listRecords(OWNER, 'app.bsky.feed.post');
     expect(page.records).toHaveLength(1);
     expect(page.records[0].rkey).toBe('p2');
+  });
+
+
+  it('filters post records to the authoritative public published Post set', async () => {
+    mockLedger([
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'published', record: postRecord('public'), createdAt: '2026-06-30T03:00:00.000Z' }),
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'draft', record: postRecord('draft secret'), createdAt: '2026-06-30T02:00:00.000Z' }),
+      row({ nsid: MENTION_POST_COLLECTION, rkey: 'private', record: postRecord('private secret'), createdAt: '2026-06-30T01:00:00.000Z' }),
+    ]);
+    mockPostFind.mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve([{ _id: 'published' }]) }),
+    });
+
+    const page = await listRecords(OWNER, 'app.bsky.feed.post');
+
+    expect(mockPostFind).toHaveBeenCalledWith({
+      _id: { $in: ['published', 'draft', 'private'] },
+      oxyUserId: OWNER,
+      visibility: 'public',
+      status: 'published',
+    });
+    expect(page.records.map((record) => record.rkey)).toEqual(['published']);
+    expect(page.records[0].value).toMatchObject({ text: 'public' });
   });
 
   it('serves likes and reposts from their own collections', async () => {

--- a/packages/backend/src/connectors/atproto/bridge/repoReadService.ts
+++ b/packages/backend/src/connectors/atproto/bridge/repoReadService.ts
@@ -27,6 +27,7 @@ import {
   MENTION_LIKE_COLLECTION,
   MENTION_REPOST_COLLECTION,
   MENTION_TOMBSTONE_COLLECTION,
+  PostVisibility,
   mentionPostRecordSchema,
   mentionLikeRecordSchema,
   mentionRepostRecordSchema,
@@ -34,6 +35,7 @@ import {
 } from '@mention/shared-types';
 import type { SignedRecordEnvelope } from '@oxyhq/contracts';
 import MentionSignedRecord from '../../../models/MentionSignedRecord';
+import { Post } from '../../../models/Post';
 import { buildUserDid } from '../../../services/mtn/mentionDid';
 import { logger } from '../../../utils/logger';
 import {
@@ -157,6 +159,21 @@ function translateRow(row: LedgerRow, bskyCollection: string): AtprotoRecordValu
  * This is the shared core both `listRecords` (paginated) and `getRecord`
  * (single) read from — one materialization, no drift.
  */
+async function getPublicPostRkeys(oxyUserId: string, rkeys: string[]): Promise<Set<string>> {
+  if (rkeys.length === 0) return new Set();
+
+  const publicPosts = await Post.find({
+    _id: { $in: rkeys },
+    oxyUserId,
+    visibility: PostVisibility.PUBLIC,
+    status: 'published',
+  })
+    .select('_id')
+    .lean<Array<{ _id: unknown }>>();
+
+  return new Set(publicPosts.map((post) => String(post._id)));
+}
+
 async function materializeCollection(
   oxyUserId: string,
   bskyCollection: string,
@@ -166,6 +183,15 @@ async function materializeCollection(
 
   const rows = await readLiveRows(oxyUserId);
   const tombstoned = collectTombstonedKeys(rows);
+  const publicPostRkeys =
+    mtnCollection === MENTION_POST_COLLECTION
+      ? await getPublicPostRkeys(
+          oxyUserId,
+          rows
+            .filter((row) => row.nsid === MENTION_POST_COLLECTION && typeof row.rkey === 'string')
+            .map((row) => row.rkey as string),
+        )
+      : undefined;
 
   const seen = new Set<string>();
   const out: BridgeRecord[] = [];
@@ -180,6 +206,11 @@ async function materializeCollection(
 
     // Tombstone removal: drop a key explicitly deleted.
     if (tombstoned.has(`${mtnCollection}/${rkey}`)) continue;
+
+    // The bridge is a public unauthenticated read surface. Ledger rows can exist
+    // for drafts or historical/private posts, so app.bsky.feed.post output must
+    // be joined back to Mongo's authoritative Post state before translation.
+    if (publicPostRkeys && !publicPostRkeys.has(rkey)) continue;
 
     const value = translateRow(row, bskyCollection);
     if (!value) continue;

--- a/packages/backend/src/scripts/backfill-mtn-records.ts
+++ b/packages/backend/src/scripts/backfill-mtn-records.ts
@@ -114,17 +114,19 @@ async function backfillMtnRecords(): Promise<void> {
     return;
   }
 
-  // The local, non-boost post set. `boostOf` excludes boosts (which are
+  // The local, public, published, non-boost post set. `boostOf` excludes boosts (which are
   // `app.mention.feed.repost` records, out of scope). The filter is immutable for
   // this run (we never mutate the fields it selects on), so the cursor is stable.
   const candidateFilter: Record<string, unknown> = {
     'federation.activityId': { $exists: false },
     oxyUserId: { $exists: true, $ne: null },
     boostOf: { $exists: false },
+    status: 'published',
+    visibility: 'public',
   };
 
   const totalCount = await Post.countDocuments(candidateFilter);
-  logger.info(`[backfill-mtn-records] ${totalCount} local non-boost posts to scan`);
+  logger.info(`[backfill-mtn-records] ${totalCount} local public published non-boost posts to scan`);
 
   if (totalCount === 0) {
     logger.info('[backfill-mtn-records] nothing to do');

--- a/packages/backend/src/services/PostCreationService.ts
+++ b/packages/backend/src/services/PostCreationService.ts
@@ -241,9 +241,11 @@ class PostCreationService {
 
     // MTN Protocol dual-write (best-effort, never blocks, never changes output).
     // Mongo is authoritative; this emits a signed `app.mention.feed.*` record for
-    // LOCAL authors only (`federation == null && oxyUserId`). A scheduled post is
-    // not yet published, so it emits when the scheduler publishes it, not here.
-    if (!isScheduled) {
+    // LOCAL authors only (`federation == null && oxyUserId`). Only published,
+    // public, non-scheduled posts are safe to expose through public bridge reads.
+    const shouldEmitMtnRecord =
+      !isScheduled && post.visibility === PostVisibility.PUBLIC && (post.status ?? 'published') === 'published';
+    if (shouldEmitMtnRecord) {
       await this.emitMtnRecord(post, params);
     }
 


### PR DESCRIPTION
### Motivation
- The public atproto bridge was materializing MTN ledger rows into atproto records without consulting the authoritative Post state, which allowed draft/private local posts to be exposed via `listRecords`/`getRecord` when MTN ledger rows existed for them. 
- The MTN dual-write and backfill paths also emitted ledger records for non-published or non-public local posts, making the ledger contain sensitive drafts that the bridge could surface.

### Description
- Join ledger materialization back to the authoritative `Post` collection: `repoReadService.materializeCollection` now restricts `app.bsky.feed.post` output to rkeys that correspond to `Post` documents with `visibility: PostVisibility.PUBLIC` and `status: 'published'` (added `getPublicPostRkeys` and `Post` import). 
- Prevent new non-public/unpublished posts from being added to the ledger: `PostCreationService` now only emits MTN records when the created post is published, public, and not scheduled. 
- Restrict the one-shot backfill to public/published, local non-boost posts by adding `status: 'published'` and `visibility: 'public'` to the backfill candidate filter. 
- Add unit coverage to `repoReadService.test.ts` that verifies ledger rows for `draft`/`private` rkeys are filtered out and only the authoritative public published rkeys are returned by `listRecords`; test mocks were extended to exercise the DB join. 
- Small imports and test mocks adjusted to support the new join/filter behavior (`Post`, `PostVisibility`, and test `mockPostFind`). Files changed: `packages/backend/src/connectors/atproto/bridge/repoReadService.ts`, `packages/backend/src/services/PostCreationService.ts`, `packages/backend/src/scripts/backfill-mtn-records.ts`, and `packages/backend/src/__tests__/connectors/atproto/bridge/repoReadService.test.ts`.

### Testing
- Ran the focused unit test file: `cd packages/backend && bun run test src/__tests__/connectors/atproto/bridge/repoReadService.test.ts`, and all tests in that file passed (11 tests). 
- Attempted a full TypeScript build (`cd packages/backend && bun run build`); the build fails due to pre-existing, unrelated TypeScript errors elsewhere in the backend (activitypub controllers, queue Redis typings, and other type issues), and there were no remaining errors attributable to the modified atproto bridge after using the `PostVisibility` enum. 
- Added the repo-read unit test asserting the bridge filters out non-public/unpublished rkeys and the test demonstrates the intended behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43fc6511388323b8c19c5c2d7e6e12)