### PR TITLE
chore(scripts): add DRY_RUN to the federated-text backfill

### DIFF
--- a/packages/backend/src/__tests__/scripts/normalizeFederatedText.test.ts
+++ b/packages/backend/src/__tests__/scripts/normalizeFederatedText.test.ts
@@ -1,31 +1,139 @@
 import mongoose from 'mongoose';
-import { describe, expect, it } from 'vitest';
-import {
-  buildActorUpdate,
-  buildPostUpdate,
-} from '../../scripts/normalizeFederatedText';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * The one-shot backfill that cleans the remote text ALREADY stored in Mongo.
  *
- * Only the pure update-builders are exercised — they hold every rule that
- * matters: which helper each field gets, that an emptied optional label is
- * UNSET rather than blanked, that a required field is never emptied, and that a
- * document with nothing to fix produces no write at all (the idempotency the
- * batch loop relies on to avoid rewriting hundreds of thousands of clean posts).
+ * Two layers are covered:
+ *
+ *  - The pure update-builders, which hold every rule that matters: which helper
+ *    each field gets, that an emptied optional label is UNSET rather than
+ *    blanked, that a required field is never emptied, and that a document with
+ *    nothing to fix produces no write at all (the idempotency the batch loop
+ *    relies on to avoid rewriting hundreds of thousands of clean posts).
+ *
+ *  - The scan itself, over canned `Post` / `FederatedActor` model mocks that
+ *    honour the script's ascending-`_id` cursor. This is what proves the DRY RUN
+ *    is real: it must issue NO `bulkWrite` at all, while still reporting exactly
+ *    the documents a real run would rewrite.
  */
