### PR TITLE
feat(frontend): custom done_all icon for mark-all-read + NativeWind UnreadBadge

### DIFF
--- a/packages/frontend/app/(app)/notifications.tsx
+++ b/packages/frontend/app/(app)/notifications.tsx
@@ -42,6 +42,7 @@ import { IconButton } from '@/components/ui/Button';
 import { Error } from '@/components/Error';
 import { EmptyState } from '@/components/common/EmptyState';
 import { Bell } from '@/assets/icons/bell-icon';
+import { DoneAllIcon } from '@/assets/icons/done-all-icon';
 import { PanelStickyHeader } from '@/components/shell/PanelChrome';
 import { prewarmUsersByIds } from '@/utils/userEnrichment';
 
@@ -475,8 +476,7 @@ const NotificationsScreen: React.FC = () => {
                                             disabled={markAllAsReadMutation.isPending}
                                             accessibilityLabel={t('notification.mark_all_read')}
                                         >
-                                            <Ionicons
-                                                name="checkmark-done-outline"
+                                            <DoneAllIcon
                                                 size={22}
                                                 color={theme.colors.primary}
                                             />

--- a/packages/frontend/assets/icons/done-all-icon.tsx
+++ b/packages/frontend/assets/icons/done-all-icon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ViewStyle } from 'react-native';
+import { Path } from 'react-native-svg';
+import { IconSvg } from '@/assets/icons/IconSvg';
+
+interface IconProps {
+  size?: number;
+  color?: string;
+  style?: ViewStyle;
+  className?: string;
+}
+
+// Material Symbols "done_all" (filled). The Material grid uses a 960 viewBox with
+// a negative y-origin, so keep `viewBox="0 -960 960 960"` verbatim.
+export const DoneAllIcon = ({ size = 24, color = 'currentColor', style, className }: IconProps) => (
+  <IconSvg width={size} height={size} viewBox="0 -960 960 960" fill="none" style={style} className={className}>
+    <Path
+      d="M66.41-426.52q-13.43-13.44-13.05-31.83.38-18.39 13.81-31.82Q80.61-502.85 99-503.23q18.39-.38 31.83 13.06L269-352l16.03 16.03 16.04 16.04q13.43 13.43 13.05 31.58-.38 18.15-13.82 31.59-13.67 12.91-32.06 13.29-18.39.38-32.07-13.29L66.41-426.52ZM494-360.89l335.7-335.7q13.43-13.43 31.7-13.05 18.27.38 31.95 13.81 12.91 13.44 13.41 31.83t-13.17 32.07L526.07-264.41q-13.68 13.67-32.07 13.67t-32.07-13.67l-170-170q-12.91-12.92-12.79-31.57.12-18.65 13.03-32.32 13.68-13.44 32.33-13.44t32.09 13.44L494-360.89Zm165.41-270.76L525.83-498.07q-12.68 12.68-31.45 12.68t-32.21-12.68q-13.43-13.43-13.43-32.2 0-18.77 13.43-32.21l133.59-133.59q12.67-12.67 31.45-12.67 18.77 0 32.2 12.67 13.44 13.44 13.44 32.21 0 18.77-13.44 32.21Z"
+      fill={color}
+    />
+  </IconSvg>
+);

--- a/packages/frontend/components/notifications/UnreadBadge.tsx
+++ b/packages/frontend/components/notifications/UnreadBadge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text } from 'react-native';
 
 /** Above this the pill collapses to "99+" so it never grows unbounded. */
 const MAX_DISPLAY_COUNT = 99;
@@ -28,8 +28,7 @@ const UnreadBadgeComponent: React.FC<UnreadBadgeProps> = ({ count, dot = false, 
   if (dot) {
     return (
       <View
-        className="bg-primary border-background"
-        style={styles.dot}
+        className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 bg-primary border-background"
         accessibilityRole="image"
         accessibilityLabel={accessibilityLabel}
       />
@@ -40,46 +39,16 @@ const UnreadBadgeComponent: React.FC<UnreadBadgeProps> = ({ count, dot = false, 
 
   return (
     <View
-      className="bg-primary border-background"
-      style={styles.pill}
+      className="absolute -top-1 -right-1.5 h-[18px] min-w-[18px] items-center justify-center rounded-full border-2 px-[5px] bg-primary border-background"
       accessibilityRole="image"
       accessibilityLabel={accessibilityLabel}
     >
-      <Text className="text-primary-foreground" style={styles.pillText} numberOfLines={1}>
+      <Text className="text-primary-foreground text-[11px] font-bold leading-[14px]" numberOfLines={1}>
         {label}
       </Text>
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  pill: {
-    position: 'absolute',
-    top: -4,
-    right: -6,
-    minWidth: 18,
-    height: 18,
-    borderRadius: 9,
-    paddingHorizontal: 5,
-    borderWidth: 2,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  pillText: {
-    fontSize: 11,
-    fontWeight: '700',
-    lineHeight: 14,
-  },
-  dot: {
-    position: 'absolute',
-    top: -2,
-    right: -2,
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    borderWidth: 2,
-  },
-});
 
 export const UnreadBadge = React.memo(UnreadBadgeComponent);
 


### PR DESCRIPTION
## Summary
- Replaces the notifications "mark all as read" header button icon (Ionicons `checkmark-done-outline`) with a custom **Material Symbols done_all** glyph — new `assets/icons/done-all-icon.tsx` built on the shared `IconSvg` primitive like the other brand icons (themed via `color`, sized via `size`).
- Converts `UnreadBadge` from `StyleSheet.create` to **NativeWind** classNames, so the notifications components have no `StyleSheet` left.

No `useEffect`/`as any`/`@ts-ignore`/`!`/`console.log` introduced.

## Test plan
- `cd packages/frontend && bun run typecheck` — clean for touched files
- `cd packages/frontend && bun run lint` — clean
- Verify in prod: the mark-all-read button shows the done_all icon; the unread badge renders identically (18px pill / 10px dot, brand color).

🤖 Generated with [Claude Code](https://claude.com/claude-code)