### PR TITLE
fix(backend): rename avatar variant to w128 + size link-preview images

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationLinkPreview.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationLinkPreview.test.ts
@@ -6,11 +6,13 @@ import type { LinkPreview } from '@oxyhq/contracts';
  * Verifies that `PostHydrationService` sources link previews from the Oxy
  * ecosystem link-preview service (`oxyServices.getLinkPreviews`) and maps the
  * `'resolved'` {@link LinkPreview}s onto the post DTO's `linkPreviews` array, in
- * text order — passing the Oxy-hosted (`cloud.oxy.so`) `image` through UNCHANGED
- * (never re-proxied). A `'pending'`/`'empty'`/missing preview is skipped (the URL
- * re-resolves on a later render, mirroring the previous warm-on-miss UX) without
- * disturbing the order of the resolved ones, and a preview-service failure never
- * fails feed hydration.
+ * text order — sizing the Oxy-hosted (`cloud.oxy.so`) `image` down to the
+ * `w320` (`MEDIA_VARIANT_THUMB`) context via `attachCdnVariant` instead of
+ * serving the no-variant original (never re-proxied, still Oxy-hosted). A
+ * `'pending'`/`'empty'`/missing preview is skipped (the URL re-resolves on a
+ * later render, mirroring the previous warm-on-miss UX) without disturbing
+ * the order of the resolved ones, and a preview-service failure never fails
+ * feed hydration.
  */
 
 const POST_ID = '650000000000000000000010';