+
+/** A canned row as the models hand it to the script (`.lean()` output). */
+interface StoredRow {
+  _id: mongoose.Types.ObjectId;
+  content?: { text?: unknown; media?: unknown };
+  federation?: { spoilerText?: unknown };
+  username?: unknown;
+  summary?: unknown;
+  fields?: unknown;
+}
+
+/** The bulk op the script builds for one dirty document. */
+interface BulkOp {
+  updateOne: {
+    filter: { _id: mongoose.Types.ObjectId };
+    update: { $set?: Record<string, unknown>; $unset?: Record<string, ''> };
+  };
+}
+
+/** The `find(...).sort(...).limit(...).lean()` chain the script calls. */
+interface FindChain {
+  sort: () => FindChain;
+  limit: (value: number) => FindChain;
+  lean: () => Promise<StoredRow[]>;
+}
+
+const h = vi.hoisted(() => {
+  const state: {
+    posts: StoredRow[];
+    actors: StoredRow[];
+    postOps: BulkOp[];
+    actorOps: BulkOp[];
+  } = { posts: [], actors: [], postOps: [], actorOps: [] };
+
+  /**
+   * Serve one page the way the real cursor does: ascending `_id`, everything
+   * strictly after the cursor, capped at the page size. Honouring `$gt` is what
+   * lets the script's `for(;;)` loop terminate — a mock that ignored it would
+   * hand back the same page forever.
+   */
+  const page = (rows: StoredRow[], filter: Record<string, unknown>, limit: number): StoredRow[] => {
+    const cursor = (filter._id as { $gt?: mongoose.Types.ObjectId } | undefined)?.$gt;
+    const after = cursor ? cursor.toString() : null;
+    return [...rows]
+      .sort((a, b) => a._id.toString().localeCompare(b._id.toString()))
+      .filter((row) => after === null || row._id.toString() > after)
+      .slice(0, limit);
+  };
+
+  const makeFind = (rows: () => StoredRow[]) =>
+    vi.fn((filter: Record<string, unknown>) => {
+      let limit = Number.MAX_SAFE_INTEGER;
+      const chain: FindChain = {
+        sort: () => chain,
+        limit: (value: number) => {
+          limit = value;
+          return chain;
+        },
+        lean: async () => page(rows(), filter, limit),
+      };
+      return chain;
+    });
+
+  return {
+    state,
+    postCount: vi.fn(async () => state.posts.length),
+    actorCount: vi.fn(async () => state.actors.length),
+    postFind: makeFind(() => state.posts),
+    actorFind: makeFind(() => state.actors),
+    postBulkWrite: vi.fn(async (ops: BulkOp[]) => {
+      state.postOps.push(...ops);
+      return { modifiedCount: ops.length };
+    }),
+    actorBulkWrite: vi.fn(async (ops: BulkOp[]) => {
+      state.actorOps.push(...ops);
+      return { modifiedCount: ops.length };
+    }),
+  };
+});
+
+vi.mock('../../models/Post', () => ({
+  Post: { countDocuments: h.postCount, find: h.postFind, bulkWrite: h.postBulkWrite },
+}));
+
+vi.mock('../../models/FederatedActor', () => ({
+  default: { countDocuments: h.actorCount, find: h.actorFind, bulkWrite: h.actorBulkWrite },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  buildActorUpdate,
+  buildPostUpdate,
+  describeChanges,
+  normalizeStoredText,
+} from '../../scripts/normalizeFederatedText';
 
 /** The `_id` of the row under test — the builders only echo it into the filter. */
 const OID = new mongoose.Types.ObjectId('000000000000000000000001');
+
+const oid = (suffix: string): mongoose.Types.ObjectId =>
+  new mongoose.Types.ObjectId(`00000000000000000000000${suffix}`);
+
+/** The body of a pretty-printed remote post: padded, with a padded blank line. */
+const DIRTY_TEXT = '  uno   \n   \n   \n  dos  ';
+const CLEAN_TEXT = 'uno\n\ndos';
 
 describe('buildPostUpdate', () => {
   it('normalizes the body as multiline, keeping the author’s paragraph break', () => {
     const { update, counts } = buildPostUpdate({
       _id: OID,
-      content: { text: '  uno   \n   \n   \n  dos  ' },
+      content: { text: DIRTY_TEXT },
     });
 
-    expect(update.set['content.text']).toBe('uno\n\ndos');
+    expect(update.set['content.text']).toBe(CLEAN_TEXT);
     expect(update.unset).toEqual({});
     expect(counts.text).toBe(1);
   });
@@ -76,7 +184,7 @@ describe('buildPostUpdate', () => {
   it('produces NO write for an already-clean post (idempotent)', () => {
     const clean = {
       _id: OID,
-      content: { text: 'uno\n\ndos', media: [{ id: 'a', type: 'image', alt: 'un gato' }] },
+      content: { text: CLEAN_TEXT, media: [{ id: 'a', type: 'image', alt: 'un gato' }] },
       federation: { spoilerText: 'CW: spoilers' },
     };
     const { update } = buildPostUpdate(clean);
@@ -141,5 +249,199 @@ describe('buildActorUpdate', () => {
     });
     expect(update.set).toEqual({});
     expect(update.unset).toEqual({});
+  });
+});
+
+describe('describeChanges', () => {
+  it('quotes both sides so the whitespace being removed is actually visible', () => {
+    const post = { _id: OID, content: { text: DIRTY_TEXT } };
+    const { update } = buildPostUpdate(post);
+
+    expect(describeChanges(post, update)).toEqual([
+      {
+        path: 'content.text',
+        before: '"  uno   \\n   \\n   \\n  dos  "',
+        after: '"uno\\n\\ndos"',
+      },
+    ]);
+  });
+
+  it('reads a value out of an array by index and reports a removal as (unset)', () => {
+    const post = {
+      _id: OID,
+      content: { media: [{ id: 'a', type: 'image', alt: 'un gato' }, { id: 'b', alt: ' \n ' }] },
+    };
+    const { update } = buildPostUpdate(post);
+
+    expect(describeChanges(post, update)).toEqual([
+      { path: 'content.media.1.alt', before: '" \\n "', after: '(unset)' },
+    ]);
+  });
+});
+
+/** Two dirty posts and one already-clean post — the shape a real run scans. */
+function seedPosts(): void {
+  h.state.posts = [
+    // Dirty: a padded, pretty-printed body.
+    { _id: oid('1'), content: { text: DIRTY_TEXT }, federation: { spoilerText: 'CW: spoilers' } },
+    // Dirty: a padded content warning plus a padded alt on the second media item.
+    {
+      _id: oid('2'),
+      content: {
+        text: CLEAN_TEXT,
+        media: [
+          { id: 'a', type: 'image', alt: 'un gato' },
+          { id: 'b', type: 'image', alt: '  un perro\n ' },
+        ],
+      },
+      federation: { spoilerText: '  CW:\n  spoilers  ' },
+    },
+    // Clean: must produce no write on either a dry or a real run.
+    { _id: oid('3'), content: { text: CLEAN_TEXT }, federation: { spoilerText: 'CW: spoilers' } },
+  ];
+}
+
+/** One dirty actor and one already-clean actor. */
+function seedActors(): void {
+  h.state.actors = [
+    { _id: oid('4'), username: '  alice\n ', summary: '  hola   \n  \n  \n  adiós ' },
+    { _id: oid('5'), username: 'bob', summary: 'hola\n\nadiós' },
+  ];
+}
+
+beforeEach(() => {
+  h.state.posts = [];
+  h.state.actors = [];
+  h.state.postOps = [];
+  h.state.actorOps = [];
+  h.postBulkWrite.mockClear();
+  h.actorBulkWrite.mockClear();
+  h.postFind.mockClear();
+  h.actorFind.mockClear();
+});
+
+describe('normalizeStoredText — DRY RUN', () => {
+  it('performs NO write at all', async () => {
+    seedPosts();
+    seedActors();
+
+    await normalizeStoredText(true);
+
+    expect(h.postBulkWrite).not.toHaveBeenCalled();
+    expect(h.actorBulkWrite).not.toHaveBeenCalled();
+    expect(h.state.postOps).toHaveLength(0);
+    expect(h.state.actorOps).toHaveLength(0);
+  });
+
+  it('reports the documents that WOULD change — not the ones it merely scanned', async () => {
+    seedPosts();
+    seedActors();
+
+    const summary = await normalizeStoredText(true);
+
+    expect(summary.dryRun).toBe(true);
+
+    // 3 posts seen, only 2 of them dirty; nothing written.
+    expect(summary.posts.scanned).toBe(3);
+    expect(summary.posts.changed).toBe(2);
+    expect(summary.posts.written).toBe(0);
+    // The per-field breakdown counts VALUES, so the second post contributes both
+    // its content warning and its one dirty media alt.
+    expect(summary.posts.counts).toEqual({ text: 1, spoilerText: 1, mediaAlt: 1 });
+
+    // 2 actors seen, 1 dirty (username + bio).
+    expect(summary.actors.scanned).toBe(2);
+    expect(summary.actors.changed).toBe(1);
+    expect(summary.actors.written).toBe(0);
+    expect(summary.actors.counts).toEqual({ username: 1, summary: 1, fields: 0 });
+  });
+
+  it('samples the real before/after values, whitespace visible', async () => {
+    seedPosts();
+    seedActors();
+
+    const summary = await normalizeStoredText(true);
+
+    expect(summary.posts.samples).toHaveLength(2);
+    expect(summary.posts.samples[0]).toEqual({
+      id: oid('1').toString(),
+      changes: [
+        {
+          path: 'content.text',
+          before: '"  uno   \\n   \\n   \\n  dos  "',
+          after: '"uno\\n\\ndos"',
+        },
+      ],
+    });
+    expect(summary.posts.samples[1].changes).toEqual([
+      { path: 'federation.spoilerText', before: '"  CW:\\n  spoilers  "', after: '"CW: spoilers"' },
+      { path: 'content.media.1.alt', before: '"  un perro\\n "', after: '"un perro"' },
+    ]);
+
+    expect(summary.actors.samples).toHaveLength(1);
+    expect(summary.actors.samples[0].changes).toEqual([
+      { path: 'username', before: '"  alice\\n "', after: '"alice"' },
+      { path: 'summary', before: '"  hola   \\n  \\n  \\n  adiós "', after: '"hola\\n\\nadiós"' },
+    ]);
+  });
+
+  it('finds nothing to change on a second (already-normalized) run', async () => {
+    h.state.posts = [{ _id: oid('1'), content: { text: CLEAN_TEXT } }];
+    h.state.actors = [{ _id: oid('4'), username: 'alice', summary: 'hola\n\nadiós' }];
+
+    const summary = await normalizeStoredText(true);
+
+    expect(summary.posts.scanned).toBe(1);
+    expect(summary.posts.changed).toBe(0);
+    expect(summary.actors.changed).toBe(0);
+    expect(summary.posts.samples).toEqual([]);
+  });
+});
+
+describe('normalizeStoredText — real run', () => {
+  it('writes exactly the dirty documents, and the dry-run plan matches what it wrote', async () => {
+    seedPosts();
+    seedActors();
+
+    const planned = await normalizeStoredText(true);
+
+    seedPosts();
+    seedActors();
+    const applied = await normalizeStoredText(false);
+
+    // What the dry run said would change is what the real run actually wrote.
+    expect(applied.posts.written).toBe(planned.posts.changed);
+    expect(applied.actors.written).toBe(planned.actors.changed);
+    expect(applied.dryRun).toBe(false);
+
+    // Only the two dirty posts are touched — the clean one gets no op at all.
+    expect(h.state.postOps).toHaveLength(2);
+    expect(h.state.postOps.map((op) => op.updateOne.filter._id.toString())).toEqual([
+      oid('1').toString(),
+      oid('2').toString(),
+    ]);
+    expect(h.state.postOps[1].updateOne.update.$set).toEqual({
+      'federation.spoilerText': 'CW: spoilers',
+      'content.media.1.alt': 'un perro',
+    });
+
+    expect(h.state.actorOps).toHaveLength(1);
+    expect(h.state.actorOps[0].updateOne.filter._id.toString()).toBe(oid('4').toString());
+    expect(h.state.actorOps[0].updateOne.update.$set).toEqual({
+      username: 'alice',
+      summary: 'hola\n\nadiós',
+    });
+  });
+
+  it('unsets an alt that normalizes to nothing rather than blanking it', async () => {
+    h.state.posts = [
+      { _id: oid('1'), content: { text: CLEAN_TEXT, media: [{ id: 'a', alt: '  \n ' }] } },
+    ];
+
+    await normalizeStoredText(false);
+
+    expect(h.state.postOps).toHaveLength(1);
+    expect(h.state.postOps[0].updateOne.update.$unset).toEqual({ 'content.media.0.alt': '' });
+    expect(h.state.postOps[0].updateOne.update.$set).toBeUndefined();
   });
 });

--- a/packages/backend/src/scripts/normalizeFederatedText.ts
+++ b/packages/backend/src/scripts/normalizeFederatedText.ts
@@ -29,8 +29,28 @@
  * `_id` cursor with `bulkWrite` (never loads the collection into memory), and it
  * only writes the documents whose values ACTUALLY change.
  *
- * Runnable as a Fargate one-shot post-deploy:
- *   node dist/scripts/normalizeFederatedText.js
+ * DRY RUN
+ * -------
+ * This rewrites the body of hundreds of thousands of production posts, so run it
+ * dry FIRST. `DRY_RUN=true` scans the same documents and computes the same
+ * updates, but performs NO `bulkWrite`. It reports how many documents WOULD
+ * change (not how many were seen), the per-field breakdown, and a bounded sample
+ * of the real before/after values. The sample is JSON-quoted deliberately: this
+ * backfill is ENTIRELY about whitespace, and a diff that prints `\n` and leading
+ * spaces as themselves shows nothing at all.
+ *
+ * Same `DRY_RUN=true` convention as the sibling backfills in this directory and
+ * as oxy-api's `normalize-user-text-fields.ts`.
+ *
+ * Run — as a Fargate one-shot against the deployed backend image (command
+ * overridden), or locally with the same env:
+ *   DRY_RUN=true bun packages/backend/dist/src/scripts/normalizeFederatedText.js   # preview, writes nothing
+ *   bun packages/backend/dist/src/scripts/normalizeFederatedText.js                # apply
+ *
+ * Env:
+ *   MONGODB_URI   the cluster (injected by ECS from SSM)
+ *   NODE_ENV      selects the database (`mention-<NODE_ENV>`)
+ *   DRY_RUN=true  plan only, no writes
  */
 
 import mongoose from 'mongoose';
@@ -44,6 +64,9 @@ const PAGE_SIZE = 500;
 
 /** Updates flushed per `bulkWrite` chunk. */
 const BULK_CHUNK_SIZE = 500;
+
+/** How many changed documents a dry run reports in full, per collection. */
+const DRY_RUN_SAMPLE_SIZE = 20;
 
 /** Matches the posts that carry remote text: everything with AP/atproto metadata. */
 const FEDERATED_POST_FILTER: Record<string, unknown> = { federation: { $ne: null } };
@@ -69,14 +92,14 @@ export interface FederatedActorRow {
   fields?: unknown;
 }
 
-/** Per-field tally of how many post values this run actually rewrote. */
+/** Per-field tally of how many post values this run rewrote (or would rewrite). */
 export interface PostCounts {
   text: number;
   spoilerText: number;
   mediaAlt: number;
 }
 
-/** Per-field tally of how many actor values this run actually rewrote. */
+/** Per-field tally of how many actor values this run rewrote (or would rewrite). */
 export interface ActorCounts {
   username: number;
   summary: number;
@@ -94,6 +117,44 @@ export interface DocumentUpdate {
   set: Record<string, unknown>;
   unset: Record<string, ''>;
 }
+
+/** One field a run would rewrite, rendered for the dry-run report. */
+export interface FieldChange {
+  /** The dotted path being written, e.g. `content.media.0.alt`. */
+  path: string;
+  /** The stored value, JSON-quoted so its whitespace is visible. */
+  before: string;
+  /** The normalized value, JSON-quoted — or `(unset)` when the field is removed. */
+  after: string;
+}
+
+/** One sampled document in the dry-run report. */
+export interface DocumentSample {
+  id: string;
+  changes: FieldChange[];
+}
+
+/** What one collection's pass did (or, dry, would do). */
+export interface CollectionResult<TCounts> {
+  scanned: number;
+  /** Documents whose stored text differs from its normalized form. */
+  changed: number;
+  /** Documents actually rewritten. Always 0 on a dry run. */
+  written: number;
+  /** Which FIELDS were dirty, across the changed documents. */
+  counts: TCounts;
+  /** A bounded before/after sample. Only collected on a dry run. */
+  samples: DocumentSample[];
+}
+
+export interface NormalizationSummary {
+  dryRun: boolean;
+  posts: CollectionResult<PostCounts>;
+  actors: CollectionResult<ActorCounts>;
+}
+
+/** Shown in place of the new value for a field the run would REMOVE. */
+const UNSET_MARKER = '(unset)';
 
 function emptyUpdate(): DocumentUpdate {
   return { set: {}, unset: {} };
@@ -216,24 +277,92 @@ export function buildActorUpdate(actor: FederatedActorRow): { update: DocumentUp
 }
 
 /**
+ * Read the value a dotted update path points at in the ORIGINAL document, so the
+ * dry run can put what is on disk next to what it would become. A numeric
+ * segment indexes into an array (`content.media.0.alt`, `fields.1.name`).
+ */
+function readPath(document: unknown, path: string): unknown {
+  let current: unknown = document;
+  for (const segment of path.split('.')) {
+    if (current === null || typeof current !== 'object') return undefined;
+    if (Array.isArray(current)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index)) return undefined;
+      current = current[index];
+      continue;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+/** JSON-quote a stored value so its newlines and padding are actually visible. */
+function renderValue(value: unknown): string {
+  const rendered = JSON.stringify(value);
+  return rendered === undefined ? 'undefined' : rendered;
+}
+
+/**
+ * Render one document's staged update as before/after pairs — the dry run's whole
+ * point. Both sides are JSON-quoted: the difference between `"Hola"` and
+ * `"\n      Hola"` is exactly what this backfill exists to remove, and it is
+ * invisible in an unquoted diff.
+ */
+export function describeChanges(document: unknown, update: DocumentUpdate): FieldChange[] {
+  const changes: FieldChange[] = [];
+  for (const [path, value] of Object.entries(update.set)) {
+    changes.push({ path, before: renderValue(readPath(document, path)), after: renderValue(value) });
+  }
+  for (const path of Object.keys(update.unset)) {
+    changes.push({ path, before: renderValue(readPath(document, path)), after: UNSET_MARKER });
+  }
+  return changes;
+}
+
+/** Print the sampled before/after pairs a dry run collected. */
+function logSamples(kind: string, samples: DocumentSample[]): void {
+  if (samples.length === 0) return;
+  logger.info(
+    `[normalizeFederatedText] DRY RUN sample — ${samples.length} ${kind}(s), values JSON-quoted so whitespace is visible:`,
+  );
+  for (const sample of samples) {
+    for (const change of sample.changes) {
+      logger.info(
+        `[normalizeFederatedText]   ${kind} ${sample.id} ${change.path}: ${change.before} -> ${change.after}`,
+      );
+    }
+  }
+}
+
+/**
  * Normalize the remote text on every federated post.
  *
  * Pages by ascending `_id` over a filter that only matches on `federation`,
  * which this script never mutates — so the scanned set is stable for the run.
  */
-async function normalizePosts(counts: PostCounts): Promise<{ scanned: number; updated: number }> {
+async function normalizePosts(dryRun: boolean): Promise<CollectionResult<PostCounts>> {
   const total = await Post.countDocuments(FEDERATED_POST_FILTER);
   logger.info(`[normalizeFederatedText] ${total} federated posts to scan`);
 
+  const counts: PostCounts = { text: 0, spoilerText: 0, mediaAlt: 0 };
+  const samples: DocumentSample[] = [];
   let scanned = 0;
-  let updated = 0;
+  let changed = 0;
+  let written = 0;
   let lastId: mongoose.Types.ObjectId | null = null;
   let pendingOps: mongoose.AnyBulkWriteOperation<typeof Post>[] = [];
 
+  // A dry run builds every operation exactly as a real one does — it just never
+  // hands them to Mongo. That is the whole guarantee: what it reports is what a
+  // real run would write, computed by the same code.
   const flush = async (): Promise<void> => {
     if (pendingOps.length === 0) return;
+    if (dryRun) {
+      pendingOps = [];
+      return;
+    }
     const result = await Post.bulkWrite(pendingOps, { ordered: false });
-    updated += result.modifiedCount;
+    written += result.modifiedCount;
     pendingOps = [];
   };
 
@@ -256,9 +385,13 @@ async function normalizePosts(counts: PostCounts): Promise<{ scanned: number; up
     for (const post of page) {
       const { update, counts: postCounts } = buildPostUpdate(post);
       if (!hasChanges(update)) continue;
+      changed += 1;
       counts.text += postCounts.text;
       counts.spoilerText += postCounts.spoilerText;
       counts.mediaAlt += postCounts.mediaAlt;
+      if (dryRun && samples.length < DRY_RUN_SAMPLE_SIZE) {
+        samples.push({ id: post._id.toString(), changes: describeChanges(post, update) });
+      }
       pendingOps.push({
         updateOne: {
           filter: { _id: post._id },
@@ -270,27 +403,36 @@ async function normalizePosts(counts: PostCounts): Promise<{ scanned: number; up
 
     scanned += page.length;
     lastId = page[page.length - 1]._id;
-    logger.info(`[normalizeFederatedText] posts: scanned ${scanned}/${total}, rewritten ${updated + pendingOps.length}`);
+    logger.info(
+      `[normalizeFederatedText] posts: scanned ${scanned}/${total}, ${dryRun ? 'would rewrite' : 'rewriting'} ${changed}`,
+    );
   }
 
   await flush();
-  return { scanned, updated };
+  return { scanned, changed, written, counts, samples };
 }
 
 /** Normalize the remote text on every federated actor (both protocols). */
-async function normalizeActors(counts: ActorCounts): Promise<{ scanned: number; updated: number }> {
+async function normalizeActors(dryRun: boolean): Promise<CollectionResult<ActorCounts>> {
   const total = await FederatedActor.countDocuments({});
   logger.info(`[normalizeFederatedText] ${total} federated actors to scan`);
 
+  const counts: ActorCounts = { username: 0, summary: 0, fields: 0 };
+  const samples: DocumentSample[] = [];
   let scanned = 0;
-  let updated = 0;
+  let changed = 0;
+  let written = 0;
   let lastId: mongoose.Types.ObjectId | null = null;
   let pendingOps: mongoose.AnyBulkWriteOperation<typeof FederatedActor>[] = [];
 
   const flush = async (): Promise<void> => {
     if (pendingOps.length === 0) return;
+    if (dryRun) {
+      pendingOps = [];
+      return;
+    }
     const result = await FederatedActor.bulkWrite(pendingOps, { ordered: false });
-    updated += result.modifiedCount;
+    written += result.modifiedCount;
     pendingOps = [];
   };
 
@@ -314,9 +456,13 @@ async function normalizeActors(counts: ActorCounts): Promise<{ scanned: number; 
     for (const actor of page) {
       const { update, counts: actorCounts } = buildActorUpdate(actor);
       if (!hasChanges(update)) continue;
+      changed += 1;
       counts.username += actorCounts.username;
       counts.summary += actorCounts.summary;
       counts.fields += actorCounts.fields;
+      if (dryRun && samples.length < DRY_RUN_SAMPLE_SIZE) {
+        samples.push({ id: actor._id.toString(), changes: describeChanges(actor, update) });
+      }
       pendingOps.push({
         updateOne: {
           filter: { _id: actor._id },
@@ -328,36 +474,57 @@ async function normalizeActors(counts: ActorCounts): Promise<{ scanned: number; 
 
     scanned += page.length;
     lastId = page[page.length - 1]._id;
-    logger.info(`[normalizeFederatedText] actors: scanned ${scanned}/${total}, rewritten ${updated + pendingOps.length}`);
+    logger.info(
+      `[normalizeFederatedText] actors: scanned ${scanned}/${total}, ${dryRun ? 'would rewrite' : 'rewriting'} ${changed}`,
+    );
   }
 
   await flush();
-  return { scanned, updated };
+  return { scanned, changed, written, counts, samples };
+}
+
+/**
+ * Scan both collections, normalize (or, dry, plan) and report. Split from the
+ * entry point below so it can be driven without a MongoDB connection.
+ */
+export async function normalizeStoredText(dryRun: boolean): Promise<NormalizationSummary> {
+  const startedAt = Date.now();
+
+  const posts = await normalizePosts(dryRun);
+  logSamples('post', posts.samples);
+
+  const actors = await normalizeActors(dryRun);
+  logSamples('actor', actors.samples);
+
+  const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+  const describeWrites = (result: CollectionResult<unknown>): string =>
+    dryRun
+      ? `${result.changed} would be rewritten`
+      : `${result.written} rewritten (${result.changed} changed)`;
+
+  logger.info(
+    `[normalizeFederatedText] done in ${elapsedSeconds}s${dryRun ? ' — DRY RUN, nothing was written' : ''}: `
+    + `posts scanned ${posts.scanned}, ${describeWrites(posts)} `
+    + `(text ${posts.counts.text}, spoilerText ${posts.counts.spoilerText}, media alt ${posts.counts.mediaAlt}); `
+    + `actors scanned ${actors.scanned}, ${describeWrites(actors)} `
+    + `(username ${actors.counts.username}, summary ${actors.counts.summary}, fields ${actors.counts.fields})`,
+  );
+
+  return { dryRun, posts, actors };
 }
 
 async function normalizeFederatedText(): Promise<void> {
-  const startedAt = Date.now();
+  const dryRun = process.env.DRY_RUN === 'true';
   const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/mention';
   const dbName = `mention-${process.env.NODE_ENV || 'development'}`;
 
   try {
     await mongoose.connect(mongoUri, { dbName });
-    logger.info(`[normalizeFederatedText] connected to MongoDB (${dbName})`);
-
-    const postCounts: PostCounts = { text: 0, spoilerText: 0, mediaAlt: 0 };
-    const actorCounts: ActorCounts = { username: 0, summary: 0, fields: 0 };
-
-    const posts = await normalizePosts(postCounts);
-    const actors = await normalizeActors(actorCounts);
-
-    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
     logger.info(
-      `[normalizeFederatedText] done in ${elapsedSeconds}s: `
-      + `posts scanned ${posts.scanned}, rewritten ${posts.updated} `
-      + `(text ${postCounts.text}, spoilerText ${postCounts.spoilerText}, media alt ${postCounts.mediaAlt}); `
-      + `actors scanned ${actors.scanned}, rewritten ${actors.updated} `
-      + `(username ${actorCounts.username}, summary ${actorCounts.summary}, fields ${actorCounts.fields})`,
+      `[normalizeFederatedText] connected to MongoDB (${dbName})${dryRun ? ' — DRY RUN, no writes will be performed' : ''}`,
     );
+
+    await normalizeStoredText(dryRun);
 
     await mongoose.disconnect();
   } catch (error) {


### PR DESCRIPTION
## Summary

`scripts/normalizeFederatedText.ts` (merged in #395) rewrites the stored text of **hundreds of thousands** of federated posts and actors — `content.text`, `federation.spoilerText`, `content.media[].alt`, plus the `FederatedActor` fields.

It shipped with **no dry-run**: no way to see what it would touch before touching it. That is not something to point at production.

## What changed

`DRY_RUN=true` walks the same cursor and builds the same `bulkWrite` ops, and skips only the flush — so what it reports is literally what it *would* write, computed by the same code path rather than a parallel estimate that could drift from it.

It reports:
- documents scanned vs. documents that would **actually change** (clean docs are not counted),
- a per-field breakdown (`content.text` / `spoilerText` / `media alt` / `username` / `summary` / `fields`),
- a bounded sample of real before/after values, rendered with `JSON.stringify` — whitespace is the entire subject here, so a diff that hides it would be useless.

Same convention as the sibling scripts (oxy-api's `normalize-user-text-fields`, and `backfillThreadRootThreadId` in this same directory), so both halves of this migration are invoked identically:

```bash
DRY_RUN=true bun packages/backend/dist/src/scripts/normalizeFederatedText.js   # preview, writes nothing
bun packages/backend/dist/src/scripts/normalizeFederatedText.js                # apply
```

No change to the normalization logic or the field set. Cursor + batched `bulkWrite`, idempotency, writing only the docs that actually change, and `mongoose.disconnect()` + `process.exit()` are all preserved.

## Test plan

18 tests green (`bun run test src/__tests__/scripts/normalizeFederatedText.test.ts`) + clean build. New coverage: dry run calls `bulkWrite` on **no** model; the would-change count excludes already-clean docs; the before/after sample keeps whitespace visible; a second pass over normalized data reports zero changes (idempotent); and a real pass writes exactly the dirty docs, with `written` matching the count the dry run predicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)