### PR TITLE
fix(backend): render federated boosts/quotes of orphan-author originals (+ author backfill script)

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -185,7 +185,7 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     // aggregation must NOT match the original. Route by query shape.
     postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
-      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+      if (Array.isArray(idIn) && idIn.some((v) => String(v) === ORIGINAL_ID)) {
         return [originalRow()];
       }
       return [];
@@ -235,7 +235,7 @@ describe('PostHydrationService — boost original embedding is deterministic', (
 
     postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
-      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+      if (Array.isArray(idIn) && idIn.some((v) => String(v) === ORIGINAL_ID)) {
         return [{
           ...originalRow(),
           visibility: 'private',
@@ -258,7 +258,7 @@ describe('PostHydrationService — boost original embedding is deterministic', (
 
     postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
-      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+      if (Array.isArray(idIn) && idIn.some((v) => String(v) === ORIGINAL_ID)) {
         return [{
           ...originalRow(),
           visibility: 'followers_only',
@@ -307,7 +307,7 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     // marked federated with the origin instance — never a fabricated handle.
     postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
-      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+      if (Array.isArray(idIn) && idIn.some((v) => String(v) === ORIGINAL_ID)) {
         return [{
           ...originalRow(),
           oxyUserId: null,
@@ -344,7 +344,7 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     const ACTOR_URI = 'https://mastodon.online/users/kaleidotrope';
     postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
-      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+      if (Array.isArray(idIn) && idIn.some((v) => String(v) === ORIGINAL_ID)) {
         return [{
           ...originalRow(),
           oxyUserId: null,
@@ -358,7 +358,7 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     // The orphan-author resolution queries FederatedActor by `uri`.
     federatedActorFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const uriIn = (query?.uri as { $in?: unknown[] } | undefined)?.$in;
-      if (Array.isArray(uriIn) && uriIn.map(String).includes(ACTOR_URI)) {
+      if (Array.isArray(uriIn) && uriIn.some((v) => String(v) === ACTOR_URI)) {
         return [{ uri: ACTOR_URI, username: 'kaleidotrope', acct: 'kaleidotrope@mastodon.online', domain: 'mastodon.online', avatarUrl: 'https://mastodon.online/a.png' }];
       }
       return [];
@@ -414,7 +414,7 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     const FEDERATED_AUTHOR_OXY_ID = 'oxy-terrible-maps';
     postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
-      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+      if (Array.isArray(idIn) && idIn.some((v) => String(v) === ORIGINAL_ID)) {
         return [{
           ...originalRow(),
           oxyUserId: FEDERATED_AUTHOR_OXY_ID,
@@ -484,7 +484,7 @@ describe('PostHydrationService — boost original embedding is deterministic', (
 
     postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
-      if (!Array.isArray(idIn) || !idIn.map(String).includes(ORIGINAL_ID)) {
+      if (!Array.isArray(idIn) || !idIn.some((v) => String(v) === ORIGINAL_ID)) {
         return [];
       }
 

--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -26,12 +26,13 @@ const BOOSTER_OXY_ID = 'oxy-booster';
 const ORIGINAL_AUTHOR_OXY_ID = 'oxy-original-author';
 const VIEWER_ID = 'oxy-viewer';
 
-const { getUserById, getUsersByIds, cacheStore, postFind, postFindOne } = vi.hoisted(() => ({
+const { getUserById, getUsersByIds, cacheStore, postFind, postFindOne, federatedActorFind } = vi.hoisted(() => ({
   getUserById: vi.fn(),
   getUsersByIds: vi.fn(),
   cacheStore: new Map<string, CachedUserSummary>(),
   postFind: vi.fn(),
   postFindOne: vi.fn(),
+  federatedActorFind: vi.fn(),
 }));
 
 vi.mock('../../../server', () => ({
@@ -86,12 +87,14 @@ vi.mock('../../models/UserSettings', () => ({
   UserSettings: { find: () => chainable([]), findOne: () => chainable(null) },
 }));
 
-// Federated enrichment lookup for any still-degraded author. Return nothing so
-// an unresolved federated author stays degraded (the boost original with no
-// oxyUserId is dropped upstream, never enriched).
+// FederatedActor lookup, shared by two paths: the degraded-author enrichment
+// (keyed by `oxyUserId`) and the orphan-federated-author resolution (keyed by
+// `uri`). Routed by query via `federatedActorFind`; defaults to no rows so an
+// unresolved federated author degrades to a neutral "Unknown user" (but its
+// content STILL renders — orphans are no longer dropped).
 vi.mock('../../models/FederatedActor', () => ({
-  FederatedActor: { find: () => ({ select: () => ({ lean: async () => [] }) }) },
-  default: { find: () => ({ select: () => ({ lean: async () => [] }) }) },
+  FederatedActor: { find: (...args: unknown[]) => ({ select: () => ({ lean: async () => federatedActorFind(...args) }) }) },
+  default: { find: (...args: unknown[]) => ({ select: () => ({ lean: async () => federatedActorFind(...args) }) }) },
 }));
 
 vi.mock('../../services/userSummaryCache', () => ({
@@ -165,6 +168,9 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     getUsersByIds.mockReset();
     postFind.mockReset();
     postFindOne.mockReset();
+    federatedActorFind.mockReset();
+    // No FederatedActor rows unless a test opts in.
+    federatedActorFind.mockResolvedValue([]);
 
     // Both authors resolve via the bulk Oxy fetch.
     getUsersByIds.mockResolvedValue([
@@ -290,18 +296,22 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     }
   });
 
-  it('drops a federated boost original that has no oxyUserId (invariant: no orphans)', async () => {
+  it('renders a federated boost original that has no oxyUserId in a degraded form (legacy orphan)', async () => {
     service = new PostHydrationService();
 
-    // Stage 1 made "every federated post has an oxyUserId" a true invariant, so
-    // an original whose author was never linked to an Oxy user no longer renders
-    // via a local-actor fallback — it is dropped, and the boost has no original.
+    // A LEGACY orphan: a federated original ingested before the federated-actor →
+    // Oxy-user link was enforced, so its `oxyUserId` is null. It is NO LONGER
+    // dropped — its content must render so the boost is not blank. With no
+    // `actorUri` (a brid.gy/Bluesky-style note carrying only an `activityId`) and
+    // no FederatedActor row, the author degrades to a neutral "Unknown user"
+    // marked federated with the origin instance — never a fabricated handle.
     postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
       const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
       if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
         return [{
           ...originalRow(),
           oxyUserId: null,
+          authorship: [],
           federation: { activityId: 'https://zpravobot.news/users/TerribleMaps/statuses/123' },
         }];
       }
@@ -312,11 +322,90 @@ describe('PostHydrationService — boost original embedding is deterministic', (
 
     const [hydrated] = await hydrateBoost(undefined);
 
-    // The boost itself still hydrates (the booster is a real Oxy user), but the
-    // authorless original is dropped rather than rendered with a fabricated name.
     expect(hydrated).toBeTruthy();
-    expect(hydrated.boost).toBeNull();
-    expect(hydrated.originalPost).toBeNull();
+    // The boost original now embeds, with its real content shown.
+    expect(hydrated.boost?.originalPost?.id).toBe(ORIGINAL_ID);
+    expect(hydrated.originalPost?.id).toBe(ORIGINAL_ID);
+    expect(hydrated.boost?.originalPost?.content?.text).toBe('the original note body');
+    // The author is the neutral, un-tappable "Unknown user" (ghost-handle rule:
+    // empty handle), marked federated with the origin instance.
+    const originalUser = hydrated.boost?.originalPost?.user;
+    expect(originalUser?.username).toBe('');
+    expect(originalUser?.name?.displayName).toBe('Unknown user');
+    expect(originalUser?.isFederated).toBe(true);
+    expect(originalUser?.instance).toBe('zpravobot.news');
+    // No collaborator byline for an orphan — the header falls back to `user`.
+    expect(hydrated.boost?.originalPost?.authors).toEqual([]);
+  });
+
+  it('renders an orphan federated boost original with its real handle from the FederatedActor record', async () => {
+    service = new PostHydrationService();
+
+    const ACTOR_URI = 'https://mastodon.online/users/kaleidotrope';
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          oxyUserId: null,
+          authorship: [],
+          federation: { activityId: `${ACTOR_URI}/statuses/9`, actorUri: ACTOR_URI },
+        }];
+      }
+      return [];
+    });
+    getUsersByIds.mockResolvedValue([makeOxyUser(BOOSTER_OXY_ID, 'booster', 'Booster')]);
+    // The orphan-author resolution queries FederatedActor by `uri`.
+    federatedActorFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const uriIn = (query?.uri as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(uriIn) && uriIn.map(String).includes(ACTOR_URI)) {
+        return [{ uri: ACTOR_URI, username: 'kaleidotrope', acct: 'kaleidotrope@mastodon.online', domain: 'mastodon.online', avatarUrl: 'https://mastodon.online/a.png' }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await hydrateBoost(undefined);
+
+    const originalUser = hydrated.boost?.originalPost?.user;
+    expect(hydrated.boost?.originalPost?.content?.text).toBe('the original note body');
+    // Authoritative federated handle + avatar, never an invented display name.
+    expect(originalUser?.username).toBe('kaleidotrope');
+    expect(originalUser?.isFederated).toBe(true);
+    expect(originalUser?.instance).toBe('mastodon.online');
+    expect(originalUser?.federation?.domain).toBe('mastodon.online');
+    expect(originalUser?.avatar).toBe('https://mastodon.online/a.png');
+    expect(originalUser?.name?.displayName).toBeUndefined();
+  });
+
+  it('hydrates a bare orphan federated post viewed directly (not dropped from the depth-0 set)', async () => {
+    service = new PostHydrationService();
+
+    const orphanRow = {
+      ...originalRow(),
+      oxyUserId: null,
+      authorship: [],
+      federation: { activityId: 'https://bsky.brid.gy/convert/ap/at://did:plc:abc/app.bsky.feed.post/xyz' },
+    };
+    // Only the depth-1 reference fetch returns rows; the orphan is the depth-0
+    // input, so no reference lookup is needed here.
+    postFind.mockReturnValue([]);
+    getUsersByIds.mockResolvedValue([]);
+
+    const [hydrated] = await service.hydratePosts([orphanRow], {
+      viewerId: undefined,
+      maxDepth: 0,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    // The orphan is NOT filtered out of the initial depth-0 set — it renders.
+    expect(hydrated).toBeTruthy();
+    expect(hydrated.id).toBe(ORIGINAL_ID);
+    expect(hydrated.content?.text).toBe('the original note body');
+    expect(hydrated.user?.username).toBe('');
+    expect(hydrated.user?.name?.displayName).toBe('Unknown user');
+    expect(hydrated.user?.isFederated).toBe(true);
+    expect(hydrated.user?.instance).toBe('bsky.brid.gy');
   });
 
   it('renders the Oxy name.displayName for a resolved federated boost original', async () => {
@@ -363,6 +452,31 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     expect(hydrated.boost?.originalPost?.user?.instance).toBe('zpravobot.news');
     // The federated avatar (a bare Oxy file id) is carried through untouched.
     expect(hydrated.boost?.originalPost?.user?.avatar).toBe('terrible-maps-avatar-file-id');
+  });
+
+  it('still drops a NATIVE post with no author (a genuine data error, not a federated orphan)', async () => {
+    service = new PostHydrationService();
+
+    // A native (non-federated) post with a null author is a real data error — the
+    // degraded-render path is scoped to FEDERATED orphans only, so this stays
+    // dropped and never surfaces a nameless row.
+    const nativeNullAuthor = {
+      ...originalRow(),
+      oxyUserId: null,
+      authorship: [],
+      // No `federation` subdoc → native.
+    };
+    postFind.mockReturnValue([]);
+    getUsersByIds.mockResolvedValue([]);
+
+    const hydrated = await service.hydratePosts([nativeNullAuthor], {
+      viewerId: undefined,
+      maxDepth: 0,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    expect(hydrated).toEqual([]);
   });
 
   it('does not embed non-public boost originals when publicReferencesOnly is enabled', async () => {

--- a/packages/backend/src/__tests__/webShellRenderer.test.ts
+++ b/packages/backend/src/__tests__/webShellRenderer.test.ts
@@ -153,6 +153,17 @@ describe('mapPostOg', () => {
     expect(mapPostOg(post, 'p1').description).toHaveLength(200);
   });
 
+  it('falls back to the boosted original text when the boost body is empty', () => {
+    // A boost carries an intentionally empty body; its text lives on the embedded
+    // original (hydrated at maxDepth:1). The OG description must not be blank.
+    const boost = {
+      ...base,
+      content: { text: '' },
+      originalPost: { id: 'orig', content: { text: 'the boosted original body' } },
+    } as unknown as HydratedPost;
+    expect(mapPostOg(boost, 'b1').description).toBe('the boosted original body');
+  });
+
   it('prefers media url over thumb/poster/linkPreview/avatar', () => {
     const post = {
       ...base,

--- a/packages/backend/src/scripts/backfillFederatedPostAuthors.ts
+++ b/packages/backend/src/scripts/backfillFederatedPostAuthors.ts
@@ -1,0 +1,290 @@
+/**
+ * One-shot remediation: backfill the missing Oxy author link on LEGACY federated
+ * "orphan" posts.
+ *
+ * BACKGROUND
+ * ----------
+ * A federated post is authored by a federated actor whose identity is bridged to
+ * an Oxy user (`oxyUserId`, denormalized onto the post + its `authorship[]`). The
+ * CURRENT ingest paths (`ensureFederatedNote`, `handleCreate`, `syncOutboxPosts`)
+ * REQUIRE a resolved author and SKIP otherwise, so no NEW orphans are created.
+ * But a cohort of LEGACY posts (ingested before that invariant) carry
+ * `oxyUserId: null` — they are invisible in author feeds and render blank when a
+ * boost/quote references them. Phase 1 made hydration render such posts in a
+ * DEGRADED form (federation-derived author, so nothing is blank); THIS script is
+ * the remediation that restores their REAL author link.
+ *
+ * PER-ORPHAN ALGORITHM
+ * --------------------
+ * For each post with `federation.activityId` set and `oxyUserId == null`:
+ *   1. Determine the author actor URI:
+ *        - use `federation.actorUri` when present (no network); else
+ *        - re-fetch the AP object by `federation.activityId` (falling back to
+ *          `federation.url`) and read `attributedTo`. This covers brid.gy /
+ *          Bluesky-bridged notes, which arrive over ActivityPub (brid.gy is an AP
+ *          bridge) and whose actor is a normal AP actor — so the SAME
+ *          `actorService` path resolves them; the atproto connector is NOT
+ *          involved (that is READ/discovery of NATIVE bsky, and our own outbound
+ *          be-discovered bridge — both unrelated to inbound bridged content).
+ *   2. Resolve the actor URI → `oxyUserId` via `actorService.getOrFetchActor`,
+ *      forcing a full `fetchRemoteActor` (which mints/refreshes the Oxy user via
+ *      the shared `resolveOxyExternalUser` identity bridge) when a cached actor
+ *      row exists but was never linked. Repeated actors are resolved once
+ *      (in-memory cache) — the 11,967 orphans come from far fewer actors.
+ *   3. On success: set the post's `oxyUserId` + `authorship` (`buildAuthorship`)
+ *      and backfill `federation.actorUri` when it was missing. `updateOne` does
+ *      NOT run the Post pre-save hook, so BOTH fields are written explicitly and
+ *      stay in lockstep (the same shape the hook would produce).
+ *   4. DELETE the post ONLY when its source is definitively gone (HTTP 404/410)
+ *      AND no author could be resolved. A transient failure (timeout, 5xx, 401/403
+ *      signature rejection, SSRF-blocked, no `attributedTo`) is LEFT UNTOUCHED for
+ *      a later re-run — never deleted.
+ *
+ * SAFETY / OPERATION
+ * ------------------
+ * Idempotent (a linked post leaves the `oxyUserId: null` set), batched via a
+ * stable ascending `_id` cursor, bounded concurrency, best-effort per post (one
+ * failure never aborts the run). Writes and deletes are OFF by default:
+ *   - `BACKFILL_APPLY=true`   — actually write `oxyUserId`/`authorship`.
+ *   - `BACKFILL_DELETE_GONE=true` — additionally allow deleting 404/410-gone posts.
+ * With neither set the script is a pure DRY RUN that reports what it WOULD do.
+ *
+ * It makes signed remote fetches (instance key pair + service token), so run it
+ * as a Fargate one-shot in the oxy-api SG/subnets, post-deploy:
+ *   BACKFILL_APPLY=true node dist/scripts/backfillFederatedPostAuthors.js
+ */
+
+import mongoose from 'mongoose';
+import { Post } from '../models/Post';
+import { actorService } from '../connectors/activitypub/actor.service';
+import { extractActorUri, signedFetch, asRecord } from '../connectors/activitypub/helpers';
+import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
+import { assertSafePublicUrl } from '../utils/ssrfGuard';
+import { buildAuthorship } from '../utils/postAuthorship';
+import { logger } from '../utils/logger';
+
+/** Orphans scanned per page (stable ascending `_id` cursor). */
+const PAGE_SIZE = 200;
+
+/** Orphans resolved in parallel within a page (bounded to be polite to remotes). */
+const CONCURRENCY = 4;
+
+/** Write `oxyUserId`/`authorship` (else dry-run: report only). */
+const APPLY = process.env.BACKFILL_APPLY === 'true';
+
+/** Additionally allow deleting posts whose source is definitively gone (404/410). */
+const DELETE_GONE = process.env.BACKFILL_DELETE_GONE === 'true';
+
+interface OrphanRow {
+  _id: mongoose.Types.ObjectId;
+  federation?: { activityId?: string; actorUri?: string; url?: string };
+}
+
+/** The outcome of resolving one orphan's author actor URI. */
+type AuthorUriResult =
+  | { kind: 'ok'; authorUri: string; actorUriWasMissing: boolean }
+  | { kind: 'gone' }
+  | { kind: 'transient' };
+
+/** actorUri → resolved oxyUserId (or null when unresolvable) — dedupes shared actors. */
+const actorOxyCache = new Map<string, string | null>();
+
+/**
+ * Resolve an actor URI to its Oxy user id, minting/linking the federated Oxy user
+ * when necessary. `getOrFetchActor` returns a cached row as-is (kicking only a
+ * background refresh), so when that row has no `oxyUserId` we force an AWAITED
+ * `fetchRemoteActor`, which runs the shared identity bridge and stamps the id.
+ */
+async function resolveAuthorOxyUserId(actorUri: string): Promise<string | null> {
+  const cached = actorOxyCache.get(actorUri);
+  if (cached !== undefined) return cached;
+
+  let oxyUserId: string | null = null;
+  try {
+    const actor = await actorService.getOrFetchActor(actorUri);
+    oxyUserId = actor?.oxyUserId ?? null;
+    if (!oxyUserId) {
+      const refreshed = await actorService.fetchRemoteActor(actorUri);
+      oxyUserId = refreshed?.oxyUserId ?? null;
+    }
+  } catch (error) {
+    logger.warn('[backfillFederatedPostAuthors] actor resolution failed', {
+      actorUri,
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+  }
+
+  actorOxyCache.set(actorUri, oxyUserId);
+  return oxyUserId;
+}
+
+/**
+ * Determine the author actor URI for an orphan: prefer the stored
+ * `federation.actorUri`, otherwise re-fetch the AP object and read `attributedTo`.
+ * Distinguishes a definitively-gone source (404/410) from a transient failure so
+ * only truly-dead posts become deletion candidates.
+ */
+async function resolveOrphanAuthorUri(orphan: OrphanRow): Promise<AuthorUriResult> {
+  const storedActorUri = orphan.federation?.actorUri;
+  if (storedActorUri) {
+    return { kind: 'ok', authorUri: storedActorUri, actorUriWasMissing: false };
+  }
+
+  const objectUrl = orphan.federation?.activityId || orphan.federation?.url;
+  if (!objectUrl) return { kind: 'transient' };
+
+  const guard = await assertSafePublicUrl(objectUrl);
+  if (!guard.ok) return { kind: 'transient' };
+
+  let res: Response;
+  try {
+    res = await signedFetch(objectUrl, AP_CONTENT_TYPE);
+  } catch {
+    return { kind: 'transient' };
+  }
+
+  if (res.status === 404 || res.status === 410) return { kind: 'gone' };
+  if (!res.ok) return { kind: 'transient' };
+
+  let note: Record<string, unknown> | null;
+  try {
+    note = asRecord(await res.json());
+  } catch {
+    return { kind: 'transient' };
+  }
+
+  const authorUri = extractActorUri(note?.attributedTo);
+  if (!authorUri) return { kind: 'transient' };
+  return { kind: 'ok', authorUri, actorUriWasMissing: true };
+}
+
+interface Counters {
+  scanned: number;
+  linked: number;
+  deleted: number;
+  unresolvedAuthor: number;
+  transient: number;
+}
+
+/** Process one orphan; returns the counter bucket it fell into. */
+async function processOrphan(orphan: OrphanRow): Promise<keyof Omit<Counters, 'scanned'>> {
+  const uriResult = await resolveOrphanAuthorUri(orphan);
+
+  if (uriResult.kind === 'transient') return 'transient';
+
+  if (uriResult.kind === 'gone') {
+    // Only delete when the source is gone AND no author is resolvable. There is no
+    // actor URI to resolve here (a gone object yields none), so the post is dead.
+    if (DELETE_GONE && APPLY) {
+      await Post.deleteOne({ _id: orphan._id });
+    }
+    return 'deleted';
+  }
+
+  const oxyUserId = await resolveAuthorOxyUserId(uriResult.authorUri);
+  if (!oxyUserId) return 'unresolvedAuthor';
+
+  if (APPLY) {
+    const set: Record<string, unknown> = {
+      oxyUserId,
+      authorship: buildAuthorship(oxyUserId, []),
+    };
+    // Backfill the actor URI when it was missing (brid.gy/Bluesky orphans) so the
+    // Phase-1 degraded-render path can also enrich by URI next time.
+    if (uriResult.actorUriWasMissing) {
+      set['federation.actorUri'] = uriResult.authorUri;
+    }
+    await Post.updateOne({ _id: orphan._id }, { $set: set });
+  }
+  return 'linked';
+}
+
+async function backfillFederatedPostAuthors(): Promise<void> {
+  const startedAt = Date.now();
+  const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/mention';
+  const dbName = `mention-${process.env.NODE_ENV || 'development'}`;
+
+  const orphanFilter = {
+    'federation.activityId': { $exists: true, $ne: null },
+    oxyUserId: null,
+  } as const;
+
+  try {
+    await mongoose.connect(mongoUri, { dbName });
+    logger.info(
+      `[backfillFederatedPostAuthors] connected to MongoDB (${dbName}); APPLY=${APPLY} DELETE_GONE=${DELETE_GONE}`,
+    );
+
+    const totalCount = await Post.countDocuments(orphanFilter);
+    logger.info(`[backfillFederatedPostAuthors] ${totalCount} orphan federated posts to scan`);
+    if (totalCount === 0) {
+      await mongoose.disconnect();
+      return;
+    }
+
+    const counters: Counters = { scanned: 0, linked: 0, deleted: 0, unresolvedAuthor: 0, transient: 0 };
+    let lastId: mongoose.Types.ObjectId | null = null;
+
+    for (;;) {
+      const pageFilter: Record<string, unknown> = { ...orphanFilter };
+      if (lastId) pageFilter._id = { $gt: lastId };
+
+      const page = await Post.find(pageFilter, { _id: 1, federation: 1 })
+        .sort({ _id: 1 })
+        .limit(PAGE_SIZE)
+        .lean<OrphanRow[]>();
+
+      if (page.length === 0) break;
+
+      // Bounded-concurrency fan-out over the page. `lastId` advances past the whole
+      // page, and mutating/deleting an already-scanned _id never affects the
+      // forward cursor, so linked posts simply leave the set.
+      for (let i = 0; i < page.length; i += CONCURRENCY) {
+        const chunk = page.slice(i, i + CONCURRENCY);
+        const buckets = await Promise.all(chunk.map((orphan) => processOrphan(orphan).catch((error) => {
+          logger.warn('[backfillFederatedPostAuthors] orphan processing failed', {
+            postId: String(orphan._id),
+            reason: error instanceof Error ? error.message : 'unknown',
+          });
+          return 'transient' as const;
+        })));
+        for (const bucket of buckets) counters[bucket] += 1;
+      }
+
+      counters.scanned += page.length;
+      lastId = page[page.length - 1]._id;
+      logger.info(
+        `[backfillFederatedPostAuthors] progress: scanned ${counters.scanned}/${totalCount}, ` +
+          `linked ${counters.linked}, deleted ${counters.deleted}, ` +
+          `unresolvedAuthor ${counters.unresolvedAuthor}, transient ${counters.transient}`,
+      );
+    }
+
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    logger.info(
+      `[backfillFederatedPostAuthors] done in ${elapsedSeconds}s: scanned ${counters.scanned}, ` +
+        `linked ${counters.linked}, deleted ${counters.deleted}, ` +
+        `unresolvedAuthor ${counters.unresolvedAuthor}, transient ${counters.transient}` +
+        (APPLY ? '' : ' (DRY RUN — no writes)'),
+    );
+
+    await mongoose.disconnect();
+  } catch (error) {
+    logger.error('[backfillFederatedPostAuthors] failed', error);
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  // Exit deterministically: imported singletons (BullMQ Redis, MediaCache workers)
+  // otherwise keep the event loop alive after the work completes.
+  backfillFederatedPostAuthors()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error('[backfillFederatedPostAuthors] unhandled failure', error);
+      process.exit(1);
+    });
+}
+
+export default backfillFederatedPostAuthors;

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -366,6 +366,114 @@ export async function resolveUserSummaries(userIds: string[]): Promise<Map<strin
   return resolved;
 }
 
+/**
+ * Lowercased host of the first parseable absolute URL among `urls` (an actor
+ * URI, a canonical post URL, or an activity id). Used as the `instance` on a
+ * degraded federated author so the ORIGIN still surfaces when no handle is
+ * knowable (e.g. a brid.gy/Bluesky-bridged note that carries only an
+ * `activityId`). Returns `undefined` when none parse.
+ */
+function federatedHost(...urls: Array<string | undefined>): string | undefined {
+  for (const url of urls) {
+    if (!url) continue;
+    try {
+      const host = new URL(url).host.toLowerCase();
+      if (host) return host;
+    } catch {
+      // Not a parseable absolute URL — try the next candidate.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build the author {@link PostUser} for FEDERATED posts whose Oxy author link is
+ * missing — legacy "orphans" ingested before the federated-actor → Oxy-user link
+ * was enforced, so `oxyUserId` is null. Such a post is NOT dropped: its CONTENT
+ * (text/media) must still render so a boost/quote referencing it — and the post
+ * itself — is not blank. The author is derived ONLY from the post's own
+ * federation data + Mention's own {@link FederatedActor} record, NEVER from a raw
+ * id (the ghost-handle rule):
+ *
+ *  1. If a {@link FederatedActor} exists for the post's `federation.actorUri`,
+ *     use its authoritative `username@domain` + avatar — the SAME enrichment
+ *     {@link enrichDegradedFederatedUsers} applies, keyed here by actor URI since
+ *     there is no `oxyUserId`. It NEVER invents a `name.displayName`.
+ *  2. Otherwise fall back to {@link degradedActorSummary} ("Unknown user", empty
+ *     handle), marked federated with the origin `instance` when a host is
+ *     derivable. The empty handle suppresses the `@handle` line and the profile
+ *     link, so no misleading handle is ever emitted.
+ *
+ * Batched (single FederatedActor query), best-effort, and never cached — the DTO
+ * self-heals once the post's `oxyUserId` is backfilled and normal Oxy resolution
+ * takes over. Keyed by post id (orphans have no `oxyUserId` to key on).
+ */
+async function resolveOrphanFederatedAuthors(
+  orphans: Array<{ postId: string; federation: PostFederationData }>,
+): Promise<Map<string, PostUser>> {
+  const result = new Map<string, PostUser>();
+  if (orphans.length === 0) return result;
+
+  const actorUris = Array.from(
+    new Set(orphans.map((o) => o.federation.actorUri).filter((uri): uri is string => Boolean(uri))),
+  );
+
+  const actorByUri = new Map<
+    string,
+    { username?: string; acct?: string; domain?: string; avatarUrl?: string; oxyUserId?: string }
+  >();
+  if (actorUris.length > 0) {
+    try {
+      const actors = await FederatedActor.find({ uri: { $in: actorUris } })
+        .select('uri username acct domain avatarUrl oxyUserId')
+        .lean();
+      for (const actor of actors) {
+        const uri = (actor as { uri?: string }).uri;
+        if (uri) actorByUri.set(uri, actor);
+      }
+    } catch (error) {
+      logger.warn('[PostHydration] Orphan federated author lookup failed', {
+        count: actorUris.length,
+        reason: error instanceof Error ? error.message : 'unknown',
+      });
+    }
+  }
+
+  for (const { postId, federation } of orphans) {
+    const actorUri = federation.actorUri;
+    const actor = actorUri ? actorByUri.get(actorUri) : undefined;
+    const username = actor?.username || (actor?.acct ? actor.acct.split('@')[0] : '');
+
+    if (actor && username) {
+      // Authoritative federated identity from Mention's own FederatedActor record
+      // (never invents a display name — the renderer falls back to the handle).
+      result.set(postId, {
+        id: actor.oxyUserId || actorUri || postId,
+        username,
+        name: {},
+        avatar: actor.avatarUrl ?? null,
+        isFederated: true,
+        federation: actor.domain
+          ? { domain: actor.domain, actorUri }
+          : (actorUri ? { actorUri } : undefined),
+        instance: actor.domain || federatedHost(actorUri),
+      });
+      continue;
+    }
+
+    // No knowable handle: a neutral "Unknown user", still marked federated with
+    // the origin host so the CONTENT (not a fabricated handle) is what renders.
+    const instance = federatedHost(actorUri, federation.url, federation.activityId);
+    result.set(postId, {
+      ...degradedActorSummary(actorUri || federation.url || federation.activityId || postId),
+      isFederated: true,
+      ...(instance ? { instance, federation: { domain: instance, ...(actorUri ? { actorUri } : {}) } } : {}),
+    });
+  }
+
+  return result;
+}
+
 export class PostHydrationService {
   async hydratePosts(rawPosts: object[], options: HydrationOptions = {}): Promise<HydratedPost[]> {
     if (!Array.isArray(rawPosts) || rawPosts.length === 0) {
@@ -377,8 +485,17 @@ export class PostHydrationService {
 
     const initialPosts = rawPosts
       .map((p): RawPost => (typeof (p as { toObject?: () => RawPost }).toObject === 'function' ? (p as { toObject: () => RawPost }).toObject() : p as RawPost))
-      .filter((post) => post && post.oxyUserId
-        && !viewerContext.blockedIds.has(String(post.oxyUserId)));
+      .filter((post) => {
+        if (!post) return false;
+        const authorId = post.oxyUserId ? String(post.oxyUserId) : undefined;
+        if (authorId) return !viewerContext.blockedIds.has(authorId);
+        // A FEDERATED post whose Oxy author link is missing (a legacy "orphan",
+        // ingested before the federated-actor → Oxy-user link was enforced) is
+        // NOT a data error — it still renders in a degraded form (see
+        // buildPostSummary) so the post itself, and any boost/quote referencing
+        // it, is not blank. A native post with no author IS a data error → drop.
+        return Boolean(post.federation?.activityId);
+      });
 
     if (initialPosts.length === 0) {
       return [];
@@ -403,6 +520,7 @@ export class PostHydrationService {
       pollMap,
       authorPrivacyMap,
       linkPreviewMap,
+      orphanAuthorMap,
     ] = await Promise.all([
       this.populateViewerInteractions(postIds, viewerContext),
       (async () => {
@@ -416,6 +534,7 @@ export class PostHydrationService {
       options.includeLinkMetadata !== false
         ? this.buildLinkPreviewMap(postsForHydration)
         : Promise.resolve(new Map<string, PostLinkPreview>()),
+      this.buildOrphanFederatedAuthorMap(postsForHydration),
     ]);
     const mentionCache: Map<string, PostUser> = new Map(userMap);
 
@@ -432,6 +551,7 @@ export class PostHydrationService {
           linkPreviewMap,
           authorPrivacyMap,
           recentReplierMap,
+          orphanAuthorMap,
         })
       )
     );
@@ -929,6 +1049,26 @@ export class PostHydrationService {
   }
 
   /**
+   * Resolve a degraded author (keyed by post id) for every FEDERATED post in the
+   * graph whose Oxy author link is missing — a legacy orphan. Native null-author
+   * posts are intentionally skipped: they carry no `federation` data and are a
+   * genuine data error that {@link buildPostSummary} drops. See
+   * {@link resolveOrphanFederatedAuthors} for the derivation.
+   */
+  private async buildOrphanFederatedAuthorMap(
+    nodes: HydratedGraphNode[],
+  ): Promise<Map<string, PostUser>> {
+    const orphans: Array<{ postId: string; federation: PostFederationData }> = [];
+    for (const { post } of nodes) {
+      if (post?.oxyUserId || !post?.federation) continue;
+      const postId = this.resolveId(post);
+      if (!postId) continue;
+      orphans.push({ postId, federation: post.federation });
+    }
+    return resolveOrphanFederatedAuthors(orphans);
+  }
+
+  /**
    * Build the per-post link-preview map for a batch of posts.
    *
    * Link previews are resolved through the Oxy ecosystem link-preview service
@@ -1180,21 +1320,33 @@ export class PostHydrationService {
     linkPreviewMap: Map<string, PostLinkPreview>;
     authorPrivacyMap: Map<string, typeof DEFAULT_PRIVACY>;
     recentReplierMap?: Map<string, string[]>;
+    orphanAuthorMap: Map<string, PostUser>;
   }): Promise<HydratedPostSummary | null> {
-    const { post, viewerContext, pollMap, userMap, mentionCache, linkPreviewMap, authorPrivacyMap, recentReplierMap } = params;
+    const { post, viewerContext, pollMap, userMap, mentionCache, linkPreviewMap, authorPrivacyMap, recentReplierMap, orphanAuthorMap } = params;
 
     const postId = this.resolveId(post);
     if (!postId) return null;
 
     const isFederatedPost = !!post?.federation;
 
-    // Every post — federated or native — now carries a mandatory `oxyUserId`:
-    // the federated-actor → Oxy user link is enforced at ingest, so orphaned
-    // federated posts no longer exist. A post with no author is a genuine data
-    // error and is dropped. The author always renders through the canonical Oxy
-    // `name.displayName` path (buildUserMap / resolveUserSummaries).
-    const authorId = post?.oxyUserId ? String(post.oxyUserId) : undefined;
-    if (!authorId) return null;
+    // A post normally carries a resolved `oxyUserId` — the federated-actor → Oxy
+    // user link is enforced at ingest, so NEW federated posts always have one and
+    // the author renders through the canonical Oxy `name.displayName` path
+    // (buildUserMap / resolveUserSummaries). Two exceptions are handled here:
+    //  - A NATIVE post with no author is a genuine data error → dropped.
+    //  - A FEDERATED post with no author is a legacy "orphan" (ingested before the
+    //    link was enforced, e.g. a brid.gy/Bluesky-bridged note). It still renders
+    //    in a DEGRADED form — its content plus a federation-derived author (see
+    //    buildOrphanFederatedAuthorMap) — so a boost/quote referencing it, and the
+    //    post itself, is not blank. The degraded author is transient/never cached,
+    //    so the DTO self-heals once `oxyUserId` is backfilled.
+    let orphanAuthor: PostUser | undefined;
+    let authorId = post?.oxyUserId ? String(post.oxyUserId) : undefined;
+    if (!authorId) {
+      if (!isFederatedPost) return null;
+      orphanAuthor = orphanAuthorMap.get(postId) ?? degradedActorSummary(postId);
+      authorId = orphanAuthor.id;
+    }
 
     const authorship = normalizeAuthorship(post.authorship as PostAuthorshipEntry[] | undefined);
 
@@ -1243,9 +1395,12 @@ export class PostHydrationService {
 
     // `resolveUserSummaries` always populates an entry for every requested id
     // (a real user or the degraded fallback), so this default is defensive — but
-    // it must STILL never emit the raw id as a handle if ever reached.
-    const user = userMap.get(authorId) ?? degradedActorSummary(authorId);
-    const headerEntries = getHeaderAuthorshipEntries(authorship);
+    // it must STILL never emit the raw id as a handle if ever reached. An orphan
+    // federated post uses its federation-derived author (its `oxyUserId` is null,
+    // so there is nothing in `userMap`), and its authorship carries no usable
+    // owner — the byline falls back to `user` from an empty `authors[]`.
+    const user = orphanAuthor ?? userMap.get(authorId) ?? degradedActorSummary(authorId);
+    const headerEntries = orphanAuthor ? [] : getHeaderAuthorshipEntries(authorship);
     const authors: HydratedAuthor[] = headerEntries.map((entry) => {
       const summary = userMap.get(entry.oxyUserId) ?? degradedActorSummary(entry.oxyUserId);
       return {

--- a/packages/backend/src/services/webShellRenderer.ts
+++ b/packages/backend/src/services/webShellRenderer.ts
@@ -170,9 +170,15 @@ export function mapPostOg(post: HydratedPost, id: string): OgData {
   const image =
     media?.url || media?.thumbUrl || media?.posterUrl || post.linkPreview?.image || avatarImage || undefined;
 
+  // A boost has an intentionally empty body — its renderable text lives on the
+  // boosted original (embedded at maxDepth:1). Fall back to the original's text so
+  // a boost's OG/preview description is not blank.
+  const ownText = (post.content?.text || '').trim();
+  const description = (ownText || (post.originalPost?.content?.text || '').trim()).slice(0, 200);
+
   return {
     title: `${author} on Mention`,
-    description: (post.content?.text || '').trim().slice(0, 200),
+    description,
     image,
     url: `${WEB_ORIGIN}/p/${id}`,
     type: 'article',


### PR DESCRIPTION
## Summary
- `packages/backend/src/services/PostHydrationService.ts` — federated posts (`federation.activityId` set) whose Oxy author link is missing (legacy orphan, `oxyUserId` null) now hydrate in a DEGRADED form — real content plus a federation-derived author (Mention's own `FederatedActor` record: username@domain + avatar by actor URI, else a neutral "Unknown user" marked federated with the origin instance; never a raw id, per the ghost-handle rule) — instead of being silently dropped. This fixes blank/missing boosts and quotes of orphan-author originals. Native (non-federated) posts with a null author are still treated as a data error and remain dropped — this change is scoped to federated posts only.
- `packages/backend/src/services/webShellRenderer.ts` — a boost's `og:description` now falls back to the boosted original's text (hydrated at `maxDepth:1`) instead of the boost's own empty body.
- NEW `packages/backend/src/scripts/backfillFederatedPostAuthors.ts` — an inert one-shot script to eventually restore the real `oxyUserId`/authorship on the ~11,967 legacy orphan posts by re-resolving `attributedTo` → federated actor → Oxy user. DRY-RUN by default; writes/deletes are opt-in via env gates (`BACKFILL_APPLY`, `BACKFILL_DELETE_GONE`). Not wired into CI or deploy — a design deliverable for prod review, not executed yet.
- Tests: `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` (expanded) and `packages/backend/src/__tests__/webShellRenderer.test.ts` (expanded) cover the new degraded-hydration and OG-fallback behavior.

## Test plan
- [x] `tsc` build clean
- [x] Backend suite: 1696/1697 passing (1 pre-existing unrelated flaky timeout in `feedRanking.test.ts`, confirmed non-regression via 2 runs including on a clean `origin/main` checkout)
- [x] New/updated hydration + webShell tests: 31/31 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)