### PR TITLE
ci: add the manual post-variants migration workflow

### DIFF
--- a/.github/workflows/run-post-variants-migration.yml
+++ b/.github/workflows/run-post-variants-migration.yml
@@ -1,0 +1,63 @@
+name: Run post-variants migration
+
+# One-shot migration onto the multilingual content model. Manual only.
+#
+# It runs in TWO PHASES, and the order matters. The new code reads
+# `content.variants` ONLY — there is no `content.text` fallback, by design — so a
+# post without variants renders blank:
+#
+#   1. phase=expand    with the OLD code still live. Posts gain their variants;
+#                      `content.text` stays put and nothing breaks.
+#   2. deploy          the new code.
+#   3. phase=expand    AGAIN. This is the step people skip, and it is the one that
+#                      matters: posts created during the deploy window were written
+#                      by the old code and have no variants yet.
+#   4. phase=contract  the old fields go.
+#
+# `dry_run` defaults to true. Run it that way first, read the plan, then re-run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      phase:
+        description: 'expand (write variants, safe with old code live) or contract (delete the old fields)'
+        required: true
+        type: choice
+        options:
+          - expand
+          - contract
+      dry_run:
+        description: 'Report what WOULD change, write nothing'
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  # Never let two migrations touch the collection at once.
+  group: post-variants-migration
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Run migration (phase=${{ inputs.phase }}, dry_run=${{ inputs.dry_run }})
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          NODE_ENV: production
+          PHASE: ${{ inputs.phase }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: bun packages/backend/dist/src/scripts/migratePostContentVariants.js


### PR DESCRIPTION
Adds a manually-dispatched workflow that runs the post-variants migration against production.

It has to live on `main` because `workflow_dispatch` only sees workflows on the default branch. The migration script itself ships with #398, and the job checks out whichever ref it is dispatched against.

**Why a workflow and not a laptop:** the migration needs `MONGODB_URI`, which lives in GitHub secrets, not on anyone's machine.

**Scoped deliberately:** it can run *this one script and nothing else*, `phase` is a fixed choice (`expand` / `contract`), `DRY_RUN` defaults to **true**, and a concurrency group stops two runs from touching the collection at once.

No application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)