### PR TITLE
fix(posts): normalize media alt at the write boundary, not on read

### DIFF
--- a/packages/backend/src/__tests__/scripts/normalizeFederatedText.test.ts
+++ b/packages/backend/src/__tests__/scripts/normalizeFederatedText.test.ts
@@ -109,12 +109,20 @@ vi.mock('../../utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+// The invariant test below drives the REAL ingest extractor. Only its media
+// materialization (network + S3) is mocked away; the text rules are the real ones.
+vi.mock('../../connectors/shared/federatedMedia', () => ({
+  materializeFederatedMedia: vi.fn(async (media: unknown[], attachments: unknown[]) => ({ media, attachments })),
+}));
+
 import {
   buildActorUpdate,
   buildPostUpdate,
   describeChanges,
   normalizeStoredText,
 } from '../../scripts/normalizeFederatedText';
+import { extractApSummary } from '../../connectors/activitypub/apPostContent';
+import { normalizeAlt } from '../../services/MediaMetadataService';
 
 /** The `_id` of the row under test — the builders only echo it into the filter. */
 const OID = new mongoose.Types.ObjectId('000000000000000000000001');
@@ -131,11 +139,29 @@ describe('buildPostUpdate', () => {
     const { update, counts } = buildPostUpdate({
       _id: OID,
       content: { variants: [{ source: 'author', text: DIRTY_TEXT }] },
+      // A federated post with no content warning: `federation` is PRESENT, which
+      // is what makes the body eligible.
+      federation: {},
     });
 
     expect(update.set['content.variants.0.text']).toBe(CLEAN_TEXT);
     expect(update.unset).toEqual({});
     expect(counts.text).toBe(1);
+  });
+
+  it('never rewrites the body of a NATIVE post — that text is the local author’s', () => {
+    // The scan covers every post now (native alt is dirty too), so what a row IS
+    // has to decide which of its fields are eligible.
+    const { update, counts } = buildPostUpdate({
+      _id: OID,
+      content: {
+        variants: [{ source: 'author', text: DIRTY_TEXT }],
+        media: [{ id: 'a', type: 'image', alt: '  un gato\n  en una caja ' }],
+      },
+    });
+
+    expect(update.set).toEqual({ 'content.media.0.alt': 'un gato en una caja' });
+    expect(counts).toEqual({ text: 0, spoilerText: 0, mediaAlt: 1 });
   });
 
   it('normalizes the content warning as inline text', () => {
@@ -145,6 +171,19 @@ describe('buildPostUpdate', () => {
     });
 
     expect(update.set['federation.spoilerText']).toBe('CW: spoilers');
+    expect(counts.spoilerText).toBe(1);
+  });
+
+  it('STRIPS THE MARKUP of a content warning the old ingest stored raw', () => {
+    // The ingest that wrote these rows persisted the AP `summary` verbatim, and a
+    // Mastodon summary arrives as HTML on plenty of servers. A backfill that only
+    // collapsed whitespace would leave `<p>…</p>` in the database forever.
+    const { update, counts } = buildPostUpdate({
+      _id: OID,
+      federation: { spoilerText: '<p>\n  Spoilers de <strong>la peli</strong>\n</p>' },
+    });
+
+    expect(update.set['federation.spoilerText']).toBe('Spoilers de la peli');
     expect(counts.spoilerText).toBe(1);
   });
 
@@ -207,6 +246,72 @@ describe('buildPostUpdate', () => {
   });
 });
 
