### PR TITLE
fix(feed): preserve ranked candidate metadata for FeedEngine

### DIFF
--- a/packages/backend/src/__tests__/customFeedDefinition.test.ts
+++ b/packages/backend/src/__tests__/customFeedDefinition.test.ts
@@ -27,6 +27,24 @@ beforeEach(() => {
 });
 
 describe('buildCustomFeedDefinition', () => {
+  it('injects safety when filters is null or undefined', () => {
+    const fromNull = buildCustomFeedDefinition({
+      _id: 'feed-1',
+      title: 'Null filters',
+      isPublic: true,
+      definition: { ...storedDefinition, filters: null as never },
+    });
+    expect(fromNull.filters.some((f) => f.module === 'safety' && f.enabled)).toBe(true);
+
+    const fromUndefined = buildCustomFeedDefinition({
+      _id: 'feed-1',
+      title: 'Undefined filters',
+      isPublic: true,
+      definition: { ...storedDefinition, filters: undefined as never },
+    });
+    expect(fromUndefined.filters.some((f) => f.module === 'safety' && f.enabled)).toBe(true);
+  });
+
   it('strips onlySensitive and injects safety when absent', () => {
     const def = buildCustomFeedDefinition({
       _id: 'feed-1',

--- a/packages/backend/src/__tests__/rankedCandidate.test.ts
+++ b/packages/backend/src/__tests__/rankedCandidate.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { sliceCursorAnchor, toRankedCandidate } from '../mtn/feed/rankedCandidate';
+import type { FeedPostSlice } from '@mention/shared-types';
+
+describe('toRankedCandidate', () => {
+  it('preserves post metadata needed by downstream feed steps', () => {
+    const post = {
+      _id: 'abc123',
+      oxyUserId: 'user-1',
+      finalScore: 9,
+      content: {
+        media: [{ type: 'video', orientation: 'portrait' }],
+      },
+      createdAt: '2026-07-10T00:00:00.000Z',
+    };
+
+    const ranked = toRankedCandidate(post);
+    expect(ranked).not.toBeNull();
+    expect(ranked?.content).toEqual(post.content);
+    expect(ranked?.createdAt).toBe(post.createdAt);
+    expect(ranked?.finalScore).toBe(9);
+    expect(ranked?._id.toString()).toBe('abc123');
+  });
+});
+
+describe('sliceCursorAnchor', () => {
+  it('extracts cursor anchor when ranked post only has a string _id', () => {
+    const slice: FeedPostSlice = {
+      _sliceKey: 'ranked-only',
+      isIncompleteThread: false,
+      items: [{
+        post: {
+          _id: 'lean-id',
+          oxyUserId: 'user-1',
+          finalScore: 12,
+        } as never,
+        isThreadParent: false,
+        isThreadChild: false,
+        isThreadLastChild: false,
+      }],
+    };
+
+    expect(sliceCursorAnchor(slice)).toEqual({ score: 12, id: 'lean-id' });
+  });
+
+  it('extracts cursor anchor when ranked post _id is numeric', () => {
+    const slice: FeedPostSlice = {
+      _sliceKey: 'numeric-id',
+      isIncompleteThread: false,
+      items: [{
+        post: {
+          _id: 42,
+          oxyUserId: 'user-1',
+          finalScore: 7,
+        } as never,
+        isThreadParent: false,
+        isThreadChild: false,
+        isThreadLastChild: false,
+      }],
+    };
+
+    expect(sliceCursorAnchor(slice)).toEqual({ score: 7, id: '42' });
+  });
+});

--- a/packages/backend/src/mtn/feed/definitions/customFeedDefinition.ts
+++ b/packages/backend/src/mtn/feed/definitions/customFeedDefinition.ts
@@ -23,8 +23,8 @@ function enabled(module: string): ModuleRef {
 }
 
 /** Strip `onlySensitive` and ensure a safety gate is present. */
-function ensureSafetyFilters(filters: ModuleRef[]): ModuleRef[] {
-  const stripped = filters.filter((f) => f.module !== 'onlySensitive');
+function ensureSafetyFilters(filters?: ModuleRef[] | null): ModuleRef[] {
+  const stripped = (filters ?? []).filter((f) => f.module !== 'onlySensitive');
   const hasSafety = stripped.some(
     (f) => f.enabled && (f.module === 'safety' || f.module === 'excludeSensitive'),
   );
@@ -40,7 +40,7 @@ type CustomFeedSource = Pick<ICustomFeed, 'title' | 'isPublic'> &
 
 /** Whether the definition excludes boosts (so boost hydration depth is unneeded). */
 function excludesBoosts(def: StoredFeedDefinition): boolean {
-  return def.filters.some((f) => f.enabled && (f.module === 'noBoosts' || f.module === 'originalOnly'));
+  return (def.filters ?? []).some((f) => f.enabled && (f.module === 'noBoosts' || f.module === 'originalOnly'));
 }
 
 /**

--- a/packages/backend/src/mtn/feed/rankedCandidate.ts
+++ b/packages/backend/src/mtn/feed/rankedCandidate.ts
@@ -3,8 +3,8 @@
  * Media).
  *
  * `FeedRankingService.rankPosts` decorates each lean Mongo document with a
- * `finalScore` number. These readers capture only the fields the feed code reads
- * directly so the feeds avoid `any` while leaving the rich post body opaque.
+ * `finalScore` number. {@link toRankedCandidate} preserves the full lean post
+ * document while narrowing `_id` for score/cursor helpers.
  */
 
 import { FeedPostSlice } from '@mention/shared-types';
@@ -29,19 +29,17 @@ function hasToString(value: object): value is { toString(): string } {
 }
 
 /** Narrow a lean engine candidate to a ranked candidate when `_id` is stringifiable. */
-export function toRankedCandidate(post: {
-  _id?: unknown;
-  oxyUserId?: string;
-  finalScore?: number;
-}): RankedCandidate | null {
+export function toRankedCandidate<T extends { _id?: unknown; oxyUserId?: string; finalScore?: number }>(
+  post: T,
+): (Omit<T, '_id'> & RankedCandidate) | null {
   const id = post._id;
   if (id === null || id === undefined) return null;
   if (typeof id === 'string' || typeof id === 'number' || typeof id === 'boolean' || typeof id === 'bigint') {
     const text = String(id);
-    return { _id: { toString: () => text }, oxyUserId: post.oxyUserId, finalScore: post.finalScore };
+    return { ...post, _id: { toString: () => text } };
   }
   if (typeof id === 'object' && hasToString(id)) {
-    return { _id: id, oxyUserId: post.oxyUserId, finalScore: post.finalScore };
+    return { ...post, _id: id };
   }
   return null;
 }
@@ -95,8 +93,8 @@ export function sliceCursorAnchor(slice: FeedPostSlice): { score: number; id: st
       return { score: finalScore, id: idField };
     }
     const rawId = Reflect.get(post, '_id');
-    if (rawId !== null && rawId !== undefined && typeof rawId === 'object' && hasToString(rawId)) {
-      const id = rawId.toString();
+    if (rawId !== null && rawId !== undefined) {
+      const id = typeof rawId === 'object' && hasToString(rawId) ? rawId.toString() : String(rawId);
       if (id) return { score: finalScore, id };
     }
   }


### PR DESCRIPTION
## Summary
- Fix `toRankedCandidate` to spread the full lean post document (content, createdAt, etc.) instead of returning a minimal object that broke FeedEngine portrait sorting and thread slicing
- Harden `sliceCursorAnchor` to stringify string/number `_id` values for score-cursor pagination
- Guard `ensureSafetyFilters` when custom feed `filters` is null/undefined

## Test plan
- [x] `rankedCandidate.test.ts` — metadata preservation + string/number `_id` cursoring
- [x] `customFeedDefinition.test.ts` — null/undefined filters inject safety
- [x] Focused feed suite: diversifyByAuthor, feedEngine, forYouCandidateSources (51 tests)
- [x] Full monorepo test + backend build green locally


Made with [Cursor](https://cursor.com)