### PR TITLE
feat(frontend): notifications skeleton, settings quick-access, delete

### DIFF
--- a/packages/frontend/app/(app)/notifications.tsx
+++ b/packages/frontend/app/(app)/notifications.tsx
@@ -27,10 +27,12 @@ import {
     findNotification,
     markNotificationsRead,
     markAllNotificationsRead,
+    removeNotification,
     bumpUnread,
     type NotificationsInfiniteData,
 } from '@/utils/notificationCache';
 import { NotificationsList } from '@/components/NotificationsList';
+import { NotificationSkeleton } from '@/components/notifications/NotificationSkeleton';
 import { useLayoutScroll } from '@/context/LayoutScrollContext';
 import AnimatedTabBar from '@/components/common/AnimatedTabBar';
 import { Header } from '@/components/Header';
@@ -43,6 +45,7 @@ import { Error } from '@/components/Error';
 import { EmptyState } from '@/components/common/EmptyState';
 import { Bell } from '@/assets/icons/bell-icon';
 import { DoneAllIcon } from '@/assets/icons/done-all-icon';
+import { Gear } from '@/assets/icons/gear-icon';
 import { PanelStickyHeader } from '@/components/shell/PanelChrome';
 import { prewarmUsersByIds } from '@/utils/userEnrichment';
 
@@ -131,6 +134,42 @@ const NotificationsScreen: React.FC = () => {
         },
     });
 
