### PR TITLE
fix(activitypub): cap signed fetch response bodies

### DIFF
--- a/packages/backend/src/__tests__/security/signedFetchBodyLimit.test.ts
+++ b/packages/backend/src/__tests__/security/signedFetchBodyLimit.test.ts
@@ -1,0 +1,117 @@
+import { PassThrough } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getPublicKey: vi.fn(),
+  signRequest: vi.fn(),
+  fetchUpstreamSingleHop: vi.fn(),
+}));
+
+vi.mock('../../connectors/activitypub/crypto', () => ({
+  getPublicKey: mocks.getPublicKey,
+  signRequest: mocks.signRequest,
+}));
+
+vi.mock('../../utils/safeUpstreamFetch', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../utils/safeUpstreamFetch')>();
+  return {
+    ...actual,
+    fetchUpstreamSingleHop: mocks.fetchUpstreamSingleHop,
+  };
+});
+
+import {
+  signedFetch,
+  SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES,
+} from '../../connectors/activitypub/helpers';
+
+function streamFromChunks(chunks: Buffer[]): PassThrough {
+  const stream = new PassThrough();
+  for (const chunk of chunks) stream.write(chunk);
+  stream.end();
+  return stream;
+}
+
+describe('signedFetch ActivityPub body size limit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPublicKey.mockResolvedValue({
+      keyId: 'https://mention.test/ap/actor#main-key',
+    });
+    mocks.signRequest.mockResolvedValue({ Signature: 'sig' });
+  });
+
+  it('rejects an oversized ActivityPub response before buffering it all', async () => {
+    const firstChunk = Buffer.alloc(
+      SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES,
+      'a',
+    );
+    const overflowChunk = Buffer.from('x');
+    const response = streamFromChunks([firstChunk, overflowChunk]);
+    const destroySpy = vi.spyOn(response, 'destroy');
+
+    mocks.fetchUpstreamSingleHop.mockResolvedValue({
+      status: 200,
+      headers: { 'content-type': 'application/activity+json' },
+      response,
+    });
+
+    await expect(
+      signedFetch(
+        'https://remote.example/users/alice',
+        'application/activity+json',
+      ),
+    ).rejects.toThrow(
+      `ActivityPub response exceeded ${SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES} bytes`,
+    );
+    expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it('rejects oversized responses from content-length without draining the stream', async () => {
+    const response = streamFromChunks([Buffer.from('{}')]);
+    const destroySpy = vi.spyOn(response, 'destroy');
+
+    mocks.fetchUpstreamSingleHop.mockResolvedValue({
+      status: 200,
+      headers: {
+        'content-type': 'application/activity+json',
+        'content-length': String(SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES + 1),
+      },
+      response,
+    });
+
+    await expect(
+      signedFetch(
+        'https://remote.example/users/alice',
+        'application/activity+json',
+      ),
+    ).rejects.toThrow(
+      `ActivityPub response exceeded ${SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES} bytes`,
+    );
+    expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it('preserves normal bounded ActivityPub responses', async () => {
+    const body = JSON.stringify({
+      id: 'https://remote.example/users/alice',
+      type: 'Person',
+    });
+    mocks.fetchUpstreamSingleHop.mockResolvedValue({
+      status: 200,
+      headers: { 'content-type': 'application/activity+json' },
+      response: streamFromChunks([Buffer.from(body)]),
+    });
+
+    const res = await signedFetch(
+      'https://remote.example/users/alice',
+      'application/activity+json',
+    );
+
+    expect(res.ok).toBe(true);
+    await expect(res.json()).resolves.toEqual({
+      id: 'https://remote.example/users/alice',
+      type: 'Person',
+    });
+  });
+});

--- a/packages/backend/src/connectors/activitypub/helpers.ts
+++ b/packages/backend/src/connectors/activitypub/helpers.ts
@@ -31,6 +31,7 @@ const SIGNED_FETCH_TIMEOUT_MS = 10000;
 const SIGNED_FETCH_MAX_REDIRECTS = 3;
 const REDIRECT_STATUS_CODES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]);
 const MAX_ACTIVITYPUB_REDIRECTS = SIGNED_FETCH_MAX_REDIRECTS;
+export const SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES = 5 * 1024 * 1024;
 
 export function asRecord(value: unknown): Record<string, any> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -134,8 +135,9 @@ function requestInitHeaders(init: RequestInit): Record<string, string> {
  * standard `Response` surface (`.ok`, `.status`, `.statusText`, `.headers.get()`,
  * `.json()`, `.text()`) unchanged.
  *
- * The body is buffered eagerly. This is acceptable here because every signed
- * federation fetch reads a single (bounded) ActivityPub JSON document — actor,
+ * The body is buffered eagerly with a strict byte cap. This is acceptable here
+ * because every signed federation fetch reads a single bounded ActivityPub JSON
+ * document — actor,
  * outbox/page collection, or a Note/Article — never a large media stream (media
  * goes through `/media/proxy`, which streams the `IncomingMessage` directly).
  * Redirect responses carry no body of interest, so their stream is destroyed.
@@ -161,11 +163,27 @@ async function singleHopToResponse(result: SingleHopResult): Promise<Response> {
     return new Response(null, { status: result.status, headers });
   }
 
-  const chunks: Buffer[] = [];
-  for await (const chunk of result.response) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  const contentLength = headers.get('content-length');
+  if (contentLength) {
+    const declaredLength = Number(contentLength);
+    if (Number.isFinite(declaredLength) && declaredLength > SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES) {
+      result.response.destroy();
+      throw new Error(`ActivityPub response exceeded ${SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES} bytes`);
+    }
   }
-  return new Response(Buffer.concat(chunks), { status: result.status, headers });
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of result.response) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.length;
+    if (totalBytes > SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES) {
+      result.response.destroy();
+      throw new Error(`ActivityPub response exceeded ${SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES} bytes`);
+    }
+    chunks.push(buffer);
+  }
+  return new Response(Buffer.concat(chunks, totalBytes), { status: result.status, headers });
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated remote actors from triggering unbounded memory growth by buffering arbitrarily large ActivityPub JSON documents during signed fetches, which could be abused via the public `/federation/resolve` path to cause DoS. 

### Description
- Introduce a byte cap constant `SIGNED_FETCH_MAX_ACTIVITYPUB_JSON_BYTES` (5 MiB) and enforce it in `singleHopToResponse` to bound buffered ActivityPub JSON responses. 
- Reject oversized responses early using the `Content-Length` header when present and enforce a streaming byte counter that destroys the upstream stream and throws if the cap is exceeded. 
- Preserve the existing `Response`-surface API while making eager buffering safe-by-contract and update the helper documentation to reflect the new cap. 
- Add regression tests `packages/backend/src/__tests__/security/signedFetchBodyLimit.test.ts` covering streaming overflow, `Content-Length` overflow, and normal bounded ActivityPub responses. 

### Testing
- Ran `vitest` for the new security test and it passed: `packages/backend/src/__tests__/security/signedFetchBodyLimit.test.ts` (3 tests passed). 
- Verified existing AP outbox validation tests still pass: `packages/backend/src/__tests__/connectors/activitypub/outboxValidation.test.ts` (9 tests passed). 
- Attempted a TypeScript build which failed due to pre-existing unrelated type issues in the repository (Mongoose query typings and BullMQ/ioredis type duplication) and not because of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a438d2ad9fc8323b356b521ac11ae95)