### PR TITLE
chore: gitignore the generated expo-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ jspm_packages/
 # Expo
 .expo/
 .expo-shared/
+expo-env.d.ts
 
 # React Native
 *.jks


### PR DESCRIPTION
## Summary

`expo-env.d.ts` is generated by Expo per app. It was the only untracked, non-ignored file under the new `packages/agora` workspace, so it just added noise to `git status`.

Scoped deliberately to the generated file — `packages/agora/` itself stays trackable, so the package can be committed to the monorepo normally when it's ready.

## Test plan

- `git check-ignore -v packages/agora/expo-env.d.ts` now matches the new rule.
- `git status` is clean; no tracked file is newly ignored (nothing was previously committed under this name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)