### PR TITLE
fix(backend): surface real HTTP status from signViaOxy (no more [object Object])

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/cryptoSignError.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/cryptoSignError.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Error legibility for the Oxy federation-signing calls in
+ * `connectors/activitypub/crypto.ts`.
+ *
+ * The Oxy service client does NOT throw a plain `Error`: `@oxyhq/core`'s
+ * `HttpService` funnels failures through `handleHttpError`, which returns an
+ * `ApiError` PLAIN OBJECT (`{ message, code, status }`). The old
+ * `err instanceof Error ? err.message : String(err)` therefore logged the
+ * useless `"[object Object]"`, which masked a real prod incident (oxy-api
+ * `/federation/sign` returning 429). These tests assert the real HTTP status is
+ * surfaced in both the log line and the re-thrown error, for every thrown shape.
+ */
+
+const mocks = vi.hoisted(() => ({
+  makeServiceRequest: vi.fn(),
+  loggerError: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerDebug: vi.fn(),
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: {
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError,
+    debug: mocks.loggerDebug,
+    fatal: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock('../../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({ makeServiceRequest: mocks.makeServiceRequest }),
+}));
+
+import { getPublicKey, signViaOxy } from '../../../connectors/activitypub/crypto';
+
+/** The single log-line string passed to `logger.error` on the most recent call. */
+function lastErrorLog(): string {
+  const calls = mocks.loggerError.mock.calls;
+  return String(calls[calls.length - 1]?.[0] ?? '');
+}
+
+describe('signViaOxy error legibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces the HTTP status from an ApiError plain object (429), never [object Object]', async () => {
+    // Exact shape @oxyhq/core throws: a plain object, NOT an Error instance.
+    mocks.makeServiceRequest.mockRejectedValueOnce({
+      message: 'Too many requests',
+      code: 'RATE_LIMITED',
+      status: 429,
+    });
+
+    await expect(signViaOxy('key#main', 'signing-string')).rejects.toThrow(/429/);
+
+    const log = lastErrorLog();
+    expect(log).toContain('429');
+    expect(log).not.toContain('[object Object]');
+  });
+
+  it('surfaces status + body from an axios-style { response: { status, data } } object', async () => {
+    mocks.makeServiceRequest.mockRejectedValueOnce({
+      response: { status: 503, data: { error: 'sign service down' } },
+    });
+
+    await expect(signViaOxy('key#main', 'signing-string')).rejects.toThrow(/503/);
+
+    const log = lastErrorLog();
+    expect(log).toContain('503');
+    expect(log).not.toContain('[object Object]');
+  });
+
+  it('uses .message for a real Error instance', async () => {
+    mocks.makeServiceRequest.mockRejectedValueOnce(
+      new Error('Service credentials not provided'),
+    );
+
+    await expect(signViaOxy('key#main', 'signing-string')).rejects.toThrow(
+      /Service credentials not provided/,
+    );
+
+    const log = lastErrorLog();
+    expect(log).toContain('Service credentials not provided');
+    expect(log).not.toContain('[object Object]');
+  });
+
+  it('never emits [object Object] even for an opaque object with no known fields', async () => {
+    mocks.makeServiceRequest.mockRejectedValueOnce({ weird: 'shape' });
+
+    await expect(signViaOxy('key#main', 'signing-string')).rejects.toThrow();
+
+    const log = lastErrorLog();
+    expect(log).not.toContain('[object Object]');
+    expect(log).toContain('weird');
+  });
+});
+
+describe('getPublicKey error legibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces the HTTP status from an ApiError plain object (429), never [object Object]', async () => {
+    mocks.makeServiceRequest.mockRejectedValueOnce({
+      message: 'Too many requests',
+      code: 'RATE_LIMITED',
+      status: 429,
+    });
+
+    await expect(getPublicKey('alice')).rejects.toThrow(/429/);
+
+    const log = lastErrorLog();
+    expect(log).toContain('429');
+    expect(log).not.toContain('[object Object]');
+  });
+});

