### PR TITLE
fix: dedupe federated profile background syncs

### DIFF
--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -69,6 +69,14 @@ const OUTBOX_SYNC_MIN_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 const FEDERATED_ACTOR_PROFILE_STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /**
+ * Process-local in-flight guard for public profile-triggered federated syncs.
+ * This keeps repeated empty profile-feed requests from spawning overlapping
+ * outbound ActivityPub/Oxy work for the same actor/user while preserving the
+ * non-blocking response behavior.
+ */
+const federatedProfileSyncsInFlight = new Set<string>();
+
+/**
  * A follower/mention reference may arrive as a bare user-id string or as a
  * populated object carrying `id`/`_id`. Used when checking reply permissions.
  */
@@ -961,6 +969,13 @@ class FeedController {
   private runFederatedProfileSyncInBackground(syncUserId: string, cachedActor?: IFederatedActor): void {
     if (!FEDERATION_ENABLED) return;
 
+    const syncKey = syncUserId;
+    if (federatedProfileSyncsInFlight.has(syncKey)) {
+      logger.info(`[FedSync] background profile sync skipped (in-flight) for userId=${syncUserId} key=${syncKey}`);
+      return;
+    }
+    federatedProfileSyncsInFlight.add(syncKey);
+
     void (async () => {
       try {
         let actor: IFederatedActor | null = cachedActor ?? null;
@@ -1120,6 +1135,8 @@ class FeedController {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.warn(`[FedSync] background profile sync failed for userId=${syncUserId}: ${message}`);
+      } finally {
+        federatedProfileSyncsInFlight.delete(syncKey);
       }
     })();
   }


### PR DESCRIPTION
### Motivation

- Prevent public profile GETs from spawning many overlapping detached federated outbox-sync jobs for the same user, which allowed resource-exhaustion / cost-abuse on outbound federation I/O.

### Description

- Add a process-local in-flight guard `federatedProfileSyncsInFlight: Set<string>` to track active background profile syncs.  
- Skip launching a new detached sync when a sync for the same `syncUserId` is already in-flight and log the skip.  
- Ensure the in-flight marker is removed in a `finally` block so the guard is cleared whether the background sync succeeds or fails.  
- Preserve the non-blocking behavior of `getUserProfileFeed` so the feed response still returns immediately while background work runs off the request path.

### Testing

- Ran `git diff --check` which reported no local diff issues.  
- Attempted `bun run build:backend` which invokes `tsc`, but the TypeScript compile failed due to a preexisting deprecation warning/error in `packages/shared-types/tsconfig.json` (`moduleResolution=node10`) unrelated to this change, so a full backend build was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d93e463a88323ab0803f4ff9c999a)