### PR TITLE
fix(backend): attach avatar variant to already-mirrored cloud.oxy.so avatars

### DIFF
--- a/packages/backend/src/__tests__/utils/mediaResolver.test.ts
+++ b/packages/backend/src/__tests__/utils/mediaResolver.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const PUBLIC_BASE = 'https://api.mention.earth';
 const OXY_BASE = 'https://api.oxy.so';
+const CLOUD_BASE = 'https://cloud.oxy.so';
 
 // Pin the backend public origin deterministically. The real `config` reads
 // `MENTION_PUBLIC_API_URL` once at module load, so mocking the module avoids any
@@ -28,9 +29,10 @@ const getFileDownloadUrl = vi.fn((fileId: string, variant?: string) => {
   return `${OXY_BASE}/assets/${encodeURIComponent(fileId)}/stream${qs}`;
 });
 const getBaseURL = vi.fn(() => OXY_BASE);
+const getCloudURL = vi.fn(() => CLOUD_BASE);
 
 vi.mock('../../utils/oxyHelpers', () => ({
-  getServiceOxyClient: () => ({ getFileDownloadUrl, getBaseURL }),
+  getServiceOxyClient: () => ({ getFileDownloadUrl, getBaseURL, getCloudURL }),
 }));
 
 import { resolveMediaRef, resolveAvatarUrl, resolveMediaItems } from '../../utils/mediaResolver';
@@ -109,6 +111,28 @@ describe('resolveAvatarUrl', () => {
     expect(resolveAvatarUrl(external)).toBe(
       `${PUBLIC_BASE}/media/proxy?url=${encodeURIComponent(external)}`,
     );
+  });
+
+  it('proxies a genuinely-external federated avatar host (regression guard)', () => {
+    // A truly-remote federated CDN must still be wrapped behind /media/proxy,
+    // NOT treated as an Oxy CDN URL.
+    const external = 'https://files.mastodon.social/accounts/avatars/original.png';
+    expect(resolveAvatarUrl(external)).toBe(
+      `${PUBLIC_BASE}/media/proxy?url=${encodeURIComponent(external)}`,
+    );
+  });
+
+  it('attaches the avatar variant to an already-mirrored Oxy CDN url', () => {
+    // A federated avatar Oxy mirrored to its CDN arrives as a final
+    // cloud.oxy.so/<id> URL. It must get the avatar variant appended, NOT be
+    // served as the no-variant original or double-proxied through /media/proxy.
+    const mirrored = `${CLOUD_BASE}/abc123`;
+    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=thumb`);
+  });
+
+  it('is idempotent when the mirrored Oxy CDN url already carries a variant', () => {
+    const mirrored = `${CLOUD_BASE}/abc123?variant=w320`;
+    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=thumb`);
   });
 
   it('returns undefined for an empty ref', () => {

--- a/packages/backend/src/utils/mediaResolver.ts
+++ b/packages/backend/src/utils/mediaResolver.ts
@@ -82,6 +82,21 @@ function getPublicBase(): string {
 }
 
 /**
+ * The Oxy CDN host (e.g. `cloud.oxy.so`). A federated avatar Oxy has already
+ * mirrored resolves to a final `cloud.oxy.so/<id>` URL (not a bare file id), so
+ * we still need to attach the avatar variant to it rather than serving the
+ * no-variant original or double-proxying our own CDN. Defensive like the rest of
+ * this module: returns `undefined` on any failure instead of throwing.
+ */
+function getCloudHost(): string | undefined {
+  try {
+    return new URL(getServiceOxyClient().getCloudURL()).host.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * The set of hostnames we consider "ours" — media already served from these is
  * returned verbatim instead of being wrapped behind the proxy. Includes the
  * backend public origin and the Oxy API origin (CDN/stream endpoints).
@@ -167,8 +182,13 @@ export function resolveMediaRef(ref: string | null | undefined): ResolvedMedia {
 /**
  * Resolve an avatar reference to a FINAL URL. For an Oxy file id this is the
  * small square `thumb` (256px) crop — avatars are rendered tiny and circular, so
- * the square crop is correct (unlike post media, which uses wider variants). For
- * federated/proxied avatars it is the proxied URL. Returns `undefined` when the
+ * the square crop is correct (unlike post media, which uses wider variants).
+ *
+ * For an absolute URL already on the Oxy CDN host (`cloud.oxy.so`) — the shape a
+ * federated avatar takes once Oxy has mirrored it at resolve/hydration time — the
+ * avatar variant is attached directly to the URL rather than serving the
+ * no-variant original or needlessly double-proxying our own CDN. For a genuinely
+ * external/federated CDN it is the proxied URL. Returns `undefined` when the
  * reference is empty so callers can omit the field.
  */
 export function resolveAvatarUrl(ref?: string | null): string | undefined {
@@ -177,6 +197,25 @@ export function resolveAvatarUrl(ref?: string | null): string | undefined {
   }
   try {
     if (isAbsoluteHttpUrl(ref)) {
+      let host: string | undefined;
+      try {
+        host = new URL(ref).host.toLowerCase();
+      } catch {
+        // Malformed absolute URL — return it untouched rather than proxying garbage.
+        return ref;
+      }
+      if (host && host === getCloudHost()) {
+        // Federated avatar Oxy already mirrored to its CDN: attach the avatar
+        // variant to the existing URL (idempotent via `set`) instead of serving
+        // the no-variant original or proxying our own CDN through /media/proxy.
+        try {
+          const url = new URL(ref);
+          url.searchParams.set('variant', MEDIA_VARIANT_AVATAR);
+          return url.toString();
+        } catch {
+          return ref;
+        }
+      }
       // Defer to the shared resolver for own-origin passthrough / proxy wrapping.
       const resolved = resolveMediaRef(ref);
       return (resolved.thumbUrl || resolved.url) || undefined;


### PR DESCRIPTION
## Summary
- Federated avatars Oxy has already mirrored to its own CDN host (`cloud.oxy.so`) were being served as the no-variant original image, or needlessly double-proxied through Mention's own `/media/proxy` endpoint, instead of getting the small `thumb` avatar variant attached directly to the existing `cloud.oxy.so` URL.
- Root cause: `resolveAvatarUrl` (`packages/backend/src/utils/mediaResolver.ts`) only attached the avatar variant for bare Oxy file ids; an absolute URL was always handed to the generic `resolveMediaRef` passthrough/proxy path, even when that URL already pointed at Oxy's own CDN.
- Fix: detect when an absolute avatar URL's host matches the Oxy CDN host (new defensive `getCloudHost()` helper, fails soft to `undefined`) and attach the variant with `URLSearchParams.set('variant', ...)` (idempotent — safe if a variant is already present). `resolveMediaRef` is intentionally untouched; scope is avatar resolution only.

## Test plan
- [x] `packages/backend/src/__tests__/utils/mediaResolver.test.ts` updated: mocks `getCloudURL`, adds a case attaching the variant to a mirrored `cloud.oxy.so` URL, an idempotency case when a variant is already present, and a regression guard proving a genuinely-external federated CDN host is still proxied via `/media/proxy` (unaffected by this change).
- [x] Backend test suite green
- [x] Backend build green
- [x] Lockfile unaffected (no `package.json` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)