### PR TITLE
Enforce ACL and existence checks for entity follow operations (feeds & lists)

### DIFF
--- a/packages/backend/src/routes/entity-follow.routes.ts
+++ b/packages/backend/src/routes/entity-follow.routes.ts
@@ -1,5 +1,7 @@
 import { Router, Response } from 'express';
 import { EntityFollow } from '../models/EntityFollow';
+import { CustomFeed } from '../models/CustomFeed';
+import { AccountList } from '../models/AccountList';
 import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { logger } from '../utils/logger';
 import { listSubscriptionService, LIST_ENTITY_TYPE } from '../services/ListSubscriptionService';
@@ -7,9 +9,39 @@ import { listSubscriptionService, LIST_ENTITY_TYPE } from '../services/ListSubsc
 const router = Router();
 
 const VALID_ENTITY_TYPES = ['hashtag', 'feed', 'list', 'topic'] as const;
+type EntityType = (typeof VALID_ENTITY_TYPES)[number];
+type AccessError = { status: number; message: string };
 
 function isValidEntityType(type: string): type is (typeof VALID_ENTITY_TYPES)[number] {
   return (VALID_ENTITY_TYPES as readonly string[]).includes(type);
+}
+
+async function assertEntityFollowAccess(
+  entityType: EntityType,
+  entityId: string,
+  userId: string,
+): Promise<AccessError | null> {
+  if (entityType === 'feed') {
+    const feed = await CustomFeed.findById(entityId).select('isPublic ownerOxyUserId').lean();
+    if (!feed) {
+      return { status: 404, message: 'Feed not found' };
+    }
+    if (!feed.isPublic && feed.ownerOxyUserId !== userId) {
+      return { status: 403, message: 'Not allowed' };
+    }
+  }
+
+  if (entityType === LIST_ENTITY_TYPE) {
+    const list = await AccountList.findById(entityId).select('isPublic ownerOxyUserId').lean();
+    if (!list) {
+      return { status: 404, message: 'List not found' };
+    }
+    if (!list.isPublic && list.ownerOxyUserId !== userId) {
+      return { status: 403, message: 'Not allowed' };
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -31,6 +63,11 @@ router.post('/', async (req: AuthRequest, res: Response) => {
 
     if (!isValidEntityType(entityType)) {
       return res.status(400).json({ message: `entityType must be one of: ${VALID_ENTITY_TYPES.join(', ')}` });
+    }
+
+    const accessError = await assertEntityFollowAccess(entityType, entityId, userId);
+    if (accessError) {
+      return res.status(accessError.status).json({ message: accessError.message });
     }
 
     const follow = new EntityFollow({ userId, entityType, entityId });
@@ -197,6 +234,11 @@ router.get('/:entityType/:entityId/followers', async (req: AuthRequest, res: Res
 
     if (!isValidEntityType(entityType)) {
       return res.status(400).json({ message: `entityType must be one of: ${VALID_ENTITY_TYPES.join(', ')}` });
+    }
+
+    const accessError = await assertEntityFollowAccess(entityType, entityId, userId);
+    if (accessError) {
+      return res.status(accessError.status).json({ message: accessError.message });
     }
 
     const limit = Math.min(Math.max(parseInt(String(req.query.limit || 20), 10), 1), 50);


### PR DESCRIPTION
### Motivation
- The EntityFollow API allowed authenticated users to create follows for arbitrary `feed`/`list` IDs and to list followers without verifying the target exists or is accessible, which can disclose private follower metadata. 
- Existing `CustomFeed` and `AccountList` routes enforce public-or-owner ACLs, but the generic entity-follow endpoints bypassed those checks. 
- This change closes that authorization gap by ensuring feed/list follows and follower queries consult the same existence and privacy rules.

### Description
- Add imports for `CustomFeed` and `AccountList` and introduce a shared helper `assertEntityFollowAccess(entityType, entityId, userId)` that verifies existence and enforces `isPublic || owner` for `feed` and `list` entity types in `packages/backend/src/routes/entity-follow.routes.ts`.
- Apply the access helper before creating an `EntityFollow` (POST `/entity-follows`) to prevent following nonexistent or private feeds/lists, and before returning follower lists (GET `/entity-follows/:entityType/:entityId/followers`) to prevent disclosure of private follower records.
- Preserve existing behavior for list subscriber bookkeeping (`listSubscriptionService.incrementSubscriberCount` / `decrementSubscriberCount`) and follow uniqueness handling; add small types for clarity (`EntityType`, `AccessError`).

### Testing
- Ran `git diff --check` which passed locally. (verification of no whitespace/errors in diff)
- Attempted dependency install with `bun install --frozen-lockfile`, which failed due to external registry `403` responses so a full install could not be performed. (blocked)
- Attempted to build the backend with `bun run build:backend` and run `tsc --noEmit`, which could not complete due to TypeScript / environment issues (existing tsconfig deprecation and missing type packages after the failed install). (blocked)
- No automated integration/unit tests were completed because the environment prevented installing dependencies and running the TypeScript build/test pipeline; the change is intentionally minimal and localized to the entity-follow route to limit risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d93e3a9708323a7f3762ee4042c21)