### PR TITLE
Constrain thread reply-context parent fetches to public/published

### DIFF
--- a/packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts
+++ b/packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts
@@ -120,6 +120,33 @@ describe('ThreadSlicingService reply-context parent author', () => {
     expect(resolveUserSummaries.mock.calls[0][0]).toContain(PARENT_AUTHOR_ID);
   });
 
+  it('fetches reply-context parents only when public and published', async () => {
+    postFind.mockImplementation(() => []);
+    resolveUserSummaries.mockResolvedValue(new Map<string, CachedUserSummary>());
+
+    const reply = {
+      _id: REPLY_ID,
+      oxyUserId: REPLY_AUTHOR_ID,
+      parentPostId: PARENT_ID,
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+      content: { text: 'a public reply' },
+    };
+
+    await threadSlicingService.sliceFeed([reply], {
+      enableThreadGrouping: false,
+      enableReplyContext: true,
+      maxSliceSize: 3,
+    });
+
+    expect(postFind).toHaveBeenCalledTimes(1);
+    expect(postFind.mock.calls[0][0]).toMatchObject({
+      _id: { $in: [PARENT_ID] },
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+    });
+  });
+
   it('never emits a blank displayName/handle when the author cannot be resolved', async () => {
     // Author resolution returns nothing (e.g. Oxy lookup miss).
     resolveUserSummaries.mockResolvedValue(new Map<string, CachedUserSummary>());

--- a/packages/backend/src/services/ThreadSlicingService.ts
+++ b/packages/backend/src/services/ThreadSlicingService.ts
@@ -262,8 +262,10 @@ class ThreadSlicingService {
     try {
       const parents = await Post.find({
         _id: { $in: uniqueParentIds },
+        visibility: PostVisibility.PUBLIC,
+        status: 'published',
       })
-        .select('_id oxyUserId createdAt parentPostId threadId content stats metadata hashtags mentions language visibility type boostOf quoteOf')
+        .select('_id oxyUserId createdAt parentPostId threadId content stats metadata hashtags mentions language visibility status type boostOf quoteOf')
         .maxTimeMS(3000)
         .lean();
 


### PR DESCRIPTION
### Motivation
- Prevent information disclosure where thread slicing or reply-context injection could pull non-public (followers-only, private, draft, or scheduled) posts into public feed responses.
- Ensure reply-context parent lookups follow the same visibility/status guards already applied to thread-child fetching to keep feed slices safe for unauthenticated viewers.

### Description
- Require reply-context parent fetches in `ThreadSlicingService` to include `visibility: PostVisibility.PUBLIC` and `status: 'published'` so only public, published parents are returned for reply-context slices (`packages/backend/src/services/ThreadSlicingService.ts`).
- Include `status` in the parent projection so downstream hydration sees the visibility/status field where needed (`packages/backend/src/services/ThreadSlicingService.ts`).
- Add a regression unit test asserting the parent-query includes `visibility: PostVisibility.PUBLIC` and `status: 'published'` for reply-context lookups (`packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts`).

### Testing
- Added a unit test `packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts` that verifies reply-context parent lookups are constrained to public/published posts; the test is present in the test suite but was not executed in this environment.
- Attempted to run the targeted test via `cd packages/backend && bun run test src/__tests__/services/threadSlicingReplyContext.test.ts`, but test execution was blocked because dependency installation failed (`bun install` encountered registry 403 responses), so automated test execution could not complete.
- Performed static checks (`git diff --check`) with no issues reported in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d9266a40c8323ace60234ed353143)