### PR TITLE
feat(feed): rank posts by starter-pack curation, weighted by curator reach

### DIFF
--- a/packages/backend/src/__tests__/feedModulesCatalog.test.ts
+++ b/packages/backend/src/__tests__/feedModulesCatalog.test.ts
@@ -78,6 +78,7 @@ describe('buildModuleCatalog', () => {
       'socialProof',
       'reciprocityBoost',
       'noveltyBoost',
+      'starterPackBoost',
     ]) {
       expect(signalIds).toContain(id);
     }

--- a/packages/backend/src/__tests__/feedRankingStarterPackSignal.test.ts
+++ b/packages/backend/src/__tests__/feedRankingStarterPackSignal.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MtnConfig } from '@mention/shared-types';
+
+// Redis is unavailable in unit tests — degrade the cache to a no-op (see the
+// other ranking suites for the identical stub).
+vi.mock('../utils/redis', () => ({
+  getRedisClient: vi.fn().mockReturnValue({
+    isReady: false,
+    isOpen: false,
+    connect: vi.fn().mockRejectedValue(Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' })),
+    ping: vi.fn().mockRejectedValue(new Error('not connected')),
+    get: vi.fn(),
+    set: vi.fn(),
+    setEx: vi.fn(),
+    del: vi.fn(),
+  }),
+}));
+
+import { FeedRankingService } from '../services/FeedRankingService';
+import { curatorAuthority } from '../services/starterPackCuration';
+
+/**
+ * `starterPackBoost` — the RANKING side of starter-pack curation.
+ *
+ * The curation POLICY (which packs count, dedupe by curator, the score bound) is
+ * covered in `services/starterPackCuration.test.ts`. This suite covers the scorer:
+ * the score → multiplier map, its clamps, and the fact that it is inert unless the
+ * feed definition enables it (so no other feed — and no golden master — moves).
+ */
+
+const service = new FeedRankingService();
+const CURATION = MtnConfig.ranking.optInSignals.starterPackBoost;
+
+function makePost(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    _id: 'post-1',
+    oxyUserId: 'author-1',
+    createdAt: new Date(),
+    type: 'text',
+    hashtags: [],
+    stats: { likesCount: 0, boostsCount: 0, commentsCount: 0, viewsCount: 0 },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+async function scoreWith(
+  post: Record<string, unknown>,
+  context: Parameters<FeedRankingService['calculatePostScore']>[2] = {},
+): Promise<number> {
+  const engagementScoreCache = new Map<string, number>([[String(post._id), 1]]);
+  return service.calculatePostScore(post, undefined, { ...context, engagementScoreCache });
+}
+
+/** The documented multiplier: `clamp(1 + scale · log1p(score), 1, maxBoost)`. */
+function expectedMultiplier(score: number): number {
+  return Math.min(CURATION.maxBoost, Math.max(1, 1 + CURATION.scale * Math.log1p(score)));
+}
+
+describe('starterPackBoost scorer', () => {
+  it('is EXACTLY neutral for an uncurated author (never penalizes)', () => {
+    expect(service.calculateStarterPackBoost(makePost(), new Map())).toBe(1.0);
+    expect(
+      service.calculateStarterPackBoost(makePost(), new Map([['someone-else', 10]])),
+    ).toBe(1.0);
+  });
+
+  it('is EXACTLY neutral when the score map is absent (signal off / resolution failed)', () => {
+    expect(service.calculateStarterPackBoost(makePost(), undefined)).toBe(1.0);
+  });
+
+  it('is EXACTLY neutral for a non-positive or non-finite score', () => {
+    expect(service.calculateStarterPackBoost(makePost(), new Map([['author-1', 0]]))).toBe(1.0);
+    expect(service.calculateStarterPackBoost(makePost(), new Map([['author-1', -3]]))).toBe(1.0);
+    expect(service.calculateStarterPackBoost(makePost(), new Map([['author-1', Number.NaN]]))).toBe(1.0);
+  });
+
+  it('lifts a curated author, log-scaled in the curation score', () => {
+    const small = service.calculateStarterPackBoost(makePost(), new Map([['author-1', 1]]));
+    const large = service.calculateStarterPackBoost(makePost(), new Map([['author-1', 8]]));
+
+    expect(small).toBeCloseTo(expectedMultiplier(1), 10);
+    expect(large).toBeCloseTo(expectedMultiplier(8), 10);
+    expect(large).toBeGreaterThan(small);
+    // Log scale: 8× the score is nowhere near 8× the lift.
+    expect(large - 1).toBeLessThan(8 * (small - 1));
+  });
+
+  it('is CLAMPED at `maxBoost` — curation can never run away with the score', () => {
+    expect(service.calculateStarterPackBoost(makePost(), new Map([['author-1', CURATION.maxScore]]))).toBe(
+      CURATION.maxBoost,
+    );
+    // Even an (impossible) score far above the policy's own clamp saturates.
+    expect(service.calculateStarterPackBoost(makePost(), new Map([['author-1', 1_000_000]]))).toBe(
+      CURATION.maxBoost,
+    );
+  });
+
+  it('a low-follower curation RING earns a small lift; a real curator set earns the cap', () => {
+    // Mirrors the policy suite: 3 zero-follower sybils with single-use packs.
+    const ringScore = 3 * Math.log1p(1) * curatorAuthority(undefined);
+    const ringBoost = service.calculateStarterPackBoost(makePost(), new Map([['author-1', ringScore]]));
+
+    expect(ringBoost).toBeLessThan(1 + (CURATION.maxBoost - 1) * 0.5);
+
+    const genuineBoost = service.calculateStarterPackBoost(
+      makePost(),
+      new Map([['author-1', CURATION.maxScore]]),
+    );
+    expect(ringBoost).toBeLessThan(genuineBoost);
+  });
+});
+
+describe('starterPackBoost is OFF unless the definition enables it', () => {
+  const curated = new Map([['author-1', CURATION.maxScore]]);
+
+  it('a curated author scores identically when the signal is not enabled', async () => {
+    const post = makePost();
+    const off = await scoreWith(post, { authorStarterPackScores: curated });
+    const otherEnabled = await scoreWith(post, {
+      authorStarterPackScores: curated,
+      enabledSignals: new Set(['engagement']),
+    });
+
+    expect(otherEnabled).toBeCloseTo(off, 10);
+  });
+
+  it('enabling starterPackBoost lifts a curated author by exactly the multiplier', async () => {
+    const post = makePost();
+    const off = await scoreWith(post, { authorStarterPackScores: curated });
+    const on = await scoreWith(post, {
+      authorStarterPackScores: curated,
+      enabledSignals: new Set(['starterPackBoost']),
+    });
+
+    expect(on / off).toBeCloseTo(CURATION.maxBoost, 5);
+  });
+
+  it('enabling starterPackBoost does NOT touch an uncurated author', async () => {
+    const post = makePost({ oxyUserId: 'uncurated-author' });
+    const off = await scoreWith(post, { authorStarterPackScores: curated });
+    const on = await scoreWith(post, {
+      authorStarterPackScores: curated,
+      enabledSignals: new Set(['starterPackBoost']),
+    });
+
+    expect(on / off).toBeCloseTo(1.0, 10);
+  });
+
+  it('is neutral when enabled but no scores were resolved (fail-soft feed still serves)', async () => {
+    const post = makePost();
+    const off = await scoreWith(post, {});
+    const on = await scoreWith(post, { enabledSignals: new Set(['starterPackBoost']) });
+
+    expect(on / off).toBeCloseTo(1.0, 10);
+  });
+});

--- a/packages/backend/src/__tests__/presetsPhase2b.test.ts
+++ b/packages/backend/src/__tests__/presetsPhase2b.test.ts
@@ -30,6 +30,7 @@ describe('resolvePhase2bSignals', () => {
       'verifiedBoost',
       'localBoost',
       'languageMismatchPenalty',
+      'starterPackBoost',
     ]);
   });
 
