### PR TITLE
fix(frontend): stop lightbox aspect-ratio snap causing open flicker

### DIFF
--- a/packages/frontend/components/Post/PostAttachmentsRow.tsx
+++ b/packages/frontend/components/Post/PostAttachmentsRow.tsx
@@ -17,6 +17,7 @@ import { PodcastCard } from '@/components/Podcast/PodcastCard';
 import { MEDIA_CARD_HEIGHT } from '@/utils/composeUtils';
 import { getCachedFileDownloadUrlSync, videoPosterUrl } from '@/utils/imageUrlCache';
 import { useImagePreload } from '@/hooks/useImagePreload';
+import { readMediaAspectRatio } from '@/utils/mediaTypes';
 import {
   ZoomableImageGallery,
   type ZoomableImageGalleryHandle,
@@ -403,7 +404,7 @@ const PostAttachmentsRow: React.FC<Props> = React.memo(({
   const galleryImages = useMemo<GalleryImage[]>(
     () => mediaItems
       .filter((item): item is Extract<typeof item, { type: 'image' }> => item.type === 'image')
-      .map(item => ({ uri: item.fullSrc, alt: item.alt })),
+      .map(item => ({ uri: item.fullSrc, alt: item.alt, aspectRatio: readMediaAspectRatio(item) })),
     [mediaItems]
   );
 

--- a/packages/frontend/components/ZoomableImageGallery.tsx
+++ b/packages/frontend/components/ZoomableImageGallery.tsx
@@ -72,6 +72,15 @@ export interface GalleryImage {
    * shown as a caption at the bottom of the fullscreen viewer for the active image.
    */
   alt?: string;
+  /**
+   * Known aspect ratio (width / height) from the server media metadata, when
+   * available. `uri` is the large lightbox variant, a different cache key than
+   * the thumbnail's own uri in the shared aspect-ratio cache — passing the
+   * already-known ratio here lets `open()` fit the box correctly on the FIRST
+   * frame instead of starting at `DEFAULT_ASPECT_RATIO` and snapping once an
+   * `Image.getSize` probe resolves mid-animation.
+   */
+  aspectRatio?: number;
 }
 
 export interface ZoomableImageGalleryHandle {
@@ -308,16 +317,25 @@ const ZoomableImageGalleryInner = React.forwardRef<ZoomableImageGalleryHandle, Z
       if (isOpen || nextImages.length === 0) return;
       const safeIndex = Math.min(Math.max(index, 0), nextImages.length - 1);
       const target = nextImages[safeIndex];
-      const ratio = getAspectRatio(target.uri) ?? DEFAULT_ASPECT_RATIO;
+      const knownRatio = target.aspectRatio ?? getAspectRatio(target.uri);
+      const ratio = knownRatio ?? DEFAULT_ASPECT_RATIO;
 
       setImages(nextImages);
       setActiveIndexBoth(safeIndex);
       setOpenRatio(ratio);
-      setPageRatios({ [safeIndex]: ratio });
+      // Seed every page whose ratio is already known (server metadata or a
+      // previously-cached probe) so swiping never hits the same snap — only a
+      // genuinely-unknown image falls through to `ensureRatio`'s async probe.
+      const initialRatios: Record<number, number> = {};
+      nextImages.forEach((img, i) => {
+        const r = img.aspectRatio ?? getAspectRatio(img.uri);
+        if (r !== undefined) initialRatios[i] = r;
+      });
+      setPageRatios(initialRatios);
       pendingIndexRef.current = safeIndex;
 
-      // Resolve the opening ratio if it was not yet cached, then re-fit.
-      if (getAspectRatio(target.uri) === undefined) {
+      // Resolve the opening ratio if it was not yet known, then re-fit.
+      if (knownRatio === undefined) {
         void fetchAspectRatio(target.uri).then((resolved) => {
           setOpenRatio(resolved);
           setPageRatios((prev) => ({ ...prev, [safeIndex]: resolved }));


### PR DESCRIPTION
## Summary
- `ZoomableImageGallery.open()` resolved the opening image's aspect ratio from a shared cache keyed by the full-res lightbox URI, but the post thumbnail only ever warms that cache under its own (smaller-variant) URI — a different cache key. Every open was therefore a guaranteed cache miss.
- The box would fit at `DEFAULT_ASPECT_RATIO` (4:3), then an async `Image.getSize` resolved the real ratio mid zoom-in and snapped the box to size, visible as a flicker.
- The real ratio was already known from server media metadata (`width`/`height`/`aspectRatio`) and unused by the gallery.
- Fix: pass it through `GalleryImage.aspectRatio` and prefer it over the cache/fetch round trip, seeding every page up front so swiping doesn't hit the same snap.

## Test plan
- [x] Frontend build (`bun run build:frontend`, expo export web) passed
- [x] Backend build (`bun run build:backend`, shared-types + backend tsc) passed with 0 errors
- [x] MCP package build (`packages/mcp`, tsc) passed with 0 errors
- [x] Backend test suite (vitest): 212 test files passed, 2260 tests passed, 0 failures
- [x] Typecheck and eslint verified clean in a prior pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)