### PR TITLE
Fix federated backfill activity ID prefix query

### DIFF
--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -1112,7 +1112,10 @@ class FeedController {
           // Backfill oxyUserId on any posts that were stored without it
           if (syncedCount > 0) {
             await Post.updateMany(
-              { 'federation.activityId': { $regex: `^${actor.uri}` }, oxyUserId: null },
+              {
+                'federation.activityId': { $gte: actor.uri + '/', $lt: actor.uri + '/\uffff' },
+                oxyUserId: null,
+              },
               { $set: { oxyUserId: syncUserId } },
             );
           }


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled ActivityPub actor URIs from being interpreted as regex syntax during the orphaned-post backfill, which could misassign `oxyUserId` to unrelated posts or cause expensive regex scans.

### Description
- Replace the unescaped regex backfill with a literal indexed range query in `packages/backend/src/controllers/feed.controller.ts`, using `{'federation.activityId': { $gte: actor.uri + '/', $lt: actor.uri + '/\uffff' }}` to restrict matches to the actor's activity ID namespace.

### Testing
- Ran a pre-commit check (`git diff --check`) and committed the fix; an attempt to run the backend test `cd packages/backend && bun run test -- src/__tests__/utils/outboxSyncCooldown.test.ts` failed because `vitest` is not available in this environment, so no unit tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d93e3d8288323adc1afc156af933a)