### PR TITLE
chore(frontend): consume @oxyhq/bloom 0.34.0 gallery feature pack + cleanups

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.5",
-        "@oxyhq/bloom": "^0.33.0",
+        "@oxyhq/bloom": "^0.34.0",
         "@oxyhq/contracts": "^0.14.0",
         "@oxyhq/core": "^11.0.0",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.33.0",
+        "@oxyhq/bloom": "^0.34.0",
         "@oxyhq/core": "^11.0.0",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
         "@oxyhq/services": "^21.0.0",
@@ -208,7 +208,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.33.0",
+    "@oxyhq/bloom": "^0.34.0",
     "@oxyhq/core": "^11.0.0",
     "@oxyhq/services": "^21.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -702,7 +702,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.33.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-ThL5RkbfPj7AB0Xm/5ZkOkxxRXmYgvQKwj6T0q/0bpG9hknwlyLXycHgbbFfb9AfOw95PgrWSEKli5pkEcmdlQ=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-OrL5KJgxjaZg81KbmPkg2c8OuC5sqUpnPqRj8MWyfEv/UYrLads9KvciD4Zw8eTRKq5Se290sOUnZYOekRLkmw=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.14.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-oQps/7+yHTUWRYY4ENu7nilQbINN7277lWTc0HmprPW45wcDo86sfU8kQElpbLCoEHBTyXptJfOjvWpbBiTV8Q=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.5",
-    "@oxyhq/bloom": "^0.33.0",
+    "@oxyhq/bloom": "^0.34.0",
     "@oxyhq/contracts": "^0.14.0",
     "@oxyhq/core": "^11.0.0",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.33.0",
+    "@oxyhq/bloom": "^0.34.0",
     "@oxyhq/core": "^11.0.0",
     "@oxyhq/services": "^21.0.0",
     "mongoose": "^8.17.0",

