### PR TITLE
fix(media): validate proxy URL before cache access

### DIFF
--- a/packages/backend/src/__tests__/routes/mediaProxy.test.ts
+++ b/packages/backend/src/__tests__/routes/mediaProxy.test.ts
@@ -21,10 +21,23 @@ vi.mock('../../middleware/rateLimitStore', () => ({
   },
 }));
 
-/** Keep the media cache front inert so the tests hit the remote-stream path. */
+const mediaCache = vi.hoisted(() => ({
+  enabled: false,
+  lookupCacheRow: vi.fn().mockResolvedValue(null),
+  bumpAccess: vi.fn().mockResolvedValue(undefined),
+  recordAccessAndMaybeEnqueue: vi.fn().mockResolvedValue(true),
+}));
+
+/** Keep the media cache front inert by default so tests hit the remote-stream path. */
 vi.mock('../../services/mediaCache/oxyMediaStore', () => ({
-  isMediaCacheEnabled: () => false,
+  isMediaCacheEnabled: () => mediaCache.enabled,
   resolveOxyDownloadUrl: vi.fn(),
+}));
+
+vi.mock('../../services/mediaCache/cacheStore', () => ({
+  lookupCacheRow: (...args: unknown[]) => mediaCache.lookupCacheRow(...args),
+  bumpAccess: (...args: unknown[]) => mediaCache.bumpAccess(...args),
+  recordAccessAndMaybeEnqueue: (...args: unknown[]) => mediaCache.recordAccessAndMaybeEnqueue(...args),
 }));
 
 /**
@@ -82,9 +95,26 @@ const REMOTE = 'https://remote.example/media/cat.jpg';
 
 describe('GET /media/proxy — upstream status mapping', () => {
   beforeEach(() => {
+    mediaCache.enabled = false;
     fetchUpstreamFollowingRedirects.mockReset();
+    mediaCache.lookupCacheRow.mockReset().mockResolvedValue(null);
+    mediaCache.bumpAccess.mockReset().mockResolvedValue(undefined);
+    mediaCache.recordAccessAndMaybeEnqueue.mockReset().mockResolvedValue(true);
     isNegativelyCached.mockReset().mockResolvedValue(false);
     markNegativelyCached.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('rejects unsafe URLs before cache lookup or enqueue when media cache is enabled', async () => {
+    mediaCache.enabled = true;
+
+    const res = await request(app).get('/media/proxy').query({ url: 'http://127.0.0.1:22/internal' });
+
+    expect(res.status).toBe(403);
+    expect(mediaCache.lookupCacheRow).not.toHaveBeenCalled();
+    expect(mediaCache.recordAccessAndMaybeEnqueue).not.toHaveBeenCalled();
+    expect(mediaCache.bumpAccess).not.toHaveBeenCalled();
+    expect(isNegativelyCached).not.toHaveBeenCalled();
+    expect(fetchUpstreamFollowingRedirects).not.toHaveBeenCalled();
   });
 
   it('maps an upstream 403 to our 404 (not 502) and negative-caches it', async () => {

--- a/packages/backend/src/routes/media.ts
+++ b/packages/backend/src/routes/media.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import { IncomingMessage } from 'node:http';
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { logger } from '../utils/logger';
+import { assertSafePublicUrl } from '../utils/ssrfGuard';
 import { RedisStore } from '../middleware/rateLimitStore';
 import {
   SsrfRejection,
@@ -368,8 +369,9 @@ function shouldNegativeCacheClientError(status: number, hasRequestSpecificUpstre
  * through our origin so the browser sees same-origin (CORS-safe), cacheable,
  * range-seekable bytes instead of hot-linking third-party CDNs.
  *
- * SECURITY: every upstream request — including hop 0 and each redirect hop — is
- * validated by `assertSafePublicUrl` inside `fetchUpstreamFollowingRedirects`
+ * SECURITY: the initial URL is validated before cache state is touched, then
+ * every upstream request — including hop 0 and each redirect hop — is validated
+ * again by `assertSafePublicUrl` inside `fetchUpstreamFollowingRedirects`
  * (BEFORE any socket is opened) and the TCP connection is pinned to the validated
  * IP. A blocked target surfaces as an `SsrfRejection` and maps to 403.
  */
@@ -377,6 +379,18 @@ router.get('/proxy', mediaProxyRateLimiter, async (req: Request, res: Response):
   const rawUrl = req.query.url;
   if (typeof rawUrl !== 'string' || rawUrl.length === 0) {
     res.status(HTTP_STATUS.BAD_REQUEST).json({ error: 'Missing required "url" query parameter' });
+    return;
+  }
+
+  // Validate before any cache lookup/write. The upstream fetch repeats this
+  // check immediately before opening a socket (and for every redirect hop), but
+  // the cache path can mutate DB state first when enabled. Keep this precheck so
+  // malformed or blocked unauthenticated inputs cannot pollute cache rows or
+  // enqueue background work.
+  const initialGuard = await assertSafePublicUrl(rawUrl);
+  if (!initialGuard.ok) {
+    logger.warn('[MediaProxy] Rejected initial URL', { reason: initialGuard.reason });
+    res.status(HTTP_STATUS.FORBIDDEN).json({ error: 'URL not permitted' });
     return;
   }
 


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated/malformed URLs from creating/updating `FederatedMediaCache` rows or enqueuing background work when `FEDERATION_MEDIA_CACHE_WRITE_ENABLED` is true. 
- The cache front previously ran before any SSRF/URL validation, allowing attacker-controlled strings to pollute DB state even when later rejected by the SSRF guard. 

### Description

- Added a pre-check call to `assertSafePublicUrl(rawUrl)` at the start of the `/media/proxy` handler to validate the URL before any cache lookup, bump, or enqueue is performed (`packages/backend/src/routes/media.ts`).
- Preserved the existing upstream validation inside `fetchUpstreamFollowingRedirects` (per-hop, socket-pin SSRF protection) and updated the route comment to document the two-stage validation.
- Added a regression test that enables the media cache and asserts unsafe URLs are rejected before any cache read/write or upstream fetch occurs in `packages/backend/src/__tests__/routes/mediaProxy.test.ts` (test: `rejects unsafe URLs before cache lookup or enqueue when media cache is enabled`).

### Testing

- Ran `git diff --check` to validate whitespace / diff sanity, which passed without errors. 
- Added a unit test in `packages/backend/src/__tests__/routes/mediaProxy.test.ts` to cover the regression case; the test code was committed. 
- Attempted to run `bun test packages/backend/src/__tests__/routes/mediaProxy.test.ts` but execution was blocked due to missing workspace dependencies (`express` et al.) in the environment, and `bun install` failed due to registry access returning 403, so tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5a4ca37c83239ba88684fbd1bca8)