### PR TITLE
fix(frontend): rebuild notification row from Post anatomy (NativeWind, full-width) + list parity

### DIFF
--- a/packages/frontend/components/NotificationsList.web.tsx
+++ b/packages/frontend/components/NotificationsList.web.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { View } from 'react-native';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import { useScrollRestoration } from '@oxyhq/bloom/scroll';
@@ -22,9 +22,16 @@ export interface NotificationsListProps {
     isFetchingMore?: boolean;
 }
 
-// Notification rows are short; a small estimate + per-row measurement keeps the
-// mounted node count bounded while the document scrolls.
-const ESTIMATED_ROW_HEIGHT = 84;
+// First-paint size guess before a row is measured. Single-actor rows land around
+// ~71px and grouped rows (avatar strip + "Show all" + preview) around ~158px, so
+// the mix skews toward the single row. The estimate is biased slightly ABOVE the
+// common single-row height: an estimate under a grouped row's real height would
+// position the next row against the shorter guess and overlap it for a frame,
+// whereas a slightly-high guess only yields a transient gap that measurement
+// closes. `measureElement` (a ResizeObserver, wired via a stable ref below)
+// replaces this with the real height as each row mounts and as its grouped
+// content settles.
+const ESTIMATED_ROW_HEIGHT = 96;
 const OVERSCAN_ROWS = 8;
 
 /**
@@ -53,6 +60,35 @@ export function NotificationsList({ items, renderRow, header, emptyState, tabKey
         scrollMargin,
         getItemKey: (index) => items[index].key,
     });
+
+    // Per-row ref factory: returns a STABLE callback (cached per row key) that
+    // wires the virtualizer's measurement ref on the row node. Stability matters —
+    // a fresh inline `virtualizer.measureElement` each render makes React
+    // detach/re-attach the ref on every render, tearing down and rebuilding the
+    // ResizeObserver `measureElement` installs. That drops the resize
+    // notification when a grouped row grows from its short first mount (~71px) to
+    // its settled height (~158px), so the next row keeps its stale position and
+    // overlaps the grown row. Caching one callback per key (so the ref only fires
+    // on real mount/unmount, and the ResizeObserver stays attached) is the same
+    // robustness the posts feed uses in `components/Feed/Feed.web.tsx`.
+    // `measureElement` is stable for the lifetime of this virtualizer.
+    const measureElement = virtualizer.measureElement;
+    const rowRefCallbacks = useRef(new Map<string, (node: HTMLDivElement | null) => void>());
+    const getRowRef = useCallback((key: string) => {
+        const cache = rowRefCallbacks.current;
+        const existing = cache.get(key);
+        if (existing) return existing;
+        // Bound the cache so a long scroll session doesn't accumulate one closure
+        // per row forever. Only rows in the virtual window are ever mounted, so a
+        // modest cap covers the live set; evicting the rest just recreates a
+        // row's callback once on a future re-scroll.
+        if (cache.size > 500) cache.clear();
+        const cb = (node: HTMLDivElement | null) => {
+            measureElement(node);
+        };
+        cache.set(key, cb);
+        return cb;
+    }, [measureElement]);
 
     useScrollRestoration('window', { enabled: true, key: `notifications-${tabKey}` });
 
@@ -89,7 +125,10 @@ export function NotificationsList({ items, renderRow, header, emptyState, tabKey
                     return (
                         <div
                             key={virtualRow.key as React.Key}
-                            ref={virtualizer.measureElement}
+                            // Stable per-key ref (cached) so the ResizeObserver
+                            // `measureElement` installs survives re-renders and
+                            // catches a grouped row growing after first paint.
+                            ref={getRowRef(item.key)}
                             data-index={virtualRow.index}
                             style={{
                                 position: 'absolute',

--- a/packages/frontend/components/notifications/NotificationItem.tsx
+++ b/packages/frontend/components/notifications/NotificationItem.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
-import { View, Pressable, StyleSheet, Text } from 'react-native';
+import { View, Pressable, Text } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Ionicons } from '@expo/vector-icons';
-import { PressableScale } from '@oxyhq/bloom/pressable-scale';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { Button } from '@oxyhq/bloom/button';
+import { SubtleHover } from '@oxyhq/bloom/subtle-hover';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { show as toast } from '@oxyhq/bloom/toast';
 import { queryKeys as sdkQueryKeys } from '@oxyhq/services';
@@ -14,7 +14,6 @@ import { getNormalizedUserHandle } from '@oxyhq/core';
 import type { User } from '@oxyhq/core';
 import type { PostUser } from '@mention/shared-types';
 
-import { ThemedText } from '../ThemedText';
 import UserName from '../UserName';
 import { LinkifiedText } from '../common/LinkifiedText';
 import { RemoteActorBadge } from '@/components/Fediverse/FediverseBadge';
@@ -35,18 +34,12 @@ const logger = createScopedLogger('NotificationItem');
 
 type GroupedActor = GroupedNotification['actors'][number];
 
-// Layout tokens copied (NOT imported) from the Post anatomy so notification rows
-// share the feed's avatar-column + content-column rhythm.
+// The avatar column mirrors the feed post anatomy (single source of truth:
+// POST_ITEM_SPACING). AVATAR_SIZE = 40. The row's horizontal padding (HPAD = 12
+// → px-3), vertical padding (VPAD = 12 → py-3) and avatar gap (AVATAR_GAP = 12 →
+// mr-3) are expressed as NativeWind classes below so the row reads like a post.
 const AVATAR_SIZE = POST_ITEM_SPACING.AVATAR_SIZE;
-const AVATAR_GAP = POST_ITEM_SPACING.AVATAR_GAP;
-const HPAD = POST_ITEM_SPACING.HPAD;
-const VPAD = POST_ITEM_SPACING.VPAD;
 
-// Byline row gap between name/handle and the trailing "· time" — mirrors
-// PostHeader's `ROW_GAP` so a notification reads like a feed post byline.
-const ROW_GAP = 8;
-
-const BADGE_SIZE = 20;
 const BADGE_ICON_SIZE = 12;
 // The action badge FILL is themed (`theme.colors[colorToken]`); this white glyph
 // sits on top of that saturated fill for contrast across every preset/mode. A
@@ -54,7 +47,6 @@ const BADGE_ICON_SIZE = 12;
 const BADGE_GLYPH_COLOR = '#ffffff';
 
 const STACK_AVATAR_SIZE = 24;
-const STACK_OVERLAP = -8;
 // Actors shown in the collapsed avatar strip before collapsing into "+N".
 const COLLAPSED_STRIP_LIMIT = 3;
 // Matches a bare Oxy user id so it is never surfaced as a display name.
@@ -170,7 +162,7 @@ function postContentText(content: unknown): string | undefined {
  * hooks or SQLite reads). Renders nothing when there is no text.
  */
 const NotificationPreview: React.FC<{ text: string }> = ({ text }) => (
-  <LinkifiedText text={text} numberOfLines={2} className="text-muted-foreground" style={styles.preview} />
+  <LinkifiedText text={text} numberOfLines={2} className="text-muted-foreground text-sm leading-5" />
 );
 
 /** Collapsed stacked-avatar strip (up to 3 + "+N") for grouped rows. */