--- a/packages/frontend/app/(app)/lists.tsx
+++ b/packages/frontend/app/(app)/lists.tsx
@@ -28,7 +28,6 @@ function toListCardData(list: MentionList): ListCardData {
     uri: `list:${list._id || list.id}`,
     name: list.title || 'Untitled List',
     description: list.description,
-    avatar: typeof list.avatar === 'string' ? list.avatar : undefined,
     creator: owner
       ? {
           username: owner.username || '',

--- a/packages/frontend/app/(app)/search/index.tsx
+++ b/packages/frontend/app/(app)/search/index.tsx
@@ -206,7 +206,6 @@ function toListCardData(list: SearchListResult): ListCardData | null {
         uri: list.uri || `list:${id}`,
         name: list.name || list.title || "Untitled List",
         description: list.description,
-        avatar: list.avatar,
         creator: owner
             ? {
                 username: owner.username || owner.handle || "",

--- a/packages/frontend/components/ListCard.tsx
+++ b/packages/frontend/components/ListCard.tsx
@@ -24,7 +24,6 @@ export interface ListCardData {
     uri: string;
     name: string;
     description?: string;
-    avatar?: string | null;
     creator?: {
         username: string;
         displayName?: string;
@@ -81,7 +80,6 @@ export function ListCard({
             style={isRow ? undefined : { borderWidth: StyleSheet.hairlineWidth }}>
             <View className="flex-row items-center gap-3">
                 <Avatar
-                    source={list.avatar}
                     size={40}
                     variant={MEDIA_VARIANT_AVATAR}
                 />

--- a/packages/frontend/components/Post/PostAttachmentsRow.tsx
+++ b/packages/frontend/components/Post/PostAttachmentsRow.tsx
@@ -737,7 +737,7 @@ const PostAttachmentsRow: React.FC<Props> = React.memo(({
         return null;
       })}
     </ScrollView>
-    {galleryImages.length > 0 && <ZoomableImageGallery ref={galleryRef} measureThumb={measureThumb} cornerRadius={MEDIA_CARD_RADIUS} />}
+    {galleryImages.length > 0 && <ZoomableImageGallery ref={galleryRef} measureThumb={measureThumb} cornerRadius={MEDIA_CARD_RADIUS} indicatorVariant="dots" />}
     </>
   );
 }, (prevProps, nextProps) => {

--- a/packages/frontend/components/Profile/ProfileTabs.tsx
+++ b/packages/frontend/components/Profile/ProfileTabs.tsx
@@ -346,7 +346,6 @@ const ProfileLists = memo(function ProfileLists({
             uri: (l.uri as string) || `list:${listId}`,
             name: (l.title as string) || 'Untitled List',
             description: l.description as string | undefined,
-            avatar: l.avatar as string | undefined,
             creator: owner
               ? {
                   username: owner.username || '',

--- a/packages/frontend/components/ZoomableAvatar.tsx
+++ b/packages/frontend/components/ZoomableAvatar.tsx
@@ -36,6 +36,18 @@ import { useImageUrl } from '@/hooks/useImageUrl';
 import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import DefaultAvatar from '@/assets/images/default-avatar.jpg';
 import { Portal } from '@oxyhq/bloom/portal';
+import {
+  OPEN_SPRING,
+  CLOSE_SPRING,
+  SNAP_BACK_SPRING,
+  OPEN_DURATION_WEB,
+  CLOSE_DURATION_WEB,
+  OPACITY_DURATION,
+  MAX_DRAG_FRACTION,
+  SCALE_DRAG_FRACTION,
+  MIN_DRAG_SCALE,
+  DISMISS_FRACTION,
+} from '@oxyhq/bloom/zoomable-image-gallery';
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
 const AnimatedImage = Animated.createAnimatedComponent(Image);
@@ -218,7 +230,7 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
         if (Platform.OS === 'web') {
           // Web: use timing with easing
           requestAnimationFrame(() => {
-            const duration = 300;
+            const duration = OPEN_DURATION_WEB;
             const easing = Easing.out(Easing.cubic);
             scale.value = withTiming(zoomScale, { duration, easing });
             translateX.value = withTiming(0, { duration, easing });
@@ -229,15 +241,10 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
           // Native: use spring animations on UI thread for best performance
           // Reduced delay for immediate response
           setTimeout(() => {
-            const springConfig = {
-              damping: 18,
-              stiffness: 400,
-              mass: 0.4,
-            };
-            scale.value = withSpring(zoomScale, springConfig);
-            translateX.value = withSpring(0, springConfig);
-            translateY.value = withSpring(0, springConfig);
-            opacity.value = withTiming(1, { duration: 200 });
+            scale.value = withSpring(zoomScale, OPEN_SPRING);
+            translateX.value = withSpring(0, OPEN_SPRING);
+            translateY.value = withSpring(0, OPEN_SPRING);
+            opacity.value = withTiming(1, { duration: OPACITY_DURATION });
           }, 0);
         }
       };
@@ -259,7 +266,7 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
     // Animate back to original position with smooth, coordinated animations
     if (Platform.OS === 'web') {
       // Web: use timing with easing
-      const duration = 280;
+      const duration = CLOSE_DURATION_WEB;
       const easing = Easing.in(Easing.cubic);
       scale.value = withTiming(1, { duration, easing });
       translateX.value = withTiming(originX.value, { duration, easing });
@@ -275,16 +282,11 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
       }, duration + 20);
     } else {
       // Native: use optimized spring for smooth, fast animations
-      const springConfig = {
-        damping: 22,
-        stiffness: 450,
-        mass: 0.35,
-      };
-      scale.value = withSpring(1, springConfig);
-      translateX.value = withSpring(originX.value, springConfig);
-      translateY.value = withSpring(originY.value, springConfig);
-      opacity.value = withTiming(0, { duration: 200 });
-      
+      scale.value = withSpring(1, CLOSE_SPRING);
+      translateX.value = withSpring(originX.value, CLOSE_SPRING);
+      translateY.value = withSpring(originY.value, CLOSE_SPRING);
+      opacity.value = withTiming(0, { duration: OPACITY_DURATION });
+
       // Spring animations complete faster with higher stiffness
       setTimeout(() => {
         setIsZoomed(false);
@@ -292,7 +294,7 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
         translateX.value = 0;
         translateY.value = 0;
         opacity.value = 0;
-      }, 280);
+      }, CLOSE_DURATION_WEB);
     }
   }, []);
 
@@ -320,19 +322,19 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
           const dragDistance = Math.sqrt(
             event.translationX ** 2 + event.translationY ** 2
           );
-          const maxDrag = SCREEN_HEIGHT * 0.3;
+          const maxDrag = SCREEN_HEIGHT * MAX_DRAG_FRACTION;
           const opacityValue = Math.max(0, 1 - dragDistance / maxDrag);
           opacity.value = opacityValue;
 
           // Scale down slightly when dragging
-          const scaleReduction = Math.max(0.5, 1 - dragDistance / (SCREEN_HEIGHT * 0.5));
+          const scaleReduction = Math.max(MIN_DRAG_SCALE, 1 - dragDistance / (SCREEN_HEIGHT * SCALE_DRAG_FRACTION));
           scale.value = startScale.value * scaleReduction;
         })
         .onEnd((event) => {
           const dragDistance = Math.sqrt(
             event.translationX ** 2 + event.translationY ** 2
           );
-          const dismissThreshold = SCREEN_HEIGHT * 0.15;
+          const dismissThreshold = SCREEN_HEIGHT * DISMISS_FRACTION;
 
           if (dragDistance > dismissThreshold) {
             // Dragged far enough — dismiss
@@ -340,11 +342,10 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
           } else {
             // Snap back to center (stay zoomed)
             const zoomScale = MAX_ZOOM_SIZE / size;
-            const springConfig = { damping: 20, stiffness: 400, mass: 0.4 };
-            scale.value = withSpring(zoomScale, springConfig);
-            translateX.value = withSpring(0, springConfig);
-            translateY.value = withSpring(0, springConfig);
-            opacity.value = withTiming(1, { duration: 200 });
+            scale.value = withSpring(zoomScale, SNAP_BACK_SPRING);
+            translateX.value = withSpring(0, SNAP_BACK_SPRING);
+            translateY.value = withSpring(0, SNAP_BACK_SPRING);
+            opacity.value = withTiming(1, { duration: OPACITY_DURATION });
           }
         }),
     [handleDismiss, isZoomed, SCREEN_HEIGHT, MAX_ZOOM_SIZE, size]

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.33.0",
+    "@oxyhq/bloom": "^0.34.0",
     "@oxyhq/core": "^11.0.0",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
     "@oxyhq/services": "^21.0.0",


### PR DESCRIPTION
## Summary
- Bumps `@oxyhq/bloom` to `^0.34.0` (published, tagged, propagation-verified) — adds arrow nav, keyboard nav, thumbnail-strip indicator variant, pinch/double-tap zoom, and a share button to the post lightbox, all automatic once the version bumps.
- Passes `indicatorVariant="dots"` explicitly on the existing gallery usage in `PostAttachmentsRow.tsx` to preserve current behavior.
- Dedupes `ZoomableAvatar.tsx`'s 10 copy-pasted spring/timing/fraction constants against Bloom's now-publicly-exported ones from `@oxyhq/bloom/zoomable-image-gallery` (verified value-for-value identical: `OPEN_SPRING`, `CLOSE_SPRING`, `SNAP_BACK_SPRING`, `OPEN_DURATION_WEB`, `CLOSE_DURATION_WEB`, `OPACITY_DURATION`, `MAX_DRAG_FRACTION`, `SCALE_DRAG_FRACTION`, `MIN_DRAG_SCALE`, `DISMISS_FRACTION`). Avatar-specific sizing/shape logic was left untouched.
- Removes a dead `list.avatar` field from 4 list-card builders (`ListCard.tsx`, `app/(app)/lists.tsx`, `app/(app)/search/index.tsx`, `components/Profile/ProfileTabs.tsx`) — 2 originally flagged, 2 more found via repo grep.

## Verification
- `bun install --frozen-lockfile`: passed
- Frontend typecheck (`tsc --noEmit` in `packages/frontend`): 0 errors
- Frontend lint (`bun run lint` in `packages/frontend`): 0 errors, 293 pre-existing warnings (none new)
- Frontend build (`bun run build:frontend`): succeeded, dist exported
- Top-level `bun run build` (shared-types + backend + mcp): succeeded
- Backend tests (`bun run test` run from `packages/backend`): 212 files / 2260 tests passed

## Known gap
A live browser check of the new lightbox interactions (arrow nav, keyboard nav, pinch/double-tap zoom, share button, thumbnail-strip indicator variant) could not be performed in this session — it hit a persistent, structural conflict with ~6 other concurrent Claude Code sessions all sharing the same default chrome-devtools-mcp browser profile (confirmed via `ps aux`, reproduced 3 times, not a transient issue). Flagging this explicitly as needing manual verification before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)