### PR TITLE
ci: run the migration one-shot with the service's public-IP setting

### DIFF
--- a/.github/workflows/run-post-variants-migration.yml
+++ b/.github/workflows/run-post-variants-migration.yml
@@ -119,6 +119,10 @@ jobs:
           LIVE_TASK_DEF=$(echo "$SERVICE_JSON" | jq -r '.taskDefinition')
           SUBNETS=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.subnets | join(",")')
           SEC_GROUPS=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.securityGroups | join(",")')
+          # Mirror the service's public-IP setting: the cluster's subnets are
+          # public with NO NAT gateway, so a task without a public IP cannot
+          # even pull its image from ECR.
+          ASSIGN_IP=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.assignPublicIp')
 
           echo "live task definition: $LIVE_TASK_DEF"
 
@@ -159,7 +163,7 @@ jobs:
             --cluster "$CLUSTER" \
             --task-definition "$MIGRATION_TASK_DEF" \
             --launch-type FARGATE \
-            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SEC_GROUPS],assignPublicIp=DISABLED}" \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SEC_GROUPS],assignPublicIp=$ASSIGN_IP}" \
             --overrides "$OVERRIDES" \
             --started-by "gh-migration-$PHASE" \
             --query 'tasks[0].taskArn' --output text)


### PR DESCRIPTION
The post-variants migration workflow failed all 4 runs on 2026-07-14. Two independent blockers:

1. **IAM (fixed in oxy-infra 72d1f09):** `oxy-github-deploy` lacked `ecs:RunTask`, `ecs:DescribeTasks` and `logs:GetLogEvents` — `aws ecs run-task` died with AccessDenied (exit 254).
2. **This PR:** the one-shot hardcoded `assignPublicIp=DISABLED`, but the cluster's subnets are public with no NAT gateway — the task could never pull its image from ECR. Mirror the live service's setting, like the subnets and security groups already are.

Context: the multilingual reader (variants-only, no `content.text` fallback) deployed 2026-07-14 14:30Z with the expand migration still blocked, so every pre-deploy post is currently rendering blank in prod. The expand run is being dispatched from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)