### PR TITLE
fix(frontend): wire the 128px avatar variant into every avatar render

### DIFF
--- a/packages/frontend/app/(app)/[username]/about.tsx
+++ b/packages/frontend/app/(app)/[username]/about.tsx
@@ -4,6 +4,7 @@ import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import { Link, useLocalSearchParams } from 'expo-router';
 import { useSafeBack } from '@/hooks/useSafeBack';
 import React, { useMemo } from 'react';
@@ -141,6 +142,7 @@ function AccountInfoContent({ profileData, profileLoading }: AccountInfoContentP
             <Avatar
               source={profileData.design.avatar || profileData.avatar}
               size={56}
+              variant={MEDIA_VARIANT_VIDEO_POSTER}
               verified={profileData.verified}
             />
           </View>

--- a/packages/frontend/app/(app)/compose.tsx
+++ b/packages/frontend/app/(app)/compose.tsx
@@ -36,6 +36,7 @@ import { show as toast } from '@oxyhq/bloom/toast';
 import { usePostsStore } from '@/stores/postsStore';
 import { feedService } from '@/services/feedService';
 import type { CreatePostRequest, HydratedPost } from '@mention/shared-types';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { useTheme } from '@oxyhq/bloom/theme';
 import MentionTextInput, { MentionData, MentionTextInputHandle } from '@/components/MentionTextInput';
 import SEO from '@/components/SEO';
@@ -1920,7 +1921,7 @@ const ComposeScreenBody = () => {
                       verified: Boolean(user?.verified)
                     }}
                     avatarSource={user?.avatar ?? undefined}
-                    avatarVariant="thumb"
+                    avatarVariant={MEDIA_VARIANT_AVATAR}
                     avatarSize={AVATAR_SIZE}
                     onPressUser={() => { }}
                     onPressAvatar={() => { }}
