### PR TITLE
fix(frontend): bump @oxyhq/bloom to 0.34.1 (web lightbox dismiss hotfix)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.5",
-        "@oxyhq/bloom": "^0.34.0",
+        "@oxyhq/bloom": "^0.34.1",
         "@oxyhq/contracts": "^0.14.0",
         "@oxyhq/core": "^11.0.0",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.34.0",
+        "@oxyhq/bloom": "^0.34.1",
         "@oxyhq/core": "^11.0.0",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
         "@oxyhq/services": "^21.0.0",
@@ -208,7 +208,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.34.0",
+    "@oxyhq/bloom": "^0.34.1",
     "@oxyhq/core": "^11.0.0",
     "@oxyhq/services": "^21.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -702,7 +702,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-OrL5KJgxjaZg81KbmPkg2c8OuC5sqUpnPqRj8MWyfEv/UYrLads9KvciD4Zw8eTRKq5Se290sOUnZYOekRLkmw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-B52araNm5NiBJh9wUhynfgZRaSRQULkOT8NeQ6Ew4mNh/IJjj5NxkoT4MlzyuBTVdOt8xb63CMSC/d0j5rBsAA=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.14.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-oQps/7+yHTUWRYY4ENu7nilQbINN7277lWTc0HmprPW45wcDo86sfU8kQElpbLCoEHBTyXptJfOjvWpbBiTV8Q=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.5",
-    "@oxyhq/bloom": "^0.34.0",
+    "@oxyhq/bloom": "^0.34.1",
     "@oxyhq/contracts": "^0.14.0",
     "@oxyhq/core": "^11.0.0",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.34.0",
+    "@oxyhq/bloom": "^0.34.1",
     "@oxyhq/core": "^11.0.0",
     "@oxyhq/services": "^21.0.0",
     "mongoose": "^8.17.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.34.0",
+    "@oxyhq/bloom": "^0.34.1",
     "@oxyhq/core": "^11.0.0",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
     "@oxyhq/services": "^21.0.0",


### PR DESCRIPTION
## Summary
**Live production hotfix.** The post lightbox shipped in 0.34.0/#417 with single-tap dismiss on web gated behind double-tap-to-zoom discrimination (`Gesture.Exclusive`) — this requires react-native-gesture-handler's web tap-exclusivity timing to resolve before dismiss fires at all, and users reported being unable to close the lightbox on web.

`@oxyhq/bloom@0.34.1` (published) disables double-tap-to-zoom on web (native unaffected) so single-tap dismiss fires immediately, matching standard web lightbox click-to-close behavior. This PR just bumps the dependency — no other code changes needed since Mention already consumes the gallery component as-is.

## Test plan
- [x] `bun install --frozen-lockfile` — Bun 1.3.14's known non-deterministic lockfile churn produced a false-positive on the first check (already-documented gotcha this session); verified the lockfile is genuinely in sync via a clean reinstall
- [x] Frontend typecheck — 0 errors
- [x] Frontend lint — 0 errors, 293 pre-existing warnings (unchanged baseline)
- [x] `bun run build:frontend` — succeeded
- [x] Backend tests — 212 files / 2260 tests passed
- [ ] Live browser verification — still blocked by a shared browser-resource conflict across concurrent sessions all session; strongly recommend a manual check on mention.earth immediately after this merges