### PR TITLE
Add MCP attachment support and MCP-compatible media upload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,11 @@
 ## AWS Deployment
 
 - **Port**: `3000` | **Domain**: `api.mention.earth` (DNS-only → ALB) **+ apex `mention.earth`** (CF-proxied → same ALB → same backend, which serves the whole web app + OG + federation — see "Fediverse Discovery"). No Cloudflare Worker.
-- **ECR**: `237343248947.dkr.ecr.us-west-2.amazonaws.com/oxy/mention`
-- **Deploy**: `git push origin main` → `.github/workflows/deploy-aws.yml` builds `linux/arm64` → ECR → `ecs update-service --force-new-deployment`
+- **MCP**: `https://mcp.mention.earth` → ECS `mention-mcp` (port `3100`, ALB rule priority 140). Separate image/workflow from main backend — see § MCP below.
+- **ECR**: `237343248947.dkr.ecr.us-west-2.amazonaws.com/oxy/mention` (+ `oxy/mention-mcp` for MCP)
+- **Deploy**: `git push origin main` → `.github/workflows/deploy-aws.yml` (backend) + `deploy-mcp-aws.yml` (MCP, path-filtered) → ECR → `ecs update-service --force-new-deployment`
 - **Auth**: GitHub OIDC → role `oxy-github-deploy`. No AWS keys in GitHub.
-- **Secrets**: GitHub Actions secrets → synced to SSM `/oxy/mention/*`; ECS injects them. Change a secret in GitHub — the next deploy applies it.
+- **Secrets**: GitHub Actions secrets → synced to SSM `/oxy/mention/*` and `/oxy/mention-mcp/*`; ECS injects them. Change a secret in GitHub — the next deploy applies it.
 
 ## Commands
 
@@ -16,7 +17,8 @@
 bun run dev                 # All packages dev mode
 bun run dev:frontend        # Frontend dev (Expo tunnel)
 bun run dev:backend         # Backend dev (watch mode)
-bun run dev:mcp             # MCP server (internal dev only — prod: https://mcp.mention.earth)
+bun run dev:mcp             # MCP stdio transport (local)
+bun run dev:mcp:http        # MCP HTTP transport (local; matches production)
 bun run build               # shared-types + backend + mcp
 bun run build:frontend      # Frontend only
 bun run build:backend       # shared-types then backend
@@ -201,6 +203,19 @@ Use `oxyServices.getFileDownloadUrl(id, variant)` everywhere. Mention backend `u
 - Platform split: `shareIntent.web.ts` / `shareIntent.native.ts`
 - Quote flow: `hooks/useQuoteManager.ts` + `components/Compose/QuoteCard.tsx`
 - Quote wire format: `quoted_post_id` top-level snake_case body field (NOT nested under `content`)
+
+## MCP (Claude / remote connector)
+
+Production: **`https://mcp.mention.earth`**. Full doc: [`packages/mcp/README.md`](packages/mcp/README.md).
+
+- **Two ECS services:** `mention` (OAuth AS + REST API on `api.mention.earth`) and `mention-mcp` (streamable HTTP MCP on port 3100). Backend OAuth/bundle changes → `deploy-aws.yml`; MCP tools/transport → `deploy-mcp-aws.yml`.
+- **OAuth:** RFC 8414 AS on backend, protected-resource on MCP server. `resource` and JWT `aud` MUST equal `https://mcp.mention.earth` (no trailing slash). DCR at `POST /mcp/oauth/register`. Claude requires **401 + `WWW-Authenticate`** on unauthenticated `GET /` and OAuth Bearer before `initialize` POST.
+- **Multi-account:** Claude allows only one connector per URL. Users link extra accounts via MCP tool `link-account` → browser `mention.earth/oauth/mcp/link` → `switch-account` / `whoami`. Server-side **bundles** (`McpConnection.bundleId`); active account in Redis + `activeOxyUserId` on primary connection. Link tokens are **single-use** (HMAC + Redis).
+- **Auth on API:** `createRequireMcpOrOxyAuth` in `packages/backend/src/mcp/middleware/mcpAuth.ts` — MCP JWT OR Oxy session; resolves active bundle member to `req.user.id`.
+- **UI:** consent `oauth/mcp/authorize.tsx`, link `oauth/mcp/link.tsx`, revoke Settings → Connected AI (`/mcp/connections`).
+- **Secret:** `MENTION_MCP_JWT_SECRET` in GitHub → SSM `/oxy/mention/` + `/oxy/mention-mcp/` (must match both services).
+- **Do not** add a second MCP URL per account — use bundle link flow. **Do not** add `as_user` on `create-post`; require `switch-account` first.
+- **Media upload:** MCP uses `POST /posts/intent-media` (`url` or `base64`) → Oxy `POST /assets/service/user-media` via service token when auth is MCP JWT. Never call Oxy `assetUpload` directly from `@mention/mcp`.
 
 ## Oxy SDK Conventions
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This is a **monorepo** using Bun workspaces with the following structure:
 │   │   └── ...
 │   ├── agora/           # Agora audio/video spaces app (Expo)
 │   ├── agora-shared/    # Shared utilities for Agora
+│   ├── mcp/             # Remote MCP server for Claude (https://mcp.mention.earth)
 │   └── shared-types/    # Shared TypeScript types
 │       ├── src/         # Type definitions
 │       └── dist/        # Compiled types
@@ -99,6 +100,9 @@ bun run dev:frontend
 
 # Backend only
 bun run dev:backend
+
+# MCP HTTP server (requires backend on :3000)
+bun run dev:mcp:http
 ```
 
 #### Frontend Development
@@ -119,6 +123,8 @@ bun run dev:backend
 - `bun run dev` — Start all services in development mode
 - `bun run dev:frontend` — Start frontend development server
 - `bun run dev:backend` — Start backend development server
+- `bun run dev:mcp` — Start local MCP server (stdio transport)
+- `bun run dev:mcp:http` — Start local MCP HTTP server (matches production transport)
 - `bun run build` — Build all packages
 - `bun run build:shared-types` — Build shared types package
 - `bun run build:frontend` — Build frontend for production
@@ -168,6 +174,7 @@ All project documentation is available in the [`docs/`](./docs/) folder:
 - [Compose Refactoring](./docs/COMPOSE_REFACTORING.md) - Compose screen architecture
 - [Performance Optimizations](./docs/PERFORMANCE_OPTIMIZATIONS.md) - Performance best practices
 - [Federation (ActivityPub)](./packages/backend/README.md#federation-activitypub--fediverse) - Fediverse federation setup, endpoints, and sync
+- [MCP / Claude connector](./packages/mcp/README.md) - Remote MCP server, OAuth, multi-account bundles, deployment
 - [DigitalOcean Deployment](./docs/DIGITALOCEAN_DEPLOYMENT.md) - Production deployment guide for DigitalOcean App Platform
 - [Vercel Deployment](./docs/VERCEL_DEPLOYMENT.md) - Deployment guide for Vercel
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,11 @@ Welcome to the Mention project documentation.
 - **[Federation (ActivityPub)](../packages/backend/README.md#federation-activitypub--fediverse)**
   ActivityPub/Fediverse federation setup, endpoints, environment variables, and deployment requirements.
 
+### MCP (Claude / AI connectors)
+
+- **[MCP Server](../packages/mcp/README.md)**
+  Remote Model Context Protocol server at `https://mcp.mention.earth`: Claude Web setup, OAuth, multi-account bundles (`link-account` / `switch-account`), tool catalog, backend routes, AWS deployment, and production checklist.
+
 ### Performance & Deployment
 
 - **[Performance Optimizations](./PERFORMANCE_OPTIMIZATIONS.md)**
@@ -61,6 +66,7 @@ Welcome to the Mention project documentation.
 - New to the project? Start with [Mention System Overview](./MENTION_SYSTEM_README.md)
 - Working on theming? Check [Theme Quick Reference](./THEME_QUICK_REFERENCE.md)
 - Need to deploy? See [DigitalOcean Deployment](./DIGITALOCEAN_DEPLOYMENT.md) or [Vercel Deployment](./VERCEL_DEPLOYMENT.md)
+- Connecting Claude to Mention? See [MCP Server](../packages/mcp/README.md)
 
 ### For Contributors
 - [Theming Guide](./THEMING_REFACTOR_SUMMARY.md) - Complete theming implementation
@@ -75,4 +81,5 @@ Welcome to the Mention project documentation.
 
 - [Main README](../README.md) - Project overview and getting started guide
 - [Backend README](../packages/backend/README.md) - API documentation
+- [MCP README](../packages/mcp/README.md) - Claude connector and OAuth
 - [Frontend README](../packages/frontend/README.md) - Frontend package documentation

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -8,6 +8,8 @@ order: 3
 
 `@mention/backend` is an Express 5 service that powers the Mention frontend, the mobile apps, the MCP server, and the federation surface. It speaks REST over HTTPS for request/response work and Socket.io for real-time updates. Authentication is delegated to Oxy: every authenticated request carries an Oxy access token in `Authorization: Bearer <token>`, verified by `@oxyhq/core`'s `auth()` middleware.
 
+MCP-specific routes (`/mcp/oauth/*`, `/mcp/bundles/*`, `/mcp/connections`) also accept a Mention MCP access JWT with the same Bearer header; see [`packages/mcp/README.md`](../packages/mcp/README.md).
+
 ## Base URL
 
 ```

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -218,7 +218,14 @@ A separate Expo app for live audio and video rooms, built on LiveKit. It shares 
 
 ## MCP (`@mention/mcp`)
 
-Remote MCP server at **https://mcp.mention.earth** for Claude Web, ChatGPT, and other MCP clients. Proxies tool calls to `api.mention.earth`; public reads work anonymously, account actions require OAuth consent on mention.earth (revoke in Settings → Connected AI). Deployed as a separate ECS service (`mention-mcp`). See [`packages/mcp/README.md`](../packages/mcp/README.md).
+Remote MCP server at **https://mcp.mention.earth** for Claude Web and other MCP clients.
+
+- **Protocol** runs in ECS `mention-mcp`; **OAuth AS + bundle API** run in the main backend (`packages/backend/src/mcp/`).
+- Claude connects once per URL; **multiple Mention accounts** use server-side bundles (`link-account` → browser `/oauth/mcp/link` → `switch-account`).
+- Tool handlers proxy to `api.mention.earth`. OAuth consent on `mention.earth`; revoke in Settings → Connected AI.
+- Dual auth on bundle/post routes: MCP access JWT (`aud` = `https://mcp.mention.earth`) **or** Oxy session (`createRequireMcpOrOxyAuth`).
+
+Full guide: [`packages/mcp/README.md`](../packages/mcp/README.md). Agent gotchas: [`AGENTS.md`](../AGENTS.md) § MCP.
 
 ## Deployment
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -59,8 +59,11 @@ Or run pieces individually:
 bun run dev:frontend    # Expo dev server (press w / i / a for web / iOS / Android)
 bun run dev:backend     # Express server, watch mode
 bun run dev:agora       # Agora app (LiveKit rooms)