@@ -34,7 +36,7 @@ vi.mock('../../../server', () => ({
 }));
 
 vi.mock('../../utils/oxyHelpers', () => ({
-  getServiceOxyClient: () => ({ getUsersByIds, getLinkPreviews }),
+  getServiceOxyClient: () => ({ getUsersByIds, getLinkPreviews, getCloudURL: () => 'https://cloud.oxy.so' }),
 }));
 
 vi.mock('../../utils/privacyHelpers', () => ({
@@ -134,20 +136,24 @@ describe('PostHydrationService — link previews sourced from Oxy', () => {
       status: 'resolved',
       title,
       description: `${title} description`,
-      image: 'https://cloud.oxy.so/file123?variant=thumb',
+      // No variant on the source — proves the service attaches one, not just
+      // preserves a pre-existing param.
+      image: 'https://cloud.oxy.so/file123',
       siteName: 'Example',
       favicon: 'https://cloud.oxy.so/favicon456',
       resolvedAt: new Date().toISOString(),
     };
   }
 
-  it('maps a resolved Oxy LinkPreview onto the post, passing the cloud.oxy.so image through unchanged', async () => {
+  it('maps a resolved Oxy LinkPreview onto the post, sizing the cloud.oxy.so image to the thumb (w320) variant', async () => {
     const resolved: LinkPreview = {
       url: 'https://example.com/some-article?canonical=1',
       status: 'resolved',
       title: 'Some Article',
       description: 'A description',
-      image: 'https://cloud.oxy.so/file123?variant=thumb',
+      // Already carries an unrelated variant — proves the service OVERWRITES
+      // it (idempotent `set`) rather than appending a duplicate param.
+      image: 'https://cloud.oxy.so/file123?variant=w2048',
       siteName: 'Example',
       favicon: 'https://cloud.oxy.so/favicon456',
       resolvedAt: new Date().toISOString(),
@@ -165,11 +171,30 @@ describe('PostHydrationService — link previews sourced from Oxy', () => {
         url: resolved.url,
         title: 'Some Article',
         description: 'A description',
-        // Oxy-hosted image is rendered directly, never re-proxied.
-        image: 'https://cloud.oxy.so/file123?variant=thumb',
+        // Oxy-hosted image is never re-proxied, but sized to w320 instead of
+        // serving the no-variant original (or an unrelated variant).
+        image: 'https://cloud.oxy.so/file123?variant=w320',
         siteName: 'Example',
       },
     ]);
+  });
+
+  it('leaves a non-Oxy-hosted image untouched (never attaches our variant to a third-party host)', async () => {
+    const resolved: LinkPreview = {
+      url: 'https://example.com/some-article?canonical=1',
+      status: 'resolved',
+      title: 'External image',
+      description: 'A description',
+      image: 'https://images.example.com/og-image.png',
+      siteName: 'Example',
+      favicon: undefined,
+      resolvedAt: new Date().toISOString(),
+    };
+    getLinkPreviews.mockResolvedValue({ [POST_URL]: resolved });
+
+    const hydrated = await hydrate();
+
+    expect(hydrated.linkPreviews?.[0]?.image).toBe('https://images.example.com/og-image.png');
   });
 
   it('maps every resolved preview of a multi-link post, in text order', async () => {

--- a/packages/backend/src/__tests__/utils/mediaResolver.test.ts
+++ b/packages/backend/src/__tests__/utils/mediaResolver.test.ts
@@ -104,7 +104,7 @@ describe('resolveAvatarUrl', () => {
     // Avatars use the dedicated 128px square `avatar` crop (not the wider w320
     // used for post media, nor the 256px `thumb`), since they render tiny and
     // circular.
-    expect(resolveAvatarUrl('avatar1')).toBe(`${OXY_BASE}/assets/avatar1/stream?variant=avatar`);
+    expect(resolveAvatarUrl('avatar1')).toBe(`${OXY_BASE}/assets/avatar1/stream?variant=w128`);
   });
 
   it('returns the proxy url for an external avatar', () => {
@@ -128,12 +128,12 @@ describe('resolveAvatarUrl', () => {
     // cloud.oxy.so/<id> URL. It must get the avatar variant appended, NOT be
     // served as the no-variant original or double-proxied through /media/proxy.
     const mirrored = `${CLOUD_BASE}/abc123`;
-    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=avatar`);
+    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=w128`);
   });
 
   it('is idempotent when the mirrored Oxy CDN url already carries a variant', () => {
     const mirrored = `${CLOUD_BASE}/abc123?variant=w320`;
-    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=avatar`);
+    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=w128`);
   });
 
   it('returns undefined for an empty ref', () => {

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1,4 +1,4 @@
-import { FeedPostSlice, FeedSliceItem, HydratedPost, HydratedPostSummary, HydratedBoostContext, HydratedAuthor, PostUser, PostAttachmentBundle, PostEngagementSummary, PostLinkPreview, PostPermissions, PostViewerState, PostVisibility, PostAuthorshipEntry } from '@mention/shared-types';
+import { FeedPostSlice, FeedSliceItem, HydratedPost, HydratedPostSummary, HydratedBoostContext, HydratedAuthor, PostUser, PostAttachmentBundle, PostEngagementSummary, PostLinkPreview, PostPermissions, PostViewerState, PostVisibility, PostAuthorshipEntry, MEDIA_VARIANT_THUMB } from '@mention/shared-types';
 import mongoose from 'mongoose';
 import { Post, type PostFederationData } from '../models/Post';
 import Poll from '../models/Poll';
@@ -10,7 +10,7 @@ import { oxy as defaultOxyClient } from '../../server';
 import { getServiceOxyClient } from '../utils/oxyHelpers';
 import { extractUrls } from '../utils/extractUrls';
 import { getBlockedUserIds, getRestrictedUserIds, extractFollowingIds, extractFollowersIds, OxyClient } from '../utils/privacyHelpers';
-import { resolveMediaItems } from '../utils/mediaResolver';
+import { resolveMediaItems, attachCdnVariant } from '../utils/mediaResolver';
 import { logger } from '../utils/logger';
 import { readPersistedMediaFields } from './MediaMetadataService';
 import type { User as OxyUser } from '@oxyhq/core';
@@ -1246,8 +1246,10 @@ export class PostHydrationService {
    * ({@link OxyServices.getLinkPreviews}) instead of being scraped locally. Oxy
    * owns BOTH resolution and privacy-preserving image hosting: the `image` /
    * `favicon` on every returned preview is an absolute Oxy-hosted
-   * (`cloud.oxy.so`) URL, so it is passed through to the post DTO unchanged —
-   * never re-proxied via `/media/proxy`.
+   * (`cloud.oxy.so`) URL — never re-proxied via `/media/proxy`, but sized down
+   * via {@link attachCdnVariant} (the `MEDIA_VARIANT_THUMB`/`w320` context,
+   * matching the link-preview card's rendered width) instead of serving the
+   * no-variant original for what renders as a small card cover image.
    *
    * This stays safe on the `/feed/*` response path: the batch call is a fast
    * cached read (mirroring the {@link OxyServices.getUsersByIds} author-batch
@@ -1318,8 +1320,9 @@ export class PostHydrationService {
         url: preview.url,
         title: preview.title || undefined,
         description: preview.description || undefined,
-        // Already an absolute Oxy-hosted `cloud.oxy.so` URL — render directly.
-        image: preview.image || undefined,
+        // Already an absolute Oxy-hosted `cloud.oxy.so` URL — attach the
+        // thumb-context variant instead of serving the no-variant original.
+        image: preview.image ? attachCdnVariant(preview.image, MEDIA_VARIANT_THUMB) : undefined,
         siteName: preview.siteName || undefined,
       });
     }

--- a/packages/backend/src/utils/mediaResolver.ts
+++ b/packages/backend/src/utils/mediaResolver.ts
@@ -126,6 +126,29 @@ function getOwnHosts(): Set<string> {
   return hosts;
 }
 
+/**
+ * Attach `variant` to `url` if it's hosted on our own Oxy CDN
+ * (`cloud.oxy.so`) — idempotent (`set`, not `append`, so a pre-existing
+ * `variant` param is overwritten rather than duplicated). Returns `url`
+ * unchanged for any other host or if it isn't a parseable absolute URL.
+ * Never throws. Shared by every caller that has an already-final Oxy CDN URL
+ * (not a bare file id) and needs to size it down instead of serving the
+ * no-variant original — {@link resolveAvatarUrl} and Oxy-hosted link-preview
+ * images.
+ */
+export function attachCdnVariant(url: string, variant: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.host.toLowerCase() !== getCloudHost()) {
+      return url;
+    }
+    parsed.searchParams.set('variant', variant);
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 /** True when `ref` is an absolute `http(s)` URL. */
 function isAbsoluteHttpUrl(ref: string): boolean {
   return /^https?:\/\//i.test(ref);
@@ -213,15 +236,9 @@ export function resolveAvatarUrl(ref?: string | null): string | undefined {
       }
       if (host && host === getCloudHost()) {
         // Federated avatar Oxy already mirrored to its CDN: attach the avatar
-        // variant to the existing URL (idempotent via `set`) instead of serving
-        // the no-variant original or proxying our own CDN through /media/proxy.
-        try {
-          const url = new URL(ref);
-          url.searchParams.set('variant', MEDIA_VARIANT_AVATAR);
-          return url.toString();
-        } catch {
-          return ref;
-        }
+        // variant to the existing URL instead of serving the no-variant
+        // original or proxying our own CDN through /media/proxy.
+        return attachCdnVariant(ref, MEDIA_VARIANT_AVATAR);
       }
       // Defer to the shared resolver for own-origin passthrough / proxy wrapping.
       const resolved = resolveMediaRef(ref);

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -23,8 +23,13 @@ export enum PostVisibility {
 /**
  * Oxy asset IMAGE variant names that the central asset service actually
  * generates (`packages/api/src/services/variantService.ts` `imageVariants`):
- * `avatar`(128) / `thumb`(256) / `w320` / `w640` / `w1280` / `w2048`.
- * `small`/`medium`/`large`/`original` do NOT exist server-side and 404 on the CDN.
+ * `w128` / `thumb`(256) / `w320` / `w640` / `w1280` / `w2048` — all named for
+ * their pixel width except the legacy `thumb` (also 256px, predates the
+ * width-naming convention). `small`/`medium`/`large`/`original`/`avatar` do
+ * NOT exist server-side and 404 on the CDN (`avatar` was the w128 variant's
+ * name for its first few hours before being renamed to match convention —
+ * it's a generic small-image size, not avatar-specific, so other small-image
+ * contexts can reach for it too).
  *
  * These are the SINGLE source of truth for which variant each render context
  * requests, shared by the backend resolver (`utils/mediaResolver.ts`) and the
@@ -37,14 +42,14 @@ export enum PostVisibility {
  * `w640`/`w1280`/`w2048` variants reserved for wider displays / the lightbox.
  *
  * Avatars render small and circular, so the AVATAR context maps to the dedicated
- * 128px square `avatar` crop — lighter still than `thumb` (~68% fewer bytes for a
+ * 128px square `w128` crop — lighter still than `thumb` (~68% fewer bytes for a
  * typical source). Video posters are a DIFFERENT context: they fill the (up to
  * ~320px wide) media card as a rectangle, so they keep the 256px `thumb` crop via
- * VIDEO_POSTER rather than being shrunk to the 128px avatar square.
+ * VIDEO_POSTER rather than being shrunk to the 128px square.
  */
 export const MEDIA_VARIANT_THUMB = 'w320';
 export const MEDIA_VARIANT_FULL = 'w2048';
-export const MEDIA_VARIANT_AVATAR = 'avatar';
+export const MEDIA_VARIANT_AVATAR = 'w128';
 export const MEDIA_VARIANT_VIDEO_POSTER = 'thumb';
 
 export interface MediaItem {


### PR DESCRIPTION
## Summary
Two related backend fixes, shipped together:

1. **Rename `MEDIA_VARIANT_AVATAR`'s value from `'avatar'` to `'w128'`**, matching OxyHQServices' server-side rename (already deployed, live-verified: `cloud.oxy.so/<id>?variant=w128` resolves correctly). More generic/consistent naming — matches the existing size-based convention (`w320`/`w640`/`w1280`/`w2048`) instead of implying avatar-only use, since it's a generic small-image size other contexts can reach for too.
2. **Fix link-preview images loading full-size.** `PostHydrationService.buildLinkPreviewMap` passed Oxy's already-hosted `cloud.oxy.so` link-preview image straight through with no variant — same bug class as the earlier federated-avatar fix, just for the ~280px-wide link preview card in the feed. Extracted the avatar fix's URL+variant logic into a shared `attachCdnVariant` helper (now used by both `resolveAvatarUrl` and this) and applied `MEDIA_VARIANT_THUMB` (w320), matching the card's rendered width. Non-Oxy image hosts are left untouched.

## Test plan
- [x] Backend test suite: 2260/2260 passing (includes 2 new test cases for the link-preview fix — variant is actually attached/overwritten, and non-Oxy hosts are left alone)
- [x] Frontend typecheck/lint: 0 errors
- [x] Live-verified the w128 rename is already deployed server-side before pushing this (sequencing: server first, consumer second, to avoid a window where Mention requests a variant name the server doesn't recognize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)