### PR TITLE
ci: run the post-variants migration as an ECS one-shot

### DIFF
--- a/.github/workflows/run-post-variants-migration.yml
+++ b/.github/workflows/run-post-variants-migration.yml
@@ -2,23 +2,42 @@ name: Run post-variants migration
 
 # One-shot migration onto the multilingual content model. Manual only.
 #
-# It runs in TWO PHASES, and the order matters. The new code reads
-# `content.variants` ONLY — there is no `content.text` fallback, by design — so a
-# post without variants renders blank:
+# WHY IT IS SHAPED LIKE THIS — two constraints, both discovered the hard way:
 #
-#   1. phase=expand    with the OLD code still live. Posts gain their variants;
-#                      `content.text` stays put and nothing breaks.
-#   2. deploy          the new code.
-#   3. phase=expand    AGAIN. This is the step people skip, and it is the one that
-#                      matters: posts created during the deploy window were written
-#                      by the old code and have no variants yet.
-#   4. phase=contract  the old fields go.
+# 1. The database lives on a PRIVATE VPC address. A GitHub runner cannot reach it
+#    (it times out on connect), so the script has to run as an ECS task inside the
+#    VPC — which is what AGENTS.md means by "Fargate one-shot".
+#
+# 2. The migration script only exists on the branch that introduces it, but the
+#    RUNNING service must keep serving the OLD code while `expand` executes. So we
+#    build an image from `ref`, push it under its own tag (never `latest`), and run
+#    a one-shot task from a throwaway task-definition revision. The live service is
+#    never touched.
+#
+# The `expand` phase is safe to run while the old code is live: it only ADDS
+# `content.variants`. `contract` deletes the old fields and must run only once the
+# new code is fully deployed.
+#
+# THE ORDER MATTERS. The new code reads `content.variants` ONLY — there is no
+# `content.text` fallback, deliberately — so a post without variants has no body:
+#
+#   1. phase=expand    (old code live; posts gain their renditions, nothing breaks)
+#   2. deploy          the new code
+#   3. phase=expand    AGAIN — the step people skip, and the one that matters:
+#                      posts created during the deploy window were written by the
+#                      old code and have no variants yet
+#   4. phase=contract  (the old fields go)
 #
 # `dry_run` defaults to true. Run it that way first, read the plan, then re-run.
 
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Branch or SHA to build the migration image from'
+        required: true
+        type: string
+        default: 'main'
       phase:
         description: 'expand (write variants, safe with old code live) or contract (delete the old fields)'
         required: true
@@ -37,27 +56,140 @@ concurrency:
   group: post-variants-migration
   cancel-in-progress: false
 