@@ -61,10 +62,11 @@ describe('preset definitions include Phase 2b signals', () => {
     expect(ids).toContain('verifiedBoost');
     expect(ids).toContain('localBoost');
     expect(ids).toContain('languageMismatchPenalty');
+    expect(ids).toContain('starterPackBoost');
     // `mediaBoost` / `dwellTime` are OPTIONAL — never in the default set.
     expect(ids).not.toContain('mediaBoost');
     expect(ids).not.toContain('dwellTime');
-    expect(forYouDefinition.signals.length).toBeGreaterThanOrEqual(BASE_SIGNAL_COUNT + 7);
+    expect(forYouDefinition.signals.length).toBeGreaterThanOrEqual(BASE_SIGNAL_COUNT + 8);
   });
 
   it('videosDefinition signals include the same Phase 2b modules as forYou', () => {

--- a/packages/backend/src/__tests__/services/curatorFollowerCounts.test.ts
+++ b/packages/backend/src/__tests__/services/curatorFollowerCounts.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * CURATOR FOLLOWER COUNTS — the dedicated resolver behind `curatorAuthority`.
+ *
+ * The whole reason this module exists is that a COLD curator (one who happens not
+ * to be in any cache) must STILL be resolved, so that "a pack owned by someone with
+ * a big audience is worth more" actually holds. Reading the count off the shared
+ * `usersummary:` identity cache would have been recursive (that cache is filled by
+ * the same function that computes curation scores) and would have made a summary's
+ * own score depend on cache fill order — so this suite also LOCKS IN that nothing
+ * on this path ever touches a `usersummary:` key.
+ */
+
+const { getUsersByIds, redisStore, mGet, setEx } = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  return {
+    getUsersByIds: vi.fn(),
+    redisStore: store,
+    mGet: vi.fn(async (keys: string[]) => keys.map((key) => store.get(key) ?? null)),
+    setEx: vi.fn(async (key: string, _ttl: number, value: string) => {
+      store.set(key, value);
+    }),
+  };
+});
+
+// A ready Redis client whose MULTI pipeline writes straight through to the store,
+// so a second pass can observe the cache the first pass populated.
+vi.mock('../../utils/redis', () => ({
+  getRedisClient: vi.fn().mockReturnValue({
+    isReady: true,
+    isOpen: true,
+    connect: vi.fn().mockResolvedValue(undefined),
+    ping: vi.fn().mockResolvedValue('PONG'),
+    mGet,
+    multi: () => {
+      const queued: Array<() => Promise<void>> = [];
+      const pipeline = {
+        setEx: (key: string, ttl: number, value: string) => {
+          queued.push(() => setEx(key, ttl, value));
+          return pipeline;
+        },
+        exec: async () => {
+          for (const write of queued) await write();
+        },
+      };
+      return pipeline;
+    },
+  }),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({ getUsersByIds }),
+}));
+
+import { MtnConfig } from '@mention/shared-types';
+import { resolveCuratorFollowerCounts } from '../../services/curatorFollowerCounts';
+import { computeStarterPackScores, curatorAuthority } from '../../services/starterPackCuration';
+
+const CURATION = MtnConfig.ranking.optInSignals.starterPackBoost;
+
+/** Minimal Oxy user shape the resolver reads: an id and a follower count. */
+function oxyUser(id: string, followers: number): Record<string, unknown> {
+  return { id, username: id, name: {}, _count: { followers } };
+}
+
+/** Every Redis key this path touched, in call order (reads and writes). */
+function touchedKeys(): string[] {
+  const readKeys = mGet.mock.calls.flatMap(([keys]) => keys as string[]);
+  const writeKeys = setEx.mock.calls.map(([key]) => key as string);
+  return [...readKeys, ...writeKeys];
+}
+
+beforeEach(() => {
+  redisStore.clear();
+  vi.clearAllMocks();
+});
+
+describe('resolveCuratorFollowerCounts', () => {
+  it('resolves a COLD curator from Oxy — a big audience still amplifies', async () => {
+    getUsersByIds.mockResolvedValue([oxyUser('whale', 100_000)]);
+
+    const counts = await resolveCuratorFollowerCounts(['whale']);
+
+    expect(counts.get('whale')).toBe(100_000);
+    // The point of the whole module: a cold curator does NOT collapse to the floor.
+    expect(curatorAuthority(counts.get('whale'))).toBeGreaterThan(CURATION.curatorAuthority.min);
+  });
+
+  it('issues exactly ONE bulk Oxy call for N curators', async () => {
+    const curatorIds = Array.from({ length: 25 }, (_, i) => `curator-${i}`);
+    getUsersByIds.mockResolvedValue(curatorIds.map((id, i) => oxyUser(id, i * 10)));
+
+    const counts = await resolveCuratorFollowerCounts(curatorIds);
+
+    expect(counts.size).toBe(curatorIds.length);
+    expect(getUsersByIds).toHaveBeenCalledTimes(1);
+    expect(getUsersByIds).toHaveBeenCalledWith(curatorIds);
+  });
+
+  it('CACHES: a second pass serves from Redis without touching Oxy', async () => {
+    getUsersByIds.mockResolvedValue([oxyUser('curator-1', 4_200)]);
+
+    const first = await resolveCuratorFollowerCounts(['curator-1']);
+    const second = await resolveCuratorFollowerCounts(['curator-1']);
+
+    expect(first.get('curator-1')).toBe(4_200);
+    expect(second.get('curator-1')).toBe(4_200);
+    expect(getUsersByIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches ONLY the misses when the batch is partially cached', async () => {
+    getUsersByIds.mockResolvedValue([oxyUser('warm', 10)]);
+    await resolveCuratorFollowerCounts(['warm']);
+    getUsersByIds.mockClear();
+
+    getUsersByIds.mockResolvedValue([oxyUser('cold', 20)]);
+    const counts = await resolveCuratorFollowerCounts(['warm', 'cold']);
+
+    expect(getUsersByIds).toHaveBeenCalledTimes(1);
+    expect(getUsersByIds).toHaveBeenCalledWith(['cold']);
+    expect(counts.get('warm')).toBe(10);
+    expect(counts.get('cold')).toBe(20);
+  });
+
+  it('dedupes ids and short-circuits an empty batch', async () => {
+    getUsersByIds.mockResolvedValue([oxyUser('curator-1', 5)]);
+
+    await resolveCuratorFollowerCounts(['curator-1', 'curator-1', '']);
+    expect(getUsersByIds).toHaveBeenCalledWith(['curator-1']);
+
+    getUsersByIds.mockClear();
+    await expect(resolveCuratorFollowerCounts([])).resolves.toEqual(new Map());
+    expect(getUsersByIds).not.toHaveBeenCalled();
+  });
+
+  it('is FAIL-SOFT: an Oxy failure yields UNKNOWN counts (neutral authority), never throws', async () => {
+    getUsersByIds.mockRejectedValue(new Error('oxy unreachable'));
+
+    const counts = await resolveCuratorFollowerCounts(['curator-1']);
+
+    expect(counts.size).toBe(0);
+    expect(curatorAuthority(counts.get('curator-1'))).toBe(CURATION.curatorAuthority.min);
+  });
+
+  it('ignores curators Oxy does not return, or whose count is unusable', async () => {
+    getUsersByIds.mockResolvedValue([
+      oxyUser('good', 7),
+      { id: 'no-count', name: {} },
+      { id: 'negative', name: {}, _count: { followers: -1 } },
+    ]);
+
+    const counts = await resolveCuratorFollowerCounts(['good', 'no-count', 'negative', 'missing']);
+
+    expect(counts.get('good')).toBe(7);
+    expect(counts.has('no-count')).toBe(false);
+    expect(counts.has('negative')).toBe(false);
+    expect(counts.has('missing')).toBe(false);
+  });
+
+  it('NEVER touches a `usersummary:` key — its cache is entirely its own', async () => {
+    getUsersByIds.mockResolvedValue([oxyUser('curator-1', 9)]);
+
+    await resolveCuratorFollowerCounts(['curator-1']);
+    await resolveCuratorFollowerCounts(['curator-1']);
+
+    const keys = touchedKeys();
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys.every((key) => key.startsWith('curatorfollowers:v1:'))).toBe(true);
+    expect(keys.some((key) => key.startsWith('usersummary:'))).toBe(false);
+  });
+
+  it('writes with the configured TTL (no magic number)', async () => {
+    getUsersByIds.mockResolvedValue([oxyUser('curator-1', 9)]);
+
+    await resolveCuratorFollowerCounts(['curator-1']);
+
+    expect(setEx).toHaveBeenCalledWith(
+      'curatorfollowers:v1:curator-1',
+      CURATION.curatorAuthority.cacheTtlSeconds,
+      '9',
+    );
+  });
+});
+
+describe('starter-pack curation with the real curator resolver', () => {
+  const edges = [{ authorId: 'author-1', curatorId: 'whale', useCount: 10 }];
+  const deps = {
+    loadCurationEdges: vi.fn(async () => edges),
+    loadCuratorFollowerCounts: resolveCuratorFollowerCounts,
+  };
+
+  beforeEach(() => {
+    deps.loadCurationEdges.mockClear();
+  });
+
+  it('a COLD, well-followed curator amplifies the score (resolved via Oxy)', async () => {
+    getUsersByIds.mockResolvedValue([oxyUser('whale', 100_000)]);
+    const amplified = await computeStarterPackScores(['author-1'], deps);
+
+    redisStore.clear();
+    getUsersByIds.mockResolvedValue([oxyUser('whale', 0)]);
+    const neutral = await computeStarterPackScores(['author-1'], deps);
+
+    expect(amplified.get('author-1') ?? 0).toBeGreaterThan(neutral.get('author-1') ?? 0);
+  });
+
+  it('an Oxy outage still scores the author (neutral curator authority), feed unaffected', async () => {
+    getUsersByIds.mockRejectedValue(new Error('oxy unreachable'));
+
+    const scores = await computeStarterPackScores(['author-1'], deps);
+
+    expect(scores.get('author-1')).toBeCloseTo(
+      Math.log1p(10) * CURATION.curatorAuthority.min,
+      10,
+    );
+  });
+});

