### PR TITLE
perf(frontend): preload lightbox full-res image on post row render

### DIFF
--- a/packages/frontend/components/Post/PostAttachmentsRow.tsx
+++ b/packages/frontend/components/Post/PostAttachmentsRow.tsx
@@ -16,6 +16,7 @@ import { useRouter } from 'expo-router';
 import { PodcastCard } from '@/components/Podcast/PodcastCard';
 import { MEDIA_CARD_HEIGHT } from '@/utils/composeUtils';
 import { getCachedFileDownloadUrlSync, videoPosterUrl } from '@/utils/imageUrlCache';
+import { useImagePreload } from '@/hooks/useImagePreload';
 import {
   ZoomableImageGallery,
   type ZoomableImageGalleryHandle,
@@ -405,6 +406,12 @@ const PostAttachmentsRow: React.FC<Props> = React.memo(({
       .map(item => ({ uri: item.fullSrc, alt: item.alt })),
     [mediaItems]
   );
+
+  // Prefetch the lightbox's large variant as soon as the row renders — rows only
+  // mount within the feed virtualizer's viewport window, same gating PostItem
+  // already relies on to preload author avatars — so tapping a thumbnail opens
+  // against a warm image cache instead of a cold fetch.
+  useImagePreload(useMemo(() => galleryImages.map(image => image.uri), [galleryImages]));
 
   const imageIndexByMediaId = useMemo<Map<string, number>>(() => {
     const map = new Map<string, number>();


### PR DESCRIPTION
## Summary
- Wires the existing `useImagePreload` hook into `PostAttachmentsRow` to prefetch the post lightbox's full-res gallery image URLs as soon as a post row renders
- Tapping a photo to open the lightbox now hits a warm image cache instead of triggering a cold network fetch

## Test plan
- [x] Frontend build (`bun run build:frontend`) passed
- [x] Backend build (`bun run build:backend`) passed
- [x] Backend test suite (`cd packages/backend && bun run test`) — 212 test files / 2260 tests passed
- [x] Lockfile gate (`bun install --frozen-lockfile`) passed, no drift
- [x] Frontend typecheck clean, eslint clean (only 2 pre-existing unrelated warnings)