@@ -178,23 +170,25 @@ const AvatarStrip: React.FC<{ actors: ResolvedActor[]; totalActors: number }> = 
   const shown = actors.slice(0, COLLAPSED_STRIP_LIMIT);
   const extra = totalActors - shown.length;
   return (
-    <View style={styles.stripRow}>
+    <View className="flex-row items-center">
       {shown.map((actor, index) => (
+        // `zIndex` is the only per-item dynamic value (stack order) — everything
+        // else is NativeWind. The -8px overlap for every avatar after the first
+        // is `-ml-2`.
         <View
           key={actor.id}
-          style={[styles.stripItem, { marginLeft: index > 0 ? STACK_OVERLAP : 0, zIndex: shown.length - index }]}
+          className={cn(index > 0 && '-ml-2')}
+          style={{ zIndex: shown.length - index }}
         >
-          <View className="border-background" style={styles.stripAvatarBorder}>
+          <View className="border-2 border-background rounded-full">
             <Avatar source={actor.avatar} size={STACK_AVATAR_SIZE} />
           </View>
         </View>
       ))}
       {extra > 0 ? (
-        <View style={[styles.stripItem, { marginLeft: STACK_OVERLAP }]}>
-          <View className="bg-primary border-background" style={styles.moreBadge}>
-            <ThemedText className="text-primary-foreground" style={styles.moreText}>
-              +{extra}
-            </ThemedText>
+        <View className="-ml-2">
+          <View className="w-7 h-7 rounded-full border-2 bg-primary border-background items-center justify-center">
+            <Text className="text-primary-foreground text-[9px] font-bold">+{extra}</Text>
           </View>
         </View>
       ) : null}
@@ -370,217 +364,120 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
 
   const showStrip = isGroup && resolvedActors.length > 1 && !expanded;
 
+  // Row anatomy copied (NOT imported) from PostItem + PostHeader: a full-width,
+  // edge-to-edge Pressable (background + bottom border span the whole width, the
+  // group-hover wash matches the feed) with the horizontal padding living INSIDE
+  // via the px-3 wrapper — exactly how PostHeader insets its content. Unread rows
+  // get the same subtle primary tint the feed uses for emphasis.
   return (
-    <PressableScale
-      className={cn('border-border', hasUnread && 'bg-primary/5')}
-      style={styles.container}
+    <Pressable
+      className={cn('group bg-background border-b border-border py-3', hasUnread && 'bg-primary/5')}
       onPress={handlePress}
       onLongPress={handleLongPress}
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
     >
-      <View style={styles.avatarColumn}>
-        <Avatar source={resolvedPrimary.avatar} size={AVATAR_SIZE} />
-        <View className="border-background" style={[styles.actionBadge, { backgroundColor: badgeColor }]}>
-          <Ionicons name={descriptor.icon} size={BADGE_ICON_SIZE} color={BADGE_GLYPH_COLOR} />
-        </View>
-      </View>
+      <SubtleHover />
+      <View className="px-3">
+        <View className="flex-row items-start justify-between">
+          {/* Avatar column: avatar + themed action-badge overlay. */}
+          <View className="relative mr-3">
+            <Avatar source={resolvedPrimary.avatar} size={AVATAR_SIZE} />
+            <View
+              className="absolute -bottom-0.5 -right-0.5 w-5 h-5 rounded-full border-2 border-background items-center justify-center"
+              style={{ backgroundColor: badgeColor }}
+            >
+              <Ionicons name={descriptor.icon} size={BADGE_ICON_SIZE} color={BADGE_GLYPH_COLOR} />
+            </View>
+          </View>
 
-      <View style={styles.content}>
-        {showStrip ? <AvatarStrip actors={resolvedActors} totalActors={item.totalActors} /> : null}
+          {/* Content column — mirrors PostHeader's flex-1 name/handle/time byline
+              plus the muted action phrase and the text preview. */}
+          <View className="flex-1 gap-1">
+            {showStrip ? <AvatarStrip actors={resolvedActors} totalActors={item.totalActors} /> : null}
 
-        {/* Byline: bold name + muted @handle + "· time", mirroring PostHeader. */}
-        <View className="flex-row items-end" style={{ gap: ROW_GAP }}>
-          <View className="flex-row items-end flex-shrink" style={styles.bylineName}>
-            <UserName
-              name={bylineName}
-              verified={isSingleActor && resolvedPrimary.verified}
-              style={{ container: styles.nameContainer, name: styles.nameText }}
-            />
-            {showHandleLine ? (
-              <Text
-                className="text-muted-foreground"
-                style={styles.handle}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {` @${resolvedPrimary.handle}`}
+            {/* Byline: bold name + muted @handle + federated badge + "· time". */}
+            <View className="flex-row items-end gap-2">
+              <View className="flex-row items-end flex-shrink min-w-0">
+                <UserName
+                  name={bylineName}
+                  verified={isSingleActor && resolvedPrimary.verified}
+                  style={{ container: { flexShrink: 0 } }}
+                />
+                {showHandleLine ? (
+                  <Text
+                    className="text-muted-foreground text-[15px] leading-5"
+                    style={{ flexShrink: 10, minWidth: 0 }}
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                  >
+                    {` @${resolvedPrimary.handle}`}
+                  </Text>
+                ) : null}
+                {isSingleActor && resolvedPrimary.isFederated ? (
+                  <RemoteActorBadge size={13} className="text-muted-foreground" containerClassName="self-center ml-1" />
+                ) : null}
+              </View>
+              {timeLabel ? (
+                <Text className="text-muted-foreground text-[15px] leading-5 shrink-0 web:whitespace-nowrap">
+                  {'·'} {timeLabel}
+                </Text>
+              ) : null}
+            </View>
+
+            {actionText ? (
+              <Text className="text-muted-foreground text-[15px] leading-5" numberOfLines={2}>
+                {actionText}
               </Text>
             ) : null}
-            {isSingleActor && resolvedPrimary.isFederated ? (
-              <RemoteActorBadge size={13} className="text-muted-foreground" containerClassName="self-center ml-1" />
-            ) : null}
-          </View>
-          {timeLabel ? (
-            <Text className="text-muted-foreground web:whitespace-nowrap" style={styles.time}>
-              {'·'} {timeLabel}
-            </Text>
-          ) : null}
-        </View>
 
-        {actionText ? (
-          <ThemedText className="text-muted-foreground" style={styles.action} numberOfLines={2}>
-            {actionText}
-          </ThemedText>
-        ) : null}
+            {previewText ? <NotificationPreview text={previewText} /> : null}
 
-        {previewText ? <NotificationPreview text={previewText} /> : null}
-
-        {isGroup && item.expandable ? (
-          <View style={styles.expandBlock}>
-            {expanded ? (
-              <View style={styles.actorList}>
-                {resolvedActors.map((actor) => (
-                  <Pressable
-                    key={actor.id}
-                    onPress={() => openActorProfile(actor)}
-                    style={styles.actorRow}
-                    accessibilityRole="button"
-                  >
-                    <Avatar source={actor.avatar} size={STACK_AVATAR_SIZE} />
-                    <UserName name={actorLabel(actor, someone)} variant="small" style={{ name: styles.actorListName }} />
-                  </Pressable>
-                ))}
+            {isGroup && item.expandable ? (
+              <View className="mt-1 gap-2">
+                {expanded ? (
+                  <View className="gap-2">
+                    {resolvedActors.map((actor) => (
+                      <Pressable
+                        key={actor.id}
+                        onPress={() => openActorProfile(actor)}
+                        className="flex-row items-center gap-2"
+                        accessibilityRole="button"
+                      >
+                        <Avatar source={actor.avatar} size={STACK_AVATAR_SIZE} />
+                        <UserName name={actorLabel(actor, someone)} variant="small" />
+                      </Pressable>
+                    ))}
+                  </View>
+                ) : null}
+                <Pressable onPress={toggleExpanded} hitSlop={8} accessibilityRole="button">
+                  <Text className="text-primary text-sm font-semibold">
+                    {expanded
+                      ? t('notification.group.showLess', { defaultValue: 'Show less' })
+                      : t('notification.group.showAll', { defaultValue: 'Show all' })}
+                  </Text>
+                </Pressable>
               </View>
             ) : null}
-            <Pressable onPress={toggleExpanded} hitSlop={8} accessibilityRole="button">
-              <ThemedText className="text-primary" style={styles.toggle}>
-                {expanded
-                  ? t('notification.group.showLess', { defaultValue: 'Show less' })
-                  : t('notification.group.showAll', { defaultValue: 'Show all' })}
-              </ThemedText>
-            </Pressable>
-          </View>
-        ) : null}
 
-        {isCollabInvite ? (
-          <View style={styles.collabActions}>
-            <Button className="flex-1" onPress={openAcceptSheet} disabled={actionLoading}>
-              {t('collab.accept', { defaultValue: 'Accept' })}
-            </Button>
-            <Button variant="secondary" className="flex-1" onPress={runDecline} disabled={actionLoading}>
-              {t('collab.decline', { defaultValue: 'Decline' })}
-            </Button>
+            {isCollabInvite ? (
+              <View className="flex-row gap-2 mt-2">
+                <Button className="flex-1" onPress={openAcceptSheet} disabled={actionLoading}>
+                  {t('collab.accept', { defaultValue: 'Accept' })}
+                </Button>
+                <Button variant="secondary" className="flex-1" onPress={runDecline} disabled={actionLoading}>
+                  {t('collab.decline', { defaultValue: 'Decline' })}
+                </Button>
+              </View>
+            ) : null}
           </View>
-        ) : null}
+
+          {hasUnread ? <View className="w-2 h-2 rounded-full bg-primary self-center ml-2" /> : null}
+        </View>
       </View>
-
-      {hasUnread ? <View className="bg-primary" style={styles.unreadDot} /> : null}
-    </PressableScale>
+    </Pressable>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    paddingHorizontal: HPAD,
-    paddingVertical: VPAD,
-    borderBottomWidth: 1,
-    backgroundColor: 'transparent',
-  },
-  avatarColumn: {
-    position: 'relative',
-    marginRight: AVATAR_GAP,
-  },
-  actionBadge: {
-    position: 'absolute',
-    bottom: -2,
-    right: -2,
-    width: BADGE_SIZE,
-    height: BADGE_SIZE,
-    borderRadius: BADGE_SIZE / 2,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 2,
-  },
-  content: {
-    flex: 1,
-    gap: 2,
-  },
-  bylineName: {
-    minWidth: 0,
-  },
-  nameContainer: {
-    flexShrink: 0,
-  },
-  nameText: {
-    fontSize: 15,
-    lineHeight: 20,
-  },
-  handle: {
-    fontSize: 15,
-    lineHeight: 20,
-    flexShrink: 10,
-    minWidth: 0,
-  },
-  time: {
-    fontSize: 15,
-    lineHeight: 20,
-    flexShrink: 0,
-  },
-  action: {
-    fontSize: 15,
-    lineHeight: 20,
-  },
-  preview: {
-    fontSize: 14,
-    lineHeight: 19,
-    marginTop: 2,
-  },
-  stripRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  stripItem: {},
-  stripAvatarBorder: {
-    borderWidth: 2,
-    borderRadius: 14,
-  },
-  moreBadge: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    borderWidth: 2,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  moreText: {
-    fontSize: 9,
-    fontWeight: '700',
-  },
-  expandBlock: {
-    marginTop: 4,
-    gap: 8,
-  },
-  actorList: {
-    gap: 8,
-  },
-  actorRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  actorListName: {
-    fontSize: 14,
-  },
-  toggle: {
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  collabActions: {
-    flexDirection: 'row',
-    gap: 8,
-    marginTop: 8,
-  },
-  unreadDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    alignSelf: 'center',
-    marginLeft: 8,
-  },
-});
 
 // Memoized: a realtime patch to one notification (or a parent re-render) must not
 // re-render every row — the parent passes a stable `item` and a memoized


### PR DESCRIPTION
## Summary
Addresses feedback that the notifications screen didn't match the posts: rows weren't full-width, used StyleSheet instead of NativeWind, weren't based on the real Post structure, and the list briefly overlapped rows on load.

- Row rebuilt copying the feed post anatomy (PostItem container + PostHeader byline): full-width edge-to-edge Pressable + SubtleHover + bottom border, bold name + muted @handle + federated badge + relative time, then action phrase + text preview. StyleSheet.create removed — NativeWind classNames throughout.
- Web notifications list brought to parity with `Feed.web.tsx` (stable per-key measurement ref) so a grouped row growing after first paint is re-measured and rows no longer overlap on load.

## Test plan
- `cd packages/frontend && bun run typecheck` — clean for touched files (only the 12 pre-existing errors in feeds.tsx / FollowedByRow.tsx / utils/api.ts remain)
- `cd packages/frontend && bun run lint` — clean
- `bun run build:frontend` (web export) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->