### PR TITLE
fix(mtn): scope node materialization by owner

### DIFF
--- a/packages/backend/src/__tests__/services/mtn/postMaterializer.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/postMaterializer.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import mongoose from 'mongoose';
-import type { SignedRecordEnvelope } from '@oxyhq/contracts';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import mongoose from "mongoose";
+import type { SignedRecordEnvelope } from "@oxyhq/contracts";
 
 /**
  * MTN PostMaterializer — `projectRecord` projection + idempotency tests.
@@ -31,7 +31,10 @@ const h = vi.hoisted(() => {
   function applyUpsert(
     map: Map<string, StoredDoc>,
     id: string,
-    update: { $set?: Record<string, unknown>; $setOnInsert?: Record<string, unknown> },
+    update: {
+      $set?: Record<string, unknown>;
+      $setOnInsert?: Record<string, unknown>;
+    },
   ): StoredDoc {
     const isInsert = !map.has(id);
     const doc: StoredDoc = map.get(id) ?? { _id: id };
@@ -46,12 +49,16 @@ const h = vi.hoisted(() => {
     return doc;
   }
 
-  function setDottedPath(target: Record<string, unknown>, path: string, value: unknown): void {
-    const segments = path.split('.');
+  function setDottedPath(
+    target: Record<string, unknown>,
+    path: string,
+    value: unknown,
+  ): void {
+    const segments = path.split(".");
     let cursor = target;
     for (let i = 0; i < segments.length - 1; i++) {
       const seg = segments[i];
-      if (typeof cursor[seg] !== 'object' || cursor[seg] === null) {
+      if (typeof cursor[seg] !== "object" || cursor[seg] === null) {
         cursor[seg] = {};
       }
       cursor = cursor[seg] as Record<string, unknown>;
@@ -59,23 +66,51 @@ const h = vi.hoisted(() => {
     cursor[segments[segments.length - 1]] = value;
   }
 
-  function findByIdAndUpdate(map: Map<string, StoredDoc>) {
+  type OwnerFilter = { _id: string; oxyUserId?: string; userId?: string };
+
+  function matchesFilter(
+    doc: StoredDoc | undefined,
+    filter: OwnerFilter,
+  ): boolean {
+    if (!doc) return false;
+    if (filter.oxyUserId !== undefined && doc.oxyUserId !== filter.oxyUserId)
+      return false;
+    if (filter.userId !== undefined && doc.userId !== filter.userId)
+      return false;
+    return true;
+  }
+
+  function duplicateKeyError(): Error & { code: number } {
+    return Object.assign(new Error("E11000 duplicate key error"), {
+      code: 11000,
+    });
+  }
+
+  function findOneAndUpdate(map: Map<string, StoredDoc>) {
     return vi.fn(
       async (
-        id: string,
-        update: { $set?: Record<string, unknown>; $setOnInsert?: Record<string, unknown> },
+        filter: OwnerFilter,
+        update: {
+          $set?: Record<string, unknown>;
+          $setOnInsert?: Record<string, unknown>;
+        },
         options?: { upsert?: boolean },
       ) => {
-        if (!map.has(id) && !options?.upsert) return null;
-        return applyUpsert(map, id, update);
+        const existing = map.get(filter._id);
+        if (!matchesFilter(existing, filter)) {
+          if (existing && options?.upsert) throw duplicateKeyError();
+          if (!options?.upsert) return null;
+        }
+        return applyUpsert(map, filter._id, update);
       },
     );
   }
 
-  function findByIdAndDelete(map: Map<string, StoredDoc>) {
-    return vi.fn(async (id: string) => {
-      const existing = map.get(id) ?? null;
-      map.delete(id);
+  function findOneAndDelete(map: Map<string, StoredDoc>) {
+    return vi.fn(async (filter: OwnerFilter) => {
+      const existing = map.get(filter._id) ?? null;
+      if (!matchesFilter(existing, filter)) return null;
+      map.delete(filter._id);
       return existing;
     });
   }
@@ -84,25 +119,31 @@ const h = vi.hoisted(() => {
     posts,
     likes,
     bookmarks,
-    Post: { findByIdAndUpdate: findByIdAndUpdate(posts), findByIdAndDelete: findByIdAndDelete(posts) },
-    Like: { findByIdAndUpdate: findByIdAndUpdate(likes), findByIdAndDelete: findByIdAndDelete(likes) },
+    Post: {
+      findOneAndUpdate: findOneAndUpdate(posts),
+      findOneAndDelete: findOneAndDelete(posts),
+    },
+    Like: {
+      findOneAndUpdate: findOneAndUpdate(likes),
+      findOneAndDelete: findOneAndDelete(likes),
+    },
     Bookmark: {
-      findByIdAndUpdate: findByIdAndUpdate(bookmarks),
-      findByIdAndDelete: findByIdAndDelete(bookmarks),
+      findOneAndUpdate: findOneAndUpdate(bookmarks),
+      findOneAndDelete: findOneAndDelete(bookmarks),
     },
   };
 });
 
-vi.mock('../../../models/Post', () => ({
+vi.mock("../../../models/Post", () => ({
   Post: h.Post,
-  POST_CLASSIFICATION_PENDING: 'pending',
+  POST_CLASSIFICATION_PENDING: "pending",
 }));
-vi.mock('../../../models/Like', () => ({ default: h.Like }));
-vi.mock('../../../models/Bookmark', () => ({ default: h.Bookmark }));
+vi.mock("../../../models/Like", () => ({ default: h.Like }));
+vi.mock("../../../models/Bookmark", () => ({ default: h.Bookmark }));
 
-import { projectRecord } from '../../../services/mtn/PostMaterializer';
-import { buildUserDid } from '../../../services/mtn/mentionDid';
-import { baselineContentClassifier } from '../../../services/BaselineContentClassifier';
+import { projectRecord } from "../../../services/mtn/PostMaterializer";
+import { buildUserDid } from "../../../services/mtn/mentionDid";
+import { baselineContentClassifier } from "../../../services/BaselineContentClassifier";
 import {
   MENTION_POST_COLLECTION,
   MENTION_LIKE_COLLECTION,
@@ -112,17 +153,17 @@ import {
   createPostUri,
   createLikeUri,
   createBookmarkUri,
-} from '@mention/shared-types';
+} from "@mention/shared-types";
 
-const SUBJECT_OXY_ID = '650000000000000000000abc';
+const SUBJECT_OXY_ID = "650000000000000000000abc";
 const SUBJECT_DID = buildUserDid(SUBJECT_OXY_ID);
 // 24-hex Mongo ObjectId strings used as rkeys / post ids.
-const POST_RKEY = '650000000000000000000001';
-const LIKE_RKEY = '650000000000000000000002';
-const REPOST_RKEY = '650000000000000000000003';
-const BOOKMARK_RKEY = '650000000000000000000004';
-const LIKED_POST_ID = '650000000000000000000005';
-const OWNER_OXY_ID = '650000000000000000000fff';
+const POST_RKEY = "650000000000000000000001";
+const LIKE_RKEY = "650000000000000000000002";
+const REPOST_RKEY = "650000000000000000000003";
+const BOOKMARK_RKEY = "650000000000000000000004";
+const LIKED_POST_ID = "650000000000000000000005";
+const OWNER_OXY_ID = "650000000000000000000fff";
 
 /** Build a v2 envelope around an inner `record` for the materializer to project. */
 function envelope(
@@ -133,18 +174,18 @@ function envelope(
 ): SignedRecordEnvelope {
   return {
     version: 2,
-    type: 'app_record',
+    type: "app_record",
     subject,
-    issuer: 'did:web:mention.earth',
+    issuer: "did:web:mention.earth",
     record,
     issuedAt: Date.now(),
     seq: 0,
     prev: null,
     collection,
     rkey,
-    publicKey: 'pub',
-    alg: 'ES256K-DER-SHA256',
-    signature: 'sig',
+    publicKey: "pub",
+    alg: "ES256K-DER-SHA256",
+    signature: "sig",
   };
 }
 
@@ -152,43 +193,47 @@ beforeEach(() => {
   h.posts.clear();
   h.likes.clear();
   h.bookmarks.clear();
-  h.Post.findByIdAndUpdate.mockClear();
-  h.Post.findByIdAndDelete.mockClear();
-  h.Like.findByIdAndUpdate.mockClear();
-  h.Like.findByIdAndDelete.mockClear();
-  h.Bookmark.findByIdAndUpdate.mockClear();
-  h.Bookmark.findByIdAndDelete.mockClear();
+  h.Post.findOneAndUpdate.mockClear();
+  h.Post.findOneAndDelete.mockClear();
+  h.Like.findOneAndUpdate.mockClear();
+  h.Like.findOneAndDelete.mockClear();
+  h.Bookmark.findOneAndUpdate.mockClear();
+  h.Bookmark.findOneAndDelete.mockClear();
 });
 
-describe('projectRecord — post', () => {
-  const createdAtIso = '2024-01-02T03:04:05.000Z';
+describe("projectRecord — post", () => {
+  const createdAtIso = "2024-01-02T03:04:05.000Z";
   const postRecord = {
-    text: 'hello materialized world from the chain',
+    text: "hello materialized world from the chain",
     createdAt: createdAtIso,
-    tags: ['mtn', 'protocol'],
-    langs: ['en'],
+    tags: ["mtn", "protocol"],
+    langs: ["en"],
   };
 
-  it('projects a post record into a feed-identical Post row', async () => {
-    const result = await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord));
+  it("projects a post record into a feed-identical Post row", async () => {
+    const result = await projectRecord(
+      envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord),
+    );
 
-    expect(result).toEqual({ ok: true, kind: 'post', id: POST_RKEY });
+    expect(result).toEqual({ ok: true, kind: "post", id: POST_RKEY });
     const doc = h.posts.get(POST_RKEY);
     expect(doc).toBeDefined();
     expect(doc?.oxyUserId).toBe(SUBJECT_OXY_ID);
-    expect(doc?.type).toBe('text');
+    expect(doc?.type).toBe("text");
     expect((doc?.content as { text: string }).text).toBe(postRecord.text);
-    expect(doc?.hashtags).toEqual(['mtn', 'protocol']);
+    expect(doc?.hashtags).toEqual(["mtn", "protocol"]);
     expect(doc?.parentPostId).toBeNull();
     expect(doc?.threadId).toBeNull();
     expect((doc?.createdAt as Date).toISOString()).toBe(createdAtIso);
     // Insert-only defaults applied.
-    expect(doc?.visibility).toBe('public');
-    expect(doc?.status).toBe('published');
+    expect(doc?.visibility).toBe("public");
+    expect(doc?.status).toBe("published");
   });
 
-  it('writes a postClassification identical to baselineContentClassifier output', async () => {
-    await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord));
+  it("writes a postClassification identical to baselineContentClassifier output", async () => {
+    await projectRecord(
+      envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord),
+    );
 
     const expected = baselineContentClassifier.classify({
       text: postRecord.text,
@@ -206,7 +251,7 @@ describe('projectRecord — post', () => {
       sensitive?: boolean;
       version: number;
     };
-    expect(classification.status).toBe('pending');
+    expect(classification.status).toBe("pending");
     expect(classification.topics).toEqual(expected.topics);
     expect(classification.languages).toEqual(expected.languages);
     expect(classification.hashtagsNorm).toEqual(expected.hashtagsNorm);
@@ -216,11 +261,15 @@ describe('projectRecord — post', () => {
     expect(doc?.language).toBe(expected.languages[0]);
   });
 
-  it('is idempotent on a second projection (same row, stable classification)', async () => {
-    await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord));
+  it("is idempotent on a second projection (same row, stable classification)", async () => {
+    await projectRecord(
+      envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord),
+    );
     const first = JSON.parse(JSON.stringify(h.posts.get(POST_RKEY)));
 
-    await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord));
+    await projectRecord(
+      envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord),
+    );
     const second = JSON.parse(JSON.stringify(h.posts.get(POST_RKEY)));
 
     // Exactly one row, and its content/structure is stable across re-projection
@@ -229,15 +278,19 @@ describe('projectRecord — post', () => {
     expect(second.oxyUserId).toBe(first.oxyUserId);
     expect(second.content).toEqual(first.content);
     expect(second.hashtags).toEqual(first.hashtags);
-    expect(second.postClassification.topics).toEqual(first.postClassification.topics);
-    expect(second.postClassification.languages).toEqual(first.postClassification.languages);
+    expect(second.postClassification.topics).toEqual(
+      first.postClassification.topics,
+    );
+    expect(second.postClassification.languages).toEqual(
+      first.postClassification.languages,
+    );
   });
 
-  it('recovers reply context (threadId=root rkey, parentPostId=parent rkey)', async () => {
-    const rootId = '650000000000000000000010';
-    const parentId = '650000000000000000000011';
+  it("recovers reply context (threadId=root rkey, parentPostId=parent rkey)", async () => {
+    const rootId = "650000000000000000000010";
+    const parentId = "650000000000000000000011";
     const replyRecord = {
-      text: 'a reply in a thread that is long enough to classify',
+      text: "a reply in a thread that is long enough to classify",
       createdAt: createdAtIso,
       reply: {
         root: createPostUri(OWNER_OXY_ID, rootId),
@@ -245,36 +298,43 @@ describe('projectRecord — post', () => {
       },
     };
 
-    await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, replyRecord));
+    await projectRecord(
+      envelope(MENTION_POST_COLLECTION, POST_RKEY, replyRecord),
+    );
 
     const doc = h.posts.get(POST_RKEY);
     expect(doc?.threadId).toBe(rootId);
     expect(doc?.parentPostId).toBe(parentId);
   });
 
-  it('PRESERVES existing content.media (BLOB DEFERRED — never clobbers to empty)', async () => {
+  it("PRESERVES existing content.media (BLOB DEFERRED — never clobbers to empty)", async () => {
     // Seed an existing post that already carries fileId media (the B2 corpus case).
     h.posts.set(POST_RKEY, {
       _id: POST_RKEY,
       oxyUserId: SUBJECT_OXY_ID,
       content: {
-        text: 'original',
-        media: [{ id: 'file-abc', type: 'image' }],
+        text: "original",
+        media: [{ id: "file-abc", type: "image" }],
       },
     });
 
-    const result = await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord));
+    const result = await projectRecord(
+      envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord),
+    );
     expect(result.ok).toBe(true);
 
     const doc = h.posts.get(POST_RKEY);
-    const content = doc?.content as { text: string; media: Array<{ id: string; type: string }> };
+    const content = doc?.content as {
+      text: string;
+      media: Array<{ id: string; type: string }>;
+    };
     // Text was updated from the record…
     expect(content.text).toBe(postRecord.text);
     // …but the fileId media survives (the materializer never writes content.media).
-    expect(content.media).toEqual([{ id: 'file-abc', type: 'image' }]);
+    expect(content.media).toEqual([{ id: "file-abc", type: "image" }]);
   });
 
-  it('READ-SIDE DEFERRED: a record that CARRIES a blob embed never writes content.media', async () => {
+  it("READ-SIDE DEFERRED: a record that CARRIES a blob embed never writes content.media", async () => {
     // The write side now emits content-addressed blob refs, but the read side
     // cannot turn a bare sha256 back into a servable fileId/URL (no reverse
     // upstream index). The materializer must NOT write content.media from the
@@ -283,13 +343,24 @@ describe('projectRecord — post', () => {
     const recordWithEmbed = {
       ...postRecord,
       embed: {
-        type: 'media',
-        items: [{ blob: { sha256: 'sha-from-chain', mediaType: 'image', mime: 'image/png', size: 42 } }],
+        type: "media",
+        items: [
+          {
+            blob: {
+              sha256: "sha-from-chain",
+              mediaType: "image",
+              mime: "image/png",
+              size: 42,
+            },
+          },
+        ],
       },
     };
 
-    const result = await projectRecord(envelope(MENTION_POST_COLLECTION, POST_RKEY, recordWithEmbed));
-    expect(result).toEqual({ ok: true, kind: 'post', id: POST_RKEY });
+    const result = await projectRecord(
+      envelope(MENTION_POST_COLLECTION, POST_RKEY, recordWithEmbed),
+    );
+    expect(result).toEqual({ ok: true, kind: "post", id: POST_RKEY });
 
     const doc = h.posts.get(POST_RKEY);
     const content = doc?.content as { text: string; media?: unknown };
@@ -298,127 +369,229 @@ describe('projectRecord — post', () => {
     expect(content.media).toBeUndefined();
   });
 
-  it('rejects an invalid inner record with reason invalid_record', async () => {
+  it("rejects projection when the rkey already belongs to another post owner", async () => {
+    h.posts.set(POST_RKEY, {
+      _id: POST_RKEY,
+      oxyUserId: OWNER_OXY_ID,
+      content: { text: "victim" },
+    });
+
+    const result = await projectRecord(
+      envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord),
+    );
+
+    expect(result).toEqual({ ok: false, reason: "record_owner_mismatch" });
+    const doc = h.posts.get(POST_RKEY);
+    expect(doc?.oxyUserId).toBe(OWNER_OXY_ID);
+    expect((doc?.content as { text: string }).text).toBe("victim");
+  });
+
+  it("rejects an invalid inner record with reason invalid_record", async () => {
     // `text` is required by mentionPostRecordSchema; omit it.
     const result = await projectRecord(
       envelope(MENTION_POST_COLLECTION, POST_RKEY, { createdAt: createdAtIso }),
     );
-    expect(result).toEqual({ ok: false, reason: 'invalid_record' });
+    expect(result).toEqual({ ok: false, reason: "invalid_record" });
     expect(h.posts.size).toBe(0);
   });
 
-  it('is a clear no-op for a non-parseable subject DID', async () => {
+  it("is a clear no-op for a non-parseable subject DID", async () => {
     const result = await projectRecord(
-      envelope(MENTION_POST_COLLECTION, POST_RKEY, postRecord, 'did:web:not-a-user-did'),
+      envelope(
+        MENTION_POST_COLLECTION,
+        POST_RKEY,
+        postRecord,
+        "did:web:not-a-user-did",
+      ),
     );
-    expect(result).toEqual({ ok: false, reason: 'unresolvable_subject_did' });
+    expect(result).toEqual({ ok: false, reason: "unresolvable_subject_did" });
     expect(h.posts.size).toBe(0);
   });
 });
 
-describe('projectRecord — like', () => {
-  it('projects a like record into a Like row', async () => {
+describe("projectRecord — like", () => {
+  it("projects a like record into a Like row", async () => {
     const likeRecord = {
       subject: createPostUri(OWNER_OXY_ID, LIKED_POST_ID),
-      createdAt: '2024-01-02T03:04:05.000Z',
+      createdAt: "2024-01-02T03:04:05.000Z",
     };
-    const result = await projectRecord(envelope(MENTION_LIKE_COLLECTION, LIKE_RKEY, likeRecord));
+    const result = await projectRecord(
+      envelope(MENTION_LIKE_COLLECTION, LIKE_RKEY, likeRecord),
+    );
 
-    expect(result).toEqual({ ok: true, kind: 'like', id: LIKE_RKEY });
+    expect(result).toEqual({ ok: true, kind: "like", id: LIKE_RKEY });
     const doc = h.likes.get(LIKE_RKEY);
     expect(doc?.userId).toBe(SUBJECT_OXY_ID);
-    expect((doc?.postId as mongoose.Types.ObjectId).toString()).toBe(LIKED_POST_ID);
+    expect((doc?.postId as mongoose.Types.ObjectId).toString()).toBe(
+      LIKED_POST_ID,
+    );
     expect(doc?.value).toBe(1);
   });
-});
 
-describe('projectRecord — repost', () => {
-  it('projects a repost record into a boost Post (type boost, boostOf set, empty body)', async () => {
-    const repostRecord = {
+  it("rejects projection when the rkey already belongs to another liker", async () => {
+    h.likes.set(LIKE_RKEY, { _id: LIKE_RKEY, userId: OWNER_OXY_ID, value: 1 });
+    const likeRecord = {
       subject: createPostUri(OWNER_OXY_ID, LIKED_POST_ID),
-      createdAt: '2024-01-02T03:04:05.000Z',
+      createdAt: "2024-01-02T03:04:05.000Z",
     };
-    const result = await projectRecord(envelope(MENTION_REPOST_COLLECTION, REPOST_RKEY, repostRecord));
 
-    expect(result).toEqual({ ok: true, kind: 'repost', id: REPOST_RKEY });
-    const doc = h.posts.get(REPOST_RKEY);
-    expect(doc?.type).toBe('boost');
-    expect(doc?.boostOf).toBe(LIKED_POST_ID);
-    expect(doc?.oxyUserId).toBe(SUBJECT_OXY_ID);
-    expect((doc?.content as { text: string }).text).toBe('');
+    const result = await projectRecord(
+      envelope(MENTION_LIKE_COLLECTION, LIKE_RKEY, likeRecord),
+    );
+
+    expect(result).toEqual({ ok: false, reason: "record_owner_mismatch" });
+    expect(h.likes.get(LIKE_RKEY)?.userId).toBe(OWNER_OXY_ID);
   });
 });
 
-describe('projectRecord — bookmark', () => {
-  it('projects a bookmark record into a Bookmark row', async () => {
+describe("projectRecord — repost", () => {
+  it("projects a repost record into a boost Post (type boost, boostOf set, empty body)", async () => {
+    const repostRecord = {
+      subject: createPostUri(OWNER_OXY_ID, LIKED_POST_ID),
+      createdAt: "2024-01-02T03:04:05.000Z",
+    };
+    const result = await projectRecord(
+      envelope(MENTION_REPOST_COLLECTION, REPOST_RKEY, repostRecord),
+    );
+
+    expect(result).toEqual({ ok: true, kind: "repost", id: REPOST_RKEY });
+    const doc = h.posts.get(REPOST_RKEY);
+    expect(doc?.type).toBe("boost");
+    expect(doc?.boostOf).toBe(LIKED_POST_ID);
+    expect(doc?.oxyUserId).toBe(SUBJECT_OXY_ID);
+    expect((doc?.content as { text: string }).text).toBe("");
+  });
+});
+
+describe("projectRecord — bookmark", () => {
+  it("projects a bookmark record into a Bookmark row", async () => {
     const bookmarkRecord = {
       subject: createPostUri(OWNER_OXY_ID, LIKED_POST_ID),
-      createdAt: '2024-01-02T03:04:05.000Z',
+      createdAt: "2024-01-02T03:04:05.000Z",
     };
     const result = await projectRecord(
       envelope(MENTION_BOOKMARK_COLLECTION, BOOKMARK_RKEY, bookmarkRecord),
     );
 
-    expect(result).toEqual({ ok: true, kind: 'bookmark', id: BOOKMARK_RKEY });
+    expect(result).toEqual({ ok: true, kind: "bookmark", id: BOOKMARK_RKEY });
     const doc = h.bookmarks.get(BOOKMARK_RKEY);
     expect(doc?.userId).toBe(SUBJECT_OXY_ID);
-    expect((doc?.postId as mongoose.Types.ObjectId).toString()).toBe(LIKED_POST_ID);
+    expect((doc?.postId as mongoose.Types.ObjectId).toString()).toBe(
+      LIKED_POST_ID,
+    );
   });
 });
 
-describe('projectRecord — tombstone', () => {
-  it('removes the referenced Post for a post-subject tombstone', async () => {
+describe("projectRecord — tombstone", () => {
+  it("removes the referenced Post for a post-subject tombstone", async () => {
     h.posts.set(POST_RKEY, { _id: POST_RKEY, oxyUserId: SUBJECT_OXY_ID });
     const tombstone = {
       subject: createPostUri(SUBJECT_OXY_ID, POST_RKEY),
-      createdAt: '2024-01-02T03:04:05.000Z',
+      createdAt: "2024-01-02T03:04:05.000Z",
     };
 
     const result = await projectRecord(
-      envelope(MENTION_TOMBSTONE_COLLECTION, '650000000000000000000099', tombstone),
+      envelope(
+        MENTION_TOMBSTONE_COLLECTION,
+        "650000000000000000000099",
+        tombstone,
+      ),
     );
 
-    expect(result).toEqual({ ok: true, kind: 'tombstone', id: POST_RKEY });
+    expect(result).toEqual({ ok: true, kind: "tombstone", id: POST_RKEY });
     expect(h.posts.has(POST_RKEY)).toBe(false);
   });
 
-  it('removes the referenced Like for a like-subject tombstone', async () => {
+  it("removes the referenced Like for a like-subject tombstone", async () => {
     h.likes.set(LIKE_RKEY, { _id: LIKE_RKEY, userId: SUBJECT_OXY_ID });
     const tombstone = {
       subject: createLikeUri(SUBJECT_OXY_ID, LIKE_RKEY),
-      createdAt: '2024-01-02T03:04:05.000Z',
+      createdAt: "2024-01-02T03:04:05.000Z",
     };
 
     const result = await projectRecord(
-      envelope(MENTION_TOMBSTONE_COLLECTION, '650000000000000000000098', tombstone),
+      envelope(
+        MENTION_TOMBSTONE_COLLECTION,
+        "650000000000000000000098",
+        tombstone,
+      ),
     );
 
-    expect(result).toEqual({ ok: true, kind: 'tombstone', id: LIKE_RKEY });
+    expect(result).toEqual({ ok: true, kind: "tombstone", id: LIKE_RKEY });
     expect(h.likes.has(LIKE_RKEY)).toBe(false);
   });
 
-  it('removes the referenced Bookmark for a bookmark-subject tombstone', async () => {
-    h.bookmarks.set(BOOKMARK_RKEY, { _id: BOOKMARK_RKEY, userId: SUBJECT_OXY_ID });
+  it("removes the referenced Bookmark for a bookmark-subject tombstone", async () => {
+    h.bookmarks.set(BOOKMARK_RKEY, {
+      _id: BOOKMARK_RKEY,
+      userId: SUBJECT_OXY_ID,
+    });
     const tombstone = {
       subject: createBookmarkUri(SUBJECT_OXY_ID, BOOKMARK_RKEY),
-      createdAt: '2024-01-02T03:04:05.000Z',
+      createdAt: "2024-01-02T03:04:05.000Z",
     };
 
     const result = await projectRecord(
-      envelope(MENTION_TOMBSTONE_COLLECTION, '650000000000000000000097', tombstone),
+      envelope(
+        MENTION_TOMBSTONE_COLLECTION,
+        "650000000000000000000097",
+        tombstone,
+      ),
     );
 
-    expect(result).toEqual({ ok: true, kind: 'tombstone', id: BOOKMARK_RKEY });
+    expect(result).toEqual({ ok: true, kind: "tombstone", id: BOOKMARK_RKEY });
     expect(h.bookmarks.has(BOOKMARK_RKEY)).toBe(false);
   });
 
-  it('is idempotent: tombstoning an already-removed row is a no-op success', async () => {
+  it("rejects a tombstone whose subject identity differs from the envelope signer", async () => {
+    h.posts.set(POST_RKEY, { _id: POST_RKEY, oxyUserId: OWNER_OXY_ID });
+    const tombstone = {
+      subject: createPostUri(OWNER_OXY_ID, POST_RKEY),
+      createdAt: "2024-01-02T03:04:05.000Z",
+    };
+
+    const result = await projectRecord(
+      envelope(
+        MENTION_TOMBSTONE_COLLECTION,
+        "650000000000000000000095",
+        tombstone,
+      ),
+    );
+
+    expect(result).toEqual({ ok: false, reason: "tombstone_owner_mismatch" });
+    expect(h.posts.has(POST_RKEY)).toBe(true);
+  });
+
+  it("does not delete a row owned by another user even if the tombstone identity matches signer", async () => {
+    h.posts.set(POST_RKEY, { _id: POST_RKEY, oxyUserId: OWNER_OXY_ID });
     const tombstone = {
       subject: createPostUri(SUBJECT_OXY_ID, POST_RKEY),
-      createdAt: '2024-01-02T03:04:05.000Z',
+      createdAt: "2024-01-02T03:04:05.000Z",
+    };
+
+    const result = await projectRecord(
+      envelope(
+        MENTION_TOMBSTONE_COLLECTION,
+        "650000000000000000000094",
+        tombstone,
+      ),
+    );
+
+    expect(result).toEqual({ ok: true, kind: "tombstone", id: POST_RKEY });
+    expect(h.posts.has(POST_RKEY)).toBe(true);
+  });
+
+  it("is idempotent: tombstoning an already-removed row is a no-op success", async () => {
+    const tombstone = {
+      subject: createPostUri(SUBJECT_OXY_ID, POST_RKEY),
+      createdAt: "2024-01-02T03:04:05.000Z",
     };
     const result = await projectRecord(
-      envelope(MENTION_TOMBSTONE_COLLECTION, '650000000000000000000096', tombstone),
+      envelope(
+        MENTION_TOMBSTONE_COLLECTION,
+        "650000000000000000000096",
+        tombstone,
+      ),
     );
     expect(result.ok).toBe(true);
   });

--- a/packages/backend/src/services/mtn/PostMaterializer.ts
+++ b/packages/backend/src/services/mtn/PostMaterializer.ts
@@ -40,8 +40,8 @@
  *    parsed with the matching `mention*RecordSchema` before any projection.
  */
 
-import mongoose from 'mongoose';
-import type { SignedRecordEnvelope } from '@oxyhq/contracts';
+import mongoose from "mongoose";
+import type { SignedRecordEnvelope } from "@oxyhq/contracts";
 import {
   MENTION_POST_COLLECTION,
   MENTION_LIKE_COLLECTION,
@@ -60,17 +60,22 @@ import {
   type MentionTombstoneRecord,
   type MentionBookmarkRecord,
   type MtnMediaEmbed,
-} from '@mention/shared-types';
-import { PostType, PostVisibility } from '@mention/shared-types';
-import { Post, POST_CLASSIFICATION_PENDING } from '../../models/Post';
-import Like from '../../models/Like';
-import Bookmark from '../../models/Bookmark';
-import { logger } from '../../utils/logger';
-import { parseUserDid } from './mentionDid';
-import { baselineContentClassifier } from '../BaselineContentClassifier';
+} from "@mention/shared-types";
+import { PostType, PostVisibility } from "@mention/shared-types";
+import { Post, POST_CLASSIFICATION_PENDING } from "../../models/Post";
+import Like from "../../models/Like";
+import Bookmark from "../../models/Bookmark";
+import { logger } from "../../utils/logger";
+import { parseUserDid } from "./mentionDid";
+import { baselineContentClassifier } from "../BaselineContentClassifier";
 
 /** The kind of native row a successful projection produced/removed. */
-export type ProjectedKind = 'post' | 'like' | 'repost' | 'tombstone' | 'bookmark';
+export type ProjectedKind =
+  | "post"
+  | "like"
+  | "repost"
+  | "tombstone"
+  | "bookmark";
 
 /**
  * The outcome of {@link projectRecord}. Discriminates a successful projection
@@ -121,6 +126,19 @@ function toObjectId(rkey: string): mongoose.Types.ObjectId | null {
   return new mongoose.Types.ObjectId(rkey);
 }
 
+function isDuplicateKeyError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === 11000
+  );
+}
+
+function ownerMatchesUriIdentity(uri: MtnUri, oxyUserId: string): boolean {
+  return uri.identity === oxyUserId || parseUserDid(uri.identity) === oxyUserId;
+}
+
 /**
  * Build the Stage-A `postClassification` subdoc + primary `language` for a post
  * record, MIRRORING `PostCreationService.applyBaselineClassification` EXACTLY so
@@ -130,7 +148,9 @@ function toObjectId(rkey: string): mongoose.Types.ObjectId | null {
  * can never fail projection — the caller then leaves the schema-default
  * `{ status: 'pending' }` subdoc in place (mirrors PostCreationService).
  */
-function buildClassificationFields(record: MentionPostRecord): Record<string, unknown> {
+function buildClassificationFields(
+  record: MentionPostRecord,
+): Record<string, unknown> {
   try {
     const signals = baselineContentClassifier.classify({
       text: record.text,
@@ -168,7 +188,10 @@ function buildClassificationFields(record: MentionPostRecord): Record<string, un
     return fields;
   } catch (error) {
     // Never fail projection on classification — leave the default pending subdoc.
-    logger.warn('PostMaterializer: baseline classification failed; projecting without Stage-A signals', error);
+    logger.warn(
+      "PostMaterializer: baseline classification failed; projecting without Stage-A signals",
+      error,
+    );
     return {};
   }
 }
@@ -202,7 +225,7 @@ async function projectPost(
   const set: Record<string, unknown> = {
     oxyUserId,
     type: PostType.TEXT,
-    'content.text': record.text ?? '',
+    "content.text": record.text ?? "",
     hashtags: tags,
     parentPostId,
     threadId,
@@ -215,37 +238,53 @@ async function projectPost(
 
   // `content.sources`: map the record's source links to the native shape.
   if (Array.isArray(record.sources) && record.sources.length > 0) {
-    set['content.sources'] = record.sources.map((s) =>
+    set["content.sources"] = record.sources.map((s) =>
       s.title ? { url: s.url, title: s.title } : { url: s.url },
     );
   }
 
   // `content.location`: a GeoJSON Point, when present on the record.
   if (record.location) {
-    set['content.location'] = {
-      type: 'Point',
-      coordinates: [record.location.coordinates[0], record.location.coordinates[1]],
+    set["content.location"] = {
+      type: "Point",
+      coordinates: [
+        record.location.coordinates[0],
+        record.location.coordinates[1],
+      ],
     };
   }
 
-  await Post.findByIdAndUpdate(
-    rkey,
-    {
-      $set: set,
-      $setOnInsert: { visibility: PostVisibility.PUBLIC, status: 'published' },
-    },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
+  try {
+    await Post.findOneAndUpdate(
+      { _id: rkey, oxyUserId },
+      {
+        $set: set,
+        $setOnInsert: {
+          visibility: PostVisibility.PUBLIC,
+          status: "published",
+        },
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+  } catch (error) {
+    if (isDuplicateKeyError(error)) {
+      return { ok: false, reason: "record_owner_mismatch" };
+    }
+    throw error;
+  }
 
   // Re-derive the Stage-A classification from the SAME inputs the native path
   // uses, and write it with a dotted `$set` (so it overwrites the whole subdoc
   // + the top-level primary language without touching unrelated fields).
   const classificationFields = buildClassificationFields(record);
   if (Object.keys(classificationFields).length > 0) {
-    await Post.findByIdAndUpdate(rkey, { $set: classificationFields });
+    await Post.findOneAndUpdate(
+      { _id: rkey, oxyUserId },
+      { $set: classificationFields },
+    );
   }
 
-  return { ok: true, kind: 'post', id: rkey };
+  return { ok: true, kind: "post", id: rkey };
 }
 
 /** Project an `app.mention.feed.like` record into a `Like` row (upsert by _id). */
@@ -255,17 +294,24 @@ async function projectLike(
   record: MentionLikeRecord,
 ): Promise<ProjectResult> {
   const likedRkey = rkeyFromMtnUri(record.subject);
-  if (!likedRkey) return { ok: false, reason: 'unresolvable_like_subject' };
+  if (!likedRkey) return { ok: false, reason: "unresolvable_like_subject" };
   const postId = toObjectId(likedRkey);
-  if (!postId) return { ok: false, reason: 'invalid_like_post_id' };
+  if (!postId) return { ok: false, reason: "invalid_like_post_id" };
 
-  await Like.findByIdAndUpdate(
-    rkey,
-    { $set: { userId, postId, value: 1 } },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
+  try {
+    await Like.findOneAndUpdate(
+      { _id: rkey, userId },
+      { $set: { userId, postId, value: 1 } },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+  } catch (error) {
+    if (isDuplicateKeyError(error)) {
+      return { ok: false, reason: "record_owner_mismatch" };
+    }
+    throw error;
+  }
 
-  return { ok: true, kind: 'like', id: rkey };
+  return { ok: true, kind: "like", id: rkey };
 }
 
 /**
@@ -280,24 +326,34 @@ async function projectRepost(
   createdAt: Date,
 ): Promise<ProjectResult> {
   const boostOf = rkeyFromMtnUri(record.subject);
-  if (!boostOf) return { ok: false, reason: 'unresolvable_repost_subject' };
+  if (!boostOf) return { ok: false, reason: "unresolvable_repost_subject" };
 
-  await Post.findByIdAndUpdate(
-    rkey,
-    {
-      $set: {
-        oxyUserId,
-        type: PostType.BOOST,
-        boostOf,
-        'content.text': '',
-        createdAt,
+  try {
+    await Post.findOneAndUpdate(
+      { _id: rkey, oxyUserId },
+      {
+        $set: {
+          oxyUserId,
+          type: PostType.BOOST,
+          boostOf,
+          "content.text": "",
+          createdAt,
+        },
+        $setOnInsert: {
+          visibility: PostVisibility.PUBLIC,
+          status: "published",
+        },
       },
-      $setOnInsert: { visibility: PostVisibility.PUBLIC, status: 'published' },
-    },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+  } catch (error) {
+    if (isDuplicateKeyError(error)) {
+      return { ok: false, reason: "record_owner_mismatch" };
+    }
+    throw error;
+  }
 
-  return { ok: true, kind: 'repost', id: rkey };
+  return { ok: true, kind: "repost", id: rkey };
 }
 
 /** Project an `app.mention.feed.bookmark` record into a `Bookmark` row (upsert). */
@@ -307,17 +363,25 @@ async function projectBookmark(
   record: MentionBookmarkRecord,
 ): Promise<ProjectResult> {
   const bookmarkedRkey = rkeyFromMtnUri(record.subject);
-  if (!bookmarkedRkey) return { ok: false, reason: 'unresolvable_bookmark_subject' };
+  if (!bookmarkedRkey)
+    return { ok: false, reason: "unresolvable_bookmark_subject" };
   const postId = toObjectId(bookmarkedRkey);
-  if (!postId) return { ok: false, reason: 'invalid_bookmark_post_id' };
+  if (!postId) return { ok: false, reason: "invalid_bookmark_post_id" };
 
-  await Bookmark.findByIdAndUpdate(
-    rkey,
-    { $set: { userId, postId } },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
+  try {
+    await Bookmark.findOneAndUpdate(
+      { _id: rkey, userId },
+      { $set: { userId, postId } },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+  } catch (error) {
+    if (isDuplicateKeyError(error)) {
+      return { ok: false, reason: "record_owner_mismatch" };
+    }
+    throw error;
+  }
 
-  return { ok: true, kind: 'bookmark', id: rkey };
+  return { ok: true, kind: "bookmark", id: rkey };
 }
 
 /**
@@ -328,15 +392,22 @@ async function projectBookmark(
  * COLLECTION selects which model to delete from. Idempotent: removing an
  * already-removed row is a no-op (still `ok`).
  */
-async function projectTombstone(record: MentionTombstoneRecord): Promise<ProjectResult> {
+async function projectTombstone(
+  record: MentionTombstoneRecord,
+  oxyUserId: string,
+): Promise<ProjectResult> {
   if (!MtnUri.isValid(record.subject)) {
-    return { ok: false, reason: 'unresolvable_tombstone_subject' };
+    return { ok: false, reason: "unresolvable_tombstone_subject" };
   }
   let subject: MtnUri;
   try {
     subject = MtnUri.parse(record.subject);
   } catch {
-    return { ok: false, reason: 'unresolvable_tombstone_subject' };
+    return { ok: false, reason: "unresolvable_tombstone_subject" };
+  }
+
+  if (!ownerMatchesUriIdentity(subject, oxyUserId)) {
+    return { ok: false, reason: "tombstone_owner_mismatch" };
   }
 
   const rkey = subject.rkey;
@@ -346,16 +417,16 @@ async function projectTombstone(record: MentionTombstoneRecord): Promise<Project
     case MENTION_REPOST_COLLECTION:
       // A post or boost: delete the Post by id (mirrors delete-post's hard
       // delete). Idempotent — a missing row deletes nothing.
-      await Post.findByIdAndDelete(rkey);
-      return { ok: true, kind: 'tombstone', id: rkey };
+      await Post.findOneAndDelete({ _id: rkey, oxyUserId });
+      return { ok: true, kind: "tombstone", id: rkey };
     case MENTION_LIKE_COLLECTION:
-      await Like.findByIdAndDelete(rkey);
-      return { ok: true, kind: 'tombstone', id: rkey };
+      await Like.findOneAndDelete({ _id: rkey, userId: oxyUserId });
+      return { ok: true, kind: "tombstone", id: rkey };
     case MENTION_BOOKMARK_COLLECTION:
-      await Bookmark.findByIdAndDelete(rkey);
-      return { ok: true, kind: 'tombstone', id: rkey };
+      await Bookmark.findOneAndDelete({ _id: rkey, userId: oxyUserId });
+      return { ok: true, kind: "tombstone", id: rkey };
     default:
-      return { ok: false, reason: 'unsupported_tombstone_subject_collection' };
+      return { ok: false, reason: "unsupported_tombstone_subject_collection" };
   }
 }
 
@@ -371,56 +442,72 @@ async function projectTombstone(record: MentionTombstoneRecord): Promise<Project
  *
  * @param envelope A verified v2 envelope with `collection`/`rkey`/`subject`/`record`.
  */
-export async function projectRecord(envelope: SignedRecordEnvelope): Promise<ProjectResult> {
+export async function projectRecord(
+  envelope: SignedRecordEnvelope,
+): Promise<ProjectResult> {
   try {
     const { collection, rkey, subject, record } = envelope;
 
-    if (typeof collection !== 'string' || typeof rkey !== 'string' || rkey.length === 0) {
-      return { ok: false, reason: 'missing_record_key' };
+    if (
+      typeof collection !== "string" ||
+      typeof rkey !== "string" ||
+      rkey.length === 0
+    ) {
+      return { ok: false, reason: "missing_record_key" };
     }
 
     // The subject DID identifies the chain owner (the author / liker / bookmarker).
     // A non-parseable subject DID is a clear no-op (we cannot key a native row).
     const oxyUserId = parseUserDid(subject);
     if (!oxyUserId) {
-      return { ok: false, reason: 'unresolvable_subject_did' };
+      return { ok: false, reason: "unresolvable_subject_did" };
     }
 
     switch (collection) {
       case MENTION_POST_COLLECTION: {
         const parsed = mentionPostRecordSchema.safeParse(record);
-        if (!parsed.success) return { ok: false, reason: 'invalid_record' };
-        return await projectPost(rkey, oxyUserId, parsed.data, new Date(parsed.data.createdAt));
+        if (!parsed.success) return { ok: false, reason: "invalid_record" };
+        return await projectPost(
+          rkey,
+          oxyUserId,
+          parsed.data,
+          new Date(parsed.data.createdAt),
+        );
       }
       case MENTION_LIKE_COLLECTION: {
         const parsed = mentionLikeRecordSchema.safeParse(record);
-        if (!parsed.success) return { ok: false, reason: 'invalid_record' };
+        if (!parsed.success) return { ok: false, reason: "invalid_record" };
         return await projectLike(rkey, oxyUserId, parsed.data);
       }
       case MENTION_REPOST_COLLECTION: {
         const parsed = mentionRepostRecordSchema.safeParse(record);
-        if (!parsed.success) return { ok: false, reason: 'invalid_record' };
-        return await projectRepost(rkey, oxyUserId, parsed.data, new Date(parsed.data.createdAt));
+        if (!parsed.success) return { ok: false, reason: "invalid_record" };
+        return await projectRepost(
+          rkey,
+          oxyUserId,
+          parsed.data,
+          new Date(parsed.data.createdAt),
+        );
       }
       case MENTION_TOMBSTONE_COLLECTION: {
         const parsed = mentionTombstoneRecordSchema.safeParse(record);
-        if (!parsed.success) return { ok: false, reason: 'invalid_record' };
-        return await projectTombstone(parsed.data);
+        if (!parsed.success) return { ok: false, reason: "invalid_record" };
+        return await projectTombstone(parsed.data, oxyUserId);
       }
       case MENTION_BOOKMARK_COLLECTION: {
         const parsed = mentionBookmarkRecordSchema.safeParse(record);
-        if (!parsed.success) return { ok: false, reason: 'invalid_record' };
+        if (!parsed.success) return { ok: false, reason: "invalid_record" };
         return await projectBookmark(rkey, oxyUserId, parsed.data);
       }
       default:
-        return { ok: false, reason: 'unsupported_collection' };
+        return { ok: false, reason: "unsupported_collection" };
     }
   } catch (error) {
-    logger.error('PostMaterializer: projectRecord failed', {
+    logger.error("PostMaterializer: projectRecord failed", {
       collection: envelope.collection,
       rkey: envelope.rkey,
       error: error instanceof Error ? error.message : String(error),
     });
-    return { ok: false, reason: 'error' };
+    return { ok: false, reason: "error" };
   }
 }


### PR DESCRIPTION
### Motivation
- Node-supplied MTN records were being materialized into native Mongo rows keyed by attacker-controlled `rkey` without object-level authorization, allowing cross-user overwrites and deletes. 
- The change ensures materialization enforces that the envelope signer is authorized to mutate or delete the target native row.

### Description
- Scope post/repost upserts to the envelope signer by switching to `findOneAndUpdate({ _id: rkey, oxyUserId })` and return a clear `record_owner_mismatch` on duplicate-key collisions instead of silently overwriting another user's row. 
- Apply the same owner-scoped upsert protection to `Like` and `Bookmark` projections and to `Repost` boosts. 
- Harden tombstone handling by requiring the tombstone subject identity to match the envelope signer (`ownerMatchesUriIdentity`) and by deleting only rows owned by that signer using owner-scoped `findOneAndDelete` filters. 
- Update the PostMaterializer test mocks to model owner-scoped `findOneAndUpdate`/`findOneAndDelete` behavior, add regression tests for cross-owner upsert collisions and tombstone owner-mismatch cases, and tidy a few minor formatting/strings for consistency.

### Testing
- Ran `git diff --check` to verify no whitespace/errors in diffs, which passed. 
- Ran unit tests for the materializer: `cd packages/backend && bun run test src/__tests__/services/mtn/postMaterializer.test.ts`, and all tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43e60781fc83239d5040c509685024)