### PR TITLE
feat(post): show save count beside bookmark icon

### DIFF
--- a/packages/frontend/components/Post/PostActions.tsx
+++ b/packages/frontend/components/Post/PostActions.tsx
@@ -211,6 +211,8 @@ const PostActions: React.FC<Props> = ({
           </PressableScale>
 
           <PressableScale
+            className="flex-row items-center"
+            style={{ gap: 6 }}
             onPress={() => {
               haptic('light');
               onSave();
@@ -223,6 +225,14 @@ const PostActions: React.FC<Props> = ({
               <BookmarkActive size={DETAIL_ICON_SIZE} color={theme.colors.primary} />
             ) : (
               <Bookmark size={DETAIL_ICON_SIZE} className="text-muted-foreground" />
+            )}
+            {saves > 0 && (
+              <Text
+                className={isSaved ? 'text-[13px]' : 'text-[13px] text-muted-foreground'}
+                style={isSaved ? { color: theme.colors.primary } : undefined}
+              >
+                {formatCompactNumber(saves)}
+              </Text>
             )}
           </PressableScale>
 
@@ -346,7 +356,8 @@ const PostActions: React.FC<Props> = ({
         <View className="flex-1" />
 
         <PressableScale
-          style={styles.iconButton}
+          className="flex-row items-center"
+          style={[styles.iconButton, { gap: 6 }]}
           onPress={() => {
             haptic('light');
             onSave();
@@ -359,6 +370,14 @@ const PostActions: React.FC<Props> = ({
             <BookmarkActive size={ICON_SIZE} color={theme.colors.primary} />
           ) : (
             <Bookmark size={ICON_SIZE} className="text-muted-foreground" />
+          )}
+          {saves > 0 && (
+            <Text
+              className={isSaved ? 'text-[13px]' : 'text-[13px] text-muted-foreground'}
+              style={isSaved ? { color: theme.colors.primary } : undefined}
+            >
+              {formatCompactNumber(saves)}
+            </Text>
           )}
         </PressableScale>
 

--- a/packages/frontend/stores/postsStore.ts
+++ b/packages/frontend/stores/postsStore.ts
@@ -1013,6 +1013,12 @@ export const usePostsStore = create<PostsStoreState>()(
             ...prev,
             isSaved: true,
             viewerState: { ...prev.viewerState, isSaved: true },
+            engagement: {
+              ...prev.engagement,
+              ...(typeof prev.engagement.saves === 'number'
+                ? { saves: prev.engagement.saves + 1 }
+                : {}),
+            },
           }));
         }
 
@@ -1043,6 +1049,12 @@ export const usePostsStore = create<PostsStoreState>()(
             ...prev,
             isSaved: false,
             viewerState: { ...prev.viewerState, isSaved: false },
+            engagement: {
+              ...prev.engagement,
+              ...(typeof prev.engagement.saves === 'number'
+                ? { saves: Math.max(0, prev.engagement.saves - 1) }
+                : {}),
+            },
           }));
         }
 


### PR DESCRIPTION
## Summary
- Show compact save counts next to the bookmark icon in feed and post-detail action bars
- Optimistically update `engagement.saves` in `postsStore` on save/unsave
- No who-saved list — count-only display, matching like/repost patterns

## Test plan
- [x] Frontend typecheck passes
- [x] Frontend Jest tests pass (189/189)
- [x] `bun run build:frontend` succeeds
- [x] `bun install --frozen-lockfile` passes
- [ ] Manual: saved post shows count beside bookmark; save/unsave updates count optimistically


Made with [Cursor](https://cursor.com)