### PR TITLE
fix: restrict thread context feed posts

### DIFF
--- a/packages/backend/src/__tests__/feedQueryBuilder.visibility.test.ts
+++ b/packages/backend/src/__tests__/feedQueryBuilder.visibility.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { PostVisibility } from '@mention/shared-types';
+import { FeedQueryBuilder } from '../utils/feedQueryBuilder';
+
+describe('FeedQueryBuilder feed publication filters', () => {
+  it('requires following-feed posts, including replies, to be public and published', () => {
+    const query = FeedQueryBuilder.buildFollowingQuery(['user-1']);
+
+    expect(query).toMatchObject({
+      oxyUserId: { $in: ['user-1'] },
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+    });
+  });
+
+  it('requires explore-feed posts to be public and published', () => {
+    const query = FeedQueryBuilder.buildExploreQuery();
+
+    expect(query).toMatchObject({
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+    });
+  });
+});

--- a/packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts
+++ b/packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts
@@ -184,3 +184,30 @@ describe('ThreadSlicingService thread children visibility', () => {
     });
   });
 });
+
+describe('ThreadSlicingService reply parent visibility', () => {
+  it('fetches reply-context parents only when public and published', async () => {
+    postFind.mockImplementation(() => []);
+    resolveUserSummaries.mockResolvedValue(new Map<string, CachedUserSummary>());
+
+    const reply = {
+      _id: REPLY_ID,
+      oxyUserId: REPLY_AUTHOR_ID,
+      parentPostId: PARENT_ID,
+      content: { text: 'a reply' },
+    };
+
+    await threadSlicingService.sliceFeed([reply], {
+      enableThreadGrouping: false,
+      enableReplyContext: true,
+      maxSliceSize: 3,
+    });
+
+    expect(postFind).toHaveBeenCalledTimes(1);
+    expect(postFind.mock.calls[0][0]).toMatchObject({
+      _id: { $in: [PARENT_ID] },
+      visibility: PostVisibility.PUBLIC,
+      status: 'published',
+    });
+  });
+});

--- a/packages/backend/src/services/ThreadSlicingService.ts
+++ b/packages/backend/src/services/ThreadSlicingService.ts
@@ -262,6 +262,8 @@ class ThreadSlicingService {
     try {
       const parents = await Post.find({
         _id: { $in: uniqueParentIds },
+        visibility: PostVisibility.PUBLIC,
+        status: 'published',
       })
         .select('_id oxyUserId createdAt parentPostId threadId content stats metadata hashtags mentions language visibility type boostOf quoteOf')
         .maxTimeMS(3000)

--- a/packages/backend/src/utils/feedQueryBuilder.ts
+++ b/packages/backend/src/utils/feedQueryBuilder.ts
@@ -429,6 +429,7 @@ export class FeedQueryBuilder {
     const query: Record<string, unknown> = {
       oxyUserId: { $in: followingIds },
       visibility: PostVisibility.PUBLIC,
+      status: 'published',
       // No parentPostId filter — replies flow through for thread slicing
       // Exclude boosts (they are shown differently)
       $and: [
@@ -450,6 +451,7 @@ export class FeedQueryBuilder {
   static buildExploreQuery(cursor?: string): Record<string, unknown> {
     const match: Record<string, unknown> = {
       visibility: PostVisibility.PUBLIC,
+      status: 'published',
       $and: [
         { $or: [{ parentPostId: null }, { parentPostId: { $exists: false } }] },
         { $or: [{ boostOf: null }, { boostOf: { $exists: false } }] }
@@ -540,4 +542,3 @@ export class FeedQueryBuilder {
     return query;
   }
 }
-


### PR DESCRIPTION
### Motivation

- Thread-slicing injected parent/child context posts using secondary Mongo queries but did not preserve the feed-level post publication/visibility constraints, allowing non-public/draft/scheduled posts to be fetched and serialized into public feeds.

### Description

- Require reply-context parent lookups in `ThreadSlicingService.sliceFeed` to include `visibility: PostVisibility.PUBLIC` and `status: 'published'` so only visible, published parents are fetched for reply-context slices (`packages/backend/src/services/ThreadSlicingService.ts`).
- Ensure Following and Explore feed query builders include `status: 'published'` so replies that flow through for slicing remain subject to publication filtering (`packages/backend/src/utils/feedQueryBuilder.ts`).
- Add regression unit tests asserting parent lookups and Following/Explore queries require public/published posts (`packages/backend/src/__tests__/services/threadSlicingReplyContext.test.ts`, `packages/backend/src/__tests__/feedQueryBuilder.visibility.test.ts`).

### Testing

- Ran `git diff --check` which reported no whitespace errors.
- Added unit tests under `packages/backend/src/__tests__` to cover the new query constraints but could not execute them in this environment because the test runner binary is not present (`vitest: command not found`) when invoking `bun run test`.
- Manual code inspection and existing unit-test harness updates confirm the new Mongo predicates match the same `visibility`/`status` semantics used throughout other feed queries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d99062df8832388dc3dc472de1959)