### PR TITLE
chore(deps): @syra.fm/sdk 0.6.0 + scan it for NativeWind classes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@oxyhq/core": "^9.2.0",
         "@oxyhq/protocol": "^0.1.3",
         "@socket.io/redis-adapter": "^8.3.0",
-        "@syra.fm/sdk": "^0.5.0",
+        "@syra.fm/sdk": "^0.6.0",
         "@types/compression": "^1.8.1",
         "@types/multer": "^2.1.0",
         "ai": "^6.0.134",
@@ -102,7 +102,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/netinfo": "^12.0.1",
         "@shopify/flash-list": "2.3.2",
-        "@syra.fm/sdk": "^0.5.0",
+        "@syra.fm/sdk": "^0.6.0",
         "@tanstack/query-async-storage-persister": "^5.101.1",
         "@tanstack/react-query": "^5.100.0",
         "@tanstack/react-query-persist-client": "^5.101.0",
@@ -1026,7 +1026,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@syra.fm/sdk": ["@syra.fm/sdk@0.5.0", "", { "dependencies": { "zod": "^3.25.76" }, "peerDependencies": { "@expo/vector-icons": "^15.0.2", "@livekit/react-native": "^2.11.1", "@oxyhq/core": "^5.2.1", "@oxyhq/services": "^13.1.7", "expo-audio": "~56.0.12", "expo-blur": "~56.0.3", "expo-image-picker": "~56.0.18", "livekit-client": "^2.20.0", "react": "^19.2.3", "react-native": "^0.85.3", "react-native-reanimated": "^4.3.1", "react-native-safe-area-context": "^5.7.0", "react-native-svg": "15.15.4", "socket.io-client": "^4.8.1", "sonner-native": "^0.21.1" }, "optionalPeers": ["@expo/vector-icons", "@livekit/react-native", "@oxyhq/core", "@oxyhq/services", "expo-audio", "expo-blur", "expo-image-picker", "livekit-client", "react", "react-native", "react-native-reanimated", "react-native-safe-area-context", "react-native-svg", "socket.io-client", "sonner-native"] }, "sha512-9eQExlDaEDCqIC50wJZGgBr78NM4JloMjIORbLNXsYEKxpLJKTa+dXSNXmqi/RZEpACbgY/Wa5cQZr57v3zqCQ=="],
+    "@syra.fm/sdk": ["@syra.fm/sdk@0.6.0", "", { "dependencies": { "zod": "^3.25.76" }, "peerDependencies": { "@expo/vector-icons": "^15.0.2", "@livekit/react-native": "^2.11.1", "@oxyhq/services": "^15.0.0", "expo-audio": "~56.0.12", "expo-blur": "~56.0.3", "expo-image-picker": "~56.0.18", "livekit-client": "^2.20.0", "react": "^19.2.3", "react-native": "^0.85.3", "react-native-reanimated": "^4.3.1", "react-native-safe-area-context": "^5.7.0", "react-native-svg": "15.15.4", "socket.io-client": "^4.8.1" }, "optionalPeers": ["@expo/vector-icons", "@livekit/react-native", "@oxyhq/services", "expo-audio", "expo-blur", "expo-image-picker", "livekit-client", "react", "react-native", "react-native-reanimated", "react-native-safe-area-context", "react-native-svg", "socket.io-client"] }, "sha512-koXLrmUu+KAxqegmM4M66kUEWzIcHoo6eYzQ4Y9WvmPzE9wfw3QaVnto0dPDO+xuSVa1agKWdlll+7DuBeGJjA=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
     "@oxyhq/core": "^9.2.0",
     "@oxyhq/protocol": "^0.1.3",
     "@socket.io/redis-adapter": "^8.3.0",
-    "@syra.fm/sdk": "^0.5.0",
+    "@syra.fm/sdk": "^0.6.0",
     "@types/compression": "^1.8.1",
     "@types/multer": "^2.1.0",
     "ai": "^6.0.134",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -56,7 +56,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^12.0.1",
     "@shopify/flash-list": "2.3.2",
-    "@syra.fm/sdk": "^0.5.0",
+    "@syra.fm/sdk": "^0.6.0",
     "@tanstack/query-async-storage-persister": "^5.101.1",
     "@tanstack/react-query": "^5.100.0",
     "@tanstack/react-query-persist-client": "^5.101.0",

--- a/packages/frontend/tailwind.config.js
+++ b/packages/frontend/tailwind.config.js
@@ -9,6 +9,9 @@ module.exports = {
     "./hooks/**/*.{js,jsx,ts,tsx}",
     "../../node_modules/@oxyhq/services/lib/**/*.{js,jsx}",
     "../../node_modules/@oxyhq/bloom/lib/**/*.{js,jsx}",
+    // The live-rooms UI (RoomCard, sheets) ships NativeWind classNames from the
+    // Syra SDK; Tailwind must scan the package so those classes are generated.
+    "../../node_modules/@syra.fm/sdk/lib/**/*.{js,jsx}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
Consumes the upstream live-rooms redesign (Syra PR #51, published as `@syra.fm/sdk@0.6.0`).

The SDK now ships the redesigned `RoomCard` as **NativeWind classNames** — a full-width flush feed row instead of a bordered card box with a 32px title — plus shared live-color tokens (replacing the `#FF4458`/`#3B82F6`/`#FF6B35` hex duplicated across the live components).

Two changes are needed to consume it:
- **Bump `@syra.fm/sdk` to `^0.6.0`** in frontend and backend (the `^0.5.0` caret excludes 0.6.0 on a 0.x range).
- **Add the package to the Tailwind `content` globs** so its classNames are actually generated — exactly as we already do for `@oxyhq/services` and `@oxyhq/bloom`.

## Test plan
- `bun install` — lockfile updated; `@syra.fm/sdk@0.6.0` resolved, and `lib/.../RoomCard.js` confirmed to ship `className`
- `cd packages/frontend && bun run typecheck` — passes
- `cd packages/frontend && bun run lint` — 0 errors
- `bun run build:shared-types && bun run build:backend` — clean
- Verify in prod: the live-rooms list renders rooms as flush full-width feed rows with feed-consistent typography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)