+    // Optimistically drop the given ids from the cached list + decrement the
+    // badge for any that were unread (mirrors `applyReadPatch`). The server echo
+    // to `user:<id>` reconciles idempotently; `onError` resyncs.
+    const applyRemovePatch = useCallback((ids: string[]) => {
+        const prev = queryClient.getQueryData<NotificationsInfiniteData>(notificationsQueryKey);
+        let delta = 0;
+        if (prev) {
+            for (const id of ids) {
+                const found = findNotification(prev, id);
+                if (found && !found.read) delta -= 1;
+            }
+        }
+        queryClient.setQueryData<NotificationsInfiniteData>(notificationsQueryKey, (data) => {
+            if (!data) return data;
+            let next = data;
+            for (const id of ids) next = removeNotification(next, id);
+            return next;
+        });
+        if (delta !== 0) bumpUnread(queryClient, user?.id, delta);
+    }, [queryClient, notificationsQueryKey, user?.id]);
+
+    // Delete notification(s) — group rows pass every id in the group.
+    const deleteMutation = useMutation({
+        mutationFn: (ids: string[]) => Promise.all(ids.map((id) => notificationService.deleteNotification(id))),
+        onMutate: (ids: string[]) => applyRemovePatch(ids),
+        onSuccess: () => {
+            toast(t('notification.deleted', { defaultValue: 'Notification deleted' }), { type: 'success' });
+        },
+        onError: (error: unknown) => {
+            notificationLogger.error('Error deleting notification', { error });
+            toast(t('notification.delete_error', { defaultValue: 'Failed to delete notification' }), { type: 'error' });
+            // Resync from the server on failure to undo the optimistic patch.
+            queryClient.invalidateQueries({ queryKey: ['notifications'] });
+        },
+    });
+
     // Mark all as read mutation
     const markAllAsReadMutation = useMutation({
         mutationFn: () => notificationService.markAllAsRead(),
@@ -164,6 +203,10 @@ const NotificationsScreen: React.FC = () => {
     const handleMarkAsRead = useCallback((ids: string[]) => {
         markAsReadMutation.mutate(ids);
     }, [markAsReadMutation]);
+
+    const handleDelete = useCallback((ids: string[]) => {
+        deleteMutation.mutate(ids);
+    }, [deleteMutation]);
 
     const handleMarkAllAsRead = useCallback(async () => {
         if (unreadCount === 0) {
@@ -272,9 +315,9 @@ const NotificationsScreen: React.FC = () => {
             retryLabel={t("error.boundary.retry")}
             onError={handleBoundaryError}
         >
-            <NotificationItem item={item} onMarkAsRead={handleMarkAsRead} />
+            <NotificationItem item={item} onMarkAsRead={handleMarkAsRead} onDelete={handleDelete} />
         </ErrorBoundary>
-    ), [t, handleBoundaryError, handleMarkAsRead]);
+    ), [t, handleBoundaryError, handleMarkAsRead, handleDelete]);
 
     const emptyStateConfig = useMemo(() => {
         const iconBg = `${theme.colors.border}33`;
@@ -382,8 +425,8 @@ const NotificationsScreen: React.FC = () => {
 
         if (isLoading && !refreshing) {
             return (
-                <ThemedView className="flex-1 justify-center items-center">
-                    <Loading className="text-primary" size="large" />
+                <ThemedView className="flex-1">
+                    <NotificationSkeleton />
                 </ThemedView>
             );
         }
@@ -482,6 +525,16 @@ const NotificationsScreen: React.FC = () => {
                                             />
                                         </IconButton>
                                     ) : null,
+                                    <IconButton variant="icon"
+                                        key="notification-settings"
+                                        onPress={() => router.push('/settings/notifications')}
+                                        accessibilityLabel={t('notification.settings', { defaultValue: 'Notification settings' })}
+                                    >
+                                        <Gear
+                                            size={22}
+                                            color={theme.colors.text}
+                                        />
+                                    </IconButton>,
                                 ].filter(Boolean),
                             }}
                             hideBottomBorder={canUsePrivateApi}

--- a/packages/frontend/components/notifications/NotificationItem.tsx
+++ b/packages/frontend/components/notifications/NotificationItem.tsx
@@ -18,12 +18,13 @@ import UserName from '../UserName';
 import { LinkifiedText } from '../common/LinkifiedText';
 import { RemoteActorBadge } from '@/components/Fediverse/FediverseBadge';
 import CollabAcceptSheet from '@/components/Compose/CollabAcceptSheet';
+import { DoneAllIcon } from '@/assets/icons/done-all-icon';
+import { TrashIcon } from '@/assets/icons/trash-icon';
 import { getDescriptor, type TranslateFn } from './notificationDescriptors';
 import { useUserById } from '@/hooks/useCachedUser';
 import type { GroupedNotification } from '@/utils/groupNotifications';
 import { POST_ITEM_SPACING } from '@/styles/shared';
 import { formatRelativeTimeLocalized } from '@/utils/dateUtils';
-import { confirmDialog } from '@/utils/alerts';
 import { BottomSheetContext } from '@/context/BottomSheetContext';
 import { feedService } from '@/services/feedService';
 import { queryKeys } from '@/hooks/useOptimizedQuery';
@@ -196,13 +197,45 @@ const AvatarStrip: React.FC<{ actors: ResolvedActor[]; totalActors: number }> = 
   );
 };
 
+const ACTION_ICON_SIZE = 20;
+
+/**
+ * One row of the long-press action sheet. Mirrors the grouped, rounded row
+ * treatment the shared widget menu uses (`useWidgetItemMenu`), with a
+ * `destructive` variant for the red delete affordance.
+ */
+const NotificationActionRow: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  onPress: () => void;
+  destructive?: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+}> = ({ icon, label, onPress, destructive, isFirst, isLast }) => (
+  <Pressable
+    className={cn(
+      'bg-surface flex-row items-center justify-between py-3 px-3.5 active:opacity-70',
+      isFirst && 'rounded-t-2xl',
+      isLast ? 'rounded-b-2xl' : 'mb-1',
+    )}
+    onPress={onPress}
+    accessibilityRole="button"
+    accessibilityLabel={label}
+  >
+    <Text className={cn('text-base font-medium', destructive ? 'text-destructive' : 'text-foreground')}>{label}</Text>
+    <View className="ml-3">{icon}</View>
+  </Pressable>
+);
+
 interface NotificationItemProps {
   item: GroupedNotification;
   /** Marks the given notification ids read (single -> `[id]`, group -> all ids). */
   onMarkAsRead: (ids: string[]) => void;
+  /** Deletes the given notification ids (single -> `[id]`, group -> all ids). */
+  onDelete: (ids: string[]) => void;
 }
 
-const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMarkAsRead }) => {
+const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMarkAsRead, onDelete }) => {
   const router = useRouter();
   const { t } = useTranslation();
   const theme = useTheme();
@@ -294,15 +327,50 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
     }
   }, [markRead, item.entityType, item.entityId, resolvedPrimary.handle, router]);
 
