### PR TITLE
chore(frontend): remove Chat item from sidebar

### DIFF
--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -25,7 +25,6 @@ import { Video, VideoActive } from "@/assets/icons/video-icon";
 import { Hashtag, HashtagActive } from "@/assets/icons/hashtag-icon";
 import { AnalyticsIcon, AnalyticsIconActive } from "@/assets/icons/analytics-icon";
 import { useTheme } from '@oxyhq/bloom/theme';
-import { Chat, ChatActive } from '@/assets/icons/chat-icon';
 import { Bell, BellActive } from '@/assets/icons/bell-icon';
 import { SyraIcon, SyraIconActive } from '@syra.fm/sdk';
 import { useAuth, ProfileButton } from '@oxyhq/services';
@@ -64,7 +63,7 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
     const avatarUri = user?.avatar;
 
     // Every sidebar destination is a TAB ROOT (home, the current user's own
-    // profile, explore, notifications, chat, live rooms, insights, saved, feeds,
+    // profile, explore, notifications, live rooms, insights, saved, feeds,
     // lists, videos, settings). With the (app) center now a Stack, `navigate`
     // pops to an existing instance of the target instead of stacking a new copy,
     // so repeatedly clicking tabs never grows the stack or duplicates Home.
@@ -128,12 +127,6 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
             icon: <Bell />,
             iconActive: <BellActive />,
             route: '/notifications',
-        },
-        {
-            title: t("sidebar.chat"),
-            icon: <Chat />,
-            iconActive: <ChatActive />,
-            route: '/chat',
         },
         {
             title: t("sidebar.liveRooms"),


### PR DESCRIPTION
## Summary
- Removes the "Chat" item from the sidebar (`sideBarData`) and its now-unused `Chat`/`ChatActive` icon import.
- Updates a stale inline comment that listed sidebar destinations.

## Test plan
- [x] Scoped `eslint` run on the modified file: 0 errors (2 pre-existing warnings unrelated to this change).
- [x] Verified no remaining references to `Chat`/`chat-icon` in the file.
- [ ] CI checks on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->