-bun run dev:mcp         # MCP server for Claude
+bun run dev:mcp         # MCP server (stdio)
+bun run dev:mcp:http    # MCP HTTP server (local prod-like transport)
 ```
+
+Claude connector docs: [`packages/mcp/README.md`](../packages/mcp/README.md).
 
 Build the apps:
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -451,6 +451,68 @@ Routes:
 
 When a notification is created, the server attempts to send an FCM push to registered tokens.
 
+## MCP OAuth & bundles (Claude connector)
+
+The backend hosts Mention's **OAuth authorization server** and **multi-account bundle API** for the remote MCP server at `https://mcp.mention.earth`. Full operator guide: [`packages/mcp/README.md`](../mcp/README.md).
+
+### Architecture
+
+- **MCP protocol** runs in ECS `mention-mcp` (`@mention/mcp` package).
+- **OAuth AS + bundle state** runs in this backend (`packages/backend/src/mcp/`).
+- **Consent / link UI** on `mention.earth` (`packages/frontend/app/(app)/oauth/mcp/`).
+
+Claude allows only one connector per MCP URL. Extra Mention accounts are linked via browser flow (`link-account` tool → `/oauth/mcp/link`) and switched server-side per request (`bundleId` + `activeOxyUserId`).
+
+### Public routes (no Oxy session)
+
+| Route | Purpose |
+|-------|---------|
+| `GET /.well-known/oauth-authorization-server` | RFC 8414 AS metadata (+ `registration_endpoint`) |
+| `GET /.well-known/oauth-protected-resource` | Resource metadata for MCP origin |
+| `POST /mcp/oauth/register` | Dynamic client registration (RFC 7591) |
+| `GET /mcp/oauth/authorize` | Authorization code + PKCE |
+| `POST /mcp/oauth/token` | Token exchange / refresh |
+| `GET /mcp/bundles/link/preview` | Link-token preview (public) |
+
+### Authenticated routes (MCP JWT or Oxy session)
+
+Mounted under the authenticated API router:
+
+| Route | Purpose |
+|-------|---------|
+| `POST /mcp/oauth/approve` | User consent after Oxy sign-in |
+| `GET /mcp/connections` | List authorized MCP clients |
+| `DELETE /mcp/connections/:id` | Revoke access |
+| `GET /mcp/bundles/accounts` | Linked accounts in bundle |
+| `GET /mcp/bundles/me` | Active account |
+| `POST /mcp/bundles/link-token` | Mint single-use link token |
+| `POST /mcp/bundles/link/complete` | Complete account link |
+| `POST /mcp/bundles/active` | Switch active account |
+
+`createRequireMcpOrOxyAuth` (`src/mcp/middleware/mcpAuth.ts`) accepts either a valid MCP access JWT (`aud` = `https://mcp.mention.earth`) or a normal Oxy session, and resolves the active bundle member to `req.user.id`.
+
+### Environment variables
+
+```env
+MENTION_MCP_JWT_SECRET=...           # Shared with mention-mcp ECS task
+MENTION_MCP_PUBLIC_URL=https://mcp.mention.earth
+MENTION_FRONTEND_ORIGIN=https://mention.earth
+MENTION_PUBLIC_API_URL=https://api.mention.earth
+MCP_LINK_TOKEN_TTL_SECONDS=900       # Optional; link token TTL
+MCP_MAX_BUNDLE_MEMBERS=8             # Optional; max linked accounts
+```
+
+### Key files
+
+- `src/mcp/routes/mcpOAuth.routes.ts` — OAuth AS
+- `src/mcp/routes/mcpBundles.routes.ts` — multi-account bundles
+- `src/mcp/routes/mcpConnections.routes.ts` — list/revoke
+- `src/mcp/middleware/mcpAuth.ts` — dual auth + active account
+- `src/mcp/services/mcpBundleService.ts` — bundle + link tokens
+- `src/mcp/models/McpConnection.ts` — OAuth grants
+
+Tests: `src/__tests__/mcp/`
+
 ## Troubleshooting Guide
 
 ### Common Issues

--- a/packages/backend/src/__tests__/routes/intentMedia.test.ts
+++ b/packages/backend/src/__tests__/routes/intentMedia.test.ts
@@ -29,8 +29,9 @@ vi.mock('../../utils/safeUpstreamFetch', async () => {
   };
 });
 
