### PR TITLE
fix(backend): CSP allowlist for the apex web app

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -183,9 +183,45 @@ app.use((req, res, next) => {
 // Basic liveness/readiness endpoints
 app.use(healthRoutes);
 
-// Security headers — crossOriginResourcePolicy set to cross-origin since API serves a different subdomain
+// Security headers. This backend serves BOTH the JSON API (api.mention.earth) AND the
+// web-app HTML at the apex (mention.earth, via apexFrontendProxy + webShell.routes), so
+// the CSP must permit everything the SPA talks to — helmet's default `default-src 'self'`
+// would block every cross-origin call/image/embed. connect-src is the exfiltration-
+// sensitive directive and is kept to an explicit first-party allowlist; img/media are
+// generous (passive resources); frame-src mirrors the embed players in
+// packages/frontend/utils/embedPlayer.ts. crossOriginResourcePolicy stays cross-origin
+// because the API is served from a different subdomain than the web app.
+const CSP_CONNECT_SRC = [
+  "'self'", "blob:", "data:",
+  "https://api.mention.earth", "wss://api.mention.earth", // Mention API + socket.io
+  "https://api.oxy.so",                                   // Oxy SDK (auth/profiles)
+  "https://cloud.oxy.so",                                 // canonical media
+  "https://api.syra.fm", "wss://api.syra.fm",             // Syra live rooms
+  "https://livekit.oxy.so", "wss://livekit.oxy.so",       // LiveKit signaling
+];
+const CSP_FRAME_SRC = [
+  "'self'",
+  "https://www.youtube-nocookie.com", "https://www.youtube.com",
+  "https://player.vimeo.com",
+  "https://open.spotify.com",
+  "https://player.twitch.tv", "https://clips.twitch.tv",
+  "https://w.soundcloud.com",
+  "https://embed.music.apple.com",
+  "https://embedr.flickr.com",
+  "https://bandcamp.com",
+];
 app.use(helmet({
   crossOriginResourcePolicy: { policy: "cross-origin" },
+  contentSecurityPolicy: {
+    useDefaults: true,
+    directives: {
+      "connect-src": CSP_CONNECT_SRC,
+      "img-src": ["'self'", "data:", "blob:", "https:"],
+      "media-src": ["'self'", "data:", "blob:", "https:"],
+      "frame-src": CSP_FRAME_SRC,
+      "worker-src": ["'self'", "blob:"],
+    },
+  },
 }));
 
 // Response compression - compress responses > 1KB


### PR DESCRIPTION
## Prod incident
`Fetch API cannot load https://api.mention.earth/recommendations … violates the document's Content Security Policy.`

## Root cause
The apex `mention.earth` is now served by the backend (CF-Pages→backend migration). Helmet was left on its **default CSP** (`default-src 'self'`, no `connect-src`), which is fine for a JSON API but now gates the **SPA HTML**. CF Pages never set a CSP, so this regressed at the cutover. It blocked: every `api.mention.earth` fetch (recommendations, feed, …), `cloud.oxy.so` avatars (`img-src 'self' data:`), socket.io/Syra/LiveKit `wss`, and the oEmbed iframe players.

## Fix (`server.ts` helmet)
Proper CSP via `useDefaults: true` + explicit directives:
- **`connect-src`** — strict first-party allowlist (the exfiltration-sensitive one): `api.mention.earth` (+`wss`), `api.oxy.so`, `cloud.oxy.so`, `api.syra.fm` (+`wss`), `livekit.oxy.so` (+`wss`), `blob:`/`data:`.
- **`img-src` / `media-src`** — `'self' data: blob: https:` (passive resources; social media pulls images from many hosts + proxied federated media).
- **`frame-src`** — mirrors `packages/frontend/utils/embedPlayer.ts` (YouTube/Vimeo/Spotify/Twitch/SoundCloud/Apple Music/Flickr/Bandcamp).
- **`worker-src`** — `'self' blob:`.
- `script-src`/`style-src`/`font-src`/`frame-ancestors`/`object-src` stay on helmet defaults (already correct; the SPA boots under `script-src 'self'`).

Verified: `bunx tsc` clean. Klipy/Stripe/push confirmed non-direct (backend/redirect), so not in `connect-src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)