### PR TITLE
feat(backend): host-aware apex frontend reverse-proxy (bskyweb-full)

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -65,6 +65,7 @@ import mediaRoutes from './src/routes/media';
 import recommendationsRoutes from './src/routes/recommendations';
 import mtnNodesRoutes from './src/routes/mtn-nodes.routes';
 import webShellRoutes from './src/routes/webShell.routes';
+import { apexFrontendProxy, isApexHost } from './src/middleware/apexFrontendProxy';
 
 // Federation (ActivityPub) — network connectors. Importing the connectors index
 // instantiates the enabled connectors and registers the connector registry as
@@ -815,7 +816,12 @@ authenticatedApiRouter.use("/entity-follows", entityFollowRoutes);
 // shared pack links resolve during cold boot; its write routes enforce auth internally.
 
 // --- Root API Welcome Route ---
-app.get("", async (req, res) => {
+// On the API host `/` is the API root; on the frontend apex `/` is the SPA
+// homepage, so defer to the apex frontend proxy (mounted below) for apex hosts.
+app.get("", async (req, res, next) => {
+  if (isApexHost(req)) {
+    return next();
+  }
   try {
     const postsCount = await Post.countDocuments();
     res.json({ message: "Welcome to the API", posts: postsCount });
@@ -918,17 +924,29 @@ app.use('/.well-known', wellKnownBridgeRouter);
 // public path is exactly `/media/proxy`. SSRF-guarded internally.
 app.use('/media', mediaRoutes);
 
-// Mount public and authenticated API routers
-app.use("/", publicApiRouter);
-
 // --- Public web shell with OpenGraph (PUBLIC, no auth) ---
 // Serves the SPA shell HTML with per-request OG tags for `/@handle` and `/p/:id`
 // (the `bskyweb` model — replaces the retired CF Pages `_worker.js` OG injection).
-// Mounted LAST among the public routes and BEFORE the authenticated router so
-// anonymous browsers/crawlers reach it — the auth router's oxy.auth() middleware
-// would otherwise reject these public page loads. Its RegExp routes (`/@…`, `/p/…`)
-// do not collide with any API/federation mount.
+// Mounted BEFORE the apex proxy and the API routers so anonymous browsers/crawlers
+// reach it (the auth router's oxy.auth() would otherwise reject these public page
+// loads) AND so apex `/@handle` / `/p/:id` get the OG-injected shell rather than a
+// dumb CDN proxy. Its RegExp routes (`/@…`, `/p/…`) do not collide with any
+// API/federation mount.
 app.use("/", webShellRoutes);
+
+// --- Apex frontend reverse-proxy (host-aware; the "bskyweb-full" model) ---
+// For the frontend apex host (`mention.earth`) this proxies every remaining
+// request (`/`, `/explore`, `/feed`, `/notifications`, `/lists`, `/starter-packs`,
+// `/_expo/*`, …) to the static frontend CDN so the apex serves the whole SPA. It
+// is a STRICT no-op (`next()`) for the API host, so the API routers below are
+// reached ONLY by non-apex hosts and behave exactly as before. Must sit BEFORE the
+// API routers so apex SPA routes whose prefixes collide with API mounts are
+// proxied to the SPA instead of hitting the API.
+app.use(apexFrontendProxy);
+
+// Mount public and authenticated API routers (API host only — apex traffic was
+// already handled by the proxy above).
+app.use("/", publicApiRouter);
 
 app.use("/", oxy.auth(), authenticatedApiRouter);
 

--- a/packages/backend/src/__tests__/apexFrontendProxy.integration.test.ts
+++ b/packages/backend/src/__tests__/apexFrontendProxy.integration.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+import { apexFrontendProxy, isApexHost } from '../middleware/apexFrontendProxy';
+
+/** SPA shell the mocked frontend CDN returns for any proxied request. */
+const SPA_SHELL =
+  '<!DOCTYPE html><html lang="en"><head><title>Mention</title></head>' +
+  '<body><div id="root"></div><script src="/_expo/static/js/web/entry.js" defer></script></body></html>';
+
+/**
+ * Build an app that mirrors server.ts's relevant mount order: the host-gated root
+ * welcome route, then the apex proxy, then stub API routes. The stub API routes let
+ * us prove that on the apex host a colliding path (`/feed`) is proxied to the SPA
+ * rather than hitting the API, while on the API host it hits the API.
+ */
+function makeApp() {
+  const app = express();
+  app.set('trust proxy', 1);
+
+  // Root welcome, host-gated exactly like server.ts.
+  app.get('', (req, res, next) => {
+    if (isApexHost(req)) return next();
+    res.json({ who: 'api-welcome' });
+  });
+
+  app.use(apexFrontendProxy);
+
+  // Stub API routes (only reached by the API host after the proxy no-ops).
+  app.get('/feed', (_req, res) => res.json({ who: 'api-feed' }));
+  app.get('/feed/item/:id', (req, res) => res.json({ who: 'api-feed-item', id: req.params.id }));
+
+  return app;
+}
+
+/** Stub `global.fetch` so the CDN returns the SPA shell; returns the mock for URL assertions. */
+function stubCdn(overrides?: { status?: number; cacheControl?: string; contentType?: string; fail?: boolean }) {
+  const fetchMock = vi.fn(async (_url: string | URL) => {
+    if (overrides?.fail) throw new Error('CDN unreachable');
+    return {
+      status: overrides?.status ?? 200,
+      headers: new Headers({
+        'content-type': overrides?.contentType ?? 'text/html; charset=utf-8',
+        'cache-control': overrides?.cacheControl ?? 'public, max-age=0, must-revalidate',
+      }),
+      arrayBuffer: async () => new TextEncoder().encode(SPA_SHELL).buffer,
+    } as unknown as Response;
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+const APEX = 'mention.earth';
+const API = 'api.mention.earth';
+
+describe('apexFrontendProxy (host-aware reverse-proxy)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('proxies apex `/` to the frontend CDN (SPA homepage, not the API welcome)', async () => {
+    const fetchMock = stubCdn();
+
+    const res = await request(makeApp()).get('/').set('X-Forwarded-Host', APEX);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.text).toContain('id="root"');
+    expect(res.body.who).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe('https://mention-frontend.pages.dev/');
+  });
+
+  it('proxies an apex SPA route (`/explore`) to the CDN, preserving path + query', async () => {
+    const fetchMock = stubCdn();
+
+    const res = await request(makeApp()).get('/explore?tab=news').set('X-Forwarded-Host', APEX);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('id="root"');
+    expect(String(fetchMock.mock.calls[0][0])).toBe('https://mention-frontend.pages.dev/explore?tab=news');
+  });
+
+  it('proxies apex `/feed` to the SPA instead of hitting the API feed route', async () => {
+    const fetchMock = stubCdn();
+
+    const res = await request(makeApp()).get('/feed').set('X-Forwarded-Host', APEX);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('id="root"');
+    expect(res.body.who).toBeUndefined(); // NOT { who: 'api-feed' }
+    expect(String(fetchMock.mock.calls[0][0])).toBe('https://mention-frontend.pages.dev/feed');
+  });
+
+  it('passes the CDN content-type and cache-control through (so CF can edge-cache)', async () => {
+    stubCdn({ contentType: 'application/javascript', cacheControl: 'public, max-age=31536000, immutable' });
+
+    const res = await request(makeApp())
+      .get('/_expo/static/js/web/entry-abc123.js')
+      .set('X-Forwarded-Host', APEX);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('application/javascript');
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+  });
+
+  it('does NOT proxy the API host — `/feed/item/:id` still hits the API', async () => {
+    const fetchMock = stubCdn();
+
+    const res = await request(makeApp()).get('/feed/item/507f1f77bcf86cd799439011').set('X-Forwarded-Host', API);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ who: 'api-feed-item', id: '507f1f77bcf86cd799439011' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT proxy the API host root — `/` returns the API welcome', async () => {
+    const fetchMock = stubCdn();
+
+    const res = await request(makeApp()).get('/').set('X-Forwarded-Host', API);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ who: 'api-welcome' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT proxy when there is no apex host at all (bare/unknown host)', async () => {
+    const fetchMock = stubCdn();
+
+    const res = await request(makeApp()).get('/feed'); // no X-Forwarded-Host → 127.0.0.1
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ who: 'api-feed' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('answers 405 for a non-GET/HEAD method on the apex host without proxying', async () => {
+    const fetchMock = stubCdn();
+
+    const res = await request(makeApp()).post('/feed').set('X-Forwarded-Host', APEX);
+
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe('GET, HEAD');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails soft with a 502 bootable shell when the CDN is unreachable', async () => {
+    stubCdn({ fail: true });
+
+    const res = await request(makeApp()).get('/explore').set('X-Forwarded-Host', APEX);
+
+    expect(res.status).toBe(502);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.text).toContain('id="root"');
+  });
+
+  describe('isApexHost', () => {
+    it('matches the apex via the first X-Forwarded-Host token', () => {
+      const req = { headers: { 'x-forwarded-host': 'mention.earth, other.internal' }, hostname: '' } as unknown as express.Request;
+      expect(isApexHost(req)).toBe(true);
+    });
+
+    it('does not match the API host', () => {
+      const req = { headers: { 'x-forwarded-host': 'api.mention.earth' }, hostname: 'api.mention.earth' } as unknown as express.Request;
+      expect(isApexHost(req)).toBe(false);
+    });
+
+    it('ignores a :port suffix when matching', () => {
+      const req = { headers: { 'x-forwarded-host': 'mention.earth:443' }, hostname: '' } as unknown as express.Request;
+      expect(isApexHost(req)).toBe(true);
+    });
+  });
+});

--- a/packages/backend/src/middleware/apexFrontendProxy.ts
+++ b/packages/backend/src/middleware/apexFrontendProxy.ts
@@ -1,0 +1,162 @@
+/**
+ * Host-aware apex frontend reverse-proxy — the "bskyweb-full" model.
+ *
+ * When the frontend apex host (`mention.earth`) resolves to THIS backend (via the
+ * ALB), every request that isn't a federation endpoint or an OG web-shell page
+ * must be served the static Expo frontend. This middleware reverse-proxies those
+ * apex requests to the frontend's static CDN (CloudFlare Pages) so we can point
+ * `mention.earth` DNS at the ALB and retire the CF Pages `_worker.js`.
+ *
+ * It is a STRICT no-op for the API host (`api.mention.earth`): a non-apex request
+ * calls `next()` untouched, so every existing API route behaves exactly as before.
+ *
+ * Mount order (see server.ts): it runs AFTER the federation routers (`/ap`,
+ * `/.well-known`, `/xrpc`, `/nodeinfo`, `/media`) and the OG web-shell (`/@…`,
+ * `/p/…`) — those must keep serving their own content on the apex host too — but
+ * BEFORE the API routers, so apex SPA routes whose prefixes collide with API
+ * mounts (`/feed`, `/notifications`, `/lists`, `/starter-packs`, `/topics`,
+ * `/trending`, `/articles`, `/recommendations`, `/hashtags`, `/feeds`, …) are
+ * proxied to the SPA instead of hitting the API. The SPA fetches the API from
+ * `api.mention.earth`, so those apex paths are always frontend routes.
+ *
+ * Fail-soft: a slow/broken CDN yields a 502 with a minimal bootable shell rather
+ * than a crash or a hung apex.
+ */
+import type { Request, Response, NextFunction } from 'express';
+import { logger } from '../utils/logger';
+
+/**
+ * The frontend apex host (`mention.earth`). Derived from the SAME `MENTION_WEB_ORIGIN`
+ * config the OG web-shell renderer uses, so the public web origin is defined in one
+ * place. Only the bare hostname (no scheme / port) is compared.
+ */
+const APEX_HOST = extractHost(process.env.MENTION_WEB_ORIGIN || 'https://mention.earth');
+
+/**
+ * Static frontend CDN the SPA + its assets are proxied from (CloudFlare Pages).
+ * Reuses `WEB_SHELL_ORIGIN` — the same origin the OG web-shell fetches its shell
+ * from — so the CDN origin is configured in exactly one place. Trailing slash is
+ * stripped so it concatenates cleanly with `req.originalUrl` (which starts `/`).
+ */
+const FRONTEND_CDN_ORIGIN = (process.env.WEB_SHELL_ORIGIN || 'https://mention-frontend.pages.dev').replace(/\/+$/, '');
+
+/** Hard timeout for a single upstream proxy fetch. The apex must never hang on a slow CDN. */
+const PROXY_FETCH_TIMEOUT_MS = 8000;
+
+/**
+ * Minimal, valid HTML returned only when the CDN is unreachable — never a crash,
+ * never a blank 500. Browsers hitting this rare state reboot the SPA once the CDN
+ * recovers.
+ */
+const PROXY_FALLBACK_HTML =
+  '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">' +
+  '<meta name="viewport" content="width=device-width, initial-scale=1"><title>Mention</title>' +
+  '</head><body><div id="root"></div></body></html>';
+
+/** Extract a bare lowercase hostname (no scheme, no port) from an origin URL or host string. */
+function extractHost(origin: string): string {
+  const withScheme = /^https?:\/\//i.test(origin) ? origin : `https://${origin}`;
+  try {
+    return new URL(withScheme).hostname.toLowerCase();
+  } catch {
+    return origin.replace(/^https?:\/\//i, '').replace(/[:/].*$/, '').toLowerCase();
+  }
+}
+
+/** Normalize a `Host` / `X-Forwarded-Host` token to a bare lowercase hostname (drops any `:port`). */
+function normalizeHost(value: string): string {
+  return value.trim().toLowerCase().replace(/:\d+$/, '');
+}
+
+/**
+ * True when the request targets the frontend apex (`mention.earth`) rather than the
+ * API host (`api.mention.earth`). Checks the ALB-forwarded `X-Forwarded-Host`
+ * (first token — the original client host) AND Express's resolved `req.hostname`
+ * (which also honors `X-Forwarded-Host` under `trust proxy`). Non-apex hosts are API.
+ */
+export function isApexHost(req: Request): boolean {
+  const forwarded = req.headers['x-forwarded-host'];
+  const forwardedValue = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+  if (forwardedValue) {
+    const first = forwardedValue.split(',')[0];
+    if (first && normalizeHost(first) === APEX_HOST) return true;
+  }
+  if (req.hostname && normalizeHost(req.hostname) === APEX_HOST) return true;
+  return false;
+}
+
+/** Reverse-proxy one apex request to the static frontend CDN. Fail-soft: never throws, never hangs. */
+async function proxyToFrontend(req: Request, res: Response): Promise<void> {
+  const target = `${FRONTEND_CDN_ORIGIN}${req.originalUrl}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROXY_FETCH_TIMEOUT_MS);
+  try {
+    const upstream = await fetch(target, {
+      method: req.method,
+      // Request `identity` so the downstream compression middleware owns the final
+      // transfer-encoding and no stale Content-Encoding/Content-Length is relayed.
+      headers: {
+        Accept: typeof req.headers.accept === 'string' ? req.headers.accept : '*/*',
+        'Accept-Encoding': 'identity',
+        'User-Agent': typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : 'Mention-apex-proxy',
+      },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+
+    res.status(upstream.status);
+    const contentType = upstream.headers.get('content-type');
+    if (contentType) res.setHeader('Content-Type', contentType);
+    // Pass the CDN's caching directives through, overriding the API `no-store`
+    // default the CORS middleware set — this is what lets CF edge-cache the static
+    // assets (`/_expo/static/*`, `/icons/*`, `/manifest.json`, `/favicon.ico`, …).
+    const cacheControl = upstream.headers.get('cache-control');
+    res.setHeader('Cache-Control', cacheControl ?? 'public, max-age=60');
+    const etag = upstream.headers.get('etag');
+    if (etag) res.setHeader('ETag', etag);
+    const lastModified = upstream.headers.get('last-modified');
+    if (lastModified) res.setHeader('Last-Modified', lastModified);
+
+    if (req.method === 'HEAD') {
+      res.end();
+      return;
+    }
+    // Buffer the body (SPA assets are small/static); Express + compression set the
+    // final Content-Length/Content-Encoding. Do NOT rewrite the body — the SPA's
+    // asset refs are root-relative and resolve against the apex correctly.
+    const body = Buffer.from(await upstream.arrayBuffer());
+    res.send(body);
+  } catch (error) {
+    if (res.headersSent) {
+      res.end();
+      return;
+    }
+    logger.warn(`[apexProxy] Upstream fetch failed for ${req.originalUrl}`, error);
+    res.status(502);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    res.send(PROXY_FALLBACK_HTML);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Host-aware apex frontend reverse-proxy middleware. STRICT no-op (`next()`) for the
+ * API host so every existing API route is untouched. Only GET/HEAD are proxied
+ * (the static SPA has no write surface — the app writes to `api.mention.earth`);
+ * any other method on the apex is answered `405`. `OPTIONS` never reaches here — the
+ * CORS middleware short-circuits preflight upstream.
+ */
+export async function apexFrontendProxy(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (!isApexHost(req)) {
+    next();
+    return;
+  }
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.setHeader('Allow', 'GET, HEAD');
+    res.status(405).end();
+    return;
+  }
+  await proxyToFrontend(req, res);
+}


### PR DESCRIPTION
Lets the backend serve the entire `mention.earth` frontend (bskyweb-full model) so the apex DNS can move off CF Pages and the Pages worker can be deleted. **Not wired to traffic yet** — `mention.earth` still resolves to CF Pages; this only adds the capability (tested via a `Host: mention.earth` override before the DNS switch).

- New `apexFrontendProxy`: apex-host requests not handled by federation (`/ap`, webfinger, xrpc, nodeinfo) or the OG web-shell (`/@*`, `/p/*`) reverse-proxy GET/HEAD to `mention-frontend.pages.dev`, passing through `content-type`/`cache-control` (CF edge-caches assets). 8s timeout, 502 fallback.
- **Host-gated**: strict `next()` no-op for `api.mention.earth` → the API is byte-for-byte unchanged. Root welcome route host-gated too.
- Mount order: federation → webShell → apexFrontendProxy → public/auth API.
- 35 backend tests pass; api-host routes verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
