### PR TITLE
fix(metrics): aggregate counters in Redis so /metrics is readable across the fleet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,15 @@ Panel chrome insets: `packages/frontend/components/shell/PanelChrome.tsx` (`PANE
 - **View counts**: `services/feedViewCounter.ts` (Redis SET NX EX `viewseen:<postId>:<viewerId>`). Frontend reports impressions via `utils/feedTelemetry.ts`.
 - **Instant post-detail**: memory-mode feeds seed the shared post cache (`postsStore.cachePosts`) in `useFeedState`; `app/(app)/p/[id].tsx` paints from cache + background-revalidates (`revalidatePostById`).
 
+## Metrics (`/metrics`)
+
+The fleet runs several ECS tasks behind the ALB, so a scrape hits ONE arbitrary task. Counters are therefore aggregated in Redis; `GET /metrics` serves the fleet-wide total.
+
+- **Hot path stays I/O-free**: `metrics.incrementCounter` (`utils/metrics.ts`) is a Map update — the discovery gate increments per rejected candidate (~150/feed request). NEVER add a Redis call to a metric write.
+- **`services/metricsAggregator.ts`**: every task (NOT leader-gated) flushes its counter DELTAS every `config.metrics.flushIntervalMs` (10s) in ONE pipeline — `HINCRBY metrics:counter:<name> <labelSet>` + a `metrics:counters` registry SET. Counters are monotonic and never reset in Redis. Failure is fail-soft: deltas are handed back to the collector and retried, `/metrics` falls back to the in-memory values, nothing throws. No Redis configured ⇒ metrics stay in-memory, per-instance.
+- **Counters only, never gauges, for anything that must survive aggregation.** A gauge set per request cannot be summed across tasks. `feed_federated_share` was exactly that bug and is now `feed_pool_candidates_total{descriptor,origin}` — the share is DERIVED (`federated / (federated + local)`). Histograms/gauges remain per-instance by design.
+- Keep labels LOW-CARDINALITY (`mtn/feed/feedMetrics.ts` `baseDescriptor`) — every distinct label set is a Redis hash field.
+
 ## Feed Ranking, Content Classification & Safety
 
 ### Unified Content Classification (two-stage hybrid)

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -930,11 +930,16 @@ app.get("/health", async (req, res) => {
 });
 
 // --- Metrics Endpoint ---
-// Exposes Prometheus-format metrics for monitoring systems
-import { metrics } from './src/utils/metrics';
-app.get('/metrics', (req, res) => {
+// Exposes Prometheus-format metrics for monitoring systems. Counters are the
+// Redis-aggregated FLEET-WIDE totals (every task flushes its deltas on a timer),
+// so a scrape is meaningful regardless of which task the ALB routes it to.
+// Histograms/gauges remain this task's own values. Never throws: with Redis
+// unavailable the in-memory values are served instead.
+import { metricsAggregator } from './src/services/metricsAggregator';
+app.get('/metrics', async (req, res) => {
+  const document = await metricsAggregator.renderPrometheus();
   res.set('Content-Type', 'text/plain');
-  res.send(metrics.getPrometheusFormat());
+  res.send(document);
 });
 
 // --- Federation routes (ActivityPub protocol — must be public, before auth) ---
@@ -1238,6 +1243,11 @@ const bootServer = async () => {
     logger.warn("Failed to start federation queue workers", error);
   }
 
+  // Metrics aggregation runs on EVERY task (deliberately not leader-gated): each
+  // task must push its OWN counter deltas to Redis, otherwise `/metrics` would only
+  // ever show the leader's fragment. No-op when Redis is not configured.
+  metricsAggregator.start();
+
   // Register MTN Protocol feed engine modules (sources / signals / filters)
   registerAllModules();
 
@@ -1275,6 +1285,10 @@ const gracefulShutdown = (signal: string): void => {
       } catch (error) {
         logger.error("Error shutting down federation queues", error);
       }
+
+      // Stop the metrics flusher and push this task's final window of counter
+      // deltas, so a rolling deploy never drops the last interval. Never throws.
+      await metricsAggregator.stop();
     })
     .finally(() => {
       // Stop accepting new HTTP/socket connections.

--- a/packages/backend/src/__tests__/feedDiscoveryGateMetrics.test.ts
+++ b/packages/backend/src/__tests__/feedDiscoveryGateMetrics.test.ts
@@ -180,8 +180,8 @@ describe('A/B enforcement via ctx.discoveryGateBucket', () => {
   });
 });
 
-describe('feed_federated_share', () => {
-  it('records the federated share of the merged pool by base descriptor', async () => {
+describe('feed_pool_candidates_total', () => {
+  it('counts the merged pool by origin under the base descriptor', async () => {
     setShadow(true);
     registry.register(source('disc', [
       makePost(1, { federation: { actorUri: 'https://remote/users/a' } }),
@@ -190,7 +190,30 @@ describe('feed_federated_share', () => {
 
     await engine.run(def([{ module: 'disc', enabled: true }]), ctx(), { limit: 30 });
 
-    // pool = [#1 federated, #2 local] → share 0.5.
-    expect(metrics.getGauge(FEED_METRICS.federatedShare, { descriptor: 'for_you' })).toBeCloseTo(0.5, 5);
+    // pool = [#1 federated, #2 local] → federated share 0.5, derived from the counters.
+    const federated = metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'for_you', origin: 'federated' });
+    const local = metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'for_you', origin: 'local' });
+    expect(federated).toBe(1);
+    expect(local).toBe(1);
+    expect(federated / (federated + local)).toBeCloseTo(0.5, 5);
+  });
+
+  it('accumulates across requests so the derived share stays correct', async () => {
+    setShadow(true);
+    registry.register(source('disc', [
+      makePost(1, { federation: { actorUri: 'https://remote/users/a' } }),
+      makePost(2), // local
+      makePost(3), // local
+    ]));
+
+    const definition = def([{ module: 'disc', enabled: true }]);
+    await engine.run(definition, ctx(), { limit: 30 });
+    await engine.run(definition, ctx(), { limit: 30 });
+
+    const federated = metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'for_you', origin: 'federated' });
+    const local = metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'for_you', origin: 'local' });
+    expect(federated).toBe(2);
+    expect(local).toBe(4);
+    expect(federated / (federated + local)).toBeCloseTo(1 / 3, 5);
   });
 });

--- a/packages/backend/src/__tests__/feedOnlineMetrics.test.ts
+++ b/packages/backend/src/__tests__/feedOnlineMetrics.test.ts
@@ -30,9 +30,9 @@ import {
   baseDescriptor,
   originForFederation,
   recordDiscoveryGated,
-  recordFederatedShare,
   recordImpression,
   recordInteractionSignal,
+  recordPoolCandidates,
   recordReport,
 } from '../mtn/feed/feedMetrics';
 import {
@@ -80,11 +80,29 @@ describe('feedMetrics helpers', () => {
     expect(metrics.getCounter(FEED_METRICS.discoveryGated, { reason: 'nativeEngagement', source: 'globalDiscovery', shadow: 'false' })).toBe(1);
   });
 
-  it('emits feed_federated_share as a per-descriptor gauge', () => {
-    recordFederatedShare('for_you', 0.42);
-    recordFederatedShare('author|123', 0.9);
-    expect(metrics.getGauge(FEED_METRICS.federatedShare, { descriptor: 'for_you' })).toBeCloseTo(0.42, 5);
-    expect(metrics.getGauge(FEED_METRICS.federatedShare, { descriptor: 'author' })).toBeCloseTo(0.9, 5);
+  it('emits feed_pool_candidates_total as additive per-origin counters', () => {
+    recordPoolCandidates('for_you', 3, 7);
+    recordPoolCandidates('author|123', 1, 1);
+
+    const federated = metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'for_you', origin: 'federated' });
+    const local = metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'for_you', origin: 'local' });
+    expect(federated).toBe(3);
+    expect(local).toBe(7);
+    // The share is DERIVED from the two counters (and stays correct when summed).
+    expect(federated / (federated + local)).toBeCloseTo(0.3, 5);
+
+    expect(metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'author', origin: 'federated' })).toBe(1);
+    expect(metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'author', origin: 'local' })).toBe(1);
+  });
+
+  it('does not emit a zero-valued origin series', () => {
+    recordPoolCandidates('for_you', 0, 5);
+    expect(metrics.getCounter(FEED_METRICS.poolCandidates, { descriptor: 'for_you', origin: 'local' })).toBe(5);
+    expect(
+      metrics
+        .getCounterSamples()
+        .some((sample) => sample.name === FEED_METRICS.poolCandidates && sample.labelSet.includes('federated')),
+    ).toBe(false);
   });
 
   it('emits impression / interaction-signal / report counters with correct labels', () => {

--- a/packages/backend/src/__tests__/metricsAggregator.test.ts
+++ b/packages/backend/src/__tests__/metricsAggregator.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Cross-instance metrics aggregation.
+ *
+ * Production runs several ECS tasks behind an ALB, so `/metrics` must serve the
+ * Redis-aggregated FLEET total rather than the fragment held by whichever task the
+ * scrape happened to land on. These tests pin the four invariants that design rests
+ * on:
+ *
+ *  1. The HOT PATH does zero I/O — incrementing a counter never touches Redis.
+ *  2. The flusher batches every delta into ONE pipeline and resets the local deltas.
+ *  3. `/metrics` renders the Redis aggregate (two "instances" ⇒ the sum).
+ *  4. Redis down / not configured ⇒ fall back to the in-memory values, never throw.
+ *
+ * The Redis client is injected, so the suite exercises the real aggregator against a
+ * faithful in-memory Redis instead of mocking the code under test. `../utils/redis`
+ * is un-stubbed here (the global setup replaces it with an always-unavailable client)
+ * so the REDIS_URL gate itself can be asserted for real.
+ */
+vi.mock('../utils/redis', async (importOriginal) => await importOriginal<typeof import('../utils/redis')>());
+
+import { MetricsAggregator, type MetricsRedisClient, type MetricsRedisMulti } from '../services/metricsAggregator';
+import { MetricsCollector } from '../utils/metrics';
+import { isRedisConfigured } from '../utils/redis';
+import { FEED_METRICS, recordPoolCandidates } from '../mtn/feed/feedMetrics';
+
+type QueuedCommand = () => unknown;
+
+/**
+ * An in-memory stand-in for the shared node-redis client, implementing exactly the
+ * surface the aggregator uses. It counts every interaction so a test can assert the
+ * client was never touched at all.
+ */
+class FakeRedis implements MetricsRedisClient {
+  isReady = true;
+  /** Set by a test to make `exec()` reject, simulating a mid-flush Redis failure. */
+  failOnExec = false;
+
+  readonly hashes = new Map<string, Map<string, number>>();
+  readonly sets = new Map<string, Set<string>>();
+  readonly expiries = new Map<string, number>();
+
+  multiCalls = 0;
+  execCalls = 0;
+  sMembersCalls = 0;
+  commandsQueued = 0;
+
+  /** Every interaction with this client (used to prove the hot path is I/O-free). */
+  get totalCalls(): number {
+    return this.multiCalls + this.execCalls + this.sMembersCalls + this.commandsQueued;
+  }
+
+  async sMembers(key: string): Promise<string[]> {
+    this.sMembersCalls += 1;
+    return [...(this.sets.get(key) ?? [])];
+  }
+
+  multi(): MetricsRedisMulti {
+    this.multiCalls += 1;
+    const queue: QueuedCommand[] = [];
+    const client = this;
+
+    const chain: MetricsRedisMulti = {
+      sAdd(key: string, members: string[]): MetricsRedisMulti {
+        client.commandsQueued += 1;
+        queue.push(() => {
+          const set = client.sets.get(key) ?? new Set<string>();
+          client.sets.set(key, set);
+          for (const member of members) set.add(member);
+          return members.length;
+        });
+        return chain;
+      },
+      hIncrBy(key: string, field: string, increment: number): MetricsRedisMulti {
+        client.commandsQueued += 1;
+        queue.push(() => {
+          const hash = client.hashes.get(key) ?? new Map<string, number>();
+          client.hashes.set(key, hash);
+          const next = (hash.get(field) ?? 0) + increment;
+          hash.set(field, next);
+          return next;
+        });
+        return chain;
+      },
+      expire(key: string, seconds: number): MetricsRedisMulti {
+        client.commandsQueued += 1;
+        queue.push(() => {
+          client.expiries.set(key, seconds);
+          return 1;
+        });
+        return chain;
+      },
+      hGetAll(key: string): MetricsRedisMulti {
+        client.commandsQueued += 1;
+        queue.push(() => {
+          const hash = client.hashes.get(key);
+          if (!hash) return {};
+          return Object.fromEntries([...hash.entries()].map(([field, value]) => [field, String(value)]));
+        });
+        return chain;
+      },
+      async exec(): Promise<unknown[]> {
+        client.execCalls += 1;
+        if (client.failOnExec) {
+          throw new Error('READONLY You can not write against a read only replica.');
+        }
+        return queue.map((command) => command());
+      },
+    };
+
+    return chain;
+  }
+}
+
+/** Build an aggregator bound to `collector` + `redis`, with Redis considered available. */
+function aggregatorFor(collector: MetricsCollector, redis: FakeRedis, flushIntervalMs = 10_000): MetricsAggregator {
+  return new MetricsAggregator({
+    collector,
+    getClient: () => redis,
+    isEnabled: () => true,
+    flushIntervalMs,
+    keyTtlSeconds: 60,
+  });
+}
+
+/** Read one counter series out of a rendered Prometheus document. */
+function seriesValue(document: string, series: string): number | undefined {
+  const line = document.split('\n').find((candidate) => candidate.startsWith(`${series} `));
+  if (!line) return undefined;
+  return Number(line.slice(series.length + 1));
+}
+
+const IMPRESSION_LOCAL = `${FEED_METRICS.impression}{descriptor="for_you",origin="local"}`;
+const POOL_FEDERATED = `${FEED_METRICS.poolCandidates}{descriptor="for_you",origin="federated"}`;
+const POOL_LOCAL = `${FEED_METRICS.poolCandidates}{descriptor="for_you",origin="local"}`;
+
+let collector: MetricsCollector;
+let redis: FakeRedis;
+let aggregator: MetricsAggregator;
+
+beforeEach(() => {
+  collector = new MetricsCollector();
+  redis = new FakeRedis();
+  aggregator = aggregatorFor(collector, redis);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('hot path', () => {
+  it('performs ZERO Redis calls while recording counters', () => {
+    aggregator.start();
+
+    for (let i = 0; i < 500; i += 1) {
+      collector.incrementCounter(FEED_METRICS.discoveryGated, 1, {
+        reason: 'lowEffortGate',
+        source: 'trending',
+        shadow: 'true',
+      });
+      collector.incrementCounter(FEED_METRICS.impression, 1, { origin: 'local', descriptor: 'for_you' });
+    }
+
+    expect(redis.totalCalls).toBe(0);
+    expect(collector.getCounter(FEED_METRICS.impression, { origin: 'local', descriptor: 'for_you' })).toBe(500);
+  });
+});
+
+describe('flusher', () => {
+  it('batches every delta into ONE pipeline and resets the local deltas', async () => {
+    collector.incrementCounter(FEED_METRICS.impression, 1, { origin: 'local', descriptor: 'for_you' });
+    collector.incrementCounter(FEED_METRICS.impression, 1, { origin: 'local', descriptor: 'for_you' });
+    collector.incrementCounter(FEED_METRICS.impression, 1, { origin: 'federated', descriptor: 'for_you' });
+    collector.incrementCounter(FEED_METRICS.report, 1, { descriptor: 'for_you', origin: 'local' });
+
+    await aggregator.flush();
+
+    // One pipeline, one round trip — regardless of how many series were touched.
+    expect(redis.multiCalls).toBe(1);
+    expect(redis.execCalls).toBe(1);
+
+    // 3 series → 3 HINCRBY; plus the registry SADD and the 3 refreshed expiries
+    // (registry + one per metric name).
+    expect(redis.commandsQueued).toBe(3 + 1 + 1 + 2);
+
+    expect(redis.hashes.get(`metrics:counter:${FEED_METRICS.impression}`)).toEqual(
+      new Map([
+        ['{descriptor="for_you",origin="local"}', 2],
+        ['{descriptor="for_you",origin="federated"}', 1],
+      ]),
+    );
+    expect(redis.sets.get('metrics:counters')).toEqual(
+      new Set([FEED_METRICS.impression, FEED_METRICS.report]),
+    );
+
+    // Local deltas were reset: a flush with nothing new opens no pipeline at all.
+    await aggregator.flush();
+    expect(redis.multiCalls).toBe(1);
+    expect(redis.execCalls).toBe(1);
+
+    // ...while the local running total is untouched (it is the fallback view).
+    expect(collector.getCounter(FEED_METRICS.impression, { origin: 'local', descriptor: 'for_you' })).toBe(2);
+  });
+
+  it('pushes deltas on the configured interval', async () => {
+    vi.useFakeTimers();
+    aggregator.start();
+
+    collector.incrementCounter(FEED_METRICS.impression, 1, { origin: 'local', descriptor: 'for_you' });
+    expect(redis.execCalls).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(redis.execCalls).toBe(1);
+    expect(redis.hashes.get(`metrics:counter:${FEED_METRICS.impression}`)?.get('{descriptor="for_you",origin="local"}')).toBe(1);
+
+    await aggregator.stop();
+  });
+
+  it('only flushes the DELTA, never the running total (counters stay monotonic in Redis)', async () => {
+    collector.incrementCounter(FEED_METRICS.impression, 3, { origin: 'local', descriptor: 'for_you' });
+    await aggregator.flush();
+
+    collector.incrementCounter(FEED_METRICS.impression, 2, { origin: 'local', descriptor: 'for_you' });
+    await aggregator.flush();
+
+    // 3 + 2 — not 3 + 5 (which is what flushing the local total would have written).
+    expect(redis.hashes.get(`metrics:counter:${FEED_METRICS.impression}`)?.get('{descriptor="for_you",origin="local"}')).toBe(5);
+  });
+});
+
+describe('GET /metrics rendering', () => {
+  it('renders the Redis aggregate across instances (two tasks ⇒ the sum)', async () => {
+    // Two tasks = two collectors with their own aggregator, one shared Redis.
+    const collectorB = new MetricsCollector();
+    const aggregatorB = aggregatorFor(collectorB, redis);
+
+    for (let i = 0; i < 2; i += 1) {
+      collector.incrementCounter(FEED_METRICS.impression, 1, { origin: 'local', descriptor: 'for_you' });
+    }
+    for (let i = 0; i < 3; i += 1) {
+      collectorB.incrementCounter(FEED_METRICS.impression, 1, { origin: 'local', descriptor: 'for_you' });
+    }
+
+    await aggregator.flush();
+    await aggregatorB.flush();
+
+    // A scrape landing on EITHER task sees the fleet total.
+    const fromA = await aggregator.renderPrometheus();
+    const fromB = await aggregatorB.renderPrometheus();
+
+    expect(seriesValue(fromA, IMPRESSION_LOCAL)).toBe(5);
+    expect(seriesValue(fromB, IMPRESSION_LOCAL)).toBe(5);
+    expect(fromA).toContain(`# TYPE ${FEED_METRICS.impression} counter`);
+  });
+
+  it('flushes this task\'s pending deltas before reading, so a scrape is never stale', async () => {
+    collector.incrementCounter(FEED_METRICS.impression, 4, { origin: 'local', descriptor: 'for_you' });
+
+    // No explicit flush: the scrape itself must publish the pending deltas.
+    const document = await aggregator.renderPrometheus();
+
+    expect(seriesValue(document, IMPRESSION_LOCAL)).toBe(4);
+  });
+
+  it('derives the correct federated share from the two pool counters across instances', async () => {
+    // Task A merged a pool of 1 federated + 3 local (share 0.25); task B, 3 federated
+    // + 1 local (share 0.75). Fleet-wide the truth is 4 of 8 ⇒ 0.5 — a number the old
+    // per-request GAUGE could never produce (a scrape saw one task's last write).
+    const collectorB = new MetricsCollector();
+    const aggregatorB = aggregatorFor(collectorB, redis);
+
+    const recordPool = (target: MetricsCollector, federated: number, local: number): void => {
+      target.incrementCounter(FEED_METRICS.poolCandidates, federated, { descriptor: 'for_you', origin: 'federated' });
+      target.incrementCounter(FEED_METRICS.poolCandidates, local, { descriptor: 'for_you', origin: 'local' });
+    };
+
+    recordPool(collector, 1, 3);
+    recordPool(collectorB, 3, 1);
+
+    await aggregator.flush();
+    await aggregatorB.flush();
+
+    const document = await aggregator.renderPrometheus();
+    const federated = seriesValue(document, POOL_FEDERATED) ?? 0;
+    const local = seriesValue(document, POOL_LOCAL) ?? 0;
+
+    expect(federated).toBe(4);
+    expect(local).toBe(4);
+    expect(federated / (federated + local)).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe('fail-soft', () => {
+  it('falls back to the in-memory values when Redis is not ready, and retains the deltas', async () => {
+    redis.isReady = false;
+    collector.incrementCounter(FEED_METRICS.impression, 7, { origin: 'local', descriptor: 'for_you' });
+
+    await expect(aggregator.flush()).resolves.toBeUndefined();
+
+    const document = await aggregator.renderPrometheus();
+    expect(seriesValue(document, IMPRESSION_LOCAL)).toBe(7); // this task's own total
+    expect(redis.hashes.size).toBe(0);
+
+    // Nothing was lost: once Redis recovers, the retained delta lands in full.
+    redis.isReady = true;
+    await aggregator.flush();
+    expect(redis.hashes.get(`metrics:counter:${FEED_METRICS.impression}`)?.get('{descriptor="for_you",origin="local"}')).toBe(7);
+  });
+
+  it('never throws when the pipeline fails, and retries the deltas on the next flush', async () => {
+    redis.failOnExec = true;
+    collector.incrementCounter(FEED_METRICS.impression, 2, { origin: 'local', descriptor: 'for_you' });
+
+    await expect(aggregator.flush()).resolves.toBeUndefined();
+    expect(redis.hashes.size).toBe(0);
+
+    collector.incrementCounter(FEED_METRICS.impression, 3, { origin: 'local', descriptor: 'for_you' });
+    redis.failOnExec = false;
+    await aggregator.flush();
+
+    // The failed delta (2) was retried alongside the new one (3).
+    expect(redis.hashes.get(`metrics:counter:${FEED_METRICS.impression}`)?.get('{descriptor="for_you",origin="local"}')).toBe(5);
+  });
+
+  it('never throws when the read fails mid-scrape', async () => {
+    collector.incrementCounter(FEED_METRICS.impression, 1, { origin: 'local', descriptor: 'for_you' });
+    await aggregator.flush();
+
+    redis.failOnExec = true;
+    const document = await aggregator.renderPrometheus();
+
+    expect(seriesValue(document, IMPRESSION_LOCAL)).toBe(1); // in-memory fallback
+  });
+});
+
+describe('Redis not configured', () => {
+  const originalUrl = process.env.REDIS_URL;
+  const originalUri = process.env.REDIS_URI;
+  const originalHost = process.env.REDIS_HOST;
+
+  afterEach(() => {
+    process.env.REDIS_URL = originalUrl;
+    process.env.REDIS_URI = originalUri;
+    process.env.REDIS_HOST = originalHost;
+    if (originalUrl === undefined) delete process.env.REDIS_URL;
+    if (originalUri === undefined) delete process.env.REDIS_URI;
+    if (originalHost === undefined) delete process.env.REDIS_HOST;
+  });
+
+  it('reports Redis as unconfigured when REDIS_URL/REDIS_URI/REDIS_HOST are unset', () => {
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_URI;
+    delete process.env.REDIS_HOST;
+    expect(isRedisConfigured()).toBe(false);
+
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    expect(isRedisConfigured()).toBe(true);
+  });
+
+  it('keeps working in-memory: start/flush/stop are no-ops and /metrics still renders', async () => {
+    const disabled = new MetricsAggregator({
+      collector,
+      getClient: () => redis,
+      isEnabled: () => false,
+      flushIntervalMs: 10_000,
+      keyTtlSeconds: 60,
+    });
+
+    disabled.start();
+    collector.incrementCounter(FEED_METRICS.impression, 9, { origin: 'local', descriptor: 'for_you' });
+    await disabled.flush();
+
+    const document = await disabled.renderPrometheus();
+    expect(seriesValue(document, IMPRESSION_LOCAL)).toBe(9);
+    expect(redis.totalCalls).toBe(0); // the client was never even asked for
+
+    await disabled.stop();
+  });
+});
+
+describe('feedMetrics emitters feed the aggregator', () => {
+  it('flushes what recordPoolCandidates emitted on the process singleton', async () => {
+    const { metrics: singleton } = await import('../utils/metrics');
+    singleton.reset();
+
+    const singletonAggregator = new MetricsAggregator({
+      getClient: () => redis,
+      isEnabled: () => true,
+      flushIntervalMs: 10_000,
+      keyTtlSeconds: 60,
+    });
+
+    recordPoolCandidates('for_you', 2, 6);
+    await singletonAggregator.flush();
+
+    const document = await singletonAggregator.renderPrometheus();
+    expect(seriesValue(document, POOL_FEDERATED)).toBe(2);
+    expect(seriesValue(document, POOL_LOCAL)).toBe(6);
+
+    singleton.reset();
+  });
+});

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -101,6 +101,21 @@ export const config = {
   classification: {
     enabled: process.env.POST_CLASSIFICATION_ENABLED === 'true',
   },
+  /**
+   * Cross-instance metrics aggregation (see `services/metricsAggregator.ts`).
+   * Counters are accumulated in memory on the hot path and pushed to Redis on a
+   * timer, so `/metrics` can serve a fleet-wide total instead of one task's
+   * fragment.
+   */
+  metrics: {
+    /** How often each task pushes its accumulated counter deltas to Redis. */
+    flushIntervalMs: parseInt(process.env.METRICS_FLUSH_INTERVAL_MS || '10000', 10), // 10s
+    /**
+     * Expiry on the Redis counter keys, REFRESHED on every flush. It never expires
+     * a live metric — it only reclaims keys for metrics no task emits any more.
+     */
+    redisKeyTtlSeconds: parseInt(process.env.METRICS_REDIS_KEY_TTL_SECONDS || '2592000', 10), // 30 days
+  },
 } as const;
 
 // Validate critical environment variables at startup

--- a/packages/backend/src/mtn/feed/engine/FeedEngine.ts
+++ b/packages/backend/src/mtn/feed/engine/FeedEngine.ts
@@ -31,7 +31,7 @@ import {
   toRankedCandidate,
 } from '../rankedCandidate';
 import { logger } from '../../../utils/logger';
-import { recordDiscoveryGated, recordFederatedShare, originForFederation } from '../feedMetrics';
+import { recordDiscoveryGated, recordPoolCandidates, originForFederation } from '../feedMetrics';
 import { feedModuleRegistry, FeedModuleRegistry } from './FeedModuleRegistry';
 import type {
   CandidatePost,
@@ -104,16 +104,17 @@ export class FeedEngine {
 
     const pool = await this.gatherPool(definition, ctx, exec, limit);
 
-    // Phase 7: record the federated share of the merged candidate pool for this
-    // feed (a gauge keyed by the base feed type). Emitted from the served `run`
-    // path only — never from the cheap `peekLatest` probe — so the share reflects
-    // real page builds. Non-empty guard avoids a spurious 0 on an empty pool.
+    // Phase 7: count the merged candidate pool by origin, keyed by the base feed
+    // type. Two COUNTERS (not a share gauge) so the federated share is derivable —
+    // and stays correct — once the fleet's per-task counters are summed. Emitted
+    // from the served `run` path only, never from the cheap `peekLatest` probe, so
+    // the numbers reflect real page builds.
     if (pool.length > 0) {
       let federatedCount = 0;
       for (const post of pool) {
         if (originForFederation(post.federation) === 'federated') federatedCount += 1;
       }
-      recordFederatedShare(definition.id, federatedCount / pool.length);
+      recordPoolCandidates(definition.id, federatedCount, pool.length - federatedCount);
     }
 
     return definition.mode === 'ranked'

--- a/packages/backend/src/mtn/feed/feedMetrics.ts
+++ b/packages/backend/src/mtn/feed/feedMetrics.ts
@@ -10,8 +10,9 @@
  *   - `feed_discovery_gated_total{reason,source,shadow}` — a discovery candidate
  *     the gate rejected, labelled by the filter that rejected it, the source lane
  *     it came from, and whether the rejection was measure-only (`shadow`).
- *   - `feed_federated_share{descriptor}` — the federated share (0..1) of a feed's
- *     merged candidate pool.
+ *   - `feed_pool_candidates_total{descriptor,origin}` — candidates in a feed's
+ *     merged pool, split by federated vs local origin. The federated SHARE is
+ *     derived from the two series: `federated / (federated + local)`.
  *   - `feed_impression_total{origin,descriptor}` — a genuine feed impression,
  *     split by federated vs local origin. The denominator for engagement- and
  *     report-per-impression.
@@ -23,13 +24,18 @@
  * are fixed small sets, and free-form descriptors are normalized to their base
  * feed type via {@link baseDescriptor} (so `author|<id>` / `hashtag|<tag>` never
  * explode the label space).
+ *
+ * Every signal here is a COUNTER, never a gauge: the fleet runs several tasks and
+ * `/metrics` serves the Redis-aggregated total (see `services/metricsAggregator`).
+ * Counters sum correctly across instances; a gauge (a point-in-time value written
+ * per request) does not — summing or last-writing one across tasks is meaningless.
  */
 
 import { metrics } from '../../utils/metrics';
 
 export const FEED_METRICS = {
   discoveryGated: 'feed_discovery_gated_total',
-  federatedShare: 'feed_federated_share',
+  poolCandidates: 'feed_pool_candidates_total',
   impression: 'feed_impression_total',
   interactionSignal: 'feed_interaction_signal_total',
   report: 'feed_report_total',
@@ -54,6 +60,28 @@ export function originForFederation(federation: unknown): PostOrigin {
   return federation != null ? 'federated' : 'local';
 }
 
+/** Coarse pool-size buckets — the upper bound of each bucket, ascending. */
+const POOL_SIZE_BUCKETS = [10, 25, 50, 100, 150] as const;
+
+/**
+ * Bucket a candidate-pool size into one of a FIXED set of labels
+ * (`0-10`, `11-25`, …, `150+`).
+ *
+ * The raw count must never be used as a metric label: every distinct label set is
+ * a retained histogram series, so an unbounded label (a raw count, a user id) grows
+ * the in-process histogram map forever. Bucketing keeps "is ranking slow on big
+ * pools?" answerable with a bounded, constant number of series.
+ */
+export function poolSizeBucket(size: number): string {
+  if (!Number.isFinite(size) || size < 0) return 'unknown';
+  let lower = 0;
+  for (const upper of POOL_SIZE_BUCKETS) {
+    if (size <= upper) return `${lower}-${upper}`;
+    lower = upper + 1;
+  }
+  return `${POOL_SIZE_BUCKETS[POOL_SIZE_BUCKETS.length - 1]}+`;
+}
+
 /** Count a discovery candidate the gate rejected (see {@link FEED_METRICS}). */
 export function recordDiscoveryGated(reason: string, source: string, measureOnly: boolean): void {
   metrics.incrementCounter(FEED_METRICS.discoveryGated, 1, {
@@ -63,9 +91,25 @@ export function recordDiscoveryGated(reason: string, source: string, measureOnly
   });
 }
 
-/** Record the federated share (0..1) of a feed's merged candidate pool. */
-export function recordFederatedShare(descriptor: string, share: number): void {
-  metrics.setGauge(FEED_METRICS.federatedShare, share, { descriptor: baseDescriptor(descriptor) });
+/**
+ * Count a feed's merged candidate pool, split by origin. The federated share is
+ * DERIVED from the two series at query time:
+ *
+ *   feed_pool_candidates_total{origin="federated"}
+ *   / sum without (origin) (feed_pool_candidates_total)
+ *
+ * which stays correct once the fleet's counters are summed — unlike the gauge this
+ * replaces, whose per-request value could not be aggregated across instances.
+ * Zero-valued origins are not emitted (an increment of 0 is not a data point).
+ */
+export function recordPoolCandidates(descriptor: string, federated: number, local: number): void {
+  const label = baseDescriptor(descriptor);
+  if (federated > 0) {
+    metrics.incrementCounter(FEED_METRICS.poolCandidates, federated, { descriptor: label, origin: 'federated' });
+  }
+  if (local > 0) {
+    metrics.incrementCounter(FEED_METRICS.poolCandidates, local, { descriptor: label, origin: 'local' });
+  }
 }
 
 /** Count a genuine feed impression, split by origin. */

--- a/packages/backend/src/services/FeedRankingService.ts
+++ b/packages/backend/src/services/FeedRankingService.ts
@@ -20,6 +20,7 @@ import {
 } from './ranking/signalContext';
 import { engagementScore } from './ranking/signals/engagement';
 import { authorityScore } from './ranking/signals/authority';
+import { poolSizeBucket } from '../mtn/feed/feedMetrics';
 import {
   coldStartBoost,
   conversationalBoost,
@@ -638,13 +639,17 @@ export class FeedRankingService {
       post.rankingExplanation = explainRanking(post);
     });
 
-    // Record ranking metrics
+    // Record ranking metrics.
+    //
+    // Labels MUST stay low-cardinality: every distinct label set is a retained
+    // histogram bucket (up to 1000 samples each). This used to be labelled with
+    // `user_id` and the raw `post_count`, which grew one retained series PER USER,
+    // forever — an in-process memory leak. The pool size is kept as a coarse bucket
+    // so "is ranking slow on big pools?" stays answerable without unbounded series.
     const rankingDuration = Date.now() - rankingStartTime;
     metrics.recordLatency('feed_ranking_duration_ms', rankingDuration, {
-      post_count: posts.length.toString(),
-      user_id: userId || 'anonymous'
+      pool_size: poolSizeBucket(posts.length),
     });
-    metrics.setGauge('feed_ranking_posts_processed', posts.length);
 
     // Return ranked posts with scores attached
     return postsWithScores.map(item => item.post);

--- a/packages/backend/src/services/metricsAggregator.ts
+++ b/packages/backend/src/services/metricsAggregator.ts
@@ -1,0 +1,287 @@
+/**
+ * Cross-instance metrics aggregation.
+ *
+ * Production runs several backend tasks behind an ALB, so a `GET /metrics` scrape
+ * lands on ONE arbitrary task. With purely in-memory counters each task holds a
+ * fragment of the truth and the aggregate is unreadable — a counter that is absent
+ * from a scrape is indistinguishable from a counter that never fired. This service
+ * makes `/metrics` serve the fleet-wide total.
+ *
+ * Design:
+ *  - The WRITE path stays exactly as it was: `metrics.incrementCounter` is a Map
+ *    update. No Redis call ever happens on a request (the discovery gate increments
+ *    a counter per rejected candidate, ~150 per feed request — a round trip there
+ *    would be a catastrophic regression).
+ *  - A PERIODIC FLUSHER (every `config.metrics.flushIntervalMs`, on EVERY task —
+ *    deliberately NOT leader-gated, each task owns its own deltas) drains the
+ *    counter increments accumulated since the last tick and pushes them to Redis in
+ *    a SINGLE pipeline: one `HINCRBY` per counter series. Batched, bounded by the
+ *    number of distinct series (low-cardinality by discipline), off the request path.
+ *  - `GET /metrics` reads the Redis aggregate (`SMEMBERS` of the registry + one
+ *    `HGETALL` per registered metric, pipelined) and renders Prometheus format.
+ *
+ * Storage:
+ *  - `metrics:counter:<name>` — HASH; field = the canonical serialized label set
+ *    (`{origin="local"}`, empty for unlabelled), value = the running total.
+ *  - `metrics:counters` — SET of registered metric names, so the read path never
+ *    has to scan the keyspace.
+ *  Counters are MONOTONIC and are never reset in Redis: a redeploy resets local
+ *  memory while Redis keeps the running total, which is precisely the semantics
+ *  Prometheus expects of a counter. The only expiry is a long, refreshed-on-every-
+ *  flush TTL that reclaims keys for metrics no longer emitted by any task.
+ *
+ * Failure behaviour (fail-soft, always):
+ *  - Redis unavailable or not configured → `/metrics` serves the in-memory values
+ *    (the previous behaviour) and drained deltas are handed back to the collector so
+ *    they are retried on the next tick rather than lost. Nothing throws, no request
+ *    is broken, the feed is never blocked. The first failure of an outage logs at
+ *    `warn` (subsequent ones stay quiet until the next success).
+ *
+ * Gauges and histograms are point-in-time / per-process values that cannot be summed
+ * across instances, so they are intentionally NOT aggregated and remain per-task in
+ * the exposition. Any quantity that must survive aggregation has to be modelled as a
+ * counter (see `feed_pool_candidates_total`).
+ */
+
+import { config } from '../config';
+import { logger } from '../utils/logger';
+import { metrics, MetricsCollector, type CounterSample } from '../utils/metrics';
+import { getRedisClient, isRedisConfigured } from '../utils/redis';
+
+/** Key prefix for the per-metric counter HASH. */
+const COUNTER_KEY_PREFIX = 'metrics:counter:';
+
+/** SET holding every counter metric name that has ever been flushed. */
+const COUNTER_REGISTRY_KEY = 'metrics:counters';
+
+/** The queued-command surface the aggregator needs from a Redis pipeline. */
+export interface MetricsRedisMulti {
+  sAdd(key: string, members: string[]): MetricsRedisMulti;
+  hIncrBy(key: string, field: string, increment: number): MetricsRedisMulti;
+  expire(key: string, seconds: number): MetricsRedisMulti;
+  hGetAll(key: string): MetricsRedisMulti;
+  exec(): Promise<unknown[]>;
+}
+
+/**
+ * The minimal Redis surface the aggregator needs. Narrow by design: the shared
+ * node-redis client satisfies it structurally, and tests can supply a fake without
+ * reconstructing the full client type.
+ */
+export interface MetricsRedisClient {
+  readonly isReady: boolean;
+  sMembers(key: string): Promise<string[]>;
+  multi(): MetricsRedisMulti;
+}
+
+export interface MetricsAggregatorOptions {
+  /** Collector to drain. Defaults to the process-wide `metrics` singleton. */
+  collector?: MetricsCollector;
+  /** Redis client provider. Defaults to the shared app client (no new connection). */
+  getClient?: () => MetricsRedisClient;
+  /** Whether Redis aggregation is available. Defaults to "a Redis target is configured". */
+  isEnabled?: () => boolean;
+  flushIntervalMs?: number;
+  keyTtlSeconds?: number;
+}
+
+/** Redis key holding a metric's counter series. */
+function counterKey(metricName: string): string {
+  return `${COUNTER_KEY_PREFIX}${metricName}`;
+}
+
+/** Narrow an `HGETALL` reply to the field→value map it is documented to be. */
+function asHashReply(reply: unknown): Record<string, string> | null {
+  if (!reply || typeof reply !== 'object' || Array.isArray(reply)) return null;
+  const entries = Object.entries(reply as Record<string, unknown>);
+  const hash: Record<string, string> = {};
+  for (const [field, value] of entries) {
+    if (typeof value !== 'string') return null;
+    hash[field] = value;
+  }
+  return hash;
+}
+
+export class MetricsAggregator {
+  private readonly collector: MetricsCollector;
+  private readonly getClient: () => MetricsRedisClient;
+  private readonly isEnabled: () => boolean;
+  private readonly flushIntervalMs: number;
+  private readonly keyTtlSeconds: number;
+
+  private interval: ReturnType<typeof setInterval> | null = null;
+  /** In-flight flush, so a scrape-triggered flush never races the timer's. */
+  private inFlightFlush: Promise<void> | null = null;
+  /** True once an outage has been logged; reset on the next success (no log spam). */
+  private hasLoggedFailure = false;
+
+  constructor(options: MetricsAggregatorOptions = {}) {
+    this.collector = options.collector ?? metrics;
+    this.getClient = options.getClient ?? (() => getRedisClient());
+    this.isEnabled = options.isEnabled ?? (() => isRedisConfigured());
+    this.flushIntervalMs = options.flushIntervalMs ?? config.metrics.flushIntervalMs;
+    this.keyTtlSeconds = options.keyTtlSeconds ?? config.metrics.redisKeyTtlSeconds;
+  }
+
+  /**
+   * Start the periodic flusher. Runs on EVERY task (not leader-gated — each task
+   * must publish its own deltas). Idempotent; a no-op when Redis is not configured,
+   * in which case metrics simply stay in-memory and per-instance.
+   */
+  start(): void {
+    if (this.interval) return;
+
+    if (!this.isEnabled()) {
+      logger.info('[Metrics] Redis not configured — metrics stay in-memory (per-instance only)');
+      return;
+    }
+
+    this.interval = setInterval(() => {
+      void this.flush();
+    }, this.flushIntervalMs);
+    // Never keep the event loop alive on the flusher's account.
+    this.interval.unref?.();
+
+    logger.info(`[Metrics] cross-instance aggregation enabled (flushing counter deltas every ${this.flushIntervalMs}ms)`);
+  }
+
+  /**
+   * Stop the flusher and push whatever this task accumulated since the last tick,
+   * so a rolling deploy does not drop the final window. Idempotent; never throws.
+   */
+  async stop(): Promise<void> {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    await this.flush();
+  }
+
+  /**
+   * Push the counter deltas accumulated since the last flush to Redis in one
+   * pipeline. Never throws. Concurrent callers share the in-flight flush.
+   */
+  async flush(): Promise<void> {
+    if (!this.isEnabled()) return;
+    if (this.inFlightFlush) return this.inFlightFlush;
+
+    const flushing = this.runFlush().finally(() => {
+      this.inFlightFlush = null;
+    });
+    this.inFlightFlush = flushing;
+    return flushing;
+  }
+
+  /**
+   * Render the Prometheus exposition. Serves the Redis (fleet-wide) counter totals
+   * plus this task's histograms/gauges. Falls back to the purely in-memory document
+   * when Redis is unavailable. Never throws.
+   */
+  async renderPrometheus(): Promise<string> {
+    if (!this.isEnabled()) {
+      return this.collector.getPrometheusFormat();
+    }
+
+    try {
+      // Publish this task's pending deltas first so a scrape is never up to one
+      // flush interval stale about the instance it landed on.
+      await this.flush();
+
+      const samples = await this.readCounterSamples();
+      if (samples === null) {
+        return this.collector.getPrometheusFormat();
+      }
+      return this.collector.buildPrometheusDocument(samples);
+    } catch (error) {
+      this.logFailure('metrics read failed — serving in-memory values for this instance', error);
+      return this.collector.getPrometheusFormat();
+    }
+  }
+
+  /** One flush attempt: drain → single pipeline → restore the deltas on failure. */
+  private async runFlush(): Promise<void> {
+    const deltas = this.collector.drainCounterDeltas();
+    if (deltas.length === 0) return;
+
+    try {
+      const client = this.getClient();
+      if (!client.isReady) {
+        this.collector.restoreCounterDeltas(deltas);
+        this.logFailure('Redis not ready — counter deltas retained for the next flush', null);
+        return;
+      }
+
+      const names = [...new Set(deltas.map((delta) => delta.name))];
+      const multi = client.multi();
+
+      // Registry: `/metrics` reads it instead of scanning the keyspace.
+      multi.sAdd(COUNTER_REGISTRY_KEY, names);
+      multi.expire(COUNTER_REGISTRY_KEY, this.keyTtlSeconds);
+
+      for (const delta of deltas) {
+        multi.hIncrBy(counterKey(delta.name), delta.labelSet, delta.value);
+      }
+      for (const name of names) {
+        multi.expire(counterKey(name), this.keyTtlSeconds);
+      }
+
+      await multi.exec();
+      this.hasLoggedFailure = false;
+    } catch (error) {
+      // Counters are additive: handing the deltas back means the next successful
+      // flush still lands the full count. Nothing is lost to a transient outage.
+      this.collector.restoreCounterDeltas(deltas);
+      this.logFailure('counter flush failed — deltas retained for the next flush', error);
+    }
+  }
+
+  /**
+   * Read every registered counter series from Redis. Returns `null` when Redis is
+   * not ready, signalling the caller to fall back to the in-memory document.
+   */
+  private async readCounterSamples(): Promise<CounterSample[] | null> {
+    const client = this.getClient();
+    if (!client.isReady) {
+      this.logFailure('Redis not ready — serving in-memory values for this instance', null);
+      return null;
+    }
+
+    const names = (await client.sMembers(COUNTER_REGISTRY_KEY)).sort();
+    if (names.length === 0) return [];
+
+    const multi = client.multi();
+    for (const name of names) {
+      multi.hGetAll(counterKey(name));
+    }
+    const replies = await multi.exec();
+
+    const samples: CounterSample[] = [];
+    names.forEach((name, index) => {
+      const hash = asHashReply(replies[index]);
+      if (!hash) return;
+      for (const [labelSet, raw] of Object.entries(hash)) {
+        const value = Number(raw);
+        if (!Number.isFinite(value)) continue;
+        samples.push({ name, labelSet, value });
+      }
+    });
+
+    this.hasLoggedFailure = false;
+    return samples;
+  }
+
+  /** Log the FIRST failure of an outage at warn; stay quiet until the next success. */
+  private logFailure(message: string, error: unknown): void {
+    if (this.hasLoggedFailure) return;
+    this.hasLoggedFailure = true;
+
+    if (error instanceof Error) {
+      logger.warn(`[Metrics] ${message}`, { error: error.message });
+      return;
+    }
+    logger.warn(`[Metrics] ${message}`);
+  }
+}
+
+/** Process-wide aggregator, started on every task at boot (see `server.ts`). */
+export const metricsAggregator = new MetricsAggregator();

--- a/packages/backend/src/utils/metrics.ts
+++ b/packages/backend/src/utils/metrics.ts
@@ -1,7 +1,24 @@
 /**
  * Performance Metrics Utility
- * Collects and exports metrics for monitoring feed performance
- * Supports Prometheus/StatsD-style metrics
+ *
+ * An in-process, allocation-light collector for the feed/observability signals.
+ * Counters, gauges and histograms are kept in memory and NEVER perform I/O on the
+ * write path — the discovery gate increments a counter per rejected candidate
+ * (~150 per feed request), so a write here must stay a Map update.
+ *
+ * Because production runs several ECS tasks behind an ALB, the in-memory value of
+ * a counter is only ever a FRAGMENT of the truth (a `GET /metrics` scrape lands on
+ * one arbitrary task). Cross-instance aggregation therefore happens OUT of band:
+ * {@link MetricsCollector.drainCounterDeltas} hands the counter deltas accumulated
+ * since the last drain to `services/metricsAggregator`, which pushes them to Redis
+ * on a timer and renders the fleet-wide totals for `/metrics`.
+ *
+ * Split of responsibilities:
+ *  - COUNTERS are monotonic and additive → aggregated across the fleet in Redis.
+ *  - GAUGES and HISTOGRAMS are point-in-time / per-process values that cannot be
+ *    summed across instances, so they stay local and are rendered per-instance.
+ *    A quantity that must survive aggregation has to be modelled as a counter
+ *    (see `feed_pool_candidates_total` in `mtn/feed/feedMetrics.ts`).
  */
 
 import { logger } from './logger';
@@ -15,53 +32,70 @@ export interface HistogramValue {
   labels?: MetricLabels;
 }
 
-class MetricsCollector {
-  // Histograms for latency measurements (p50, p95, p99)
-  private histograms: Map<string, number[]> = new Map();
-  
-  // Counters for event counting
-  private counters: Map<string, number> = new Map();
-  
-  // Gauges for current values
-  private gauges: Map<string, number> = new Map();
-  
-  // Maximum samples to keep per histogram (for percentile calculation)
-  private readonly MAX_HISTOGRAM_SAMPLES = 1000;
+/**
+ * One counter time series: the metric name plus its canonical serialized label set
+ * (`{origin="local"}`, or an empty string when the metric has no labels).
+ */
+export interface CounterSample {
+  name: string;
+  labelSet: string;
+  value: number;
+}
+
+/** Latency above which an operation is considered slow and worth a log line. */
+const SLOW_OPERATION_THRESHOLD_MS = 1000;
+
+/** Maximum samples retained per histogram (bounds memory, enough for percentiles). */
+const MAX_HISTOGRAM_SAMPLES = 1000;
+
+export class MetricsCollector {
+  /** Histograms for latency measurements (p50, p95, p99). Per-process. */
+  private readonly histograms: Map<string, number[]> = new Map();
+
+  /** Running counter totals observed by THIS process since it booted. */
+  private readonly counters: Map<string, number> = new Map();
+
+  /** Counter increments accumulated since the last {@link drainCounterDeltas}. */
+  private readonly counterDeltas: Map<string, number> = new Map();
+
+  /** Gauges for current values. Per-process. */
+  private readonly gauges: Map<string, number> = new Map();
 
   /**
    * Record a latency measurement (histogram)
    */
   recordLatency(metricName: string, durationMs: number, labels?: MetricLabels): void {
     const key = this.getMetricKey(metricName, labels);
-    if (!this.histograms.has(key)) {
-      this.histograms.set(key, []);
+    const samples = this.histograms.get(key) ?? [];
+    if (samples.length === 0) {
+      this.histograms.set(key, samples);
     }
-    
-    const samples = this.histograms.get(key)!;
+
     samples.push(durationMs);
-    
-    // Keep only recent samples to prevent memory bloat
-    if (samples.length > this.MAX_HISTOGRAM_SAMPLES) {
-      samples.shift(); // Remove oldest
+
+    // Keep only recent samples to prevent memory bloat.
+    if (samples.length > MAX_HISTOGRAM_SAMPLES) {
+      samples.shift();
     }
-    
-    // Log slow operations
-    if (durationMs > 1000) {
+
+    if (durationMs > SLOW_OPERATION_THRESHOLD_MS) {
       logger.warn(`Slow operation detected: ${metricName} took ${durationMs}ms`, labels);
     }
   }
 
   /**
-   * Increment a counter
+   * Increment a counter. Hot path: two Map writes, zero I/O, zero allocation
+   * beyond the metric key.
    */
   incrementCounter(metricName: string, value: number = 1, labels?: MetricLabels): void {
     const key = this.getMetricKey(metricName, labels);
-    const current = this.counters.get(key) || 0;
-    this.counters.set(key, current + value);
+    this.counters.set(key, (this.counters.get(key) ?? 0) + value);
+    this.counterDeltas.set(key, (this.counterDeltas.get(key) ?? 0) + value);
   }
 
   /**
-   * Set a gauge value
+   * Set a gauge value. Per-process only — a gauge cannot be aggregated across the
+   * fleet (summing or last-writing point-in-time values is meaningless).
    */
   setGauge(metricName: string, value: number, labels?: MetricLabels): void {
     const key = this.getMetricKey(metricName, labels);
@@ -77,18 +111,19 @@ class MetricsCollector {
     if (!samples || samples.length === 0) {
       return 0;
     }
-    
+
     const sorted = [...samples].sort((a, b) => a - b);
     const index = Math.ceil((percentile / 100) * sorted.length) - 1;
-    return sorted[Math.max(0, index)] || 0;
+    return sorted[Math.max(0, index)] ?? 0;
   }
 
   /**
-   * Get counter value
+   * Get this process's counter value. NOTE: this is the local fragment, not the
+   * fleet-wide total (see `services/metricsAggregator` for the aggregate).
    */
   getCounter(metricName: string, labels?: MetricLabels): number {
     const key = this.getMetricKey(metricName, labels);
-    return this.counters.get(key) || 0;
+    return this.counters.get(key) ?? 0;
   }
 
   /**
@@ -96,56 +131,71 @@ class MetricsCollector {
    */
   getGauge(metricName: string, labels?: MetricLabels): number {
     const key = this.getMetricKey(metricName, labels);
-    return this.gauges.get(key) || 0;
+    return this.gauges.get(key) ?? 0;
   }
 
   /**
-   * Get all metrics as Prometheus-style format
+   * Take the counter increments accumulated since the last drain and clear them.
+   * Called by the metrics aggregator on its flush tick; the caller owns the
+   * returned deltas and MUST hand them back via {@link restoreCounterDeltas} if
+   * it fails to persist them.
+   */
+  drainCounterDeltas(): CounterSample[] {
+    const drained: CounterSample[] = [];
+    for (const [key, value] of this.counterDeltas.entries()) {
+      if (value === 0) continue;
+      const [name, labelSet] = this.parseMetricKey(key);
+      drained.push({ name, labelSet, value });
+    }
+    this.counterDeltas.clear();
+    return drained;
+  }
+
+  /**
+   * Put drained deltas back into the pending set (merging with anything recorded
+   * in the meantime) so a failed flush is retried on the next tick instead of
+   * losing counts.
+   */
+  restoreCounterDeltas(samples: CounterSample[]): void {
+    for (const sample of samples) {
+      const key = sample.labelSet ? `${sample.name}${sample.labelSet}` : sample.name;
+      this.counterDeltas.set(key, (this.counterDeltas.get(key) ?? 0) + sample.value);
+    }
+  }
+
+  /** This process's counter series (the local fragment of each total). */
+  getCounterSamples(): CounterSample[] {
+    const samples: CounterSample[] = [];
+    for (const [key, value] of this.counters.entries()) {
+      const [name, labelSet] = this.parseMetricKey(key);
+      samples.push({ name, labelSet, value });
+    }
+    return samples;
+  }
+
+  /**
+   * Render a Prometheus exposition document from this process's histograms and
+   * gauges plus the supplied counter series. The aggregator passes the Redis
+   * (fleet-wide) counters; {@link getPrometheusFormat} passes the local ones.
+   */
+  buildPrometheusDocument(counterSamples: CounterSample[]): string {
+    return [
+      ...this.buildHistogramLines(),
+      ...buildSeriesLines(counterSamples, 'counter'),
+      ...buildSeriesLines(this.getGaugeSamples(), 'gauge'),
+    ].join('\n');
+  }
+
+  /**
+   * Get all metrics as Prometheus-style format, using THIS process's counters.
+   * Used as the fail-soft fallback when Redis is unavailable or not configured.
    */
   getPrometheusFormat(): string {
-    const lines: string[] = [];
-    
-    // Histograms
-    for (const [key, samples] of this.histograms.entries()) {
-      if (samples.length === 0) continue;
-      
-      const sorted = [...samples].sort((a, b) => a - b);
-      const p50 = sorted[Math.ceil(0.5 * sorted.length) - 1] || 0;
-      const p95 = sorted[Math.ceil(0.95 * sorted.length) - 1] || 0;
-      const p99 = sorted[Math.ceil(0.99 * sorted.length) - 1] || 0;
-      const sum = samples.reduce((a, b) => a + b, 0);
-      const count = samples.length;
-      const avg = sum / count;
-      
-      const [name, labelStr] = this.parseMetricKey(key);
-      lines.push(`# TYPE ${name}_duration_ms histogram`);
-      lines.push(`${name}_duration_ms{quantile="0.5"${labelStr}} ${p50}`);
-      lines.push(`${name}_duration_ms{quantile="0.95"${labelStr}} ${p95}`);
-      lines.push(`${name}_duration_ms{quantile="0.99"${labelStr}} ${p99}`);
-      lines.push(`${name}_duration_ms_sum${labelStr} ${sum}`);
-      lines.push(`${name}_duration_ms_count${labelStr} ${count}`);
-      lines.push(`${name}_duration_ms_avg${labelStr} ${avg}`);
-    }
-    
-    // Counters
-    for (const [key, value] of this.counters.entries()) {
-      const [name, labelStr] = this.parseMetricKey(key);
-      lines.push(`# TYPE ${name} counter`);
-      lines.push(`${name}${labelStr} ${value}`);
-    }
-    
-    // Gauges
-    for (const [key, value] of this.gauges.entries()) {
-      const [name, labelStr] = this.parseMetricKey(key);
-      lines.push(`# TYPE ${name} gauge`);
-      lines.push(`${name}${labelStr} ${value}`);
-    }
-    
-    return lines.join('\n');
+    return this.buildPrometheusDocument(this.getCounterSamples());
   }
 
   /**
-   * Get metrics summary as JSON
+   * Get metrics summary as JSON (local values only).
    */
   getMetricsSummary(): {
     histograms: Record<string, { p50: number; p95: number; p99: number; avg: number; count: number }>;
@@ -155,31 +205,30 @@ class MetricsCollector {
     const histograms: Record<string, { p50: number; p95: number; p99: number; avg: number; count: number }> = {};
     const counters: Record<string, number> = {};
     const gauges: Record<string, number> = {};
-    
+
     for (const [key, samples] of this.histograms.entries()) {
       if (samples.length === 0) continue;
       const [name] = this.parseMetricKey(key);
-      const sorted = [...samples].sort((a, b) => a - b);
-      const p50 = sorted[Math.ceil(0.5 * sorted.length) - 1] || 0;
-      const p95 = sorted[Math.ceil(0.95 * sorted.length) - 1] || 0;
-      const p99 = sorted[Math.ceil(0.99 * sorted.length) - 1] || 0;
-      const sum = samples.reduce((a, b) => a + b, 0);
-      const count = samples.length;
-      const avg = sum / count;
-      
-      histograms[name] = { p50, p95, p99, avg, count };
+      const stats = summarize(samples);
+      histograms[name] = {
+        p50: stats.p50,
+        p95: stats.p95,
+        p99: stats.p99,
+        avg: stats.avg,
+        count: stats.count,
+      };
     }
-    
+
     for (const [key, value] of this.counters.entries()) {
       const [name] = this.parseMetricKey(key);
       counters[name] = value;
     }
-    
+
     for (const [key, value] of this.gauges.entries()) {
       const [name] = this.parseMetricKey(key);
       gauges[name] = value;
     }
-    
+
     return { histograms, counters, gauges };
   }
 
@@ -189,7 +238,53 @@ class MetricsCollector {
   reset(): void {
     this.histograms.clear();
     this.counters.clear();
+    this.counterDeltas.clear();
     this.gauges.clear();
+  }
+
+  /** This process's gauge series. */
+  private getGaugeSamples(): CounterSample[] {
+    const samples: CounterSample[] = [];
+    for (const [key, value] of this.gauges.entries()) {
+      const [name, labelSet] = this.parseMetricKey(key);
+      samples.push({ name, labelSet, value });
+    }
+    return samples;
+  }
+
+  /** Prometheus lines for the local latency histograms (one TYPE line per metric). */
+  private buildHistogramLines(): string[] {
+    const seriesByName = new Map<string, string[]>();
+
+    for (const [key, samples] of this.histograms.entries()) {
+      if (samples.length === 0) continue;
+
+      const [name, labelSet] = this.parseMetricKey(key);
+      const metricName = `${name}_duration_ms`;
+      const stats = summarize(samples);
+      const quantileLabels = (quantile: string): string =>
+        labelSet ? `{quantile="${quantile}",${labelSet.slice(1)}` : `{quantile="${quantile}"}`;
+
+      const series = seriesByName.get(metricName) ?? [];
+      if (series.length === 0) {
+        seriesByName.set(metricName, series);
+      }
+      series.push(
+        `${metricName}${quantileLabels('0.5')} ${stats.p50}`,
+        `${metricName}${quantileLabels('0.95')} ${stats.p95}`,
+        `${metricName}${quantileLabels('0.99')} ${stats.p99}`,
+        `${metricName}_sum${labelSet} ${stats.sum}`,
+        `${metricName}_count${labelSet} ${stats.count}`,
+        `${metricName}_avg${labelSet} ${stats.avg}`,
+      );
+    }
+
+    const lines: string[] = [];
+    for (const [metricName, series] of seriesByName.entries()) {
+      lines.push(`# TYPE ${metricName} histogram`);
+      lines.push(...series);
+    }
+    return lines;
   }
 
   /**
@@ -199,27 +294,66 @@ class MetricsCollector {
     if (!labels || Object.keys(labels).length === 0) {
       return metricName;
     }
-    
+
     const labelParts = Object.entries(labels)
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([key, value]) => `${key}="${value}"`);
-    
+
     return `${metricName}{${labelParts.join(',')}}`;
   }
 
   /**
-   * Parse metric key back to name and labels
+   * Parse metric key back to name and serialized label set
    */
   private parseMetricKey(key: string): [string, string] {
-    const match = key.match(/^([^{]+)(\{.*\})?$/);
-    if (!match) {
+    const braceIndex = key.indexOf('{');
+    if (braceIndex === -1) {
       return [key, ''];
     }
-    
-    const name = match[1];
-    const labels = match[2] || '';
-    return [name, labels];
+    return [key.slice(0, braceIndex), key.slice(braceIndex)];
   }
+}
+
+/** Percentiles + totals for a histogram's retained samples. */
+function summarize(samples: number[]): {
+  p50: number;
+  p95: number;
+  p99: number;
+  sum: number;
+  count: number;
+  avg: number;
+} {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const at = (quantile: number): number => sorted[Math.ceil(quantile * sorted.length) - 1] ?? 0;
+  const sum = samples.reduce((total, sample) => total + sample, 0);
+  const count = samples.length;
+  return { p50: at(0.5), p95: at(0.95), p99: at(0.99), sum, count, avg: sum / count };
+}
+
+/**
+ * Render counter/gauge series, grouped so exactly ONE `# TYPE` line is emitted per
+ * metric name (a repeated TYPE line for the same metric is a Prometheus parse
+ * error). Series are sorted for a stable, diffable exposition.
+ */
+function buildSeriesLines(samples: CounterSample[], type: 'counter' | 'gauge'): string[] {
+  const seriesByName = new Map<string, CounterSample[]>();
+  for (const sample of samples) {
+    const series = seriesByName.get(sample.name) ?? [];
+    if (series.length === 0) {
+      seriesByName.set(sample.name, series);
+    }
+    series.push(sample);
+  }
+
+  const lines: string[] = [];
+  for (const name of [...seriesByName.keys()].sort()) {
+    const series = seriesByName.get(name) ?? [];
+    lines.push(`# TYPE ${name} ${type}`);
+    for (const sample of [...series].sort((a, b) => a.labelSet.localeCompare(b.labelSet))) {
+      lines.push(`${name}${sample.labelSet} ${sample.value}`);
+    }
+  }
+  return lines;
 }
 
 // Singleton instance
@@ -266,16 +400,3 @@ export function measureDurationSync<T>(
     throw error;
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/backend/src/utils/redis.ts
+++ b/packages/backend/src/utils/redis.ts
@@ -221,6 +221,20 @@ export function getRedisClient(): RedisClientType {
 }
 
 /**
+ * Whether a Redis target is CONFIGURED in the environment (no connection attempt).
+ *
+ * A bare `localhost` default (no Redis env at all) is deliberately NOT considered
+ * configured, so local dev / a Redis-less task cleanly degrades to its in-process
+ * fallback instead of dialling a server that isn't there. Mirrors
+ * `queue/connection.ts#isQueueEnabled`.
+ */
+export function isRedisConfigured(): boolean {
+  const { redisUrl } = getRedisConfig();
+  if (redisUrl) return true;
+  return Boolean(process.env.REDIS_HOST && process.env.REDIS_HOST.trim().length > 0);
+}
+
+/**
  * Check if Redis is connected and healthy
  * This performs an actual ping to verify the connection is working
  */


### PR DESCRIPTION
## Summary

**The metrics were unreadable in production**, which I only discovered when I tried to use them.

Counters lived **in memory, per process**. Production runs several ECS tasks behind the ALB, and `GET /metrics` hits **one arbitrary task** — so each instance held a fragment and nobody could read the total. Verified against prod: `feed_impression_total` appeared, `feed_discovery_gated_total` did not, and it was impossible to tell whether the discovery gate wasn't firing or I'd just landed on a different task.

That made the metrics useless for the exact decision they exist to support: **validating the discovery gate in shadow before enforcing it.**

### The fix
- Counters are aggregated in **Redis**; `/metrics` serves the **fleet-wide total**.
- **The hot path stays I/O-free.** The gate increments a counter per rejected candidate (~150 per feed request) — a Redis round trip per increment would have been a catastrophic regression. Increments stay in-memory Map writes (a test asserts **zero** Redis calls across 1000 increments); a 10s flusher pushes **deltas** in **one** pipeline.
- **Fail-soft**: a failed flush hands the deltas back and retries, so nothing is lost to a blip. Redis down or unconfigured → falls back to in-memory (today's behavior). Never throws.

### Two real bugs fixed on the way
- **`feed_federated_share` was a gauge** — and a per-request gauge **cannot be aggregated** across tasks (summing and last-write are both meaningless). It's now `feed_pool_candidates_total{descriptor,origin}` with the share **derived**. Across two instances it now reports the true **0.5** where the gauge showed **0.25 or 0.75** depending on which task you scraped.
- **`feed_ranking_duration_ms` was labelled with `user_id`** and the raw `post_count` — unbounded cardinality, retaining one histogram series **per user, forever** (up to 1000 samples each). An in-process memory leak. Now a bounded `pool_size` bucket.
- (Bonus) The Prometheus exposition for labelled histograms was **malformed and unparseable** (`{quantile="0.5"{feed_type="for_you"}}`), plus a repeated `# TYPE` line. Both fixed.

## ⚠️ Merge order

`GET /metrics` is **public and unauthenticated** (mounted ahead of the auth routers). This change makes it serve fleet-wide totals rather than one task's fragment, which **widens** that exposure.

**Apply [oxy-infra#6](https://github.com/OxyHQ/oxy-infra/pull/6) first** — it blocks `/metrics` at the ALB (404) for the Mention hosts. In-VPC scrapers reach the tasks directly and are unaffected.

## Test plan

- Backend: **2043 pass / 1 fail** — only the pre-existing `federationThreadLinking` 5s timeout.
- New suite: zero-I/O hot path; one pipeline per flush and local deltas reset; deltas-not-totals (3 then 2 ⇒ 5, not 8); two simulated instances ⇒ `/metrics` shows the **sum**; Redis not ready ⇒ fallback + deltas retained and landed in full on recovery; `exec` rejects ⇒ never throws; `REDIS_URL` unset ⇒ still boots and serves (smoke-tested live).
- F3 golden master unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)