-const { assetUploadMock } = vi.hoisted(() => ({
+const { assetUploadMock, uploadServiceUserMediaMock } = vi.hoisted(() => ({
   assetUploadMock: vi.fn(),
+  uploadServiceUserMediaMock: vi.fn(),
 }));
 vi.mock('@oxyhq/core', async () => {
   const actual = await vi.importActual<typeof import('@oxyhq/core')>('@oxyhq/core');
@@ -47,6 +48,7 @@ vi.mock('../../utils/oxyHelpers', () => ({
   getServiceOxyClient: () => ({
     getServiceAssetMetadataByIds: vi.fn().mockResolvedValue([]),
   }),
+  uploadServiceUserMedia: (...args: unknown[]) => uploadServiceUserMediaMock(...args),
 }));
 
 import intentMediaRoutes from '../../routes/intentMedia';
@@ -71,6 +73,43 @@ describe('POST /posts/intent-media', () => {
   beforeEach(() => {
     fetchUpstreamFollowingRedirects.mockReset();
     assetUploadMock.mockReset();
+    uploadServiceUserMediaMock.mockReset();
+    assetUploadMock.mockResolvedValue({ file: { id: 'oxy-file-1' } });
+    uploadServiceUserMediaMock.mockResolvedValue({ fileId: 'mcp-file-1', contentType: 'image/png' });
+  });
+
+  it('uploads via service path when MCP context is present', async () => {
+    const mcpApp = express();
+    mcpApp.use(express.json());
+    mcpApp.use((req, _res, next) => {
+      const r = req as express.Request & { user?: { id: string }; mcp?: { activeUserId: string } };
+      r.user = { id: 'user-mcp' };
+      r.mcp = { activeUserId: 'user-mcp' } as { activeUserId: string };
+      next();
+    });
+    mcpApp.use('/', intentMediaRoutes);
+
+    const png = Buffer.from('PNG!');
+    const res = await request(mcpApp)
+      .post('/')
+      .send({ base64: png.toString('base64'), mimeType: 'image/png', filename: 'x.png' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.fileId).toBe('mcp-file-1');
+    expect(uploadServiceUserMediaMock).toHaveBeenCalledTimes(1);
+    expect(assetUploadMock).not.toHaveBeenCalled();
+  });
+
+  it('uploads via Oxy session when accessToken is present', async () => {
+    const png = Buffer.from('PNG!');
+    const res = await request(app)
+      .post('/')
+      .send({ base64: png.toString('base64'), mimeType: 'image/png' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.fileId).toBe('oxy-file-1');
+    expect(assetUploadMock).toHaveBeenCalledTimes(1);
+    expect(uploadServiceUserMediaMock).not.toHaveBeenCalled();
   });
 
   it('returns 401 without auth user', async () => {

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -695,6 +695,16 @@ export const createPost = async (req: AuthRequest, res: Response) => {
       }
     }
 
+    const rawVisibility = typeof req.body.visibility === 'string' ? req.body.visibility : undefined;
+    let resolvedVisibility = PostVisibility.PUBLIC;
+    if (rawVisibility === 'followers' || rawVisibility === 'followers_only') {
+      resolvedVisibility = PostVisibility.FOLLOWERS_ONLY;
+    } else if (rawVisibility === 'private') {
+      resolvedVisibility = PostVisibility.PRIVATE;
+    } else if (rawVisibility === 'public') {
+      resolvedVisibility = PostVisibility.PUBLIC;
+    }
+
     const post = await postCreationService.create({
       oxyUserId: userId,
       content: postContent,
@@ -706,7 +716,7 @@ export const createPost = async (req: AuthRequest, res: Response) => {
       boostOf: boost_of || null,
       parentPostId: parentPostId || in_reply_to_status_id || null,
       threadId: threadId || null,
-      visibility: PostVisibility.PUBLIC,
+      visibility: resolvedVisibility,
       replyPermission: replyPermission || ['anyone'],
       reviewReplies: reviewReplies || false,
       quotesDisabled: quotesDisabled || false,

--- a/packages/backend/src/routes/intentMedia.ts
+++ b/packages/backend/src/routes/intentMedia.ts
@@ -6,7 +6,8 @@ import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 
 import { logger } from '../utils/logger';
 import { RedisStore } from '../middleware/rateLimitStore';
-import { getServiceOxyClient } from '../utils/oxyHelpers';
+import { getServiceOxyClient, uploadServiceUserMedia } from '../utils/oxyHelpers';
+import type { OxyAuthRequestWithMcp } from '../mcp/middleware/mcpAuth';
 import {
   SsrfRejection,
   UpstreamResult,
@@ -18,45 +19,26 @@ import { MEDIA_REJECTED_TYPES } from '../services/mediaCache/mediaTypes';
 /**
  * POST /posts/intent-media
  *
- * Authenticated. Fetches a REMOTE http(s) media URL (from a compose intent
- * `mediaUrl=` parameter) through the SAME SSRF-safe upstream contract the media
- * proxy uses (`fetchUpstreamFollowingRedirects` → `assertSafePublicUrl` on every
- * hop, connection pinned to the validated IP), enforces an image/video
- * content-type allowlist, then uploads the bytes to Oxy as an asset owned by the
- * requesting user and returns the resulting `fileId` so the composer can attach
- * it exactly like a picked file.
+ * Authenticated. Accepts either:
+ *  - `{ url }` — SSRF-safe remote fetch (compose intent / MCP)
+ *  - `{ base64, mimeType, filename? }` — inline bytes (MCP / Claude)
  *
- * This is the server side of Compose Share Phase 2's `mediaUrl=` support. Local
- * (native share-sheet) files never reach here — they are uploaded directly from
- * the client via the Oxy SDK.
+ * Uploads to Oxy as an asset owned by the requesting user and returns `fileId`.
+ * Oxy-session callers use `assetUpload` with the user bearer; MCP JWT callers
+ * use the service-token `POST /assets/service/user-media` path.
  */
 
 const router = Router();
 
 const OXY_API_URL = process.env.OXY_API_URL || 'https://api.oxy.so';
 
-/** Rate-limit window for the intent-media fetch. */
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
-/** Max intent-media fetches per user per window. Each one hits a remote origin. */
 const RATE_LIMIT_MAX = 20;
-
-/** Max accepted length of the input URL (matches the SSRF guard's own cap). */
 const MAX_URL_LENGTH = 2048;
-
-/**
- * Hard cap on the fetched media body. Unlike the streaming media proxy this
- * endpoint buffers the whole body in memory to hand it to the Oxy upload, so the
- * cap is deliberately tighter than the proxy's 256 MiB stream ceiling.
- */
-const MAX_MEDIA_BYTES = 40 * 1024 * 1024; // 40 MiB
-
-/** Absolute wall-clock ceiling for the fetch + upload round trip. */
+const MAX_MEDIA_BYTES = 40 * 1024 * 1024;
+const MAX_BASE64_LENGTH = Math.ceil((MAX_MEDIA_BYTES * 4) / 3) + 256;
 const REQUEST_DEADLINE_MS = 25_000;
-
-/** Idle socket timeout while reading the upstream body. */
 const UPSTREAM_SOCKET_TIMEOUT_MS = 20_000;
-
-/** Content-type families the composer accepts (audio is not a composer media type). */
 const ALLOWED_MEDIA_PREFIXES = ['image/', 'video/'] as const;
 
 const HTTP_STATUS = {
@@ -64,13 +46,11 @@ const HTTP_STATUS = {
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
   FORBIDDEN: 403,
-  NOT_FOUND: 404,
   UNSUPPORTED_MEDIA_TYPE: 415,
   PAYLOAD_TOO_LARGE: 413,
   BAD_GATEWAY: 502,
 } as const;
 
-/** Marker error for an over-cap body (maps to 413 at the route layer). */
 class PayloadTooLargeError extends Error {
   constructor() {
     super('media body exceeds cap');
@@ -87,8 +67,6 @@ const intentMediaRateLimiter = rateLimit({
   store: intentMediaStore,
   windowMs: RATE_LIMIT_WINDOW_MS,
   max: RATE_LIMIT_MAX,
-  // Authenticated route — key by the resolved user id, falling back to the
-  // (IPv6-normalized) client address when the id is somehow absent.
   keyGenerator: (req: AuthRequest) =>
     req.user?.id || ipKeyGenerator(req.ip || req.socket.remoteAddress || 'unknown'),
   message: { error: 'Too many media fetch requests. Please slow down.' },
@@ -96,17 +74,11 @@ const intentMediaRateLimiter = rateLimit({
   legacyHeaders: false,
 });
 
-/** True when a parameter-stripped content-type family is an accepted composer media type. */
 function isComposerMediaType(family: string): boolean {
   if (MEDIA_REJECTED_TYPES.has(family)) return false;
   return ALLOWED_MEDIA_PREFIXES.some((prefix) => family.startsWith(prefix));
 }
 
-/**
- * Read the full upstream body into a single Buffer, aborting (413) once the cap
- * is exceeded. Rejects on socket idle timeout or stream error. The response
- * socket is always destroyed once we settle so it never leaks.
- */
 function readFullBodyBounded(response: IncomingMessage, maxBytes: number): Promise<Buffer> {
   return new Promise<Buffer>((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -142,31 +114,152 @@ function readFullBodyBounded(response: IncomingMessage, maxBytes: number): Promi
   });
 }
 
-/** Derive a filename (with extension when present) from the final upstream URL. */
 function deriveFileName(finalUrl: string): string {
   try {
     const last = new URL(finalUrl).pathname.split('/').filter(Boolean).pop();
     if (last && last.length > 0) return decodeURIComponent(last).slice(0, 200);
   } catch {
-    // Fall through to the default below.
+    // fall through
   }
   return 'shared-media';
 }
 
+function extensionForMime(mime: string): string {
+  if (mime === 'image/jpeg') return 'jpg';
+  if (mime === 'image/png') return 'png';
+  if (mime === 'image/webp') return 'webp';
+  if (mime === 'image/gif') return 'gif';
+  if (mime === 'video/mp4') return 'mp4';
+  if (mime.startsWith('video/')) return 'mp4';
+  if (mime.startsWith('image/')) return 'img';
+  return 'bin';
+}
+
+function decodeBase64Payload(raw: string): Buffer {
+  const trimmed = raw.trim();
+  const dataUrlMatch = /^data:([^;,]+);base64,(.+)$/i.exec(trimmed);
+  const payload = dataUrlMatch ? dataUrlMatch[2] : trimmed;
+  if (payload.length === 0 || payload.length > MAX_BASE64_LENGTH) {
+    throw new PayloadTooLargeError();
+  }
+  return Buffer.from(payload, 'base64');
+}
+
+async function fetchRemoteMediaBuffer(rawUrl: string, abortSignal: AbortSignal): Promise<{
+  buffer: Buffer;
+  contentType: string;
+  fileName: string;
+}> {
+  let upstream: UpstreamResult;
+  try {
+    upstream = await fetchUpstreamFollowingRedirects(rawUrl, {}, abortSignal);
+  } catch (error) {
+    if (error instanceof SsrfRejection) {
+      throw Object.assign(new Error('URL not permitted'), { status: HTTP_STATUS.FORBIDDEN });
+    }
+    throw Object.assign(new Error('Could not fetch the media URL'), { status: HTTP_STATUS.BAD_GATEWAY });
+  }
+
+  const { response, finalUrl } = upstream;
+  const status = response.statusCode ?? HTTP_STATUS.BAD_GATEWAY;
+  if (status !== HTTP_STATUS.OK) {
+    response.resume();
+    throw Object.assign(new Error('Could not fetch the media URL'), { status: HTTP_STATUS.BAD_GATEWAY });
+  }
+
+  const family = contentTypeFamily(response.headers);
+  if (!isComposerMediaType(family)) {
+    response.destroy();
+    throw Object.assign(new Error('URL is not a supported image or video'), { status: HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE });
+  }
+
+  const declaredLength = Number(response.headers['content-length']);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_MEDIA_BYTES) {
+    response.destroy();
+    throw Object.assign(new Error('Media is too large'), { status: HTTP_STATUS.PAYLOAD_TOO_LARGE });
+  }
+
+  let buffer: Buffer;
+  try {
+    buffer = await readFullBodyBounded(response, MAX_MEDIA_BYTES);
+  } catch (error) {
+    if (error instanceof PayloadTooLargeError) {
+      throw Object.assign(new Error('Media is too large'), { status: HTTP_STATUS.PAYLOAD_TOO_LARGE });
+    }
+    throw Object.assign(new Error('Could not fetch the media URL'), { status: HTTP_STATUS.BAD_GATEWAY });
+  }
+
+  if (buffer.length === 0) {
+    throw Object.assign(new Error('Could not fetch the media URL'), { status: HTTP_STATUS.BAD_GATEWAY });
+  }
+
+  return {
+    buffer,
+    contentType: family,
+    fileName: deriveFileName(finalUrl),
+  };
+}
+
+async function uploadWithOxySession(
+  token: string,
+  buffer: Buffer,
+  contentType: string,
+  fileName: string,
+): Promise<string> {
+  const file = new File([new Uint8Array(buffer)], fileName, { type: contentType });
+  const oxyClient = new OxyServices({ baseURL: OXY_API_URL });
+  oxyClient.setTokens(token);
+  const uploadResult = await oxyClient.assetUpload(file);
+  const fileId = uploadResult?.file?.id;
+  if (typeof fileId !== 'string' || fileId.length === 0) {
+    throw new Error('Could not save the media');
+  }
+  return fileId;
+}
+
+async function enrichUploadResponse(fileId: string, contentType: string): Promise<Record<string, unknown>> {
+  const responseBody: Record<string, unknown> = { fileId, contentType };
+  try {
+    const assets = await getServiceOxyClient().getServiceAssetMetadataByIds([fileId]);
+    const asset = assets[0];
+    if (asset) {
+      if (asset.width !== undefined) responseBody.width = asset.width;
+      if (asset.height !== undefined) responseBody.height = asset.height;
+      if (asset.durationSec !== undefined) responseBody.durationSec = asset.durationSec;
+      if (asset.orientation !== undefined) responseBody.orientation = asset.orientation;
+      if (asset.aspectRatio !== undefined) responseBody.aspectRatio = asset.aspectRatio;
+      if (asset.size !== undefined) responseBody.sizeBytes = asset.size;
+    }
+  } catch (error) {
+    logger.debug('[IntentMedia] Metadata lookup after upload failed', {
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+  }
+  return responseBody;
+}
+
 router.post('/', intentMediaRateLimiter, async (req: AuthRequest, res: Response): Promise<void> => {
   const userId = req.user?.id;
-  const token = req.accessToken || req.headers.authorization?.replace('Bearer ', '');
-  if (!userId || !token) {
+  if (!userId) {
     res.status(HTTP_STATUS.UNAUTHORIZED).json({ error: 'Unauthorized' });
     return;
   }
 
   const rawUrl = typeof req.body?.url === 'string' ? req.body.url.trim() : '';
-  if (rawUrl.length === 0) {
-    res.status(HTTP_STATUS.BAD_REQUEST).json({ error: 'Missing required "url" field' });
+  const rawBase64 = typeof req.body?.base64 === 'string' ? req.body.base64 : '';
+  const hasUrl = rawUrl.length > 0;
+  const hasBase64 = rawBase64.length > 0;
+
+  if (hasUrl === hasBase64) {
+    res.status(HTTP_STATUS.BAD_REQUEST).json({
+      error: hasUrl && hasBase64
+        ? 'Provide either "url" or "base64", not both'
+        : 'Missing required "url" or "base64" field',
+    });
     return;
   }
-  if (rawUrl.length > MAX_URL_LENGTH) {
+
+  if (hasUrl && rawUrl.length > MAX_URL_LENGTH) {
     res.status(HTTP_STATUS.BAD_REQUEST).json({ error: 'URL is too long' });
     return;
   }
@@ -175,120 +268,85 @@ router.post('/', intentMediaRateLimiter, async (req: AuthRequest, res: Response)
   const deadline = setTimeout(() => abortController.abort(), REQUEST_DEADLINE_MS);
 
   try {
-    let upstream: UpstreamResult;
-    try {
-      upstream = await fetchUpstreamFollowingRedirects(rawUrl, {}, abortController.signal);
-    } catch (error) {
-      if (error instanceof SsrfRejection) {
-        logger.warn('[IntentMedia] Rejected target', { reason: error.message });
-        res.status(HTTP_STATUS.FORBIDDEN).json({ error: 'URL not permitted' });
+    let buffer: Buffer;
+    let contentType: string;
+    let fileName: string;
+
+    if (hasUrl) {
+      try {
+        const fetched = await fetchRemoteMediaBuffer(rawUrl, abortController.signal);
+        buffer = fetched.buffer;
+        contentType = fetched.contentType;
+        fileName = fetched.fileName;
+      } catch (error) {
+        const status = typeof error === 'object' && error !== null && 'status' in error
+          ? Number((error as { status: number }).status)
+          : HTTP_STATUS.BAD_GATEWAY;
+        const message = error instanceof Error ? error.message : 'Could not fetch the media URL';
+        if (status === HTTP_STATUS.FORBIDDEN) {
+          logger.warn('[IntentMedia] Rejected target', { reason: message });
+        }
+        res.status(status).json({ error: message });
         return;
       }
-      logger.warn('[IntentMedia] Upstream fetch failed', {
-        reason: error instanceof Error ? error.message : 'unknown',
-      });
-      res.status(HTTP_STATUS.BAD_GATEWAY).json({ error: 'Could not fetch the media URL' });
-      return;
-    }
-
-    const { response, finalUrl } = upstream;
-    const status = response.statusCode ?? HTTP_STATUS.BAD_GATEWAY;
-    if (status !== HTTP_STATUS.OK) {
-      response.resume();
-      logger.debug('[IntentMedia] Upstream returned non-OK status', { status });
-      res.status(HTTP_STATUS.BAD_GATEWAY).json({ error: 'Could not fetch the media URL' });
-      return;
-    }
-
-    const family = contentTypeFamily(response.headers);
-    if (!isComposerMediaType(family)) {
-      response.destroy();
-      logger.warn('[IntentMedia] Rejected non-media content type', { contentType: family || 'unknown' });
-      res.status(HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE).json({ error: 'URL is not a supported image or video' });
-      return;
-    }
-
-    const declaredLength = Number(response.headers['content-length']);
-    if (Number.isFinite(declaredLength) && declaredLength > MAX_MEDIA_BYTES) {
-      response.destroy();
-      logger.warn('[IntentMedia] Declared body exceeds cap', { declaredLength });
-      res.status(HTTP_STATUS.PAYLOAD_TOO_LARGE).json({ error: 'Media is too large' });
-      return;
-    }
-
-    let buffer: Buffer;
-    try {
-      buffer = await readFullBodyBounded(response, MAX_MEDIA_BYTES);
-    } catch (error) {
-      if (error instanceof PayloadTooLargeError) {
-        logger.warn('[IntentMedia] Streamed body exceeds cap');
+    } else {
+      const mimeType = typeof req.body?.mimeType === 'string' ? req.body.mimeType.trim().toLowerCase() : '';
+      if (!mimeType || !isComposerMediaType(mimeType)) {
+        res.status(HTTP_STATUS.BAD_REQUEST).json({ error: 'Valid "mimeType" (image/* or video/*) is required with base64' });
+        return;
+      }
+      try {
+        buffer = decodeBase64Payload(rawBase64);
+      } catch (error) {
+        if (error instanceof PayloadTooLargeError) {
+          res.status(HTTP_STATUS.PAYLOAD_TOO_LARGE).json({ error: 'Media is too large' });
+          return;
+        }
+        res.status(HTTP_STATUS.BAD_REQUEST).json({ error: 'Invalid base64 payload' });
+        return;
+      }
+      if (buffer.length === 0 || buffer.length > MAX_MEDIA_BYTES) {
         res.status(HTTP_STATUS.PAYLOAD_TOO_LARGE).json({ error: 'Media is too large' });
         return;
       }
-      logger.warn('[IntentMedia] Failed to read upstream body', {
-        reason: error instanceof Error ? error.message : 'unknown',
-      });
-      res.status(HTTP_STATUS.BAD_GATEWAY).json({ error: 'Could not fetch the media URL' });
-      return;
+      contentType = mimeType;
+      const requestedName = typeof req.body?.filename === 'string' ? req.body.filename.trim() : '';
+      fileName = requestedName.length > 0
+        ? requestedName.slice(0, 200)
+        : `upload.${extensionForMime(mimeType)}`;
     }
 
-    if (buffer.length === 0) {
-      res.status(HTTP_STATUS.BAD_GATEWAY).json({ error: 'Could not fetch the media URL' });
-      return;
-    }
+    const mcpContext = (req as OxyAuthRequestWithMcp).mcp;
+    const oxySessionToken = req.accessToken;
+    let fileId: string;
 
-    const contentType = family;
-    const fileName = deriveFileName(finalUrl);
-    // Bun/Node global File (typed by @types/node) — provides a name + MIME type
-    // so the multipart upload carries a sensible filename. `assetUpload` appends
-    // this straight into its FormData and sends it to Oxy's asset service.
-    // Copy into a fresh ArrayBuffer-backed view: a Node Buffer's backing store is
-    // typed `ArrayBufferLike` (possibly SharedArrayBuffer), which is not a valid
-    // `BlobPart`.
-    const file = new File([new Uint8Array(buffer)], fileName, { type: contentType });
-
-    // Upload as the requesting user (owner-scoped), never the service client, so
-    // the asset is attributable to them exactly like a picked file. A scoped
-    // client avoids mutating the shared service singleton under concurrency.
-    const oxyClient = new OxyServices({ baseURL: OXY_API_URL });
-    oxyClient.setTokens(token);
-
-    let uploadResult: { file?: { id?: unknown } } | undefined;
     try {
-      uploadResult = await oxyClient.assetUpload(file);
-    } catch (error) {
-      logger.error('[IntentMedia] Oxy asset upload failed', {
-        reason: error instanceof Error ? error.message : 'unknown',
-      });
-      res.status(HTTP_STATUS.BAD_GATEWAY).json({ error: 'Could not save the media' });
-      return;
-    }
-
-    const fileId = uploadResult?.file?.id;
-    if (typeof fileId !== 'string' || fileId.length === 0) {
-      logger.error('[IntentMedia] Upload response missing file id');
-      res.status(HTTP_STATUS.BAD_GATEWAY).json({ error: 'Could not save the media' });
-      return;
-    }
-
-    const responseBody: Record<string, unknown> = { fileId, contentType };
-    try {
-      const assets = await getServiceOxyClient().getServiceAssetMetadataByIds([fileId]);
-      const asset = assets[0];
-      if (asset) {
-        if (asset.width !== undefined) responseBody.width = asset.width;
-        if (asset.height !== undefined) responseBody.height = asset.height;
-        if (asset.durationSec !== undefined) responseBody.durationSec = asset.durationSec;
-        if (asset.orientation !== undefined) responseBody.orientation = asset.orientation;
-        if (asset.aspectRatio !== undefined) responseBody.aspectRatio = asset.aspectRatio;
-        if (asset.size !== undefined) responseBody.sizeBytes = asset.size;
+      if (mcpContext) {
+        const uploaded = await uploadServiceUserMedia({
+          ownerUserId: userId,
+          buffer,
+          contentType,
+          fileName,
+        });
+        fileId = uploaded.fileId;
+      } else {
+        const token = oxySessionToken || req.headers.authorization?.replace(/^Bearer\s+/i, '');
+        if (!token) {
+          res.status(HTTP_STATUS.UNAUTHORIZED).json({ error: 'Unauthorized' });
+          return;
+        }
+        fileId = await uploadWithOxySession(token, buffer, contentType, fileName);
       }
     } catch (error) {
-      logger.debug('[IntentMedia] Metadata lookup after upload failed (variant may still be pending)', {
+      logger.error('[IntentMedia] Upload failed', {
         reason: error instanceof Error ? error.message : 'unknown',
+        mcp: Boolean(mcpContext),
       });
+      res.status(HTTP_STATUS.BAD_GATEWAY).json({ error: 'Could not save the media' });
+      return;
     }
 
+    const responseBody = await enrichUploadResponse(fileId, contentType);
     res.status(HTTP_STATUS.OK).json(responseBody);
   } finally {
     clearTimeout(deadline);

--- a/packages/backend/src/utils/oxyHelpers.ts
+++ b/packages/backend/src/utils/oxyHelpers.ts
@@ -46,6 +46,62 @@ export function getServiceOxyClient(): OxyServices {
   return serviceClient;
 }
 
+const OXY_ASSET_USER_MEDIA_PATH = '/assets/service/user-media';
+
+export interface ServiceUserMediaUploadResult {
+  fileId: string;
+  contentType: string;
+}
+
+/**
+ * Upload media bytes to Oxy as a durable public asset owned by a local user,
+ * using the Mention service credential. Used when the caller authenticated with
+ * an MCP JWT (no Oxy session bearer).
+ */
+export async function uploadServiceUserMedia(params: {
+  ownerUserId: string;
+  buffer: Buffer;
+  contentType: string;
+  fileName: string;
+}): Promise<ServiceUserMediaUploadResult> {
+  const client = getServiceOxyClient();
+  const token = await client.getServiceToken();
+  const baseUrl = client.getBaseURL().replace(/\/+$/, '');
+  const url = `${baseUrl}${OXY_ASSET_USER_MEDIA_PATH}`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': params.contentType,
+      'Content-Length': String(params.buffer.length),
+      'x-owner-user-id': params.ownerUserId,
+      'x-original-name': params.fileName,
+      Accept: 'application/json',
+    },
+    body: new Uint8Array(params.buffer),
+  });
+
+  if (!response.ok) {
+    let detail = '';
+    try {
+      const errBody = await response.json() as { message?: string; error?: string };
+      detail = errBody.message || errBody.error || '';
+    } catch {
+      detail = await response.text().catch(() => '');
+    }
+    throw new Error(detail || `Oxy user-media upload failed (${response.status})`);
+  }
+
+  const body = await response.json() as { data?: { file?: { id?: string } } };
+  const fileId = body.data?.file?.id;
+  if (typeof fileId !== 'string' || fileId.length === 0) {
+    throw new Error('Oxy user-media upload response missing file id');
+  }
+
+  return { fileId, contentType: params.contentType };
+}
+
 /**
  * Promote an Oxy asset that a user has set as public-facing profile media
  * (e.g. the Mention profile banner) to `public` visibility, so it renders for

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -158,6 +158,18 @@ This package is part of the Mention monorepo and integrates with:
 - The app registers the device push token after the user authenticates and posts it to the backend endpoint `/api/notifications/push-token`.
 - Backend requires Firebase Admin credentials via env vars to send FCM pushes.
 
+## MCP OAuth UI (Claude connector)
+
+Browser screens for authorizing the remote MCP server (`https://mcp.mention.earth`):
+
+| Route | Purpose |
+|-------|---------|
+| `app/(app)/oauth/mcp/authorize.tsx` | Initial OAuth consent (shows @handle) |
+| `app/(app)/oauth/mcp/link.tsx` | Link an additional Mention account to an existing Claude connector |
+| `app/(app)/settings/connected-ai.tsx` | List/revoke MCP connections (grouped by bundle) |
+
+i18n keys: `mcp.authorize.*`, `mcp.link.*` in `locales/{en,es,it}.json`. See [`packages/mcp/README.md`](../mcp/README.md) for the full flow.
+
 ## Contributing
 
 Contributions are welcome! Please see the [main README](../../README.md) for the complete contributing guidelines.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,99 +1,204 @@
 # @mention/mcp — remote MCP server for Claude Web / ChatGPT
-#
-# Production URL: https://mcp.mention.earth/
 
-## Connect
+Production URL: **https://mcp.mention.earth/**
 
-Add a custom MCP connector in Claude Web (Settings → Connectors):
+Canonical user + operator guide. Mention agents: see also [`AGENTS.md`](../../AGENTS.md) § MCP.
 
-```
-https://mcp.mention.earth
-```
+## Connect (Claude Web)
 
-Public read tools work without authorization. Posting, liking, personalized feeds, and other account actions require OAuth — Claude opens mention.earth for consent. Revoke access anytime in Mention → Settings → Connected AI.
+1. Settings → Connectors → Add custom connector
+2. URL: `https://mcp.mention.earth` (no trailing slash)
+3. Complete OAuth on mention.earth when prompted
+4. Revoke anytime: Mention → Settings → **Connected AI**
 
-## Multiple accounts
+Claude blocks duplicate URLs — you cannot add the same MCP URL twice. Use **linked accounts** (below) to post as multiple Mention users from one connector.
 
-Claude allows only **one** connector for `https://mcp.mention.earth`. To publish as different Mention accounts from the same connector:
+## Multiple accounts (one connector)
 
-1. Connect once (OAuth as your first account).
-2. In chat, run **`link-account`** → open the URL in your browser → sign in as the other account → **Link**.
-3. Run **`switch-account`** with the target `@handle`.
-4. Run **`whoami`** to confirm, then **`create-post`**.
+| Step | Action |
+|------|--------|
+| 1 | Connect once → OAuth as your first account (primary) |
+| 2 | In chat: **`link-account`** → open URL in browser → sign in as other account → **Link to Claude** |
+| 3 | **`switch-account`** with target `@handle` |
+| 4 | **`whoami`** to confirm → **`create-post`** |
 
 | Tool | Purpose |
 |------|---------|
-| `whoami` | Active account for this connector |
-| `list-accounts` | All linked accounts |
-| `link-account` | Browser URL to add another account |
-| `switch-account` | Set active account by @handle |
+| `whoami` | Active account (@handle, display name, user id) |
+| `list-accounts` | All accounts linked to this connector |
+| `link-account` | Browser URL to add another account (single-use, 15 min) |
+| `switch-account` | Set active account by `@handle` |
+
+Max **8** linked accounts per connector (`MCP_MAX_BUNDLE_MEMBERS`).
 
 ## Architecture
 
 ```
-Claude Web  →  mcp.mention.earth  →  api.mention.earth
-                     ↑ OAuth consent on mention.earth
+Claude Web  →  mcp.mention.earth (ECS mention-mcp)  →  api.mention.earth (ECS mention)
+                     ↑ OAuth consent + link UI on mention.earth
 ```
 
 | Component | Role |
 |-----------|------|
-| `@mention/mcp` | MCP protocol + tool handlers |
-| `api.mention.earth` | REST API + OAuth authorization server |
-| `mention.earth` | Consent UI + Settings revoke |
+| `@mention/mcp` | MCP protocol (streamable HTTP), tool handlers |
+| `api.mention.earth` | REST API + OAuth authorization server (RFC 8414 / 9728 / 7591 DCR) |
+| `mention.earth` | Consent UI (`/oauth/mcp/authorize`), link UI (`/oauth/mcp/link`), Settings revoke |
 
-## Tool access levels
+**Identity model:** Claude holds one OAuth token (primary account). The backend resolves the **active account** per request via `bundleId` + Redis/Mongo (`activeOxyUserId` on the primary `McpConnection`). Linked accounts approve via browser link flow — not a second Claude OAuth grant.
 
-### Public (no token)
+## MCP tools (42 total)
+
+### Accounts (auth required)
 
 | Tool | Backend |
 |------|---------|
-| `get-feed`, `get-explore-feed` | `GET /feed/mtn?descriptor=explore` |
-| `get-user-feed` | `GET /feed/mtn?descriptor=author\|<id>` |
-| `get-replies` | `GET /feed/replies/:id` |
-| `get-feed-item`, `get-post` | `GET /feed/item/:id` |
-| `get-trending-hashtags` | `GET /trending?type=hashtag` |
-| `get-posts-by-hashtag` | `GET /feed/mtn?descriptor=hashtag\|<tag>` |
-| `get-profile` | `GET /profile/design/:userId` |
-| `get-starter-pack` | `GET /starter-packs/:id` |
+| `whoami` | `GET /mcp/bundles/me` |
+| `list-accounts` | `GET /mcp/bundles/accounts` |
+| `link-account` | `POST /mcp/bundles/link-token` |
+| `switch-account` | `POST /mcp/bundles/active` |
 
-### Requires Mention OAuth token
+### Posts (auth required)
 
-All write tools, `get-for-you-feed`, `get-following-feed`, `get-videos-feed`, `search`, lists, notifications, polls, follow/unfollow.
+| Tool | Backend |
+|------|---------|
+| `create-post` | `POST /posts` |
+| `create-thread` | `POST /posts/thread` |
+| `update-post` | `PUT /posts/:id` |
+| `delete-post` | `DELETE /posts/:id` |
+| `get-drafts` | `GET /posts/drafts` |
+| `get-scheduled-posts` | `GET /posts/scheduled` |
+
+### Feed (public unless noted)
+
+| Tool | Auth | Backend |
+|------|------|---------|
+| `get-feed` | no | `GET /feed/mtn` |
+| `get-explore-feed` | no | `GET /feed/mtn?descriptor=explore` |
+| `get-for-you-feed` | yes | `GET /feed/mtn?descriptor=for_you` |
+| `get-following-feed` | yes | `GET /feed/mtn?descriptor=following` |
+| `get-videos-feed` | yes | `GET /feed/mtn?descriptor=videos` |
+| `get-user-feed` | no | `GET /feed/mtn?descriptor=author\|<id>` |
+| `get-replies` | no | `GET /feed/replies/:id` |
+| `get-feed-item` | no | `GET /feed/item/:id` |
+| `get-post` | no | `GET /feed/item/:id` |
+
+### Interactions (auth required)
+
+`like-post`, `unlike-post`, `save-post`, `unsave-post`, `boost`, `quote-post`
+
+### Social, search, lists, notifications, polls, hashtags, profile, starter packs
+
+See `packages/mcp/tools/*.ts`. Most write/personalized reads require auth per `lib/tool-auth.ts`.
+
+**Session note:** Claude must complete OAuth before `initialize` (POST requires Bearer). Some tools are callable without extra per-tool auth once the session is open, but the connector itself always needs OAuth first.
+
+## Backend OAuth & bundle API
+
+Implemented in `packages/backend/src/mcp/`.
+
+### Public OAuth (no session)
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /.well-known/oauth-authorization-server` | AS discovery (includes `registration_endpoint`) |
+| `GET /.well-known/oauth-protected-resource` | Resource metadata (`resource` = `https://mcp.mention.earth`, no slash) |
+| `POST /mcp/oauth/register` | RFC 7591 dynamic client registration |
+| `GET /mcp/oauth/authorize` | Start auth code + PKCE flow |
+| `POST /mcp/oauth/token` | Exchange code / refresh token |
+| `GET /mcp/bundles/link/preview?token=` | Link-flow preview (public) |
+
+### Authenticated (MCP JWT or Oxy session)
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /mcp/oauth/approve` | Consent approval (Oxy session) |
+| `GET /mcp/connections` | List authorized clients (Settings data) |
+| `DELETE /mcp/connections/:id` | Revoke connection |
+| `GET /mcp/bundles/accounts` | Linked accounts in bundle |
+| `GET /mcp/bundles/me` | Active account summary |
+| `POST /mcp/bundles/link-token` | Mint single-use browser link token |
+| `POST /mcp/bundles/link/complete` | Complete link (Oxy session + token) |
+| `POST /mcp/bundles/active` | Switch active account |
+
+### Key backend files
+
+- `src/mcp/routes/mcpOAuth.routes.ts` — OAuth AS + link preview
+- `src/mcp/routes/mcpBundles.routes.ts` — multi-account bundle API
+- `src/mcp/routes/mcpConnections.routes.ts` — list/revoke
+- `src/mcp/middleware/mcpAuth.ts` — dual MCP/Oxy auth + active account resolution
+- `src/mcp/services/mcpBundleService.ts` — bundles, link tokens, Redis active account
+- `src/mcp/models/McpConnection.ts` — grants (`bundleId`, `isBundlePrimary`, `activeOxyUserId`)
+
+### Frontend UI
+
+- `packages/frontend/app/(app)/oauth/mcp/authorize.tsx` — initial OAuth consent (@handle shown)
+- `packages/frontend/app/(app)/oauth/mcp/link.tsx` — link additional account
+- `packages/frontend/app/(app)/settings/connected-ai.tsx` — revoke + bundle handles
 
 ## Environment variables
+
+### MCP server (`mention-mcp` ECS)
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `MENTION_API_URL` | `https://api.mention.earth` | Mention REST API |
-| `MENTION_MCP_PUBLIC_URL` | `https://mcp.mention.earth` | This server's public URL |
-| `MENTION_OAUTH_AS_URL` | `https://api.mention.earth` | OAuth authorization server |
+| `MENTION_MCP_PUBLIC_URL` | `https://mcp.mention.earth` | Public MCP URL (JWT `aud`) |
+| `MENTION_OAUTH_AS_URL` | `https://api.mention.earth` | OAuth AS origin |
 | `MCP_PORT` | `3100` | HTTP listen port |
-| `MCP_ALLOWED_ORIGINS` | (see server defaults) | Extra CORS origins |
+| `MENTION_MCP_JWT_SECRET` | (required) | Must match backend secret |
+| `MCP_ALLOWED_ORIGINS` | Claude defaults | Extra CORS origins |
 
-Backend OAuth (separate ECS service):
+### Backend (`mention` ECS)
 
 | Variable | Purpose |
 |----------|---------|
 | `MENTION_MCP_JWT_SECRET` | Sign/verify MCP access tokens |
+| `MENTION_MCP_PUBLIC_URL` | Protected-resource `resource` + JWT `aud` |
 | `MENTION_FRONTEND_ORIGIN` | Consent redirect (`https://mention.earth`) |
 | `MENTION_PUBLIC_API_URL` | OAuth issuer (`https://api.mention.earth`) |
+| `MCP_LINK_TOKEN_TTL_SECONDS` | Link token lifetime (default 900) |
+| `MCP_MAX_BUNDLE_MEMBERS` | Max accounts per bundle (default 8) |
 
-## Internal development only
+Secrets: GitHub Actions → SSM `/oxy/mention/*` and `/oxy/mention-mcp/*`.
+
+## Deployment (AWS)
+
+| Service | ECR | Domain | Workflow |
+|---------|-----|--------|----------|
+| `mention` | `oxy/mention` | `api.mention.earth`, `mention.earth` | `.github/workflows/deploy-aws.yml` |
+| `mention-mcp` | `oxy/mention-mcp` | `mcp.mention.earth` | `.github/workflows/deploy-mcp-aws.yml` |
+
+Infra: `oxy-infra` — ALB rule priority 140, ACM cert `mcp.mention.earth`, DNS CNAME → ALB (DNS-only/grey cloud like `api.mention.earth`).
+
+Backend MCP OAuth changes deploy with **mention**; tool/protocol changes deploy with **mention-mcp**. Frontend consent/link UI deploys with **mention** (apex web shell).
+
+## Local development
 
 ```bash
+# Terminal 1 — backend
+cd packages/backend && bun run dev
+
+# Terminal 2 — MCP HTTP server (not for end users)
 cd packages/mcp
 MENTION_API_URL=http://localhost:3000 bun run dev:http
 ```
 
-Not intended for end users.
+From repo root: `bun run dev:mcp:http`
 
 ## Production checklist (E2E)
 
-After deploy (`mention-mcp` ECS service + `mcp.mention.earth` DNS in oxy-infra):
-
 1. `curl https://mcp.mention.earth/health` → 200
-2. `curl https://mcp.mention.earth/.well-known/oauth-protected-resource` → JSON with `authorization_servers`
-3. Claude Web connector `https://mcp.mention.earth` → `get-explore-feed` without auth
-4. `create-post` prompts OAuth → consent at mention.earth/oauth/mcp/authorize → post succeeds
-5. Mention Settings → Connected AI → revoke → writes fail again
-6. Set `MENTION_MCP_JWT_SECRET` in GitHub secrets (synced to SSM `/oxy/mention/` and `/oxy/mention-mcp/`)
+2. `curl -D - -o /dev/null https://mcp.mention.earth/` → **401** + `WWW-Authenticate: Bearer ...`
+3. `curl https://mcp.mention.earth/.well-known/oauth-protected-resource` → `resource` without trailing slash
+4. `curl https://api.mention.earth/.well-known/oauth-authorization-server` → includes `registration_endpoint`
+5. Claude connector → OAuth → `whoami` / `create-post` succeed
+6. `link-account` → browser link → second account → `switch-account` → `whoami` shows second account
+7. Settings → Connected AI → revoke → writes fail
+8. `MENTION_MCP_JWT_SECRET` set in GitHub secrets (synced to SSM)
+
+## Security
+
+- Link tokens: HMAC-signed, TTL 15 min, **single-use** (Redis `NX`)
+- Bundle membership: explicit approve on `/oauth/mcp/link`; unique index on `(bundleId, oxyUserId)` when not revoked
+- Active account: persisted on primary `McpConnection.activeOxyUserId` + Redis; switch fails closed (`503`) if neither persists
+- No `as_user` on `create-post` — must `switch-account` first

--- a/packages/mcp/__tests__/post-content-schema.test.ts
+++ b/packages/mcp/__tests__/post-content-schema.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { mediaInputSchema, pollInputSchema, postContentSchema } from "../lib/post-content-schema.js";
+
+describe("post-content-schema", () => {
+  it("accepts fileId media", () => {
+    const parsed = mediaInputSchema.parse({
+      kind: "fileId",
+      fileId: "abc123",
+      type: "image",
+    });
+    expect(parsed.kind).toBe("fileId");
+  });
+
+  it("rejects poll with one option", () => {
+    expect(() =>
+      pollInputSchema.parse({ question: "Q?", options: ["only"] }),
+    ).toThrow();
+  });
+
+  it("accepts full post content", () => {
+    const parsed = postContentSchema.parse({
+      text: "hello",
+      media: [{ kind: "url", url: "https://example.com/a.jpg" }],
+      poll: { question: "Pick", options: ["A", "B"] },
+    });
+    expect(parsed.text).toBe("hello");
+    expect(parsed.media?.[0]?.kind).toBe("url");
+  });
+});

--- a/packages/mcp/lib/create-server.ts
+++ b/packages/mcp/lib/create-server.ts
@@ -14,6 +14,7 @@ import { registerProfileTools } from "../tools/profile.js";
 import { registerSocialTools } from "../tools/social.js";
 import { registerStarterPackTools } from "../tools/starter-packs.js";
 import { registerAccountTools } from "../tools/accounts.js";
+import { registerMediaTools } from "../tools/media.js";
 import { SERVER_INSTRUCTIONS } from "./instructions.js";
 
 export function createMcpServer(): McpServer {
@@ -37,6 +38,7 @@ export function createMcpServer(): McpServer {
   registerSocialTools(server);
   registerStarterPackTools(server);
   registerAccountTools(server);
+  registerMediaTools(server);
 
   return server;
 }

--- a/packages/mcp/lib/formatters.ts
+++ b/packages/mcp/lib/formatters.ts
@@ -26,8 +26,13 @@ interface PostData {
     text?: string;
     media?: Array<{ id: string; type: string }>;
     pollId?: string;
+    poll?: { question?: string; options?: string[] };
     sources?: Array<{ url: string; title?: string }>;
     location?: { address?: string; coordinates?: [number, number] };
+    article?: { title?: string; excerpt?: string };
+    event?: { name?: string; date?: string; location?: string };
+    room?: { roomId?: string; title?: string; status?: string };
+    podcast?: { syraPodcastId?: string; title?: string };
   };
   type?: string;
   visibility?: string;
@@ -84,6 +89,32 @@ export function formatPost(post: PostData): string {
 
   if (post.content?.sources && post.content.sources.length > 0) {
     parts.push(`Sources: ${post.content.sources.map((s) => s.title || s.url).join(", ")}`);
+  }
+
+  if (post.content?.poll?.question) {
+    parts.push(`Poll: ${post.content.poll.question}`);
+  } else if (post.content?.pollId) {
+    parts.push(`Poll: ${post.content.pollId}`);
+  }
+
+  if (post.content?.location?.address) {
+    parts.push(`Location: ${post.content.location.address}`);
+  }
+
+  if (post.content?.article?.title) {
+    parts.push(`Article: ${post.content.article.title}`);
+  }
+
+  if (post.content?.event?.name) {
+    parts.push(`Event: ${post.content.event.name} (${post.content.event.date ?? ""})`);
+  }
+
+  if (post.content?.room?.title) {
+    parts.push(`Room: ${post.content.room.title}`);
+  }
+
+  if (post.content?.podcast?.title) {
+    parts.push(`Podcast: ${post.content.podcast.title}`);
   }
 
   if (post.parentPostId) parts.push(`Reply to: ${post.parentPostId}`);

--- a/packages/mcp/lib/instructions.ts
+++ b/packages/mcp/lib/instructions.ts
@@ -27,6 +27,14 @@ All feed tools use the unified MTN feed engine via descriptors: \`for_you\`, \`f
 ## Post visibility
 Valid values: \`public\`, \`private\`, \`followers_only\` (alias \`followers\` accepted).
 
+## Attachments & media
+\`create-post\` and \`create-thread\` support the full Mention attachment model:
+- **Media** — pass \`media[]\` with \`kind: "fileId"\` (after upload), \`kind: "url"\` (remote fetch), or \`kind: "base64"\` (inline bytes)
+- **Poll, article, event, room, podcast, location, sources** — pass the matching fields on create-post / per thread post
+- **Upload helpers** — \`upload-media-from-url\`, \`upload-media\`, \`search-gifs\`, \`use-gif\` return \`fileId\` values for \`kind: "fileId"\`
+
+Typical flow: \`upload-media-from-url\` → \`create-post\` with \`media: [{ kind: "fileId", fileId: "..." }]\`, or inline \`media: [{ kind: "url", url: "https://..." }]\`.
+
 ## Pagination
 Feed and list tools support \`cursor\` and \`limit\`. Responses include \`hasMore\` and \`nextCursor\` when more results exist.
 `;

--- a/packages/mcp/lib/post-content-schema.ts
+++ b/packages/mcp/lib/post-content-schema.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+
+export const visibilitySchema = z
+  .enum(["public", "private", "followers", "followers_only"])
+  .optional()
+  .describe("Post visibility (default: public)");
+
+export const replyPermissionSchema = z
+  .array(z.enum(["anyone", "followers", "following", "mentioned", "nobody"]))
+  .optional()
+  .describe("Who may reply to this post");
+
+export const sourceLinkSchema = z.object({
+  url: z.string().min(1).describe("Source URL"),
+  title: z.string().optional().describe("Optional display title"),
+});
+
+export const mediaByFileIdSchema = z.object({
+  kind: z.literal("fileId"),
+  fileId: z.string().describe("Oxy file id from upload-media or Mention compose"),
+  type: z.enum(["image", "video", "gif"]).optional().describe("Media type hint"),
+  alt: z.string().max(2000).optional().describe("Accessibility alt text"),
+});
+
+export const mediaByUrlSchema = z.object({
+  kind: z.literal("url"),
+  url: z.string().url().describe("Remote image/video URL — fetched server-side before attach"),
+  type: z.enum(["image", "video", "gif"]).optional(),
+  alt: z.string().max(2000).optional(),
+});
+
+export const mediaByBase64Schema = z.object({
+  kind: z.literal("base64"),
+  base64: z.string().describe("Base64-encoded image/video bytes or data: URL"),
+  mimeType: z.string().describe("MIME type, e.g. image/jpeg or video/mp4"),
+  filename: z.string().optional().describe("Optional filename"),
+  type: z.enum(["image", "video", "gif"]).optional(),
+  alt: z.string().max(2000).optional(),
+});
+
+export const mediaInputSchema = z.discriminatedUnion("kind", [
+  mediaByFileIdSchema,
+  mediaByUrlSchema,
+  mediaByBase64Schema,
+]);
+
+export const pollInputSchema = z.object({
+  question: z.string().min(1).describe("Poll question"),
+  options: z.array(z.string().min(1)).min(2).max(4).describe("2–4 answer options"),
+  endTime: z.string().optional().describe("ISO end time (default ~7 days)"),
+  isMultipleChoice: z.boolean().optional(),
+  isAnonymous: z.boolean().optional(),
+});
+
+export const locationInputSchema = z.object({
+  latitude: z.number().min(-90).max(90),
+  longitude: z.number().min(-180).max(180),
+  address: z.string().optional(),
+});
+
+export const articleInputSchema = z.object({
+  title: z.string().optional(),
+  body: z.string().optional(),
+});
+
+export const eventInputSchema = z.object({
+  name: z.string().min(1),
+  date: z.string().describe("ISO date/time"),
+  location: z.string().optional(),
+  description: z.string().optional(),
+});
+
+export const roomInputSchema = z.object({
+  roomId: z.string().min(1),
+  title: z.string().min(1),
+  status: z.enum(["scheduled", "live", "ended"]).optional(),
+  topic: z.string().optional(),
+  host: z.string().optional(),
+});
+
+export const podcastInputSchema = z.object({
+  syraPodcastId: z.string().min(1).describe("Syra podcast show id"),
+});
+
+export const attachmentDescriptorSchema = z.object({
+  type: z.enum(["media", "poll", "article", "location", "sources", "event", "room", "podcast"]),
+  id: z.string().optional(),
+  mediaType: z.enum(["image", "video", "gif"]).optional(),
+});
+
+export const postContentSchema = z.object({
+  text: z.string().optional().describe("Post body text"),
+  media: z.array(mediaInputSchema).max(10).optional().describe("Images/videos/gifs"),
+  poll: pollInputSchema.optional(),
+  location: locationInputSchema.optional(),
+  sources: z.array(sourceLinkSchema).max(5).optional(),
+  article: articleInputSchema.optional(),
+  event: eventInputSchema.optional(),
+  room: roomInputSchema.optional(),
+  podcast: podcastInputSchema.optional(),
+  attachments: z.array(attachmentDescriptorSchema).optional().describe("Render order"),
+});
+
+export const postMetadataSchema = z.object({
+  isSensitive: z.boolean().optional(),
+});
+
+export const threadPostSchema = z.object({
+  content: postContentSchema,
+  visibility: visibilitySchema,
+  hashtags: z.array(z.string()).optional(),
+  mentions: z.array(z.string()).optional(),
+  replyPermission: replyPermissionSchema,
+  reviewReplies: z.boolean().optional(),
+  quotesDisabled: z.boolean().optional(),
+  metadata: postMetadataSchema.optional(),
+});
+
+export type MediaInput = z.infer<typeof mediaInputSchema>;
+export type PostContentInput = z.infer<typeof postContentSchema>;

--- a/packages/mcp/lib/resolve-media.ts
+++ b/packages/mcp/lib/resolve-media.ts
@@ -1,0 +1,96 @@
+import { api } from "./api-client.js";
+import type { MediaInput, PostContentInput } from "./post-content-schema.js";
+
+interface IntentMediaResponse {
+  fileId: string;
+  contentType?: string;
+}
+
+export interface ResolvedMediaItem {
+  id: string;
+  type?: "image" | "video" | "gif";
+  alt?: string;
+}
+
+function mediaTypeFromMime(mime?: string, hint?: "image" | "video" | "gif"): "image" | "video" | "gif" {
+  if (hint) return hint;
+  if (!mime) return "image";
+  if (mime === "image/gif" || mime.endsWith("/gif")) return "gif";
+  if (mime.startsWith("video/")) return "video";
+  return "image";
+}
+
+async function uploadFromUrl(url: string): Promise<IntentMediaResponse> {
+  return api.post<IntentMediaResponse>("/posts/intent-media", { url });
+}
+
+async function uploadFromBase64(base64: string, mimeType: string, filename?: string): Promise<IntentMediaResponse> {
+  return api.post<IntentMediaResponse>("/posts/intent-media", {
+    base64,
+    mimeType,
+    ...(filename ? { filename } : {}),
+  });
+}
+
+/** Resolve MCP media inputs (fileId / url / base64) to wire-format media items. */
+export async function resolveMediaInputs(items: MediaInput[]): Promise<ResolvedMediaItem[]> {
+  const resolved: ResolvedMediaItem[] = [];
+
+  for (const item of items) {
+    if (item.kind === "fileId") {
+      resolved.push({
+        id: item.fileId,
+        ...(item.type ? { type: item.type } : {}),
+        ...(item.alt ? { alt: item.alt } : {}),
+      });
+      continue;
+    }
+
+    if (item.kind === "url") {
+      const uploaded = await uploadFromUrl(item.url);
+      resolved.push({
+        id: uploaded.fileId,
+        type: mediaTypeFromMime(uploaded.contentType, item.type),
+        ...(item.alt ? { alt: item.alt } : {}),
+      });
+      continue;
+    }
+
+    const uploaded = await uploadFromBase64(item.base64, item.mimeType, item.filename);
+    resolved.push({
+      id: uploaded.fileId,
+      type: mediaTypeFromMime(uploaded.contentType, item.type),
+      ...(item.alt ? { alt: item.alt } : {}),
+    });
+  }
+
+  return resolved;
+}
+
+/** Build backend `content` object from validated MCP post content. */
+export async function buildPostContentPayload(
+  content: PostContentInput,
+): Promise<Record<string, unknown>> {
+  const payload: Record<string, unknown> = {};
+
+  if (content.text !== undefined) payload.text = content.text;
+  if (content.media && content.media.length > 0) {
+    payload.media = await resolveMediaInputs(content.media);
+  }
+  if (content.poll) payload.poll = content.poll;
+  if (content.location) {
+    payload.location = {
+      type: "Point",
+      coordinates: [content.location.longitude, content.location.latitude],
+      ...(content.location.address ? { address: content.location.address } : {}),
+    };
+  }
+  if (content.sources) payload.sources = content.sources;
+  if (content.article) payload.article = content.article;
+  if (content.event) payload.event = content.event;
+  if (content.room) payload.room = content.room;
+  if (content.podcast) payload.podcast = content.podcast;
+  if (content.attachments) payload.attachments = content.attachments;
+
+  return payload;
+}

--- a/packages/mcp/lib/tool-auth.ts
+++ b/packages/mcp/lib/tool-auth.ts
@@ -39,6 +39,10 @@ export const AUTH_REQUIRED_TOOLS = new Set<string>([
   "follow-user",
   "unfollow-user",
   "get-starter-pack",
+  "upload-media-from-url",
+  "upload-media",
+  "search-gifs",
+  "use-gif",
 ]);
 
 export const AUTH_REQUIRED_MESSAGE =

--- a/packages/mcp/tools/interactions.ts
+++ b/packages/mcp/tools/interactions.ts
@@ -4,6 +4,8 @@ import { api, formatApiError } from "../lib/api-client.js";
 import { unwrapApiResponse } from "../lib/api-response.js";
 import { withAuthGuard } from "../lib/auth-guard.js";
 import { formatPost } from "../lib/formatters.js";
+import { buildPostContentPayload } from "../lib/resolve-media.js";
+import { mediaInputSchema } from "../lib/post-content-schema.js";
 
 export function registerInteractionsTools(server: McpServer): void {
   server.tool(
@@ -86,15 +88,20 @@ export function registerInteractionsTools(server: McpServer): void {
 
   server.tool(
     "quote-post",
-    "Quote a post with commentary (requires authorization).",
+    "Quote a post with commentary and optional media (requires authorization).",
     {
       id: z.string(),
       text: z.string().describe("Your commentary"),
+      media: z.array(mediaInputSchema).max(10).optional(),
     },
-    withAuthGuard(async ({ id, text }) => {
+    withAuthGuard(async ({ id, text, media }) => {
       try {
+        const content = await buildPostContentPayload({
+          text,
+          ...(media ? { media } : {}),
+        });
         const result = await api.post("/posts", {
-          content: { text, media: [] },
+          content,
           hashtags: [],
           mentions: [],
           visibility: "public",

--- a/packages/mcp/tools/media.ts
+++ b/packages/mcp/tools/media.ts
@@ -1,0 +1,111 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { api, formatApiError } from "../lib/api-client.js";
+import { withAuthGuard } from "../lib/auth-guard.js";
+
+export function registerMediaTools(server: McpServer): void {
+  server.tool(
+    "upload-media-from-url",
+    "Fetch a remote image/video URL and upload it to your Mention account (returns fileId for create-post).",
+    {
+      url: z.string().url().describe("Public http(s) image or video URL"),
+    },
+    withAuthGuard(async ({ url }) => {
+      try {
+        const result = await api.post<Record<string, unknown>>("/posts/intent-media", { url });
+        const fileId = result.fileId;
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Uploaded. fileId: ${String(fileId)}\ncontentType: ${String(result.contentType ?? "unknown")}`,
+          }],
+        };
+      } catch (error) {
+        return { content: [{ type: "text" as const, text: formatApiError(error) }], isError: true };
+      }
+    }),
+  );
+
+  server.tool(
+    "upload-media",
+    "Upload base64-encoded image/video bytes to your Mention account (returns fileId for create-post).",
+    {
+      base64: z.string().describe("Base64 payload or data: URL"),
+      mimeType: z.string().describe("MIME type, e.g. image/jpeg"),
+      filename: z.string().optional().describe("Optional filename"),
+    },
+    withAuthGuard(async ({ base64, mimeType, filename }) => {
+      try {
+        const result = await api.post<Record<string, unknown>>("/posts/intent-media", {
+          base64,
+          mimeType,
+          ...(filename ? { filename } : {}),
+        });
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Uploaded. fileId: ${String(result.fileId)}\ncontentType: ${String(result.contentType ?? mimeType)}`,
+          }],
+        };
+      } catch (error) {
+        return { content: [{ type: "text" as const, text: formatApiError(error) }], isError: true };
+      }
+    }),
+  );
+
+  server.tool(
+    "search-gifs",
+    "Search GIFs to attach to a post (requires authorization).",
+    {
+      query: z.string().describe("Search query"),
+      limit: z.number().optional(),
+    },
+    withAuthGuard(async ({ query, limit }) => {
+      try {
+        const result = await api.get<{ gifs?: Array<Record<string, unknown>> }>("/gifs/search", {
+          q: query,
+          ...(limit !== undefined ? { limit } : {}),
+        });
+        const gifs = result.gifs ?? [];
+        if (gifs.length === 0) {
+          return { content: [{ type: "text" as const, text: "No GIFs found." }] };
+        }
+        const lines = gifs.map((g) => {
+          const id = String(g.klipyId ?? g.id ?? "");
+          const title = String(g.title ?? g.slug ?? id);
+          return `- ${title} (klipyId: ${id})`;
+        });
+        return { content: [{ type: "text" as const, text: `GIFs (${gifs.length}):\n${lines.join("\n")}` }] };
+      } catch (error) {
+        return { content: [{ type: "text" as const, text: formatApiError(error) }], isError: true };
+      }
+    }),
+  );
+
+  server.tool(
+    "use-gif",
+    "Import a GIF to your account and get a fileId for create-post (requires authorization).",
+    {
+      klipyId: z.string(),
+      slug: z.string().optional(),
+      title: z.string().optional(),
+      mp4Url: z.string().optional(),
+      previewUrl: z.string().optional(),
+      width: z.number().optional(),
+      height: z.number().optional(),
+    },
+    withAuthGuard(async (body) => {
+      try {
+        const result = await api.post<Record<string, unknown>>("/gifs/use", body);
+        return {
+          content: [{
+            type: "text" as const,
+            text: `GIF ready. fileId: ${String(result.fileId ?? "")}\ngifId: ${String(result.gifId ?? "")}`,
+          }],
+        };
+      } catch (error) {
+        return { content: [{ type: "text" as const, text: formatApiError(error) }], isError: true };
+      }
+    }),
+  );
+}

--- a/packages/mcp/tools/posts.ts
+++ b/packages/mcp/tools/posts.ts
@@ -4,46 +4,80 @@ import { api, formatApiError } from "../lib/api-client.js";
 import { normalizeVisibility, unwrapApiResponse } from "../lib/api-response.js";
 import { withAuthGuard } from "../lib/auth-guard.js";
 import { formatPost } from "../lib/formatters.js";
+import { buildPostContentPayload, resolveMediaInputs } from "../lib/resolve-media.js";
+import {
+  articleInputSchema,
+  attachmentDescriptorSchema,
+  eventInputSchema,
+  locationInputSchema,
+  mediaInputSchema,
+  pollInputSchema,
+  podcastInputSchema,
+  postMetadataSchema,
+  replyPermissionSchema,
+  roomInputSchema,
+  sourceLinkSchema,
+  threadPostSchema,
+  visibilitySchema,
+} from "../lib/post-content-schema.js";
 
-const visibilitySchema = z
-  .enum(["public", "private", "followers", "followers_only"])
-  .optional()
-  .describe("Post visibility (default: public)");
+const createPostFields = {
+  text: z.string().describe("The text content of the post"),
+  media: z.array(mediaInputSchema).max(10).optional().describe("Images/videos — fileId, url, or base64"),
+  poll: pollInputSchema.optional(),
+  location: locationInputSchema.optional(),
+  sources: z.array(sourceLinkSchema).max(5).optional(),
+  article: articleInputSchema.optional(),
+  event: eventInputSchema.optional(),
+  room: roomInputSchema.optional(),
+  podcast: podcastInputSchema.optional(),
+  attachments: z.array(attachmentDescriptorSchema).optional(),
+  visibility: visibilitySchema,
+  hashtags: z.array(z.string()).optional().describe("Hashtags (without # prefix)"),
+  mentions: z.array(z.string()).optional().describe("User IDs to mention"),
+  parentPostId: z.string().optional().describe("ID of the post to reply to"),
+  status: z.enum(["published", "draft", "scheduled"]).optional(),
+  scheduledFor: z.string().optional().describe("ISO date for scheduled posts"),
+  replyPermission: replyPermissionSchema,
+  reviewReplies: z.boolean().optional(),
+  quotesDisabled: z.boolean().optional(),
+  collaboratorIds: z.array(z.string()).optional(),
+  metadata: postMetadataSchema.optional(),
+};
 
 export function registerPostsTools(server: McpServer): void {
   server.tool(
     "create-post",
-    "Create a new post on Mention (requires authorization).",
-    {
-      text: z.string().describe("The text content of the post"),
-      visibility: visibilitySchema,
-      hashtags: z.array(z.string()).optional().describe("Hashtags (without # prefix)"),
-      mentions: z.array(z.string()).optional().describe("User IDs to mention"),
-      parentPostId: z.string().optional().describe("ID of the post to reply to"),
-      sources: z
-        .array(z.object({ url: z.string(), title: z.string().optional() }))
-        .optional()
-        .describe("External sources cited in the post"),
-      status: z.enum(["published", "draft", "scheduled"]).optional(),
-      scheduledFor: z.string().optional().describe("ISO date for scheduled posts"),
-      language: z.string().optional().describe("Language code (default: en)"),
-      replyPermission: z
-        .array(z.enum(["anyone", "followers", "following", "mentioned", "nobody"]))
-        .optional(),
-    },
-    withAuthGuard(async ({ text, visibility, hashtags, mentions, parentPostId, sources, status, scheduledFor, language, replyPermission }) => {
+    "Create a new post on Mention with optional media, poll, article, event, room, podcast, location, and sources (requires authorization).",
+    createPostFields,
+    withAuthGuard(async (args) => {
       try {
-        const body: Record<string, unknown> = { content: { text } };
-        const vis = normalizeVisibility(visibility);
+        const content = await buildPostContentPayload({
+          text: args.text,
+          ...(args.media ? { media: args.media } : {}),
+          ...(args.poll ? { poll: args.poll } : {}),
+          ...(args.location ? { location: args.location } : {}),
+          ...(args.sources ? { sources: args.sources } : {}),
+          ...(args.article ? { article: args.article } : {}),
+          ...(args.event ? { event: args.event } : {}),
+          ...(args.room ? { room: args.room } : {}),
+          ...(args.podcast ? { podcast: args.podcast } : {}),
+          ...(args.attachments ? { attachments: args.attachments } : {}),
+        });
+
+        const body: Record<string, unknown> = { content };
+        const vis = normalizeVisibility(args.visibility);
         if (vis) body.visibility = vis;
-        if (hashtags) body.hashtags = hashtags;
-        if (mentions) body.mentions = mentions;
-        if (parentPostId) body.parentPostId = parentPostId;
-        if (sources) body.sources = sources;
-        if (status) body.status = status;
-        if (scheduledFor) body.scheduledFor = scheduledFor;
-        if (language) body.language = language;
-        if (replyPermission) body.replyPermission = replyPermission;
+        if (args.hashtags) body.hashtags = args.hashtags;
+        if (args.mentions) body.mentions = args.mentions;
+        if (args.parentPostId) body.parentPostId = args.parentPostId;
+        if (args.status) body.status = args.status;
+        if (args.scheduledFor) body.scheduledFor = args.scheduledFor;
+        if (args.replyPermission) body.replyPermission = args.replyPermission;
+        if (args.reviewReplies !== undefined) body.reviewReplies = args.reviewReplies;
+        if (args.quotesDisabled !== undefined) body.quotesDisabled = args.quotesDisabled;
+        if (args.collaboratorIds) body.collaboratorIds = args.collaboratorIds;
+        if (args.metadata) body.metadata = args.metadata;
 
         const result = await api.post("/posts", body);
         const post = unwrapApiResponse(result);
@@ -56,26 +90,33 @@ export function registerPostsTools(server: McpServer): void {
 
   server.tool(
     "create-thread",
-    "Create a multi-post thread (requires authorization).",
+    "Create a multi-post thread with full attachment support per post (requires authorization).",
     {
-      posts: z
-        .array(
-          z.object({
-            text: z.string(),
-            hashtags: z.array(z.string()).optional(),
-            mentions: z.array(z.string()).optional(),
-          }),
-        )
-        .min(2),
-      visibility: visibilitySchema,
+      posts: z.array(threadPostSchema).min(2),
+      mode: z.enum(["thread", "beast"]).optional().describe("thread = linked chain (default); beast = separate posts"),
     },
-    withAuthGuard(async ({ posts, visibility }) => {
+    withAuthGuard(async ({ posts, mode }) => {
       try {
-        const body: Record<string, unknown> = { posts };
-        const vis = normalizeVisibility(visibility);
-        if (vis) body.visibility = vis;
+        const wirePosts = await Promise.all(
+          posts.map(async (post) => {
+            const content = await buildPostContentPayload(post.content);
+            const entry: Record<string, unknown> = { content };
+            const vis = normalizeVisibility(post.visibility);
+            if (vis) entry.visibility = vis;
+            if (post.hashtags) entry.hashtags = post.hashtags;
+            if (post.mentions) entry.mentions = post.mentions;
+            if (post.replyPermission) entry.replyPermission = post.replyPermission;
+            if (post.reviewReplies !== undefined) entry.reviewReplies = post.reviewReplies;
+            if (post.quotesDisabled !== undefined) entry.quotesDisabled = post.quotesDisabled;
+            if (post.metadata) entry.metadata = post.metadata;
+            return entry;
+          }),
+        );
 
-        const result = await api.post("/posts/thread", body);
+        const result = await api.post("/posts/thread", {
+          mode: mode ?? "thread",
+          posts: wirePosts,
+        });
         const resultObj = unwrapApiResponse<Record<string, unknown>>(result);
         const threadPosts = Array.isArray(resultObj.posts) ? resultObj.posts : [resultObj];
         const formatted = threadPosts.map((p: Record<string, unknown>) => formatPost(p)).join("\n\n---\n\n");
@@ -102,17 +143,26 @@ export function registerPostsTools(server: McpServer): void {
 
   server.tool(
     "update-post",
-    "Update an existing post (requires authorization).",
+    "Update an existing post including media and sources (requires authorization).",
     {
       id: z.string(),
       text: z.string().optional(),
+      media: z.array(mediaInputSchema).max(10).optional(),
+      sources: z.array(sourceLinkSchema).max(5).optional(),
       visibility: visibilitySchema,
       hashtags: z.array(z.string()).optional(),
     },
-    withAuthGuard(async ({ id, text, visibility, hashtags }) => {
+    withAuthGuard(async ({ id, text, media, sources, visibility, hashtags }) => {
       try {
         const body: Record<string, unknown> = {};
-        if (text !== undefined) body.content = { text };
+        const content: Record<string, unknown> = {};
+        if (text !== undefined) content.text = text;
+        if (media && media.length > 0) {
+          content.media = await resolveMediaInputs(media);
+        }
+        if (sources) content.sources = sources;
+        if (Object.keys(content).length > 0) body.content = content;
+
         const vis = normalizeVisibility(visibility);
         if (vis) body.visibility = vis;
         if (hashtags) body.hashtags = hashtags;


### PR DESCRIPTION
## Summary
- Centralize MCP post content Zod schemas and add full attachment support across create/update/quote/thread tools
- Route MCP media uploads through `POST /posts/intent-media` (URL + base64) using Oxy service `user-media` for MCP JWT callers
- Fix `createPost` visibility passthrough and document MCP media/tools across repo docs

## Test plan
- [x] `cd packages/mcp && bun test` (10/10)
- [x] `cd packages/backend && bun test src/__tests__/routes/intentMedia.test.ts` (5/5)
- [ ] Verify oxy-api deploy completes before mention backend/mcp deploy
- [ ] Smoke test MCP `upload-media` / `create-post` with media on `mcp.mention.earth`


Made with [Cursor](https://cursor.com)