### PR TITLE
fix(frontend): federated avatar variant bug + smaller w96 tier + type cleanup

### DIFF
--- a/packages/backend/src/__tests__/utils/mediaResolver.test.ts
+++ b/packages/backend/src/__tests__/utils/mediaResolver.test.ts
@@ -101,10 +101,10 @@ describe('resolveMediaRef', () => {
 
 describe('resolveAvatarUrl', () => {
   it('returns the dedicated avatar crop for an Oxy file id', () => {
-    // Avatars use the dedicated 128px square `avatar` crop (not the wider w320
+    // Avatars use the dedicated 96px square `w96` crop (not the wider w320
     // used for post media, nor the 256px `thumb`), since they render tiny and
     // circular.
-    expect(resolveAvatarUrl('avatar1')).toBe(`${OXY_BASE}/assets/avatar1/stream?variant=w128`);
+    expect(resolveAvatarUrl('avatar1')).toBe(`${OXY_BASE}/assets/avatar1/stream?variant=w96`);
   });
 
   it('returns the proxy url for an external avatar', () => {
@@ -128,12 +128,12 @@ describe('resolveAvatarUrl', () => {
     // cloud.oxy.so/<id> URL. It must get the avatar variant appended, NOT be
     // served as the no-variant original or double-proxied through /media/proxy.
     const mirrored = `${CLOUD_BASE}/abc123`;
-    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=w128`);
+    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=w96`);
   });
 
   it('is idempotent when the mirrored Oxy CDN url already carries a variant', () => {
     const mirrored = `${CLOUD_BASE}/abc123?variant=w320`;
-    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=w128`);
+    expect(resolveAvatarUrl(mirrored)).toBe(`${CLOUD_BASE}/abc123?variant=w96`);
   });
 
   it('returns undefined for an empty ref', () => {

--- a/packages/backend/src/utils/mediaResolver.ts
+++ b/packages/backend/src/utils/mediaResolver.ts
@@ -26,7 +26,7 @@ import { logger } from './logger';
  *  - anything else → treated as an Oxy file id and turned into a CDN/stream URL
  *    via the SDK's synchronous `getFileDownloadUrl` (pure URL construction, no
  *    network), with image variants for image thumbnails/fullscreen, the dedicated
- *    128px `avatar` crop for avatars, and the 256px `thumb` crop for video posters.
+ *    96px `w96` crop for avatars, and the 256px `thumb` crop for video posters.
  *
  * This module NEVER throws: on any failure it degrades to the safest passthrough
  * (`{ url: ref }` or `undefined`).
@@ -58,11 +58,10 @@ export interface ResolvedMedia {
  * Oxy asset IMAGE variant taxonomy lives in `@mention/shared-types`
  * (`MEDIA_VARIANT_*`) as the single source of truth shared with the frontend.
  * The asset service (`packages/api/src/services/variantService.ts`
- * `imageVariants`) generates only `avatar`(128) / `thumb`(256) / `w320` / `w640`
- * / `w1280` / `w2048`; `small`/`medium`/`large`/`original` 404 on the CDN.
- * Verified live scale: `avatar`~4.1KB, `thumb`~13KB (for the same source),
- * `w320`~4KB, `w2048`~25.2KB, raw original ~77KB. Each render context maps to a
- * real, existing variant instead of the raw original.
+ * `imageVariants`) generates only `w96` / `w128` / `thumb`(256) / `w320` /
+ * `w640` / `w1280` / `w2048`; `small`/`medium`/`large`/`original`/`avatar` 404
+ * on the CDN. Each render context maps to a real, existing variant instead of
+ * the raw original.
  *
  *  - thumbnail (post media card / profile grid) → {@link MEDIA_VARIANT_THUMB}.
  *    Both surfaces are ≤320px wide, so this resolves to the lighter `w320`
@@ -70,11 +69,11 @@ export interface ResolvedMedia {
  *    small cards/cells without paying for the wider variants.
  *  - fullscreen lightbox (upgrade on open)      → {@link MEDIA_VARIANT_FULL}.
  *  - avatars (small, circular crop)             → {@link MEDIA_VARIANT_AVATAR}.
- *    The dedicated 128px square `avatar` crop — ~68% lighter than the old 256px
- *    `thumb` for a typical source.
+ *    The dedicated 96px square `w96` crop — most avatars across the app
+ *    render ≤40px, comfortably covered even at 3x DPR.
  *  - video posters (feed media rectangle)       → {@link MEDIA_VARIANT_VIDEO_POSTER}.
- *    Kept on the 256px `thumb` crop: a poster fills the media card, so it must
- *    not be shrunk to the 128px avatar square.
+ *    Kept on the 256px `thumb` crop: a poster fills the media card, so it
+ *    must not be shrunk to a small square.
  */
 
 /** Backend route that proxies remote media through our own origin. */
@@ -210,9 +209,9 @@ export function resolveMediaRef(ref: string | null | undefined): ResolvedMedia {
 
 /**
  * Resolve an avatar reference to a FINAL URL. For an Oxy file id this is the
- * dedicated 128px square `avatar` crop — avatars are rendered tiny and circular,
+ * dedicated 96px square `w96` crop — avatars are rendered tiny and circular,
  * so the small square crop is correct (unlike post media, which uses wider
- * variants) and far lighter than the old 256px `thumb`.
+ * variants) and far lighter than the 256px `thumb`.
  *
  * For an absolute URL already on the Oxy CDN host (`cloud.oxy.so`) — the shape a
  * federated avatar takes once Oxy has mirrored it at resolve/hydration time — the

--- a/packages/frontend/app/(app)/compose.tsx
+++ b/packages/frontend/app/(app)/compose.tsx
@@ -1920,7 +1920,7 @@ const ComposeScreenBody = () => {
                       handle: user?.username || '',
                       verified: Boolean(user?.verified)
                     }}
-                    avatarSource={user?.avatar ?? undefined}
+                    avatarSource={user?.avatar}
                     avatarVariant={MEDIA_VARIANT_AVATAR}
                     avatarSize={AVATAR_SIZE}
                     onPressUser={() => { }}

--- a/packages/frontend/app/(app)/lists.tsx
+++ b/packages/frontend/app/(app)/lists.tsx
@@ -27,13 +27,13 @@ function toListCardData(list: MentionList): ListCardData {
     id: String(list._id || list.id),
     uri: `list:${list._id || list.id}`,
     name: list.title || 'Untitled List',
-    description: typeof list.description === 'string' ? list.description : undefined,
+    description: list.description,
     avatar: typeof list.avatar === 'string' ? list.avatar : undefined,
     creator: owner
       ? {
           username: owner.username || '',
           displayName: owner.displayName,
-          avatar: typeof owner.avatar === 'string' ? owner.avatar : undefined,
+          avatar: owner.avatar,
         }
       : undefined,
     purpose: list.purpose === 'modlist' ? 'modlist' : 'curatelist',

--- a/packages/frontend/components/Compose/QuoteCard.tsx
+++ b/packages/frontend/components/Compose/QuoteCard.tsx
@@ -43,20 +43,6 @@ const QuoteCard: React.FC<QuoteCardProps> = ({ post, loading, onDismiss }) => {
 
   const userHandle = useMemo(() => getNormalizedUserHandle(post?.user) ?? '', [post]);
 
-  // Federation-aware avatar source for Bloom's Avatar (via the app-wide
-  // ImageResolver): a FEDERATED/remote actor carries an absolute http(s) URL
-  // (rendered directly; variant ignored); a LOCAL actor carries an Oxy file id
-  // (resolved with `variant={MEDIA_VARIANT_AVATAR}` — the 128px crop). Bloom
-  // disambiguates URL vs file id, so we pass the raw value through and only steer
-  // the variant.
-  const avatar = useMemo(() => {
-    const raw = post?.user?.avatar;
-    if (typeof raw !== 'string' || !raw) return { source: undefined, variant: undefined };
-    const isRemote =
-      post?.user?.isFederated === true || raw.startsWith('http://') || raw.startsWith('https://');
-    return { source: raw, variant: isRemote ? undefined : MEDIA_VARIANT_AVATAR };
-  }, [post]);
-
   if (loading) {
     return (
       <View
@@ -79,7 +65,11 @@ const QuoteCard: React.FC<QuoteCardProps> = ({ post, loading, onDismiss }) => {
   return (
     <View className="border-border bg-secondary relative rounded-2xl border px-4 py-3">
       <View className="flex-row items-start">
-        <Avatar source={avatar.source} variant={avatar.variant} size={28} style={{ marginRight: 10 }} />
+        {/* `avatar` is a bare Oxy file id OR an absolute URL, for local and
+            federated authors alike — Bloom's Avatar accepts both shapes
+            (and `null`) directly and ignores `variant` for an absolute URL,
+            so nothing needs branching or coercing here. */}
+        <Avatar source={post?.user?.avatar} variant={MEDIA_VARIANT_AVATAR} size={28} style={{ marginRight: 10 }} />
         <View className="flex-1 pr-6">
           <View className="flex-row items-center">
             {userName ? (

--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -251,35 +251,27 @@ const PostItem: React.FC<PostItemProps> = ({
         ? content.attachments
         : undefined;
 
-    // Avatar source resolution is federation-aware and delegated to Bloom's
-    // Avatar (via the app-wide ImageResolver). FEDERATED/remote actors carry a
-    // remote http(s) avatar URL — passed straight through; the `variant` is
-    // ignored for absolute URLs. LOCAL actors carry an Oxy file id — passed as
-    // `source` with `variant={MEDIA_VARIANT_AVATAR}` so Bloom's resolver fetches
-    // the lightweight 128px avatar rendition. We no longer pre-resolve the file
-    // id with `useImageUrl`.
-    //
-    // The backend emits the canonical Oxy `User` shape: `avatar` is a bare Oxy
-    // file id for local actors and an absolute remote URL for federated actors.
-    // We branch on `isFederated` and on whether the value is already an absolute
-    // URL so Bloom's resolver only gets a `variant` for local file ids.
-    const rawAvatar = viewPost?.user?.avatar;
-    const isRemoteAvatar =
-        typeof rawAvatar === 'string' &&
-        (viewPost?.user?.isFederated === true ||
-            rawAvatar.startsWith('http://') ||
-            rawAvatar.startsWith('https://'));
-    // Federated avatars are mirrored into Oxy at resolve/hydration time and arrive
-    // as file ids or cloud.oxy.so URLs — same path as local users. No client proxy.
-    const avatarSource = typeof rawAvatar === 'string' ? rawAvatar : undefined;
-    const avatarVariant = isRemoteAvatar ? undefined : MEDIA_VARIANT_AVATAR;
+    // Avatar source resolution is delegated to Bloom's Avatar (via the
+    // app-wide ImageResolver). The backend emits the canonical Oxy `User`
+    // shape: `avatar` is EITHER a bare Oxy file id OR an absolute URL — for
+    // BOTH local and federated actors alike (both are mirrored into the same
+    // Oxy storage, so there's no federation-based distinction to make here).
+    // We always pass `variant={MEDIA_VARIANT_AVATAR}` unconditionally: Bloom's
+    // Avatar ignores `variant` entirely when `source` turns out to be an
+    // already-absolute URL (rendered straight through) and only applies it
+    // when resolving a bare Oxy file id, so there's nothing for this
+    // component to detect or branch on. We no longer pre-resolve the file id
+    // with `useImageUrl`.
+    const avatarSource = viewPost?.user?.avatar;
+    const avatarVariant = MEDIA_VARIANT_AVATAR;
 
-    // Preload only when the avatar is already an absolute URL (remote/federated).
-    // Local file ids are resolved+cached by Bloom's resolver, and media items are
-    // referenced by id and resolved inside PostAttachmentsRow.
+    // Preload only makes sense when the avatar is already an absolute URL —
+    // a bare file id needs async resolution first, handled internally by
+    // Bloom's resolver/cache. Media items are referenced by id and resolved
+    // inside PostAttachmentsRow.
     const imageUrls = useMemo(
-        () => (isRemoteAvatar && avatarSource ? [avatarSource] : []),
-        [isRemoteAvatar, avatarSource],
+        () => (avatarSource && (avatarSource.startsWith('http://') || avatarSource.startsWith('https://')) ? [avatarSource] : []),
+        [avatarSource],
     );
 
     useImagePreload(imageUrls, true);

--- a/packages/frontend/components/ListCard.tsx
+++ b/packages/frontend/components/ListCard.tsx
@@ -28,7 +28,7 @@ export interface ListCardData {
     creator?: {
         username: string;
         displayName?: string;
-        avatar?: string;
+        avatar?: string | null;
     };
     purpose?: 'curatelist' | 'modlist';
     itemCount?: number;
@@ -81,7 +81,7 @@ export function ListCard({
             style={isRow ? undefined : { borderWidth: StyleSheet.hairlineWidth }}>
             <View className="flex-row items-center gap-3">
                 <Avatar
-                    source={list.avatar || undefined}
+                    source={list.avatar}
                     size={40}
                     variant={MEDIA_VARIANT_AVATAR}
                 />

--- a/packages/frontend/components/Post/PostHeader.tsx
+++ b/packages/frontend/components/Post/PostHeader.tsx
@@ -70,13 +70,14 @@ interface PostHeaderProps {
    */
   contextTop?: React.ReactNode;
   /**
-   * Avatar image source passed straight to Bloom's {@link Avatar}. Accepts a full
-   * http(s) URL (federated/remote actor avatar — rendered directly) OR a bare Oxy
-   * file id for a LOCAL actor — Bloom's `ImageResolver` resolves the file id with
-   * {@link avatarVariant}. The federated-vs-local branch is owned by the caller
-   * (it picks the URL or the file id); Bloom disambiguates URL vs file id again.
+   * Avatar image source passed straight to Bloom's {@link Avatar}, which
+   * accepts this exact shape natively — a bare Oxy file id (resolved with
+   * {@link avatarVariant}), an absolute http(s) URL (rendered directly,
+   * `avatarVariant` ignored), or `null`/`undefined` (no author avatar yet).
+   * No branching or coercion needed here: pass `user.avatar` straight
+   * through, for local and federated authors alike.
    */
-  avatarSource?: string;
+  avatarSource?: string | null;
   /**
    * Rendition variant for `avatarSource` when it is a bare file id (local actor).
    * Ignored by Bloom when `avatarSource` is already a full URL.

--- a/packages/frontend/utils/userEnrichment.ts
+++ b/packages/frontend/utils/userEnrichment.ts
@@ -19,7 +19,7 @@ export function enrichMissingAvatars(
   queryClient: QueryClient,
 ): Promise<void> {
   const missingIds = users
-    .filter((u) => !u.avatar || (typeof u.avatar === 'string' && !u.avatar.startsWith('http')))
+    .filter((u) => !u.avatar || !u.avatar.startsWith('http'))
     .map((u) => u.id)
     .filter((id) => id.length > 0);
   if (missingIds.length === 0) return Promise.resolve();

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -23,13 +23,13 @@ export enum PostVisibility {
 /**
  * Oxy asset IMAGE variant names that the central asset service actually
  * generates (`packages/api/src/services/variantService.ts` `imageVariants`):
- * `w128` / `thumb`(256) / `w320` / `w640` / `w1280` / `w2048` — all named for
- * their pixel width except the legacy `thumb` (also 256px, predates the
- * width-naming convention). `small`/`medium`/`large`/`original`/`avatar` do
- * NOT exist server-side and 404 on the CDN (`avatar` was the w128 variant's
+ * `w96` / `w128` / `thumb`(256) / `w320` / `w640` / `w1280` / `w2048` — all
+ * named for their pixel width except the legacy `thumb` (also 256px,
+ * predates the width-naming convention). `small`/`medium`/`large`/`original`/
+ * `avatar` do NOT exist server-side and 404 on the CDN (`avatar` was `w128`'s
  * name for its first few hours before being renamed to match convention —
- * it's a generic small-image size, not avatar-specific, so other small-image
- * contexts can reach for it too).
+ * these are generic small-image sizes, not avatar-specific, so other
+ * small-image contexts can reach for them too).
  *
  * These are the SINGLE source of truth for which variant each render context
  * requests, shared by the backend resolver (`utils/mediaResolver.ts`) and the
@@ -41,15 +41,17 @@ export enum PostVisibility {
  * enough for a retina render of those small surfaces, but far lighter than the
  * `w640`/`w1280`/`w2048` variants reserved for wider displays / the lightbox.
  *
- * Avatars render small and circular, so the AVATAR context maps to the dedicated
- * 128px square `w128` crop — lighter still than `thumb` (~68% fewer bytes for a
- * typical source). Video posters are a DIFFERENT context: they fill the (up to
- * ~320px wide) media card as a rectangle, so they keep the 256px `thumb` crop via
- * VIDEO_POSTER rather than being shrunk to the 128px square.
+ * Avatars render small and circular, so the AVATAR context maps to the
+ * dedicated 96px square `w96` crop — most avatars across the app render
+ * ≤40px (post headers ~36px, notifications, facepiles), so `w96` covers
+ * those comfortably even at 3x DPR while staying lighter than the 128px
+ * crop it replaced. Video posters are a DIFFERENT context: they fill the (up
+ * to ~320px wide) media card as a rectangle, so they keep the 256px `thumb`
+ * crop via VIDEO_POSTER rather than being shrunk to a small square.
  */
 export const MEDIA_VARIANT_THUMB = 'w320';
 export const MEDIA_VARIANT_FULL = 'w2048';
-export const MEDIA_VARIANT_AVATAR = 'w128';
+export const MEDIA_VARIANT_AVATAR = 'w96';
 export const MEDIA_VARIANT_VIDEO_POSTER = 'thumb';
 
 export interface MediaItem {


### PR DESCRIPTION
## Summary
Three related commits:

1. **Federated post avatars were stuck on the wrong (largest) variant.** `PostItem.tsx`/`QuoteCard.tsx` forced `avatarVariant=undefined` for ANY federated author, purely on `isFederated===true` — live-verified every federated author in a real feed response carries a bare Oxy file id (Oxy mirrors it), same as local users, so this fell through to Bloom's own `'thumb'` (256px) default instead of the small avatar variant. Simplified past just fixing it: Bloom's `Avatar` already ignores `variant` for an absolute-URL source and only applies it to a bare file id, so callers don't need to branch on federation (or even detect the source's shape) at all — just pass the variant unconditionally.
2. **Dropped redundant `typeof`/coercion checks** on fields already typed `string | null | undefined` (`PostHeader.avatarSource`, `ListCardData.creator.avatar`, a few others) — fixed at the root (widened the inconsistent type) rather than patching each call site.
3. **Switched `MEDIA_VARIANT_AVATAR` to the new, smaller `w96` crop** (OxyHQServices #629, live-verified before this push) — most avatars across the app render ≤40px, comfortably covered by 96px even at 3x DPR, lighter than the 128px crop it replaces.

## Test plan
- [x] Backend test suite: 2260/2260 passing
- [x] Frontend typecheck/lint: 0 errors
- [x] Live-verified `?variant=w96` resolves correctly on `cloud.oxy.so` before pushing (server-first sequencing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)