### PR TITLE
fix: restrict manual frontend deploys to main

### DIFF
--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -39,7 +39,7 @@ jobs:
 
   deploy-frontend:
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -65,7 +65,7 @@ jobs:
 
   deploy-agora:
     needs: detect-changes
-    if: needs.detect-changes.outputs.agora == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.agora == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
### Motivation
- Prevent unreviewed branches from being built and deployed to production via an unrestricted `workflow_dispatch` that could check out an arbitrary ref while using production Cloudflare credentials.

### Description
- Add explicit main-branch guards to both deployment jobs in ` .github/workflows/deploy-frontends.yml` by requiring `github.ref == 'refs/heads/main'` in each job `if` (applied to `deploy-frontend` and `deploy-agora`).

### Testing
- Verified the new guards are present by running a Python assertion that reads `.github/workflows/deploy-frontends.yml` and checks for the guarded `if` expressions, which succeeded; `actionlint` was not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d92294d1c8323851bc8e47efcf39d)