### PR TITLE
fix(frontend): make notification row full-width (w-full)

### DIFF
--- a/packages/frontend/components/notifications/NotificationItem.tsx
+++ b/packages/frontend/components/notifications/NotificationItem.tsx
@@ -371,7 +371,7 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
   // get the same subtle primary tint the feed uses for emphasis.
   return (
     <Pressable
-      className={cn('group bg-background border-b border-border py-3', hasUnread && 'bg-primary/5')}
+      className={cn('group w-full bg-background border-b border-border py-3', hasUnread && 'bg-primary/5')}
       onPress={handlePress}
       onLongPress={handleLongPress}
       accessibilityRole="button"


### PR DESCRIPTION
## Summary
The notification row's background, bottom border, hover wash and unread dot stopped partway across the panel instead of spanning it. Root cause (pinned via live DOM inspection on prod): the virtualizer's row div is the full panel width (592px), but the row's root RN-Web `Pressable` renders as a flex box that shrinks to its content (~379px) inside a plain block parent, so it never filled the container. Adding `w-full` makes the row fill the list width edge-to-edge like a feed post (verified live: forcing width:100% took the Pressable from ~379px to the full 592px panel).

One-line change: `w-full` on the row Pressable.

## Test plan
- `cd packages/frontend && bun run typecheck` — clean for the touched file
- `cd packages/frontend && bun run lint` — clean
- Verified live in prod that width:100% on the Pressable spans the full panel; this lands it in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->