### PR TITLE
fix(backend): dedup in-flight actor resolution in federated author backfill

### DIFF
--- a/packages/backend/src/__tests__/scripts/backfillFederatedPostAuthors.test.ts
+++ b/packages/backend/src/__tests__/scripts/backfillFederatedPostAuthors.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Concurrency test for the federated-post author backfill's actor resolution.
+ *
+ * The dry run showed HTTP 409 "conflict" races on `/users/resolve`: within a
+ * page-chunk, multiple orphans of the SAME actor concurrently trigger federated
+ * Oxy-user creation. `resolveAuthorOxyUserId` memoizes the IN-FLIGHT promise per
+ * actor URI so concurrent callers for one actor await a SINGLE underlying resolve
+ * (`actorService.getOrFetchActor`), and the settled value is then cached for the
+ * rest of the run. These offline tests mock the actor service (and the script's
+ * other module imports) so ONLY the dedup logic runs — no DB, no network.
+ */
+
+const { getOrFetchActor, fetchRemoteActor } = vi.hoisted(() => ({
+  getOrFetchActor: vi.fn(),
+  fetchRemoteActor: vi.fn(),
+}));
+
+vi.mock('../../connectors/activitypub/actor.service', () => ({
+  actorService: { getOrFetchActor, fetchRemoteActor },
+}));
+
+// The script imports these at module load; stub them so importing it stays
+// hermetic (none are exercised by `resolveAuthorOxyUserId`).
+vi.mock('../../connectors/activitypub/helpers', () => ({
+  extractActorUri: vi.fn(),
+  signedFetch: vi.fn(),
+  asRecord: vi.fn(),
+}));
+vi.mock('../../connectors/activitypub/constants', () => ({ AP_CONTENT_TYPE: 'application/activity+json' }));
+vi.mock('../../models/Post', () => ({ Post: {} }));
+vi.mock('../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn() }));
+
+import { resolveAuthorOxyUserId } from '../../scripts/backfillFederatedPostAuthors';
+
+/** A promise plus its externally-callable resolver, for holding a resolve in-flight. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('backfillFederatedPostAuthors — resolveAuthorOxyUserId in-flight dedup', () => {
+  beforeEach(() => {
+    getOrFetchActor.mockReset();
+    fetchRemoteActor.mockReset();
+  });
+
+  it('collapses two CONCURRENT resolves of the same actor onto ONE getOrFetchActor', async () => {
+    const uri = 'https://mastodon.online/users/kaleidotrope';
+    const gate = deferred<{ oxyUserId: string }>();
+    // Hold the resolve in-flight so both callers are pending simultaneously.
+    getOrFetchActor.mockReturnValueOnce(gate.promise);
+
+    const first = resolveAuthorOxyUserId(uri);
+    const second = resolveAuthorOxyUserId(uri);
+
+    // Both callers are now awaiting the SAME in-flight resolution.
+    gate.resolve({ oxyUserId: 'oxy-kaleidotrope' });
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a).toBe('oxy-kaleidotrope');
+    expect(b).toBe('oxy-kaleidotrope');
+    // The whole point: the underlying resolve ran exactly once.
+    expect(getOrFetchActor).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteActor).not.toHaveBeenCalled();
+  });
+
+  it('serves a settled actor from the cache without re-resolving', async () => {
+    const uri = 'https://mastodon.social/users/gargron';
+    getOrFetchActor.mockResolvedValueOnce({ oxyUserId: 'oxy-gargron' });
+
+    const firstPass = await resolveAuthorOxyUserId(uri);
+    const secondPass = await resolveAuthorOxyUserId(uri);
+
+    expect(firstPass).toBe('oxy-gargron');
+    expect(secondPass).toBe('oxy-gargron');
+    // The second (sequential) call is served from actorOxyCache.
+    expect(getOrFetchActor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/scripts/backfillFederatedPostAuthors.ts
+++ b/packages/backend/src/scripts/backfillFederatedPostAuthors.ts
@@ -86,36 +86,62 @@ type AuthorUriResult =
   | { kind: 'gone' }
   | { kind: 'transient' };
 
-/** actorUri → resolved oxyUserId (or null when unresolvable) — dedupes shared actors. */
+/** actorUri → resolved oxyUserId (or null when unresolvable) — dedupes shared actors across the whole run. */
 const actorOxyCache = new Map<string, string | null>();
+
+/**
+ * actorUri → in-flight resolution promise. The bulk of the 11,967 orphans come
+ * from far fewer actors, so within a page-chunk MANY concurrent orphans share one
+ * actor. `actorOxyCache` only dedupes AFTER a resolve settles, so without this two
+ * concurrent orphans of the same actor both hit `/users/resolve` and RACE on
+ * federated-user creation (observed as HTTP 409s in the dry run). Memoizing the
+ * in-flight PROMISE collapses concurrent callers for one actor onto a SINGLE
+ * resolve; the settled value then lands in `actorOxyCache` for the rest of the run.
+ */
+const inFlightActorResolves = new Map<string, Promise<string | null>>();
 
 /**
  * Resolve an actor URI to its Oxy user id, minting/linking the federated Oxy user
  * when necessary. `getOrFetchActor` returns a cached row as-is (kicking only a
  * background refresh), so when that row has no `oxyUserId` we force an AWAITED
  * `fetchRemoteActor`, which runs the shared identity bridge and stamps the id.
+ *
+ * Concurrency-safe: a settled result is served from `actorOxyCache`; a concurrent
+ * call for an actor already resolving awaits the SAME in-flight promise (no
+ * duplicate `/users/resolve`, no 409 race).
  */
-async function resolveAuthorOxyUserId(actorUri: string): Promise<string | null> {
+export async function resolveAuthorOxyUserId(actorUri: string): Promise<string | null> {
   const cached = actorOxyCache.get(actorUri);
   if (cached !== undefined) return cached;
 
-  let oxyUserId: string | null = null;
-  try {
-    const actor = await actorService.getOrFetchActor(actorUri);
-    oxyUserId = actor?.oxyUserId ?? null;
-    if (!oxyUserId) {
-      const refreshed = await actorService.fetchRemoteActor(actorUri);
-      oxyUserId = refreshed?.oxyUserId ?? null;
-    }
-  } catch (error) {
-    logger.warn('[backfillFederatedPostAuthors] actor resolution failed', {
-      actorUri,
-      reason: error instanceof Error ? error.message : 'unknown',
-    });
-  }
+  const inFlight = inFlightActorResolves.get(actorUri);
+  if (inFlight) return inFlight;
 
-  actorOxyCache.set(actorUri, oxyUserId);
-  return oxyUserId;
+  const resolution = (async (): Promise<string | null> => {
+    let oxyUserId: string | null = null;
+    try {
+      const actor = await actorService.getOrFetchActor(actorUri);
+      oxyUserId = actor?.oxyUserId ?? null;
+      if (!oxyUserId) {
+        const refreshed = await actorService.fetchRemoteActor(actorUri);
+        oxyUserId = refreshed?.oxyUserId ?? null;
+      }
+    } catch (error) {
+      logger.warn('[backfillFederatedPostAuthors] actor resolution failed', {
+        actorUri,
+        reason: error instanceof Error ? error.message : 'unknown',
+      });
+    }
+    actorOxyCache.set(actorUri, oxyUserId);
+    return oxyUserId;
+  })();
+
+  inFlightActorResolves.set(actorUri, resolution);
+  try {
+    return await resolution;
+  } finally {
+    inFlightActorResolves.delete(actorUri);
+  }
 }
 
 /**


### PR DESCRIPTION
## What

The prod DRY-RUN of `backfillFederatedPostAuthors.ts` surfaced ~210 HTTP 409 conflicts on oxy-api `/users/resolve`: within a page-chunk, concurrent orphans of the **same** federated actor both trigger federated Oxy-user creation and race. The existing `actorOxyCache` only dedupes **after** a resolve settles, so concurrent in-flight resolves for one actor weren't shared.

## Fix

`resolveAuthorOxyUserId` now memoizes the **in-flight promise** per actor URI (`Map<string, Promise<string|null>>`). Concurrent callers for one actor await a single `getOrFetchActor` / `/users/resolve`; the settled value still lands in `actorOxyCache` for the rest of the run. Standard promise-dedup — removes the 409 races and cuts resolve load.

Unchanged: delete semantics (gone → delete only with `BACKFILL_DELETE_GONE`), dry-run default, `BACKFILL_APPLY`/`DELETE_GONE` gates, bounded concurrency.

## Test

Adds `src/__tests__/scripts/backfillFederatedPostAuthors.test.ts` proving two **concurrent** `resolveAuthorOxyUserId(sameUri)` calls invoke the underlying resolve **once**, plus a cache-hit case. Offline (mocks the actor service + the script's other imports).

## Verification

- `bun run build:backend` — exit 0.
- Connectors suite (`src/__tests__/connectors/`) — 296/296 pass.
- New dedup test — 2/2 pass.

Context: unblocks the backfill APPLY run (link-only pass) now that oxy-api's `/federation/sign` rate-limit fix (#604) is deployed and the dry-run links ~83%/pass with 0 signViaOxy failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)