### PR TITLE
perf(media): wire the new 128px avatar variant + bump Bloom

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3266,7 +3266,11 @@
 
     "@livekit/react-native-webrtc/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
+    "@mention/backend/@mention/shared-types": ["@mention/shared-types@file:packages/shared-types", { "dependencies": { "@oxyhq/contracts": "^0.14.0", "zod": "^4.4.3" }, "devDependencies": { "@types/node": "^25.5.0", "typescript": "^5.9.3" } }],
+
     "@mention/backend/@oxyhq/contracts": ["@oxyhq/contracts@0.14.1", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-d82VWCR4+OEzrQkENjCg/f/ZdlG2m/04/0Fp/v6HMC7r8Gxa6m6LdrZLQbOtemZ5kojg7H5ZbZ9Tk3q+qLyi1Q=="],
+
+    "@mention/mcp/@mention/shared-types": ["@mention/shared-types@file:packages/shared-types", { "dependencies": { "@oxyhq/contracts": "^0.14.0", "zod": "^4.4.3" }, "devDependencies": { "@types/node": "^25.5.0", "typescript": "^5.9.3" } }],
 
     "@mention/mcp/@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
 
@@ -3780,7 +3784,11 @@
 
     "@livekit/react-native-webrtc/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
+    "@mention/backend/@mention/shared-types/@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
+
     "@mention/backend/@oxyhq/contracts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@mention/mcp/@mention/shared-types/@oxyhq/contracts": ["@oxyhq/contracts@0.14.1", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-d82VWCR4+OEzrQkENjCg/f/ZdlG2m/04/0Fp/v6HMC7r8Gxa6m6LdrZLQbOtemZ5kojg7H5ZbZ9Tk3q+qLyi1Q=="],
 
     "@mention/mcp/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -4007,6 +4015,10 @@
     "@google-cloud/storage/google-auth-library/gcp-metadata/google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "@mention/backend/@mention/shared-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "@mention/mcp/@mention/shared-types/@oxyhq/contracts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-context-menu/@radix-ui/react-menu/@radix-ui/react-popper/@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.10", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.5",
-        "@oxyhq/bloom": "^0.30.3",
+        "@oxyhq/bloom": "^0.30.8",
         "@oxyhq/contracts": "^0.14.0",
         "@oxyhq/core": "^10.2.0",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.30.3",
+        "@oxyhq/bloom": "^0.30.8",
         "@oxyhq/core": "^10.2.0",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
         "@oxyhq/services": "^20.0.0",
@@ -208,7 +208,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.30.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/core": "^10.2.0",
     "@oxyhq/services": "^20.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -702,7 +702,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.30.3", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-haptics": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-9F9H98lnIZ+zasXOROogLDoAioxguoKaczZLac30lXzQxNmJy4LpfAPb6HbJXdGThW3rS9HayY/IIkLy/v7BJA=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.30.8", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-haptics": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-+0LJhWefPicQV7GzmU/QZYd+5vvygsyOLJQR0tlPDCfXWemLu4EsnN1VrI8QjsqDJ2fBEFh5MEYT5Ici4KbGWA=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.14.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-oQps/7+yHTUWRYY4ENu7nilQbINN7277lWTc0HmprPW45wcDo86sfU8kQElpbLCoEHBTyXptJfOjvWpbBiTV8Q=="],
 
@@ -3266,13 +3266,11 @@
 
     "@livekit/react-native-webrtc/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
-    "@mention/backend/@mention/shared-types": ["@mention/shared-types@file:packages/shared-types", { "dependencies": { "@oxyhq/contracts": "^0.14.0", "zod": "^4.4.3" }, "devDependencies": { "@types/node": "^25.5.0", "typescript": "^5.9.3" } }],
-
     "@mention/backend/@oxyhq/contracts": ["@oxyhq/contracts@0.14.1", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-d82VWCR4+OEzrQkENjCg/f/ZdlG2m/04/0Fp/v6HMC7r8Gxa6m6LdrZLQbOtemZ5kojg7H5ZbZ9Tk3q+qLyi1Q=="],
 
-    "@mention/mcp/@mention/shared-types": ["@mention/shared-types@file:packages/shared-types", { "dependencies": { "@oxyhq/contracts": "^0.14.0", "zod": "^4.4.3" }, "devDependencies": { "@types/node": "^25.5.0", "typescript": "^5.9.3" } }],
-
     "@mention/mcp/@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
+
+    "@mention/shared-types/@oxyhq/contracts": ["@oxyhq/contracts@0.14.1", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-d82VWCR4+OEzrQkENjCg/f/ZdlG2m/04/0Fp/v6HMC7r8Gxa6m6LdrZLQbOtemZ5kojg7H5ZbZ9Tk3q+qLyi1Q=="],
 
     "@mention/shared-types/@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
 
@@ -3782,13 +3780,11 @@
 
     "@livekit/react-native-webrtc/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
-    "@mention/backend/@mention/shared-types/@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
-
     "@mention/backend/@oxyhq/contracts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@mention/mcp/@mention/shared-types/@oxyhq/contracts": ["@oxyhq/contracts@0.14.1", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-d82VWCR4+OEzrQkENjCg/f/ZdlG2m/04/0Fp/v6HMC7r8Gxa6m6LdrZLQbOtemZ5kojg7H5ZbZ9Tk3q+qLyi1Q=="],
-
     "@mention/mcp/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "@mention/shared-types/@oxyhq/contracts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@mention/shared-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -4011,10 +4007,6 @@
     "@google-cloud/storage/google-auth-library/gcp-metadata/google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "@mention/backend/@mention/shared-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
-
-    "@mention/mcp/@mention/shared-types/@oxyhq/contracts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-context-menu/@radix-ui/react-menu/@radix-ui/react-popper/@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.10", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.5",
-    "@oxyhq/bloom": "^0.30.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/contracts": "^0.14.0",
     "@oxyhq/core": "^10.2.0",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.30.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/core": "^10.2.0",
     "@oxyhq/services": "^20.0.0",
     "mongoose": "^8.17.0",

--- a/packages/backend/src/__tests__/utils/mediaResolver.test.ts
+++ b/packages/backend/src/__tests__/utils/mediaResolver.test.ts
@@ -100,10 +100,11 @@ describe('resolveMediaRef', () => {
 });
 
 describe('resolveAvatarUrl', () => {
-  it('returns the square thumb crop for an Oxy file id', () => {
-    // Avatars stay on the small square `thumb` crop (not the wider w320 used for
-    // post media), since they render tiny and circular.
-    expect(resolveAvatarUrl('avatar1')).toBe(`${OXY_BASE}/assets/avatar1/stream?variant=thumb`);
+  it('returns the dedicated avatar crop for an Oxy file id', () => {
+    // Avatars use the dedicated 128px square `avatar` crop (not the wider w320
+    // used for post media, nor the 256px `thumb`), since they render tiny and
+    // circular.
+    expect(resolveAvatarUrl('avatar1')).toBe(`${OXY_BASE}/assets/avatar1/stream?variant=avatar`);
   });
 
   it('returns the proxy url for an external avatar', () => {
@@ -127,12 +128,12 @@ describe('resolveAvatarUrl', () => {
     // cloud.oxy.so/<id> URL. It must get the avatar variant appended, NOT be
     // served as the no-variant original or double-proxied through /media/proxy.
     const mirrored = `${CLOUD_BASE}/abc123`;
-    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=thumb`);
+    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=avatar`);
   });
 
   it('is idempotent when the mirrored Oxy CDN url already carries a variant', () => {
     const mirrored = `${CLOUD_BASE}/abc123?variant=w320`;
-    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=thumb`);
+    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=avatar`);
   });
 
   it('returns undefined for an empty ref', () => {

--- a/packages/backend/src/utils/mediaResolver.ts
+++ b/packages/backend/src/utils/mediaResolver.ts
@@ -3,6 +3,7 @@ import {
   MEDIA_VARIANT_THUMB,
   MEDIA_VARIANT_FULL,
   MEDIA_VARIANT_AVATAR,
+  MEDIA_VARIANT_VIDEO_POSTER,
 } from '@mention/shared-types';
 import { config } from '../config';
 import { getServiceOxyClient } from './oxyHelpers';
@@ -24,8 +25,8 @@ import { logger } from './logger';
  *        sees same-origin, cacheable, range-seekable bytes.
  *  - anything else → treated as an Oxy file id and turned into a CDN/stream URL
  *    via the SDK's synchronous `getFileDownloadUrl` (pure URL construction, no
- *    network), with image variants for image thumbnails/fullscreen and the
- *    native `thumb` variant for video posters.
+ *    network), with image variants for image thumbnails/fullscreen, the dedicated
+ *    128px `avatar` crop for avatars, and the 256px `thumb` crop for video posters.
  *
  * This module NEVER throws: on any failure it degrades to the safest passthrough
  * (`{ url: ref }` or `undefined`).
@@ -57,18 +58,23 @@ export interface ResolvedMedia {
  * Oxy asset IMAGE variant taxonomy lives in `@mention/shared-types`
  * (`MEDIA_VARIANT_*`) as the single source of truth shared with the frontend.
  * The asset service (`packages/api/src/services/variantService.ts`
- * `imageVariants`) generates only `thumb`(256) / `w320` / `w640` / `w1280` /
- * `w2048`; `small`/`medium`/`large`/`original` 404 on the CDN. Verified live
- * scale: `thumb`~2.6KB, `w320`~4KB, `w2048`~25.2KB, raw original ~77KB. Each
- * render context maps to a real, existing variant instead of the 256px thumb or
- * the raw original.
+ * `imageVariants`) generates only `avatar`(128) / `thumb`(256) / `w320` / `w640`
+ * / `w1280` / `w2048`; `small`/`medium`/`large`/`original` 404 on the CDN.
+ * Verified live scale: `avatar`~4.1KB, `thumb`~13KB (for the same source),
+ * `w320`~4KB, `w2048`~25.2KB, raw original ~77KB. Each render context maps to a
+ * real, existing variant instead of the raw original.
  *
  *  - thumbnail (post media card / profile grid) → {@link MEDIA_VARIANT_THUMB}.
  *    Both surfaces are ≤320px wide, so this resolves to the lighter `w320`
  *    variant rather than a wider one — big enough for a retina render of those
  *    small cards/cells without paying for the wider variants.
  *  - fullscreen lightbox (upgrade on open)      → {@link MEDIA_VARIANT_FULL}.
- *  - avatars (small, square crop)               → {@link MEDIA_VARIANT_AVATAR}.
+ *  - avatars (small, circular crop)             → {@link MEDIA_VARIANT_AVATAR}.
+ *    The dedicated 128px square `avatar` crop — ~68% lighter than the old 256px
+ *    `thumb` for a typical source.
+ *  - video posters (feed media rectangle)       → {@link MEDIA_VARIANT_VIDEO_POSTER}.
+ *    Kept on the 256px `thumb` crop: a poster fills the media card, so it must
+ *    not be shrunk to the 128px avatar square.
  */
 
 /** Backend route that proxies remote media through our own origin. */
@@ -181,8 +187,9 @@ export function resolveMediaRef(ref: string | null | undefined): ResolvedMedia {
 
 /**
  * Resolve an avatar reference to a FINAL URL. For an Oxy file id this is the
- * small square `thumb` (256px) crop — avatars are rendered tiny and circular, so
- * the square crop is correct (unlike post media, which uses wider variants).
+ * dedicated 128px square `avatar` crop — avatars are rendered tiny and circular,
+ * so the small square crop is correct (unlike post media, which uses wider
+ * variants) and far lighter than the old 256px `thumb`.
  *
  * For an absolute URL already on the Oxy CDN host (`cloud.oxy.so`) — the shape a
  * federated avatar takes once Oxy has mirrored it at resolve/hydration time — the
@@ -248,7 +255,7 @@ export function resolveMediaItems(items: MediaItem[] | undefined | null): MediaI
 
       if (item.type === 'video' && !isAbsoluteHttpUrl(item.id)) {
         try {
-          const posterUrl = getServiceOxyClient().getFileDownloadUrl(item.id, MEDIA_VARIANT_AVATAR);
+          const posterUrl = getServiceOxyClient().getFileDownloadUrl(item.id, MEDIA_VARIANT_VIDEO_POSTER);
           // Adaptive-bitrate HLS master playlist. NOT guaranteed to exist yet
           // (background transcode is fire-and-forget on upload) — the frontend
           // player MUST fall back to `url` (the raw original) on a playback

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.30.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/core": "^10.2.0",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
     "@oxyhq/services": "^20.0.0",

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -23,8 +23,8 @@ export enum PostVisibility {
 /**
  * Oxy asset IMAGE variant names that the central asset service actually
  * generates (`packages/api/src/services/variantService.ts` `imageVariants`):
- * `thumb`(256) / `w320` / `w640` / `w1280` / `w2048`. `small`/`medium`/`large`/
- * `original` do NOT exist server-side and 404 on the CDN.
+ * `avatar`(128) / `thumb`(256) / `w320` / `w640` / `w1280` / `w2048`.
+ * `small`/`medium`/`large`/`original` do NOT exist server-side and 404 on the CDN.
  *
  * These are the SINGLE source of truth for which variant each render context
  * requests, shared by the backend resolver (`utils/mediaResolver.ts`) and the
@@ -35,10 +35,17 @@ export enum PostVisibility {
  * (~190px cells) are both ≤320px, so the THUMB context maps to `w320` — large
  * enough for a retina render of those small surfaces, but far lighter than the
  * `w640`/`w1280`/`w2048` variants reserved for wider displays / the lightbox.
+ *
+ * Avatars render small and circular, so the AVATAR context maps to the dedicated
+ * 128px square `avatar` crop — lighter still than `thumb` (~68% fewer bytes for a
+ * typical source). Video posters are a DIFFERENT context: they fill the (up to
+ * ~320px wide) media card as a rectangle, so they keep the 256px `thumb` crop via
+ * VIDEO_POSTER rather than being shrunk to the 128px avatar square.
  */
 export const MEDIA_VARIANT_THUMB = 'w320';
 export const MEDIA_VARIANT_FULL = 'w2048';
-export const MEDIA_VARIANT_AVATAR = 'thumb';
+export const MEDIA_VARIANT_AVATAR = 'avatar';
+export const MEDIA_VARIANT_VIDEO_POSTER = 'thumb';
 
 export interface MediaItem {
   id: string;


### PR DESCRIPTION
## Summary
- Switch `MEDIA_VARIANT_AVATAR` from the generic 256px `thumb` alias to the dedicated `avatar` (128px) variant OxyHQServices now generates — real user-facing avatars (post authors, notifications, federated/mirrored avatars) drop from ~13KB to ~4.1KB per image.
- Split video posters onto a new `MEDIA_VARIANT_VIDEO_POSTER` constant (still `thumb`/256px) so feed video thumbnails don't shrink alongside avatars — they render at rectangle/feed-card size, not circular-avatar size.
- Bump `@oxyhq/bloom` 0.30.3 → 0.30.8 (all three pins: root `dependencies`, root `overrides`, frontend `dependencies`) — 0.30.7 fixed `Avatar`'s `variant` prop defaulting to `'thumb'` instead of the full-size original when no variant is explicitly passed.

## Test plan
- [x] Backend test suite: 2259/2259 passing (`packages/backend`, includes updated `mediaResolver.test.ts` assertions for the variant split)
- [x] `shared-types` build clean
- [x] Frontend typecheck: 0 errors (bonus: the Bloom bump also resolved 3 previously-allowlisted `livekit-client` typecheck errors)
- [x] Frontend lint: 0 errors, 290 warnings (7 fewer than before, pre-existing/unrelated)
- [x] `bun.lock` diff scoped to the `@oxyhq/bloom` version bump + benign Bun workspace-symlink nesting-path bookkeeping (no other dependency versions changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)