--- a/packages/backend/src/connectors/activitypub/crypto.ts
+++ b/packages/backend/src/connectors/activitypub/crypto.ts
@@ -35,6 +35,100 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
+ * Shape of the error the Oxy service client throws. It does NOT throw a plain
+ * `Error`: `@oxyhq/core`'s `HttpService` funnels every failure through
+ * `handleHttpError`, which returns an `ApiError` PLAIN OBJECT
+ * (`{ message, code, status }`). So `err instanceof Error` is false and a naive
+ * `String(err)` yields the useless `"[object Object]"`. Other client layers may
+ * instead throw a real `Error` (e.g. missing service credentials) or an
+ * axios-style object with `response.status`/`response.data`, so this stays wide.
+ */
+interface ServiceClientError {
+  message?: unknown;
+  status?: unknown;
+  statusCode?: unknown;
+  response?: { status?: unknown; statusText?: unknown; data?: unknown };
+  data?: unknown;
+  body?: unknown;
+}
+
+function asServiceClientError(value: unknown): ServiceClientError | undefined {
+  return value && typeof value === 'object' ? (value as ServiceClientError) : undefined;
+}
+
+function coerceStatus(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) return Number(value);
+  return undefined;
+}
+
+const MAX_ERROR_DETAIL_LENGTH = 300;
+
+/**
+ * Build a meaningful log/throw message from whatever the Oxy service client
+ * throws, regardless of shape. Surfaces the real HTTP status and body so a
+ * `/federation/sign` outage (e.g. oxy-api returning 429) is diagnosable from
+ * logs — historically these failures logged only `[object Object]`, masking the
+ * incident. NEVER returns `[object Object]`.
+ *
+ * Note: `@oxyhq/core`'s `ApiError` discards upstream response headers, so a
+ * 429's `Retry-After` is not recoverable at this layer — surfacing the `429`
+ * status itself is the legibility win.
+ */
+function describeServiceError(err: unknown): string {
+  const record = asServiceClientError(err);
+  const status =
+    coerceStatus(record?.status) ??
+    coerceStatus(record?.statusCode) ??
+    coerceStatus(record?.response?.status);
+
+  let detail: string | undefined;
+  if (err instanceof Error) {
+    detail = err.message || undefined;
+  } else if (record) {
+    if (isNonEmptyString(record.message)) {
+      detail = record.message;
+    } else {
+      const body = record.response?.data ?? record.data ?? record.body;
+      if (isNonEmptyString(body)) {
+        detail = body;
+      } else if (body !== undefined && body !== null) {
+        try {
+          detail = JSON.stringify(body);
+        } catch {
+          // Non-serializable body (circular) — leave detail unset.
+        }
+      }
+      const statusText = record.response?.statusText;
+      if (!detail && isNonEmptyString(statusText)) {
+        detail = statusText;
+      }
+    }
+  }
+
+  if (detail && detail.length > MAX_ERROR_DETAIL_LENGTH) {
+    detail = `${detail.slice(0, MAX_ERROR_DETAIL_LENGTH)}…`;
+  }
+
+  if (status !== undefined) {
+    // Avoid a doubled "HTTP 429: HTTP 429: …" when the detail already names it.
+    if (detail && detail.includes(String(status))) return detail;
+    return detail ? `HTTP ${status}: ${detail}` : `HTTP ${status}`;
+  }
+  if (detail) return detail;
+
+  // Last resort — still never emit "[object Object]".
+  try {
+    const serialized = JSON.stringify(err);
+    if (serialized && serialized !== '{}' && serialized !== 'null') return serialized;
+  } catch {
+    // Circular / non-serializable — fall through to String().
+  }
+  const asString = String(err);
+  return asString === '[object Object]' ? 'unknown error' : asString;
+}
+
+/**
  * Fetch an actor's public key from Oxy's federation API.
  *
  * Oxy owns all federation key material. This returns the mention.earth-scoped
@@ -55,7 +149,7 @@ export async function getPublicKey(username: string): Promise<FederationPublicKe
   try {
     response = await getServiceOxyClient().makeServiceRequest<OxyPublicKeyResponse>('GET', path);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = describeServiceError(err);
     // The public key drives the actor's advertised key material. Without it the
     // actor doc is incomplete and remote servers cannot verify our signatures.
     // Surface at error level — historically these failures were invisible.
@@ -94,7 +188,7 @@ export async function signViaOxy(keyId: string, signingString: string): Promise<
       { keyId, signingString },
     );
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = describeServiceError(err);
     // A signing failure means every outbound signed request for this key fails.
     // Surface at error level so the outage is observable in production.
     logger.error(`[Federation] signViaOxy failed (keyId=${keyId}): ${message}`);


### PR DESCRIPTION
## Why
`@oxyhq/core`'s `HttpService` re-throws an **`ApiError` plain object** (not an `Error`) that carries `status` + `message`. `signViaOxy`'s `err instanceof Error ? err.message : String(err)` therefore collapsed every failure to **`[object Object]`**, discarding the HTTP status. This masked a real prod incident — oxy-api `/federation/sign` returning **429 / 1–3.3s slowDown** under Mention's outbound-federation load (see OxyHQServices#604) — and made it undiagnosable from logs.

## What
- Typed `describeServiceError(err: unknown)` helper: extracts status (`status` / `statusCode` / `response.status`) + a detail (`Error.message` or `message` / `response.data` / `data` / `body` / `statusText`, truncated to 300), returns `HTTP <status>: <detail>`, and **never** returns `[object Object]`. Narrow guards, no `any`/`@ts-ignore`/`!`.
- Applied to both `signViaOxy` and `getPublicKey` catches (same log level + rethrow wording).
- **Retry-After left out on purpose**: core's `ApiError` discards response headers, so it's unreadable here (would be dead code). Surfacing the `429` status is the legibility win; a real Retry-After needs an upstream `@oxyhq/core` change to preserve headers.

## Tests
New `cryptoSignError.test.ts` (5/5): 429 ApiError plain object, axios-style `{response:{status,data}}` (503), a real `Error`, an opaque object — all assert the message contains the status, not `[object Object]`. Full backend suite: only the 3 known pre-existing flakes fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)