### PR TITLE
fix(federation): deliver posts to remote followers + full outbound AP surface

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
@@ -24,12 +24,15 @@ const mocks = vi.hoisted(() => ({
   resolveOxyUser: vi.fn(),
   getPublicKey: vi.fn(),
   buildCreateNoteActivity: vi.fn(),
+  resolveReplyContext: vi.fn(),
   userSettingsFindOne: vi.fn(),
   postFind: vi.fn(),
   postCountDocuments: vi.fn(),
   postFindOne: vi.fn(),
   resolveAvatarUrl: vi.fn(),
   resolveMediaRef: vi.fn(),
+  followFind: vi.fn(),
+  followCountDocuments: vi.fn(),
 }));
 
 vi.mock('express-rate-limit', () => ({
@@ -41,6 +44,7 @@ vi.mock('../../../queue/producers', () => ({ enqueueInboxActivity: vi.fn() }));
 vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
   activityPubConnector: {
     buildCreateNoteActivity: (...args: unknown[]) => mocks.buildCreateNoteActivity(...args),
+    resolveReplyContext: (...args: unknown[]) => mocks.resolveReplyContext(...args),
     fetchPublicKey: vi.fn(),
     processInboxActivity: vi.fn(),
   },
@@ -74,7 +78,10 @@ vi.mock('../../../models/UserSettings', () => ({
 }));
 
 vi.mock('../../../models/FederatedFollow', () => ({
-  default: { countDocuments: vi.fn() },
+  default: {
+    countDocuments: (...args: unknown[]) => mocks.followCountDocuments(...args),
+    find: (...args: unknown[]) => mocks.followFind(...args),
+  },
 }));
 
 import apRoutes from '../../../connectors/activitypub/routes/ap.routes';
@@ -92,6 +99,10 @@ beforeEach(() => {
   });
   mocks.resolveAvatarUrl.mockReturnValue(undefined);
   mocks.userSettingsFindOne.mockReturnValue({ lean: async () => null });
+  mocks.followCountDocuments.mockResolvedValue(0);
+  // Default: not a reply (or unresolvable parent) — the dereference route serves
+  // the Note with no `inReplyTo`. Individual tests override for a reply post.
+  mocks.resolveReplyContext.mockResolvedValue(null);
 });
 
 describe('GET /ap/users/:username — actor image (banner)', () => {
@@ -121,6 +132,11 @@ describe('GET /ap/users/:username — actor image (banner)', () => {
 
     expect(res.body.image).toBeUndefined();
     expect('image' in res.body).toBe(false);
+  });
+
+  it('advertises the featured collection so Mastodon can fetch pinned posts on discovery', async () => {
+    const res = await request(app).get('/ap/users/alice').set('Accept', AP_ACCEPT).expect(200);
+    expect(res.body.featured).toBe('https://mention.earth/ap/users/alice/collections/featured');
   });
 
   it('omits image when the banner cannot resolve to an absolute URL', async () => {
@@ -159,6 +175,256 @@ describe('GET /ap/users/:username/outbox?page=true — reuses buildCreateNoteAct
       { type: 'Create', object: { id: 'https://mention.earth/ap/users/alice/posts/p1' } },
       { type: 'Create', object: { id: 'https://mention.earth/ap/users/alice/posts/p2' } },
     ]);
+    // A page that does not overfetch past the window has no further page.
+    expect(res.body.next).toBeUndefined();
+  });
+});
+
+describe('GET /ap/users/:username/outbox?page=true — keyset pagination', () => {
+  it('returns 20 items + a `next` cursor when more posts exist (fixes unreachable posts past page 1)', async () => {
+    mocks.resolveOxyUser.mockResolvedValue({ _id: 'u1' });
+    mocks.postCountDocuments.mockResolvedValue(42);
+    // Overfetch: the handler asks for PAGE_SIZE + 1 (21). Return 21 so it detects
+    // a further page, trims to 20, and emits a `next` keyed on the 20th item.
+    const posts = Array.from({ length: 21 }, (_, i) => ({
+      _id: `p${i}`,
+      createdAt: new Date(Date.UTC(2020, 0, 1, 0, 0, i)).toISOString(),
+    }));
+    mocks.postFind.mockReturnValue({
+      sort: () => ({ limit: () => ({ lean: async () => posts }) }),
+    });
+    mocks.buildCreateNoteActivity.mockImplementation((post: { _id: string }) => ({
+      type: 'Create',
+      object: { id: `https://mention.earth/ap/users/alice/posts/${post._id}` },
+    }));
+
+    const res = await request(app)
+      .get('/ap/users/alice/outbox?page=true')
+      .set('Accept', AP_ACCEPT)
+      .expect(200);
+
+    // Only the window is serialized, not the overfetched probe row.
+    expect(res.body.orderedItems).toHaveLength(20);
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledTimes(20);
+    expect(res.body.totalItems).toBe(42);
+    // `next` exists and is a same-collection page cursor — walking it reaches
+    // the remaining 22 posts that the old handler stranded.
+    expect(typeof res.body.next).toBe('string');
+    expect(res.body.next).toContain('/ap/users/alice/outbox?page=true&cursor=');
+    // The cursor is keyed on the LAST item of the window (p19), timestamp:id.
+    const cursorValue = decodeURIComponent(new URL(res.body.next).searchParams.get('cursor') ?? '');
+    expect(cursorValue).toBe(`${Date.UTC(2020, 0, 1, 0, 0, 19)}:p19`);
+  });
+
+  it('follows a `cursor` param into a keyset filter and self-references the page id', async () => {
+    mocks.resolveOxyUser.mockResolvedValue({ _id: 'u1' });
+    mocks.postCountDocuments.mockResolvedValue(42);
+    const posts = [
+      { _id: 'p20', createdAt: new Date(Date.UTC(2020, 0, 1, 0, 0, 20)).toISOString() },
+    ];
+    const findSpy = vi.fn().mockReturnValue({
+      sort: () => ({ limit: () => ({ lean: async () => posts }) }),
+    });
+    mocks.postFind.mockImplementation((query: unknown) => findSpy(query));
+    mocks.buildCreateNoteActivity.mockImplementation((post: { _id: string }) => ({
+      type: 'Create',
+      object: { id: `https://mention.earth/ap/users/alice/posts/${post._id}` },
+    }));
+
+    const cursor = `${Date.UTC(2020, 0, 1, 0, 0, 19)}:507f1f77bcf86cd799439011`;
+    const res = await request(app)
+      .get(`/ap/users/alice/outbox?page=true&cursor=${encodeURIComponent(cursor)}`)
+      .set('Accept', AP_ACCEPT)
+      .expect(200);
+
+    // The keyset boundary is applied to the Mongo filter as an $or clause.
+    const query = findSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(query.$or).toBeDefined();
+    // No further page (1 item < window) → no `next`. The page id echoes the cursor.
+    expect(res.body.next).toBeUndefined();
+    expect(res.body.id).toContain(`cursor=${encodeURIComponent(cursor)}`);
+  });
+});
+
+describe('GET /ap/users/:username/collections/featured — pinned posts', () => {
+  it('returns an OrderedCollection of bare Note objects for the user\'s pinned posts', async () => {
+    mocks.resolveOxyUser.mockResolvedValue({ _id: 'u1' });
+    const pinned = [{ _id: 'p1' }, { _id: 'p2' }];
+    const findSpy = vi.fn().mockReturnValue({
+      sort: () => ({ limit: () => ({ lean: async () => pinned }) }),
+    });
+    mocks.postFind.mockImplementation((query: unknown) => findSpy(query));
+    mocks.buildCreateNoteActivity.mockImplementation((post: { _id: string }) => ({
+      '@context': AP_CONTEXT,
+      type: 'Create',
+      object: { id: `https://mention.earth/ap/users/alice/posts/${post._id}`, type: 'Note' },
+    }));
+
+    const res = await request(app)
+      .get('/ap/users/alice/collections/featured')
+      .set('Accept', AP_ACCEPT)
+      .expect(200);
+
+    // Query filters on the pinned flag + the outbox's exact ownership/visibility.
+    const query = findSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(query).toMatchObject({
+      oxyUserId: 'u1',
+      'metadata.isPinned': true,
+      visibility: 'public',
+      status: 'published',
+      parentPostId: null,
+    });
+
+    // The collection is NOT paginated: inline orderedItems, no `first`.
+    expect(res.body.type).toBe('OrderedCollection');
+    expect(res.body.id).toBe('https://mention.earth/ap/users/alice/collections/featured');
+    expect(res.body.totalItems).toBe(2);
+    expect(res.body.first).toBeUndefined();
+    // orderedItems are the BARE Note objects (Create envelope unwrapped), NOT
+    // Create activities.
+    expect(res.body.orderedItems).toEqual([
+      { id: 'https://mention.earth/ap/users/alice/posts/p1', type: 'Note' },
+      { id: 'https://mention.earth/ap/users/alice/posts/p2', type: 'Note' },
+    ]);
+  });
+
+  it('returns an empty OrderedCollection when the user has no pinned posts', async () => {
+    mocks.resolveOxyUser.mockResolvedValue({ _id: 'u1' });
+    mocks.postFind.mockReturnValue({ sort: () => ({ limit: () => ({ lean: async () => [] }) }) });
+
+    const res = await request(app)
+      .get('/ap/users/alice/collections/featured')
+      .set('Accept', AP_ACCEPT)
+      .expect(200);
+
+    expect(res.body.type).toBe('OrderedCollection');
+    expect(res.body.totalItems).toBe(0);
+    expect(res.body.orderedItems).toEqual([]);
+    expect(mocks.buildCreateNoteActivity).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown user', async () => {
+    mocks.resolveOxyUser.mockResolvedValue(null);
+    await request(app).get('/ap/users/ghost/collections/featured').set('Accept', AP_ACCEPT).expect(404);
+    expect(mocks.postFind).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /ap/users/:username/followers — paginated collection', () => {
+  beforeEach(() => {
+    mocks.resolveOxyUser.mockResolvedValue({ _id: 'u1' });
+  });
+
+  it('summary advertises totalItems AND a first page link so remotes can enumerate members', async () => {
+    mocks.followCountDocuments.mockResolvedValue(3);
+
+    const res = await request(app).get('/ap/users/alice/followers').set('Accept', AP_ACCEPT).expect(200);
+
+    expect(res.body.type).toBe('OrderedCollection');
+    expect(res.body.id).toBe('https://mention.earth/ap/users/alice/followers');
+    expect(res.body.totalItems).toBe(3);
+    expect(res.body.first).toBe('https://mention.earth/ap/users/alice/followers?page=true');
+    // The summary must not enumerate rows — that is the page's job.
+    expect(mocks.followFind).not.toHaveBeenCalled();
+  });
+
+  it('page enumerates the remote actor URIs and emits a `next` cursor when overflowing', async () => {
+    mocks.followCountDocuments.mockResolvedValue(42);
+    // Overfetch: the handler asks for PAGE_SIZE + 1 (21). Return 21 so it detects
+    // a further page, trims to 20, and keys `next` on the 20th row.
+    const rows = Array.from({ length: 21 }, (_, i) => ({
+      _id: `f${i}`,
+      remoteActorUri: `https://remote.example/users/u${i}`,
+      createdAt: new Date(Date.UTC(2020, 0, 1, 0, 0, i)).toISOString(),
+    }));
+    const findSpy = vi.fn().mockReturnValue({
+      sort: () => ({ limit: () => ({ lean: async () => rows }) }),
+    });
+    mocks.followFind.mockImplementation((query: unknown) => findSpy(query));
+
+    const res = await request(app)
+      .get('/ap/users/alice/followers?page=true')
+      .set('Accept', AP_ACCEPT)
+      .expect(200);
+
+    // The query filters on inbound accepted edges for the resolved user.
+    const query = findSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(query).toMatchObject({ localUserId: 'u1', direction: 'inbound', status: 'accepted' });
+
+    expect(res.body.type).toBe('OrderedCollectionPage');
+    expect(res.body.partOf).toBe('https://mention.earth/ap/users/alice/followers');
+    expect(res.body.totalItems).toBe(42);
+    // Only the window (20) is enumerated, as BARE remote actor URI strings.
+    expect(res.body.orderedItems).toHaveLength(20);
+    expect(res.body.orderedItems[0]).toBe('https://remote.example/users/u0');
+    expect(res.body.orderedItems[19]).toBe('https://remote.example/users/u19');
+    // `next` is a same-collection page cursor keyed on the last row of the window.
+    expect(typeof res.body.next).toBe('string');
+    expect(res.body.next).toContain('/ap/users/alice/followers?page=true&cursor=');
+    const cursorValue = decodeURIComponent(new URL(res.body.next).searchParams.get('cursor') ?? '');
+    expect(cursorValue).toBe(`${Date.UTC(2020, 0, 1, 0, 0, 19)}:f19`);
+  });
+
+  it('page has no `next` when the window is not overflowed', async () => {
+    mocks.followCountDocuments.mockResolvedValue(2);
+    const rows = [
+      { _id: 'f1', remoteActorUri: 'https://remote.example/users/a', createdAt: new Date(Date.UTC(2020, 0, 1)).toISOString() },
+      { _id: 'f2', remoteActorUri: 'https://remote.example/users/b', createdAt: new Date(Date.UTC(2020, 0, 2)).toISOString() },
+    ];
+    mocks.followFind.mockReturnValue({ sort: () => ({ limit: () => ({ lean: async () => rows }) }) });
+
+    const res = await request(app).get('/ap/users/alice/followers?page=true').set('Accept', AP_ACCEPT).expect(200);
+
+    expect(res.body.orderedItems).toEqual([
+      'https://remote.example/users/a',
+      'https://remote.example/users/b',
+    ]);
+    expect(res.body.next).toBeUndefined();
+  });
+
+  it('404s an unknown user', async () => {
+    mocks.resolveOxyUser.mockResolvedValue(null);
+    await request(app).get('/ap/users/ghost/followers').set('Accept', AP_ACCEPT).expect(404);
+    expect(mocks.followFind).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /ap/users/:username/following — paginated collection', () => {
+  beforeEach(() => {
+    mocks.resolveOxyUser.mockResolvedValue({ _id: 'u1' });
+  });
+
+  it('summary advertises a first page link + totalItems', async () => {
+    mocks.followCountDocuments.mockResolvedValue(5);
+
+    const res = await request(app).get('/ap/users/alice/following').set('Accept', AP_ACCEPT).expect(200);
+
+    expect(res.body.type).toBe('OrderedCollection');
+    expect(res.body.first).toBe('https://mention.earth/ap/users/alice/following?page=true');
+    expect(res.body.totalItems).toBe(5);
+  });
+
+  it('page enumerates the OUTBOUND target actor URIs', async () => {
+    mocks.followCountDocuments.mockResolvedValue(1);
+    const rows = [
+      { _id: 'f1', remoteActorUri: 'https://remote.example/users/z', createdAt: new Date(Date.UTC(2021, 5, 1)).toISOString() },
+    ];
+    const findSpy = vi.fn().mockReturnValue({
+      sort: () => ({ limit: () => ({ lean: async () => rows }) }),
+    });
+    mocks.followFind.mockImplementation((query: unknown) => findSpy(query));
+
+    const res = await request(app)
+      .get('/ap/users/alice/following?page=true')
+      .set('Accept', AP_ACCEPT)
+      .expect(200);
+
+    const query = findSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(query).toMatchObject({ localUserId: 'u1', direction: 'outbound', status: 'accepted' });
+    expect(res.body.type).toBe('OrderedCollectionPage');
+    expect(res.body.partOf).toBe('https://mention.earth/ap/users/alice/following');
+    expect(res.body.orderedItems).toEqual(['https://remote.example/users/z']);
+    expect(res.body.next).toBeUndefined();
   });
 });
 
@@ -199,6 +465,23 @@ describe('GET /ap/users/:username/posts/:id — dereference', () => {
 
     await request(app).get(`/ap/users/alice/posts/${VALID_ID}`).set('Accept', AP_ACCEPT).expect(404);
     expect(mocks.buildCreateNoteActivity).not.toHaveBeenCalled();
+  });
+
+  it('passes the resolved reply context into the Note builder for a reply post', async () => {
+    const replyDoc = { _id: VALID_ID, content: { text: 'a reply' }, parentPostId: 'parent1' };
+    mocks.postFindOne.mockReturnValue({ lean: async () => replyDoc });
+    const replyContext = {
+      inReplyTo: 'https://remote.example/users/bob/statuses/9',
+      mention: { href: 'https://remote.example/users/bob', name: '@bob@remote.example' },
+    };
+    mocks.resolveReplyContext.mockResolvedValue(replyContext);
+
+    await request(app).get(`/ap/users/alice/posts/${VALID_ID}`).set('Accept', AP_ACCEPT).expect(200);
+
+    // The route resolves the reply addressing from the served post and threads it
+    // into the pure Note builder as the third argument.
+    expect(mocks.resolveReplyContext).toHaveBeenCalledWith(replyDoc);
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(replyDoc, 'alice', replyContext);
   });
 
   it('404s a malformed post id without touching the database', async () => {

--- a/packages/backend/src/__tests__/connectors/activitypub/boostFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/boostFederation.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound boost federation (PART 1): the `Announce` / `Undo(Announce)` path and
+ * the addressing extension that unions follower inboxes with an explicit target
+ * inbox.
+ *
+ * These pin:
+ *   - the addressing dedupe in `deliverToFollowers({ extraInboxes })`
+ *     (follower shared inbox vs. an explicit inbox → each instance once);
+ *   - `federateBoost` emitting an `Announce` whose `object` is the boosted
+ *     original's canonical AP id, `cc`'d to the booster's followers + the
+ *     original author, delivered to followers + (federated original) the author
+ *     inbox;
+ *   - `federateUndoBoost` emitting the matching `Undo(Announce)`;
+ *   - the REGRESSION GUARD: a bare boost routed through `federateNewPost` (the
+ *     `POST /posts` `boost_of` path) produces an `Announce`, NEVER an empty
+ *     `Create(Note)` — while a normal post still federates as a `Create(Note)`.
+ *
+ * The delivery/queue layer, the models, and the Oxy client are mocked so the
+ * real `FollowService` runs in isolation; assertions read the captured
+ * `enqueueDelivery` calls.
+ */
+
+const {
+  enqueueDelivery,
+  isFediverseSharingEnabled,
+  getUserById,
+  followFindLean,
+  actorFindLean,
+  actorFindOneLean,
+  postFindByIdLean,
+  insertMany,
+} = vi.hoisted(() => ({
+  enqueueDelivery: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  getUserById: vi.fn(),
+  followFindLean: vi.fn(),
+  actorFindLean: vi.fn(),
+  actorFindOneLean: vi.fn(),
+  postFindByIdLean: vi.fn(),
+  insertMany: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../connectors/activitypub/constants')>(
+    '../../../connectors/activitypub/constants',
+  );
+  return { ...actual, FEDERATION_ENABLED: true };
+});
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey: vi.fn(), signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery, enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    find: () => ({ lean: () => actorFindLean() }),
+    findOne: () => ({ lean: () => actorFindOneLean() }),
+  },
+}));
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { find: () => ({ lean: () => followFindLean() }) },
+}));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: { insertMany, create: vi.fn() },
+}));
+vi.mock('../../../models/Post', () => ({
+  Post: { findById: () => ({ select: () => ({ lean: () => postFindByIdLean() }) }) },
+}));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+}));
+vi.mock('../../../services/fediverseSharing', () => ({ isFediverseSharingEnabled }));
+vi.mock('../../../utils/oxyHelpers', () => ({ getServiceOxyClient: () => ({ getUserById }) }));
+
+import { followService } from '../../../connectors/activitypub/follow.service';
+
+const ISO = '2024-05-06T07:08:09.000Z';
+const ALICE_ACTOR = 'https://mention.earth/ap/users/alice';
+const ALICE_FOLLOWERS = `${ALICE_ACTOR}/followers`;
+const AP_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
+
+/** The distinct target inboxes `enqueueDelivery` was asked to deliver to. */
+function deliveredInboxes(): string[] {
+  return enqueueDelivery.mock.calls.map((c) => (c[0] as { targetInbox: string }).targetInbox);
+}
+
+/** The activity enqueued (identical across all inboxes in one fan-out). */
+function deliveredActivity(): Record<string, unknown> {
+  return (enqueueDelivery.mock.calls[0]?.[0] as { activityJson: Record<string, unknown> }).activityJson;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueDelivery.mockResolvedValue(true);
+  isFediverseSharingEnabled.mockResolvedValue(true);
+  followFindLean.mockResolvedValue([]);
+  actorFindLean.mockResolvedValue([]);
+  actorFindOneLean.mockResolvedValue(null);
+  postFindByIdLean.mockResolvedValue(null);
+  getUserById.mockResolvedValue({ id: 'u', username: 'bob' });
+});
+
+describe('deliverToFollowers — addressing extension', () => {
+  it('unions a follower shared inbox and an explicit extra inbox, delivering each once', async () => {
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/f' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.deliverToFollowers({ type: 'X' }, 'sender', 'alice', {
+      extraInboxes: ['https://bar.example/inbox'],
+    });
+
+    expect(deliveredInboxes().sort()).toEqual(
+      ['https://bar.example/inbox', 'https://foo.example/inbox'].sort(),
+    );
+    expect(enqueueDelivery).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupes an explicit inbox that coincides with a follower shared inbox (delivers once)', async () => {
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://shared.example/users/f' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://shared.example/inbox' }]);
+
+    await followService.deliverToFollowers({ type: 'X' }, 'sender', 'alice', {
+      extraInboxes: ['https://shared.example/inbox'],
+    });
+
+    expect(deliveredInboxes()).toEqual(['https://shared.example/inbox']);
+    expect(enqueueDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers to an explicit inbox even when the sender has zero followers', async () => {
+    followFindLean.mockResolvedValue([]);
+
+    await followService.deliverToFollowers({ type: 'X' }, 'sender', 'alice', {
+      extraInboxes: ['https://only.example/inbox'],
+    });
+
+    expect(deliveredInboxes()).toEqual(['https://only.example/inbox']);
+  });
+});
+
+describe('federateBoost — Announce', () => {
+  it('announces a boost of a FEDERATED original to followers + the original author inbox', async () => {
+    postFindByIdLean.mockResolvedValue({
+      oxyUserId: 'orig-owner',
+      federation: {
+        activityId: 'https://remote.example/users/bob/statuses/9',
+        actorUri: 'https://remote.example/users/bob',
+      },
+    });
+    // resolveActorInbox(bob) → the remote author's shared inbox.
+    actorFindOneLean.mockResolvedValue({ sharedInboxUrl: 'https://remote.example/inbox' });
+    // The booster's own remote followers.
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateBoost(
+      { _id: 'boost1', boostOf: 'orig1', createdAt: ISO },
+      'booster-oxy',
+      'alice',
+    );
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Announce');
+    expect(activity.actor).toBe(ALICE_ACTOR);
+    expect(activity.id).toBe(`${ALICE_ACTOR}/boosts/boost1`);
+    expect(activity.object).toBe('https://remote.example/users/bob/statuses/9');
+    expect(activity.to).toEqual([AP_PUBLIC]);
+    expect(activity.cc).toEqual([ALICE_FOLLOWERS, 'https://remote.example/users/bob']);
+    expect(activity.published).toBe(ISO);
+
+    // Delivered to the booster's follower inbox AND the original author's inbox.
+    expect(deliveredInboxes().sort()).toEqual(
+      ['https://foo.example/inbox', 'https://remote.example/inbox'].sort(),
+    );
+  });
+
+  it('announces a boost of a LOCAL original with the minted note URI and no extra inbox', async () => {
+    postFindByIdLean.mockResolvedValue({ oxyUserId: 'local-owner-id', federation: undefined });
+    // The local original's author username, resolved server-side.
+    getUserById.mockResolvedValue({ id: 'local-owner-id', username: 'bob' });
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateBoost(
+      { _id: 'boost1', boostOf: 'orig1', createdAt: ISO },
+      'booster-oxy',
+      'alice',
+    );
+
+    expect(getUserById).toHaveBeenCalledWith('local-owner-id');
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Announce');
+    expect(activity.object).toBe('https://mention.earth/ap/users/bob/posts/orig1');
+    expect(activity.cc).toEqual([ALICE_FOLLOWERS, 'https://mention.earth/ap/users/bob']);
+    // A local original has no remote inbox — only the booster's follower is hit.
+    expect(deliveredInboxes()).toEqual(['https://foo.example/inbox']);
+  });
+
+  it('skips federation entirely when the booster has sharing disabled', async () => {
+    isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await followService.federateBoost(
+      { _id: 'boost1', boostOf: 'orig1', createdAt: ISO },
+      'booster-oxy',
+      'alice',
+    );
+
+    expect(postFindByIdLean).not.toHaveBeenCalled();
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+});
+
+describe('federateUndoBoost — Undo(Announce)', () => {
+  it('retracts a boost with an Undo(Announce) to followers + the original author inbox', async () => {
+    postFindByIdLean.mockResolvedValue({
+      oxyUserId: 'orig-owner',
+      federation: {
+        activityId: 'https://remote.example/users/bob/statuses/9',
+        actorUri: 'https://remote.example/users/bob',
+      },
+    });
+    actorFindOneLean.mockResolvedValue({ sharedInboxUrl: 'https://remote.example/inbox' });
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateUndoBoost(
+      { _id: 'boost1', boostOf: 'orig1', createdAt: ISO },
+      'booster-oxy',
+      'alice',
+    );
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Undo');
+    expect(activity.actor).toBe(ALICE_ACTOR);
+    expect(activity.id).toBe(`${ALICE_ACTOR}/boosts/boost1/undo`);
+    const inner = activity.object as Record<string, unknown>;
+    expect(inner.type).toBe('Announce');
+    expect(inner.id).toBe(`${ALICE_ACTOR}/boosts/boost1`);
+    expect(inner.object).toBe('https://remote.example/users/bob/statuses/9');
+    expect(activity.cc).toEqual([ALICE_FOLLOWERS, 'https://remote.example/users/bob']);
+    expect(deliveredInboxes().sort()).toEqual(
+      ['https://foo.example/inbox', 'https://remote.example/inbox'].sort(),
+    );
+  });
+});
+
+describe('federateNewPost — boost regression guard (POST /posts boost_of)', () => {
+  it('federates a bare boost as an Announce, NEVER an empty Create(Note)', async () => {
+    const buildNoteSpy = vi.spyOn(followService, 'buildCreateNoteActivity');
+    postFindByIdLean.mockResolvedValue({
+      oxyUserId: 'orig-owner',
+      federation: {
+        activityId: 'https://remote.example/users/bob/statuses/9',
+        actorUri: 'https://remote.example/users/bob',
+      },
+    });
+    actorFindOneLean.mockResolvedValue({ sharedInboxUrl: 'https://remote.example/inbox' });
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    // The shape PostCreationService passes: a boost has an EMPTY body + boostOf.
+    await followService.federateNewPost(
+      { _id: 'boost1', boostOf: 'orig1', content: { variants: [] }, createdAt: ISO, visibility: 'public' },
+      'booster-oxy',
+      'alice',
+    );
+
+    // The Create(Note) builder must not run for a boost.
+    expect(buildNoteSpy).not.toHaveBeenCalled();
+    expect(deliveredActivity().type).toBe('Announce');
+    buildNoteSpy.mockRestore();
+  });
+
+  it('still federates a normal (non-boost) post as a Create(Note)', async () => {
+    const buildNoteSpy = vi.spyOn(followService, 'buildCreateNoteActivity');
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateNewPost(
+      {
+        _id: 'post1',
+        content: { variants: [{ source: 'author', text: 'hello world', tag: 'en' }] },
+        createdAt: ISO,
+        visibility: 'public',
+      },
+      'author-oxy',
+      'alice',
+    );
+
+    expect(buildNoteSpy).toHaveBeenCalledTimes(1);
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Create');
+    expect((activity.object as Record<string, unknown>).type).toBe('Note');
+    expect(postFindByIdLean).not.toHaveBeenCalled();
+    buildNoteSpy.mockRestore();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => ({
   getFediverseSharingStateByUsername: vi.fn(),
   getPublicKey: vi.fn(),
   buildCreateNoteActivity: vi.fn(),
+  resolveReplyContext: vi.fn(),
   userSettingsFindOne: vi.fn(),
   postFind: vi.fn(),
   postCountDocuments: vi.fn(),
@@ -63,6 +64,7 @@ vi.mock('../../../queue/producers', () => ({
 vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
   activityPubConnector: {
     buildCreateNoteActivity: (...args: unknown[]) => mocks.buildCreateNoteActivity(...args),
+    resolveReplyContext: (...args: unknown[]) => mocks.resolveReplyContext(...args),
     fetchPublicKey: vi.fn(),
     processInboxActivity: vi.fn().mockResolvedValue(undefined),
   },
@@ -149,6 +151,9 @@ beforeEach(() => {
     type: 'Create',
     object: { id: `https://mention.earth/ap/users/alice/posts/${VALID_ID}`, type: 'Note' },
   });
+  // The dereference route resolves reply addressing before building the Note; the
+  // gate tests serve a non-reply post, so default to "no reply context".
+  mocks.resolveReplyContext.mockResolvedValue(null);
   mocks.verifyHttpSignature.mockResolvedValue({
     verified: true,
     actorUri: 'https://remote.example/users/bob',
@@ -262,6 +267,27 @@ describe('fediverseSharing gates — user-scoped AP/discovery surfaces', () => {
       mocks.isFediverseSharingEnabledFromUser.mockReturnValue(false);
       const res = await request(apApp).get('/ap/users/alice/outbox').set('Accept', AP_ACCEPT).expect(404);
       expect(res.body).toEqual(NOT_FOUND_BODY);
+    });
+  });
+
+  describe('GET /ap/users/:username/collections/featured', () => {
+    it('200s when sharing is enabled', async () => {
+      mocks.isFediverseSharingEnabledFromUser.mockReturnValue(true);
+      const res = await request(apApp)
+        .get('/ap/users/alice/collections/featured')
+        .set('Accept', AP_ACCEPT)
+        .expect(200);
+      expect(res.body.type).toBe('OrderedCollection');
+    });
+
+    it('404s with the unknown-user body when sharing is disabled, without querying posts', async () => {
+      mocks.isFediverseSharingEnabledFromUser.mockReturnValue(false);
+      const res = await request(apApp)
+        .get('/ap/users/alice/collections/featured')
+        .set('Accept', AP_ACCEPT)
+        .expect(404);
+      expect(res.body).toEqual(NOT_FOUND_BODY);
+      expect(mocks.postFind).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/__tests__/connectors/activitypub/replyFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/replyFederation.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound reply federation (PART 2): a reply Note carries `inReplyTo` (the
+ * parent's canonical AP object id) + a parent-author `Mention` tag, and is
+ * delivered to the replier's followers AND — for a FEDERATED parent — the parent
+ * author's inbox, so Mastodon threads the reply under the parent and notifies its
+ * author.
+ *
+ * Both reply entry points (`POST /feed/reply` and the `POST /posts` reply path)
+ * converge on `FollowService.federateNewPost`, which reads `post.parentPostId` and
+ * routes to the reply-addressing branch — so these tests exercise that ONE
+ * convergence point.
+ *
+ * These pin:
+ *   - a reply to a FEDERATED parent → Create(Note) with `inReplyTo` = the parent's
+ *     `federation.activityId`, a Mention tag for the parent author, `cc` unioning
+ *     the author actor, delivered to followers + the parent author's inbox;
+ *   - a reply to a LOCAL parent → a locally-minted `inReplyTo`, a local Mention,
+ *     and NO bogus extra inbox (a local author is reached through their own
+ *     followers, never a remote POST);
+ *   - a TOP-LEVEL post → a Note with NO `inReplyTo` and no parent lookup at all;
+ *   - a parent that cannot be resolved → fail-soft: the reply still federates as a
+ *     normal Note (no `inReplyTo`), never throwing.
+ *
+ * The delivery/queue layer, the models, and the Oxy client are mocked so the real
+ * `FollowService` runs in isolation; assertions read the captured
+ * `enqueueDelivery` calls.
+ */
+
+const {
+  enqueueDelivery,
+  isFediverseSharingEnabled,
+  getUserById,
+  followFindLean,
+  actorFindLean,
+  actorFindOneLean,
+  postFindByIdLean,
+  insertMany,
+} = vi.hoisted(() => ({
+  enqueueDelivery: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  getUserById: vi.fn(),
+  followFindLean: vi.fn(),
+  actorFindLean: vi.fn(),
+  actorFindOneLean: vi.fn(),
+  postFindByIdLean: vi.fn(),
+  insertMany: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../connectors/activitypub/constants')>(
+    '../../../connectors/activitypub/constants',
+  );
+  return { ...actual, FEDERATION_ENABLED: true };
+});
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey: vi.fn(), signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery, enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    find: () => ({ lean: () => actorFindLean() }),
+    findOne: () => ({ lean: () => actorFindOneLean() }),
+  },
+}));
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { find: () => ({ lean: () => followFindLean() }) },
+}));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: { insertMany, create: vi.fn() },
+}));
+vi.mock('../../../models/Post', () => ({
+  Post: { findById: () => ({ select: () => ({ lean: () => postFindByIdLean() }) }) },
+}));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+}));
+vi.mock('../../../services/fediverseSharing', () => ({ isFediverseSharingEnabled }));
+vi.mock('../../../utils/oxyHelpers', () => ({ getServiceOxyClient: () => ({ getUserById }) }));
+
+import { followService } from '../../../connectors/activitypub/follow.service';
+
+const ISO = '2024-05-06T07:08:09.000Z';
+const ALICE_ACTOR = 'https://mention.earth/ap/users/alice';
+const ALICE_FOLLOWERS = `${ALICE_ACTOR}/followers`;
+const AP_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
+
+/** A reply post as the seam hands it to `federateNewPost`. */
+function replyPost(parentPostId: string | undefined): {
+  _id: string;
+  parentPostId?: string;
+  content: { variants: Array<{ source: 'author'; text: string; tag: string }> };
+  createdAt: string;
+  visibility: string;
+} {
+  return {
+    _id: 'reply1',
+    ...(parentPostId ? { parentPostId } : {}),
+    content: { variants: [{ source: 'author', text: 'threaded response', tag: 'en' }] },
+    createdAt: ISO,
+    visibility: 'public',
+  };
+}
+
+/** The distinct target inboxes `enqueueDelivery` was asked to deliver to. */
+function deliveredInboxes(): string[] {
+  return enqueueDelivery.mock.calls.map((c) => (c[0] as { targetInbox: string }).targetInbox);
+}
+
+/** The activity enqueued (identical across all inboxes in one fan-out). */
+function deliveredActivity(): Record<string, unknown> {
+  return (enqueueDelivery.mock.calls[0]?.[0] as { activityJson: Record<string, unknown> }).activityJson;
+}
+
+/** The embedded Note object of the enqueued Create activity. */
+function deliveredNote(): Record<string, unknown> {
+  return deliveredActivity().object as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueDelivery.mockResolvedValue(true);
+  isFediverseSharingEnabled.mockResolvedValue(true);
+  followFindLean.mockResolvedValue([]);
+  actorFindLean.mockResolvedValue([]);
+  actorFindOneLean.mockResolvedValue(null);
+  postFindByIdLean.mockResolvedValue(null);
+  getUserById.mockResolvedValue({ id: 'u', username: 'bob' });
+});
+
+describe('federateNewPost — reply to a FEDERATED parent', () => {
+  beforeEach(() => {
+    // The parent post is a federated (remote) Note.
+    postFindByIdLean.mockResolvedValue({
+      oxyUserId: 'parent-owner',
+      federation: {
+        activityId: 'https://remote.example/users/bob/statuses/9',
+        actorUri: 'https://remote.example/users/bob',
+      },
+    });
+    // The parent author's FederatedActor row → its inbox + acct.
+    actorFindOneLean.mockResolvedValue({
+      sharedInboxUrl: 'https://remote.example/inbox',
+      acct: 'bob@remote.example',
+    });
+    // The replier's own remote followers.
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+  });
+
+  it('emits a Create(Note) with inReplyTo = the parent activityId + a parent-author Mention', async () => {
+    await followService.federateNewPost(replyPost('parent1'), 'replier-oxy', 'alice');
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Create');
+    const note = deliveredNote();
+    expect(note.type).toBe('Note');
+    expect(note.inReplyTo).toBe('https://remote.example/users/bob/statuses/9');
+    expect(note.content).toBe('threaded response');
+
+    // The Mention tag threads + notifies the remote author (href resolves it;
+    // name is the human-readable @user@domain from the stored acct).
+    const tags = note.tag as Array<Record<string, string>>;
+    expect(tags).toContainEqual({
+      type: 'Mention',
+      href: 'https://remote.example/users/bob',
+      name: '@bob@remote.example',
+    });
+
+    // The mentioned author joins the followers collection in cc (both envelope
+    // and object).
+    expect(activity.cc).toEqual([ALICE_FOLLOWERS, 'https://remote.example/users/bob']);
+    expect(note.cc).toEqual([ALICE_FOLLOWERS, 'https://remote.example/users/bob']);
+    expect(note.to).toEqual([AP_PUBLIC]);
+  });
+
+  it('delivers to the replier followers AND the parent author inbox (deduped)', async () => {
+    await followService.federateNewPost(replyPost('parent1'), 'replier-oxy', 'alice');
+
+    expect(deliveredInboxes().sort()).toEqual(
+      ['https://foo.example/inbox', 'https://remote.example/inbox'].sort(),
+    );
+  });
+});
+
+describe('federateNewPost — reply to a LOCAL parent', () => {
+  it('emits a locally-minted inReplyTo + local Mention and adds NO extra inbox', async () => {
+    // A local parent: no federation block, resolved to its owner username.
+    postFindByIdLean.mockResolvedValue({ oxyUserId: 'local-parent-owner', federation: undefined });
+    getUserById.mockResolvedValue({ id: 'local-parent-owner', username: 'bob' });
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateNewPost(replyPost('parent1'), 'replier-oxy', 'alice');
+
+    expect(getUserById).toHaveBeenCalledWith('local-parent-owner');
+    const note = deliveredNote();
+    expect(note.inReplyTo).toBe('https://mention.earth/ap/users/bob/posts/parent1');
+    expect(note.tag).toContainEqual({
+      type: 'Mention',
+      href: 'https://mention.earth/ap/users/bob',
+      name: '@bob@mention.earth',
+    });
+    expect(note.cc).toEqual([ALICE_FOLLOWERS, 'https://mention.earth/ap/users/bob']);
+
+    // A local parent's author is reached through the replier's followers — never a
+    // bogus remote POST to a nonexistent inbox.
+    expect(deliveredInboxes()).toEqual(['https://foo.example/inbox']);
+  });
+});
+
+describe('federateNewPost — top-level (non-reply) post', () => {
+  it('emits a Note with NO inReplyTo and never looks up a parent', async () => {
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateNewPost(replyPost(undefined), 'author-oxy', 'alice');
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Create');
+    const note = deliveredNote();
+    expect(note.inReplyTo).toBeUndefined();
+    // No hashtags + no reply Mention → no tag array at all.
+    expect(note.tag).toBeUndefined();
+    expect(note.cc).toEqual([ALICE_FOLLOWERS]);
+    // A top-level post never resolves a parent.
+    expect(postFindByIdLean).not.toHaveBeenCalled();
+    expect(deliveredInboxes()).toEqual(['https://foo.example/inbox']);
+  });
+});
+
+describe('federateNewPost — parent unresolvable (fail-soft)', () => {
+  it('still federates the reply as a normal Note (no inReplyTo), never throwing', async () => {
+    // The parent post cannot be found.
+    postFindByIdLean.mockResolvedValue(null);
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await expect(
+      followService.federateNewPost(replyPost('ghost-parent'), 'replier-oxy', 'alice'),
+    ).resolves.toBeUndefined();
+
+    // It attempted to resolve the parent, found nothing, and fell back cleanly.
+    expect(postFindByIdLean).toHaveBeenCalled();
+    const note = deliveredNote();
+    expect(note.inReplyTo).toBeUndefined();
+    expect(note.tag).toBeUndefined();
+    // Delivered to the replier's followers only (no parent-author inbox).
+    expect(deliveredInboxes()).toEqual(['https://foo.example/inbox']);
+  });
+});

--- a/packages/backend/src/__tests__/services/postCreationFederation.test.ts
+++ b/packages/backend/src/__tests__/services/postCreationFederation.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Regression coverage for the immediate-create federation fan-out
+ * ({@link PostCreationService.runPostSideEffects}).
+ *
+ * Root cause this guards: the Oxy auth middleware guards every `POST /posts` path
+ * WITHOUT `loadUser:true`, so `req.user` is only `{ id }` and the caller-supplied
+ * `senderUsername` is effectively ALWAYS undefined on the immediate create path.
+ * The federation gate used to require `ctx.senderUsername`, so `federateNewPost`
+ * NEVER ran and `metadata.federationDelivered` was true on ZERO posts.
+ *
+ * The fix resolves the federation username server-side from the authoritative
+ * `oxyUserId` (via the service Oxy client) whenever no non-empty username was
+ * supplied — the SAME mechanism the scheduled-publish path already used. These
+ * tests assert:
+ *   1. a published local public post with NO senderUsername STILL federates,
+ *      using the server-resolved username, and marks federationDelivered;
+ *   2. a supplied non-empty senderUsername is preferred as a fast path (no SDK
+ *      lookup) — preserving existing callers/tests.
+ *
+ * Test (1) FAILS against the pre-fix gate (federateNewPost is never called) and
+ * PASSES after it.
+ *
+ * The Post model + every side-effect collaborator are mocked so the test isolates
+ * the federation-username sourcing and gate. The classifier is pure and left real.
+ */
+
+const { federateNewPost, getUserById, MockPost, postFindLean } = vi.hoisted(() => {
+  class HoistedMockPost {
+    [key: string]: unknown;
+    constructor(data: Record<string, unknown>) {
+      Object.assign(this, data);
+    }
+    save = vi.fn().mockResolvedValue(undefined);
+    markModified = vi.fn();
+    toObject(): Record<string, unknown> {
+      return { ...this };
+    }
+    _id = 'mock_post_id';
+  }
+  return {
+    federateNewPost: vi.fn().mockResolvedValue(undefined),
+    getUserById: vi.fn(),
+    MockPost: HoistedMockPost,
+    postFindLean: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock('../../models/Post', async () => {
+  const actual = await vi.importActual<typeof import('../../models/Post')>('../../models/Post');
+  return {
+    POST_CLASSIFICATION_PENDING: actual.POST_CLASSIFICATION_PENDING,
+    Post: Object.assign(MockPost, {
+      find: () => ({ select: () => ({ lean: () => postFindLean() }) }),
+    }),
+  };
+});
+
+vi.mock('../../utils/notificationUtils', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  createMentionNotifications: vi.fn().mockResolvedValue(undefined),
+  createBatchNotifications: vi.fn().mockResolvedValue(undefined),
+  createPostAuthorNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../models/PostSubscription', () => ({
+  default: { find: () => ({ lean: () => Promise.resolve([]) }) },
+}));
+
+vi.mock('../../services/serviceRegistry', () => ({
+  getPostFederator: () => ({ federateNewPost }),
+  registerPostCreator: vi.fn(),
+}));
+
+// Mocked to a no-op so importing PostCreationService does not pull in the heavy
+// `../../server` module graph via the socket-emit hydration path.
+vi.mock('../../services/PostHydrationService', () => ({
+  postHydrationService: { hydratePosts: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({ getUserById, getUsersByIds: vi.fn().mockResolvedValue([]) }),
+}));
+
+import { postCreationService } from '../../services/PostCreationService';
+import { PostVisibility } from '@mention/shared-types';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUserById.mockResolvedValue({ id: 'oxy_user_fed', username: 'resolved_alice' });
+  postFindLean.mockResolvedValue([]);
+});
+
+describe('PostCreationService — immediate-create federation username sourcing', () => {
+  it('federates a published public post with NO senderUsername using the server-resolved username', async () => {
+    const post = await postCreationService.create({
+      oxyUserId: 'oxy_user_fed',
+      content: { text: 'a public post that should reach remote followers' },
+      visibility: PostVisibility.PUBLIC,
+      // Simulate the real request: req.user is only { id } (no username), so the
+      // controller passes senderUsername: undefined.
+      senderUsername: undefined,
+      skipSocketEmit: true,
+    });
+
+    // The username was resolved server-side from the authoritative oxyUserId.
+    expect(getUserById).toHaveBeenCalledWith('oxy_user_fed');
+
+    // The fan-out ran with that resolved username.
+    expect(federateNewPost).toHaveBeenCalledTimes(1);
+    const [, calledOxyId, calledUsername] = federateNewPost.mock.calls[0];
+    expect(calledOxyId).toBe('oxy_user_fed');
+    expect(calledUsername).toBe('resolved_alice');
+
+    // Idempotency marker is set so the post never re-federates.
+    const meta = (post as unknown as { metadata?: Record<string, unknown> }).metadata;
+    expect(meta?.federationDelivered).toBe(true);
+  });
+
+  it('prefers a supplied non-empty senderUsername (fast path, no SDK lookup)', async () => {
+    await postCreationService.create({
+      oxyUserId: 'oxy_user_fed',
+      content: { text: 'a post created with an explicit sender username' },
+      visibility: PostVisibility.PUBLIC,
+      senderUsername: 'provided_bob',
+      skipSocketEmit: true,
+    });
+
+    // The provided username short-circuits the server-side lookup.
+    expect(getUserById).not.toHaveBeenCalled();
+    expect(federateNewPost).toHaveBeenCalledTimes(1);
+    const [, , calledUsername] = federateNewPost.mock.calls[0];
+    expect(calledUsername).toBe('provided_bob');
+  });
+
+  it('does NOT federate when the server-side username cannot be resolved', async () => {
+    getUserById.mockResolvedValue({ id: 'oxy_user_fed', username: undefined });
+
+    const post = await postCreationService.create({
+      oxyUserId: 'oxy_user_fed',
+      content: { text: 'a post whose author has no resolvable username' },
+      visibility: PostVisibility.PUBLIC,
+      senderUsername: undefined,
+      skipSocketEmit: true,
+    });
+
+    expect(getUserById).toHaveBeenCalledWith('oxy_user_fed');
+    expect(federateNewPost).not.toHaveBeenCalled();
+    const meta = (post as unknown as { metadata?: Record<string, unknown> }).metadata;
+    expect(meta?.federationDelivered).toBeUndefined();
+  });
+});

--- a/packages/backend/src/connectors/ConnectorRegistry.ts
+++ b/packages/backend/src/connectors/ConnectorRegistry.ts
@@ -12,6 +12,8 @@ import type {
 function actingOxyUserId(event: LocalNetworkEvent): string {
   switch (event.kind) {
     case 'post.create':
+    case 'post.boost':
+    case 'post.unboost':
       return event.actorOxyUserId;
     case 'follow.add':
     case 'follow.remove':

--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -11,7 +11,7 @@ import type {
 import { resolveOxyExternalUser } from '../identity';
 import { isAbsoluteHttpUrl } from '../shared/url';
 import { actorService } from './actor.service';
-import { followService, type NoteSourcePost } from './follow.service';
+import { followService, type NoteSourcePost, type NoteReplyContext } from './follow.service';
 import { outboxSyncService } from './outbox.service';
 import { inboxProcessingService } from './inbox.service';
 import { FEDERATION_ENABLED, isBlockedDomain } from './constants';
@@ -121,6 +121,14 @@ class ActivityPubConnector implements NetworkConnector {
     switch (event.kind) {
       case 'post.create':
         await followService.federateNewPost(event.post, event.actorOxyUserId, event.actorUsername);
+        break;
+      case 'post.boost':
+        // A boost federates as an Announce of the original's canonical AP id,
+        // delivered to the booster's followers + (federated original) its author.
+        await followService.federateBoost(event.boost, event.actorOxyUserId, event.actorUsername);
+        break;
+      case 'post.unboost':
+        await followService.federateUndoBoost(event.boost, event.actorOxyUserId, event.actorUsername);
         break;
       case 'follow.add':
         // Sends a Follow activity + records the outbound FederatedFollow. The
@@ -254,8 +262,23 @@ class ActivityPubConnector implements NetworkConnector {
     return followService.deliverToFollowers(activity, senderOxyUserId, senderUsername);
   }
 
-  buildCreateNoteActivity(post: NoteSourcePost, username: string): Record<string, unknown> {
-    return followService.buildCreateNoteActivity(post, username);
+  buildCreateNoteActivity(
+    post: NoteSourcePost,
+    username: string,
+    reply?: NoteReplyContext,
+  ): Record<string, unknown> {
+    return followService.buildCreateNoteActivity(post, username, reply);
+  }
+
+  /**
+   * Resolve a post's reply addressing (`inReplyTo` + parent-author `Mention`) for
+   * a PULL surface (the per-post dereference route). Null when the post is not a
+   * reply or the parent is unresolvable (fail-soft). The push path resolves this
+   * internally in {@link FollowService.federateNewPost}, unioning the parent
+   * author's inbox into delivery.
+   */
+  resolveReplyContext(post: NoteSourcePost): Promise<NoteReplyContext | null> {
+    return followService.resolveReplyContext(post);
   }
 
   federateNewPost(

--- a/packages/backend/src/connectors/activitypub/constants.ts
+++ b/packages/backend/src/connectors/activitypub/constants.ts
@@ -83,6 +83,19 @@ export function outboxUrl(username: string): string {
   return `https://${FEDERATION_DOMAIN}/ap/users/${username}/outbox`;
 }
 
+/**
+ * The actor's `featured` collection (pinned posts). Mastodon reads this URL from
+ * the actor's `featured` property and fetches it on profile view — it is the ONLY
+ * way a freshly-discovered account's posts populate its profile Posts tab
+ * (Mastodon never backfills a remote timeline from the regular `outbox`). The
+ * exact path only needs to be self-consistent with what the actor advertises;
+ * this mirrors Mastodon's own `/collections/featured` convention under our
+ * existing `/ap/users/:username` namespace.
+ */
+export function featuredUrl(username: string): string {
+  return `https://${FEDERATION_DOMAIN}/ap/users/${username}/collections/featured`;
+}
+
 export function followersUrl(username: string): string {
   return `https://${FEDERATION_DOMAIN}/ap/users/${username}/followers`;
 }

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -2,6 +2,7 @@ import { logger } from '../../utils/logger';
 import FederatedActor, { IFederatedActor } from '../../models/FederatedActor';
 import FederatedFollow from '../../models/FederatedFollow';
 import FederationDeliveryQueue from '../../models/FederationDeliveryQueue';
+import { Post } from '../../models/Post';
 import { signRequest, getPublicKey } from './crypto';
 import {
   FEDERATION_DOMAIN,
@@ -15,6 +16,8 @@ import { PostVisibility, canonicalizeLanguageTag, type MediaItem, type PostConte
 import { authorVariants, resolveVariant } from '../../services/postVariants';
 import { enqueueDelivery } from '../../queue/producers';
 import { isFediverseSharingEnabled } from '../../services/fediverseSharing';
+import { getServiceOxyClient } from '../../utils/oxyHelpers';
+import type { LocalBoostEventPayload } from '../types';
 import { actorService } from './actor.service';
 import { fetchUpstreamSingleHop } from '../../utils/safeUpstreamFetch';
 import { assertSafePublicUrl } from '../../utils/ssrfGuard';
@@ -23,6 +26,31 @@ import { isAbsoluteHttpUrl } from '../shared/url';
 
 const DELIVER_ACTIVITY_TIMEOUT_MS = 15000;
 const DELIVERY_RESPONSE_PREVIEW_MAX_BYTES = 1024;
+
+/** The ActivityStreams public collection — the `to` addressee of a public activity. */
+const AP_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
+
+/**
+ * The canonical AP object id of a boosted/replied/liked ORIGINAL post, plus the
+ * original author's remote inbox and actor URI when the original is federated.
+ *
+ * `objectUri` is what an `Announce`/`Undo(Announce)` (and later a reply's
+ * `inReplyTo`, a Like's `object`) points at. `authorInbox` is an EXPLICIT
+ * delivery target unioned into the follower set so the original author's
+ * instance learns about the interaction; it is undefined for a local original
+ * (that author is us — reached through their own followers, never a remote POST).
+ */
+interface FederationTarget {
+  objectUri: string;
+  authorActorUri?: string;
+  authorInbox?: string;
+  /**
+   * The author's fediverse acct (`user@domain`) — the source of a reply's
+   * `Mention` tag `name` (`@<acct>`). For a federated original it is the stored
+   * `FederatedActor.acct`; for a local original it is `<username>@<domain>`.
+   */
+  authorAcct?: string;
+}
 
 /**
  * MIME derivation for an ActivityPub media `attachment`. Extension-first (for the
@@ -100,6 +128,36 @@ export interface NoteSourcePost {
   hashtags?: string[];
   mentions?: string[];
   createdAt: string | Date;
+  /**
+   * Set when the post is a boost. A boost has an intentionally empty body and
+   * MUST federate as an `Announce`, never as a blank `Create(Note)` — the
+   * federation entry point ({@link FollowService.federateNewPost}) reads this to
+   * re-route the post to the Announce path.
+   */
+  boostOf?: string | null;
+  /**
+   * The local Post `_id` of the parent when this post is a REPLY. Drives the
+   * Note's `inReplyTo` + parent-author `Mention` addressing: the federation
+   * caller resolves the parent's canonical AP object uri + author via
+   * {@link FollowService.resolveReplyContext} and passes it into the pure Note
+   * builder. Absent for a top-level post.
+   */
+  parentPostId?: string | null;
+}
+
+/**
+ * The reply addressing a Note carries when the post is a reply: the parent's
+ * canonical AP object id (the Note's `inReplyTo`) plus, when the parent author is
+ * resolvable, a `Mention` tag (href = author actor uri, name = `@user@domain`)
+ * that Mastodon uses to thread the reply AND notify the author. Resolved by the
+ * async federation caller (a DB lookup) and passed into the PURE Note builder so
+ * {@link FollowService.buildCreateNoteActivity} never touches the database.
+ */
+export interface NoteReplyContext {
+  /** Canonical AP object id of the parent post — the Note's `inReplyTo`. */
+  inReplyTo: string;
+  /** Parent-author addressing for the `Mention` tag + `cc` (present when resolvable). */
+  mention?: { href: string; name: string };
 }
 
 /**
@@ -263,13 +321,38 @@ export class FollowService {
   }
 
   /**
-   * Deliver an activity to all remote followers of a local user.
-   * Groups deliveries by shared inbox for efficiency.
+   * Resolve a remote AP actor's delivery inbox (shared inbox preferred) from the
+   * stored `FederatedActor` row — the SAME source the follower fan-out below and
+   * the inbound ingest side read, so an inbox unioned in via `extraInboxes`
+   * dedupes cleanly against the follower set. Returns undefined when the actor is
+   * unknown locally or carries no inbox (e.g. an atproto-only actor).
+   *
+   * General-purpose by design: the standalone inbox resolver for a caller that
+   * holds only an actor uri (e.g. a Like target's author in Part 3).
+   * {@link resolveFederationTarget} does its OWN single actor read instead, because
+   * it needs the acct (`user@domain`) off the same row for a reply's `Mention`
+   * name, and a shared string-only helper would force a second query for it.
+   */
+  async resolveActorInbox(actorUri: string | undefined): Promise<string | undefined> {
+    if (!actorUri) return undefined;
+    const actor = await FederatedActor.findOne({ uri: actorUri }).lean();
+    if (!actor) return undefined;
+    return actor.sharedInboxUrl ?? actor.inboxUrl ?? undefined;
+  }
+
+  /**
+   * Deliver an activity to all remote followers of a local user, plus any
+   * EXPLICIT remote inboxes passed in `options.extraInboxes` (e.g. the boosted
+   * original's author inbox, a reply parent's author inbox). Deliveries are
+   * grouped by shared inbox so an instance is never POSTed the same activity
+   * twice — an explicit inbox that coincides with a follower's shared inbox is
+   * delivered exactly once.
    */
   async deliverToFollowers(
     activity: Record<string, unknown>,
     senderOxyUserId: string,
     senderUsername: string,
+    options: { extraInboxes?: string[] } = {},
   ): Promise<void> {
     const follows = await FederatedFollow.find({
       localUserId: senderOxyUserId,
@@ -277,16 +360,24 @@ export class FollowService {
       status: 'accepted',
     }).lean();
 
-    if (follows.length === 0) return;
-
     const actorUris = follows.map((f) => f.remoteActorUri);
-    const actors = await FederatedActor.find({ uri: { $in: actorUris } }).lean();
+    const actors = actorUris.length > 0
+      ? await FederatedActor.find({ uri: { $in: actorUris } }).lean()
+      : [];
 
-    // Group by shared inbox to avoid duplicate deliveries.
+    // Group by shared inbox to avoid duplicate deliveries. Follower inboxes
+    // first, then the explicit targets — the shared `seen` set dedupes an
+    // explicit inbox that an instance already receives as a follower.
     const seen = new Set<string>();
     const inboxes: string[] = [];
     for (const actor of actors) {
       const inbox = actor.sharedInboxUrl || actor.inboxUrl;
+      if (inbox && !seen.has(inbox)) {
+        seen.add(inbox);
+        inboxes.push(inbox);
+      }
+    }
+    for (const inbox of options.extraInboxes ?? []) {
       if (inbox && !seen.has(inbox)) {
         seen.add(inbox);
         inboxes.push(inbox);
@@ -358,7 +449,11 @@ export class FollowService {
    * localized by the resolver). A non-primary variant's media override is
    * internal to Mention — there is nowhere in AS2 to put a second attachment set.
    */
-  buildCreateNoteActivity(post: NoteSourcePost, username: string): Record<string, unknown> {
+  buildCreateNoteActivity(
+    post: NoteSourcePost,
+    username: string,
+    reply?: NoteReplyContext,
+  ): Record<string, unknown> {
     const actor = actorUrl(username);
     const postId = String(post._id);
     const noteId = `${actor}/posts/${postId}`;
@@ -376,6 +471,13 @@ export class FollowService {
         });
       }
     }
+    // A reply addressed at the parent author: the `Mention` tag is what makes
+    // Mastodon thread the reply under the parent and notify its author. `href`
+    // (the actor uri) is the authoritative resolution key; `name` (`@user@domain`)
+    // is the human-readable handle.
+    if (reply?.mention) {
+      tags.push({ type: 'Mention', href: reply.mention.href, name: reply.mention.name });
+    }
 
     // The primary rendition: its body, its media (shared or overridden, alt
     // localized) and the tag it is written in — all from the one resolver.
@@ -391,25 +493,35 @@ export class FollowService {
     const language = canonicalizeLanguageTag(primary.tag) ?? undefined;
     const contentMap = buildNoteContentMap(post, language, primaryBody);
 
+    // The public collection stays in `to`; the mentioned parent author joins the
+    // followers collection in `cc` so a public reply is delivered/attributed to
+    // them (mirrors how the boost path cc's the boosted author). Same set on the
+    // Create envelope and the embedded Note.
+    const cc = [`${actor}/followers`];
+    if (reply?.mention) cc.push(reply.mention.href);
+
     return {
       '@context': AP_CONTEXT,
       id: `${noteId}/activity`,
       type: 'Create',
       actor,
       published,
-      to: ['https://www.w3.org/ns/activitystreams#Public'],
-      cc: [`${actor}/followers`],
+      to: [AP_PUBLIC],
+      cc,
       object: {
         id: noteId,
         type: 'Note',
         attributedTo: actor,
+        // Only present on a reply — undefined is dropped by JSON serialization,
+        // so a top-level Note carries no `inReplyTo`.
+        inReplyTo: reply?.inReplyTo,
         url: `https://${FEDERATION_DOMAIN}/@${username}/posts/${postId}`,
         content: primaryBody,
         contentMap,
         language,
         published,
-        to: ['https://www.w3.org/ns/activitystreams#Public'],
-        cc: [`${actor}/followers`],
+        to: [AP_PUBLIC],
+        cc,
         tag: tags.length > 0 ? tags : undefined,
         attachment: attachments.length > 0 ? attachments : undefined,
       },
@@ -430,13 +542,294 @@ export class FollowService {
     // duplicate check protects any other caller that might reach
     // `federateNewPost` directly, bypassing the registry.
     if (!(await isFediverseSharingEnabled(senderOxyUserId))) return;
+
+    // A boost carries an intentionally EMPTY body. It must NEVER federate as a
+    // `Create(Note)` — that would push a blank status to every remote follower.
+    // Route it to the `Announce` path instead. (A QUOTE post has a real body AND
+    // a `quoteOf`, no `boostOf`, so it correctly falls through to the Create path
+    // below and federates as a normal Note.)
+    if (post.boostOf) {
+      await this.federateBoost(
+        { _id: post._id, boostOf: String(post.boostOf), createdAt: post.createdAt },
+        senderOxyUserId,
+        senderUsername,
+      );
+      return;
+    }
+
     if (post.visibility !== PostVisibility.PUBLIC) return;
 
     try {
-      const activity = this.buildCreateNoteActivity(post, senderUsername);
-      await this.deliverToFollowers(activity, senderOxyUserId, senderUsername);
+      // A reply carries `inReplyTo` + a parent-author `Mention`, and is ALSO
+      // delivered to the parent author's inbox (federated parent only) so their
+      // instance threads + notifies it. Fail-soft: an unresolvable parent yields
+      // `null`, so the Note federates as a normal post (no `inReplyTo`) rather
+      // than being dropped.
+      const reply = await this.resolveReplyDelivery(post);
+      const activity = this.buildCreateNoteActivity(post, senderUsername, reply?.context);
+      await this.deliverToFollowers(activity, senderOxyUserId, senderUsername, {
+        extraInboxes: reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : [],
+      });
     } catch (err) {
       logger.error('Failed to federate new post:', err);
+    }
+  }
+
+  /**
+   * Build the reply `Mention` (`href` = parent author actor uri, `name` =
+   * `@<acct>`) from a resolved {@link FederationTarget}. Shared by the push and
+   * pull surfaces so the tag is identical everywhere. The mention is omitted when
+   * the author cannot be resolved to both an actor uri and an acct — the Note
+   * still carries `inReplyTo`, which is enough for threading.
+   */
+  private buildReplyContextFromTarget(target: FederationTarget): NoteReplyContext {
+    const mention =
+      target.authorActorUri && target.authorAcct
+        ? { href: target.authorActorUri, name: `@${target.authorAcct}` }
+        : undefined;
+    return { inReplyTo: target.objectUri, mention };
+  }
+
+  /**
+   * Resolve a post's reply addressing for the PULL surfaces (the per-post
+   * dereference route serving a Note without delivering it): the `inReplyTo` +
+   * parent-author `Mention`. Returns null when the post is not a reply OR the
+   * parent cannot be resolved. Fail-soft — any error resolves to null (the Note
+   * is served without `inReplyTo` rather than 500ing), so a caller never needs
+   * its own try/catch.
+   */
+  async resolveReplyContext(post: NoteSourcePost): Promise<NoteReplyContext | null> {
+    const parentId = post.parentPostId ? String(post.parentPostId) : undefined;
+    if (!parentId) return null;
+    try {
+      const target = await this.resolveFederationTarget(parentId);
+      if (!target) return null;
+      return this.buildReplyContextFromTarget(target);
+    } catch (err) {
+      logger.warn(`[FedDeliver] failed to resolve reply context for parent ${parentId}:`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Resolve a post's reply addressing for the PUSH path — the reply Note's
+   * {@link NoteReplyContext} PLUS the parent author's remote inbox to union into
+   * delivery. The inbox is set only for a FEDERATED parent (a local parent's
+   * author is one of us, reached through their own followers, never a remote
+   * POST), so a reply to a local post adds no bogus extra inbox. Fail-soft: not a
+   * reply or unresolvable parent → null (federates as a normal post).
+   */
+  private async resolveReplyDelivery(
+    post: NoteSourcePost,
+  ): Promise<{ context: NoteReplyContext; parentAuthorInbox?: string } | null> {
+    const parentId = post.parentPostId ? String(post.parentPostId) : undefined;
+    if (!parentId) return null;
+    try {
+      const target = await this.resolveFederationTarget(parentId);
+      if (!target) return null;
+      return {
+        context: this.buildReplyContextFromTarget(target),
+        parentAuthorInbox: target.authorInbox,
+      };
+    } catch (err) {
+      logger.warn(`[FedDeliver] failed to resolve reply delivery for parent ${parentId}:`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the canonical ActivityPub object id of a boosted/replied/liked
+   * ORIGINAL post (plus, for a federated original, its author's remote inbox).
+   *
+   *  - FEDERATED original → the remote `federation.activityId` IS its canonical
+   *    AP id; the author's inbox is resolved from the stored `FederatedActor`.
+   *  - LOCAL original → we mint our own note URI
+   *    `https://<domain>/ap/users/<owner-username>/posts/<postId>` (the exact id
+   *    `buildCreateNoteActivity` / the outbox / the per-post dereference route
+   *    advertise), so a remote server can dereference it. The owner username is
+   *    resolved server-side from the authoritative `oxyUserId`; there is no
+   *    remote inbox (the author is local).
+   *
+   * Returns null when the original is missing or its author cannot be resolved.
+   */
+  private async resolveFederationTarget(originalPostId: string): Promise<FederationTarget | null> {
+    const original = await Post.findById(originalPostId).select('oxyUserId federation').lean();
+    if (!original) return null;
+
+    const activityId = original.federation?.activityId;
+    if (activityId) {
+      const authorActorUri = original.federation?.actorUri;
+      // ONE actor read yields both the delivery inbox and the acct (`user@domain`)
+      // a reply's `Mention` name is built from — the same `FederatedActor` row
+      // `resolveActorInbox` reads. (`resolveActorInbox` remains the standalone
+      // inbox resolver for callers that have only an actor uri.)
+      const actor = authorActorUri
+        ? await FederatedActor.findOne({ uri: authorActorUri }).lean()
+        : null;
+      return {
+        objectUri: activityId,
+        authorActorUri,
+        authorInbox: actor?.sharedInboxUrl ?? actor?.inboxUrl ?? undefined,
+        authorAcct: actor?.acct ?? undefined,
+      };
+    }
+
+    const ownerId = original.oxyUserId ? String(original.oxyUserId) : undefined;
+    if (!ownerId) return null;
+    let ownerUsername: string | undefined;
+    try {
+      const owner = await getServiceOxyClient().getUserById(ownerId);
+      ownerUsername = owner.username?.trim() || undefined;
+    } catch (err) {
+      logger.warn(`[FedDeliver] failed to resolve original author username for post ${originalPostId}:`, err);
+      return null;
+    }
+    if (!ownerUsername) return null;
+
+    const authorActorUri = actorUrl(ownerUsername);
+    return {
+      objectUri: `${authorActorUri}/posts/${originalPostId}`,
+      authorActorUri,
+      authorAcct: `${ownerUsername}@${FEDERATION_DOMAIN}`,
+    };
+  }
+
+  /**
+   * Build an `Announce` (boost) activity for a local booster of `objectUri`.
+   * Addressed to the public collection, `cc`'d to the booster's followers and
+   * (when known) the original author's actor URI. The activity id is minted
+   * deterministically from the boost's local `_id` so `Undo(Announce)` can
+   * reference the same id without persisting it.
+   */
+  buildAnnounceActivity(
+    boosterUsername: string,
+    boostId: string,
+    objectUri: string,
+    originalAuthorActorUri: string | undefined,
+    published: string | Date,
+  ): Record<string, unknown> {
+    const actor = actorUrl(boosterUsername);
+    const cc = [`${actor}/followers`];
+    if (originalAuthorActorUri) cc.push(originalAuthorActorUri);
+    return {
+      '@context': AP_CONTEXT,
+      id: `${actor}/boosts/${boostId}`,
+      type: 'Announce',
+      actor,
+      object: objectUri,
+      published: published instanceof Date ? published.toISOString() : published,
+      to: [AP_PUBLIC],
+      cc,
+    };
+  }
+
+  /**
+   * Build the matching `Undo(Announce)` for an unboost. The embedded `Announce`
+   * re-mints the SAME id + addressing `buildAnnounceActivity` emitted so remote
+   * servers can retract the exact boost.
+   */
+  buildUndoAnnounceActivity(
+    boosterUsername: string,
+    boostId: string,
+    objectUri: string,
+    originalAuthorActorUri: string | undefined,
+  ): Record<string, unknown> {
+    const actor = actorUrl(boosterUsername);
+    const cc = [`${actor}/followers`];
+    if (originalAuthorActorUri) cc.push(originalAuthorActorUri);
+    const announceId = `${actor}/boosts/${boostId}`;
+    return {
+      '@context': AP_CONTEXT,
+      id: `${announceId}/undo`,
+      type: 'Undo',
+      actor,
+      to: [AP_PUBLIC],
+      cc,
+      object: {
+        id: announceId,
+        type: 'Announce',
+        actor,
+        object: objectUri,
+        to: [AP_PUBLIC],
+        cc,
+      },
+    };
+  }
+
+  /**
+   * Federate a local user's boost as an `Announce`. Delivered to the booster's
+   * remote followers AND — when the boosted original is federated — the original
+   * author's inbox (so their instance records the boost), deduped by the shared
+   * addressing helper. Boosts of purely-local content still reach the booster's
+   * remote followers so their Mastodon timeline shows the boost.
+   *
+   * Gated identically to {@link federateNewPost}: local booster, sharing on.
+   * Best-effort — a failure never surfaces to the caller.
+   */
+  async federateBoost(
+    boost: LocalBoostEventPayload,
+    boosterOxyUserId: string,
+    boosterUsername: string,
+  ): Promise<void> {
+    if (!FEDERATION_ENABLED) return;
+    if (!(await isFediverseSharingEnabled(boosterOxyUserId))) return;
+    const boostOf = boost.boostOf ? String(boost.boostOf) : undefined;
+    if (!boostOf) return;
+
+    try {
+      const target = await this.resolveFederationTarget(boostOf);
+      if (!target) {
+        logger.warn(`[FedDeliver] cannot federate boost ${String(boost._id)}: unresolved original ${boostOf}`);
+        return;
+      }
+      const activity = this.buildAnnounceActivity(
+        boosterUsername,
+        String(boost._id),
+        target.objectUri,
+        target.authorActorUri,
+        boost.createdAt,
+      );
+      await this.deliverToFollowers(activity, boosterOxyUserId, boosterUsername, {
+        extraInboxes: target.authorInbox ? [target.authorInbox] : [],
+      });
+    } catch (err) {
+      logger.error('Failed to federate boost:', err);
+    }
+  }
+
+  /**
+   * Federate an unboost as an `Undo(Announce)`. Same addressing as
+   * {@link federateBoost}. The caller must invoke this with the boost's data
+   * still available (before or right after deleting the local boost row); the
+   * ORIGINAL post is untouched by an unboost, so target resolution still works.
+   */
+  async federateUndoBoost(
+    boost: LocalBoostEventPayload,
+    boosterOxyUserId: string,
+    boosterUsername: string,
+  ): Promise<void> {
+    if (!FEDERATION_ENABLED) return;
+    if (!(await isFediverseSharingEnabled(boosterOxyUserId))) return;
+    const boostOf = boost.boostOf ? String(boost.boostOf) : undefined;
+    if (!boostOf) return;
+
+    try {
+      const target = await this.resolveFederationTarget(boostOf);
+      if (!target) {
+        logger.warn(`[FedDeliver] cannot federate unboost ${String(boost._id)}: unresolved original ${boostOf}`);
+        return;
+      }
+      const activity = this.buildUndoAnnounceActivity(
+        boosterUsername,
+        String(boost._id),
+        target.objectUri,
+        target.authorActorUri,
+      );
+      await this.deliverToFollowers(activity, boosterOxyUserId, boosterUsername, {
+        extraInboxes: target.authorInbox ? [target.authorInbox] : [],
+      });
+    } catch (err) {
+      logger.error('Failed to federate unboost:', err);
     }
   }
 

--- a/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
+++ b/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
@@ -15,11 +15,13 @@ import {
   actorUrl,
   inboxUrl,
   outboxUrl,
+  featuredUrl,
   followersUrl,
   followingUrl,
   sharedInboxUrl,
   resolveOxyUser,
 } from '../constants';
+import { ChronoCursor } from '../../../mtn/feed/CursorBuilder';
 import rateLimit from 'express-rate-limit';
 import { RedisStore } from '../../../middleware/rateLimitStore';
 import { hashedIpKey } from '../../../utils/ipKey';
@@ -249,6 +251,7 @@ router.get('/users/:username', async (req: Request, res: Response) => {
       url: `https://${FEDERATION_DOMAIN}/@${username}`,
       inbox: inboxUrl(username),
       outbox: outboxUrl(username),
+      featured: featuredUrl(username),
       followers: followersUrl(username),
       following: followingUrl(username),
       endpoints: { sharedInbox: sharedInboxUrl() },
@@ -406,35 +409,132 @@ router.get('/users/:username/outbox', async (req: Request, res: Response) => {
       });
     }
 
-    // Return paginated items
-    const limit = 20;
-    const posts = await Post.find({
+    // Return paginated items. Keyset pagination by (createdAt, _id) — the same
+    // ChronoCursor axis the native feeds use — so EVERY post is reachable by
+    // walking `next`. Previously the page returned only the first 20 items with
+    // no `next`, silently stranding every post beyond the first page from any AP
+    // consumer that paginates (e.g. a 42-post outbox exposed only 20). Overfetch
+    // one extra row to detect whether a further page exists without a second
+    // count query.
+    const PAGE_SIZE = 20;
+    const cursor = typeof req.query.cursor === 'string' ? req.query.cursor : undefined;
+
+    const pageMatch: Record<string, unknown> = {
       oxyUserId: userId,
       visibility: 'public',
       status: 'published',
       parentPostId: null,
-    })
-      .sort({ createdAt: -1 })
-      .limit(limit)
+    };
+    ChronoCursor.applyToQuery(pageMatch, cursor);
+
+    const overfetched = await Post.find(pageMatch)
+      .sort({ createdAt: -1, _id: -1 })
+      .limit(PAGE_SIZE + 1)
       .lean();
+
+    const hasNext = overfetched.length > PAGE_SIZE;
+    const pagePosts = hasNext ? overfetched.slice(0, PAGE_SIZE) : overfetched;
 
     // Reuse the SINGLE Note builder that push delivery uses, so outbox backfill
     // (Mastodon ≥4.4 imports up to 20 items on discovery) carries the same
     // fidelity as pushed posts: canonical url, hashtag `tag`s, and media
     // `attachment`s. One implementation for both paths.
-    const items = posts.map((post) => activityPubConnector.buildCreateNoteActivity(post, username));
+    const items = pagePosts.map((post) => activityPubConnector.buildCreateNoteActivity(post, username));
 
-    res.set('Content-Type', AP_CONTENT_TYPE);
-    return res.json({
+    const pageId = cursor
+      ? `${outboxUrl(username)}?page=true&cursor=${encodeURIComponent(cursor)}`
+      : `${outboxUrl(username)}?page=true`;
+
+    const pageResponse: Record<string, unknown> = {
       '@context': AP_CONTEXT,
-      id: `${outboxUrl(username)}?page=true`,
+      id: pageId,
       type: 'OrderedCollectionPage',
       partOf: outboxUrl(username),
       totalItems: totalPosts,
       orderedItems: items,
-    });
+    };
+
+    if (hasNext) {
+      const lastPost = pagePosts[pagePosts.length - 1];
+      const nextCursor = ChronoCursor.build(String(lastPost._id), lastPost.createdAt);
+      pageResponse.next = `${outboxUrl(username)}?page=true&cursor=${encodeURIComponent(nextCursor)}`;
+    }
+
+    res.set('Content-Type', AP_CONTENT_TYPE);
+    return res.json(pageResponse);
   } catch (err) {
     logger.error('Outbox endpoint error:', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /ap/users/:username/collections/featured — Featured collection (pinned posts)
+ *
+ * Mastodon does NOT backfill a freshly-discovered remote account's timeline from
+ * the `outbox`; on profile view it fetches this `featured` collection (advertised
+ * on the actor) and renders those PINNED posts. Without it a discovered Mention
+ * profile shows avatar/banner/post-count but ZERO posts. This is the fix.
+ *
+ * Returns a NON-paginated `OrderedCollection` whose `orderedItems` are the user's
+ * pinned posts as bare AP `Note` objects (NOT `Create` activities) — reusing the
+ * SAME Note builder as the outbox/push/dereference paths (unwrapping the `Create`
+ * envelope), so featured Notes carry identical fidelity. Ownership + visibility
+ * exactly mirror the outbox filter (public + published + top-level, owned by the
+ * named user), plus `metadata.isPinned`; newest-first. Same fediverse-sharing
+ * consent gate + 404-when-off behavior as the sibling AP surfaces.
+ */
+router.get('/users/:username/collections/featured', async (req: Request, res: Response) => {
+  if (!FEDERATION_ENABLED) return res.status(404).json({ error: 'Federation disabled' });
+
+  const username = getUsername(req);
+
+  try {
+    const user = await resolveOxyUser(username);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    // Sharing OFF must be indistinguishable from a nonexistent user — same
+    // 404 body, no separate error code.
+    if (!isFediverseSharingEnabledFromUser(user)) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const userId = user._id || user.id;
+
+    // Only PUBLIC + PUBLISHED top-level pinned posts are exposed — identical
+    // ownership/visibility filter to the outbox, narrowed to pinned. Mastodon
+    // caps featured display at ~5, but we serve all pinned posts newest-first;
+    // FEATURED_LIMIT is a defensive upper bound.
+    const FEATURED_LIMIT = 20;
+    const pinnedPosts = await Post.find({
+      oxyUserId: userId,
+      'metadata.isPinned': true,
+      visibility: 'public',
+      status: 'published',
+      parentPostId: null,
+    })
+      .sort({ createdAt: -1, _id: -1 })
+      .limit(FEATURED_LIMIT)
+      .lean();
+
+    // Build via the shared Note path, then unwrap the Create envelope: a featured
+    // collection contains bare Note OBJECTS, carrying no per-item `@context` (the
+    // collection's top-level `@context` covers them).
+    const items = pinnedPosts.map(
+      (post) => activityPubConnector.buildCreateNoteActivity(post, username).object as Record<string, unknown>,
+    );
+
+    res.set('Content-Type', AP_CONTENT_TYPE);
+    res.set('Cache-Control', 'max-age=300');
+    return res.json({
+      '@context': AP_CONTEXT,
+      id: featuredUrl(username),
+      type: 'OrderedCollection',
+      totalItems: items.length,
+      orderedItems: items,
+    });
+  } catch (err) {
+    logger.error('Featured collection endpoint error:', err);
     return res.status(500).json({ error: 'Internal server error' });
   }
 });
@@ -489,9 +589,15 @@ router.get('/users/:username/posts/:id', async (req: Request, res: Response) => 
     }).lean();
     if (!post) return res.status(404).json({ error: 'Post not found' });
 
+    // When the dereferenced post is a REPLY, carry `inReplyTo` + the parent-author
+    // `Mention` so a remote server that pulls this Note by URL threads it. Resolved
+    // here (the builder stays pure); fail-soft — a non-reply or unresolvable parent
+    // yields null, so the Note is served without `inReplyTo` rather than erroring.
+    const replyContext = await activityPubConnector.resolveReplyContext(post);
+
     // Build via the shared Note path, then unwrap the Create envelope: a
     // dereferenced Note is the `object`, carrying its own top-level `@context`.
-    const activity = activityPubConnector.buildCreateNoteActivity(post, username);
+    const activity = activityPubConnector.buildCreateNoteActivity(post, username, replyContext ?? undefined);
     const note = activity.object as Record<string, unknown>;
 
     res.set('Content-Type', AP_CONTENT_TYPE);
@@ -503,13 +609,38 @@ router.get('/users/:username/posts/:id', async (req: Request, res: Response) => 
   }
 });
 
+/** Page size for the paginated followers/following collections (mirrors the outbox). */
+const FOLLOW_PAGE_SIZE = 20;
+
 /**
- * GET /ap/users/:username/followers — Followers collection
+ * Serve a user's followers OR following as a paginated ActivityPub
+ * `OrderedCollection` — the two surfaces differ only by follow `direction`
+ * (`inbound` = followers, `outbound` = following) and the collection URL builder,
+ * so they share this one handler.
+ *
+ * The summary (no `?page=true`) advertises `totalItems` AND a `first` page link,
+ * so a remote instance (e.g. mastodon.social) can actually ENUMERATE the members
+ * — previously the collection exposed only `totalItems`, so the list rendered
+ * empty even when federated edges existed. The paged branch returns an
+ * `OrderedCollectionPage` whose `orderedItems` are the remote actor URIs
+ * (strings), keyset-paginated by (createdAt, _id) via the SAME ChronoCursor axis
+ * the outbox uses, so every member is reachable by walking `next`.
+ *
+ * Source is `FederatedFollow` (accepted edges in the given direction), the SAME
+ * rows the `totalItems` count is derived from — so the count and the enumerated
+ * list stay consistent. Keeps the identical fediverse-sharing consent gate +
+ * 404-when-off behavior as the sibling AP surfaces.
  */
-router.get('/users/:username/followers', async (req: Request, res: Response) => {
+async function serveFollowCollection(
+  req: Request,
+  res: Response,
+  direction: 'inbound' | 'outbound',
+  collectionUrl: (username: string) => string,
+): Promise<Response> {
   if (!FEDERATION_ENABLED) return res.status(404).json({ error: 'Federation disabled' });
 
   const username = getUsername(req);
+  const page = req.query.page === 'true';
 
   try {
     const user = await resolveOxyUser(username);
@@ -522,63 +653,78 @@ router.get('/users/:username/followers', async (req: Request, res: Response) => 
     }
 
     const userId = String(user._id || user.id);
+    const baseMatch = { localUserId: userId, direction, status: 'accepted' as const };
 
-    const count = await FederatedFollow.countDocuments({
-      localUserId: userId,
-      direction: 'inbound',
-      status: 'accepted',
-    });
+    const count = await FederatedFollow.countDocuments(baseMatch);
 
-    res.set('Content-Type', AP_CONTENT_TYPE);
-    return res.json({
-      '@context': AP_CONTEXT,
-      id: followersUrl(username),
-      type: 'OrderedCollection',
-      totalItems: count,
-    });
-  } catch (err) {
-    logger.error('Followers endpoint error:', err);
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-/**
- * GET /ap/users/:username/following — Following collection
- */
-router.get('/users/:username/following', async (req: Request, res: Response) => {
-  if (!FEDERATION_ENABLED) return res.status(404).json({ error: 'Federation disabled' });
-
-  const username = getUsername(req);
-
-  try {
-    const user = await resolveOxyUser(username);
-    if (!user) return res.status(404).json({ error: 'User not found' });
-
-    // Sharing OFF must be indistinguishable from a nonexistent user — same
-    // 404 body, no separate error code.
-    if (!isFediverseSharingEnabledFromUser(user)) {
-      return res.status(404).json({ error: 'User not found' });
+    if (!page) {
+      res.set('Content-Type', AP_CONTENT_TYPE);
+      return res.json({
+        '@context': AP_CONTEXT,
+        id: collectionUrl(username),
+        type: 'OrderedCollection',
+        totalItems: count,
+        first: `${collectionUrl(username)}?page=true`,
+      });
     }
 
-    const userId = String(user._id || user.id);
+    // Keyset pagination by (createdAt, _id) — overfetch one row to detect a
+    // further page without a second count query.
+    const cursor = typeof req.query.cursor === 'string' ? req.query.cursor : undefined;
+    const pageMatch: Record<string, unknown> = { ...baseMatch };
+    ChronoCursor.applyToQuery(pageMatch, cursor);
 
-    const count = await FederatedFollow.countDocuments({
-      localUserId: userId,
-      direction: 'outbound',
-      status: 'accepted',
-    });
+    const overfetched = await FederatedFollow.find(pageMatch)
+      .sort({ createdAt: -1, _id: -1 })
+      .limit(FOLLOW_PAGE_SIZE + 1)
+      .lean();
+
+    const hasNext = overfetched.length > FOLLOW_PAGE_SIZE;
+    const pageRows = hasNext ? overfetched.slice(0, FOLLOW_PAGE_SIZE) : overfetched;
+
+    // A follower/following collection enumerates the REMOTE actor URIs (the AP
+    // ids) — bare strings, per the ActivityPub spec's actor collections.
+    const orderedItems = pageRows.map((row) => row.remoteActorUri);
+
+    const pageId = cursor
+      ? `${collectionUrl(username)}?page=true&cursor=${encodeURIComponent(cursor)}`
+      : `${collectionUrl(username)}?page=true`;
+
+    const pageResponse: Record<string, unknown> = {
+      '@context': AP_CONTEXT,
+      id: pageId,
+      type: 'OrderedCollectionPage',
+      partOf: collectionUrl(username),
+      totalItems: count,
+      orderedItems,
+    };
+
+    if (hasNext) {
+      const lastRow = pageRows[pageRows.length - 1];
+      const nextCursor = ChronoCursor.build(String(lastRow._id), lastRow.createdAt);
+      pageResponse.next = `${collectionUrl(username)}?page=true&cursor=${encodeURIComponent(nextCursor)}`;
+    }
 
     res.set('Content-Type', AP_CONTENT_TYPE);
-    return res.json({
-      '@context': AP_CONTEXT,
-      id: followingUrl(username),
-      type: 'OrderedCollection',
-      totalItems: count,
-    });
+    return res.json(pageResponse);
   } catch (err) {
-    logger.error('Following endpoint error:', err);
+    logger.error('Follow collection endpoint error:', err);
     return res.status(500).json({ error: 'Internal server error' });
   }
-});
+}
+
+/**
+ * GET /ap/users/:username/followers — Followers collection (inbound accepted edges).
+ */
+router.get('/users/:username/followers', (req: Request, res: Response) =>
+  serveFollowCollection(req, res, 'inbound', followersUrl),
+);
+
+/**
+ * GET /ap/users/:username/following — Following collection (outbound accepted edges).
+ */
+router.get('/users/:username/following', (req: Request, res: Response) =>
+  serveFollowCollection(req, res, 'outbound', followingUrl),
+);
 
 export default router;

--- a/packages/backend/src/connectors/atproto/AtprotoConnector.ts
+++ b/packages/backend/src/connectors/atproto/AtprotoConnector.ts
@@ -88,10 +88,12 @@ class AtprotoConnector implements NetworkConnector {
   async deliver(event: LocalNetworkEvent): Promise<void> {
     switch (event.kind) {
       case 'post.create':
-        // Mention does NOT publish posts INTO a foreign atproto PDS. The C4
-        // bridge is BE-DISCOVERED (the user's repo is hosted here and read via
-        // `bridge/`); foreign-PDS publishing is the documented outbound product
-        // seam (`AtprotoBridgeOutboundSeam`), not wired. No-op.
+      case 'post.boost':
+      case 'post.unboost':
+        // Mention does NOT publish posts / reposts INTO a foreign atproto PDS.
+        // The C4 bridge is BE-DISCOVERED (the user's repo is hosted here and read
+        // via `bridge/`); foreign-PDS publishing is the documented outbound
+        // product seam (`AtprotoBridgeOutboundSeam`), not wired. No-op.
         return;
       case 'follow.add':
         await this.followActor(event.localOxyUserId, event.targetActorUri);

--- a/packages/backend/src/connectors/types.ts
+++ b/packages/backend/src/connectors/types.ts
@@ -123,6 +123,35 @@ export interface LocalPostEventPayload {
   language?: string;
   visibility: string;
   createdAt: string;
+  /**
+   * The boosted original's local Post `_id` when this post is a boost
+   * (`type: 'boost'`). A boost carries an intentionally EMPTY body and MUST NOT
+   * federate as a `Create(Note)` — the connector re-routes it to an `Announce`.
+   * Preserving it through the seam is what lets `POST /posts` `boost_of` avoid
+   * emitting a blank Create.
+   */
+  boostOf?: string | null;
+  /**
+   * The parent's local Post `_id` when this post is a REPLY. The connector emits
+   * the Note with `inReplyTo` (the parent's canonical AP object id) + a
+   * parent-author `Mention`, and unions the parent author's inbox into delivery so
+   * a reply to a remote post threads and notifies its author. Preserving it through
+   * the seam is what lets the `/feed/reply` path federate replies. Absent for a
+   * top-level post.
+   */
+  parentPostId?: string | null;
+}
+
+/**
+ * The minimal boost shape a `post.boost` / `post.unboost` event carries to
+ * outbound delivery. A boost has no body of its own; the connector federates it
+ * as an `Announce` (or `Undo(Announce)`) of the original post's canonical AP id,
+ * resolved from `boostOf`. `createdAt` stamps the activity's `published`.
+ */
+export interface LocalBoostEventPayload {
+  _id: unknown;
+  boostOf: string;
+  createdAt: string | Date;
 }
 
 /**
@@ -135,6 +164,18 @@ export type LocalNetworkEvent =
   | {
       kind: 'post.create';
       post: LocalPostEventPayload;
+      actorOxyUserId: string;
+      actorUsername: string;
+    }
+  | {
+      kind: 'post.boost';
+      boost: LocalBoostEventPayload;
+      actorOxyUserId: string;
+      actorUsername: string;
+    }
+  | {
+      kind: 'post.unboost';
+      boost: LocalBoostEventPayload;
       actorOxyUserId: string;
       actorUsername: string;
     }

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -32,7 +32,9 @@ import { queryString } from '../utils/queryParams';
 import { buildAuthorship } from '../utils/postAuthorship';
 import { validatePublicShareTarget } from '../utils/postAccessControl';
 import { baselineContentClassifier } from '../services/BaselineContentClassifier';
-import { createScopedOxyClient } from '../utils/oxyHelpers';
+import { createScopedOxyClient, getServiceOxyClient } from '../utils/oxyHelpers';
+import { connectorRegistry } from '../connectors';
+import type { LocalNetworkEvent } from '../connectors/types';
 import {
   emitPostCreated,
   emitRepostCreated,
@@ -153,6 +155,84 @@ class FeedController {
       const authorId = post.oxyUserId == null ? '' : String(post.oxyUserId);
       return !blockedAndMutedIds.includes(authorId);
     });
+  }
+
+  /**
+   * Fire-and-forget outbound federation for a local interaction, through the
+   * connector seam (which applies the per-user `fediverseSharing` gate; the
+   * connector re-checks it too).
+   *
+   * The acting user's username is resolved SERVER-SIDE from the authoritative
+   * `oxyUserId`: the Oxy auth middleware runs without `loadUser`, so
+   * `req.user.username` is never populated and must not be trusted. Once resolved,
+   * `buildEvent(username)` produces the concrete `LocalNetworkEvent`. Never blocks
+   * or fails the HTTP response — a resolve miss is logged and skipped, any error
+   * is caught.
+   */
+  private federateAsResolvedActor(
+    actorOxyUserId: string,
+    context: string,
+    buildEvent: (username: string) => LocalNetworkEvent,
+  ): void {
+    void (async () => {
+      const user = await getServiceOxyClient().getUserById(actorOxyUserId);
+      const username = user.username?.trim();
+      if (!username) {
+        logger.warn(`[Feed] skipping ${context} federation for ${actorOxyUserId}: no resolvable username`);
+        return;
+      }
+      await connectorRegistry.deliver(buildEvent(username));
+    })().catch((err) => {
+      logger.error(`[Feed] failed to federate ${context}`, err);
+    });
+  }
+
+  /**
+   * Federate a local boost / unboost outbound as an ActivityPub
+   * `Announce` / `Undo(Announce)`. The boosted ORIGINAL post is untouched by an
+   * unboost, so target resolution works from `boostOf` in both directions.
+   */
+  private federateBoostChange(
+    kind: 'post.boost' | 'post.unboost',
+    boost: { _id: unknown; boostOf: string; createdAt: string | Date },
+    boosterOxyUserId: string,
+  ): void {
+    this.federateAsResolvedActor(boosterOxyUserId, kind, (username) => ({
+      kind,
+      boost: { _id: boost._id, boostOf: boost.boostOf, createdAt: boost.createdAt },
+      actorOxyUserId: boosterOxyUserId,
+      actorUsername: username,
+    }));
+  }
+
+  /**
+   * Federate a local reply (the `POST /feed/reply` path) outbound as an
+   * ActivityPub `Create(Note)` through the SAME `post.create` seam
+   * `PostCreationService` uses — so the connector applies the reply enrichment
+   * (`inReplyTo` + parent-author `Mention`, delivery to the parent author's inbox
+   * for a federated parent) and the sharing/visibility gates identically to the
+   * `POST /posts` reply path. Passing `parentPostId` is what routes it to the
+   * reply-addressing branch of `federateNewPost`. A pending-review (private) reply
+   * carries `visibility: private`, so the connector skips it.
+   */
+  private federateReply(reply: IPost, replierOxyUserId: string): void {
+    // `createdAt` is a Mongoose timestamp (a Date at runtime, though typed as
+    // string on IPost); normalize to a canonical ISO 8601 string for the wire.
+    const createdAt = new Date(reply.createdAt).toISOString();
+    this.federateAsResolvedActor(replierOxyUserId, 'reply', (username) => ({
+      kind: 'post.create',
+      post: {
+        _id: reply._id,
+        content: reply.content,
+        hashtags: reply.hashtags,
+        mentions: reply.mentions,
+        visibility: reply.visibility,
+        createdAt,
+        parentPostId: reply.parentPostId ? String(reply.parentPostId) : null,
+      },
+      actorOxyUserId: replierOxyUserId,
+      actorUsername: username,
+    }));
   }
 
   /**
@@ -367,6 +447,14 @@ class FeedController {
         $inc: { 'stats.commentsCount': 1 }
       }, { maxTimeMS: FEED_CONSTANTS.QUERY_TIMEOUT_MS });
 
+      // Outbound federation: deliver the reply as a Create(Note) with `inReplyTo`
+      // + a parent-author Mention to the replier's remote followers AND (when the
+      // parent is federated) the parent author's inbox — through the SAME seam the
+      // `POST /posts` reply path uses. Native reply only (this endpoint never
+      // creates federated posts); gated on sharing + public visibility inside the
+      // connector. Fire-and-forget — never blocks the reply response.
+      this.federateReply(reply, currentUserId);
+
       // Hydrate the created reply at maxDepth 1 so the response + socket payload
       // carry the author summary and engagement shape (and, when the reply is a
       // quote, the embedded quoted card) — matching the feed/detail DTO instead
@@ -460,6 +548,17 @@ class FeedController {
       // MTN dual-write: a boost emits an `app.mention.feed.repost` record whose
       // subject is the boosted original's MTN URI. Best-effort, never blocks.
       await emitRepostCreated(boost, String(originalPostId), originalPost?.oxyUserId?.toString?.());
+
+      // Outbound federation: announce the boost to the booster's remote
+      // followers (and, if the original is federated, its author's instance).
+      // Local booster only — a native boost has `federation == null`.
+      if (boost.federation == null) {
+        this.federateBoostChange(
+          'post.boost',
+          { _id: boost._id, boostOf: String(originalPostId), createdAt: boost.createdAt },
+          currentUserId,
+        );
+      }
 
       // Affinity graph: the booster expresses affinity toward the boosted post's
       // author. Fire-and-forget — buffering must never block or fail the boost.
@@ -556,6 +655,18 @@ class FeedController {
           tombstoneRkey: String(boost._id),
           subjectUri: repostRecordUri(boost.oxyUserId, String(boost._id)),
         });
+      }
+
+      // Outbound federation: retract the boost with an Undo(Announce). The boost
+      // row is already deleted, but the returned doc still carries what we need
+      // and the boosted ORIGINAL is untouched, so target resolution still works.
+      // Local booster only.
+      if (boost.federation == null && boost.boostOf) {
+        this.federateBoostChange(
+          'post.unboost',
+          { _id: boost._id, boostOf: String(boost.boostOf), createdAt: boost.createdAt },
+          currentUserId,
+        );
       }
 
       // Update original post boost count and get the updated count

--- a/packages/backend/src/services/PostCreationService.ts
+++ b/packages/backend/src/services/PostCreationService.ts
@@ -455,26 +455,53 @@ class PostCreationService {
     // publish moment, not the (earlier) scheduling moment.
     await this.emitMtnRecord(post);
 
-    // Resolve the owner's username so federation can build the actor. Deferred
-    // (skipped) while any collaborator invite is still pending, mirroring
-    // create(); the eventual accept() federates the post.
-    let senderUsername: string | undefined;
-    if (ownerId && !hasPendingInvites) {
-      try {
-        const owner = await getServiceOxyClient().getUserById(ownerId);
-        senderUsername = owner.username;
-      } catch (error) {
-        logger.warn('PostCreationService: failed to resolve owner username for scheduled publish', error);
-      }
-    }
-
+    // The federation username is resolved inside runPostSideEffects from the
+    // authoritative owner id (and only when the post will actually federate) —
+    // the SAME server-side path the immediate create uses — so there is no
+    // separate resolution here. Federation stays deferred while any collaborator
+    // invite is still pending (`skipFederation`), mirroring create(); the
+    // eventual accept() federates the post.
     await this.runPostSideEffects(post, {
       oxyUserId: ownerId,
-      senderUsername,
       skipFederation: hasPendingInvites,
     });
 
     return post;
+  }
+
+  /**
+   * Resolve the username outbound ActivityPub federation needs to build the local
+   * actor for a post's author.
+   *
+   * The federation decision must NOT depend on the request-scoped `req.user`
+   * carrying a `username`: the Oxy auth middleware guards every `POST /posts` path
+   * WITHOUT `loadUser:true`, so `req.user` is only `{ id }` and any caller-supplied
+   * `senderUsername` is effectively always absent on the immediate create path.
+   * The authoritative identity is the owner's `oxyUserId`, so when no non-empty
+   * username was supplied we resolve it server-side through the service Oxy client
+   * — the exact mechanism the scheduled-publish path previously used inline.
+   *
+   * Prefers a caller-supplied non-empty username (a cheap fast path that also
+   * preserves callers/tests that pass one), otherwise makes ONE (SDK-cached)
+   * lookup. Invoked only after the other federation gates pass, so the lookup
+   * never runs for a post that would not federate anyway. Fail-soft: a resolve
+   * miss returns undefined and federation is simply skipped (logged), never
+   * throwing into the publish pipeline.
+   */
+  private async resolveFederationUsername(
+    oxyUserId: string,
+    provided: string | undefined,
+  ): Promise<string | undefined> {
+    const supplied = provided?.trim();
+    if (supplied) return supplied;
+    try {
+      const owner = await getServiceOxyClient().getUserById(oxyUserId);
+      const resolved = owner.username?.trim();
+      return resolved ? resolved : undefined;
+    } catch (error) {
+      logger.warn('PostCreationService: failed to resolve federation username from oxyUserId', error);
+      return undefined;
+    }
   }
 
   /**
@@ -645,15 +672,22 @@ class PostCreationService {
 
     // Federation is published-only: a draft never fans out even if a username is
     // resolvable, and the collab-pending gate is honored via `ctx.skipFederation`.
-    if (!ctx.skipFederation && isPublished && oxyUserId && ctx.senderUsername) {
-      try {
-        // Late-bound accessor avoids a circular import with the connector registry.
-        await getPostFederator().federateNewPost(post, oxyUserId, ctx.senderUsername);
-        post.metadata = { ...(post.metadata ?? {}), federationDelivered: true };
-        post.markModified('metadata');
-        await post.save();
-      } catch (fedError) {
-        logger.error('PostCreationService: failed to federate post', fedError);
+    // The federation username is resolved server-side from the authoritative owner
+    // id (only after these gates pass), so the fan-out no longer depends on the
+    // SDK having populated `req.user.username` — which it never does, because the
+    // auth middleware runs without `loadUser:true` on every `POST /posts` path.
+    if (!ctx.skipFederation && isPublished && oxyUserId) {
+      const federationUsername = await this.resolveFederationUsername(oxyUserId, ctx.senderUsername);
+      if (federationUsername) {
+        try {
+          // Late-bound accessor avoids a circular import with the connector registry.
+          await getPostFederator().federateNewPost(post, oxyUserId, federationUsername);
+          post.metadata = { ...(post.metadata ?? {}), federationDelivered: true };
+          post.markModified('metadata');
+          await post.save();
+        } catch (fedError) {
+          logger.error('PostCreationService: failed to federate post', fedError);
+        }
       }
     }
   }

--- a/packages/backend/src/services/serviceRegistry.ts
+++ b/packages/backend/src/services/serviceRegistry.ts
@@ -34,6 +34,13 @@ export interface PostFederator {
       mentions?: string[];
       visibility: string;
       createdAt: string;
+      // A boost carries an empty body; the connector re-routes it to an Announce
+      // rather than a blank Create(Note). Threaded through so the seam preserves it.
+      boostOf?: string | null;
+      // A reply carries the parent's Post id; the connector emits `inReplyTo` + a
+      // parent-author Mention and delivers to the parent author's inbox. Threaded
+      // through so the seam preserves it (the `POST /posts` reply path).
+      parentPostId?: string | null;
     },
     senderOxyUserId: string,
     senderUsername: string,


### PR DESCRIPTION
## Summary

New posts never federated to remote followers: the Create fan-out gate required a username sourced from `req.user.username`, which the Oxy auth middleware never populates (called without `loadUser`). `federationDelivered` was `true` on zero posts ecosystem-wide. Fixed by resolving the author username server-side from `oxyUserId` instead, so immediate posts federate like scheduled ones already did.

Also adds the outbound ActivityPub surface Mastodon needs for a profile to actually work once discovered:

- **featured (pinned posts) collection** on the actor, so a freshly discovered profile shows content (Mastodon only backfills pinned posts on first discovery).
- **outbox next-page pagination** — all posts reachable, not just the first 20.
- **followers/following collections** now expose paginated member lists.
- **Announce/Undo(Announce) for boosts** + a guard so a bare boost never federates as an empty `Create(Note)`.
- **reply Create with `inReplyTo` + Mention tag**, delivered to the parent author's inbox so replies thread correctly on Mastodon.

## Test plan

- [x] `bunx tsc --noEmit` — passes
- [x] `bun run test` (packages/backend) — 215 files / 2292 tests, 0 failures
- [x] `bun run build:backend` (repo root) — passes
- [ ] Manual verification post-deploy: confirm a new post's `federationDelivered` flips true and appears in a remote follower's Mastodon timeline

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>