### PR TITLE
fix(federation): outbound Update, Delete, Like and actor refresh

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/actorUpdateFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/actorUpdateFederation.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound actor-update federation (PART 3): a Mention-owned profile change (the
+ * `profileHeaderImage` banner) rebroadcasts the FULL actor document as an
+ * `Update(Person)` to remote followers so Mastodon refreshes the cached profile.
+ *
+ * These pin:
+ *   - `federateActorUpdate` emitting an `Update` whose `object` is the SAME
+ *     `Person` document the GET actor route serves (built by the shared
+ *     `buildLocalActorObject`), carrying the current banner as AP `image`, `to`
+ *     the public collection, `cc` the followers, delivered to follower inboxes;
+ *   - the sharing gate short-circuit;
+ *   - a no-op when the user can't be resolved.
+ *
+ * The delivery/queue layer, the models, and the Oxy client are mocked so the real
+ * `FollowService` runs in isolation; assertions read the captured
+ * `enqueueDelivery` calls.
+ */
+
+const {
+  enqueueDelivery,
+  isFediverseSharingEnabled,
+  getUserById,
+  resolveOxyUser,
+  getPublicKey,
+  userSettingsFindOneLean,
+  followFindLean,
+  actorFindLean,
+  insertMany,
+} = vi.hoisted(() => ({
+  enqueueDelivery: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  getUserById: vi.fn(),
+  resolveOxyUser: vi.fn(),
+  getPublicKey: vi.fn(),
+  userSettingsFindOneLean: vi.fn(),
+  followFindLean: vi.fn(),
+  actorFindLean: vi.fn(),
+  insertMany: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../connectors/activitypub/constants')>(
+    '../../../connectors/activitypub/constants',
+  );
+  return { ...actual, FEDERATION_ENABLED: true, resolveOxyUser };
+});
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey, signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery, enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    find: () => ({ lean: () => actorFindLean() }),
+    findOne: () => ({ lean: () => null }),
+  },
+}));
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { find: () => ({ lean: () => followFindLean() }) },
+}));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: { insertMany, create: vi.fn() },
+}));
+vi.mock('../../../models/Post', () => ({
+  Post: { findById: () => ({ select: () => ({ lean: () => null }) }) },
+}));
+vi.mock('../../../models/UserSettings', () => ({
+  default: { findOne: () => ({ lean: () => userSettingsFindOneLean() }) },
+}));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+  resolveAvatarUrl: (ref: string) => `https://cloud.oxy.so/${ref}`,
+}));
+vi.mock('../../../services/fediverseSharing', () => ({ isFediverseSharingEnabled }));
+vi.mock('../../../utils/oxyHelpers', () => ({ getServiceOxyClient: () => ({ getUserById }) }));
+
+import { followService } from '../../../connectors/activitypub/follow.service';
+
+const ALICE_ACTOR = 'https://mention.earth/ap/users/alice';
+const ALICE_FOLLOWERS = `${ALICE_ACTOR}/followers`;
+const AP_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
+
+/** The distinct target inboxes `enqueueDelivery` was asked to deliver to. */
+function deliveredInboxes(): string[] {
+  return enqueueDelivery.mock.calls.map((c) => (c[0] as { targetInbox: string }).targetInbox);
+}
+
+/** The activity enqueued. */
+function deliveredActivity(): Record<string, unknown> {
+  return (enqueueDelivery.mock.calls[0]?.[0] as { activityJson: Record<string, unknown> }).activityJson;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueDelivery.mockResolvedValue(true);
+  isFediverseSharingEnabled.mockResolvedValue(true);
+  followFindLean.mockResolvedValue([]);
+  actorFindLean.mockResolvedValue([]);
+  getUserById.mockResolvedValue({ id: 'owner', username: 'alice' });
+  resolveOxyUser.mockResolvedValue({
+    _id: 'owner',
+    name: { displayName: 'Alice' },
+    bio: 'hello world',
+    avatar: null,
+    createdAt: '2020-01-01T00:00:00.000Z',
+  });
+  getPublicKey.mockResolvedValue({ keyId: `${ALICE_ACTOR}#main-key`, publicKeyPem: 'PEM' });
+  userSettingsFindOneLean.mockResolvedValue({ profileHeaderImage: 'banner-file-id' });
+});
+
+describe('federateActorUpdate — Update(Person)', () => {
+  it('broadcasts the full actor with the current banner to remote followers', async () => {
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateActorUpdate('owner', 'alice');
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Update');
+    expect(activity.actor).toBe(ALICE_ACTOR);
+    expect(activity.to).toEqual([AP_PUBLIC]);
+    expect(activity.cc).toEqual([ALICE_FOLLOWERS]);
+    expect(typeof activity.updated).toBe('string');
+
+    const object = activity.object as Record<string, unknown>;
+    expect(object.type).toBe('Person');
+    expect(object.id).toBe(ALICE_ACTOR);
+    expect(object.preferredUsername).toBe('alice');
+    expect(object.name).toBe('Alice');
+    // The embedded actor object must NOT carry its own JSON-LD context (the
+    // envelope owns it).
+    expect(object['@context']).toBeUndefined();
+    // The banner is advertised as the AP `image`, resolved to an absolute URL.
+    expect(object.image).toEqual({ type: 'Image', url: 'https://cloud.oxy.so/banner-file-id' });
+
+    expect(deliveredInboxes()).toEqual(['https://foo.example/inbox']);
+  });
+
+  it('skips entirely when sharing is disabled', async () => {
+    isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await followService.federateActorUpdate('owner', 'alice');
+
+    expect(resolveOxyUser).not.toHaveBeenCalled();
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the user cannot be resolved', async () => {
+    resolveOxyUser.mockResolvedValue(null);
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateActorUpdate('owner', 'alice');
+
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/activitypub/deleteFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/deleteFederation.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound delete federation (PART 3): a deleted local post broadcasts a
+ * `Delete(Tombstone)` to the deleter's remote followers so Mastodon removes it.
+ *
+ * These pin:
+ *   - `federateDelete` emitting a `Delete` whose `object` is a `Tombstone`
+ *     carrying the post's canonical AP id (the exact id the outbox / push /
+ *     dereference routes advertise), `to` the public collection, `cc` the
+ *     deleter's followers, delivered to the follower inboxes;
+ *   - the sharing gate short-circuit.
+ *
+ * The delivery/queue layer, the models, and the Oxy client are mocked so the real
+ * `FollowService` runs in isolation; assertions read the captured
+ * `enqueueDelivery` calls.
+ */
+
+const {
+  enqueueDelivery,
+  isFediverseSharingEnabled,
+  getUserById,
+  followFindLean,
+  actorFindLean,
+  actorFindOneLean,
+  postFindByIdLean,
+  insertMany,
+} = vi.hoisted(() => ({
+  enqueueDelivery: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  getUserById: vi.fn(),
+  followFindLean: vi.fn(),
+  actorFindLean: vi.fn(),
+  actorFindOneLean: vi.fn(),
+  postFindByIdLean: vi.fn(),
+  insertMany: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../connectors/activitypub/constants')>(
+    '../../../connectors/activitypub/constants',
+  );
+  return { ...actual, FEDERATION_ENABLED: true };
+});
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey: vi.fn(), signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery, enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    find: () => ({ lean: () => actorFindLean() }),
+    findOne: () => ({ lean: () => actorFindOneLean() }),
+  },
+}));
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { find: () => ({ lean: () => followFindLean() }) },
+}));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: { insertMany, create: vi.fn() },
+}));
+vi.mock('../../../models/Post', () => ({
+  Post: { findById: () => ({ select: () => ({ lean: () => postFindByIdLean() }) }) },
+}));
+vi.mock('../../../models/UserSettings', () => ({ default: {} }));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+  resolveAvatarUrl: (ref: string) => `https://cloud.oxy.so/${ref}`,
+}));
+vi.mock('../../../services/fediverseSharing', () => ({ isFediverseSharingEnabled }));
+vi.mock('../../../utils/oxyHelpers', () => ({ getServiceOxyClient: () => ({ getUserById }) }));
+
+import { followService } from '../../../connectors/activitypub/follow.service';
+
+const ALICE_ACTOR = 'https://mention.earth/ap/users/alice';
+const ALICE_FOLLOWERS = `${ALICE_ACTOR}/followers`;
+const AP_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
+
+/** The distinct target inboxes `enqueueDelivery` was asked to deliver to. */
+function deliveredInboxes(): string[] {
+  return enqueueDelivery.mock.calls.map((c) => (c[0] as { targetInbox: string }).targetInbox);
+}
+
+/** The activity enqueued (identical across all inboxes in one fan-out). */
+function deliveredActivity(): Record<string, unknown> {
+  return (enqueueDelivery.mock.calls[0]?.[0] as { activityJson: Record<string, unknown> }).activityJson;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueDelivery.mockResolvedValue(true);
+  isFediverseSharingEnabled.mockResolvedValue(true);
+  followFindLean.mockResolvedValue([]);
+  actorFindLean.mockResolvedValue([]);
+  actorFindOneLean.mockResolvedValue(null);
+  postFindByIdLean.mockResolvedValue(null);
+  getUserById.mockResolvedValue({ id: 'u', username: 'alice' });
+});
+
+describe('federateDelete — Delete(Tombstone)', () => {
+  it('broadcasts a Delete of the post canonical id to the deleter followers', async () => {
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateDelete({ _id: 'post1' }, 'author-oxy', 'alice');
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Delete');
+    expect(activity.actor).toBe(ALICE_ACTOR);
+    expect(activity.id).toBe(`${ALICE_ACTOR}/posts/post1/delete`);
+    expect(activity.to).toEqual([AP_PUBLIC]);
+    expect(activity.cc).toEqual([ALICE_FOLLOWERS]);
+
+    const object = activity.object as Record<string, unknown>;
+    expect(object.type).toBe('Tombstone');
+    expect(object.id).toBe(`${ALICE_ACTOR}/posts/post1`);
+
+    expect(deliveredInboxes()).toEqual(['https://foo.example/inbox']);
+  });
+
+  it('skips federation entirely when the deleter has sharing disabled', async () => {
+    isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await followService.federateDelete({ _id: 'post1' }, 'author-oxy', 'alice');
+
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/activitypub/likeFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/likeFederation.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound like federation (PART 3): a like of a FEDERATED post notifies its
+ * ORIGIN author with a `Like` (or `Undo(Like)`) delivered ONLY to that author's
+ * inbox — a like is never fanned out to the liker's own followers. Local-post
+ * likes are a no-op (the author is notified natively via the `Like` doc).
+ *
+ * These pin:
+ *   - `federateLike` on a FEDERATED post → a `Like` whose `object` is the liked
+ *     original's `federation.activityId`, a deterministic id from the Like doc,
+ *     delivered to the origin author inbox ONLY (never a follower inbox);
+ *   - `federateUndoLike` → the matching `Undo(Like)` re-minting the same Like id;
+ *   - a LOCAL post like → no delivery at all;
+ *   - the sharing gate short-circuit.
+ *
+ * The delivery/queue layer, the models, and the Oxy client are mocked so the real
+ * `FollowService` runs in isolation; assertions read the captured
+ * `enqueueDelivery` calls.
+ */
+
+const {
+  enqueueDelivery,
+  isFediverseSharingEnabled,
+  getUserById,
+  followFindLean,
+  actorFindLean,
+  actorFindOneLean,
+  postFindByIdLean,
+  insertMany,
+} = vi.hoisted(() => ({
+  enqueueDelivery: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  getUserById: vi.fn(),
+  followFindLean: vi.fn(),
+  actorFindLean: vi.fn(),
+  actorFindOneLean: vi.fn(),
+  postFindByIdLean: vi.fn(),
+  insertMany: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../connectors/activitypub/constants')>(
+    '../../../connectors/activitypub/constants',
+  );
+  return { ...actual, FEDERATION_ENABLED: true };
+});
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey: vi.fn(), signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery, enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    find: () => ({ lean: () => actorFindLean() }),
+    findOne: () => ({ lean: () => actorFindOneLean() }),
+  },
+}));
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { find: () => ({ lean: () => followFindLean() }) },
+}));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: { insertMany, create: vi.fn() },
+}));
+vi.mock('../../../models/Post', () => ({
+  Post: { findById: () => ({ select: () => ({ lean: () => postFindByIdLean() }) }) },
+}));
+vi.mock('../../../models/UserSettings', () => ({ default: {} }));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+  resolveAvatarUrl: (ref: string) => `https://cloud.oxy.so/${ref}`,
+}));
+vi.mock('../../../services/fediverseSharing', () => ({ isFediverseSharingEnabled }));
+vi.mock('../../../utils/oxyHelpers', () => ({ getServiceOxyClient: () => ({ getUserById }) }));
+
+import { followService } from '../../../connectors/activitypub/follow.service';
+
+const ALICE_ACTOR = 'https://mention.earth/ap/users/alice';
+
+/** A FEDERATED liked original: its remote activity id + author actor. */
+function mockFederatedTarget(): void {
+  postFindByIdLean.mockResolvedValue({
+    oxyUserId: 'orig-owner',
+    federation: {
+      activityId: 'https://remote.example/users/bob/statuses/9',
+      actorUri: 'https://remote.example/users/bob',
+    },
+  });
+  // resolveFederationTarget → the remote author's FederatedActor row (inbox).
+  actorFindOneLean.mockResolvedValue({ sharedInboxUrl: 'https://remote.example/inbox' });
+}
+
+/** The distinct target inboxes `enqueueDelivery` was asked to deliver to. */
+function deliveredInboxes(): string[] {
+  return enqueueDelivery.mock.calls.map((c) => (c[0] as { targetInbox: string }).targetInbox);
+}
+
+/** The activity enqueued. */
+function deliveredActivity(): Record<string, unknown> {
+  return (enqueueDelivery.mock.calls[0]?.[0] as { activityJson: Record<string, unknown> }).activityJson;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueDelivery.mockResolvedValue(true);
+  isFediverseSharingEnabled.mockResolvedValue(true);
+  followFindLean.mockResolvedValue([]);
+  actorFindLean.mockResolvedValue([]);
+  actorFindOneLean.mockResolvedValue(null);
+  postFindByIdLean.mockResolvedValue(null);
+  getUserById.mockResolvedValue({ id: 'u', username: 'bob' });
+});
+
+describe('federateLike — Like to origin', () => {
+  it('sends a Like of the remote activity id to the origin author inbox ONLY', async () => {
+    mockFederatedTarget();
+    // Even with the liker's own followers present, a like is NOT fanned out to them.
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateLike({ _id: 'like1', postId: 'orig1' }, 'liker-oxy', 'alice');
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Like');
+    expect(activity.actor).toBe(ALICE_ACTOR);
+    expect(activity.id).toBe(`${ALICE_ACTOR}/likes/like1`);
+    expect(activity.object).toBe('https://remote.example/users/bob/statuses/9');
+
+    // Delivered to the origin author inbox only — never the liker's follower inbox.
+    expect(deliveredInboxes()).toEqual(['https://remote.example/inbox']);
+    expect(deliveredInboxes()).not.toContain('https://foo.example/inbox');
+  });
+
+  it('is a no-op for a LOCAL liked post (no remote inbox)', async () => {
+    // A local original: no federation block → resolveFederationTarget yields no
+    // author inbox, so nothing is delivered over ActivityPub.
+    postFindByIdLean.mockResolvedValue({ oxyUserId: 'local-owner', federation: undefined });
+    getUserById.mockResolvedValue({ id: 'local-owner', username: 'bob' });
+
+    await followService.federateLike({ _id: 'like1', postId: 'localpost' }, 'liker-oxy', 'alice');
+
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+
+  it('skips entirely when sharing is disabled', async () => {
+    isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await followService.federateLike({ _id: 'like1', postId: 'orig1' }, 'liker-oxy', 'alice');
+
+    expect(postFindByIdLean).not.toHaveBeenCalled();
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+});
+
+describe('federateUndoLike — Undo(Like) to origin', () => {
+  it('retracts a like with an Undo(Like) re-minting the same Like id', async () => {
+    mockFederatedTarget();
+
+    await followService.federateUndoLike({ _id: 'like1', postId: 'orig1' }, 'liker-oxy', 'alice');
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Undo');
+    expect(activity.actor).toBe(ALICE_ACTOR);
+    expect(activity.id).toBe(`${ALICE_ACTOR}/likes/like1/undo`);
+
+    const inner = activity.object as Record<string, unknown>;
+    expect(inner.type).toBe('Like');
+    expect(inner.id).toBe(`${ALICE_ACTOR}/likes/like1`);
+    expect(inner.object).toBe('https://remote.example/users/bob/statuses/9');
+
+    expect(deliveredInboxes()).toEqual(['https://remote.example/inbox']);
+  });
+
+  it('is a no-op for a LOCAL liked post', async () => {
+    postFindByIdLean.mockResolvedValue({ oxyUserId: 'local-owner', federation: undefined });
+    getUserById.mockResolvedValue({ id: 'local-owner', username: 'bob' });
+
+    await followService.federateUndoLike({ _id: 'like1', postId: 'localpost' }, 'liker-oxy', 'alice');
+
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/activitypub/updateFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/updateFederation.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound edit federation (PART 3): an edited local post re-federates as an
+ * ActivityPub `Update(Note)`. The embedded Note is the SAME one the Create path
+ * builds — canonical body, and (for a reply) `inReplyTo` + the parent-author
+ * `Mention` — PLUS an `updated` timestamp, which is how Mastodon marks a status
+ * as edited.
+ *
+ * These pin:
+ *   - a top-level edit → `Update` whose object is a `Note` with `updated` set and
+ *     NO `inReplyTo`, addressed to the same audience as a fresh post;
+ *   - a reply edit to a FEDERATED parent → the Update Note keeps `inReplyTo` = the
+ *     parent's `federation.activityId` + the parent-author `Mention`, and is
+ *     delivered to the editor's followers AND the parent author's inbox;
+ *   - a boost is skipped (no editable body);
+ *   - a non-public post is skipped;
+ *   - the sharing gate short-circuit.
+ *
+ * The delivery/queue layer, the models, and the Oxy client are mocked so the real
+ * `FollowService` runs in isolation; assertions read the captured
+ * `enqueueDelivery` calls.
+ */
+
+const {
+  enqueueDelivery,
+  isFediverseSharingEnabled,
+  getUserById,
+  followFindLean,
+  actorFindLean,
+  actorFindOneLean,
+  postFindByIdLean,
+  insertMany,
+} = vi.hoisted(() => ({
+  enqueueDelivery: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  getUserById: vi.fn(),
+  followFindLean: vi.fn(),
+  actorFindLean: vi.fn(),
+  actorFindOneLean: vi.fn(),
+  postFindByIdLean: vi.fn(),
+  insertMany: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../connectors/activitypub/constants')>(
+    '../../../connectors/activitypub/constants',
+  );
+  return { ...actual, FEDERATION_ENABLED: true };
+});
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey: vi.fn(), signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery, enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    find: () => ({ lean: () => actorFindLean() }),
+    findOne: () => ({ lean: () => actorFindOneLean() }),
+  },
+}));
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { find: () => ({ lean: () => followFindLean() }) },
+}));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: { insertMany, create: vi.fn() },
+}));
+vi.mock('../../../models/Post', () => ({
+  Post: { findById: () => ({ select: () => ({ lean: () => postFindByIdLean() }) }) },
+}));
+vi.mock('../../../models/UserSettings', () => ({ default: {} }));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+  resolveAvatarUrl: (ref: string) => `https://cloud.oxy.so/${ref}`,
+}));
+vi.mock('../../../services/fediverseSharing', () => ({ isFediverseSharingEnabled }));
+vi.mock('../../../utils/oxyHelpers', () => ({ getServiceOxyClient: () => ({ getUserById }) }));
+
+import { followService } from '../../../connectors/activitypub/follow.service';
+
+const ISO = '2024-05-06T07:08:09.000Z';
+const ALICE_ACTOR = 'https://mention.earth/ap/users/alice';
+const ALICE_FOLLOWERS = `${ALICE_ACTOR}/followers`;
+const AP_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
+
+/** An editable post as the seam hands it to `federateUpdate`. */
+function editedPost(overrides: Record<string, unknown> = {}): {
+  _id: string;
+  content: { variants: Array<{ source: 'author'; text: string; tag: string }> };
+  createdAt: string;
+  visibility: string;
+  parentPostId?: string;
+  boostOf?: string;
+} {
+  return {
+    _id: 'post1',
+    content: { variants: [{ source: 'author', text: 'edited body', tag: 'en' }] },
+    createdAt: ISO,
+    visibility: 'public',
+    ...overrides,
+  };
+}
+
+/** The distinct target inboxes `enqueueDelivery` was asked to deliver to. */
+function deliveredInboxes(): string[] {
+  return enqueueDelivery.mock.calls.map((c) => (c[0] as { targetInbox: string }).targetInbox);
+}
+
+/** The activity enqueued (identical across all inboxes in one fan-out). */
+function deliveredActivity(): Record<string, unknown> {
+  return (enqueueDelivery.mock.calls[0]?.[0] as { activityJson: Record<string, unknown> }).activityJson;
+}
+
+/** The embedded Note object of the enqueued Update activity. */
+function deliveredNote(): Record<string, unknown> {
+  return deliveredActivity().object as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueDelivery.mockResolvedValue(true);
+  isFediverseSharingEnabled.mockResolvedValue(true);
+  followFindLean.mockResolvedValue([]);
+  actorFindLean.mockResolvedValue([]);
+  actorFindOneLean.mockResolvedValue(null);
+  postFindByIdLean.mockResolvedValue(null);
+  getUserById.mockResolvedValue({ id: 'u', username: 'bob' });
+});
+
+describe('federateUpdate — top-level edit', () => {
+  it('emits an Update(Note) with an `updated` stamp and no inReplyTo', async () => {
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateUpdate(editedPost(), 'author-oxy', 'alice');
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Update');
+    expect(activity.actor).toBe(ALICE_ACTOR);
+    expect(typeof activity.updated).toBe('string');
+    expect(activity.to).toEqual([AP_PUBLIC]);
+    expect(activity.cc).toEqual([ALICE_FOLLOWERS]);
+    // The edit activity id is the Note id with a unique `#updates/<ts>` fragment.
+    expect(String(activity.id)).toMatch(new RegExp(`^${ALICE_ACTOR}/posts/post1#updates/\\d+$`));
+
+    const note = deliveredNote();
+    expect(note.type).toBe('Note');
+    expect(note.content).toBe('edited body');
+    expect(note.inReplyTo).toBeUndefined();
+    // The Note carries the SAME `updated` marker as the envelope.
+    expect(note.updated).toBe(activity.updated);
+
+    // A top-level edit never resolves a parent.
+    expect(postFindByIdLean).not.toHaveBeenCalled();
+    expect(deliveredInboxes()).toEqual(['https://foo.example/inbox']);
+  });
+});
+
+describe('federateUpdate — reply edit to a FEDERATED parent', () => {
+  it('keeps inReplyTo + parent Mention and delivers to followers AND the parent inbox', async () => {
+    postFindByIdLean.mockResolvedValue({
+      oxyUserId: 'parent-owner',
+      federation: {
+        activityId: 'https://remote.example/users/bob/statuses/9',
+        actorUri: 'https://remote.example/users/bob',
+      },
+    });
+    actorFindOneLean.mockResolvedValue({
+      sharedInboxUrl: 'https://remote.example/inbox',
+      acct: 'bob@remote.example',
+    });
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateUpdate(editedPost({ parentPostId: 'parent1' }), 'replier-oxy', 'alice');
+
+    const activity = deliveredActivity();
+    expect(activity.type).toBe('Update');
+
+    const note = deliveredNote();
+    expect(note.inReplyTo).toBe('https://remote.example/users/bob/statuses/9');
+    expect(note.tag).toContainEqual({
+      type: 'Mention',
+      href: 'https://remote.example/users/bob',
+      name: '@bob@remote.example',
+    });
+    expect(note.updated).toBe(activity.updated);
+    expect(activity.cc).toEqual([ALICE_FOLLOWERS, 'https://remote.example/users/bob']);
+
+    expect(deliveredInboxes().sort()).toEqual(
+      ['https://foo.example/inbox', 'https://remote.example/inbox'].sort(),
+    );
+  });
+});
+
+describe('federateUpdate — skipped cases', () => {
+  it('skips a boost (no editable body)', async () => {
+    followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+    actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+
+    await followService.federateUpdate(editedPost({ boostOf: 'orig1' }), 'author-oxy', 'alice');
+
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+
+  it('skips a non-public post', async () => {
+    await followService.federateUpdate(editedPost({ visibility: 'private' }), 'author-oxy', 'alice');
+
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+
+  it('skips entirely when sharing is disabled', async () => {
+    isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await followService.federateUpdate(editedPost(), 'author-oxy', 'alice');
+
+    expect(enqueueDelivery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/connectors/ConnectorRegistry.ts
+++ b/packages/backend/src/connectors/ConnectorRegistry.ts
@@ -14,6 +14,11 @@ function actingOxyUserId(event: LocalNetworkEvent): string {
     case 'post.create':
     case 'post.boost':
     case 'post.unboost':
+    case 'post.update':
+    case 'post.delete':
+    case 'post.like':
+    case 'post.unlike':
+    case 'actor.update':
       return event.actorOxyUserId;
     case 'follow.add':
     case 'follow.remove':

--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -130,6 +130,29 @@ class ActivityPubConnector implements NetworkConnector {
       case 'post.unboost':
         await followService.federateUndoBoost(event.boost, event.actorOxyUserId, event.actorUsername);
         break;
+      case 'post.update':
+        // An edit re-federates the Note as an Update (with an `updated` stamp),
+        // preserving the reply enrichment via the shared Note builder.
+        await followService.federateUpdate(event.post, event.actorOxyUserId, event.actorUsername);
+        break;
+      case 'post.delete':
+        // A deletion broadcasts a Delete(Tombstone) of the post's canonical AP id
+        // to the deleter's followers.
+        await followService.federateDelete(event.post, event.actorOxyUserId, event.actorUsername);
+        break;
+      case 'post.like':
+        // A like of a FEDERATED post sends a Like to the origin author's inbox
+        // only (never fanned out to the liker's followers). Local-post likes no-op.
+        await followService.federateLike(event.like, event.actorOxyUserId, event.actorUsername);
+        break;
+      case 'post.unlike':
+        await followService.federateUndoLike(event.like, event.actorOxyUserId, event.actorUsername);
+        break;
+      case 'actor.update':
+        // A Mention-owned profile change (e.g. the banner) rebroadcasts the full
+        // actor document as an Update(Person) to remote followers.
+        await followService.federateActorUpdate(event.actorOxyUserId, event.actorUsername);
+        break;
       case 'follow.add':
         // Sends a Follow activity + records the outbound FederatedFollow. The
         // `{ success, pending }` it returns is surfaced by the route via the

--- a/packages/backend/src/connectors/activitypub/actorObject.ts
+++ b/packages/backend/src/connectors/activitypub/actorObject.ts
@@ -1,0 +1,182 @@
+import { logger } from '../../utils/logger';
+import { resolveAvatarUrl, resolveMediaRef } from '../../utils/mediaResolver';
+import {
+  FEDERATION_DOMAIN,
+  actorUrl,
+  inboxUrl,
+  outboxUrl,
+  featuredUrl,
+  followersUrl,
+  followingUrl,
+  sharedInboxUrl,
+} from './constants';
+
+/**
+ * The single builder of a LOCAL user's ActivityPub `Person` actor document.
+ *
+ * Shared by the GET actor route (`ap.routes.ts`, which serves it as a standalone
+ * JSON-LD document) and the outbound `Update(Person)` broadcast
+ * (`FollowService.federateActorUpdate`, which embeds it in an `Update` activity),
+ * so a follower's Mastodon renders the same actor whether it was fetched or
+ * pushed. Deliberately does NOT include the top-level `@context`: the GET route
+ * and the `Update` envelope each own their JSON-LD context, and an embedded actor
+ * object must not double-declare it.
+ */
+
+/** Fields of the resolved Oxy user the actor document reads. */
+export interface ActorUserView {
+  _id?: string | null;
+  id?: string | null;
+  name?: { displayName?: string | null } | null;
+  bio?: string | null;
+  avatar?: string | null;
+  createdAt?: string | null;
+}
+
+/** Map common image extensions to a MIME type for an actor image `mediaType`. */
+const IMAGE_MEDIA_TYPE_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  avif: 'image/avif',
+};
+
+/** True when `value` is an absolute `http(s)` URL. */
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    return /^https?:$/i.test(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build an ActivityPub `Image` object from an already-absolute URL, deriving
+ * `mediaType` from the URL extension when recognizable (a bare `Image` with a
+ * `url` is spec-valid, so an unknown extension simply omits `mediaType` rather
+ * than asserting a wrong one). Shared by the actor `icon` (avatar) and `image`
+ * (profile banner) builders.
+ */
+function apImageObject(url: string): { type: 'Image'; url: string; mediaType?: string } {
+  let extension: string | undefined;
+  try {
+    extension = new URL(url).pathname.split('.').pop()?.toLowerCase();
+  } catch {
+    extension = url.split('?')[0]?.split('.').pop()?.toLowerCase();
+  }
+  const mediaType = extension ? IMAGE_MEDIA_TYPE_BY_EXT[extension] : undefined;
+  return mediaType ? { type: 'Image', url, mediaType } : { type: 'Image', url };
+}
+
+/**
+ * Build the actor `icon` (avatar) object for ActivityPub.
+ *
+ * The avatar reference stored on the Oxy user may be a raw Oxy file id (e.g.
+ * `69b80c09a08af16d4b871195`) or an absolute URL. ActivityPub consumers such as
+ * Mastodon validate that `icon.url` is an absolute URL and REJECT the entire
+ * actor document when it is not — so a raw file id here makes the account
+ * undiscoverable. We therefore resolve the reference through the same
+ * server-authoritative `resolveAvatarUrl` mechanism the rest of the API uses
+ * (Oxy file id → absolute Oxy asset stream URL; external URL → proxied through
+ * our own origin), and only emit `icon` when that yields a real absolute URL.
+ *
+ * Returns undefined when there is no avatar or no absolute URL can be produced —
+ * Mastodon is fine with an avatar-less actor, but a non-absolute url breaks it.
+ */
+export function buildActorIcon(avatar: string | null | undefined): { type: 'Image'; url: string; mediaType?: string } | undefined {
+  if (!avatar) return undefined;
+
+  // Resolve a raw Oxy file id (or external URL) to a final, absolute URL. If the
+  // reference was already an absolute http(s) URL, `resolveAvatarUrl` returns an
+  // absolute URL too (verbatim for our own origins, proxied for external CDNs).
+  const resolved = resolveAvatarUrl(avatar);
+
+  // Guard the absolute-URL invariant: if resolution failed or degraded to a
+  // non-absolute passthrough (e.g. an unresolvable id), OMIT `icon` entirely
+  // rather than emit a value that would make Mastodon reject the actor.
+  if (!resolved || !isAbsoluteHttpUrl(resolved)) {
+    logger.warn(`[Federation] Omitting actor icon — avatar did not resolve to an absolute URL (ref: ${avatar})`);
+    return undefined;
+  }
+
+  return apImageObject(resolved);
+}
+
+/**
+ * Build the actor `image` (profile banner/header) object for ActivityPub.
+ *
+ * Mastodon renders the AP `image` property as the profile HEADER banner — a
+ * Mention user's banner is otherwise invisible across the fediverse. The banner
+ * reference lives in Mention's own `UserSettings.profileHeaderImage` (a raw Oxy
+ * file id or an absolute URL), the same field the profile-design endpoint reads
+ * and `mirrorFederatedBanner` writes for the inbound direction. It is resolved
+ * through the canonical media chokepoint (`resolveMediaRef`) to a final absolute
+ * URL — an Oxy file id → CDN URL, an external URL → proxied through our origin —
+ * mirroring {@link buildActorIcon}'s absolute-URL invariant.
+ *
+ * Returns undefined when there is no banner or none can be resolved to an
+ * absolute URL, so callers omit the field cleanly.
+ */
+export function buildActorImage(banner: string | null | undefined): { type: 'Image'; url: string; mediaType?: string } | undefined {
+  if (!banner) return undefined;
+
+  const resolved = resolveMediaRef(banner).url;
+  if (!resolved || !isAbsoluteHttpUrl(resolved)) {
+    logger.warn(`[Federation] Omitting actor image — banner did not resolve to an absolute URL (ref: ${banner})`);
+    return undefined;
+  }
+
+  return apImageObject(resolved);
+}
+
+/**
+ * Assemble the LOCAL user's AP `Person` actor object (WITHOUT the top-level
+ * `@context` — the caller owns that). `displayName` is the caller-resolved Oxy
+ * `name.displayName` (falling back to the handle); it is never recomposed from
+ * name parts here. The banner lives in Mention's own `UserSettings`, passed in as
+ * `profileHeaderImage`.
+ */
+export function buildLocalActorObject(params: {
+  username: string;
+  displayName: string;
+  bio?: string | null;
+  avatar?: string | null;
+  profileHeaderImage?: string | null;
+  publicKey: { keyId: string; publicKeyPem: string };
+  createdAt?: string | null;
+}): Record<string, unknown> {
+  const { username, displayName, bio, avatar, profileHeaderImage, publicKey, createdAt } = params;
+
+  const actorObject: Record<string, unknown> = {
+    id: actorUrl(username),
+    type: 'Person',
+    preferredUsername: username,
+    name: displayName,
+    summary: bio || '',
+    url: `https://${FEDERATION_DOMAIN}/@${username}`,
+    inbox: inboxUrl(username),
+    outbox: outboxUrl(username),
+    featured: featuredUrl(username),
+    followers: followersUrl(username),
+    following: followingUrl(username),
+    endpoints: { sharedInbox: sharedInboxUrl() },
+    discoverable: true,
+    manuallyApprovesFollowers: false,
+    icon: buildActorIcon(avatar),
+    image: buildActorImage(profileHeaderImage),
+    publicKey: {
+      id: publicKey.keyId,
+      owner: actorUrl(username),
+      publicKeyPem: publicKey.publicKeyPem,
+    },
+  };
+
+  // `published` (account creation date) is advertised when the API provides it.
+  if (createdAt) {
+    actorObject.published = new Date(createdAt).toISOString();
+  }
+
+  return actorObject;
+}

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -2,6 +2,7 @@ import { logger } from '../../utils/logger';
 import FederatedActor, { IFederatedActor } from '../../models/FederatedActor';
 import FederatedFollow from '../../models/FederatedFollow';
 import FederationDeliveryQueue from '../../models/FederationDeliveryQueue';
+import UserSettings from '../../models/UserSettings';
 import { Post } from '../../models/Post';
 import { signRequest, getPublicKey } from './crypto';
 import {
@@ -11,7 +12,9 @@ import {
   AP_CONTENT_TYPE,
   USER_AGENT,
   actorUrl,
+  resolveOxyUser,
 } from './constants';
+import { buildLocalActorObject, type ActorUserView } from './actorObject';
 import { PostVisibility, canonicalizeLanguageTag, type MediaItem, type PostContent } from '@mention/shared-types';
 import { authorVariants, resolveVariant } from '../../services/postVariants';
 import { enqueueDelivery } from '../../queue/producers';
@@ -830,6 +833,274 @@ export class FollowService {
       });
     } catch (err) {
       logger.error('Failed to federate unboost:', err);
+    }
+  }
+
+  /**
+   * Build a `Delete(Tombstone)` for a deleted local post. `object` is a minimal
+   * `Tombstone` carrying only the deleted Note's canonical AP id — the exact id
+   * `buildCreateNoteActivity` / the outbox / the dereference route advertised, so a
+   * remote server matches it to the status it holds and removes it. Addressed to
+   * the public collection, `cc`'d to the deleter's followers.
+   */
+  buildDeleteActivity(username: string, postId: string): Record<string, unknown> {
+    const actor = actorUrl(username);
+    const noteId = `${actor}/posts/${postId}`;
+    return {
+      '@context': AP_CONTEXT,
+      id: `${noteId}/delete`,
+      type: 'Delete',
+      actor,
+      to: [AP_PUBLIC],
+      cc: [`${actor}/followers`],
+      object: {
+        id: noteId,
+        type: 'Tombstone',
+      },
+    };
+  }
+
+  /**
+   * Federate a local post deletion as a `Delete(Tombstone)` to the deleter's
+   * remote followers. The post row is already gone — the caller captures the id
+   * BEFORE deletion — but the canonical Note id is minted purely from the
+   * username + post id, so nothing needs the row. Gated identically to
+   * {@link federateNewPost}; best-effort.
+   */
+  async federateDelete(
+    post: { _id: unknown },
+    deleterOxyUserId: string,
+    deleterUsername: string,
+  ): Promise<void> {
+    if (!FEDERATION_ENABLED) return;
+    if (!(await isFediverseSharingEnabled(deleterOxyUserId))) return;
+
+    try {
+      const activity = this.buildDeleteActivity(deleterUsername, String(post._id));
+      await this.deliverToFollowers(activity, deleterOxyUserId, deleterUsername);
+    } catch (err) {
+      logger.error('Failed to federate post delete:', err);
+    }
+  }
+
+  /**
+   * Build an `Update(Note)` for an edited local post. The embedded object is the
+   * SAME Note {@link buildCreateNoteActivity} builds (canonical body, hashtags,
+   * media, and — for a reply — `inReplyTo` + the parent-author `Mention`) PLUS an
+   * `updated` timestamp, which is how Mastodon marks a status as edited. The
+   * envelope mirrors the Note's `to`/`cc` so the edit reaches the same audience as
+   * the original.
+   */
+  buildUpdateNoteActivity(
+    post: NoteSourcePost,
+    username: string,
+    reply?: NoteReplyContext,
+  ): Record<string, unknown> {
+    const created = this.buildCreateNoteActivity(post, username, reply);
+    const note = created.object as Record<string, unknown>;
+
+    const now = new Date();
+    const updated = now.toISOString();
+    const noteId = String(note.id);
+    const actor = actorUrl(username);
+
+    return {
+      '@context': AP_CONTEXT,
+      // Mastodon-style edit activity id: the note id with a monotonically-unique
+      // `#updates/<ts>` fragment so repeated edits never collide.
+      id: `${noteId}#updates/${now.getTime()}`,
+      type: 'Update',
+      actor,
+      updated,
+      to: note.to,
+      cc: note.cc,
+      object: {
+        ...note,
+        updated,
+      },
+    };
+  }
+
+  /**
+   * Federate an edit of a local public post as an `Update(Note)` to the editor's
+   * remote followers (and, for a reply to a FEDERATED parent, that parent author's
+   * inbox — mirroring the reply Create path). A boost never carries an editable
+   * body, so it is skipped. Gated identically to {@link federateNewPost};
+   * best-effort.
+   */
+  async federateUpdate(
+    post: NoteSourcePost & { visibility: string },
+    editorOxyUserId: string,
+    editorUsername: string,
+  ): Promise<void> {
+    if (!FEDERATION_ENABLED) return;
+    if (!(await isFediverseSharingEnabled(editorOxyUserId))) return;
+    if (post.boostOf) return;
+    if (post.visibility !== PostVisibility.PUBLIC) return;
+
+    try {
+      const reply = await this.resolveReplyDelivery(post);
+      const activity = this.buildUpdateNoteActivity(post, editorUsername, reply?.context);
+      await this.deliverToFollowers(activity, editorOxyUserId, editorUsername, {
+        extraInboxes: reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : [],
+      });
+    } catch (err) {
+      logger.error('Failed to federate post update:', err);
+    }
+  }
+
+  /**
+   * Build a `Like` of a remote object. `object` is the liked original's canonical
+   * AP id (its remote `federation.activityId`). The activity id is minted
+   * deterministically from the native Like doc's id so the matching
+   * {@link buildUndoLikeActivity} re-mints it without persisting anything. A Like
+   * is addressed ONLY at the origin author's inbox (no `to`/`cc` broadcast).
+   */
+  buildLikeActivity(likerUsername: string, likeId: string, objectUri: string): Record<string, unknown> {
+    const actor = actorUrl(likerUsername);
+    return {
+      '@context': AP_CONTEXT,
+      id: `${actor}/likes/${likeId}`,
+      type: 'Like',
+      actor,
+      object: objectUri,
+    };
+  }
+
+  /** Build the matching `Undo(Like)` — re-mints the SAME Like id + object. */
+  buildUndoLikeActivity(likerUsername: string, likeId: string, objectUri: string): Record<string, unknown> {
+    const actor = actorUrl(likerUsername);
+    const likeActivityId = `${actor}/likes/${likeId}`;
+    return {
+      '@context': AP_CONTEXT,
+      id: `${likeActivityId}/undo`,
+      type: 'Undo',
+      actor,
+      object: {
+        id: likeActivityId,
+        type: 'Like',
+        actor,
+        object: objectUri,
+      },
+    };
+  }
+
+  /**
+   * Federate a like of a FEDERATED post as a `Like` delivered ONLY to that post's
+   * origin author inbox (a like is never broadcast to the liker's own followers —
+   * Mastodon does not fan out likes). Local-post likes are a no-op: a local author
+   * is notified natively (the `Like` doc), never via ActivityPub, and
+   * {@link resolveFederationTarget} yields no remote inbox for them. Gated
+   * identically to {@link federateNewPost}; best-effort.
+   */
+  async federateLike(
+    like: { _id: unknown; postId: string },
+    likerOxyUserId: string,
+    likerUsername: string,
+  ): Promise<void> {
+    if (!FEDERATION_ENABLED) return;
+    if (!(await isFediverseSharingEnabled(likerOxyUserId))) return;
+
+    try {
+      const target = await this.resolveFederationTarget(String(like.postId));
+      // A remote author inbox exists ONLY for a federated original — its absence
+      // means the liked post is local (or its actor is unresolved), so there is
+      // nothing to notify over ActivityPub.
+      if (!target?.authorInbox) return;
+      const activity = this.buildLikeActivity(likerUsername, String(like._id), target.objectUri);
+      await this.queueDelivery(activity, target.authorInbox, likerOxyUserId);
+    } catch (err) {
+      logger.error('Failed to federate like:', err);
+    }
+  }
+
+  /**
+   * Federate an unlike of a FEDERATED post as an `Undo(Like)` to the origin author
+   * inbox. The native Like doc is deleted before/around this call, but its id is
+   * passed in so the Undo re-mints the exact Like id {@link federateLike} sent.
+   * Local-post unlikes are a no-op. Gated identically; best-effort.
+   */
+  async federateUndoLike(
+    like: { _id: unknown; postId: string },
+    likerOxyUserId: string,
+    likerUsername: string,
+  ): Promise<void> {
+    if (!FEDERATION_ENABLED) return;
+    if (!(await isFediverseSharingEnabled(likerOxyUserId))) return;
+
+    try {
+      const target = await this.resolveFederationTarget(String(like.postId));
+      if (!target?.authorInbox) return;
+      const activity = this.buildUndoLikeActivity(likerUsername, String(like._id), target.objectUri);
+      await this.queueDelivery(activity, target.authorInbox, likerOxyUserId);
+    } catch (err) {
+      logger.error('Failed to federate undo like:', err);
+    }
+  }
+
+  /**
+   * Federate an actor profile change as an `Update(Person)` broadcast to the
+   * user's remote followers so Mastodon refreshes the cached actor. Rebuilds the
+   * FULL actor document through the SAME {@link buildLocalActorObject} the GET
+   * actor route serves, then wraps it in an `Update` — no field diffing, because
+   * Mastodon re-reads the whole actor on any actor `Update`.
+   *
+   * IMPORTANT boundary — only MENTION-OWNED actor fields have a write hook that
+   * reaches here (today: the `profileHeaderImage` banner via `profileSettings.ts`).
+   * The `name`/`icon`/`summary` (displayName / avatar / bio) are owned by the Oxy
+   * API and change WITHOUT any Mention-side write, so an Oxy-side edit does not
+   * trigger this broadcast. Propagating those needs a separate Oxy→Mention signal
+   * (a webhook) or a periodic actor re-broadcast — see the task report. This
+   * broadcast still emits the CURRENT Oxy values, so any Mention-owned change also
+   * carries whatever the latest Oxy fields are.
+   *
+   * Gated identically to {@link federateNewPost}; best-effort.
+   */
+  async federateActorUpdate(actorOxyUserId: string, username: string): Promise<void> {
+    if (!FEDERATION_ENABLED) return;
+    if (!(await isFediverseSharingEnabled(actorOxyUserId))) return;
+
+    try {
+      const user = (await resolveOxyUser(username)) as ActorUserView | null;
+      if (!user) {
+        logger.warn(`[FedDeliver] cannot federate actor update for ${username}: user not resolvable`);
+        return;
+      }
+
+      const publicKey = await getPublicKey(username);
+      const settings = await UserSettings.findOne({ oxyUserId: actorOxyUserId }, { profileHeaderImage: 1 })
+        .lean<{ profileHeaderImage?: string } | null>();
+
+      // Canonical display name is owned by the Oxy API; fall back to the handle
+      // when absent (never recompose from name parts).
+      const displayName = user.name?.displayName || username;
+
+      const actorObject = buildLocalActorObject({
+        username,
+        displayName,
+        bio: user.bio,
+        avatar: user.avatar,
+        profileHeaderImage: settings?.profileHeaderImage,
+        publicKey,
+        createdAt: user.createdAt,
+      });
+
+      const actor = actorUrl(username);
+      const now = new Date();
+      const activity: Record<string, unknown> = {
+        '@context': AP_CONTEXT,
+        id: `${actor}#updates/${now.getTime()}`,
+        type: 'Update',
+        actor,
+        updated: now.toISOString(),
+        to: [AP_PUBLIC],
+        cc: [`${actor}/followers`],
+        object: actorObject,
+      };
+
+      await this.deliverToFollowers(activity, actorOxyUserId, username);
+    } catch (err) {
+      logger.error('Failed to federate actor update:', err);
     }
   }
 

--- a/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
+++ b/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
@@ -26,7 +26,7 @@ import rateLimit from 'express-rate-limit';
 import { RedisStore } from '../../../middleware/rateLimitStore';
 import { hashedIpKey } from '../../../utils/ipKey';
 import { enqueueInboxActivity } from '../../../queue/producers';
-import { resolveAvatarUrl, resolveMediaRef } from '../../../utils/mediaResolver';
+import { buildLocalActorObject, type ActorUserView } from '../actorObject';
 import { isFediverseSharingEnabledFromUser, getFediverseSharingStateByUsername } from '../../../services/fediverseSharing';
 
 const router = Router();
@@ -56,118 +56,6 @@ function wantsActivityPub(req: Request): boolean {
 function getUsername(req: Request): string {
   const val = req.params.username;
   return typeof val === 'string' ? val : Array.isArray(val) ? val[0] : String(val);
-}
-
-/** Fields of the resolved Oxy user the actor document reads. */
-interface ActorUserView {
-  _id?: string | null;
-  id?: string | null;
-  name?: { displayName?: string | null } | null;
-  bio?: string | null;
-  avatar?: string | null;
-  createdAt?: string | null;
-}
-
-/** Map common image extensions to a MIME type for an actor image `mediaType`. */
-const IMAGE_MEDIA_TYPE_BY_EXT: Record<string, string> = {
-  png: 'image/png',
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  gif: 'image/gif',
-  webp: 'image/webp',
-  avif: 'image/avif',
-};
-
-/** True when `value` is an absolute `http(s)` URL. */
-function isAbsoluteHttpUrl(value: string): boolean {
-  try {
-    return /^https?:$/i.test(new URL(value).protocol);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Build an ActivityPub `Image` object from an already-absolute URL, deriving
- * `mediaType` from the URL extension when recognizable (a bare `Image` with a
- * `url` is spec-valid, so an unknown extension simply omits `mediaType` rather
- * than asserting a wrong one). Shared by the actor `icon` (avatar) and `image`
- * (profile banner) builders.
- */
-function apImageObject(url: string): { type: 'Image'; url: string; mediaType?: string } {
-  let extension: string | undefined;
-  try {
-    extension = new URL(url).pathname.split('.').pop()?.toLowerCase();
-  } catch {
-    extension = url.split('?')[0]?.split('.').pop()?.toLowerCase();
-  }
-  const mediaType = extension ? IMAGE_MEDIA_TYPE_BY_EXT[extension] : undefined;
-  return mediaType ? { type: 'Image', url, mediaType } : { type: 'Image', url };
-}
-
-/**
- * Build the actor `icon` (avatar) object for ActivityPub.
- *
- * The avatar reference stored on the Oxy user may be a raw Oxy file id (e.g.
- * `69b80c09a08af16d4b871195`) or an absolute URL. ActivityPub consumers such as
- * Mastodon validate that `icon.url` is an absolute URL and REJECT the entire
- * actor document when it is not — so a raw file id here makes the account
- * undiscoverable. We therefore resolve the reference through the same
- * server-authoritative `resolveAvatarUrl` mechanism the rest of the API uses
- * (Oxy file id → absolute Oxy asset stream URL; external URL → proxied through
- * our own origin), and only emit `icon` when that yields a real absolute URL.
- *
- * Derives `mediaType` from the resolved URL extension when recognizable;
- * otherwise the `mediaType` is omitted rather than asserting a wrong type (a
- * bare `Image` with `url` is spec-valid).
- *
- * Returns undefined when there is no avatar or no absolute URL can be produced —
- * Mastodon is fine with an avatar-less actor, but a non-absolute url breaks it.
- */
-function buildActorIcon(avatar: string | null | undefined): { type: 'Image'; url: string; mediaType?: string } | undefined {
-  if (!avatar) return undefined;
-
-  // Resolve a raw Oxy file id (or external URL) to a final, absolute URL. If the
-  // reference was already an absolute http(s) URL, `resolveAvatarUrl` returns an
-  // absolute URL too (verbatim for our own origins, proxied for external CDNs).
-  const resolved = resolveAvatarUrl(avatar);
-
-  // Guard the absolute-URL invariant: if resolution failed or degraded to a
-  // non-absolute passthrough (e.g. an unresolvable id), OMIT `icon` entirely
-  // rather than emit a value that would make Mastodon reject the actor.
-  if (!resolved || !isAbsoluteHttpUrl(resolved)) {
-    logger.warn(`[Federation] Omitting actor icon — avatar did not resolve to an absolute URL (ref: ${avatar})`);
-    return undefined;
-  }
-
-  return apImageObject(resolved);
-}
-
-/**
- * Build the actor `image` (profile banner/header) object for ActivityPub.
- *
- * Mastodon renders the AP `image` property as the profile HEADER banner — a
- * Mention user's banner is otherwise invisible across the fediverse. The banner
- * reference lives in Mention's own `UserSettings.profileHeaderImage` (a raw Oxy
- * file id or an absolute URL), the same field the profile-design endpoint reads
- * and `mirrorFederatedBanner` writes for the inbound direction. It is resolved
- * through the canonical media chokepoint (`resolveMediaRef`) to a final absolute
- * URL — an Oxy file id → CDN URL, an external URL → proxied through our origin —
- * mirroring {@link buildActorIcon}'s absolute-URL invariant.
- *
- * Returns undefined when there is no banner or none can be resolved to an
- * absolute URL, so callers omit the field cleanly.
- */
-function buildActorImage(banner: string | null | undefined): { type: 'Image'; url: string; mediaType?: string } | undefined {
-  if (!banner) return undefined;
-
-  const resolved = resolveMediaRef(banner).url;
-  if (!resolved || !isAbsoluteHttpUrl(resolved)) {
-    logger.warn(`[Federation] Omitting actor image — banner did not resolve to an absolute URL (ref: ${banner})`);
-    return undefined;
-  }
-
-  return apImageObject(resolved);
 }
 
 /**
@@ -241,39 +129,22 @@ router.get('/users/:username', async (req: Request, res: Response) => {
     // if the API somehow omitted it, so `name` is never empty.
     const displayName = user.name?.displayName || username;
 
-    const actorObject: Record<string, unknown> = {
-      '@context': AP_CONTEXT,
-      id: actorUrl(username),
-      type: 'Person',
-      preferredUsername: username,
-      name: displayName,
-      summary: user.bio || '',
-      url: `https://${FEDERATION_DOMAIN}/@${username}`,
-      inbox: inboxUrl(username),
-      outbox: outboxUrl(username),
-      featured: featuredUrl(username),
-      followers: followersUrl(username),
-      following: followingUrl(username),
-      endpoints: { sharedInbox: sharedInboxUrl() },
-      discoverable: true,
-      manuallyApprovesFollowers: false,
-      icon: buildActorIcon(user.avatar),
-      image: buildActorImage(settings?.profileHeaderImage),
-      publicKey: {
-        id: publicKey.keyId,
-        owner: actorUrl(username),
-        publicKeyPem: publicKey.publicKeyPem,
-      },
-    };
-
-    // `published` (account creation date) is advertised when the API provides it.
-    if (user.createdAt) {
-      actorObject.published = new Date(user.createdAt).toISOString();
-    }
+    // ONE actor builder — shared with the outbound `Update(Person)` broadcast — so
+    // a fetched actor and a pushed actor Update never drift. The route owns the
+    // top-level JSON-LD `@context` (the builder omits it).
+    const actorObject = buildLocalActorObject({
+      username,
+      displayName,
+      bio: user.bio,
+      avatar: user.avatar,
+      profileHeaderImage: settings?.profileHeaderImage,
+      publicKey,
+      createdAt: user.createdAt,
+    });
 
     res.set('Content-Type', AP_CONTENT_TYPE);
     res.set('Cache-Control', 'max-age=1800');
-    return res.json(actorObject);
+    return res.json({ '@context': AP_CONTEXT, ...actorObject });
   } catch (err) {
     logger.error('Actor endpoint error:', err);
     return res.status(500).json({ error: 'Internal server error' });

--- a/packages/backend/src/connectors/atproto/AtprotoConnector.ts
+++ b/packages/backend/src/connectors/atproto/AtprotoConnector.ts
@@ -90,10 +90,16 @@ class AtprotoConnector implements NetworkConnector {
       case 'post.create':
       case 'post.boost':
       case 'post.unboost':
-        // Mention does NOT publish posts / reposts INTO a foreign atproto PDS.
-        // The C4 bridge is BE-DISCOVERED (the user's repo is hosted here and read
-        // via `bridge/`); foreign-PDS publishing is the documented outbound
-        // product seam (`AtprotoBridgeOutboundSeam`), not wired. No-op.
+      case 'post.update':
+      case 'post.delete':
+      case 'post.like':
+      case 'post.unlike':
+      case 'actor.update':
+        // Mention does NOT publish posts / reposts / edits / deletes / likes /
+        // actor changes INTO a foreign atproto PDS. The C4 bridge is BE-DISCOVERED
+        // (the user's repo is hosted here and read via `bridge/`); foreign-PDS
+        // publishing is the documented outbound product seam
+        // (`AtprotoBridgeOutboundSeam`), not wired. No-op.
         return;
       case 'follow.add':
         await this.followActor(event.localOxyUserId, event.targetActorUri);

--- a/packages/backend/src/connectors/outboundFederation.ts
+++ b/packages/backend/src/connectors/outboundFederation.ts
@@ -1,0 +1,38 @@
+import { logger } from '../utils/logger';
+import { getServiceOxyClient } from '../utils/oxyHelpers';
+import { connectorRegistry } from './index';
+import type { LocalNetworkEvent } from './types';
+
+/**
+ * Fire-and-forget outbound federation for a local interaction, through the
+ * connector seam (which applies the per-user `fediverseSharing` gate; the
+ * connector re-checks it too).
+ *
+ * The acting user's username is resolved SERVER-SIDE from the authoritative
+ * `oxyUserId`: the Oxy auth middleware runs without `loadUser`, so
+ * `req.user.username` is never populated and must not be trusted. Once resolved,
+ * `buildEvent(username)` produces the concrete {@link LocalNetworkEvent}. NEVER
+ * blocks or fails the HTTP response — a resolve miss is logged and skipped, any
+ * error is caught.
+ *
+ * The single resolve-and-deliver entry point for every controller/route that
+ * federates a local action (posts create/update/delete, likes, boosts, replies,
+ * actor updates), so the username-resolution + gating live in exactly one place.
+ */
+export function federateAsResolvedActor(
+  actorOxyUserId: string,
+  context: string,
+  buildEvent: (username: string) => LocalNetworkEvent,
+): void {
+  void (async () => {
+    const user = await getServiceOxyClient().getUserById(actorOxyUserId);
+    const username = user.username?.trim();
+    if (!username) {
+      logger.warn(`[Federation] skipping ${context} federation for ${actorOxyUserId}: no resolvable username`);
+      return;
+    }
+    await connectorRegistry.deliver(buildEvent(username));
+  })().catch((err) => {
+    logger.error(`[Federation] failed to federate ${context}`, err);
+  });
+}

--- a/packages/backend/src/connectors/types.ts
+++ b/packages/backend/src/connectors/types.ts
@@ -155,10 +155,36 @@ export interface LocalBoostEventPayload {
 }
 
 /**
+ * The minimal shape a `post.delete` event carries. A local post's canonical AP
+ * object id is minted deterministically from the deleter's username + this `_id`
+ * (`https://<domain>/ap/users/<username>/posts/<_id>`), so the connector needs
+ * nothing more to emit a `Delete(Tombstone)`. The post row is already gone by the
+ * time this fires — the id is captured BEFORE deletion.
+ */
+export interface LocalDeleteEventPayload {
+  _id: unknown;
+}
+
+/**
+ * The shape a `post.like` / `post.unlike` event carries to outbound delivery.
+ * A federated-post like federates as a `Like` (or `Undo(Like)`) whose `object` is
+ * the liked original's remote `federation.activityId`, resolved from `postId`, and
+ * delivered ONLY to that origin author's inbox (never fanned out to followers).
+ * The AP activity id is minted deterministically from the native Like doc's `_id`
+ * so the `Undo` re-mints the same id without persisting it.
+ */
+export interface LocalLikeEventPayload {
+  /** The native `Like` document `_id` — the deterministic AP Like activity id. */
+  _id: unknown;
+  /** The liked post's local `_id` — resolved to its canonical AP object id + author inbox. */
+  postId: string;
+}
+
+/**
  * A local domain event handed to connectors for outbound delivery. Discriminated
- * by `kind`; starts with `post.create` (a new local post to federate) and the
- * follow lifecycle, and grows as more outbound flows (likes, reposts, deletes)
- * are wired.
+ * by `kind`: post lifecycle (`post.create` / `post.update` / `post.delete`),
+ * engagement (`post.boost` / `post.unboost` / `post.like` / `post.unlike`), actor
+ * profile changes (`actor.update`), and the follow lifecycle.
  */
 export type LocalNetworkEvent =
   | {
@@ -176,6 +202,42 @@ export type LocalNetworkEvent =
   | {
       kind: 'post.unboost';
       boost: LocalBoostEventPayload;
+      actorOxyUserId: string;
+      actorUsername: string;
+    }
+  | {
+      kind: 'post.update';
+      post: LocalPostEventPayload;
+      actorOxyUserId: string;
+      actorUsername: string;
+    }
+  | {
+      kind: 'post.delete';
+      post: LocalDeleteEventPayload;
+      actorOxyUserId: string;
+      actorUsername: string;
+    }
+  | {
+      kind: 'post.like';
+      like: LocalLikeEventPayload;
+      actorOxyUserId: string;
+      actorUsername: string;
+    }
+  | {
+      kind: 'post.unlike';
+      like: LocalLikeEventPayload;
+      actorOxyUserId: string;
+      actorUsername: string;
+    }
+  | {
+      /**
+       * A local user changed an actor-visible profile field OWNED by Mention (e.g.
+       * the `profileHeaderImage` banner). The connector rebroadcasts the FULL actor
+       * document as an `Update(Person)` to remote followers so Mastodon refreshes.
+       * Oxy-owned fields (displayName/avatar/bio) are NOT hooked here — they change
+       * in Oxy, which has no signal into Mention (see `federateActorUpdate`).
+       */
+      kind: 'actor.update';
       actorOxyUserId: string;
       actorUsername: string;
     }

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -32,9 +32,8 @@ import { queryString } from '../utils/queryParams';
 import { buildAuthorship } from '../utils/postAuthorship';
 import { validatePublicShareTarget } from '../utils/postAccessControl';
 import { baselineContentClassifier } from '../services/BaselineContentClassifier';
-import { createScopedOxyClient, getServiceOxyClient } from '../utils/oxyHelpers';
-import { connectorRegistry } from '../connectors';
-import type { LocalNetworkEvent } from '../connectors/types';
+import { createScopedOxyClient } from '../utils/oxyHelpers';
+import { federateAsResolvedActor } from '../connectors/outboundFederation';
 import {
   emitPostCreated,
   emitRepostCreated,
@@ -158,36 +157,6 @@ class FeedController {
   }
 
   /**
-   * Fire-and-forget outbound federation for a local interaction, through the
-   * connector seam (which applies the per-user `fediverseSharing` gate; the
-   * connector re-checks it too).
-   *
-   * The acting user's username is resolved SERVER-SIDE from the authoritative
-   * `oxyUserId`: the Oxy auth middleware runs without `loadUser`, so
-   * `req.user.username` is never populated and must not be trusted. Once resolved,
-   * `buildEvent(username)` produces the concrete `LocalNetworkEvent`. Never blocks
-   * or fails the HTTP response — a resolve miss is logged and skipped, any error
-   * is caught.
-   */
-  private federateAsResolvedActor(
-    actorOxyUserId: string,
-    context: string,
-    buildEvent: (username: string) => LocalNetworkEvent,
-  ): void {
-    void (async () => {
-      const user = await getServiceOxyClient().getUserById(actorOxyUserId);
-      const username = user.username?.trim();
-      if (!username) {
-        logger.warn(`[Feed] skipping ${context} federation for ${actorOxyUserId}: no resolvable username`);
-        return;
-      }
-      await connectorRegistry.deliver(buildEvent(username));
-    })().catch((err) => {
-      logger.error(`[Feed] failed to federate ${context}`, err);
-    });
-  }
-
-  /**
    * Federate a local boost / unboost outbound as an ActivityPub
    * `Announce` / `Undo(Announce)`. The boosted ORIGINAL post is untouched by an
    * unboost, so target resolution works from `boostOf` in both directions.
@@ -197,7 +166,7 @@ class FeedController {
     boost: { _id: unknown; boostOf: string; createdAt: string | Date },
     boosterOxyUserId: string,
   ): void {
-    this.federateAsResolvedActor(boosterOxyUserId, kind, (username) => ({
+    federateAsResolvedActor(boosterOxyUserId, kind, (username) => ({
       kind,
       boost: { _id: boost._id, boostOf: boost.boostOf, createdAt: boost.createdAt },
       actorOxyUserId: boosterOxyUserId,
@@ -219,7 +188,7 @@ class FeedController {
     // `createdAt` is a Mongoose timestamp (a Date at runtime, though typed as
     // string on IPost); normalize to a canonical ISO 8601 string for the wire.
     const createdAt = new Date(reply.createdAt).toISOString();
-    this.federateAsResolvedActor(replierOxyUserId, 'reply', (username) => ({
+    federateAsResolvedActor(replierOxyUserId, 'reply', (username) => ({
       kind: 'post.create',
       post: {
         _id: reply._id,

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -46,6 +46,7 @@ import {
 } from '../services/mtn/MentionRecordEmitter';
 import { postCollaborationService, CollabValidationError, CollabStateError } from '../services/PostCollaborationService';
 import { resolveMcpAutoAcceptIds } from '../mcp/utils/resolveMcpAutoAcceptIds';
+import { federateAsResolvedActor } from '../connectors/outboundFederation';
 
 // Constants from centralized config
 const MAX_SOURCES = config.posts.maxSources;
@@ -1481,6 +1482,35 @@ export const updatePost = async (req: AuthRequest, res: Response) => {
       await emitPostCreated(post);
     }
 
+    // Outbound federation: an edit re-federates the Note as an ActivityPub
+    // Update (carrying an `updated` timestamp — how Mastodon marks an edit),
+    // reusing the shared Note builder so a reply's `inReplyTo` + parent Mention
+    // survive. Local + published + public non-boost only; the same gates as
+    // creation. Username resolved server-side from the authoritative oxyUserId.
+    if (
+      post.federation == null &&
+      post.oxyUserId &&
+      !post.boostOf &&
+      post.visibility === PostVisibility.PUBLIC &&
+      (post.status ?? 'published') === 'published'
+    ) {
+      const editorOxyUserId = String(post.oxyUserId);
+      federateAsResolvedActor(editorOxyUserId, 'post update', (username) => ({
+        kind: 'post.update',
+        post: {
+          _id: post._id,
+          content: post.content,
+          hashtags: post.hashtags,
+          mentions: post.mentions,
+          visibility: post.visibility,
+          createdAt: new Date(post.createdAt).toISOString(),
+          parentPostId: post.parentPostId ? String(post.parentPostId) : null,
+        },
+        actorOxyUserId: editorOxyUserId,
+        actorUsername: username,
+      }));
+    }
+
     // Hydrate the updated post for consistent frontend response shape.
     // PostHydrationService is the single source of truth for post DTOs; we do NOT
     // hand-build a `user` object here (that would leak the raw oxyUserId as the
@@ -1605,6 +1635,27 @@ export const deletePost = async (req: AuthRequest, res: Response) => {
       });
     }
 
+    // Outbound federation: broadcast a Delete(Tombstone) so remote followers'
+    // Mastodon removes the post. The row is already gone, but its data (id +
+    // author) is captured above from the deleted doc; the canonical Note id is
+    // minted from the resolved username + post id. Local + published + public
+    // only — an unpublished/private post was never federated. Username resolved
+    // server-side from the authoritative oxyUserId.
+    if (
+      post.federation == null &&
+      post.oxyUserId &&
+      post.visibility === PostVisibility.PUBLIC &&
+      (post.status ?? 'published') === 'published'
+    ) {
+      const deleterOxyUserId = String(post.oxyUserId);
+      federateAsResolvedActor(deleterOxyUserId, 'post delete', (username) => ({
+        kind: 'post.delete',
+        post: { _id: postId },
+        actorOxyUserId: deleterOxyUserId,
+        actorUsername: username,
+      }));
+    }
+
     // Cascading cleanup — best-effort, don't fail the request
     try {
       await Promise.allSettled([
@@ -1636,6 +1687,30 @@ export const deletePost = async (req: AuthRequest, res: Response) => {
     logger.error('Error deleting post', error);
     res.status(500).json({ message: 'Error deleting post' });
   }
+};
+
+/**
+ * Fire-and-forget outbound federation of a like change: a `Like` (kind
+ * `post.like`) or `Undo(Like)` (kind `post.unlike`) sent ONLY to the origin
+ * author's inbox when the liked post is federated (the connector no-ops a local
+ * post). `likeDocId` is the native `Like` doc `_id` — the deterministic AP Like
+ * id so an Undo re-mints the exact id. Callers gate on the liked post being
+ * federated to avoid resolving a target for the common local-post case; the
+ * connector re-checks. Only upvotes (value 1) are AP likes — a downvote is a
+ * Mention-only concept and must never reach here.
+ */
+const federateLikeChange = (
+  kind: 'post.like' | 'post.unlike',
+  likeDocId: string,
+  likedPostId: string,
+  likerOxyUserId: string,
+): void => {
+  federateAsResolvedActor(likerOxyUserId, kind, (username) => ({
+    kind,
+    like: { _id: likeDocId, postId: likedPostId },
+    actorOxyUserId: likerOxyUserId,
+    actorUsername: username,
+  }));
 };
 
 // Clamp vote counts to zero and persist corrections if needed
@@ -1691,9 +1766,13 @@ export const likePost = async (req: AuthRequest, res: Response) => {
         { value, ...(surface ? { source: surface } : {}) },
         { new: true }
       );
+      // The effective Like doc id — the deterministic AP Like id. `findOneAndUpdate`
+      // keeps the same `_id`; only the rare raced-recreate path mints a new one.
+      let effectiveLikeId = updated ? String(updated._id) : '';
       if (!updated) {
         // Document was deleted between findOne and findOneAndUpdate — create fresh
-        await Like.create({ userId, postId, value, source: surface });
+        const recreated = await Like.create({ userId, postId, value, source: surface });
+        effectiveLikeId = String(recreated._id);
       }
 
       const statsUpdate = value === 1
@@ -1703,6 +1782,14 @@ export const likePost = async (req: AuthRequest, res: Response) => {
       const updatedPost = await Post.findByIdAndUpdate(postId, statsUpdate, { new: true }).lean();
 
       const { likesCount, downvotesCount } = await clampVoteCounts(postId, updatedPost);
+
+      // Outbound federation: switching TO an upvote sends a Like to a federated
+      // post's origin author; switching AWAY from an upvote (to a downvote)
+      // retracts it with Undo(Like). A downvote itself is Mention-only and never
+      // federates. Local-post likes are a no-op inside the connector.
+      if (updatedPost?.federation?.activityId) {
+        federateLikeChange(value === 1 ? 'post.like' : 'post.unlike', effectiveLikeId, postId, userId);
+      }
 
       // Best-effort preference learning — detached so it never adds latency to
       // the vote response.
@@ -1747,6 +1834,13 @@ export const likePost = async (req: AuthRequest, res: Response) => {
         void affinityEventService
           .record({ fromUserId: userId, toUserId: authorId, type: 'like', eventId: `like:${String(createdLike._id)}` })
           .catch(() => undefined);
+      }
+
+      // Outbound federation: a like of a FEDERATED post notifies its origin
+      // author with a Like delivered to their inbox only. Local-post likes are a
+      // no-op inside the connector (the author is notified natively).
+      if (likedPost?.federation?.activityId) {
+        federateLikeChange('post.like', String(createdLike._id), postId, userId);
       }
     }
 
@@ -1827,6 +1921,14 @@ export const unlikePost = async (req: AuthRequest, res: Response) => {
         tombstoneRkey: String(existingLike._id),
         subjectUri: likeRecordUri(userId, String(existingLike._id)),
       });
+    }
+
+    // Outbound federation: removing an upvote on a FEDERATED post retracts the
+    // Like at its origin with an Undo(Like) re-minting the same deterministic id
+    // from the (now-deleted) Like doc. A removed downvote never federated, so it
+    // has nothing to retract. Local-post unlikes are a no-op inside the connector.
+    if (voteValue === 1 && updatedPost?.federation?.activityId) {
+      federateLikeChange('post.unlike', String(existingLike._id), postId, userId);
     }
 
     const { likesCount, downvotesCount } = await clampVoteCounts(postId, updatedPost);

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -13,6 +13,7 @@ import { getRequiredOxyUserId as getAuthenticatedUserId } from '@oxyhq/core/serv
 import { type TrackSummary, type PodcastSummary } from '@syra.fm/sdk';
 import { EXTERNAL_EMBED_SOURCES, type EmbedPlayerSource } from '@mention/shared-types';
 import { syraClient } from '../utils/syraPodcast';
+import { federateAsResolvedActor } from '../connectors/outboundFederation';
 import { logger } from '../utils/logger';
 
 const router = Router();
@@ -85,6 +86,10 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
     // we can promote it to public AFTER the settings persist — profile banners
     // are public-facing media that an anonymous <img> must be able to load.
     let newBannerFileId: string | undefined;
+    // Whether this request changed the profile banner (set OR cleared). The banner
+    // is a Mention-owned ActivityPub actor field (`image`), so a change must
+    // rebroadcast the actor to remote followers (see below).
+    let bannerChanged = false;
 
     // Dot-notation, same safe pattern as `profileCustomization`/`externalEmbeds` below:
     // each field is set at its own leaf path, so a partial `appearance` payload (e.g. the
@@ -118,8 +123,10 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
       } else {
         unset.profileHeaderImage = '';
       }
+      bannerChanged = true;
     } else if (profileHeaderImage === null) {
       unset.profileHeaderImage = '';
+      bannerChanged = true;
     }
     
     if (profileCustomization) {
@@ -359,6 +366,22 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
     // throws and never blocks the settings update.
     if (newBannerFileId) {
       await ensureProfileMediaPublic(req.accessToken, newBannerFileId);
+    }
+
+    // Outbound federation: the banner is a Mention-owned ActivityPub actor field
+    // (`image`), so changing it (set or cleared) rebroadcasts the FULL actor
+    // document as an Update(Person) to remote followers, prompting Mastodon to
+    // refresh the cached profile. Fire-and-forget through the connector seam (which
+    // applies the fediverseSharing gate); never blocks the settings response. NOTE:
+    // Oxy-owned actor fields (displayName / avatar / bio) have NO Mention-side write
+    // to hook here — propagating those needs a separate Oxy→Mention signal or a
+    // periodic actor re-broadcast (documented follow-up).
+    if (bannerChanged) {
+      federateAsResolvedActor(oxyUserId, 'actor update', (username) => ({
+        kind: 'actor.update',
+        actorOxyUserId: oxyUserId,
+        actorUsername: username,
+      }));
     }
 
     return sendSuccessResponse(res, 200, doc);


### PR DESCRIPTION
## Summary
Completes the outbound ActivityPub surface (batch 2, following #422) so edits, deletes, likes and profile changes propagate to remote followers/origins instead of silently diverging:
- `Delete(Tombstone)` on post delete, broadcast to followers.
- `Update(Note)` with an `updated` stamp on edit (reply `inReplyTo`/Mention preserved).
- `Like` / `Undo(Like)` delivered to the origin author when liking a federated post (never fanned out to the liker's followers).
- `Update(Person)` broadcast to followers when a Mention-owned actor field (profile banner) changes.

Shared resolve-and-deliver helper (`outboundFederation.ts`) and a single actor builder (`actorObject.ts`) extracted; every trigger is fire-and-forget and gated on `FEDERATION_ENABLED` + local author + fediverse sharing.

Backend-only change, no shared-types/frontend/MCP impact.

## Test plan
- [x] `bunx tsc --noEmit` in `packages/backend` — exit 0
- [x] `bun run test` in `packages/backend` — 219 test files passed, 2307 tests passed
- [x] `bun run build:backend` from repo root — shared-types + backend build succeed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)