-  const handleLongPress = useCallback(async () => {
-    const confirmed = await confirmDialog({
-      title: t('notification.options.title'),
-      message: t('notification.options.message'),
-      okText: t('notification.mark_read', { defaultValue: 'Mark as read' }),
-      cancelText: t('cancel', { defaultValue: 'Cancel' }),
+  // Long-press opens a small action sheet offering "Mark as read" (only when the
+  // row is unread) and a destructive "Delete". Dismissing the sheet is the
+  // implicit cancel. Tapping a row acts, then closes the sheet.
+  const handleLongPress = useCallback(() => {
+    const rows: { key: string; icon: React.ReactNode; label: string; onPress: () => void; destructive?: boolean }[] = [];
+    if (hasUnread) {
+      rows.push({
+        key: 'mark-read',
+        icon: <DoneAllIcon size={ACTION_ICON_SIZE} color={theme.colors.textSecondary} />,
+        label: t('notification.mark_read', { defaultValue: 'Mark as read' }),
+        onPress: () => {
+          bottomSheet.openBottomSheet(false);
+          onMarkAsRead(item.notificationIds);
+        },
+      });
+    }
+    rows.push({
+      key: 'delete',
+      icon: <TrashIcon size={ACTION_ICON_SIZE} color={theme.colors.error} />,
+      label: t('notification.delete', { defaultValue: 'Delete' }),
+      destructive: true,
+      onPress: () => {
+        bottomSheet.openBottomSheet(false);
+        onDelete(item.notificationIds);
+      },
     });
-    if (confirmed) onMarkAsRead(item.notificationIds);
-  }, [t, onMarkAsRead, item.notificationIds]);
+
+    bottomSheet.setBottomSheetContent(
+      <View className="bg-background p-4">
+        {rows.map((row, index) => (
+          <NotificationActionRow
+            key={row.key}
+            icon={row.icon}
+            label={row.label}
+            onPress={row.onPress}
+            destructive={row.destructive}
+            isFirst={index === 0}
+            isLast={index === rows.length - 1}
+          />
+        ))}
+      </View>,
+    );
+    bottomSheet.openBottomSheet(true);
+  }, [hasUnread, theme.colors.textSecondary, theme.colors.error, t, bottomSheet, onMarkAsRead, onDelete, item.notificationIds]);
 
   const openActorProfile = useCallback((actor: ResolvedActor) => {
     if (actor.handle) router.push(`/@${actor.handle}`);

--- a/packages/frontend/components/notifications/NotificationSkeleton.tsx
+++ b/packages/frontend/components/notifications/NotificationSkeleton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View } from 'react-native';
+import * as Skeleton from '@oxyhq/bloom/skeleton';
+import { POST_ITEM_SPACING } from '@/styles/shared';
+
+// Mirrors the real NotificationItem anatomy (single source of truth:
+// POST_ITEM_SPACING). AVATAR_SIZE = 40, full-width `border-b border-border py-3`
+// rows with the horizontal padding living INSIDE via `px-3` — so the placeholder
+// list lands exactly where the real rows will, making the transition seamless.
+const AVATAR_SIZE = POST_ITEM_SPACING.AVATAR_SIZE;
+const PLACEHOLDER_ROWS = 6;
+
+// One placeholder row: a 40px avatar circle + two stacked text lines (a wider
+// byline line, a shorter action line), matching the real row's byline/action
+// stack.
+const NotificationSkeletonRow: React.FC = () => (
+  <View className="w-full border-b border-border py-3">
+    <View className="px-3 flex-row items-start">
+      <View className="mr-3">
+        <Skeleton.Circle size={AVATAR_SIZE} />
+      </View>
+      <View className="flex-1 gap-2 pt-0.5">
+        <Skeleton.Text style={{ fontSize: 15, lineHeight: 20, width: '55%' }} />
+        <Skeleton.Text style={{ fontSize: 14, lineHeight: 20, width: '35%' }} />
+      </View>
+    </View>
+  </View>
+);
+
+/**
+ * Skeleton placeholder for the initial notifications load. Renders a short list
+ * of shimmering rows that mimic the real notification rows so the screen feels
+ * instant (same treatment the feed uses) instead of a centered spinner.
+ */
+export const NotificationSkeleton: React.FC = () => (
+  <View className="w-full" accessibilityRole="progressbar">
+    {Array.from({ length: PLACEHOLDER_ROWS }).map((_, index) => (
+      <NotificationSkeletonRow key={index} />
+    ))}
+  </View>
+);
+
+export default NotificationSkeleton;


### PR DESCRIPTION
## Summary
Three notification-screen improvements (clean pattern: NativeWind, no StyleSheet, no useEffect/as-any):
- **Skeleton loading** — `NotificationSkeleton` renders 6 full-width placeholder rows mirroring the real row (40px avatar + 2 text lines) via `@oxyhq/bloom/skeleton`, replacing the centered spinner on initial load.
- **Settings quick-access** — an always-visible header `IconButton` (gear) → `/settings/notifications`.
- **Delete individual/group** — long-press opens an action sheet (Mark as read / destructive Delete); optimistic cache removal + unread decrement, reusing the `notificationCache` remove reducer and the existing `deleteNotification` service.

## Test plan
- `cd packages/frontend && bun run typecheck` — passes (only the 3 allow-listed livekit errors)
- `cd packages/frontend && bun run lint` — 0 errors
- Verify in prod: skeleton on load, gear opens settings, long-press a row → Delete removes it + decrements the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)