### PR TITLE
fix: enforce actor validation before profile outbox sync

### DIFF
--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -1012,31 +1012,12 @@ class FeedController {
 
           if (!actor) {
             // The remote actor fetch failed (network error, blocked domain,
-            // unauthorized fetch, etc.). Fall back to a minimal FederatedActor
-            // with a guessed outbox so the sync can still attempt Mastodon-style
-            // layouts; the enqueued background refresh will correct it later.
-            const domain = new URL(actorUri).hostname;
-            const username = (acctHint || '').split('@')[0] || 'unknown';
-            const acct = `${username}@${domain}`;
-            const fallbackOutboxUrl = `${actorUri}${actorUri.endsWith('/') ? '' : '/'}outbox`;
-            logger.info(`[FedSync] fetchRemoteActor failed for ${actorUri}; creating minimal FederatedActor with fallback outboxUrl=${fallbackOutboxUrl}`);
-            actor = await FederatedActor.findOneAndUpdate(
-              { uri: actorUri },
-              {
-                $set: {
-                  uri: actorUri,
-                  username,
-                  domain,
-                  acct,
-                  inboxUrl: `${actorUri}${actorUri.endsWith('/') ? '' : '/'}inbox`,
-                  outboxUrl: fallbackOutboxUrl,
-                  oxyUserId: syncUserId,
-                  lastFetchedAt: new Date(0), // Mark stale so the refresh below runs
-                },
-                $setOnInsert: { type: 'Person', manuallyApprovesFollowers: false, discoverable: true, memorial: false, suspended: false, fields: [], followersCount: 0, followingCount: 0, postsCount: 0 },
-              },
-              { upsert: true, returnDocument: 'after', lean: true },
-            ) as IFederatedActor | null;
+            // unauthorized fetch, malformed actor document, etc.). Do not create
+            // a guessed minimal FederatedActor here: `fetchRemoteActor` is the
+            // validation boundary that rejects local/blocked domains and actors
+            // without required fields before any outbox import can run.
+            logger.info(`[FedSync] fetchRemoteActor failed for ${actorUri}; skipping profile outbox sync`);
+            return;
           } else {
             await stampActorOxyUserId();
           }


### PR DESCRIPTION
### Motivation
- Prevent a validation bypass where a guessed minimal `FederatedActor` was created when `fetchRemoteActor` failed, which allowed outbox import from blocked/local domains on unauthenticated profile views.

### Description
- Remove the fallback that upserted a guessed minimal `FederatedActor` when `federationService.fetchRemoteActor(actorUri, ...)` returned `null`, and instead abort the background profile outbox sync in that case.
- Preserve the validation boundary provided by `fetchRemoteActor` (including `isBlockedDomain` and required-field checks) and keep stamping `oxyUserId` only after a valid actor is returned.
- Change is localized to `runFederatedProfileSyncInBackground` in `packages/backend/src/controllers/feed.controller.ts`.

### Testing
- `rg` search confirmed the old fallback strings (e.g. `creating minimal FederatedActor`, `fallback outbox`) are no longer present; verification succeeded.
- `cd packages/backend && bun run test` was attempted but tests did not run because `vitest` was not available in the execution environment (`command not found`).
- `bun install --frozen-lockfile` was attempted but failed due to npm registry `403` errors preventing dependency installation, so no automated test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d93e3a4c48323bbd65eb70c13567f)