--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -86,6 +86,12 @@ vi.mock('../../models/Bookmark', () => ({ default: { find: () => chainable([]) }
 vi.mock('../../models/UserSettings', () => ({
   UserSettings: { find: () => chainable([]), findOne: () => chainable(null) },
 }));
+// The starter-pack CURATION aggregation runs on the cache-fill path (it stamps the
+// ranking-side `starterPackScore`). No DB here → no packs → no scores.
+vi.mock('../../models/StarterPack', () => ({
+  StarterPack: { aggregate: async () => [] },
+  default: { aggregate: async () => [] },
+}));
 
 // FederatedActor lookup, shared by two paths: the degraded-author enrichment
 // (keyed by `oxyUserId`) and the orphan-federated-author resolution (keyed by

--- a/packages/backend/src/__tests__/services/postHydrationFederatedRepair.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationFederatedRepair.test.ts
@@ -55,6 +55,12 @@ vi.mock('../../models/Poll', () => ({ default: { find: () => chainable([]) } }))
 vi.mock('../../models/Like', () => ({ default: { find: () => chainable([]) } }));
 vi.mock('../../models/Bookmark', () => ({ default: { find: () => chainable([]) } }));
 vi.mock('../../models/UserSettings', () => ({ UserSettings: { find: () => chainable([]), findOne: () => chainable([]) } }));
+// The starter-pack CURATION aggregation runs on the cache-fill path (it stamps the
+// ranking-side `starterPackScore`). No DB here → no packs → no scores.
+vi.mock('../../models/StarterPack', () => ({
+  StarterPack: { aggregate: async () => [] },
+  default: { aggregate: async () => [] },
+}));
 // Cache always misses (so every author flows through the Oxy resolve + enrich
 // path), and writes are no-ops.
 vi.mock('../../services/userSummaryCache', () => ({

--- a/packages/backend/src/__tests__/services/postHydrationLanguages.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationLanguages.test.ts
@@ -35,6 +35,12 @@ vi.mock('../../models/Poll', () => ({ default: {} }));
 vi.mock('../../models/Like', () => ({ default: {} }));
 vi.mock('../../models/Bookmark', () => ({ default: {} }));
 vi.mock('../../models/UserSettings', () => ({ UserSettings: {} }));
+// The starter-pack CURATION aggregation runs on the cache-fill path (it stamps the
+// ranking-side `starterPackScore`). No DB here → no packs → no scores.
+vi.mock('../../models/StarterPack', () => ({
+  StarterPack: { aggregate: async () => [] },
+  default: { aggregate: async () => [] },
+}));
 vi.mock('../../models/FederatedActor', () => ({
   FederatedActor: { find: () => ({ select: () => ({ lean: async () => [] }) }) },
   default: { find: () => ({ select: () => ({ lean: async () => [] }) }) },

--- a/packages/backend/src/__tests__/services/postHydrationMentions.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationMentions.test.ts
@@ -43,6 +43,12 @@ vi.mock('../../models/Poll', () => ({ default: {} }));
 vi.mock('../../models/Like', () => ({ default: {} }));
 vi.mock('../../models/Bookmark', () => ({ default: {} }));
 vi.mock('../../models/UserSettings', () => ({ UserSettings: {} }));
+// The starter-pack CURATION aggregation runs on the cache-fill path (it stamps the
+// ranking-side `starterPackScore`). No DB here → no packs → no scores.
+vi.mock('../../models/StarterPack', () => ({
+  StarterPack: { aggregate: async () => [] },
+  default: { aggregate: async () => [] },
+}));
 // Federated enrichment lookup for still-degraded ids — return nothing so an
 // unresolved mention stays a raw placeholder (no ghost handle).
 vi.mock('../../models/FederatedActor', () => ({

--- a/packages/backend/src/__tests__/services/postHydrationViewerGraph.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationViewerGraph.test.ts
@@ -70,6 +70,12 @@ vi.mock('../../models/FederatedActor', () => ({
   FederatedActor: { find: () => ({ select: () => ({ lean: async () => [] }) }) },
   default: { find: () => ({ select: () => ({ lean: async () => [] }) }) },
 }));
+// The starter-pack CURATION aggregation runs on the cache-fill path (it stamps the
+// ranking-side `starterPackScore`). No DB here → no packs → no scores.
+vi.mock('../../models/StarterPack', () => ({
+  StarterPack: { aggregate: async () => [] },
+  default: { aggregate: async () => [] },
+}));
 
 const cacheStore = new Map<string, CachedUserSummary>();
 vi.mock('../../services/userSummaryCache', () => ({

--- a/packages/backend/src/__tests__/services/starterPackCuration.test.ts
+++ b/packages/backend/src/__tests__/services/starterPackCuration.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MtnConfig } from '@mention/shared-types';
+
+/**
+ * STARTER-PACK CURATION POLICY — the anti-gaming rules are the whole point of this
+ * signal, so each one is locked in here against the PURE policy function
+ * (`computeStarterPackScores`), driven through MOCKED accessors:
+ *
+ *   1. self-owned packs are excluded  — otherwise anyone self-boosts;
+ *   2. only crowd-validated packs count (`useCount >= minUseCount`);
+ *   3. dedupe by CURATOR, not by pack — 50 packs by one curator count ONCE;
+ *   4. everything is bounded (curator count, score, and — in the signal — the
+ *      multiplier), and log-scaled, so a low-follower ring earns almost nothing;
+ *   5. absence of curation is exactly neutral (no score at all → multiplier 1.0).
+ *
+ * Plus the batching contract (ONE aggregation for N authors) and fail-softness (an
+ * accessor that throws degrades to no scores, never to an error).
+ */
+
+import {
+  buildCurationPipeline,
+  computeStarterPackScores,
+  curatorAuthority,
+  packWeight,
+  type CurationEdge,
+  type StarterPackCurationDeps,
+} from '../../services/starterPackCuration';
+
+const CURATION = MtnConfig.ranking.optInSignals.starterPackBoost;
+
+/** Deps whose accessors are vitest mocks, so call counts can be asserted. */
+function mockDeps(
+  edges: CurationEdge[],
+  followerCounts: Map<string, number> = new Map(),
+): StarterPackCurationDeps & {
+  loadCurationEdges: ReturnType<typeof vi.fn>;
+  loadCuratorFollowerCounts: ReturnType<typeof vi.fn>;
+} {
+  return {
+    loadCurationEdges: vi.fn().mockResolvedValue(edges),
+    loadCuratorFollowerCounts: vi.fn().mockResolvedValue(followerCounts),
+  };
+}
+
+/** The score a single pack contributes, computed from the documented formula. */
+function expectedWeight(useCount: number, curatorFollowers?: number): number {
+  return Math.log1p(useCount) * curatorAuthority(curatorFollowers);
+}
+
+describe('curatorAuthority', () => {
+  it('is the NEUTRAL floor for an unknown follower count (never a penalty)', () => {
+    expect(curatorAuthority(undefined)).toBe(CURATION.curatorAuthority.min);
+    expect(curatorAuthority(Number.NaN)).toBe(CURATION.curatorAuthority.min);
+    expect(curatorAuthority(-5)).toBe(CURATION.curatorAuthority.min);
+  });
+
+  it('is the floor for a zero-follower curator and grows with log(followers)', () => {
+    expect(curatorAuthority(0)).toBe(CURATION.curatorAuthority.min);
+    expect(curatorAuthority(1_000)).toBeGreaterThan(curatorAuthority(10));
+    expect(curatorAuthority(10)).toBeGreaterThan(curatorAuthority(0));
+  });
+
+  it('is CLAMPED at the ceiling for a mega-account curator', () => {
+    expect(curatorAuthority(50_000_000)).toBe(CURATION.curatorAuthority.max);
+  });
+});
+
+describe('computeStarterPackScores — anti-gaming rules', () => {
+  it('RULE 1: excludes SELF-OWNED packs (an author cannot curate themselves)', async () => {
+    const deps = mockDeps([
+      { authorId: 'author-1', curatorId: 'author-1', useCount: 500 },
+    ]);
+
+    const scores = await computeStarterPackScores(['author-1'], deps);
+
+    expect(scores.has('author-1')).toBe(false);
+  });
+
+  it('RULE 1: a self-owned pack does not inflate a genuine curator\'s contribution', async () => {
+    const selfOnly = await computeStarterPackScores(
+      ['author-1'],
+      mockDeps([
+        { authorId: 'author-1', curatorId: 'curator-1', useCount: 4 },
+        { authorId: 'author-1', curatorId: 'author-1', useCount: 999 },
+      ]),
+    );
+    const curatorOnly = await computeStarterPackScores(
+      ['author-1'],
+      mockDeps([{ authorId: 'author-1', curatorId: 'curator-1', useCount: 4 }]),
+    );
+
+    expect(selfOnly.get('author-1')).toBe(curatorOnly.get('author-1'));
+  });
+
+  it('RULE 2: excludes packs nobody ever used (useCount below minUseCount)', async () => {
+    const deps = mockDeps([
+      { authorId: 'author-1', curatorId: 'curator-1', useCount: 0 },
+      { authorId: 'author-2', curatorId: 'curator-1', useCount: CURATION.minUseCount },
+    ]);
+
+    const scores = await computeStarterPackScores(['author-1', 'author-2'], deps);
+
+    expect(scores.has('author-1')).toBe(false);
+    expect(scores.get('author-2')).toBeCloseTo(expectedWeight(CURATION.minUseCount), 10);
+  });
+
+  it('RULE 3: DEDUPES BY CURATOR — one curator with many packs counts ONCE (their best)', async () => {
+    const spammedPacks: CurationEdge[] = Array.from({ length: 50 }, (_, index) => ({
+      authorId: 'author-1',
+      curatorId: 'curator-1',
+      useCount: index + 1, // best pack = useCount 50
+    }));
+
+    const scores = await computeStarterPackScores(['author-1'], mockDeps(spammedPacks));
+
+    // Exactly ONE curator's BEST pack — not the sum of fifty.
+    expect(scores.get('author-1')).toBeCloseTo(expectedWeight(50), 10);
+  });
+
+  it('RULE 3: distinct curators DO each contribute (dedupe is per curator, not global)', async () => {
+    const one = await computeStarterPackScores(
+      ['author-1'],
+      mockDeps([{ authorId: 'author-1', curatorId: 'curator-1', useCount: 3 }]),
+    );
+    const two = await computeStarterPackScores(
+      ['author-1'],
+      mockDeps([
+        { authorId: 'author-1', curatorId: 'curator-1', useCount: 3 },
+        { authorId: 'author-1', curatorId: 'curator-2', useCount: 3 },
+      ]),
+    );
+
+    expect(two.get('author-1')).toBeCloseTo(2 * expectedWeight(3), 10);
+    expect(two.get('author-1') ?? 0).toBeGreaterThan(one.get('author-1') ?? 0);
+  });
+
+  it('RULE 4: counts at most `maxCuratorsPerAuthor` distinct curators, highest-weight first', async () => {
+    const curatorCount = CURATION.maxCuratorsPerAuthor + 5;
+    const edges: CurationEdge[] = Array.from({ length: curatorCount }, (_, index) => ({
+      authorId: 'author-1',
+      curatorId: `curator-${index}`,
+      useCount: index + 1, // the top `maxCuratorsPerAuthor` are the HIGHEST useCounts
+    }));
+
+    const scores = await computeStarterPackScores(['author-1'], mockDeps(edges));
+
+    const topUseCounts = Array.from(
+      { length: CURATION.maxCuratorsPerAuthor },
+      (_, i) => curatorCount - i,
+    );
+    const expected = topUseCounts.reduce((sum, useCount) => sum + expectedWeight(useCount), 0);
+    expect(scores.get('author-1')).toBeCloseTo(Math.min(CURATION.maxScore, expected), 10);
+  });
+
+  it('RULE 4: the summed score is CLAMPED at `maxScore`', async () => {
+    const edges: CurationEdge[] = Array.from({ length: CURATION.maxCuratorsPerAuthor }, (_, i) => ({
+      authorId: 'author-1',
+      curatorId: `whale-${i}`,
+      useCount: 100_000,
+    }));
+    const followers = new Map(edges.map((edge) => [edge.curatorId, 5_000_000]));
+
+    const scores = await computeStarterPackScores(['author-1'], mockDeps(edges, followers));
+
+    expect(scores.get('author-1')).toBe(CURATION.maxScore);
+  });
+
+  it('RULE 5: an UNCURATED author gets no score at all (the signal reads it as neutral)', async () => {
+    const scores = await computeStarterPackScores(['author-1'], mockDeps([]));
+
+    expect(scores.size).toBe(0);
+    expect(scores.get('author-1')).toBeUndefined();
+  });
+
+  it('a curator with a real audience outweighs a curator with none (same pack usage)', async () => {
+    const whale = await computeStarterPackScores(
+      ['author-1'],
+      mockDeps(
+        [{ authorId: 'author-1', curatorId: 'whale', useCount: 10 }],
+        new Map([['whale', 100_000]]),
+      ),
+    );
+    const nobody = await computeStarterPackScores(
+      ['author-1'],
+      mockDeps([{ authorId: 'author-1', curatorId: 'nobody', useCount: 10 }], new Map()),
+    );
+
+    expect(whale.get('author-1') ?? 0).toBeGreaterThan(nobody.get('author-1') ?? 0);
+    // …but only by the BOUNDED authority spread — never unbounded amplification.
+    const ratio = (whale.get('author-1') ?? 0) / (nobody.get('author-1') ?? 1);
+    expect(ratio).toBeLessThanOrEqual(CURATION.curatorAuthority.max / CURATION.curatorAuthority.min);
+  });
+
+  it('a low-follower CURATION RING scores far below a single genuine curator', async () => {
+    // Three sybils with no audience, each with a barely-used pack containing the
+    // target — the cheapest realistic gaming attempt.
+    const ring = await computeStarterPackScores(
+      ['author-1'],
+      mockDeps(
+        [
+          { authorId: 'author-1', curatorId: 'sybil-1', useCount: 1 },
+          { authorId: 'author-1', curatorId: 'sybil-2', useCount: 1 },
+          { authorId: 'author-1', curatorId: 'sybil-3', useCount: 1 },
+        ],
+        new Map(),
+      ),
+    );
+
+    // One real curator with a real audience and a pack people actually used.
+    const genuine = await computeStarterPackScores(
+      ['author-2'],
+      mockDeps(
+        [{ authorId: 'author-2', curatorId: 'curator', useCount: 50 }],
+        new Map([['curator', 10_000]]),
+      ),
+    );
+
+    expect(ring.get('author-1') ?? 0).toBeLessThan(genuine.get('author-2') ?? 0);
+  });
+});
+
+describe('computeStarterPackScores — batching + fail-softness', () => {
+  it('issues exactly ONE edge lookup and ONE follower lookup for N authors', async () => {
+    const authorIds = Array.from({ length: 40 }, (_, i) => `author-${i}`);
+    const deps = mockDeps(
+      authorIds.map((authorId) => ({ authorId, curatorId: 'curator-1', useCount: 2 })),
+      new Map([['curator-1', 500]]),
+    );
+
+    const scores = await computeStarterPackScores(authorIds, deps);
+
+    expect(scores.size).toBe(authorIds.length);
+    expect(deps.loadCurationEdges).toHaveBeenCalledTimes(1);
+    expect(deps.loadCurationEdges).toHaveBeenCalledWith(authorIds);
+    expect(deps.loadCuratorFollowerCounts).toHaveBeenCalledTimes(1);
+    expect(deps.loadCuratorFollowerCounts).toHaveBeenCalledWith(['curator-1']);
+  });
+
+  it('deduplicates the requested author ids before querying', async () => {
+    const deps = mockDeps([]);
+
+    await computeStarterPackScores(['author-1', 'author-1', 'author-2'], deps);
+
+    expect(deps.loadCurationEdges).toHaveBeenCalledWith(['author-1', 'author-2']);
+  });
+
+  it('touches nothing when there are no authors to score', async () => {
+    const deps = mockDeps([]);
+
+    await expect(computeStarterPackScores([], deps)).resolves.toEqual(new Map());
+    expect(deps.loadCurationEdges).not.toHaveBeenCalled();
+    expect(deps.loadCuratorFollowerCounts).not.toHaveBeenCalled();
+  });
+
+  it('skips the follower lookup entirely when nobody is curated', async () => {
+    const deps = mockDeps([]);
+
+    await computeStarterPackScores(['author-1'], deps);
+
+    expect(deps.loadCuratorFollowerCounts).not.toHaveBeenCalled();
+  });
+
+  it('is FAIL-SOFT: an aggregation failure degrades to NO scores (neutral), never throws', async () => {
+    const deps: StarterPackCurationDeps = {
+      loadCurationEdges: vi.fn().mockRejectedValue(new Error('mongo unreachable')),
+      loadCuratorFollowerCounts: vi.fn(),
+    };
+
+    await expect(computeStarterPackScores(['author-1'], deps)).resolves.toEqual(new Map());
+  });
+
+  it('is FAIL-SOFT: a follower-count failure degrades to NO scores, never throws', async () => {
+    const deps: StarterPackCurationDeps = {
+      loadCurationEdges: vi
+        .fn()
+        .mockResolvedValue([{ authorId: 'author-1', curatorId: 'curator-1', useCount: 3 }]),
+      loadCuratorFollowerCounts: vi.fn().mockRejectedValue(new Error('redis unreachable')),
+    };
+
+    await expect(computeStarterPackScores(['author-1'], deps)).resolves.toEqual(new Map());
+  });
+
+  it('still scores when curator follower counts are simply UNKNOWN (neutral authority)', async () => {
+    const scores = await computeStarterPackScores(
+      ['author-1'],
+      mockDeps([{ authorId: 'author-1', curatorId: 'cold-curator', useCount: 3 }], new Map()),
+    );
+
+    expect(scores.get('author-1')).toBeCloseTo(packWeight(3, undefined), 10);
+  });
+});
+
+describe('buildCurationPipeline', () => {
+  const pipeline = buildCurationPipeline(['author-1', 'author-2']);
+
+  it('pre-filters on the indexed member array AND the crowd-validation floor', () => {
+    expect(pipeline[0]).toEqual({
+      $match: {
+        memberOxyUserIds: { $in: ['author-1', 'author-2'] },
+        useCount: { $gte: CURATION.minUseCount },
+      },
+    });
+  });
+
+  it('drops self-owned packs in the database, not just in the policy', () => {
+    expect(pipeline).toContainEqual({ $match: { $expr: { $ne: ['$authorId', '$curatorId'] } } });
+  });
+
+  it('dedupes by CURATOR in the database, keeping their best (max-useCount) pack', () => {
+    expect(pipeline).toContainEqual({
+      $group: {
+        _id: { authorId: '$authorId', curatorId: '$curatorId' },
+        useCount: { $max: '$useCount' },
+      },
+    });
+  });
+
+  it('bounds its own output at `maxCuratorsPerAuthor` curators per author', () => {
+    expect(pipeline).toContainEqual({
+      $group: {
+        _id: '$_id.authorId',
+        curators: {
+          $topN: {
+            n: CURATION.maxCuratorsPerAuthor,
+            sortBy: { useCount: -1, '_id.curatorId': 1 },
+            output: { curatorId: '$_id.curatorId', useCount: '$useCount' },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/backend/src/models/StarterPack.ts
+++ b/packages/backend/src/models/StarterPack.ts
@@ -22,6 +22,16 @@ const StarterPackSchema = new Schema<IStarterPack>({
 
 StarterPackSchema.index({ ownerOxyUserId: 1, createdAt: -1 });
 StarterPackSchema.index({ useCount: -1, createdAt: -1 });
+/**
+ * MULTIKEY index on the member array, compounded with `useCount`.
+ *
+ * Serves the starter-pack CURATION aggregation (`services/starterPackCuration.ts`),
+ * which matches `{ memberOxyUserIds: { $in: [...] }, useCount: { $gte: n } }` to
+ * find the packs that curate a batch of feed authors. `memberOxyUserIds` is the
+ * only array field in the compound (a compound index may have at most one), so the
+ * `$in` on the members is index-served and `useCount` filters within it.
+ */
+StarterPackSchema.index({ memberOxyUserIds: 1, useCount: -1 });
 
 export const StarterPack = mongoose.model<IStarterPack>('StarterPack', StarterPackSchema);
 export default StarterPack;

--- a/packages/backend/src/mtn/feed/definitions/presets.ts
+++ b/packages/backend/src/mtn/feed/definitions/presets.ts
@@ -39,6 +39,11 @@ const ALL_RANKING_SIGNALS: ModuleRef[] = [
  *   - `verifiedBoost`          — small lift for verified authors (uses pre-rank `verified`).
  *   - `localBoost` (Phase 4d)   — modest first-party lift.
  *   - `languageMismatchPenalty` (Phase 4c) — off-language DISCOVERY downrank.
+ *   - `starterPackBoost`        — bounded lift for authors OTHER people curated into
+ *                                 starter packs that newcomers actually used. Costs
+ *                                 no extra query (the score rides the cached author
+ *                                 summary) and never penalizes, so it is safe ON by
+ *                                 default; `FOR_YOU_PHASE2B_SIGNALS` still disables it.
  * `mediaBoost` and `dwellTime` stay OPTIONAL (allowed via env, not default): each
  * is a strong surface-shaping nudge better reserved for deliberate tuning/A-B.
  */
@@ -50,6 +55,7 @@ const PHASE2B_DEFAULT_SIGNAL_IDS = [
   'verifiedBoost',
   'localBoost',
   'languageMismatchPenalty',
+  'starterPackBoost',
 ] as const;
 
 const PHASE2B_ALLOWED_SIGNAL_IDS = new Set<string>([
@@ -60,6 +66,7 @@ const PHASE2B_ALLOWED_SIGNAL_IDS = new Set<string>([
   'noveltyBoost',
   'localBoost',
   'languageMismatchPenalty',
+  'starterPackBoost',
   // OPTIONAL signals — enable-able via `FOR_YOU_PHASE2B_SIGNALS` for A/B + tuning,
   // but deliberately NOT in the default set.
   'mediaBoost',

--- a/packages/backend/src/mtn/feed/engine/signals/index.ts
+++ b/packages/backend/src/mtn/feed/engine/signals/index.ts
@@ -54,6 +54,9 @@ const SIGNAL_WEIGHT_KEYS: Record<string, string> = {
   // until Phase 5); the id === weightKey is forwarded to `rankPosts` when enabled.
   localBoost: 'localBoost',
   languageMismatchPenalty: 'languageMismatchPenalty',
+  // Opt-in — curation signal. A bounded lift for authors OTHER people curated into
+  // starter packs that were actually used (see `services/starterPackCuration.ts`).
+  starterPackBoost: 'starterPackBoost',
 };
 
 export const signalModules: SignalModule[] = Object.entries(SIGNAL_WEIGHT_KEYS).map(

--- a/packages/backend/src/mtn/feed/moduleCatalog.ts
+++ b/packages/backend/src/mtn/feed/moduleCatalog.ts
@@ -367,6 +367,10 @@ const SIGNAL_LABELS: Record<string, { label: string; description: string }> = {
   noveltyBoost: { label: 'Novelty', description: 'Explore topics you have not seen recently.' },
   localBoost: { label: 'Local boost', description: 'A modest lift for local (non-federated) posts.' },
   languageMismatchPenalty: { label: 'Off-language penalty', description: 'Downrank discovery posts not in your languages.' },
+  starterPackBoost: {
+    label: 'Starter-pack curation',
+    description: 'Lift accounts other people curated into starter packs that were actually used.',
+  },
 };
 
 /** Whether a registry module should be offered to the custom-feed builder. */

--- a/packages/backend/src/routes/starterPacks.ts
+++ b/packages/backend/src/routes/starterPacks.ts
@@ -3,6 +3,7 @@ import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import StarterPack, { IStarterPack } from '../models/StarterPack';
 import { escapeRegex } from '../utils/textProcessing';
 import { resolveUserSummaries, isFallbackUserSummary } from '../services/PostHydrationService';
+import { invalidate as invalidateUserSummaries } from '../services/userSummaryCache';
 import type { PostUser } from '@mention/shared-types';
 import { logger } from '../utils/logger';
 import { endorsementSignalService } from '../services/EndorsementSignalService';
@@ -16,6 +17,36 @@ function syncPackEndorsements(packId: string): void {
   void endorsementSignalService
     .syncScope('starterPack', packId)
     .catch((error) => logger.warn(`[StarterPacks] endorsement sync failed for ${packId}:`, error));
+}
+
+/**
+ * Evict the cached author summaries of every member whose starter-pack CURATION
+ * score just changed, so the `starterPackBoost` ranking signal picks the new value
+ * up on the next hydration instead of waiting out the 10-minute TTL.
+ *
+ * The score is a function of (pack membership × pack `useCount` × curator), so it
+ * changes for the members of ANY pack that is created, edited, deleted, or used.
+ * Pass BOTH the previous and the next member sets: a removed member's score has to
+ * be recomputed just as much as an added one's.
+ *
+ * Fire-and-forget and fail-soft — a cache eviction must never fail a write, and a
+ * miss only means the score is stale for at most one TTL.
+ */
+function invalidateCurationScores(...memberIdGroups: Array<string[] | undefined>): void {
+  const memberIds = new Set<string>();
+  for (const group of memberIdGroups) {
+    for (const id of group ?? []) {
+      if (typeof id === 'string' && id.length > 0) memberIds.add(id);
+    }
+  }
+  if (memberIds.size === 0) return;
+
+  void invalidateUserSummaries(Array.from(memberIds)).catch((error) =>
+    logger.warn('[StarterPacks] curation cache invalidation failed', {
+      memberCount: memberIds.size,
+      reason: error instanceof Error ? error.message : 'unknown',
+    }),
+  );
 }
 
 function syncPackMembershipChange(
@@ -164,6 +195,7 @@ router.post('/', async (req: AuthRequest, res: Response) => {
     });
 
     syncPackEndorsements(String(pack._id));
+    invalidateCurationScores(members);
     res.status(201).json(pack);
   } catch (error) {
     res.status(500).json({ error: 'Failed to create starter pack' });
@@ -251,6 +283,7 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     await pack.save();
     if (Array.isArray(memberOxyUserIds)) {
       syncPackMembershipChange(String(pack._id), pack.ownerOxyUserId, previousMemberIds, pack.memberOxyUserIds || []);
+      invalidateCurationScores(previousMemberIds, pack.memberOxyUserIds);
     } else {
       syncPackEndorsements(String(pack._id));
     }
@@ -276,6 +309,7 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     void endorsementSignalService
       .syncScopeRemoval('starterPack', packId, ownerId, memberIds)
       .catch((error) => logger.warn(`[StarterPacks] endorsement retraction failed for ${packId}:`, error));
+    invalidateCurationScores(memberIds);
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: 'Failed to delete starter pack' });
@@ -292,11 +326,13 @@ router.post('/:id/members', async (req: AuthRequest, res: Response) => {
     if (!pack) return res.status(404).json({ error: 'Starter pack not found' });
     if (pack.ownerOxyUserId !== userId) return res.status(403).json({ error: 'Not allowed' });
 
+    const previousMemberIds = [...(pack.memberOxyUserIds || [])];
     const set = new Set([...(pack.memberOxyUserIds || []), ...(Array.isArray(userIds) ? userIds : [])]);
     if (set.size > MAX_MEMBERS) return res.status(400).json({ error: `Maximum ${MAX_MEMBERS} members allowed` });
     pack.memberOxyUserIds = Array.from(set);
     await pack.save();
     syncPackEndorsements(String(pack._id));
+    invalidateCurationScores(previousMemberIds, pack.memberOxyUserIds);
     res.json(pack);
   } catch (error) {
     res.status(500).json({ error: 'Failed to add members' });
@@ -318,6 +354,7 @@ router.delete('/:id/members', async (req: AuthRequest, res: Response) => {
     pack.memberOxyUserIds = (pack.memberOxyUserIds || []).filter(id => !toRemove.has(id));
     await pack.save();
     syncPackMembershipChange(String(pack._id), pack.ownerOxyUserId, previousMemberIds, pack.memberOxyUserIds || []);
+    invalidateCurationScores(previousMemberIds, pack.memberOxyUserIds);
     res.json(pack);
   } catch (error) {
     res.status(500).json({ error: 'Failed to remove members' });
@@ -345,6 +382,8 @@ router.post('/:id/use', async (req: AuthRequest, res: Response) => {
       return res.json({ memberOxyUserIds: existing.memberOxyUserIds, useCount: existing.useCount, alreadyUsed: true });
     }
 
+    // `useCount` actually moved, so every member's curation score changed.
+    invalidateCurationScores(pack.memberOxyUserIds);
     res.json({ memberOxyUserIds: pack.memberOxyUserIds, useCount: pack.useCount });
   } catch (error) {
     res.status(500).json({ error: 'Failed to use starter pack' });

--- a/packages/backend/src/services/FeedRankingService.ts
+++ b/packages/backend/src/services/FeedRankingService.ts
@@ -32,6 +32,7 @@ import {
   positivityBoost,
   reciprocityBoost,
   socialProofBoost,
+  starterPackBoost,
   verifiedBoost,
 } from './ranking/signals/optIn';
 
@@ -65,21 +66,27 @@ export class FeedRankingService {
    * Resolve per-author summary maps for the unique authors of a candidate post
    * set, in a SINGLE pass:
    *   - `followerCounts` (`authorId → followerCount`) for the author-authority
-   *     signal, and
-   *   - `verified` (`authorId → isVerified`) for the opt-in `verifiedBoost` signal.
+   *     signal,
+   *   - `verified` (`authorId → isVerified`) for the opt-in `verifiedBoost` signal,
+   *     and
+   *   - `starterPackScores` (`authorId → curation score`) for the opt-in
+   *     `starterPackBoost` signal.
    *
    * Backed by the shared Redis user-summary cache + a single bulk Oxy fetch for
    * cold authors, so the common case (warm cache) is one Redis round trip with no
-   * Oxy call. Authors whose value is unavailable are simply absent from the
-   * relevant map and fall back to a neutral multiplier. Resolving both maps here
-   * means `verifiedBoost` costs nothing beyond the authority resolution that
-   * already runs on every ranked request.
+   * Oxy call. The curation score is computed and cached alongside the identity on
+   * that same cache-fill (`PostHydrationService.applyStarterPackScores`), so it
+   * costs NO extra query here. Authors whose value is unavailable are simply absent
+   * from the relevant map and fall back to a neutral multiplier.
    */
-  private async resolveAuthorSummaries(
-    posts: RankablePost[],
-  ): Promise<{ followerCounts: Map<string, number>; verified: Map<string, boolean> }> {
+  private async resolveAuthorSummaries(posts: RankablePost[]): Promise<{
+    followerCounts: Map<string, number>;
+    verified: Map<string, boolean>;
+    starterPackScores: Map<string, number>;
+  }> {
     const followerCounts = new Map<string, number>();
     const verified = new Map<string, boolean>();
+    const starterPackScores = new Map<string, number>();
 
     const authorIds = Array.from(
       new Set(
@@ -89,7 +96,7 @@ export class FeedRankingService {
       ),
     );
     if (authorIds.length === 0) {
-      return { followerCounts, verified };
+      return { followerCounts, verified, starterPackScores };
     }
 
     try {
@@ -104,12 +111,15 @@ export class FeedRankingService {
         if (typeof value.user?.verified === 'boolean') {
           verified.set(authorId, value.user.verified);
         }
+        if (typeof value.starterPackScore === 'number') {
+          starterPackScores.set(authorId, value.starterPackScore);
+        }
       }
     } catch (error) {
       logger.warn('Failed to resolve author summaries for ranking signals:', error);
     }
 
-    return { followerCounts, verified };
+    return { followerCounts, verified, starterPackScores };
   }
 
   /**
@@ -130,6 +140,8 @@ export class FeedRankingService {
     enabledSignals: Set<string> | undefined;
     /** Verified flags already resolved alongside the authority follower counts. */
     authorVerified: Map<string, boolean>;
+    /** Starter-pack curation scores already resolved alongside the follower counts. */
+    authorStarterPackScores: Map<string, number>;
     /** The viewer's seen post ids (for `penalizeSeen`). */
     seenPostIds?: string[];
     /** The viewer's following ids (for `socialProof`'s network set). */
@@ -137,7 +149,16 @@ export class FeedRankingService {
     /** The viewer's mutual ids (for `socialProof` + `reciprocityBoost`). */
     mutualIds?: string[];
   }): Promise<OptInSignalContext> {
-    const { posts, userId, enabledSignals, authorVerified, seenPostIds, followingIds, mutualIds } = params;
+    const {
+      posts,
+      userId,
+      enabledSignals,
+      authorVerified,
+      authorStarterPackScores,
+      seenPostIds,
+      followingIds,
+      mutualIds,
+    } = params;
     if (!enabledSignals || enabledSignals.size === 0) {
       return {};
     }
@@ -148,6 +169,10 @@ export class FeedRankingService {
 
     if (enabledSignals.has('verifiedBoost')) {
       optIn.authorVerified = authorVerified;
+    }
+
+    if (enabledSignals.has('starterPackBoost')) {
+      optIn.authorStarterPackScores = authorStarterPackScores;
     }
 
     if (enabledSignals.has('penalizeSeen') && seenPostIds && seenPostIds.length > 0) {
@@ -262,6 +287,14 @@ export class FeedRankingService {
   /** `languageMismatchPenalty` — soft downrank of off-language discovery posts. */
   public calculateLanguageMismatchPenalty(post: RankablePost, viewerLanguages: string[] | undefined): number {
     return languageMismatchPenalty(post, viewerLanguages);
+  }
+
+  /** `starterPackBoost` — bounded lift for authors curated into others' starter packs. */
+  public calculateStarterPackBoost(
+    post: RankablePost,
+    authorStarterPackScores: Map<string, number> | undefined,
+  ): number {
+    return starterPackBoost(post, authorStarterPackScores);
   }
 
   /**
@@ -453,14 +486,22 @@ export class FeedRankingService {
     const followingIdsSet = new Set(followingIds || []);
     const behaviorSets: BehaviorSets | undefined = buildBehaviorSets(userBehavior);
 
-    // Resolve author summaries ONCE for the authority signal (follower counts)
-    // and, in the same pass, the verified flags the opt-in `verifiedBoost` reads.
-    // Skipped entirely when the caller supplied follower counts (then verified is
-    // absent → `verifiedBoost` neutral, which only custom feeds enable anyway).
-    const { followerCounts: resolvedFollowerCounts, verified: authorVerified } =
-      context.authorFollowerCounts
-        ? { followerCounts: context.authorFollowerCounts, verified: new Map<string, boolean>() }
-        : await this.resolveAuthorSummaries(posts);
+    // Resolve author summaries ONCE for the authority signal (follower counts) and,
+    // in the same pass, the verified flags the opt-in `verifiedBoost` reads plus the
+    // curation scores the opt-in `starterPackBoost` reads. Skipped entirely when the
+    // caller supplied follower counts (then both opt-in maps are empty → those
+    // signals stay neutral, exactly as `verifiedBoost` already behaved).
+    const {
+      followerCounts: resolvedFollowerCounts,
+      verified: authorVerified,
+      starterPackScores: authorStarterPackScores,
+    } = context.authorFollowerCounts
+      ? {
+          followerCounts: context.authorFollowerCounts,
+          verified: new Map<string, boolean>(),
+          starterPackScores: new Map<string, number>(),
+        }
+      : await this.resolveAuthorSummaries(posts);
     const authorFollowerCounts = resolvedFollowerCounts;
 
     // Resolve the OPT-IN (Phase 2b) signal context ONCE for this request. Every
@@ -472,6 +513,7 @@ export class FeedRankingService {
       userId,
       enabledSignals: context.enabledSignals,
       authorVerified,
+      authorStarterPackScores,
       seenPostIds: context.seenPostIds,
       followingIds: followingIds ?? [],
       mutualIds: context.mutualIds,

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -18,6 +18,7 @@ import { getNormalizedUserHandle, getUserLanguages } from '@oxyhq/core';
 import type { LinkPreview } from '@oxyhq/contracts';
 import { assignThreadState } from './ThreadSlicingService';
 import { mget as mgetUserSummaries, mset as msetUserSummaries, CachedUserSummary } from './userSummaryCache';
+import { computeStarterPackScores, mongoStarterPackCurationDeps } from './starterPackCuration';
 import {
   collectAuthorshipUserIds,
   getHeaderAuthorshipEntries,
@@ -281,7 +282,34 @@ async function enrichDegradedFederatedUsers(resolved: Map<string, CachedUserSumm
         instance: actor.domain || undefined,
       },
       followerCount: existing?.followerCount,
+      starterPackScore: existing?.starterPackScore,
     });
+  }
+}
+
+/**
+ * Stamp the bounded starter-pack CURATION score onto the summaries resolved in
+ * this batch, BEFORE they are written to the Redis cache — so the score is read
+ * back on every warm hydration and the `starterPackBoost` ranking signal costs no
+ * per-post (and no per-author) query.
+ *
+ * ONE batched aggregation for the WHOLE set of freshly-resolved authors, run only
+ * on the cache-MISS path. Fail-soft by construction: {@link computeStarterPackScores}
+ * never throws, and an author with no score is simply left without the field,
+ * which the signal reads as exactly neutral. Mutates `freshlyResolved` in place.
+ */
+async function applyStarterPackScores(freshlyResolved: Map<string, CachedUserSummary>): Promise<void> {
+  if (freshlyResolved.size === 0) return;
+
+  const scores = await computeStarterPackScores(
+    Array.from(freshlyResolved.keys()),
+    mongoStarterPackCurationDeps,
+  );
+  for (const [userId, score] of scores) {
+    const summary = freshlyResolved.get(userId);
+    if (summary) {
+      summary.starterPackScore = score;
+    }
   }
 }
 
@@ -368,8 +396,11 @@ export async function resolveUserSummaries(userIds: string[]): Promise<Map<strin
     await resolvePerId(missIds);
   }
 
-  // 3. Merge fresh results and write them back to cache (only real resolutions —
-  //    degraded/enriched users are never cached, so the DTO self-heals).
+  // 3. Enrich the freshly-resolved authors with their ranking-side starter-pack
+  //    curation score (ONE batched aggregation), then merge and write them back to
+  //    cache (only real resolutions — degraded/enriched users are never cached, so
+  //    the DTO self-heals).
+  await applyStarterPackScores(freshlyResolved);
   for (const [userId, value] of freshlyResolved) {
     resolved.set(userId, value);
   }

--- a/packages/backend/src/services/curatorFollowerCounts.ts
+++ b/packages/backend/src/services/curatorFollowerCounts.ts
@@ -1,0 +1,185 @@
+/**
+ * CURATOR FOLLOWER COUNTS — a dedicated, batched, non-recursive resolver for the
+ * one input the starter-pack curation score needs about a CURATOR: how big their
+ * audience is (`curatorAuthority`, see `services/starterPackCuration.ts`).
+ *
+ * WHY ITS OWN CACHE, SEPARATE FROM `usersummary:`:
+ *
+ * The obvious shortcut — reading the curator's follower count off the shared
+ * identity cache (`usersummary:v4:`) — is wrong twice over:
+ *  1. RECURSION. `usersummary:` entries are filled by
+ *     `PostHydrationService.resolveUserSummaries`, which is exactly the function
+ *     that computes curation scores. Resolving a curator through it would re-enter
+ *     the curation path for that curator, and so on.
+ *  2. FILL-ORDER BUG. Writing a curator's identity entry from the curation path
+ *     would cache a summary whose OWN `starterPackScore` was never computed — so
+ *     whether an author gets their curation boost would depend on the accidental
+ *     order in which the cache happened to be filled.
+ *
+ * So this is a SINGLE-VALUE cache under its own key, written and read only here.
+ * It NEVER touches `usersummary:`. That makes the resolution non-recursive and
+ * lets the follower weighting actually WORK for a cold curator (the point of the
+ * signal) instead of silently collapsing to the neutral floor.
+ *
+ * COST: one Redis MGET + at most ONE bulk Oxy `getUsersByIds` per batch, for the
+ * cache MISSES only. The curator set is already bounded by
+ * `maxCuratorsPerAuthor · authors`, and the TTL is long (a follower count is a
+ * coarse, slow-moving input to a bounded log factor), so the steady-state cost of
+ * a warm cache is a single Redis round trip.
+ *
+ * FAIL-SOFT: every failure degrades to "count unknown" for the affected curators,
+ * which `curatorAuthority` reads as the NEUTRAL floor — the curator still endorses
+ * at full base weight, they are just not amplified. Curation can never break a feed.
+ */
+
+import { MtnConfig } from '@mention/shared-types';
+import type { User as OxyUser } from '@oxyhq/core';
+import { getServiceOxyClient } from '../utils/oxyHelpers';
+import { getRedisClient } from '../utils/redis';
+import { withRedisFallback, ensureRedisConnected } from '../utils/redisHelpers';
+import { logger } from '../utils/logger';
+
+/**
+ * Redis key prefix. Bump when the cached VALUE shape changes.
+ *  - `v1` — a bare follower count (a JSON number).
+ */
+const CURATOR_FOLLOWERS_PREFIX = 'curatorfollowers:v1:';
+
+const { cacheTtlSeconds } = MtnConfig.ranking.optInSignals.starterPackBoost.curatorAuthority;
+
+function keyFor(curatorId: string): string {
+  return `${CURATOR_FOLLOWERS_PREFIX}${curatorId}`;
+}
+
+/** A follower count is only usable if it is a real, non-negative, finite number. */
+function isUsableCount(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * Batch-read cached counts in ONE Redis round trip. Returns only the HITS; any
+ * failure (no Redis, server down, corrupt entry, non-array reply) degrades to an
+ * empty map, i.e. "everything is a miss".
+ */
+async function readCached(curatorIds: string[]): Promise<Map<string, number>> {
+  const hits = new Map<string, number>();
+  const redis = getRedisClient();
+
+  return withRedisFallback(
+    redis,
+    async () => {
+      const connected = await ensureRedisConnected(redis);
+      if (!connected) return hits;
+
+      const values = await redis.mGet(curatorIds.map(keyFor));
+
+      // A Redis client/server can hand back a non-array reply for MGET (observed
+      // against ElastiCache Valkey); iterating it would throw a TypeError that
+      // `withRedisFallback` does NOT swallow. Treat it as a full miss.
+      if (!Array.isArray(values)) {
+        logger.debug('[CuratorFollowerCounts] mGet returned a non-array reply; treating as cache miss', {
+          keyCount: curatorIds.length,
+        });
+        return hits;
+      }
+
+      values.forEach((raw, index) => {
+        if (!raw) return;
+        const parsed = Number(raw);
+        if (isUsableCount(parsed)) {
+          hits.set(curatorIds[index], parsed);
+        }
+      });
+
+      return hits;
+    },
+    hits,
+    'curatorFollowerCountsRead',
+  );
+}
+
+/** Write freshly-resolved counts with a TTL, in one pipelined round trip. */
+async function writeCached(counts: Map<string, number>): Promise<void> {
+  if (counts.size === 0) return;
+
+  const redis = getRedisClient();
+  await withRedisFallback(
+    redis,
+    async () => {
+      const connected = await ensureRedisConnected(redis);
+      if (!connected) return;
+
+      const pipeline = redis.multi();
+      for (const [curatorId, count] of counts) {
+        pipeline.setEx(keyFor(curatorId), cacheTtlSeconds, String(count));
+      }
+      await pipeline.exec();
+    },
+    undefined,
+    'curatorFollowerCountsWrite',
+  ).catch((error: unknown) => {
+    logger.debug('[CuratorFollowerCounts] Store failed', {
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+  });
+}
+
+/**
+ * Resolve follower counts for a batch of curators: cache first, then ONE bulk Oxy
+ * call for the misses, then write the fresh counts back.
+ *
+ * A curator absent from the returned map has an UNKNOWN follower count (never
+ * resolved, or Oxy failed) — `curatorAuthority` maps that to the neutral floor, so
+ * an unresolvable curator is never penalized, only un-amplified. Never throws.
+ */
+export async function resolveCuratorFollowerCounts(curatorIds: string[]): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  const uniqueIds = Array.from(new Set(curatorIds.filter((id) => id.length > 0)));
+  if (uniqueIds.length === 0) {
+    return counts;
+  }
+
+  const cached = await readCached(uniqueIds);
+  const missIds: string[] = [];
+  for (const curatorId of uniqueIds) {
+    const hit = cached.get(curatorId);
+    if (hit === undefined) {
+      missIds.push(curatorId);
+    } else {
+      counts.set(curatorId, hit);
+    }
+  }
+
+  if (missIds.length === 0) {
+    return counts;
+  }
+
+  // ONE bulk service-token call for every miss. `/users/by-ids` is server-to-server,
+  // so it must go through the service client (the bare client carries no app token).
+  const resolved = new Map<string, number>();
+  try {
+    const users: OxyUser[] = await getServiceOxyClient().getUsersByIds(missIds);
+    for (const user of users) {
+      const curatorId = String(user.id ?? '');
+      const followers = user._count?.followers;
+      if (curatorId.length > 0 && isUsableCount(followers)) {
+        resolved.set(curatorId, followers);
+      }
+    }
+  } catch (error) {
+    // Fail-soft: the misses keep an UNKNOWN count → neutral curator authority. The
+    // curation signal still scores (usage-weighted), the feed still serves.
+    logger.warn('[CuratorFollowerCounts] Bulk follower lookup failed; curators fall back to neutral authority', {
+      curatorCount: missIds.length,
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+    return counts;
+  }
+
+  for (const [curatorId, count] of resolved) {
+    counts.set(curatorId, count);
+  }
+  await writeCached(resolved);
+
+  return counts;
+}

--- a/packages/backend/src/services/ranking/signalContext.ts
+++ b/packages/backend/src/services/ranking/signalContext.ts
@@ -93,6 +93,13 @@ export interface OptInSignalContext {
   dwellAverages?: Map<string, number>;
   /** Topic slugs/ids the viewer has recently seen — `noveltyBoost`. */
   viewerRecentTopics?: Set<string>;
+  /**
+   * Oxy authorId → bounded starter-pack CURATION score — `starterPackBoost`.
+   * Resolved from the same cached user-summary batch as the follower counts (see
+   * `services/starterPackCuration.ts`), so it adds no query. An author absent from
+   * the map is uncurated ⇒ the signal is exactly neutral.
+   */
+  authorStarterPackScores?: Map<string, number>;
 }
 
 /**
@@ -210,6 +217,7 @@ export interface SignalContext {
   mutualIdsSet?: Set<string>;
   dwellAverages?: Map<string, number>;
   viewerRecentTopics?: Set<string>;
+  authorStarterPackScores?: Map<string, number>;
 }
 
 /**
@@ -261,5 +269,6 @@ export function buildSignalContext(
     mutualIdsSet: context.mutualIdsSet,
     dwellAverages: context.dwellAverages,
     viewerRecentTopics: context.viewerRecentTopics,
+    authorStarterPackScores: context.authorStarterPackScores,
   };
 }

--- a/packages/backend/src/services/ranking/signals/optIn.ts
+++ b/packages/backend/src/services/ranking/signals/optIn.ts
@@ -232,6 +232,40 @@ export function localBoost(post: RankablePost): number {
 }
 
 /**
+ * `starterPackBoost` — a BOUNDED lift for a post whose AUTHOR other people curated
+ * into their starter packs, weighted by how much those packs were actually USED and
+ * by each curator's own follower count.
+ *
+ * The heavy lifting (which packs count, dedupe by curator, bounding) is the
+ * curation POLICY in `services/starterPackCuration.ts`; the per-author score it
+ * produces is resolved ONCE per request alongside the follower counts and handed in
+ * as `ctx.authorStarterPackScores`. This scorer is the pure score → multiplier map:
+ *
+ *   `clamp(1 + scale · log1p(starterPackScore), 1, maxBoost)`
+ *
+ * Log-scaled so the first genuine curator matters far more than the tenth, and
+ * clamped so curation can never dominate the product. Exactly NEUTRAL (1.0) when
+ * the map is absent (signal not enabled / resolution failed), the author is not in
+ * it (nobody curated them), or the score is non-positive — curation only ever
+ * lifts, it never penalizes.
+ */
+export function starterPackBoost(
+  post: RankablePost,
+  authorStarterPackScores: Map<string, number> | undefined,
+): number {
+  if (!authorStarterPackScores || authorStarterPackScores.size === 0) {
+    return 1.0;
+  }
+  const authorId = post?.oxyUserId ? String(post.oxyUserId) : '';
+  const score = authorId ? authorStarterPackScores.get(authorId) : undefined;
+  if (typeof score !== 'number' || !Number.isFinite(score) || score <= 0) {
+    return 1.0;
+  }
+  const { scale, maxBoost } = R.optInSignals.starterPackBoost;
+  return Math.min(maxBoost, Math.max(1, 1 + scale * Math.log1p(score)));
+}
+
+/**
  * `languageMismatchPenalty` (Phase 4c) — a SOFT downrank (never a filter) of
  * off-language DISCOVERY posts. Applies the configured penalty (< 1) ONLY when:
  *   - the post is a DISCOVERY candidate (`post._discovery === true` — trusted-lane
@@ -301,6 +335,9 @@ export const OPT_IN_SIGNALS: readonly OptInScorer[] = [
   // enabled (DORMANT until Phase 5), so preset ranking is unaffected.
   { id: 'localBoost', score: (post) => localBoost(post) },
   { id: 'languageMismatchPenalty', score: (post, ctx) => languageMismatchPenalty(post, ctx.viewerLanguages) },
+  // Curation signal — appended at the END for the same reason: an existing feed's
+  // opt-in product is untouched unless it explicitly enables this signal.
+  { id: 'starterPackBoost', score: (post, ctx) => starterPackBoost(post, ctx.authorStarterPackScores) },
 ];
 
 /**

--- a/packages/backend/src/services/starterPackCuration.ts
+++ b/packages/backend/src/services/starterPackCuration.ts
@@ -1,0 +1,288 @@
+/**
+ * STARTER-PACK CURATION scoring — the data + policy layer behind the
+ * `starterPackBoost` ranking signal.
+ *
+ * A starter pack contains USERS, so "curation" is an AUTHOR-level endorsement:
+ * other people put this author on a list that newcomers actually FOLLOWED
+ * THROUGH. That is a human, crowd-validated quality signal for authors whose
+ * follow graph is still thin, which raw engagement counts systematically miss.
+ *
+ * TWO LAYERS, deliberately split:
+ *
+ *  - The POLICY ({@link computeStarterPackScores}) is a PURE, injectable function
+ *    over curation EDGES. It owns every anti-gaming rule (self-owned packs
+ *    excluded, unused packs excluded, dedupe by CURATOR, bounded curator count,
+ *    clamped score) and is authoritative for ANY accessor, so it is fully
+ *    unit-testable with mocks.
+ *  - The ACCESSOR ({@link mongoStarterPackCurationDeps}) is the only place that
+ *    knows about Mongo. Its aggregation pre-applies the same predicates purely as
+ *    an INDEX-SERVED WORK BOUND (it must never return MORE than the policy would
+ *    keep per author); the policy re-applies them regardless.
+ *
+ * COST: per BATCH of authors — never per post and never per author — one Mongo
+ * aggregation plus one batched curator follower-count resolution (a Redis MGET, and
+ * a single bulk Oxy call only for curators not yet cached). It runs ONLY on the
+ * user-summary cache-fill path (`PostHydrationService.resolveUserSummaries`), so a
+ * warm feed pays nothing and the RANKING path pays nothing at all.
+ *
+ * FAIL-SOFT: any error yields NO score for the affected authors, which the signal
+ * reads as exactly neutral (1.0). Curation can never break or empty a feed.
+ */
+
+import { MtnConfig } from '@mention/shared-types';
+import type { PipelineStage } from 'mongoose';
+import StarterPack from '../models/StarterPack';
+import { resolveCuratorFollowerCounts } from './curatorFollowerCounts';
+import { logger } from '../utils/logger';
+
+const CURATION = MtnConfig.ranking.optInSignals.starterPackBoost;
+
+/**
+ * One curation edge: a pack owned by `curatorId` that contains `authorId` and has
+ * been used `useCount` times. One edge per (pack, member) pair — the policy is
+ * what collapses several packs by the same curator into a single contribution.
+ */
+export interface CurationEdge {
+  authorId: string;
+  curatorId: string;
+  useCount: number;
+}
+
+/**
+ * The data accessors {@link computeStarterPackScores} depends on. Injected so the
+ * policy can be tested with mocks (and so a future ingest path can supply edges
+ * from somewhere other than Mongo).
+ */
+export interface StarterPackCurationDeps {
+  /** Candidate curation edges for a batch of authors — ONE call per batch. */
+  loadCurationEdges(authorIds: string[]): Promise<CurationEdge[]>;
+  /**
+   * Follower counts for a batch of curators — ONE call per batch. An id that is
+   * absent from the returned map has an UNKNOWN follower count, which
+   * {@link curatorAuthority} treats as the neutral floor (never a penalty).
+   */
+  loadCuratorFollowerCounts(curatorIds: string[]): Promise<Map<string, number>>;
+}
+
+/**
+ * How much a curator's own audience amplifies their endorsement.
+ *
+ * Same bounded log shape as the author-authority signal: `1 + k · log1p(followers)`
+ * clamped to `[min, max]`. The floor is NEUTRAL (1.0), so a curator with no — or
+ * an unresolved — follower count still endorses at full base weight and is simply
+ * never amplified. This is what makes a ring of low-follower accounts curating
+ * each other worth a fraction of a genuine curator with a real audience, without
+ * ever penalizing a small curator.
+ */
+export function curatorAuthority(followerCount: number | undefined): number {
+  const { logScale, min, max } = CURATION.curatorAuthority;
+  if (typeof followerCount !== 'number' || !Number.isFinite(followerCount) || followerCount < 0) {
+    return min;
+  }
+  const raw = 1 + logScale * Math.log1p(followerCount);
+  return Math.min(max, Math.max(min, raw));
+}
+
+/**
+ * The weight of a single pack: `log1p(useCount) · curatorAuthority(owner)`.
+ *
+ * Log-scaled in usage so the 1st use matters far more than the 500th, and a pack
+ * can never dominate by raw volume. Monotonically increasing in `useCount` for a
+ * FIXED curator — which is exactly why "the curator's best pack" is well-defined.
+ */
+export function packWeight(useCount: number, curatorFollowerCount: number | undefined): number {
+  const uses = Number.isFinite(useCount) && useCount > 0 ? useCount : 0;
+  return Math.log1p(uses) * curatorAuthority(curatorFollowerCount);
+}
+
+/** Whether an edge survives the two hard anti-gaming rules (self-owned / unused). */
+function isEligible(edge: CurationEdge): boolean {
+  // Rule 1 — a pack NEVER endorses its own owner (otherwise: self-boosting).
+  if (!edge.authorId || !edge.curatorId || edge.curatorId === edge.authorId) {
+    return false;
+  }
+  // Rule 2 — only crowd-validated packs endorse anyone.
+  return Number.isFinite(edge.useCount) && edge.useCount >= CURATION.minUseCount;
+}
+
+/**
+ * Collapse eligible edges into `authorId → (curatorId → best useCount)`.
+ *
+ * Rule 3 — DEDUPE BY CURATOR, NOT BY PACK: one curator contributes exactly one
+ * entry, their BEST pack. Because `packWeight` is monotonic in `useCount` for a
+ * fixed curator, the highest-`useCount` pack IS the highest-weight pack, so this
+ * can be resolved before any follower count is known.
+ */
+function groupByAuthorAndCurator(edges: CurationEdge[]): Map<string, Map<string, number>> {
+  const byAuthor = new Map<string, Map<string, number>>();
+  for (const edge of edges) {
+    if (!isEligible(edge)) continue;
+    let curators = byAuthor.get(edge.authorId);
+    if (!curators) {
+      curators = new Map<string, number>();
+      byAuthor.set(edge.authorId, curators);
+    }
+    const best = curators.get(edge.curatorId);
+    if (best === undefined || edge.useCount > best) {
+      curators.set(edge.curatorId, edge.useCount);
+    }
+  }
+  return byAuthor;
+}
+
+/**
+ * Compute the bounded starter-pack curation score for a batch of authors.
+ *
+ * Pure w.r.t. its {@link StarterPackCurationDeps}: two batched accessor calls, no
+ * per-author or per-post I/O. Returns ONLY authors with a score > 0 — an author
+ * nobody curated is simply absent, which the ranking signal reads as exactly
+ * neutral (1.0). Never throws: an accessor failure degrades the whole batch to
+ * "no scores" (logged), so a Mongo/Redis hiccup can never break a feed.
+ */
+export async function computeStarterPackScores(
+  authorIds: string[],
+  deps: StarterPackCurationDeps,
+): Promise<Map<string, number>> {
+  const scores = new Map<string, number>();
+  const uniqueAuthorIds = Array.from(new Set(authorIds.filter((id) => id.length > 0)));
+  if (uniqueAuthorIds.length === 0) {
+    return scores;
+  }
+
+  try {
+    const edges = await deps.loadCurationEdges(uniqueAuthorIds);
+    const byAuthor = groupByAuthorAndCurator(edges);
+    if (byAuthor.size === 0) {
+      return scores;
+    }
+
+    // ONE batched follower-count lookup for every distinct curator in the batch.
+    const curatorIds = new Set<string>();
+    for (const curators of byAuthor.values()) {
+      for (const curatorId of curators.keys()) curatorIds.add(curatorId);
+    }
+    const followerCounts = await deps.loadCuratorFollowerCounts(Array.from(curatorIds));
+
+    for (const [authorId, curators] of byAuthor) {
+      // Rule 4 — bound everything: rank each distinct curator's best pack by
+      // weight, keep at most `maxCuratorsPerAuthor`, sum, and clamp the total.
+      const weights: number[] = [];
+      for (const [curatorId, useCount] of curators) {
+        weights.push(packWeight(useCount, followerCounts.get(curatorId)));
+      }
+      weights.sort((a, b) => b - a);
+
+      let total = 0;
+      for (const weight of weights.slice(0, CURATION.maxCuratorsPerAuthor)) {
+        total += weight;
+      }
+
+      const score = Math.min(CURATION.maxScore, total);
+      if (score > 0) {
+        scores.set(authorId, score);
+      }
+    }
+  } catch (error) {
+    logger.warn('[StarterPackCuration] Score computation failed; authors fall back to neutral', {
+      authorCount: uniqueAuthorIds.length,
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+    return new Map<string, number>();
+  }
+
+  return scores;
+}
+
+/** One author's bounded curator list as returned by the Mongo aggregation. */
+interface AggregatedCurationRow {
+  _id: string;
+  curators: Array<{ curatorId: string; useCount: number }>;
+}
+
+/**
+ * The Mongo aggregation pipeline behind {@link mongoStarterPackCurationDeps}.
+ *
+ * Exported so its stages can be asserted in a unit test without a live database.
+ * It mirrors the policy rules ONLY as a work bound — it must never return more
+ * than the policy would keep, and the policy re-applies every rule regardless:
+ *
+ *  1. `$match`   — packs containing any of these authors, already crowd-validated
+ *                  (`useCount >= minUseCount`). Index-served by
+ *                  `{ memberOxyUserIds: 1, useCount: -1 }`.
+ *  2. `$unwind`  — one row per (pack, matched author), dropping members we did not
+ *                  ask about via `$setIntersection`.
+ *  3. `$match`   — drop SELF-OWNED packs (`curator !== author`).
+ *  4. `$group`   — dedupe by CURATOR, keeping their best (max-`useCount`) pack.
+ *  5. `$group`   — keep only each author's top `maxCuratorsPerAuthor` curators by
+ *                  usage (`$topN`, MongoDB 5.2+), which caps the rows this ever
+ *                  returns at `maxCuratorsPerAuthor · authors`.
+ */
+export function buildCurationPipeline(authorIds: string[]): PipelineStage[] {
+  return [
+    {
+      $match: {
+        memberOxyUserIds: { $in: authorIds },
+        useCount: { $gte: CURATION.minUseCount },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        curatorId: '$ownerOxyUserId',
+        useCount: 1,
+        authorId: { $setIntersection: ['$memberOxyUserIds', authorIds] },
+      },
+    },
+    { $unwind: '$authorId' },
+    { $match: { $expr: { $ne: ['$authorId', '$curatorId'] } } },
+    {
+      $group: {
+        _id: { authorId: '$authorId', curatorId: '$curatorId' },
+        useCount: { $max: '$useCount' },
+      },
+    },
+    {
+      $group: {
+        _id: '$_id.authorId',
+        curators: {
+          $topN: {
+            n: CURATION.maxCuratorsPerAuthor,
+            // Deterministic: usage first, curator id as the tie-break.
+            sortBy: { useCount: -1, '_id.curatorId': 1 },
+            output: { curatorId: '$_id.curatorId', useCount: '$useCount' },
+          },
+        },
+      },
+    },
+  ];
+}
+
+/**
+ * The production accessors: starter packs from Mongo, curator follower counts from
+ * the DEDICATED curator-follower resolver (`services/curatorFollowerCounts.ts` —
+ * its own Redis cache + one bulk Oxy call for the misses).
+ *
+ * That resolver deliberately does NOT go through the shared `usersummary:` identity
+ * cache: that cache is filled by the very function which computes curation scores,
+ * so reading curators through it would be recursive AND would make a cached summary's
+ * own `starterPackScore` depend on cache fill order. Keeping curator follower counts
+ * in a separate single-value cache means a COLD curator is still resolved (from Oxy)
+ * and therefore still AMPLIFIES — which is the entire point of weighting an
+ * endorsement by the curator's audience.
+ */
+export const mongoStarterPackCurationDeps: StarterPackCurationDeps = {
+  async loadCurationEdges(authorIds: string[]): Promise<CurationEdge[]> {
+    const rows = await StarterPack.aggregate<AggregatedCurationRow>(buildCurationPipeline(authorIds));
+    const edges: CurationEdge[] = [];
+    for (const row of rows) {
+      for (const curator of row.curators) {
+        edges.push({ authorId: row._id, curatorId: curator.curatorId, useCount: curator.useCount });
+      }
+    }
+    return edges;
+  },
+
+  loadCuratorFollowerCounts(curatorIds: string[]): Promise<Map<string, number>> {
+    return resolveCuratorFollowerCounts(curatorIds);
+  },
+};

--- a/packages/backend/src/services/userSummaryCache.ts
+++ b/packages/backend/src/services/userSummaryCache.ts
@@ -35,8 +35,10 @@ import { logger } from '../utils/logger';
  *  - `v2` — raw Oxy user (replaced the old flat summary).
  *  - `v3` — adds the account's BCP-47 `languages` (ranking-side, see
  *    {@link CachedUserSummary}).
+ *  - `v4` — adds the bounded `starterPackScore` (ranking-side, see
+ *    {@link CachedUserSummary}).
  */
-const USER_SUMMARY_PREFIX = 'usersummary:v3:';
+const USER_SUMMARY_PREFIX = 'usersummary:v4:';
 
 /**
  * TTL for a cached summary. Display name / avatar / verification change rarely;
@@ -48,11 +50,12 @@ const SUMMARY_TTL_SECONDS = Number(process.env.USER_SUMMARY_CACHE_TTL_SECONDS ??
 /**
  * The cached value: the raw canonical Oxy {@link PostUser} plus the RANKING-side
  * facts about that account which never belong on a post DTO — the follower count
- * (authority signal) and the account's languages (the viewer-language signal).
+ * (authority signal), the account's languages (the viewer-language signal), and
+ * the starter-pack curation score (the `starterPackBoost` signal).
  *
- * Both are OPTIONAL: a user whose count was unavailable, or who set no account
- * languages, simply omits the field and the corresponding signal falls back to
- * its neutral multiplier.
+ * All three are OPTIONAL: a user whose count was unavailable, who set no account
+ * languages, or whom nobody curated simply omits the field and the corresponding
+ * signal falls back to its neutral multiplier.
  */
 export interface CachedUserSummary {
   user: PostUser;
@@ -64,6 +67,16 @@ export interface CachedUserSummary {
    * {@link PostUser} so it never ships inside a post's author DTO.
    */
   languages?: string[];
+  /**
+   * The bounded starter-pack CURATION score for this account — how strongly OTHER
+   * people curated them into starter packs that newcomers actually used (see
+   * `services/starterPackCuration.ts`). Computed once per cache-fill (one batched
+   * aggregation for the whole author batch) and read back on every warm hydration,
+   * so the `starterPackBoost` ranking signal costs no per-post query. RANKING-side
+   * only: like `followerCount`, it never ships on the {@link PostUser} DTO.
+   * Absent ⇒ uncurated (or unresolvable) ⇒ the signal is exactly neutral.
+   */
+  starterPackScore?: number;
 }
 
 /** Hash-free key: Oxy user ids are already short and bounded, so embed them directly. */

--- a/packages/shared-types/src/mtn/config.ts
+++ b/packages/shared-types/src/mtn/config.ts
@@ -324,6 +324,83 @@ export const MtnConfig = {
         /** Multiplier (> 1) applied to a local (non-federated) post. */
         boost: 1.1,
       },
+      /**
+       * STARTER-PACK CURATION boost — a bounded lift for an author OTHER PEOPLE
+       * curated into their starter packs, weighted by how much those packs are
+       * actually USED and by the curator's own follower count.
+       *
+       * A starter pack contains USERS, so the signal is author-level: "humans who
+       * are not this author put them on a list newcomers actually followed". That
+       * is a strong, human-in-the-loop endorsement — precisely the thing raw
+       * engagement counts miss for a good author with a thin follow graph.
+       *
+       * SCORE (see `services/starterPackCuration.ts`), per author A:
+       *   candidate packs = packs where A ∈ members
+       *                     AND owner !== A                  (rule 1)
+       *                     AND useCount >= minUseCount      (rule 2)
+       *   curatorAuthority(owner) = clamp(1 + logScale · log1p(ownerFollowers),
+       *                                   min, max)          — unknown ⇒ `min`
+       *   packWeight              = log1p(useCount) · curatorAuthority(owner)
+       *   starterPackScore        = clamp(Σ over the top `maxCuratorsPerAuthor`
+       *                                   DISTINCT curators of their best
+       *                                   packWeight, 0, maxScore)   (rules 3, 4)
+       * SIGNAL:
+       *   multiplier = clamp(1 + scale · log1p(starterPackScore), 1, maxBoost)
+       *
+       * ANTI-GAMING (the whole point — every rule below is load-bearing):
+       *  1. SELF-OWNED PACKS ARE EXCLUDED. Otherwise anyone creates a pack, adds
+       *     themselves, and self-boosts.
+       *  2. ONLY CROWD-VALIDATED PACKS COUNT (`useCount >= minUseCount`). A pack
+       *     nobody ever used endorses nothing — and `useCount` only increments for
+       *     a DISTINCT user who actually followed through it.
+       *  3. DEDUPE BY CURATOR, NOT BY PACK. Each distinct curator contributes their
+       *     single BEST pack, so one curator spinning up 50 packs counts ONCE.
+       *  4. EVERYTHING IS BOUNDED and LOG-SCALED: at most `maxCuratorsPerAuthor`
+       *     curators count, the summed score is clamped to `maxScore`, and the
+       *     final multiplier is clamped to `maxBoost`. A sybil ring of low-follower
+       *     accounts curating each other therefore earns a small, capped lift —
+       *     never a takeover — while `curatorAuthority` gives a real curator with a
+       *     real audience up to a `max`/`min` (=1.5×) edge per pack.
+       *  5. NEVER PENALIZES. An uncurated author scores 0 ⇒ multiplier exactly 1.0.
+       */
+      starterPackBoost: {
+        /** Ceiling on the multiplier — the MOST curation can ever be worth. */
+        maxBoost: 1.35,
+        /** Growth rate of the lift in `log1p(starterPackScore)`. */
+        scale: 0.12,
+        /**
+         * How much a curator's own audience weights their endorsement. Same
+         * bounded log shape as `ranking.authority`, but its floor is a NEUTRAL
+         * 1.0: a curator with no (or unresolved) followers still endorses at full
+         * base weight — they are simply never AMPLIFIED. `max` caps a mega-account
+         * curator's edge at 1.5× per pack.
+         */
+        curatorAuthority: {
+          logScale: 0.05,
+          /** Floor — also the value used when the curator's follower count is unknown. */
+          min: 1.0,
+          /** Ceiling for a very large curator. */
+          max: 1.5,
+          /**
+           * TTL (seconds) of the DEDICATED curator follower-count cache
+           * (`curatorfollowers:v1:<id>` — see `services/curatorFollowerCounts.ts`).
+           * Deliberately much longer than the 10-minute identity cache: a follower
+           * count is a coarse, slow-moving input to a bounded log-scale factor, so
+           * an hour-stale value cannot move the multiplier meaningfully, and the
+           * long TTL is what keeps the Oxy fan-out for cold curators negligible.
+           */
+          cacheTtlSeconds: 60 * 60,
+        },
+        /** A pack must have been USED at least this many times to endorse anyone. */
+        minUseCount: 1,
+        /** At most this many DISTINCT curators contribute to one author's score. */
+        maxCuratorsPerAuthor: 10,
+        /**
+         * Clamp on the summed score. With `scale`, a score at this cap already
+         * saturates the multiplier at `maxBoost`, so nothing above it can matter.
+         */
+        maxScore: 25,
+      },
     },
   },
 


### PR DESCRIPTION
## Summary

Being curated into someone else's starter pack is a strong human quality signal — and it's the one signal that can lift a **good new author with no engagement and no followers**, which is exactly the cold-start hole the discovery gate cannot fill.

New opt-in signal **`starterPackBoost`** (ON by default in For You; `FOR_YOU_PHASE2B_SIGNALS` still disables it). A post's author gets a bounded lift from the packs that curate them, weighted by how much each pack is **actually used** and by the **curator's follower count**.

### Anti-gaming is the whole design
A naive "author is in a pack" check is trivially self-serve: create a pack, add yourself, boost yourself. So:

| Rule | Why |
|---|---|
| Self-owned packs excluded (`owner ≠ author`) | You cannot curate yourself into a boost. |
| Only `useCount >= 1` packs count | A pack nobody ever used endorses nothing. Gaming it now means convincing **real people** to use your pack. |
| Deduped by **curator**, not by pack | Spinning up 50 packs does not multiply the lift. |
| Log-scale, capped, clamped throughout | A low-follower curation ring lands at **~1.135** vs **1.35** for genuine curation (asserted in tests). |
| Absence is exactly neutral (1.0) | This signal never penalizes. |

### Zero extra I/O in the ranking path
The per-author score rides the **existing** author-summary cache (next to `followerCount`/`languages` — ranking-side, never on the `PostUser` DTO). Cost lives on cache-fill: one bounded `$topN` aggregation per batch, plus a **dedicated non-recursive** curator follower-count resolver with its own Redis cache (one bulk Oxy call per batch, 1h TTL).

That separate resolver is deliberate: reading curator follower counts through the identity cache would recurse into itself and make scores depend on cache-fill order. A test asserts this path touches **only** `curatorfollowers:v1:*` keys and never `usersummary:*`.

## Test plan

- Backend: **2001 pass / 1 fail** — only the pre-existing `federationThreadLinking` 5s timeout (fails identically on clean HEAD).
- **F3 golden master passes unchanged** — the new signal is appended last and inert unless enabled, so ranking output is untouched for existing fixtures.
- Covers each anti-gaming rule individually; a cold curator with 100k followers **does** amplify (resolved via Oxy, not stuck at the neutral floor); one bulk call per N curators; cached on the second pass; fail-soft when Oxy or Redis is down (author still scores at base weight, feed never breaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)