### PR TITLE
fix(frontend): clear in-memory web feed/post cache on sign out

### DIFF
--- a/packages/frontend/app/(app)/settings/index.tsx
+++ b/packages/frontend/app/(app)/settings/index.tsx
@@ -19,6 +19,7 @@ import { confirmDialog } from "@/utils/alerts";
 import { createScopedLogger } from "@/lib/logger";
 import { useBloomTheme } from '@oxyhq/bloom/theme';
 import { useAppearanceStore } from '@/store/appearanceStore';
+import { clearViewerSessionCache } from '@/utils/sessionCache';
 
 const logger = createScopedLogger('SettingsScreen');
 
@@ -74,6 +75,7 @@ export default function SettingsScreen() {
         } catch (error) {
             logger.warn('Sign-out failed; resetting local state and navigating anyway', { error });
         }
+        clearViewerSessionCache();
         resetAppearance();
         resetTheme();
         router.replace('/');

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -34,6 +34,7 @@ import { Agora, AgoraActive } from '@mention/agora-shared';
 import { useAuth } from '@oxyhq/services';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { asViewStyle, type WebViewStyle } from '@/types/webStyles';
+import { clearViewerSessionCache } from '@/utils/sessionCache';
 
 const WindowHeight = Dimensions.get('window').height;
 
@@ -74,6 +75,7 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
         } catch (error: unknown) {
             logger.warn('Sign out failed', { error });
         }
+        clearViewerSessionCache();
         resetAppearance();
         resetTheme();
         onNavigate?.();

--- a/packages/frontend/db/__tests__/memoryStore.test.ts
+++ b/packages/frontend/db/__tests__/memoryStore.test.ts
@@ -1,0 +1,45 @@
+import {
+  memSetFeedItems,
+  memGetPostById,
+  memGetAllFeedItems,
+  memClearAll,
+  memClearAllFeeds,
+} from '../memoryStore';
+import type { FeedItem } from '../schema';
+
+describe('memoryStore session clearing', () => {
+  const post = {
+    id: 'private-post-1',
+    content: { text: 'private content' },
+  } as unknown as FeedItem;
+
+  afterEach(() => {
+    memClearAll();
+  });
+
+  it('clears feed indexes without deleting cached posts', () => {
+    memSetFeedItems('profile:alice:posts', [post], {
+      hasMore: false,
+      totalCount: 1,
+      lastUpdated: Date.now(),
+    });
+
+    memClearAllFeeds();
+
+    expect(memGetAllFeedItems('profile:alice:posts')).toEqual([]);
+    expect(memGetPostById('private-post-1')).toBe(post);
+  });
+
+  it('clears posts and feed data for viewer session changes', () => {
+    memSetFeedItems('profile:alice:posts', [post], {
+      hasMore: false,
+      totalCount: 1,
+      lastUpdated: Date.now(),
+    });
+
+    memClearAll();
+
+    expect(memGetPostById('private-post-1')).toBeNull();
+    expect(memGetAllFeedItems('profile:alice:posts')).toEqual([]);
+  });
+});

--- a/packages/frontend/db/feedQueries.ts
+++ b/packages/frontend/db/feedQueries.ts
@@ -21,6 +21,7 @@ import {
   memAddFeedItemAtStart,
   memRemovePostFromAllFeeds,
   memClearFeed,
+  memClearAllFeeds,
 } from './memoryStore';
 import { createScopedLogger } from '@/lib/logger';
 
@@ -465,6 +466,11 @@ export function clearFeed(feedKey: string): void {
  * Clear all feeds.
  */
 export function clearAllFeeds(): void {
+  if (!isDbAvailable()) {
+    memClearAllFeeds();
+    return;
+  }
+
   const db = getDb();
   if (!db) return;
   try {

--- a/packages/frontend/db/index.ts
+++ b/packages/frontend/db/index.ts
@@ -7,6 +7,7 @@
 // Core
 export type { SQLiteDb } from './database';
 export { getDb, closeDb, resetDb, isDbAvailable } from './database';
+export { memClearAll as clearMemoryStore } from './memoryStore';
 
 // Schema types & conversions
 export type {

--- a/packages/frontend/db/memoryStore.ts
+++ b/packages/frontend/db/memoryStore.ts
@@ -216,3 +216,13 @@ export function memClearFeed(feedKey: string): void {
   feedItems.delete(feedKey);
   feedMeta.delete(feedKey);
 }
+
+export function memClearAllFeeds(): void {
+  feedItems.clear();
+  feedMeta.clear();
+}
+
+export function memClearAll(): void {
+  posts.clear();
+  memClearAllFeeds();
+}

--- a/packages/frontend/utils/sessionCache.ts
+++ b/packages/frontend/utils/sessionCache.ts
@@ -1,0 +1,11 @@
+/**
+ * Helpers for clearing viewer-scoped client caches when the authenticated
+ * session changes. Web without SQLite uses process-local Maps for feed/post
+ * reads; those caches must not survive sign-out into another local session.
+ */
+
+import { clearMemoryStore } from '@/db';
+
+export function clearViewerSessionCache(): void {
+  clearMemoryStore();
+}


### PR DESCRIPTION
### Motivation
- The web fallback memory store (used when SQLite/SharedArrayBuffer is unavailable) held process-global post/feed maps keyed only by post id, allowing cached private or viewer-scoped posts to persist across a same-tab sign-out and be visible to the next local user.
- The change prevents a client-side confidentiality leak by ensuring viewer-scoped in-memory caches are cleared when the authenticated session changes.

### Description
- Add full in-memory clearing helpers (`memClearAll`, `memClearAllFeeds`) to the web fallback store and route `clearAllFeeds()` to the memory clear path when SQLite is unavailable (`packages/frontend/db/memoryStore.ts`, `packages/frontend/db/feedQueries.ts`).
- Export a memory-store clear wrapper from the DB barrel as `clearMemoryStore` and expose a small session helper `clearViewerSessionCache()` for sign-out flows (`packages/frontend/db/index.ts`, `packages/frontend/utils/sessionCache.ts`).
- Invoke `clearViewerSessionCache()` from both visible sign-out flows so the in-process memory cache cannot survive sign-out (`packages/frontend/components/SideBar/index.tsx`, `packages/frontend/app/(app)/settings/index.tsx`).
- Add a focused unit test that verifies feed-only clearing versus full session-cache clearing semantics for the memory store (`packages/frontend/db/__tests__/memoryStore.test.ts`).

### Testing
- Added a unit test `packages/frontend/db/__tests__/memoryStore.test.ts` that validates `memClearAllFeeds()` preserves posts and `memClearAll()` clears posts and indexes; test file added but could not be executed in this environment because the `jest` binary was not available in `node_modules` (test run blocked).
- Ran a quick static sanity check (`git diff --check`) which reported no whitespace/merge issues (succeeded in this environment).
- Attempted TypeScript typecheck (`bun run --cwd packages/frontend typecheck`) but it failed here because the `tsc` binary is not present in `node_modules` (typecheck blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5a4b4fe4832397f1e42548b19105)