@@ -2354,6 +2355,7 @@ const ComposeScreenBody = () => {
                     <Avatar
                       source={user?.avatar}
                       size={40}
+                      variant={MEDIA_VARIANT_AVATAR}
                       verified={Boolean(user?.verified)}
                       style={avatarMarginStyle}
                     />

--- a/packages/frontend/app/(app)/feeds.tsx
+++ b/packages/frontend/app/(app)/feeds.tsx
@@ -20,6 +20,7 @@ import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
 import { BottomBarAwareFab } from '@/components/BottomBarAwareFab';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 
 import SEO from '@/components/SEO';
 
@@ -155,7 +156,7 @@ const FeedRow = ({
         accessibilityRole="button"
         accessibilityLabel={item.title || 'Untitled Feed'}
       >
-        <Avatar source={item.avatar || undefined} size={36} />
+        <Avatar source={item.avatar || undefined} size={36} variant={MEDIA_VARIANT_AVATAR} />
         <View className="flex-1 gap-0.5">
           <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>
             {item.title || 'Untitled Feed'}

--- a/packages/frontend/app/(app)/feeds/[id].tsx
+++ b/packages/frontend/app/(app)/feeds/[id].tsx
@@ -28,6 +28,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { ComposeIcon } from '@/assets/icons/compose-icon';
 import { BottomBarAwareFab } from '@/components/BottomBarAwareFab';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 
 import { formatCompactNumber } from '@/utils/formatNumber';
 import StarRating from '@/components/StarRating';
@@ -106,7 +107,7 @@ const FeedHeaderBar = React.memo(function FeedHeaderBar({
         {({ pressed }) => (
           <>
             <View style={[headerStyles.pressHighlight, pressed && { opacity: 1 }]} className="bg-secondary" />
-            <Avatar source={feed.coverImage} size={36} />
+            <Avatar source={feed.coverImage} size={36} variant={MEDIA_VARIANT_AVATAR} />
             <View className="flex-1">
               <Text className="text-[15px] font-bold leading-snug text-foreground" numberOfLines={2}>
                 {feed.title}
@@ -183,7 +184,7 @@ const FeedInfoContent = React.memo(function FeedInfoContent({
     <View className="gap-4 px-5 pb-8 pt-2">
       {/* Avatar + title + share */}
       <View className="flex-row items-center gap-3.5">
-        <Avatar source={feed.coverImage} size={48} />
+        <Avatar source={feed.coverImage} size={48} variant={MEDIA_VARIANT_AVATAR} />
         <View className="flex-1 gap-0.5">
           <Text className="text-2xl font-bold leading-tight text-foreground" numberOfLines={2}>
             {feed.title}
@@ -338,7 +339,7 @@ const ProfilesTab = React.memo(function ProfilesTab({ members }: { members: Feed
             disabled={!handle}
             activeOpacity={0.7}
           >
-            <Avatar source={member.avatar ?? undefined} size={44} />
+            <Avatar source={member.avatar ?? undefined} size={44} variant={MEDIA_VARIANT_AVATAR} />
             <View className="flex-1 gap-0.5">
               <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>
                 {name}
@@ -586,7 +587,7 @@ const ReviewsTab = React.memo(function ReviewsTab({ feedId }: { feedId: string }
               style={[reviewStyles.reviewCard, { borderBottomColor: theme.colors.border }]}
             >
               <View className="flex-row items-start gap-2.5">
-                <Avatar source={review.reviewer?.avatar ?? undefined} size={36} />
+                <Avatar source={review.reviewer?.avatar ?? undefined} size={36} variant={MEDIA_VARIANT_AVATAR} />
                 <View className="flex-1 gap-[3px]">
                   <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>
                     {reviewerName}

--- a/packages/frontend/app/(app)/insights/weekly_recap.tsx
+++ b/packages/frontend/app/(app)/insights/weekly_recap.tsx
@@ -17,6 +17,7 @@ import { statisticsService, UserStatistics } from '@/services/statisticsService'
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@oxyhq/services';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import StatCard from '@/components/insights/StatCard';
 import { formatCompactNumber } from '@/utils/formatNumber';
 import { logger } from '@/lib/logger';
@@ -328,6 +329,7 @@ const WeeklyRecapScreen: React.FC = () => {
                     <Avatar
                         source={avatarUri}
                         size={72}
+                        variant={MEDIA_VARIANT_VIDEO_POSTER}
                     />
                     <Text className="text-2xl font-bold mt-4 mb-2 text-foreground" style={{ letterSpacing: -0.3 }}>
                         {t('insights.weeklyRecap.pageTitle')}

--- a/packages/frontend/app/(app)/lists/[id].tsx
+++ b/packages/frontend/app/(app)/lists/[id].tsx
@@ -22,6 +22,7 @@ import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import { ProfileCard, ProfileCardSkeletonList } from '@/components/ProfileCard';
 
 import Feed from '@/components/Feed/Feed';
@@ -149,6 +150,7 @@ export default function ListDetailScreen() {
         <Avatar
           source={list?.avatar || undefined}
           size={58}
+          variant={MEDIA_VARIANT_VIDEO_POSTER}
           style={{ borderRadius: 12 }}
         />
         <View className="flex-1 justify-center">

--- a/packages/frontend/app/(app)/lists/[id]/edit.tsx
+++ b/packages/frontend/app/(app)/lists/[id]/edit.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, TouchableOpacity, ScrollView, Platform, type Tex
 import { useLocalSearchParams } from 'expo-router';
 import { SpinnerIcon } from '@oxyhq/bloom/loading';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { show as toast } from '@oxyhq/bloom/toast';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { Ionicons } from '@expo/vector-icons';
@@ -251,7 +252,7 @@ export default function EditListMembersScreen() {
                   disabled={already || busy}
                   activeOpacity={0.7}
                 >
-                  <Avatar source={u.avatar} size={36} />
+                  <Avatar source={u.avatar} size={36} variant={MEDIA_VARIANT_AVATAR} />
                   <View className="flex-1">
                     <Text className="text-foreground font-medium" numberOfLines={1}>@{u.username}</Text>
                     <Text className="text-muted-foreground text-xs" numberOfLines={1}>{u.name.displayName}</Text>
@@ -288,7 +289,7 @@ export default function EditListMembersScreen() {
               const busy = pendingIds.has(m.id);
               return (
                 <View key={m.id} className="flex-row items-center gap-3 px-3 py-2.5 border-b border-border">
-                  <Avatar source={m.avatar} size={36} />
+                  <Avatar source={m.avatar} size={36} variant={MEDIA_VARIANT_AVATAR} />
                   <View className="flex-1">
                     <Text className="text-foreground font-medium" numberOfLines={1}>@{m.username}</Text>
                     <Text className="text-muted-foreground text-xs" numberOfLines={1}>{m.name.displayName}</Text>

--- a/packages/frontend/app/(app)/oauth/mcp/authorize.tsx
+++ b/packages/frontend/app/(app)/oauth/mcp/authorize.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useAuth, OxyAuthPrompt } from '@oxyhq/services';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import { ThemedView } from '@/components/ThemedView';
 import { Header } from '@/components/Header';
 import { IconButton, Button } from '@/components/ui/Button';
@@ -167,7 +168,7 @@ function ConsentBody({ params }: { params: Required<Pick<McpAuthorizeParams, 'cl
       <View className="items-center gap-4">
         <View className="flex-row items-center gap-3">
           {currentUserProfile ? (
-            <Avatar source={currentUserProfile.avatar} size={56} />
+            <Avatar source={currentUserProfile.avatar} size={56} variant={MEDIA_VARIANT_VIDEO_POSTER} />
           ) : (
             <View
               className="w-14 h-14 rounded-full items-center justify-center"

--- a/packages/frontend/app/(app)/oauth/mcp/link.tsx
+++ b/packages/frontend/app/(app)/oauth/mcp/link.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useAuth, OxyAuthPrompt } from '@oxyhq/services';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import { ThemedView } from '@/components/ThemedView';
 import { Header } from '@/components/Header';
 import { IconButton, Button } from '@/components/ui/Button';
@@ -144,7 +145,7 @@ function LinkBody({ token }: { token: string }) {
     >
       <View className="items-center gap-3">
         {currentUserProfile ? (
-          <Avatar source={currentUserProfile.avatar} size={72} />
+          <Avatar source={currentUserProfile.avatar} size={72} variant={MEDIA_VARIANT_VIDEO_POSTER} />
         ) : (
           <View
             className="w-[72px] h-[72px] rounded-full items-center justify-center"

--- a/packages/frontend/app/(app)/settings/index.tsx
+++ b/packages/frontend/app/(app)/settings/index.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "expo-router";
 import { useSafeBack } from '@/hooks/useSafeBack';
 import { useProfileData } from "@/hooks/useProfileData";
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import { Button } from "@/components/ui/Button";
 import { SettingsListGroup, SettingsListItem } from '@oxyhq/bloom/settings-list';
 import { Loading } from '@oxyhq/bloom/loading';
@@ -125,6 +126,7 @@ export default function SettingsScreen() {
                         <Avatar
                             source={currentUserProfile.avatar}
                             size={80}
+                            variant={MEDIA_VARIANT_VIDEO_POSTER}
                         />
                         <Text className="text-2xl font-bold text-foreground mt-2" numberOfLines={1}>
                             {currentUserProfile.design.displayName}

--- a/packages/frontend/app/(app)/settings/privacy/blocked.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/blocked.tsx
@@ -10,6 +10,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
 import { searchService } from '@/services/searchService';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { SettingsListGroup, SettingsListItem } from '@oxyhq/bloom/settings-list';
 import { Icon } from '@/lib/icons';
 import { useFocusEffect } from 'expo-router';
@@ -388,7 +389,7 @@ export default function BlockedUsersScreen() {
                             return (
                                 <SettingsListItem
                                     key={userId}
-                                    icon={<Avatar source={user.avatar} size={36} />}
+                                    icon={<Avatar source={user.avatar} size={36} variant={MEDIA_VARIANT_AVATAR} />}
                                     title={user.name.displayName}
                                     description={`@${handle}`}
                                     onPress={() => !isBlocking && handleBlock(user)}
@@ -439,7 +440,7 @@ export default function BlockedUsersScreen() {
                             return (
                                 <SettingsListItem
                                     key={userId}
-                                    icon={<Avatar source={user.avatar} size={40} />}
+                                    icon={<Avatar source={user.avatar} size={40} variant={MEDIA_VARIANT_AVATAR} />}
                                     title={user.name.displayName}
                                     description={`@${handle}`}
                                     showChevron={false}

--- a/packages/frontend/app/(app)/settings/privacy/restricted.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/restricted.tsx
@@ -10,6 +10,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
 import { searchService } from '@/services/searchService';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { SettingsListGroup, SettingsListItem } from '@oxyhq/bloom/settings-list';
 import { Icon } from '@/lib/icons';
 import { useFocusEffect } from 'expo-router';
@@ -457,7 +458,7 @@ export default function RestrictedUsersScreen() {
                             return (
                                 <SettingsListItem
                                     key={userId}
-                                    icon={<Avatar source={user.avatar} size={36} />}
+                                    icon={<Avatar source={user.avatar} size={36} variant={MEDIA_VARIANT_AVATAR} />}
                                     title={user.name.displayName}
                                     description={`@${handle}`}
                                     onPress={() => !isRestricting && handleRestrict(user)}
@@ -508,7 +509,7 @@ export default function RestrictedUsersScreen() {
                             return (
                                 <SettingsListItem
                                     key={userId}
-                                    icon={<Avatar source={user.avatar} size={40} />}
+                                    icon={<Avatar source={user.avatar} size={40} variant={MEDIA_VARIANT_AVATAR} />}
                                     title={user.name.displayName}
                                     description={`@${handle}`}
                                     showChevron={false}

--- a/packages/frontend/app/(app)/starter-packs/[id].tsx
+++ b/packages/frontend/app/(app)/starter-packs/[id].tsx
@@ -14,6 +14,7 @@ import { useAuth, FollowButton } from '@oxyhq/services';
 import { useHaptics } from '@oxyhq/bloom/hooks';
 import { Ionicons } from '@expo/vector-icons';
 import { AvatarGroup, type AvatarGroupItem } from '@oxyhq/bloom/avatar-group';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import { ProfileCard } from '@/components/ProfileCard';
 
 import SEO from '@/components/SEO';
@@ -126,7 +127,7 @@ export default function StarterPackDetailScreen() {
       {/* Hero section with grouped member avatars */}
       <View className="items-center px-6 pt-6 pb-4 gap-4">
         {avatarItems.length > 0 ? (
-          <AvatarGroup items={avatarItems} size={56} max={8} total={members.length} />
+          <AvatarGroup items={avatarItems} size={56} max={8} total={members.length} variant={MEDIA_VARIANT_VIDEO_POSTER} />
         ) : (
           <View className="w-16 h-16 rounded-2xl items-center justify-center bg-primary/20">
             <Ionicons name="rocket-outline" size={32} color={theme.colors.primary} />

--- a/packages/frontend/app/(app)/starter-packs/[id]/edit.tsx
+++ b/packages/frontend/app/(app)/starter-packs/[id]/edit.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, TouchableOpacity, ScrollView, Platform, type Tex
 import { useLocalSearchParams, router } from 'expo-router';
 import { SpinnerIcon } from '@oxyhq/bloom/loading';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { Button } from '@oxyhq/bloom/button';
 import { Item } from '@oxyhq/bloom/item';
 import { SearchInput } from '@oxyhq/bloom/search-input';
@@ -337,7 +338,7 @@ export default function EditStarterPackScreen() {
               return (
                 <View key={u.id} className={cn(index < results.length - 1 && 'border-b border-border')}>
                   <Item
-                    leading={<Avatar source={u.avatar} name={u.name.displayName} size={40} />}
+                    leading={<Avatar source={u.avatar} name={u.name.displayName} size={40} variant={MEDIA_VARIANT_AVATAR} />}
                     title={u.name.displayName}
                     subtitle={`@${u.username}`}
                     onPress={blockedByCap || already || busy ? undefined : () => addMember(u)}
@@ -400,7 +401,7 @@ export default function EditStarterPackScreen() {
               return (
                 <View key={m.id} className={cn(index < members.length - 1 && 'border-b border-border')}>
                   <Item
-                    leading={<Avatar source={m.avatar} name={m.name.displayName} size={40} />}
+                    leading={<Avatar source={m.avatar} name={m.name.displayName} size={40} variant={MEDIA_VARIANT_AVATAR} />}
                     title={m.name.displayName}
                     subtitle={`@${m.username}`}
                     trailing={

--- a/packages/frontend/app/(app)/videos.tsx
+++ b/packages/frontend/app/(app)/videos.tsx
@@ -18,6 +18,7 @@ import { feedService } from '@/services/feedService';
 import { proxyExternalUrl, videoPosterUrl } from '@/utils/imageUrlCache';
 import { SpinnerIcon } from '@oxyhq/bloom/loading';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import SEO from '@/components/SEO';
 import { EmptyState } from '@/components/common/EmptyState';
 import { Video } from '@/assets/icons/video-icon';
@@ -717,6 +718,7 @@ const VideoItem = memo<VideoItemProps>(({
                                 <Avatar
                                     source={item.user?.avatar ?? undefined}
                                     size={40}
+                                    variant={MEDIA_VARIANT_AVATAR}
                                     verified={item.user?.verified || false}
                                     style={styles.userAvatar}
                                 />

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -45,6 +45,7 @@ import { useHapticsStore } from '@/stores/hapticsStore';
 import { oxyServices } from '@/lib/oxyServices';
 import { queryClient } from '@/lib/queryClient';
 import { getCachedFileDownloadUrlSync } from '@/utils/imageUrlCache';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { AppInitializer } from '@/lib/appInitializer';
 import { logger } from '@/lib/logger';
 import { useShareIntentRouter } from '@/lib/shareIntent';
@@ -62,9 +63,18 @@ if (Platform.OS !== 'web') {
 }
 
 // Resolve file IDs → download URLs for Bloom's useImageResolver(). Honors the
-// rendition `variant` Bloom forwards, defaulting to 'thumb' so small avatars stay light.
+// rendition `variant` a caller forwards. This resolver is AVATAR-ONLY in practice
+// — its only consumers are Bloom's <Avatar>/<AvatarGroup> and <ZoomableAvatar>
+// (post media, banners and link previews resolve through their own dedicated
+// getFileDownloadUrl paths). When a caller omits `variant`, default to the 128px
+// square `avatar` crop (MEDIA_VARIANT_AVATAR) so bare-id avatars stay light.
+// Larger avatars (profile header, settings) request an explicit heavier variant
+// at their call site rather than relying on this default, so they are never
+// shrunk here. NOTE: Bloom's <Avatar> supplies its own `variant` default, so most
+// small avatars must ALSO pass an explicit variant={MEDIA_VARIANT_AVATAR} — this
+// default only covers direct useImageResolver callers that omit it.
 function resolveImageSource(fileId: string, variant?: string): string | undefined {
-  const url = getCachedFileDownloadUrlSync(oxyServices, fileId, variant ?? 'thumb');
+  const url = getCachedFileDownloadUrlSync(oxyServices, fileId, variant ?? MEDIA_VARIANT_AVATAR);
   return url && url.startsWith('http') ? url : undefined;
 }
 

--- a/packages/frontend/components/BoostScreen.tsx
+++ b/packages/frontend/components/BoostScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { show as toast } from '@oxyhq/bloom/toast';
 import { Dialog, useDialogControl } from '@oxyhq/bloom/dialog';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 
 import UserName from "./UserName";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -149,7 +150,7 @@ const BoostScreen: React.FC = () => {
                 {/* Original Post */}
                 <View className="py-4 border-b border-border mb-4">
                     <View className="flex-row items-center mb-2">
-                        <Avatar source={originalPost.user.avatar ?? undefined} size={32} style={{ marginRight: 8 }} />
+                        <Avatar source={originalPost.user.avatar ?? undefined} size={32} variant={MEDIA_VARIANT_AVATAR} style={{ marginRight: 8 }} />
                         <View className="flex-1">
                             <UserName
                                 name={originalPost.user.name?.displayName}
@@ -169,6 +170,7 @@ const BoostScreen: React.FC = () => {
                         <Avatar
                             source={user?.avatar}
                             size={48}
+                            variant={MEDIA_VARIANT_AVATAR}
                             style={{ marginRight: 12 }}
                         />
                         <View className="justify-center">

--- a/packages/frontend/components/BottomBar.tsx
+++ b/packages/frontend/components/BottomBar.tsx
@@ -3,6 +3,7 @@ import { Home, HomeActive, Video, VideoActive, ComposeIcon, ComposeIIconActive, 
 import { useRouter, usePathname, type Href } from 'expo-router';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 
 import { useAuth } from '@oxyhq/services';
 import { useTheme } from '@oxyhq/bloom/theme';
@@ -264,7 +265,7 @@ export const BottomBar = () => {
             onLongPress: handleLongPressProfile,
             label: t('bottomBar.profile'),
             isActive: pathname.startsWith('/@'),
-            icon: <Avatar size={ICON_SIZE + 4} source={user?.avatar} />,
+            icon: <Avatar size={ICON_SIZE + 4} source={user?.avatar} variant={MEDIA_VARIANT_AVATAR} />,
         },
     ], [
         handleHomePress, handlePressVideos, handlePressCompose, handlePressNotifications,

--- a/packages/frontend/components/Compose/CollaboratorPicker.tsx
+++ b/packages/frontend/components/Compose/CollaboratorPicker.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, TouchableOpacity, StyleSheet, FlatList } from 'r
 import { Loading } from '@oxyhq/bloom/loading';
 import { useAuth } from '@oxyhq/services';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { logger } from '@/lib/logger';
@@ -91,7 +92,7 @@ const CollaboratorPicker: React.FC<CollaboratorPickerProps> = ({ selected, onCha
         <View className="flex-row flex-wrap gap-2 mb-2">
           {selected.map((collab) => (
             <View key={collab.id} className="flex-row items-center bg-surface border border-border rounded-full pl-1 pr-2 py-1 gap-1">
-              <Avatar source={collab.avatar} size={24} />
+              <Avatar source={collab.avatar} size={24} variant={MEDIA_VARIANT_AVATAR} />
               <Text className="text-foreground text-sm" numberOfLines={1}>
                 {displayNameOrHandle(collab.displayName, `@${collab.username}`)}
               </Text>
@@ -150,7 +151,7 @@ const CollaboratorPicker: React.FC<CollaboratorPickerProps> = ({ selected, onCha
                   }
                   renderItem={({ item }) => (
                     <TouchableOpacity className="flex-row items-center px-3 py-2 gap-3" onPress={() => addUser(item)}>
-                      <Avatar source={item.avatar} size={32} />
+                      <Avatar source={item.avatar} size={32} variant={MEDIA_VARIANT_AVATAR} />
                       <View className="flex-1">
                         <Text className="text-foreground text-[15px] font-medium">
                           {displayNameOrHandle(item.displayName, item.username)}

--- a/packages/frontend/components/Compose/ComposeThreadItem.tsx
+++ b/packages/frontend/components/Compose/ComposeThreadItem.tsx
@@ -7,6 +7,7 @@ import {
   Image,
 } from 'react-native';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import PostArticlePreview from '@/components/Post/PostArticlePreview';
 import PostAttachmentEvent from '@/components/Post/Attachments/PostAttachmentEvent';
 import RoomCard from '@/components/RoomCard';
@@ -180,6 +181,7 @@ const ComposeThreadItem = memo<ComposeThreadItemProps>(({
             <Avatar
               source={userAvatar}
               size={40}
+              variant={MEDIA_VARIANT_AVATAR}
               verified={userVerified}
               style={avatarStyle}
             />

--- a/packages/frontend/components/Compose/QuoteCard.tsx
+++ b/packages/frontend/components/Compose/QuoteCard.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@oxyhq/bloom/avatar';
 import { Loading } from '@oxyhq/bloom/loading';
 import { useTranslation } from 'react-i18next';
 import type { HydratedPost, HydratedPostSummary } from '@mention/shared-types';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 
 import { CloseIcon } from '@/assets/icons/close-icon';
@@ -45,14 +46,15 @@ const QuoteCard: React.FC<QuoteCardProps> = ({ post, loading, onDismiss }) => {
   // Federation-aware avatar source for Bloom's Avatar (via the app-wide
   // ImageResolver): a FEDERATED/remote actor carries an absolute http(s) URL
   // (rendered directly; variant ignored); a LOCAL actor carries an Oxy file id
-  // (resolved with `variant="thumb"`). Bloom disambiguates URL vs file id, so we
-  // pass the raw value through and only steer the variant.
+  // (resolved with `variant={MEDIA_VARIANT_AVATAR}` — the 128px crop). Bloom
+  // disambiguates URL vs file id, so we pass the raw value through and only steer
+  // the variant.
   const avatar = useMemo(() => {
     const raw = post?.user?.avatar;
     if (typeof raw !== 'string' || !raw) return { source: undefined, variant: undefined };
     const isRemote =
       post?.user?.isFederated === true || raw.startsWith('http://') || raw.startsWith('https://');
-    return { source: raw, variant: isRemote ? undefined : 'thumb' };
+    return { source: raw, variant: isRemote ? undefined : MEDIA_VARIANT_AVATAR };
   }, [post]);
 
   if (loading) {

--- a/packages/frontend/components/Compose/VariantEditor.tsx
+++ b/packages/frontend/components/Compose/VariantEditor.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useCallback } from 'react';
 import { Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { Loading } from '@oxyhq/bloom/loading';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
@@ -105,7 +106,7 @@ const VariantEditor = memo(function VariantEditor({
   return (
     <View style={[styles.container, !isFocused && styles.unfocused]}>
       <View style={styles.headerRow}>
-        <Avatar source={userAvatar} size={AVATAR_SIZE} verified={userVerified} style={styles.avatar} />
+        <Avatar source={userAvatar} size={AVATAR_SIZE} variant={MEDIA_VARIANT_AVATAR} verified={userVerified} style={styles.avatar} />
         <View style={styles.column}>
           <MentionTextInput
             className="text-foreground"

--- a/packages/frontend/components/Feed/FeedHeader.tsx
+++ b/packages/frontend/components/Feed/FeedHeader.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@oxyhq/services';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { ThemedText } from '@/components/ThemedText';
 import { useTheme } from '@oxyhq/bloom/theme';
 
@@ -69,6 +70,7 @@ export const FeedHeader = memo<FeedHeaderProps>(
                 <Avatar
                     source={user.avatar || undefined}
                     size={32}
+                    variant={MEDIA_VARIANT_AVATAR}
                 />
                 <View style={styles.textRow}>
                     <ThemedText

--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -11,6 +11,7 @@ import {
     PostEngagementSummary,
     PostLinkPreview,
     PostRoomContent,
+    MEDIA_VARIANT_AVATAR,
 } from '@mention/shared-types';
 import { usePostSelector } from '../../stores/postsStore';
 import PostHeader, { HEADER_CONTENT_GAP, POST_CONTEXT_ROW_HEIGHT } from '../Post/PostHeader';
@@ -254,8 +255,9 @@ const PostItem: React.FC<PostItemProps> = ({
     // Avatar (via the app-wide ImageResolver). FEDERATED/remote actors carry a
     // remote http(s) avatar URL — passed straight through; the `variant` is
     // ignored for absolute URLs. LOCAL actors carry an Oxy file id — passed as
-    // `source` with `variant="thumb"` so Bloom's resolver fetches the thumb
-    // rendition. We no longer pre-resolve the file id with `useImageUrl`.
+    // `source` with `variant={MEDIA_VARIANT_AVATAR}` so Bloom's resolver fetches
+    // the lightweight 128px avatar rendition. We no longer pre-resolve the file
+    // id with `useImageUrl`.
     //
     // The backend emits the canonical Oxy `User` shape: `avatar` is a bare Oxy
     // file id for local actors and an absolute remote URL for federated actors.
@@ -270,7 +272,7 @@ const PostItem: React.FC<PostItemProps> = ({
     // Federated avatars are mirrored into Oxy at resolve/hydration time and arrive
     // as file ids or cloud.oxy.so URLs — same path as local users. No client proxy.
     const avatarSource = typeof rawAvatar === 'string' ? rawAvatar : undefined;
-    const avatarVariant = isRemoteAvatar ? undefined : 'thumb';
+    const avatarVariant = isRemoteAvatar ? undefined : MEDIA_VARIANT_AVATAR;
 
     // Preload only when the avatar is already an absolute URL (remote/federated).
     // Local file ids are resolved+cached by Bloom's resolver, and media items are

--- a/packages/frontend/components/FeedCard.tsx
+++ b/packages/frontend/components/FeedCard.tsx
@@ -5,6 +5,7 @@ import { router } from 'expo-router';
 import { ThemedText } from './ThemedText';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { AvatarGroup, type AvatarGroupItem } from '@oxyhq/bloom/avatar-group';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { formatCompactNumber } from '@/utils/formatNumber';
 
@@ -113,6 +114,7 @@ export function FeedCard({
                 <Avatar
                     source={feed.avatar || feed.creator?.avatar}
                     size={36}
+                    variant={MEDIA_VARIANT_AVATAR}
                     shape="squircle"
                 />
 
@@ -134,7 +136,7 @@ export function FeedCard({
 
                 {/* Right side: avatar cluster or custom slot */}
                 {avatarItems.length > 0 ? (
-                    <AvatarGroup items={avatarItems} size={28} max={3} />
+                    <AvatarGroup items={avatarItems} size={28} max={3} variant={MEDIA_VARIANT_AVATAR} />
                 ) : headerRight ? (
                     <View>{headerRight}</View>
                 ) : null}

--- a/packages/frontend/components/ListCard.tsx
+++ b/packages/frontend/components/ListCard.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { ThemedText } from './ThemedText';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { cn } from '@/lib/utils';
 
 /**
@@ -82,6 +83,7 @@ export function ListCard({
                 <Avatar
                     source={list.avatar || undefined}
                     size={40}
+                    variant={MEDIA_VARIANT_AVATAR}
                 />
                 <View className="flex-1 gap-1">
                     <ThemedText

--- a/packages/frontend/components/MentionPicker.tsx
+++ b/packages/frontend/components/MentionPicker.tsx
@@ -12,6 +12,7 @@ import { Loading } from '@oxyhq/bloom/loading';
 import { cn } from "@/lib/utils";
 import { useAuth } from "@oxyhq/services";
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { logger } from '@/lib/logger';
 import { displayNameOrHandle } from '@/utils/displayName';
 
@@ -134,6 +135,7 @@ const MentionPicker: React.FC<MentionPickerProps> = ({
                             <Avatar
                                 source={item.avatar}
                                 size={40}
+                                variant={MEDIA_VARIANT_AVATAR}
                             />
                             <View style={styles.userInfo}>
                                 <View style={styles.userNameRow}>

--- a/packages/frontend/components/Post/PostActions.tsx
+++ b/packages/frontend/components/Post/PostActions.tsx
@@ -8,6 +8,7 @@ import { ShareIcon } from '@/assets/icons/share-icon';
 import { Bookmark, BookmarkActive } from '@/assets/icons/bookmark-icon';
 import { AnalyticsIcon } from '@/assets/icons/analytics-icon';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useHaptics } from '@oxyhq/bloom/hooks';
@@ -437,7 +438,7 @@ const PostActions: React.FC<Props> = ({
                     { zIndex: 3 - i },
                   ]}
                 >
-                  <Avatar source={avatarId} size={MINI_AVATAR} />
+                  <Avatar source={avatarId} size={MINI_AVATAR} variant={MEDIA_VARIANT_AVATAR} />
                 </View>
               ))}
             </View>

--- a/packages/frontend/components/Profile/FollowedByRow.tsx
+++ b/packages/frontend/components/Profile/FollowedByRow.tsx
@@ -3,6 +3,7 @@ import { Pressable, Text } from 'react-native';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { AvatarGroup, type AvatarGroupItem } from '@oxyhq/bloom/avatar-group';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { useMutualFollowers } from '@/hooks/useMutualFollowers';
 import { displayNameOrHandle } from '@/utils/displayName';
 
@@ -76,7 +77,7 @@ export const FollowedByRow = memo(function FollowedByRow({ profileId, username }
       accessibilityRole="button"
       accessibilityLabel={label}
     >
-      <AvatarGroup items={avatarItems} size={20} max={3} total={total} variant="thumb" />
+      <AvatarGroup items={avatarItems} size={20} max={3} total={total} variant={MEDIA_VARIANT_AVATAR} />
       <Text className="text-muted-foreground text-[15px] shrink" numberOfLines={1}>
         {label}
       </Text>

--- a/packages/frontend/components/Profile/ProfileHeader.tsx
+++ b/packages/frontend/components/Profile/ProfileHeader.tsx
@@ -9,6 +9,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
 import { ZoomableAvatar } from '@/components/ZoomableAvatar';
 import { LiveAvatar } from '@/components/ui/LiveAvatar';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import { useLiveUsers } from '@/hooks/useLiveUsers';
 import { useLayoutScroll } from '@/context/LayoutScrollContext';
 import { AnalyticsIcon } from '@/assets/icons/analytics-icon';
@@ -89,7 +90,7 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
             className="border-[3px] border-background bg-secondary rounded-full"
             style={liveAvatarCollapseStyle}
           >
-            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={90} />
+            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={90} variant={MEDIA_VARIANT_VIDEO_POSTER} />
           </Animated.View>
         ) : (
           <ZoomableAvatar
@@ -209,7 +210,7 @@ export const ProfileHeaderMinimalist = memo(function ProfileHeaderMinimalist({
       <View className="relative">
         {isProfileLive ? (
           <View className="border-[3px] border-background bg-secondary rounded-full">
-            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={70} />
+            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={70} variant={MEDIA_VARIANT_VIDEO_POSTER} />
           </View>
         ) : (
           <ZoomableAvatar

--- a/packages/frontend/components/ProfileCard.tsx
+++ b/packages/frontend/components/ProfileCard.tsx
@@ -12,6 +12,7 @@ import { AgentIcon } from '@/assets/icons/agent-icon';
 import { AutomatedIcon } from '@/assets/icons/automated-icon';
 import { displayNameOrHandle } from '@/utils/displayName';
 import { getUserPlaceholderColor } from '@/utils/userPlaceholderColor';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { cn } from '@/lib/utils';
 
 /**
@@ -130,7 +131,7 @@ export function ProfileCard({
         <Avatar
           source={profile.avatar || undefined}
           size={40}
-          variant="thumb"
+          variant={MEDIA_VARIANT_AVATAR}
           verified={profile.verified}
           placeholderColor={getUserPlaceholderColor(profile)}
         />

--- a/packages/frontend/components/ProfileHoverCard/index.web.tsx
+++ b/packages/frontend/components/ProfileHoverCard/index.web.tsx
@@ -13,6 +13,7 @@ import { usePostActivity } from '@/hooks/usePostActivity';
 import { formatCompactNumber } from '@/utils/formatNumber';
 import { Portal } from '@oxyhq/bloom/portal';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import UserName from '@/components/UserName';
 import { RemoteActorBadge } from '@/components/Fediverse/FediverseBadge';
 import { useFederatedFollowSync } from '@/components/Profile/hooks/useFederatedFollowSync';
@@ -363,6 +364,7 @@ function CardContent({
           <Avatar
             source={profile.design.avatar || profile.avatar}
             size={64}
+            variant={MEDIA_VARIANT_VIDEO_POSTER}
             verified={profile.verified}
           />
         </View>

--- a/packages/frontend/components/ProfileScreen.tsx
+++ b/packages/frontend/components/ProfileScreen.tsx
@@ -48,6 +48,7 @@ import { ExternalLinkIcon } from '@/assets/icons/external-link-icon';
 
 // Components
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import UserName from './UserName';
 import AnimatedTabBar from './common/AnimatedTabBar';
 import { BottomBarAwareFab } from '@/components/BottomBarAwareFab';
@@ -760,6 +761,7 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
                                 <Avatar
                                     source={avatarUri}
                                     size={32}
+                                    variant={MEDIA_VARIANT_AVATAR}
                                 />
                                 <View style={{ flex: 1, minWidth: 0 }}>
                                     <UserName

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 import { useUnreadCount } from "@/hooks/useUnreadCount";
 import { SideBarItem } from "./SideBarItem";
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 
 import { Home, HomeActive } from "@/assets/icons/home-icon";
 import { Bookmark, BookmarkActive } from "@/assets/icons/bookmark-icon";
@@ -110,8 +111,8 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
         },
         ...(user ? [{
             title: t("sidebar.profile"),
-            icon: <Avatar source={avatarUri} size={24} />,
-            iconActive: <Avatar source={avatarUri} size={24} />,
+            icon: <Avatar source={avatarUri} size={24} variant={MEDIA_VARIANT_AVATAR} />,
+            iconActive: <Avatar source={avatarUri} size={24} variant={MEDIA_VARIANT_AVATAR} />,
             onPress: () => {
                 if (profileHandle) {
                     handleNavPress(`/@${profileHandle}`);

--- a/packages/frontend/components/StarterPackCard.tsx
+++ b/packages/frontend/components/StarterPackCard.tsx
@@ -4,6 +4,7 @@ import { PressableScale } from '@oxyhq/bloom/pressable-scale';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { AvatarGroup, type AvatarGroupItem } from '@oxyhq/bloom/avatar-group';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { useAuth } from '@oxyhq/services';
 import { router } from 'expo-router';
 import { ThemedText } from './ThemedText';
@@ -103,6 +104,7 @@ export function StarterPackCard({ pack, onPress, noDescription }: StarterPackCar
         <AvatarGroup
           items={avatarItems}
           size={32}
+          variant={MEDIA_VARIANT_AVATAR}
           max={MAX_ROW_AVATARS}
           total={pack.totalMembers ?? pack.memberCount}
           ringColor={theme.colors.card}

--- a/packages/frontend/components/ZoomableAvatar.tsx
+++ b/packages/frontend/components/ZoomableAvatar.tsx
@@ -33,6 +33,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useImageResolver } from '@oxyhq/bloom/image-resolver';
 import { useAuth } from '@oxyhq/services';
 import { useImageUrl } from '@/hooks/useImageUrl';
+import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import DefaultAvatar from '@/assets/images/default-avatar.jpg';
 import { Portal } from '@oxyhq/bloom/portal';
 
@@ -117,8 +118,14 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
   // (old profile-design data) and is resolved asynchronously via useImageUrl
   // (instant on cache hit, async on miss).
   const fileIdSource = typeof source === 'string' && !source.startsWith('http') ? source : undefined;
-  const providerResolvedUrl = fileIdSource ? imageResolver?.(fileIdSource) : undefined;
-  const resolvedUrl = useImageUrl(errored ? undefined : fileIdSource, 'thumb', oxyServices);
+  // ZoomableAvatar renders LARGE profile avatars (70–90px) and taps zoom to a
+  // ~400px fullscreen image, so it needs the 256px square crop (VIDEO_POSTER),
+  // NOT the 128px `avatar` crop small avatars use. Pass the variant explicitly to
+  // both resolution paths so it never inherits the resolver's small-avatar default.
+  const providerResolvedUrl = fileIdSource
+    ? imageResolver?.(fileIdSource, MEDIA_VARIANT_VIDEO_POSTER)
+    : undefined;
+  const resolvedUrl = useImageUrl(errored ? undefined : fileIdSource, MEDIA_VARIANT_VIDEO_POSTER, oxyServices);
 
   const resolvedSource = useMemo(() => {
     if (!source || errored) return undefined;

--- a/packages/frontend/components/feeds/FeedBuilder.tsx
+++ b/packages/frontend/components/feeds/FeedBuilder.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, TouchableOpacity, ScrollView, Platform, StyleShe
 import { Loading } from '@oxyhq/bloom/loading';
 import { Ionicons } from '@expo/vector-icons';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { SettingsListGroup, SettingsListItem } from '@oxyhq/bloom/settings-list';
 import { show as toast } from '@oxyhq/bloom/toast';
 import { useTranslation } from 'react-i18next';
@@ -184,7 +185,7 @@ const AccountPicker = ({
 
       {selected.map((u) => (
         <View key={u.id} className="flex-row items-center gap-3">
-          <Avatar source={u.avatar ?? undefined} size={36} />
+          <Avatar source={u.avatar ?? undefined} size={36} variant={MEDIA_VARIANT_AVATAR} />
           <View className="flex-1">
             <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>{accountName(u)}</Text>
             <Text className="text-[13px] text-muted-foreground" numberOfLines={1}>@{u.username}</Text>
@@ -209,7 +210,7 @@ const AccountPicker = ({
 
       {results.map((u) => (
         <TouchableOpacity key={u.id} className="flex-row items-center gap-3 py-1.5" onPress={() => add(u)} activeOpacity={0.7}>
-          <Avatar source={u.avatar ?? undefined} size={36} />
+          <Avatar source={u.avatar ?? undefined} size={36} variant={MEDIA_VARIANT_AVATAR} />
           <View className="flex-1">
             <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>{accountName(u)}</Text>
             <Text className="text-[13px] text-muted-foreground" numberOfLines={1}>@{u.username}</Text>

--- a/packages/frontend/components/notifications/NotificationItem.tsx
+++ b/packages/frontend/components/notifications/NotificationItem.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Ionicons } from '@expo/vector-icons';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { Button } from '@oxyhq/bloom/button';
 import { SubtleHover } from '@oxyhq/bloom/subtle-hover';
 import { useTheme } from '@oxyhq/bloom/theme';
@@ -215,7 +216,7 @@ const AvatarStrip: React.FC<{ actors: ResolvedActor[]; totalActors: number }> = 
           style={{ zIndex: shown.length - index }}
         >
           <View className="border-2 border-background rounded-full">
-            <Avatar source={actor.avatar} size={STACK_AVATAR_SIZE} />
+            <Avatar source={actor.avatar} size={STACK_AVATAR_SIZE} variant={MEDIA_VARIANT_AVATAR} />
           </View>
         </View>
       ))}
@@ -491,7 +492,7 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
         <View className="flex-row items-start justify-between">
           {/* Avatar column: avatar + themed action-badge overlay. */}
           <View className="relative mr-3">
-            <Avatar source={resolvedPrimary.avatar} size={AVATAR_SIZE} />
+            <Avatar source={resolvedPrimary.avatar} size={AVATAR_SIZE} variant={MEDIA_VARIANT_AVATAR} />
             <View
               className="absolute -bottom-0.5 -right-0.5 w-5 h-5 rounded-full border-2 border-background items-center justify-center"
               style={{ backgroundColor: badgeColor }}
@@ -553,7 +554,7 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
                         className="flex-row items-center gap-2"
                         accessibilityRole="button"
                       >
-                        <Avatar source={actor.avatar} size={STACK_AVATAR_SIZE} />
+                        <Avatar source={actor.avatar} size={STACK_AVATAR_SIZE} variant={MEDIA_VARIANT_AVATAR} />
                         <UserName name={actorLabel(actor, someone)} variant="small" />
                       </Pressable>
                     ))}


### PR DESCRIPTION
## Summary
Completes the avatar-sizing fix: a prior PR added a dedicated 128px `avatar` image variant server-side and flipped the backend's own usage, but the frontend's actual avatar renders (feed, notifications, profile cards, pickers, compose, etc.) never requested it — Bloom's `Avatar`/`AvatarGroup` hardcode their own internal `variant='thumb'` default and forward it, so the app-wide resolver's default never actually applied to a real render. This PR does the real fix: ~42 explicit call sites across 38 files now request `MEDIA_VARIANT_AVATAR` (small, ≤~48px avatars) or `MEDIA_VARIANT_VIDEO_POSTER` (large avatars >48px — profile headers, settings — kept at the same 256px rendition as before, zero regression) instead of the previous hardcoded/defaulted `'thumb'`. Every variant is an imported `@mention/shared-types` constant, no magic strings.

## Test plan
- [x] Typecheck: 0 errors
- [x] Lint: 0 errors (pre-existing warnings only)
- [x] Independent code review (opus): verified the size-threshold categorization (all "small" sites ≤48px, all "large" sites >48px), confirmed the avatar-only scope of the resolver default change (no non-avatar image affected), confirmed large avatars get byte-identical rendition to before (zero regression), confirmed no leftover magic-string `'thumb'` literals. **Ready to merge: Yes**, no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)