### PR TITLE
feat(frontend): @syra.fm/sdk 0.7.0 (RoomCard redesign) + matching skeleton

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "@oxyhq/core": "^10.0.0",
         "@oxyhq/protocol": "^0.1.5",
         "@socket.io/redis-adapter": "^8.3.0",
-        "@syra.fm/sdk": "^0.6.0",
+        "@syra.fm/sdk": "^0.7.0",
         "@types/compression": "^1.8.1",
         "@types/multer": "^2.1.0",
         "ai": "^6.0.134",
@@ -104,7 +104,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/netinfo": "^12.0.1",
         "@shopify/flash-list": "2.3.2",
-        "@syra.fm/sdk": "^0.6.0",
+        "@syra.fm/sdk": "^0.7.0",
         "@tanstack/query-async-storage-persister": "^5.101.1",
         "@tanstack/react-query": "^5.100.0",
         "@tanstack/react-query-persist-client": "^5.101.0",
@@ -1030,7 +1030,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@syra.fm/sdk": ["@syra.fm/sdk@0.6.0", "", { "dependencies": { "zod": "^3.25.76" }, "peerDependencies": { "@expo/vector-icons": "^15.0.2", "@livekit/react-native": "^2.11.1", "@oxyhq/services": "^15.0.0", "expo-audio": "~56.0.12", "expo-blur": "~56.0.3", "expo-image-picker": "~56.0.18", "livekit-client": "^2.20.0", "react": "^19.2.3", "react-native": "^0.85.3", "react-native-reanimated": "^4.3.1", "react-native-safe-area-context": "^5.7.0", "react-native-svg": "15.15.4", "socket.io-client": "^4.8.1" }, "optionalPeers": ["@expo/vector-icons", "@livekit/react-native", "@oxyhq/services", "expo-audio", "expo-blur", "expo-image-picker", "livekit-client", "react", "react-native", "react-native-reanimated", "react-native-safe-area-context", "react-native-svg", "socket.io-client"] }, "sha512-koXLrmUu+KAxqegmM4M66kUEWzIcHoo6eYzQ4Y9WvmPzE9wfw3QaVnto0dPDO+xuSVa1agKWdlll+7DuBeGJjA=="],
+    "@syra.fm/sdk": ["@syra.fm/sdk@0.7.0", "", { "dependencies": { "zod": "^3.25.76" }, "peerDependencies": { "@expo/vector-icons": "^15.0.2", "@livekit/react-native": "^2.11.1", "@oxyhq/services": "^15.0.0", "expo-audio": "~56.0.12", "expo-blur": "~56.0.3", "expo-image-picker": "~56.0.18", "livekit-client": "^2.20.0", "react": "^19.2.3", "react-native": "^0.85.3", "react-native-reanimated": "^4.3.1", "react-native-safe-area-context": "^5.7.0", "react-native-svg": "15.15.4", "socket.io-client": "^4.8.1" }, "optionalPeers": ["@expo/vector-icons", "@livekit/react-native", "@oxyhq/services", "expo-audio", "expo-blur", "expo-image-picker", "livekit-client", "react", "react-native", "react-native-reanimated", "react-native-safe-area-context", "react-native-svg", "socket.io-client"] }, "sha512-mX9r65CG4l9hPGypGkCSQTcS0JR2SEG2emGKKwYLyfOoY5Iq99CNQUY3NDBYD/3asc7xQ0/V3WX0Jn3yS0Me6g=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
     "@oxyhq/core": "^10.0.0",
     "@oxyhq/protocol": "^0.1.5",
     "@socket.io/redis-adapter": "^8.3.0",
-    "@syra.fm/sdk": "^0.6.0",
+    "@syra.fm/sdk": "^0.7.0",
     "@types/compression": "^1.8.1",
     "@types/multer": "^2.1.0",
     "ai": "^6.0.134",

--- a/packages/frontend/components/rooms/RoomsListSkeleton.tsx
+++ b/packages/frontend/components/rooms/RoomsListSkeleton.tsx
@@ -3,34 +3,72 @@ import { View } from 'react-native';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 
 /**
- * Placeholder for the initial live-rooms load. Mirrors the anatomy of the SDK
- * `RoomCard` (status pill, title, host/listener meta line, speaker avatar row)
- * so the list paints instantly and the real cards land in the same place —
- * same treatment the feed and notifications use instead of a blank screen.
+ * Placeholder for the initial live-rooms load. The SDK `RoomCard` renders TWO
+ * shapes depending on `room.status`, so the skeleton mirrors BOTH — otherwise the
+ * real cards land somewhere other than where the placeholder painted:
+ *
+ *  - LIVE rooms -> a featured card (status pill + listener count, title, speaker
+ *    avatars, host byline + Join CTA) inside a rounded surface.
+ *  - everything else -> a compact full-width row (host avatar, title + date),
+ *    flush with a hairline divider.
+ *
+ * Same treatment the feed and notifications use instead of a blank screen.
  */
-const PLACEHOLDER_CARDS = 3;
+const FEATURED_PLACEHOLDERS = 2;
+const ROW_PLACEHOLDERS = 3;
 const SPEAKER_PLACEHOLDERS = 3;
 
-const RoomCardSkeleton: React.FC = () => (
-  <View className="mb-3 gap-3 rounded-xl border border-border bg-card p-4">
-    <Skeleton.Pill size={18} style={{ width: 64 }} />
-    <Skeleton.Text style={{ fontSize: 16, lineHeight: 22, width: '70%' }} />
-    <Skeleton.Row style={{ alignItems: 'center', gap: 8 }}>
-      <Skeleton.Circle size={14} />
-      <Skeleton.Text style={{ fontSize: 12, lineHeight: 16, width: 140 }} />
+/** Mirrors the featured (live) card: rounded surface, chip, title, speakers, byline + CTA. */
+const FeaturedRoomSkeleton: React.FC = () => (
+  <View className="mb-3 w-full gap-2.5 rounded-2xl border border-border bg-surface p-3">
+    {/* LIVE chip + "· N listening" */}
+    <Skeleton.Row style={{ alignItems: 'center', gap: 6 }}>
+      <Skeleton.Pill size={18} style={{ width: 48 }} />
+      <Skeleton.Text style={{ fontSize: 13, lineHeight: 18, width: 96 }} />
     </Skeleton.Row>
-    <Skeleton.Row style={{ gap: 6 }}>
+
+    {/* Title (17px / 22px) */}
+    <Skeleton.Text style={{ fontSize: 17, lineHeight: 22, width: '80%' }} />
+
+    {/* Overlapping speaker avatars */}
+    <Skeleton.Row style={{ alignItems: 'center' }}>
       {Array.from({ length: SPEAKER_PLACEHOLDERS }).map((_, index) => (
-        <Skeleton.Circle key={index} size={28} />
+        <View key={index} className={index === 0 ? '' : '-ml-3'}>
+          <Skeleton.Circle size={36} />
+        </View>
       ))}
+    </Skeleton.Row>
+
+    {/* Host byline + Join CTA */}
+    <Skeleton.Row style={{ alignItems: 'center', gap: 8 }}>
+      <Skeleton.Circle size={20} />
+      <Skeleton.Text style={{ fontSize: 13, lineHeight: 18, width: 120 }} />
+      <View className="flex-1" />
+      <Skeleton.Pill size={28} style={{ width: 64 }} />
     </Skeleton.Row>
   </View>
 );
 
+/** Mirrors the compact (scheduled/ended) row: host avatar + title/date, hairline divider. */
+const RoomRowSkeleton: React.FC = () => (
+  <View className="w-full flex-row items-center gap-3 border-b border-border px-3 py-3">
+    <Skeleton.Circle size={40} />
+    <View className="flex-1 gap-1">
+      <Skeleton.Text style={{ fontSize: 15, lineHeight: 20, width: '65%' }} />
+      <Skeleton.Text style={{ fontSize: 13, lineHeight: 18, width: '40%' }} />
+    </View>
+  </View>
+);
+
 export const RoomsListSkeleton: React.FC = () => (
-  <View className="mt-4 px-4" accessibilityRole="progressbar">
-    {Array.from({ length: PLACEHOLDER_CARDS }).map((_, index) => (
-      <RoomCardSkeleton key={index} />
+  <View className="mt-4" accessibilityRole="progressbar">
+    <View className="px-4">
+      {Array.from({ length: FEATURED_PLACEHOLDERS }).map((_, index) => (
+        <FeaturedRoomSkeleton key={`featured-${index}`} />
+      ))}
+    </View>
+    {Array.from({ length: ROW_PLACEHOLDERS }).map((_, index) => (
+      <RoomRowSkeleton key={`row-${index}`} />
     ))}
   </View>
 );

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -57,7 +57,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^12.0.1",
     "@shopify/flash-list": "2.3.2",
-    "@syra.fm/sdk": "^0.6.0",
+    "@syra.fm/sdk": "^0.7.0",
     "@tanstack/query-async-storage-persister": "^5.101.1",
     "@tanstack/react-query": "^5.100.0",
     "@tanstack/react-query-persist-client": "^5.101.0",


### PR DESCRIPTION
## Summary
Consumes the upstream RoomCard redesign (Syra #53, published as `@syra.fm/sdk@0.7.0`) and updates the loading skeleton to match.

The SDK now renders **two** room shapes instead of one cluttered card:
- **LIVE → featured card**: one status chip, the **listener count leads** (instead of a useless "Started \<date\>"), speaker avatars, **host byline** (the host never appeared on the old default card), and an explicit **Join** CTA.
- **Scheduled / ended → compact full-width row**: host avatar, title + date.
- The redundant `SCHEDULED` chip (duplicated the date) and the room-**type** chip (only rendered on some rooms, so it read as noise) are gone; actions are icon-only.

**`RoomsListSkeleton` mirrors both new shapes** — it previously mimicked the old single bordered card, so placeholders would have painted in the wrong place and the real cards would visibly jump on load.

## Test plan
- `bun install` — `@syra.fm/sdk@0.7.0` resolved
- `cd packages/frontend && bun run typecheck` — no new errors (only the 3 pre-existing SDK livekit ones)
- `cd packages/frontend && bun run lint` — 0 errors
- `bun run build:shared-types && bun run build:backend` — clean
- Verify in prod: live rooms render as featured cards with a Join CTA; scheduled/ended as compact rows; the skeleton matches so nothing jumps on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)