+/**
+ * THE invariant this backfill lives or dies by: for the same input, it must produce
+ * exactly what the INGEST would produce today. Anything less and it "cleans" a row
+ * into a state no fresh write could ever reach — a second, divergent rule.
+ *
+ * It is not asserted against hardcoded strings but against the ingest functions
+ * themselves, so the two can never drift apart without this failing.
+ */
+describe('the backfill reproduces the ingest', () => {
+  /** Raw values as the OLD ingest stored them: HTML, padding, entities, empties. */
+  const STORED_SUMMARIES = [
+    '<p>Spoilers</p>',
+    '<p>\n  Spoilers de <strong>la peli</strong>\n</p>',
+    'CW:\n  spoilers',
+    'A &amp; B',
+    '<p>a</p><p>b</p>',
+    'ya limpio',
+    '   ',
+    '',
+  ];
+
+  it.each(STORED_SUMMARIES)('spoilerText: %j lands on exactly what the ingest extracts', (stored) => {
+    // What the ingest would write for this value if the Note arrived again today.
+    const ingested = extractApSummary({ summary: stored });
+
+    const { update } = buildPostUpdate({ _id: OID, federation: { spoilerText: stored } });
+
+    if (ingested === stored) {
+      // Already what the ingest produces: the backfill must not write at all.
+      expect(update.set['federation.spoilerText']).toBeUndefined();
+      expect(update.unset['federation.spoilerText']).toBeUndefined();
+      return;
+    }
+    if (ingested === undefined) {
+      // The ingest would omit the field, so the stored one must DISAPPEAR — a CW is
+      // read as "present ⇒ show it", and a blank label would render as an empty CW.
+      expect(update.unset['federation.spoilerText']).toBe('');
+      expect(update.set['federation.spoilerText']).toBeUndefined();
+      return;
+    }
+    expect(update.set['federation.spoilerText']).toBe(ingested);
+  });
+
+  const STORED_ALTS = ['  un gato\n  en una caja ', 'ya limpio', ' \n ', 'a  b'];
+
+  it.each(STORED_ALTS)('media alt: %j lands on exactly what the alt rule produces', (stored) => {
+    const canonical = normalizeAlt(stored);
+
+    const { update } = buildPostUpdate({
+      _id: OID,
+      content: { media: [{ id: 'a', type: 'image', alt: stored }] },
+    });
+
+    if (canonical === stored) {
+      expect(update.set['content.media.0.alt']).toBeUndefined();
+      expect(update.unset['content.media.0.alt']).toBeUndefined();
+      return;
+    }
+    if (canonical === undefined) {
+      expect(update.unset['content.media.0.alt']).toBe('');
+      return;
+    }
+    expect(update.set['content.media.0.alt']).toBe(canonical);
+  });
+});
+
 describe('buildActorUpdate', () => {
   it('normalizes the username inline and the bio as a body', () => {
     const { update, counts } = buildActorUpdate({
@@ -257,7 +362,11 @@ describe('buildActorUpdate', () => {
 
 describe('describeChanges', () => {
   it('quotes both sides so the whitespace being removed is actually visible', () => {
-    const post = { _id: OID, content: { variants: [{ source: 'author', text: DIRTY_TEXT }] } };
+    const post = {
+      _id: OID,
+      content: { variants: [{ source: 'author', text: DIRTY_TEXT }] },
+      federation: {},
+    };
     const { update } = buildPostUpdate(post);
 
     expect(describeChanges(post, update)).toEqual([
@@ -433,6 +542,30 @@ describe('normalizeStoredText — real run', () => {
     expect(h.state.actorOps[0].updateOne.update.$set).toEqual({
       username: 'alice',
       summary: 'hola\n\nadiós',
+    });
+  });
+
+  it('cleans the media alt of a NATIVE post while leaving its body alone', async () => {
+    // Native rows are the reason the scan is no longer filtered on `federation`:
+    // the composer's alt was stored verbatim, and the same raw value was signed
+    // onto the author's MTN chain, where nothing can ever fix it. The Mongo row —
+    // the one every read path actually serves — is what this cleans.
+    h.state.posts = [
+      {
+        _id: oid('1'),
+        content: {
+          variants: [{ source: 'author', text: DIRTY_TEXT }],
+          media: [{ id: 'a', type: 'image', alt: '  un gato\n  en una caja ' }],
+        },
+      },
+    ];
+
+    const summary = await normalizeStoredText(false);
+
+    expect(summary.posts.counts).toEqual({ text: 0, spoilerText: 0, mediaAlt: 1 });
+    expect(h.state.postOps).toHaveLength(1);
+    expect(h.state.postOps[0].updateOne.update.$set).toEqual({
+      'content.media.0.alt': 'un gato en una caja',
     });
   });
 

--- a/packages/backend/src/__tests__/utils/mediaInput.test.ts
+++ b/packages/backend/src/__tests__/utils/mediaInput.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { config } from '../../config';
+import { normalizeAltInput, normalizeMediaItems } from '../../utils/mediaInput';
+
+/**
+ * The WRITE boundary for client-supplied media.
+ *
+ * The alt text a Mention client sends is persisted on the post AND signed onto the
+ * author's MTN hash chain, where it is immutable. Normalizing it on the way OUT
+ * (`PostHydrationService`) makes the feed look right while a raw value is signed
+ * forever, so the invariant has to hold HERE — these tests are what pins it down.
+ *
+ * The rule itself is `normalizeAlt` (`services/MediaMetadataService.ts`), the same
+ * one the ActivityPub and atproto ingests apply; this boundary adds the product
+ * length cap on top.
+ */
+
+describe('normalizeAltInput', () => {
+  it('collapses the whitespace INSIDE the value, not just at its ends', () => {
+    // The bug a bare `.trim()` cannot see: an embedded newline survives it, and
+    // clients render text with `white-space: pre-wrap`.
+    expect(normalizeAltInput('un gato\n\n   en una caja')).toBe('un gato en una caja');
+    expect(normalizeAltInput('  un gato  ')).toBe('un gato');
+  });
+
+  it('drops an empty / whitespace-only / non-string value so the field stays ABSENT', () => {
+    expect(normalizeAltInput('   \n  ')).toBeUndefined();
+    expect(normalizeAltInput('')).toBeUndefined();
+    expect(normalizeAltInput(undefined)).toBeUndefined();
+    expect(normalizeAltInput(42)).toBeUndefined();
+  });
+
+  it('caps the length and leaves no dangling whitespace at the cut', () => {
+    const cap = config.posts.maxAltTextLength;
+    const alt = normalizeAltInput(`${'a'.repeat(cap - 1)} bcd`);
+
+    expect(alt).toBeDefined();
+    expect(alt?.length).toBeLessThanOrEqual(cap);
+    // The cut falls right after the space, which must not survive as a trailing one.
+    expect(alt).toBe('a'.repeat(cap - 1));
+  });
+
+  it('is idempotent — a value that already went through it is untouched', () => {
+    const once = normalizeAltInput(' un   gato\nen una caja ');
+    expect(normalizeAltInput(once)).toBe(once);
+  });
+});
+
+describe('normalizeMediaItems', () => {
+  it('normalizes the alt of every accepted item', () => {
+    expect(normalizeMediaItems([
+      { id: 'a', type: 'image', alt: '  un gato\n  en una caja ' },
+      { id: 'b', type: 'video', alt: 'ya limpio' },
+    ])).toEqual([
+      { id: 'a', type: 'image', alt: 'un gato en una caja' },
+      { id: 'b', type: 'video', alt: 'ya limpio' },
+    ]);
+  });
+
+  it('omits an alt that normalizes to nothing rather than storing an empty string', () => {
+    // `alt` is read as "present ⇒ describe the image", so a blank one is a lie the
+    // screen reader would have to announce.
+    expect(normalizeMediaItems([{ id: 'a', type: 'image', alt: ' \n ' }])).toEqual([
+      { id: 'a', type: 'image' },
+    ]);
+  });
+
+  it('still whitelists the fields it accepts — client metadata is never trusted', () => {
+    expect(normalizeMediaItems([
+      { id: 'a', type: 'image', alt: ' hola ', width: 9999, cachedFromFederation: true },
+    ])).toEqual([{ id: 'a', type: 'image', alt: 'hola' }]);
+  });
+});

--- a/packages/backend/src/__tests__/utils/pushPreview.test.ts
+++ b/packages/backend/src/__tests__/utils/pushPreview.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * The push-notification preview: a ONE-LINE label built from a post body, which
+ * on a federated post carries the remote markup's newlines and indentation. It
+ * used to collapse that whitespace with its own inline regex — the fifth copy of
+ * the canonical collapser in the ecosystem. It now delegates to
+ * `normalizeInlineText`, keeping only its own product rule: the length budget.
+ *
+ * `push.ts` pulls in firebase-admin and the Mongo models at import time, so both
+ * are stubbed — `buildPreview` itself is pure.
+ */
+vi.mock('firebase-admin', () => ({ default: { apps: [], initializeApp: vi.fn(), credential: { cert: vi.fn() } } }));
+vi.mock('../../models/PushToken', () => ({ default: { find: vi.fn() } }));
+vi.mock('../../models/Post', () => ({ default: { findById: vi.fn() } }));
+vi.mock('../../utils/oxyHelpers', () => ({ getServiceOxyClient: vi.fn() }));
+
+import { buildPreview } from '../../utils/push';
+
+describe('buildPreview', () => {
+  it('collapses the newlines and indentation of a federated post body', () => {
+    expect(buildPreview('  Hola\n\n      mundo  ')).toBe('Hola mundo');
+  });
+
+  it('collapses tabs, CRLF and non-breaking spaces', () => {
+    expect(buildPreview('uno\r\n\tdos  tres')).toBe('uno dos tres');
+  });
+
+  it('truncates to the limit with an ellipsis — the length budget stays a push rule', () => {
+    expect(buildPreview('a'.repeat(250), 200)).toBe(`${'a'.repeat(200)}…`);
+    expect(buildPreview('a'.repeat(200), 200)).toBe('a'.repeat(200));
+  });
+
+  it('measures the limit AFTER collapsing, not against the raw text', () => {
+    // 10 words padded with runs of whitespace: raw length is far over the limit,
+    // the collapsed preview is not, so nothing is truncated.
+    const padded = Array.from({ length: 10 }, () => 'hola').join('\n\n      ');
+    expect(buildPreview(padded, 60)).toBe(Array.from({ length: 10 }, () => 'hola').join(' '));
+  });
+
+  it('returns an empty string for empty or whitespace-only text', () => {
+    expect(buildPreview('')).toBe('');
+    expect(buildPreview('   \n\t  ')).toBe('');
+  });
+});

--- a/packages/backend/src/connectors/activitypub/apPostContent.ts
+++ b/packages/backend/src/connectors/activitypub/apPostContent.ts
@@ -4,8 +4,8 @@ import {
   type MediaItem,
   type PostContentVariant,
 } from '@mention/shared-types';
-import { normalizeInlineText, normalizeMultilineText } from '@oxyhq/core';
-import { htmlToPlainText } from '../../utils/federation/htmlToPlainText';
+import { normalizeMultilineText } from '@oxyhq/core';
+import { htmlToInlineLabel, htmlToPlainText } from '../../utils/federation/htmlToPlainText';
 import { normalizePostHashtags } from '../../utils/textProcessing';
 import { materializeFederatedMedia, type ExtractedMediaAttachment } from '../shared/federatedMedia';
 import { extractApHashtags, extractApMedia } from './helpers';
@@ -238,21 +238,22 @@ function buildApAuthorVariants(
  * Two things the raw field cannot be trusted for:
  *  1. It is HTML on some servers (the AP spec types it as a natural-language
  *     HTML string, and Mastodon's own CW is plain text only by convention), so
- *     it goes through {@link htmlToPlainText} exactly like the body — otherwise
- *     raw tags reach the CW label in the UI.
- *  2. It arrives with the remote markup's whitespace. A CW label is ONE LINE, so
- *     it is finished with `normalizeInlineText`: an embedded newline would be
- *     rendered verbatim by the client (`white-space: pre-wrap`) and break the
- *     label's layout.
+ *     the tags must be stripped exactly like the body's — otherwise raw markup
+ *     reaches the CW label in the UI.
+ *  2. It arrives with the remote markup's whitespace. A CW label is ONE LINE: an
+ *     embedded newline would be rendered verbatim by the client
+ *     (`white-space: pre-wrap`) and break the label's layout.
+ *
+ * Both are {@link htmlToInlineLabel}, which is deliberately NOT inlined here: the
+ * one-shot backfill re-normalizes the labels the OLD ingest stored raw, and it has
+ * to reproduce this function exactly. Sharing the rule is what makes that true by
+ * construction rather than by review.
  *
  * Returns `undefined` for a missing / non-string / whitespace-only summary,
  * which is what the empty-note guard and the `Update` unset path both key on.
  */
 export function extractApSummary(object: Record<string, unknown> | null | undefined): string | undefined {
-  const raw = object?.summary;
-  if (typeof raw !== 'string') return undefined;
-  const summary = normalizeInlineText(htmlToPlainText(raw));
-  return summary.length > 0 ? summary : undefined;
+  return htmlToInlineLabel(object?.summary);
 }
 
 /**

--- a/packages/backend/src/connectors/atproto/post.mapper.ts
+++ b/packages/backend/src/connectors/atproto/post.mapper.ts
@@ -1,7 +1,8 @@
 import { PostVisibility } from '@mention/shared-types';
-import { normalizeInlineText, normalizeMultilineText } from '@oxyhq/core';
+import { normalizeMultilineText } from '@oxyhq/core';
 import { logger } from '../../utils/logger';
 import { Post } from '../../models/Post';
+import { normalizeAlt } from '../../services/MediaMetadataService';
 import { getPostCreator } from '../../services/serviceRegistry';
 import { materializeFederatedMedia, type ExtractedMediaAttachment } from '../shared/federatedMedia';
 import type { MediaItem } from '@mention/shared-types';
@@ -161,14 +162,14 @@ function extractMediaFromEmbed(embed: AtprotoEmbedView | undefined): NormalizedE
         for (const image of view.images ?? []) {
           const url = image?.fullsize || image?.thumb;
           if (typeof url === 'string' && url) {
-            // Alt text is a one-line label authored on a remote client: collapse
-            // the whitespace it arrived with (the client renders it verbatim).
-            const alt = typeof image.alt === 'string' ? normalizeInlineText(image.alt) : '';
+            // Alt text is a one-line label authored on a remote client, so it gets
+            // the SAME canonical rule as every other alt in the system (native
+            // writes, AP attachments): whitespace-only becomes absent, never `''`.
             out.push({
               id: url,
               type: 'image',
               remoteUrl: url,
-              alt: alt || undefined,
+              alt: normalizeAlt(image.alt),
               ...patchFromAspectRatio(image.aspectRatio),
             });
           }

--- a/packages/backend/src/connectors/federatedProfileSync.ts
+++ b/packages/backend/src/connectors/federatedProfileSync.ts
@@ -20,7 +20,7 @@
  * a loading state and refetches shortly, instead of rendering an empty profile.
  */
 
-import type { User } from '@oxyhq/core';
+import { normalizeInlineText, type User } from '@oxyhq/core';
 import { Post } from '../models/Post';
 import FederatedActor, { IFederatedActor } from '../models/FederatedActor';
 import { logger } from '../utils/logger';
@@ -177,7 +177,11 @@ class FederatedProfileSync {
             // with a guessed outbox so the sync can still attempt Mastodon-style
             // layouts; the enqueued background refresh will correct it later.
             const domain = new URL(actorUri).hostname;
-            const username = (acctHint || '').split('@')[0] || 'unknown';
+            // The handle hint is remote text, and this row is written straight to
+            // Mongo: the schema normalizes NOTHING (see `models/FederatedActor.ts`),
+            // so this writer applies the canonical rule itself — a padded hint must
+            // not become a padded username in a unique index.
+            const username = normalizeInlineText((acctHint || '').split('@')[0]) || 'unknown';
             const acct = `${username}@${domain}`;
             const fallbackOutboxUrl = `${actorUri}${actorUri.endsWith('/') ? '' : '/'}outbox`;
             logger.info(`[FedSync] fetchRemoteActor failed for ${actorUri}; creating minimal FederatedActor with fallback outboxUrl=${fallbackOutboxUrl}`);

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -27,6 +27,7 @@ import {
   FEED_CONSTANTS
 } from '../utils/feedUtils';
 import { mergeHashtags } from '../utils/textProcessing';
+import { normalizeMediaItems } from '../utils/mediaInput';
 import { queryString } from '../utils/queryParams';
 import { buildAuthorship } from '../utils/postAuthorship';
 import { validatePublicShareTarget } from '../utils/postAccessControl';
@@ -165,6 +166,16 @@ class FeedController {
   // is only `{ syraPodcastId }` (input), so we drop it here and re-attach the
   // server-denormalized show below; everything else carries over.
   const replyContent: PostContent = typeof content === 'string' ? { text: content } : { ...(content ?? { text: '' }), podcast: undefined };
+
+      // A reply carries composer media, so it is a write boundary like
+      // `POST /posts`: the client's items go through the SAME normalizer
+      // (whitelisted fields, canonical alt text, length cap). This path persists
+      // the document itself — and signs it onto the author's MTN hash chain —
+      // so an un-normalized `alt` accepted here would be immutable.
+      if (Array.isArray(replyContent.media)) {
+        replyContent.media = normalizeMediaItems(replyContent.media);
+      }
+
       const currentUserId = req.user?.id;
 
       if (!currentUserId) {

--- a/packages/backend/src/models/FederatedActor.ts
+++ b/packages/backend/src/models/FederatedActor.ts
@@ -78,21 +78,38 @@ export interface IFederatedActor extends Document {
 }
 
 /**
- * Every text field on this model is REMOTE text, so each one carries `trim`.
- * That is defense in depth ONLY: Mongoose's `trim` strips the ends of the string
- * and does nothing to the whitespace INSIDE it, which is where the damage is (a
- * newline in a display name, a blank line in a bio). The real normalization
- * happens at ingest — `actor.service.ts` and `profile.mapper.ts` run every one
- * of these values through the canonical `normalizeInlineText` /
- * `normalizeMultilineText` from `@oxyhq/core` before they ever reach the model.
+ * THE SCHEMA DOES NOT NORMALIZE TEXT. Every text field here is REMOTE text, and
+ * the invariant "what is stored is already canonical" is owned by the INGEST
+ * paths, in exactly one place per field:
+ *
+ *   - `connectors/activitypub/actor.service.ts` — strips the HTML of `summary`
+ *     and the profile fields, entity-decodes the display name, then applies
+ *     `normalizeMultilineText` / `normalizeInlineText` from `@oxyhq/core`.
+ *   - `connectors/atproto/profile.mapper.ts` — the same rules for a Bluesky
+ *     profile.
+ *   - `connectors/federatedProfileSync.ts` — the minimal fallback row written when
+ *     the remote actor cannot be fetched.
+ *
+ * These fields USED to carry Mongoose's `trim`, which was worse than nothing: it
+ * strips the ENDS of a string and does nothing to the whitespace INSIDE it — the
+ * newline in a display name, the blank line in a bio — which is the entire bug.
+ * A writer that saw `trim: true` on the schema and assumed the model had it
+ * covered would ship exactly that bug. Half an invariant, enforced in a second
+ * place, is a trap; it is gone.
+ *
+ * The model cannot own this anyway: the ingest has to strip markup and decode
+ * entities BEFORE normalizing (an encoded `&#10;` is only whitespace once
+ * decoded), so a setter here could never be the whole rule — only a duplicate of
+ * its tail. A NEW WRITER MUST NORMALIZE ITS OWN VALUES. Legacy rows are cleaned
+ * by `scripts/normalizeFederatedText.ts`.
  */
 const FederatedActorSchema = new Schema<IFederatedActor>({
   protocol: { type: String, enum: ['activitypub', 'atproto'], default: 'activitypub', index: true },
-  uri: { type: String, required: true, unique: true, index: true, trim: true },
-  username: { type: String, required: true, trim: true },
-  domain: { type: String, required: true, index: true, trim: true },
-  acct: { type: String, required: true, unique: true, index: true, trim: true },
-  summary: { type: String, trim: true },
+  uri: { type: String, required: true, unique: true, index: true },
+  username: { type: String, required: true },
+  domain: { type: String, required: true, index: true },
+  acct: { type: String, required: true, unique: true, index: true },
+  summary: { type: String },
   avatarUrl: { type: String },
   headerUrl: { type: String },
   inboxUrl: { type: String },
@@ -108,8 +125,8 @@ const FederatedActorSchema = new Schema<IFederatedActor>({
   memorial: { type: Boolean, default: false },
   suspended: { type: Boolean, default: false },
   fields: [{
-    name: { type: String, trim: true },
-    value: { type: String, trim: true },
+    name: { type: String },
+    value: { type: String },
     verifiedAt: { type: Date },
   }],
   featuredUrl: { type: String },

--- a/packages/backend/src/scripts/normalizeFederatedText.ts
+++ b/packages/backend/src/scripts/normalizeFederatedText.ts
@@ -1,31 +1,51 @@
 /**
- * One-shot backfill: normalize the whitespace of every piece of REMOTE text
- * already stored in Mongo.
+ * One-shot backfill: normalize the whitespace of the text already stored in
+ * Mongo — every piece of REMOTE text, plus the media `alt` of native posts.
  *
  * Third-party text used to be persisted exactly as the remote server sent it —
  * indentation, embedded newlines and all. That is invisible in HTML (whitespace
  * collapses at render time) but NOT in our clients: React Native Web renders
  * `Text` with `white-space: pre-wrap`, so a pretty-printed remote body
  * (`<p>\n      Hola\n    </p>`) showed up as a blank line plus a six-space
- * indent. The ingest paths now run every remote value through the canonical
- * `normalizeInlineText` / `normalizeMultilineText` from `@oxyhq/core`, but rows
- * written before that fix stay dirty forever — nothing rewrites a stored post,
- * and an actor is only rewritten if the remote profile happens to change. This
- * script cleans them.
+ * indent. Alt text written by our OWN composer had the same problem for the same
+ * reason: it was stored verbatim. The ingest and write paths now run every value
+ * through the canonical rule that owns its field, but rows written before that
+ * fix stay dirty forever — nothing rewrites a stored post, and an actor is only
+ * rewritten if the remote profile happens to change. This script cleans them.
  *
- * What it normalizes (the same helper the ingest path now uses for each field):
+ * What it normalizes (in every case by calling the SAME function the ingest /
+ * write path calls — never a second copy of the rule):
  *   - `Post.content.variants[].text` — MULTILINE (the author's paragraphs survive).
  *                                    EVERY rendition, not just the primary: each
  *                                    one is remote text and each one is rendered.
- *   - `Post.federation.spoilerText`— INLINE (a CW label is one line; unset when
- *                                    it normalizes to empty)
- *   - `Post.content.media[].alt`   — INLINE (unset when it normalizes to empty)
+ *                                    FEDERATED posts only.
+ *   - `Post.federation.spoilerText`— `htmlToInlineLabel`, the ingest's own summary
+ *                                    rule. NOT a bare inline collapse: the ingest
+ *                                    that wrote these rows stored the AP `summary`
+ *                                    RAW, so a stored CW can still contain
+ *                                    `<p>…</p>`, and stripping the markup is half
+ *                                    of what the current ingest does. Unset when it
+ *                                    normalizes to empty. FEDERATED posts only.
+ *   - `Post.content.media[].alt`   — `normalizeAlt`, the canonical alt rule, on
+ *                                    NATIVE AND FEDERATED posts alike (unset when
+ *                                    it normalizes to empty). A native alt is not
+ *                                    the author's prose — it is a one-line label,
+ *                                    and until the write boundary enforced the rule
+ *                                    the composer's value was stored verbatim.
  *   - `FederatedActor.username`    — INLINE
  *   - `FederatedActor.summary`     — MULTILINE (a bio is a body)
  *   - `FederatedActor.fields[].name` / `.value` — INLINE
  *
- * Only FEDERATED posts (`federation != null`) are touched: native post bodies
- * are the local author's own text and are not ours to rewrite.
+ * Post BODIES are rewritten only on FEDERATED posts: a native body is the local
+ * author's own text and is not ours to touch. Media `alt` is the one field this
+ * script normalizes on native rows too.
+ *
+ * WHAT IT CANNOT FIX: a native post is also dual-written as a SIGNED record on the
+ * author's MTN hash chain, and a signed record is immutable. Rows whose alt was
+ * signed before the write boundary was fixed keep that raw alt on-chain forever;
+ * this script cleans the Mongo row that every read path actually serves. There is
+ * no backfill for the chain, and there must not be one — rewriting a signed record
+ * would break the chain it belongs to.
  *
  * Idempotent (a second run writes nothing), batched through a stable ascending
  * `_id` cursor with `bulkWrite` (never loads the collection into memory), and it
@@ -59,6 +79,8 @@ import mongoose from 'mongoose';
 import { normalizeInlineText, normalizeMultilineText } from '@oxyhq/core';
 import { Post } from '../models/Post';
 import FederatedActor from '../models/FederatedActor';
+import { normalizeAlt } from '../services/MediaMetadataService';
+import { htmlToInlineLabel } from '../utils/federation/htmlToPlainText';
 import { logger } from '../utils/logger';
 
 /** Documents scanned per page (stable `_id` cursor pagination). */
@@ -70,8 +92,13 @@ const BULK_CHUNK_SIZE = 500;
 /** How many changed documents a dry run reports in full, per collection. */
 const DRY_RUN_SAMPLE_SIZE = 20;
 
-/** Matches the posts that carry remote text: everything with AP/atproto metadata. */
-const FEDERATED_POST_FILTER: Record<string, unknown> = { federation: { $ne: null } };
+/**
+ * EVERY post is scanned, native and federated alike: media `alt` is dirty on both
+ * (see the header). What a row is decides which of its fields are eligible, not
+ * whether it is looked at — {@link buildPostUpdate} keys that off `federation`,
+ * which is why the subdocument is projected rather than a single field of it.
+ */
+const POST_SCAN_FILTER: Record<string, unknown> = {};
 
 /** The fields this script reads off a post (nothing else is loaded). */
 export interface FederatedPostRow {
@@ -80,9 +107,10 @@ export interface FederatedPostRow {
     variants?: unknown;
     media?: unknown;
   };
+  /** Present ⇒ the post came from a remote network. Absent/null ⇒ native. */
   federation?: {
     spoilerText?: unknown;
-  };
+  } | null;
 }
 
 /** The fields this script reads off a federated actor. */
@@ -175,15 +203,23 @@ function toUpdateDocument(update: DocumentUpdate): Record<string, unknown> {
 }
 
 /**
- * Stage an OPTIONAL inline label: rewritten when it changes, unset when it
- * normalizes to nothing. A non-string stored value is left untouched — this
- * script normalizes whitespace, it does not repair a corrupt schema.
+ * Stage an OPTIONAL label: rewritten when it changes, unset when it normalizes to
+ * nothing. `normalize` is the rule that OWNS the field — the very function its
+ * write path calls — so what this script produces is what a fresh write would.
+ *
+ * A non-string stored value is left untouched (the rules all return `undefined`
+ * for one): this script normalizes text, it does not repair a corrupt schema.
  */
-function stageOptionalInline(update: DocumentUpdate, path: string, value: unknown): boolean {
+function stageOptionalLabel(
+  update: DocumentUpdate,
+  path: string,
+  value: unknown,
+  normalize: (value: unknown) => string | undefined,
+): boolean {
   if (typeof value !== 'string') return false;
-  const normalized = normalizeInlineText(value);
+  const normalized = normalize(value);
   if (normalized === value) return false;
-  if (normalized.length === 0) {
+  if (normalized === undefined) {
     update.unset[path] = '';
   } else {
     update.set[path] = normalized;
@@ -191,17 +227,19 @@ function stageOptionalInline(update: DocumentUpdate, path: string, value: unknow
   return true;
 }
 
-/** Collect every normalization needed by a single federated post. */
+/** Collect every normalization needed by a single post. */
 export function buildPostUpdate(post: FederatedPostRow): { update: DocumentUpdate; counts: PostCounts } {
   const update = emptyUpdate();
   const counts: PostCounts = { text: 0, spoilerText: 0, mediaAlt: 0 };
+  const isFederated = post.federation !== undefined && post.federation !== null;
 
-  // Each rendition is addressed by INDEX, so the untouched fields of a variant
-  // (its tag, source, alt map, media override) are never re-serialized and cannot
-  // be lost. The body always stays a string — an empty rendition is not written
-  // back as one, it simply never existed.
+  // A BODY is only rewritten on a federated post — a native body is the local
+  // author's own text. Each rendition is addressed by INDEX, so the untouched
+  // fields of a variant (its tag, source, alt map, media override) are never
+  // re-serialized and cannot be lost. The body always stays a string — an empty
+  // rendition is not written back as one, it simply never existed.
   const variants = post.content?.variants;
-  if (Array.isArray(variants)) {
+  if (isFederated && Array.isArray(variants)) {
     variants.forEach((variant, index) => {
       if (typeof variant !== 'object' || variant === null) return;
       const text = (variant as { text?: unknown }).text;
@@ -213,10 +251,17 @@ export function buildPostUpdate(post: FederatedPostRow): { update: DocumentUpdat
     });
   }
 
-  if (stageOptionalInline(update, 'federation.spoilerText', post.federation?.spoilerText)) {
+  // The CW goes through the INGEST'S OWN summary rule, markup strip included: the
+  // ingest that wrote these rows stored the AP `summary` raw, so a stored label
+  // can still be `<p>CW</p>`, and a bare whitespace collapse would leave the tags
+  // in the database forever.
+  if (stageOptionalLabel(update, 'federation.spoilerText', post.federation?.spoilerText, htmlToInlineLabel)) {
     counts.spoilerText += 1;
   }
 
+  // Media `alt` is normalized on NATIVE posts too: it is a one-line label, not the
+  // author's prose, and the composer's value used to be stored verbatim.
+  //
   // `content.media` is a Mixed array, so each item is addressed by index rather
   // than rewriting the whole array — the untouched fields of an item (id, type,
   // dimensions, cache flags) are never re-serialized and cannot be lost.
@@ -225,7 +270,7 @@ export function buildPostUpdate(post: FederatedPostRow): { update: DocumentUpdat
     media.forEach((item, index) => {
       if (typeof item !== 'object' || item === null) return;
       const alt = (item as { alt?: unknown }).alt;
-      if (stageOptionalInline(update, `content.media.${index}.alt`, alt)) {
+      if (stageOptionalLabel(update, `content.media.${index}.alt`, alt, normalizeAlt)) {
         counts.mediaAlt += 1;
       }
     });
@@ -343,14 +388,15 @@ function logSamples(kind: string, samples: DocumentSample[]): void {
 }
 
 /**
- * Normalize the remote text on every federated post.
+ * Normalize the stored text on every post.
  *
- * Pages by ascending `_id` over a filter that only matches on `federation`,
- * which this script never mutates — so the scanned set is stable for the run.
+ * Pages by ascending `_id`; the scan matches every document and this script
+ * mutates none of the fields it pages on, so the scanned set is stable for the
+ * run.
  */
 async function normalizePosts(dryRun: boolean): Promise<CollectionResult<PostCounts>> {
-  const total = await Post.countDocuments(FEDERATED_POST_FILTER);
-  logger.info(`[normalizeFederatedText] ${total} federated posts to scan`);
+  const total = await Post.countDocuments(POST_SCAN_FILTER);
+  logger.info(`[normalizeFederatedText] ${total} posts to scan`);
 
   const counts: PostCounts = { text: 0, spoilerText: 0, mediaAlt: 0 };
   const samples: DocumentSample[] = [];
@@ -375,14 +421,17 @@ async function normalizePosts(dryRun: boolean): Promise<CollectionResult<PostCou
   };
 
   for (;;) {
-    const pageFilter: Record<string, unknown> = { ...FEDERATED_POST_FILTER };
+    const pageFilter: Record<string, unknown> = { ...POST_SCAN_FILTER };
     if (lastId) pageFilter._id = { $gt: lastId };
 
+    // `federation` is projected whole (it is a 6-field subdocument) so its mere
+    // PRESENCE can be read: that is what tells a native row from a federated one,
+    // and projecting `federation.spoilerText` alone could not.
     const page = await Post.find(pageFilter, {
       _id: 1,
       'content.variants': 1,
       'content.media': 1,
-      'federation.spoilerText': 1,
+      federation: 1,
     })
       .sort({ _id: 1 })
       .limit(PAGE_SIZE)

--- a/packages/backend/src/services/MediaMetadataService.ts
+++ b/packages/backend/src/services/MediaMetadataService.ts
@@ -23,24 +23,39 @@ function positiveNumber(value: unknown): number | undefined {
 }
 
 /**
- * Normalize an `alt` value at every entry point it can reach a media item.
+ * THE alt-text rule. Every path that can put an `alt` on a media item runs a
+ * value through this and nothing else: the native write boundary
+ * (`utils/mediaInput.ts`, which caps the length on top), the ActivityPub ingest
+ * ({@link patchFromApAttachment}), the atproto ingest (`connectors/atproto/post.mapper.ts`)
+ * and the one-shot backfill that cleans legacy rows.
  *
- * Alt text is a ONE-LINE label, and on a federated item it is third-party text:
- * it carries whatever whitespace the remote markup held. Clients render text
- * faithfully (React Native Web maps `Text` to `white-space: pre-wrap`), so an
- * embedded newline or a run of spaces would be visible, hence the canonical
- * inline normalizer rather than a bare `.trim()`.
+ * Alt text is a ONE-LINE label carrying whatever whitespace its author's client
+ * (ours or a remote one) happened to send. Clients render text faithfully (React
+ * Native Web maps `Text` to `white-space: pre-wrap`), so an embedded newline or a
+ * run of spaces would be visible, hence the canonical inline normalizer rather
+ * than a bare `.trim()`.
+ *
+ * It has to hold at the WRITE boundary, not just on the way out: a native post's
+ * media is signed onto the author's MTN hash chain (`mentionRecordBuilders`), and
+ * a signed record is immutable — an un-normalized alt persisted there can never
+ * be repaired, by this or any other backfill.
  *
  * Returns undefined for a missing / non-string / whitespace-only value so the
  * caller omits the field instead of storing a blank one.
  */
-function normalizeAlt(value: unknown): string | undefined {
+export function normalizeAlt(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const alt = normalizeInlineText(value);
   return alt.length > 0 ? alt : undefined;
 }
 
-/** Copy persisted intrinsic fields from a raw Mongo/hydration object. */
+/**
+ * Copy persisted intrinsic fields from a raw Mongo/hydration object.
+ *
+ * The {@link normalizeAlt} call below is a READ BACKSTOP for legacy rows written
+ * before the write boundary enforced the rule — NOT where the invariant lives.
+ * Everything stored from now on is already normalized (see {@link normalizeAlt}).
+ */
 export function readPersistedMediaFields(raw: Record<string, unknown>): Partial<MediaItem> {
   const out: Partial<MediaItem> = {};
   const width = positiveInt(raw.width);

--- a/packages/backend/src/services/postVariants.ts
+++ b/packages/backend/src/services/postVariants.ts
@@ -9,7 +9,7 @@ import {
   type StoredPostContent,
 } from '@mention/shared-types';
 import { config } from '../config';
-import { normalizeMediaItems } from '../utils/mediaInput';
+import { normalizeAltInput, normalizeMediaItems } from '../utils/mediaInput';
 
 /**
  * Multilingual post content: the ONE place that knows how a localized rendition
@@ -378,9 +378,11 @@ function normalizeAltMap(
     if (typeof value !== 'string') {
       return { ok: false, error: `Language variant ${tag} has a non-text alt description` };
     }
-    const trimmed = value.trim().slice(0, config.posts.maxAltTextLength);
-    if (trimmed.length > 0) {
-      alt[mediaId] = trimmed;
+    // A localized description is alt text like any other: same rule, same cap as
+    // the `alt` on a media item ({@link normalizeAltInput}).
+    const normalized = normalizeAltInput(value);
+    if (normalized !== undefined) {
+      alt[mediaId] = normalized;
     }
   }
   return { ok: true, alt };

--- a/packages/backend/src/utils/federation/htmlToPlainText.ts
+++ b/packages/backend/src/utils/federation/htmlToPlainText.ts
@@ -1,5 +1,5 @@
 import { decode as decodeEntities } from 'he';
-import { normalizeMultilineText } from '@oxyhq/core';
+import { normalizeInlineText, normalizeMultilineText } from '@oxyhq/core';
 
 /**
  * Convert ActivityPub HTML content to plain text for storage.
@@ -42,4 +42,30 @@ export function htmlToPlainText(html: string): string {
 
   // Normalize the whitespace the source markup left behind (see above).
   return normalizeMultilineText(text);
+}
+
+/**
+ * THE rule for a remote ONE-LINE LABEL that arrives as markup — today the
+ * ActivityPub `summary` (the content warning).
+ *
+ * A CW is a single line: {@link htmlToPlainText} strips the tags and decodes the
+ * entities, then the canonical inline normalizer collapses what is left onto one
+ * line. Both steps are needed and both are load-bearing — a Mastodon summary
+ * arrives as `<p>…</p>` on some servers and as bare text on others.
+ *
+ * Lives here, below the connector, because TWO callers must produce byte-identical
+ * output from the same input: the ingest ({@link extractApSummary}) and the
+ * one-shot backfill that re-normalizes the labels stored by the OLD ingest, which
+ * persisted the summary raw — HTML included. A backfill that applied only half of
+ * this rule would leave `<p>…</p>` sitting in the database forever.
+ *
+ * Returns undefined when nothing is left, which is what "no content warning" is:
+ * the field must be ABSENT, never an empty string.
+ *
+ * Idempotent — running it over an already-clean label is a no-op.
+ */
+export function htmlToInlineLabel(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const label = normalizeInlineText(htmlToPlainText(value));
+  return label.length > 0 ? label : undefined;
 }

--- a/packages/backend/src/utils/mediaInput.ts
+++ b/packages/backend/src/utils/mediaInput.ts
@@ -1,4 +1,5 @@
 import { config } from '../config';
+import { normalizeAlt } from '../services/MediaMetadataService';
 
 /**
  * A media entry accepted from a request body, normalized to the persisted shape.
@@ -10,8 +11,27 @@ export interface NormalizedMediaItem {
   id: string;
   type: 'image' | 'video' | 'gif';
   mime?: string;
-  /** Accessibility description (alt text) for the image; trimmed + length-capped. */
+  /** Accessibility description (alt text) for the image; normalized + length-capped. */
   alt?: string;
+}
+
+/**
+ * Client-supplied alt text, at the write boundary: the canonical alt rule
+ * ({@link normalizeAlt} — the SAME one the federated ingest paths apply), then the
+ * product length cap.
+ *
+ * The cap runs last and its cut can leave a dangling space, so the rule runs
+ * again over the truncated value; it is idempotent, so a value that was already
+ * short is untouched.
+ *
+ * This is where the invariant lives for everything a Mention client writes. It
+ * cannot be deferred to the read path: a native post's media is signed onto the
+ * author's MTN hash chain at creation, and a signed record is immutable.
+ */
+export function normalizeAltInput(value: unknown): string | undefined {
+  const alt = normalizeAlt(value);
+  if (alt === undefined || alt.length <= config.posts.maxAltTextLength) return alt;
+  return normalizeAlt(alt.slice(0, config.posts.maxAltTextLength));
 }
 
 /** Untrusted media entry shape accepted from the request body before normalization. */
@@ -73,17 +93,17 @@ export function normalizeMediaItems(arr: unknown): NormalizedMediaItem[] {
         resolvedType = 'image';
       }
 
-      // Accessibility description (alt text). Explicitly whitelisted, trimmed, and
-      // length-capped — never spread from the raw body. Empty/whitespace-only
+      // Accessibility description (alt text). Explicitly whitelisted, normalized,
+      // and length-capped — never spread from the raw body. Empty/whitespace-only
       // values are dropped so the field stays absent rather than an empty string.
-      const altRaw = typeof obj.alt === 'string' ? obj.alt.trim().slice(0, config.posts.maxAltTextLength) : '';
+      const alt = normalizeAltInput(obj.alt);
 
       seen.add(id);
       normalized.push({
         id,
         type: resolvedType,
         ...(mimeValue ? { mime: String(mimeValue) } : {}),
-        ...(altRaw ? { alt: altRaw } : {}),
+        ...(alt ? { alt } : {}),
       });
     }
   });


### PR DESCRIPTION
## Summary

Quality pass on #395 (whitespace normalization), before the backfill is pointed at production.

**`alt` was normalized on a READ path.** `readPersistedMediaFields` runs during feed hydration. Nothing normalized the composer's alt on the way *in* — `enrichFromOxy`'s patch carries width/height/mime, never alt, so the client's value was persisted verbatim. The read-path cleanup then made the feed *look* correct, which is exactly why nobody noticed.

Meanwhile `mentionRecordBuilders` copies `content.media[].alt` straight into the signed MTN record. **A signed record is immutable: raw alt was being written into the user's hash chain permanently, where no backfill can ever reach it.**

## What changed

- Alt is normalized where it is **accepted**: `POST /posts`, the reply path, the edit path and the variant path all go through `normalizeAltInput` in `utils/mediaInput`, reusing the **same** `normalizeAlt` the federated ingest applies. The read-path call stays, demoted to what it should have been all along — a backstop for legacy rows.
- **`htmlToInlineLabel`** — the ingest turned a remote `summary` into a CW label with `normalizeInlineText(htmlToPlainText(x))`, while the backfill applied only the inline half. A CW stored with raw `<p>` tags (the *old* ingest persisted the summary untouched) would have survived the backfill with its markup intact. The rule now lives in one function both call, and a test pins the invariant: **the backfill produces exactly what the ingest would**.
- atproto's `alt` reuses `normalizeAlt` instead of restating the rule inline.
- `federatedProfileSync` normalizes the remote handle hint — it is the third writer to `FederatedActor`, and it was writing straight to the row.

## Test plan

`bun run build` (tsc clean) + **132 tests green** across the touched suites: `mediaInput`, `pushPreview`, `normalizeFederatedText`, `postMapper`, `apPostContent`, `htmlToPlainText`, `postVariants`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->