+env:
+  AWS_REGION: us-west-2
+  APP: mention
+  CLUSTER: oxy-cluster
+  SERVICE: mention
+  DOCKERFILE: packages/backend/Dockerfile
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   migrate:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Same arch as the deployed image — the service runs linux/arm64.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          ref: ${{ inputs.ref }}
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Configure AWS credentials (OIDC, no stored keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: Build
-        run: bun run build
+      - name: Login to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Run migration (phase=${{ inputs.phase }}, dry_run=${{ inputs.dry_run }})
+      - name: Build and push the migration image (its own tag; never `latest`)
+        id: image
         env:
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
-          NODE_ENV: production
+          ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          TAG="migration-$(git rev-parse --short HEAD)"
+          IMG="$ECR_REGISTRY/oxy/$APP:$TAG"
+          docker build -f "$DOCKERFILE" -t "$IMG" .
+          docker push "$IMG"
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+          echo "Built $IMG"
+
+      - name: Run the migration as an ECS one-shot task
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
           PHASE: ${{ inputs.phase }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: bun packages/backend/dist/src/scripts/migratePostContentVariants.js
+        run: |
+          set -euo pipefail
+
+          # Take the task definition and network config from the LIVE service, so
+          # the one-shot runs with the same secrets, roles, subnets and security
+          # groups the backend already runs with. Nothing is hardcoded, and nothing
+          # drifts when the service is redeployed.
+          SERVICE_JSON=$(aws ecs describe-services \
+            --cluster "$CLUSTER" --services "$SERVICE" \
+            --query 'services[0]' --output json)
+
+          LIVE_TASK_DEF=$(echo "$SERVICE_JSON" | jq -r '.taskDefinition')
+          SUBNETS=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.subnets | join(",")')
+          SEC_GROUPS=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.securityGroups | join(",")')
+
+          echo "live task definition: $LIVE_TASK_DEF"
+
+          # A throwaway revision that differs from the live one ONLY by the image.
+          # The service keeps running its own revision; this one exists so the task
+          # can run code that is not deployed yet.
+          aws ecs describe-task-definition --task-definition "$LIVE_TASK_DEF" \
+            --query 'taskDefinition' --output json > live-taskdef.json
+
+          CONTAINER=$(jq -r '.containerDefinitions[0].name' live-taskdef.json)
+
+          jq --arg img "$IMAGE" '
+            .containerDefinitions[0].image = $img
+            | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                  .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)
+          ' live-taskdef.json > migration-taskdef.json
+
+          MIGRATION_TASK_DEF=$(aws ecs register-task-definition \
+            --cli-input-json file://migration-taskdef.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+
+          echo "migration task definition: $MIGRATION_TASK_DEF"
+
+          OVERRIDES=$(jq -nc \
+            --arg name "$CONTAINER" \
+            --arg phase "$PHASE" \
+            --arg dry "$DRY_RUN" \
+            '{containerOverrides:[{
+               name: $name,
+               command: ["bun","packages/backend/dist/src/scripts/migratePostContentVariants.js"],
+               environment: [
+                 {name:"PHASE", value:$phase},
+                 {name:"DRY_RUN", value:$dry}
+               ]
+             }]}')
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$CLUSTER" \
+            --task-definition "$MIGRATION_TASK_DEF" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SEC_GROUPS],assignPublicIp=DISABLED}" \
+            --overrides "$OVERRIDES" \
+            --started-by "gh-migration-$PHASE" \
+            --query 'tasks[0].taskArn' --output text)
+
+          echo "task: $TASK_ARN"
+          echo "Waiting for the task to stop…"
+          aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK_ARN"
+
+          TASK_ID="${TASK_ARN##*/}"
+          LOG_OPTS=$(jq -r '.containerDefinitions[0].logConfiguration.options' live-taskdef.json)
+          LOG_GROUP=$(echo "$LOG_OPTS" | jq -r '."awslogs-group"')
+          LOG_PREFIX=$(echo "$LOG_OPTS" | jq -r '."awslogs-stream-prefix"')
+
+          echo "──────── migration output ────────"
+          aws logs get-log-events \
+            --log-group-name "$LOG_GROUP" \
+            --log-stream-name "$LOG_PREFIX/$CONTAINER/$TASK_ID" \
+            --start-from-head \
+            --query 'events[].message' --output text || echo "(no logs retrieved)"
+          echo "──────────────────────────────────"
+
+          EXIT_CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' --output text)
+          REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].stoppedReason' --output text)
+
+          echo "exit code: $EXIT_CODE  (stopped reason: $REASON)"
+
+          # A migration whose result you cannot see is a migration you have not run.
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::Migration task exited with $EXIT_CODE"
+            exit 1
+          fi


### PR DESCRIPTION
Replaces the runner-based migration job (#399) after two instructive failures:

1. **The database is on a private VPC address.** A GitHub runner times out on connect — it is unreachable from outside AWS by design. The script has to run inside the VPC, which is what AGENTS.md means by *Fargate one-shot*.
2. **The script only exists on the branch that introduces it**, but the live service must keep serving the OLD code while `expand` runs — that is the entire point of the phase. So the job builds an image from the given `ref`, pushes it under **its own tag (never `latest`)**, and runs a one-shot task from a throwaway task-definition revision that differs from the live one only by the image. **The running service is never touched.**

Network config, secrets and roles are read from the live service, so nothing is hardcoded and nothing drifts on redeploy. The job waits for the task, prints its CloudWatch output, and fails on a non-zero exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->