### PR TITLE
Fix private post topic metadata exposure

### DIFF
--- a/packages/backend/src/__tests__/services/postClassification.test.ts
+++ b/packages/backend/src/__tests__/services/postClassification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ClassificationTopicRef } from '@mention/shared-types';
+import { PostVisibility, type ClassificationTopicRef } from '@mention/shared-types';
 
 /**
  * Unit coverage for the AI post-classification batch service.
@@ -421,6 +421,19 @@ describe('PostClassificationService — Stage-A baseline preservation', () => {
 });
 
 describe('PostClassificationService — canonical topicRefs resolution', () => {
+  it('only selects public posts for AI topic registry resolution', async () => {
+    findResult.docs = [];
+
+    await postClassificationService.processQueue();
+
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(find.mock.calls[0][0]).toMatchObject({
+      status: 'published',
+      visibility: PostVisibility.PUBLIC,
+      boostOf: { $exists: false },
+    });
+  });
+
   it('resolves AI-refined topics into registry-linked topicRefs (preserving topicId linkage)', async () => {
     findResult.docs = [post('refs_post', 'A post about basketball and the lakers.')];
     aliaJSON.mockResolvedValue([

--- a/packages/backend/src/__tests__/services/trendingService.test.ts
+++ b/packages/backend/src/__tests__/services/trendingService.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PostVisibility } from '@mention/shared-types';
 
 /**
  * Unit coverage for {@link TrendingService} NSFW/sensitive exclusion.
@@ -133,6 +134,9 @@ describe('TrendingService.aggregateTopics — canonical topicRefs source with sl
     ]);
     // The window is keyed on the post createdAt (shared time basis for both sources).
     expect(firstMatch.createdAt).toHaveProperty('$gte');
+    // Public trend/topic endpoints must never aggregate topics from private or
+    // followers-only posts.
+    expect(firstMatch.visibility).toBe(PostVisibility.PUBLIC);
 
     // An $addFields stage computes the unified `_topicSource`: topicRefs when
     // non-empty, else the slug-only `postClassification.topics` mapped to `{ name }`.

--- a/packages/backend/src/services/PostClassificationService.ts
+++ b/packages/backend/src/services/PostClassificationService.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { AnyBulkWriteOperation, Types } from 'mongoose';
 import { Post, type IPost } from '../models/Post';
-import type { PostClassificationScores } from '@mention/shared-types';
+import { PostVisibility, type PostClassificationScores } from '@mention/shared-types';
 import { aliaJSON, isAliaEnabled } from '../utils/alia';
 import { logger } from '../utils/logger';
 import { config } from '../config';
@@ -208,6 +208,7 @@ class PostClassificationService {
       ...UNCLASSIFIED_FILTER,
       'content.text': { $exists: true, $ne: '' },
       status: 'published',
+      visibility: PostVisibility.PUBLIC,
       boostOf: { $exists: false },
     })
       .select({ 'content.text': 1, createdAt: 1, 'postClassification.attempts': 1 })

--- a/packages/backend/src/services/TrendingService.ts
+++ b/packages/backend/src/services/TrendingService.ts
@@ -1,6 +1,6 @@
 import { Post } from '../models/Post';
 import Trending, { TrendingType, ITrending } from '../models/Trending';
-import { TopicType } from '@mention/shared-types';
+import { PostVisibility, TopicType } from '@mention/shared-types';
 import TrendBatch from '../models/TrendBatch';
 import { logger } from '../utils/logger';
 import { getRedisClient } from '../utils/redis';
@@ -227,6 +227,7 @@ class TrendingService {
         $match: {
           createdAt: { $gte: oneDayAgo },
           status: 'published',
+          visibility: PostVisibility.PUBLIC,
           boostOf: { $exists: false },
           // At least one topic source must be present.
           $or: [


### PR DESCRIPTION
### Motivation

- The async topic extraction/classification and trending aggregation pipelines were deriving and publishing canonical `Topic` metadata from posts without enforcing `visibility: 'public'`, allowing topics from `followers_only` or `private` posts to be materialized and exposed via public `/topics` endpoints.
- This change prevents leakage of sensitive metadata and aggregate counts derived from non-public posts by ensuring only public posts contribute to registry linkage and trending/popularity metrics.

### Description

- Restrict the AI classification batch selection to only include public published posts by adding a `visibility: PostVisibility.PUBLIC` predicate to the `Post.find` query in `PostClassificationService.classifyBatch` and import `PostVisibility` from `@mention/shared-types`.
- Restrict trending topic aggregation to public published posts by adding `visibility: PostVisibility.PUBLIC` to the `$match` pipeline in `TrendingService.aggregateTopics` and import `PostVisibility` where needed.
- Add regression assertions to unit tests to ensure the visibility gates remain enforced by updating `packages/backend/src/__tests__/services/postClassification.test.ts` and `packages/backend/src/__tests__/services/trendingService.test.ts`.

### Testing

- Ran `git diff --check` and verified the code changes and test updates are staged and committed successfully (local checks passed).
- Attempted to run the updated unit tests with `bun run test -- src/__tests__/services/postClassification.test.ts src/__tests__/services/trendingService.test.ts` but test execution is blocked in this environment because `vitest` and other dependencies could not be installed (`bun install` failed due to registry 403 responses), so full test execution could not be completed here.
- Added focused unit assertions that cover the new visibility predicates (`PostVisibility.PUBLIC`) in the updated test files; these tests should pass in CI once `npm`/`bun` dependencies are available and `vitest` runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d93e3ba808323bf7407576d86f693)