### PR TITLE
fix(feed): create the starter-pack member index in production via migration

### DIFF
--- a/packages/backend/src/__tests__/migrations/starterPackMemberIndex.test.ts
+++ b/packages/backend/src/__tests__/migrations/starterPackMemberIndex.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+import { migrationStarterPackMemberIndex } from '../../migrations/0005-starter-pack-member-index';
+
+/**
+ * Offline coverage for migration 0005 (starter-pack curation index).
+ *
+ * `autoIndex`/`autoCreate` are OFF in production, so this migration is the only
+ * thing that creates the multikey `{ memberOxyUserIds: 1, useCount: -1 }` index
+ * that serves the curation aggregation. The Mongo `Db` / collection are faked
+ * (indexes/createIndex captured) so the real branch logic runs without a database.
+ */
+
+interface FakeIndex {
+  name: string;
+  key: Record<string, unknown>;
+}
+
+function makeDb(indexes: FakeIndex[], indexesThrows?: unknown) {
+  const createIndex = vi.fn().mockResolvedValue('idx');
+  const indexesFn = indexesThrows
+    ? vi.fn().mockRejectedValue(indexesThrows)
+    : vi.fn().mockResolvedValue(indexes);
+  const collection = { collectionName: 'starterpacks', indexes: indexesFn, createIndex };
+  const db = { collection: vi.fn().mockReturnValue(collection) } as unknown as mongoose.mongo.Db;
+  return { db, collection, createIndex };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('migration 0005 — starter-pack curation index', () => {
+  it('targets the collection resolved from the model, not a hardcoded name', async () => {
+    const { db } = makeDb([{ name: '_id_', key: { _id: 1 } }]);
+
+    await migrationStarterPackMemberIndex.run(db);
+
+    expect(db.collection).toHaveBeenCalledWith('starterpacks');
+  });
+
+  it('creates the curation index when it does not exist', async () => {
+    const { db, createIndex } = makeDb([
+      { name: '_id_', key: { _id: 1 } },
+      { name: 'ownerOxyUserId_1_createdAt_-1', key: { ownerOxyUserId: 1, createdAt: -1 } },
+      { name: 'useCount_-1_createdAt_-1', key: { useCount: -1, createdAt: -1 } },
+    ]);
+
+    await migrationStarterPackMemberIndex.run(db);
+
+    expect(createIndex).toHaveBeenCalledWith({ memberOxyUserIds: 1, useCount: -1 });
+    expect(createIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when the curation index already exists', async () => {
+    const { db, createIndex } = makeDb([
+      { name: '_id_', key: { _id: 1 } },
+      { name: 'memberOxyUserIds_1_useCount_-1', key: { memberOxyUserIds: 1, useCount: -1 } },
+    ]);
+
+    await migrationStarterPackMemberIndex.run(db);
+
+    expect(createIndex).not.toHaveBeenCalled();
+  });
+
+  it('creates the index when the collection does not exist yet', async () => {
+    const nsErr = new mongoose.mongo.MongoServerError({
+      message: 'ns not found',
+      codeName: 'NamespaceNotFound',
+    });
+    const { db, createIndex } = makeDb([], nsErr);
+
+    await migrationStarterPackMemberIndex.run(db);
+
+    expect(createIndex).toHaveBeenCalledWith({ memberOxyUserIds: 1, useCount: -1 });
+  });
+
+  it('rethrows non-NamespaceNotFound errors from indexes()', async () => {
+    const { db, createIndex } = makeDb([], new Error('connection reset'));
+
+    await expect(migrationStarterPackMemberIndex.run(db)).rejects.toThrow('connection reset');
+    expect(createIndex).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a member-only or differently-ordered index as equivalent', async () => {
+    const { db, createIndex } = makeDb([
+      { name: 'memberOxyUserIds_1', key: { memberOxyUserIds: 1 } },
+      { name: 'memberOxyUserIds_1_useCount_1', key: { memberOxyUserIds: 1, useCount: 1 } },
+      { name: 'useCount_-1_memberOxyUserIds_1', key: { useCount: -1, memberOxyUserIds: 1 } },
+    ]);
+
+    await migrationStarterPackMemberIndex.run(db);
+
+    // None of the above serve `{ $in: members }` + `useCount` in that key order,
+    // so the real index must still be created.
+    expect(createIndex).toHaveBeenCalledWith({ memberOxyUserIds: 1, useCount: -1 });
+  });
+});

--- a/packages/backend/src/migrations/0005-starter-pack-member-index.ts
+++ b/packages/backend/src/migrations/0005-starter-pack-member-index.ts
@@ -1,0 +1,94 @@
+/**
+ * Migration 0005: index the starter-pack CURATION aggregation.
+ *
+ * The `starterPackBoost` ranking signal (`services/starterPackCuration.ts`) reads
+ * curation edges with an aggregation whose first stage is
+ * `$match: { memberOxyUserIds: { $in: [...authors] }, useCount: { $gte: n } }`.
+ * That stage runs on EVERY user-summary cache-fill batch
+ * (`PostHydrationService.resolveUserSummaries`), i.e. on cold feed hydration for
+ * every viewer.
+ *
+ * `StarterPack.ts` declares the MULTIKEY compound index
+ * `{ memberOxyUserIds: 1, useCount: -1 }` that serves exactly that match — but
+ * `autoIndex`/`autoCreate` are OFF in production (see `utils/database.ts`), so a
+ * schema-declared index NEVER reaches production. Without it, the aggregation
+ * falls back to a COLLECTION SCAN of `starterpacks` on every cache-fill batch: a
+ * silent, ever-growing performance regression that no test or type check catches.
+ * This migration is therefore the only thing that creates the index in production.
+ *
+ * `memberOxyUserIds` is the only array field in the compound (a compound index may
+ * have at most one), so the `$in` on the members is index-served and `useCount`
+ * filters within it.
+ *
+ * Idempotent: an equivalent existing index is left untouched and re-running is a
+ * no-op. Data-free — creating an index needs no backfill.
+ */
+
+import mongoose from 'mongoose';
+import { logger } from '../utils/logger';
+import { MIGRATION_STARTER_PACK_MEMBER_INDEX } from './constants';
+import StarterPack from '../models/StarterPack';
+import type { Migration } from './runner';
+
+interface MongoIndexInfo {
+  name: string;
+  key: Record<string, unknown>;
+}
+
+/**
+ * The index this migration guarantees. Written as an ordered field list because a
+ * compound index's key ORDER is semantic: `{ useCount: -1, memberOxyUserIds: 1 }`
+ * has the same fields but a range-scan prefix, so it does not serve the curation
+ * `$match` and must NOT be mistaken for an equivalent index.
+ */
+const CURATION_INDEX_FIELDS: ReadonlyArray<readonly [field: string, direction: 1 | -1]> = [
+  ['memberOxyUserIds', 1],
+  ['useCount', -1],
+];
+
+/** True only for an index whose key is exactly {@link CURATION_INDEX_FIELDS}, in order. */
+function isCurationIndex(index: MongoIndexInfo): boolean {
+  const fields = Object.keys(index.key);
+  if (fields.length !== CURATION_INDEX_FIELDS.length) {
+    return false;
+  }
+  return CURATION_INDEX_FIELDS.every(
+    ([field, direction], position) =>
+      fields[position] === field && index.key[field] === direction,
+  );
+}
+
+export const migrationStarterPackMemberIndex: Migration = {
+  id: MIGRATION_STARTER_PACK_MEMBER_INDEX,
+
+  async run(db: mongoose.mongo.Db): Promise<void> {
+    const collection = db.collection(StarterPack.collection.collectionName);
+
+    let indexes: MongoIndexInfo[];
+    try {
+      indexes = (await collection.indexes()) as MongoIndexInfo[];
+    } catch (error) {
+      // NamespaceNotFound means the collection does not exist yet — treat it as
+      // having no indexes; createIndex below creates both it and the index.
+      if (error instanceof mongoose.mongo.MongoServerError && error.codeName === 'NamespaceNotFound') {
+        indexes = [];
+      } else {
+        throw error;
+      }
+    }
+
+    const existing = indexes.find(isCurationIndex);
+
+    if (existing) {
+      logger.info(
+        `[migration] starter-pack curation index already present (${existing.name}) — skipping`,
+      );
+      return;
+    }
+
+    await collection.createIndex({ memberOxyUserIds: 1, useCount: -1 });
+    logger.info(
+      `[migration] created curation index on ${collection.collectionName} { memberOxyUserIds: 1, useCount: -1 }`,
+    );
+  },
+};

--- a/packages/backend/src/migrations/constants.ts
+++ b/packages/backend/src/migrations/constants.ts
@@ -39,3 +39,13 @@ export const MIGRATION_TRENDING_TTL_INDEX = '0003-trending-ttl-index';
  * schema-declared indexes are created here. See {@link ./0004-notification-ttl-index}.
  */
 export const MIGRATION_NOTIFICATION_TTL_INDEX = '0004-notification-ttl-index';
+
+/**
+ * One-shot creation of the multikey `{ memberOxyUserIds: 1, useCount: -1 }` index
+ * on `starterpacks`, which serves the starter-pack curation aggregation
+ * (`services/starterPackCuration.ts`) run on every user-summary cache-fill batch.
+ * `autoIndex`/`autoCreate` are OFF in production, so the schema-declared index is
+ * created here — without it that aggregation collection-scans.
+ * See {@link ./0005-starter-pack-member-index}.
+ */
+export const MIGRATION_STARTER_PACK_MEMBER_INDEX = '0005-starter-pack-member-index';

--- a/packages/backend/src/migrations/runner.ts
+++ b/packages/backend/src/migrations/runner.ts
@@ -17,6 +17,7 @@ import { migrationRepostToBoost } from './0001-repost-to-boost';
 import { migrationLowercaseHashtags } from './0002-lowercase-hashtags';
 import { migrationTrendingTtlIndex } from './0003-trending-ttl-index';
 import { migrationNotificationTtlIndex } from './0004-notification-ttl-index';
+import { migrationStarterPackMemberIndex } from './0005-starter-pack-member-index';
 
 export interface Migration {
   /** Stable, unique migration id recorded in the migrations collection. */
@@ -36,6 +37,7 @@ const MIGRATIONS: readonly Migration[] = [
   migrationLowercaseHashtags,
   migrationTrendingTtlIndex,
   migrationNotificationTtlIndex,
+  migrationStarterPackMemberIndex,
 ];
 
 /**

--- a/packages/backend/src/models/StarterPack.ts
+++ b/packages/backend/src/models/StarterPack.ts
@@ -30,6 +30,9 @@ StarterPackSchema.index({ useCount: -1, createdAt: -1 });
  * find the packs that curate a batch of feed authors. `memberOxyUserIds` is the
  * only array field in the compound (a compound index may have at most one), so the
  * `$in` on the members is index-served and `useCount` filters within it.
+ *
+ * NOTE: `autoIndex`/`autoCreate` are OFF in production — this index is created by
+ * migration `0005-starter-pack-member-index`, not on model load.
  */
 StarterPackSchema.index({ memberOxyUserIds: 1, useCount: -1 });
 


### PR DESCRIPTION
## Summary

PR #390 added `StarterPackSchema.index({ memberOxyUserIds: 1, useCount: -1 })` — the multikey index that serves the curation aggregation run on **every author cache-fill batch**.

But `autoIndex`/`autoCreate` are **OFF in production** (see `utils/database.ts`, and the same notes on `Trending`/`Notification`), so a schema-declared index never actually reaches prod. Without it that aggregation does a **collection scan on every batch** — a silent performance regression that would only have shown up as feed latency under load.

Adds migration **`0005-starter-pack-member-index`** (idempotent, `NamespaceNotFound`-tolerant, collection name resolved from the model) and annotates the model so the next reader knows the index comes from the migration, not model load.

The existing-index equivalence check is **order-aware** on purpose: `{ useCount: -1, memberOxyUserIds: 1 }` has identical *fields* but the wrong prefix and does **not** serve the `$match`. A value-only check (as in 0004) would wrongly skip creation and silently leave the scan in place.

## Test plan

- Backend: **2009 pass / 1 fail** — only the pre-existing `federationThreadLinking` 5s timeout.
- Migration suite: 17 tests pass. New suite covers: creates when absent; no-op when present; tolerates an empty/missing collection; and rejects the wrong-order, member-only, and ascending-`useCount` near-miss variants.
- F3 golden master unchanged.

Deploy note: run `bun run migrate` after deploy — the signal is live and works without the index, just slowly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)