### PR TITLE
feat(fediverse): preferred primary language for federated posts

### DIFF
--- a/packages/backend/src/__tests__/routes/profileSettingsFediverseLanguage.test.ts
+++ b/packages/backend/src/__tests__/routes/profileSettingsFediverseLanguage.test.ts
@@ -1,0 +1,218 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Route-level coverage for the `fediversePreferredLanguage` field in the
+ * `PUT /profile/settings` handler. Exercises the REAL route handler against an
+ * in-memory UserSettings store so the test asserts the actual canonicalization,
+ * 400-on-invalid, and clear-via-unset behaviour, plus the round-trip through
+ * GET /settings/me.
+ *
+ * Mocks mirror `profileSettingsExternalEmbeds.test.ts` (the real userSettings
+ * module pulls mediaResolver -> oxyHelpers -> the server entrypoint, a circular
+ * import, so it is reproduced faithfully here).
+ */
+
+const store = new Map<string, Record<string, unknown>>();
+const TEST_USER = 'user-1';
+
+function getDoc(oxyUserId: string): Record<string, unknown> {
+  let doc = store.get(oxyUserId);
+  if (!doc) {
+    doc = { oxyUserId };
+    store.set(oxyUserId, doc);
+  }
+  return doc;
+}
+
+const FORBIDDEN_DOT_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function setDot(obj: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split('.');
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (FORBIDDEN_DOT_KEYS.has(parts[i])) return;
+    const next = cur[parts[i]];
+    if (typeof next !== 'object' || next === null) {
+      cur[parts[i]] = {};
+    }
+    cur = cur[parts[i]] as Record<string, unknown>;
+  }
+  const last = parts[parts.length - 1];
+  if (FORBIDDEN_DOT_KEYS.has(last)) return;
+  cur[last] = value;
+}
+
+function unsetDot(obj: Record<string, unknown>, path: string): void {
+  const parts = path.split('.');
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (FORBIDDEN_DOT_KEYS.has(parts[i])) return;
+    const next = cur[parts[i]];
+    if (typeof next !== 'object' || next === null) return;
+    cur = next as Record<string, unknown>;
+  }
+  const last = parts[parts.length - 1];
+  if (FORBIDDEN_DOT_KEYS.has(last)) return;
+  delete cur[last];
+}
+
+vi.mock('@oxyhq/core/server', () => ({
+  requireOxyAuth: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (req as express.Request & { user?: { id: string }; accessToken?: string }).user = { id: TEST_USER };
+    (req as express.Request & { accessToken?: string }).accessToken = 'test-token';
+    next();
+  },
+  getRequiredOxyUserId: (req: express.Request & { user?: { id: string } }) => req.user?.id ?? '',
+}));
+
+vi.mock('../../models/UserSettings', () => ({
+  default: {
+    findOneAndUpdate: vi.fn((filter: { oxyUserId: string }, operation: Record<string, Record<string, unknown>>) => {
+      const doc = getDoc(filter.oxyUserId);
+      if (operation.$set) {
+        for (const [path, value] of Object.entries(operation.$set)) setDot(doc, path, value);
+      }
+      if (operation.$unset) {
+        for (const path of Object.keys(operation.$unset)) unsetDot(doc, path);
+      }
+      return { lean: () => Promise.resolve(JSON.parse(JSON.stringify(doc))) };
+    }),
+  },
+}));
+
+vi.mock('../../utils/userSettings', () => ({
+  ensureUserSettings: (oxyUserId: string) => Promise.resolve(JSON.parse(JSON.stringify(getDoc(oxyUserId)))),
+  buildSettingsResponseForViewer: (
+    doc: unknown,
+    targetUserId: string,
+    viewerUserId: string,
+  ) => (targetUserId === viewerUserId ? doc : {}),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  ensureProfileMediaPublic: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../utils/syraPodcast', () => ({
+  syraClient: {},
+}));
+
+vi.mock('../../models/UserBehavior', () => ({ default: {} }));
+vi.mock('../../models/Post', () => ({ default: {} }));
+vi.mock('../../models/Bookmark', () => ({ default: {} }));
+vi.mock('../../models/Like', () => ({ default: {} }));
+
+import profileSettingsRoutes from '../../routes/profileSettings';
+
+const app = express();
+app.use(express.json());
+app.use('/profile', profileSettingsRoutes);
+
+async function getSettings() {
+  const res = await request(app).get('/profile/settings/me').expect(200);
+  return res.body.data as Record<string, unknown>;
+}
+
+describe('PUT /profile/settings fediversePreferredLanguage', () => {
+  beforeEach(() => {
+    store.clear();
+    vi.clearAllMocks();
+  });
+
+  it('stores a plain base tag and round-trips it via GET', async () => {
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: 'en' })
+      .expect(200);
+
+    const settings = await getSettings();
+    expect(settings.fediversePreferredLanguage).toBe('en');
+  });
+
+  it('preserves a canonical region tag (es-ES)', async () => {
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: 'es-ES' })
+      .expect(200);
+
+    const settings = await getSettings();
+    expect(settings.fediversePreferredLanguage).toBe('es-ES');
+  });
+
+  it('canonicalizes an underscore/lowercase tag (pt_BR -> pt-BR)', async () => {
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: 'pt_BR' })
+      .expect(200);
+
+    const settings = await getSettings();
+    expect(settings.fediversePreferredLanguage).toBe('pt-BR');
+  });
+
+  it('rejects an invalid tag with 400 and stores nothing', async () => {
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: 'not a language!!' })
+      .expect(400);
+
+    const settings = await getSettings();
+    expect(settings.fediversePreferredLanguage).toBeUndefined();
+  });
+
+  it('rejects a non-string value with 400', async () => {
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: 123 })
+      .expect(400);
+
+    const settings = await getSettings();
+    expect(settings.fediversePreferredLanguage).toBeUndefined();
+  });
+
+  it('unsets a previously-set preference when passed null', async () => {
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: 'fr' })
+      .expect(200);
+
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: null })
+      .expect(200);
+
+    const settings = await getSettings();
+    expect(settings.fediversePreferredLanguage).toBeUndefined();
+  });
+
+  it('unsets a previously-set preference when passed an empty string', async () => {
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: 'de' })
+      .expect(200);
+
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: '   ' })
+      .expect(200);
+
+    const settings = await getSettings();
+    expect(settings.fediversePreferredLanguage).toBeUndefined();
+  });
+
+  it('leaves the field untouched when the key is absent from the payload', async () => {
+    await request(app)
+      .put('/profile/settings')
+      .send({ fediversePreferredLanguage: 'it' })
+      .expect(200);
+
+    // A subsequent unrelated update must not clear the stored preference.
+    await request(app)
+      .put('/profile/settings')
+      .send({ externalEmbeds: { youtube: 'show' } })
+      .expect(200);
+
+    const settings = await getSettings();
+    expect(settings.fediversePreferredLanguage).toBe('it');
+  });
+});

--- a/packages/backend/src/models/UserSettings.ts
+++ b/packages/backend/src/models/UserSettings.ts
@@ -156,6 +156,15 @@ export interface UserSettingsData {
    * `@mention/shared-types` (`ExternalEmbedsSettings`).
    */
   externalEmbeds?: ExternalEmbedsSettings;
+  /**
+   * The user's global default "primary" post language — a canonical BCP-47 tag
+   * (`en`, `es-ES`, `pt-BR`). Mention-owned (NOT an Oxy identity field): it seeds
+   * the composer's default primary language variant client-side. A post's actual
+   * primary variant is still `content.variants[0]` per-post; this is only the
+   * default the composer starts from. Absent ⇒ the client falls back to its own
+   * heuristic (device/account locale). Validated + canonicalized on write.
+   */
+  fediversePreferredLanguage?: string;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -309,6 +318,7 @@ const UserSettingsSchema = new Schema<IUserSettings>({
   feedTuning: { type: FeedTuningSchema },
   notificationPreferences: { type: NotificationPreferencesSchema },
   externalEmbeds: { type: ExternalEmbedsSchema },
+  fediversePreferredLanguage: { type: String, default: undefined },
 }, { timestamps: true, versionKey: false });
 
 export const UserSettings = mongoose.model<IUserSettings>('UserSettings', UserSettingsSchema);

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -11,7 +11,7 @@ import { ensureProfileMediaPublic } from '../utils/oxyHelpers';
 import { sendErrorResponse, sendSuccessResponse, validateRequired } from '../utils/apiHelpers';
 import { getRequiredOxyUserId as getAuthenticatedUserId } from '@oxyhq/core/server';
 import { type TrackSummary, type PodcastSummary } from '@syra.fm/sdk';
-import { EXTERNAL_EMBED_SOURCES, type EmbedPlayerSource } from '@mention/shared-types';
+import { EXTERNAL_EMBED_SOURCES, type EmbedPlayerSource, canonicalizeLanguageTag } from '@mention/shared-types';
 import { syraClient } from '../utils/syraPodcast';
 import { federateAsResolvedActor } from '../connectors/outboundFederation';
 import { logger } from '../utils/logger';
@@ -78,7 +78,7 @@ router.get('/settings/:userId', async (req: AuthRequest, res: Response) => {
 router.put('/settings', async (req: AuthRequest, res: Response) => {
   try {
     const oxyUserId = getAuthenticatedUserId(req);
-    const { appearance, profileHeaderImage, privacy, profileCustomization, profileMedia, interests, feedSettings, notificationPreferences, externalEmbeds } = req.body || {};
+    const { appearance, profileHeaderImage, privacy, profileCustomization, profileMedia, interests, feedSettings, notificationPreferences, externalEmbeds, fediversePreferredLanguage } = req.body || {};
 
     const update: Record<string, any> = {};
     const unset: Record<string, ''> = {};
@@ -338,6 +338,28 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
         } else if (value === null) {
           unset[`externalEmbeds.${source}`] = '';
         }
+      }
+    }
+
+    // Global default "primary" post language (Mention-owned; NOT an Oxy identity
+    // field). Seeds the composer's default primary variant client-side; a post's
+    // actual primary is still per-post `content.variants[0]`. Canonicalized to a
+    // BCP-47 tag on write via the shared language module — an invalid /
+    // uncanonicalizable value is REJECTED (400) rather than stored as garbage.
+    // `null` or an empty/whitespace-only string clears the preference (the client
+    // then falls back to its own device/account-locale heuristic).
+    if (fediversePreferredLanguage !== undefined) {
+      if (
+        fediversePreferredLanguage === null
+        || (typeof fediversePreferredLanguage === 'string' && fediversePreferredLanguage.trim() === '')
+      ) {
+        unset.fediversePreferredLanguage = '';
+      } else {
+        const canonical = canonicalizeLanguageTag(fediversePreferredLanguage);
+        if (canonical === null) {
+          return sendErrorResponse(res, 400, 'Bad Request', 'fediversePreferredLanguage must be a valid BCP-47 language tag');
+        }
+        update.fediversePreferredLanguage = canonical;
       }
     }
 

--- a/packages/frontend/__tests__/composeVariants.test.ts
+++ b/packages/frontend/__tests__/composeVariants.test.ts
@@ -9,11 +9,13 @@ import {
   getVariantItem,
   hasVariantWork,
   primaryTextFromPost,
+  promoteVariantToPrimary,
   serializeVariants,
   variantsReducer,
   variantsStateFromPost,
   type ComposeVariantsAction,
   type ComposeVariantsState,
+  type PromotablePrimary,
 } from '@/utils/composeVariants';
 import { buildEditPost, buildMainPost, buildThreadPost } from '@/utils/postBuilder';
 import type { ThreadItem } from '@/hooks/useThreadManager';
@@ -411,6 +413,111 @@ describe('drafts', () => {
       media: { mode: 'inherit', alt: {} },
       article: null,
     });
+  });
+});
+
+describe('promoting a secondary language to primary', () => {
+  const primary = (text: string, media: ComposerMediaItem[] = [], article: PromotablePrimary['article'] = null): PromotablePrimary => ({
+    text,
+    media,
+    article,
+  });
+
+  it('makes the promoted language the post’s face and demotes the old primary to a variant', () => {
+    const state = run(
+      createVariantsState(ES),
+      { type: 'add-language', tag: EN },
+      { type: 'set-text', tag: EN, itemId: MAIN_ITEM_ID, text: 'Hello world' },
+    );
+
+    const outcome = promoteVariantToPrimary(state, EN, { [MAIN_ITEM_ID]: primary('Hola mundo') });
+
+    expect(outcome.state.primaryTag).toBe(EN);
+    expect(outcome.state.variantTags).toEqual([ES]);
+    expect(outcome.state.primaryChosen).toBe(true);
+    expect(outcome.state.activeTag).toBe(EN);
+    // The promoted rendition is what the composer writes back as its primary state.
+    expect(outcome.primaryByItem[MAIN_ITEM_ID]).toEqual({ text: 'Hello world', media: [], article: null });
+
+    // `variants[0]` is now the promoted language; the old primary survives as a variant.
+    const payload = buildVariantContent(outcome.state, MAIN_ITEM_ID, outcome.primaryByItem[MAIN_ITEM_ID].text, []);
+    expect(payload).toEqual([
+      { tag: EN, source: 'author', text: 'Hello world' },
+      { tag: ES, source: 'author', text: 'Hola mundo' },
+    ]);
+  });
+
+  it('carries the promotion through the reducer action too', () => {
+    const state = run(
+      createVariantsState(ES),
+      { type: 'add-language', tag: EN },
+      { type: 'set-text', tag: EN, itemId: MAIN_ITEM_ID, text: 'Hello' },
+      { type: 'promote-to-primary', tag: EN, oldPrimaryByItem: { [MAIN_ITEM_ID]: primary('Hola') } },
+    );
+
+    expect(state.primaryTag).toBe(EN);
+    expect(state.variantTags).toEqual([ES]);
+    expect(getVariantItem(state, ES, MAIN_ITEM_ID).text).toBe('Hola');
+  });
+
+  it('promotes a language with its OWN images: they become the shared set, the old images are pinned, and inheritors keep the old ones', () => {
+    const state = run(
+      createVariantsState(ES),
+      { type: 'add-language', tag: EN },
+      { type: 'set-text', tag: EN, itemId: MAIN_ITEM_ID, text: 'Hello' },
+      { type: 'append-media', tag: EN, itemId: MAIN_ITEM_ID, media: [image('img-en', 'English chart')] },
+      { type: 'add-language', tag: 'fr' },
+      { type: 'set-media-alt', tag: 'fr', itemId: MAIN_ITEM_ID, mediaId: 'img-1', alt: 'Un graphique' },
+    );
+
+    const outcome = promoteVariantToPrimary(state, EN, {
+      [MAIN_ITEM_ID]: primary('Hola', [image('img-1', 'Un gráfico')]),
+    });
+
+    // The promoted language's own images become the composer's shared set.
+    expect(outcome.primaryByItem[MAIN_ITEM_ID].media).toEqual([image('img-en', 'English chart')]);
+    // The old primary is pinned to the images it showed (as an override variant).
+    expect(getVariantItem(outcome.state, ES, MAIN_ITEM_ID).media).toEqual({
+      mode: 'override',
+      media: [image('img-1', 'Un gráfico')],
+    });
+    // French inherited the OLD shared images; it keeps them (with its own alt), not the new ones.
+    expect(getVariantItem(outcome.state, 'fr', MAIN_ITEM_ID).media).toEqual({
+      mode: 'override',
+      media: [image('img-1', 'Un graphique')],
+    });
+  });
+
+  it('swaps localized alt when the shared images are unchanged', () => {
+    const state = run(
+      createVariantsState(ES),
+      { type: 'add-language', tag: EN },
+      { type: 'set-text', tag: EN, itemId: MAIN_ITEM_ID, text: 'Hello' },
+      { type: 'set-media-alt', tag: EN, itemId: MAIN_ITEM_ID, mediaId: 'img-1', alt: 'The English chart' },
+    );
+
+    const outcome = promoteVariantToPrimary(state, EN, {
+      [MAIN_ITEM_ID]: primary('Hola', [image('img-1', 'El gráfico español')]),
+    });
+
+    // The new primary keeps the shared image but now carries the promoted language's alt.
+    expect(outcome.primaryByItem[MAIN_ITEM_ID].media).toEqual([image('img-1', 'The English chart')]);
+    // The old primary's alt is preserved as its localized inherit map.
+    expect(getVariantItem(outcome.state, ES, MAIN_ITEM_ID).media).toEqual({
+      mode: 'inherit',
+      alt: { 'img-1': 'El gráfico español' },
+    });
+  });
+
+  it('is a no-op — same state reference — when the tag is not a current author variant', () => {
+    const state = run(
+      createVariantsState(ES),
+      { type: 'add-language', tag: EN },
+    );
+
+    expect(promoteVariantToPrimary(state, 'de', {}).state).toBe(state);
+    // The current primary is not a promotable variant either.
+    expect(promoteVariantToPrimary(state, ES, {}).state).toBe(state);
   });
 });
 

--- a/packages/frontend/app/(app)/compose.tsx
+++ b/packages/frontend/app/(app)/compose.tsx
@@ -149,10 +149,13 @@ import {
   getVariantItem,
   hasVariantWork,
   primaryTextFromPost,
+  promoteVariantToPrimary,
   serializeVariants,
   type ComposeVariantArticle,
+  type PromotablePrimary,
 } from '@/utils/composeVariants';
 import { contentLanguageForLocale, describeContentLanguage } from '@/constants/contentLanguages';
+import { useFediversePreferredLanguage } from '@/hooks/useFediversePreferredLanguage';
 import type { ThreadItem } from '@/hooks/useThreadManager';
 import { useQuoteManager } from '@/hooks/useQuoteManager';
 import QuoteCard from '@/components/Compose/QuoteCard';
@@ -231,6 +234,7 @@ const ComposeScreenBody = () => {
   const { sources, setSources, addSource, updateSourceField, removeSource: removeSourceEntry, getSanitizedSources, hasInvalidSources } = sourcesManager;
   const {
     threadItems,
+    setThreadItems,
     addThread,
     removeThread,
     updateThreadText,
@@ -325,10 +329,18 @@ const ComposeScreenBody = () => {
   const hasRoomContent = useMemo(() => roomHasContent(), [roomHasContent]);
   const hasPodcastContent = useMemo(() => podcastHasContent(), [podcastHasContent]);
 
-  // Multilingual buffer. The composer OPENS on the app's locale — a preference,
-  // not a declaration — so this default never reaches the wire on its own; only
-  // a language the author actually picked does (`hasDeclaredLanguages`).
-  const defaultPrimaryTag = useMemo(() => contentLanguageForLocale(i18n.language), [i18n.language]);
+  // The author's saved default primary language, applied to fresh composes below.
+  const { preferredLanguage } = useFediversePreferredLanguage();
+
+  // Multilingual buffer. The composer OPENS on the author's saved preferred
+  // language when set, otherwise the app's UI locale. The UI locale is a
+  // preference, not a declaration, so that default never reaches the wire on its
+  // own (`hasDeclaredLanguages`); an explicit preferred language IS a declaration
+  // and is seeded as chosen below.
+  const defaultPrimaryTag = useMemo(
+    () => contentLanguageForLocale(preferredLanguage ?? i18n.language),
+    [preferredLanguage, i18n.language],
+  );
   const {
     variants,
     setActiveTag,
@@ -336,6 +348,7 @@ const ComposeScreenBody = () => {
     removeLanguage,
     renameLanguage,
     setPrimaryLanguage,
+    promoteLanguage,
     setVariantText,
     setVariantMediaAlt,
     appendVariantMedia,
@@ -351,6 +364,32 @@ const ComposeScreenBody = () => {
   const isPrimaryTab = activeTag === variants.primaryTag;
   const languageTags = useMemo(() => allTags(variants), [variants]);
   const [translatingItemId, setTranslatingItemId] = useState<string | null>(null);
+
+  // Seed a fresh compose from the author's saved preferred language, ONCE. An
+  // explicit preference is a real declaration, so it is marked chosen (it reaches
+  // the wire even for a single-language post). Edit/reply carry the post's own
+  // language, and a composer the author already touched (declared a language,
+  // added a variant, or wrote variant work) is left untouched — only a pristine
+  // composer is seeded, and only when a preference is actually set.
+  const preferredSeededRef = useRef(false);
+  useEffect(() => {
+    if (preferredSeededRef.current) return;
+    if (editPostId || replyToPostId) {
+      preferredSeededRef.current = true;
+      return;
+    }
+    if (preferredLanguage === undefined) return; // Still resolving.
+    if (preferredLanguage === null) {
+      preferredSeededRef.current = true; // No preference — keep the locale default undeclared.
+      return;
+    }
+    if (variants.primaryChosen || variants.variantTags.length > 0 || hasVariantWork(variants)) {
+      preferredSeededRef.current = true;
+      return;
+    }
+    setPrimaryLanguage(contentLanguageForLocale(preferredLanguage));
+    preferredSeededRef.current = true;
+  }, [preferredLanguage, editPostId, replyToPostId, variants, setPrimaryLanguage]);
 
   // Remaining local state
   const [postContent, setPostContent] = useState('');
@@ -1480,12 +1519,50 @@ const ComposeScreenBody = () => {
   // ── Languages ─────────────────────────────────────────────────────────────
 
   /**
+   * Promote a secondary language to the post's primary. The primary's content
+   * lives in the composer's own state (`postContent`/`mediaIds`/`article` and each
+   * thread item), so the buffer swap is paired with writing the promoted rendition
+   * back into that state — after which `variants[0]` federates as the promoted
+   * language.
+   */
+  const promoteToPrimary = useCallback((tag: string) => {
+    if (tag === variants.primaryTag) return;
+    const oldPrimaryByItem: Record<string, PromotablePrimary> = {
+      [MAIN_ITEM_ID]: { text: postContent, media: mediaIds, article },
+    };
+    for (const item of threadItems) {
+      oldPrimaryByItem[item.id] = { text: item.text, media: item.mediaIds, article: item.article };
+    }
+
+    const { state: nextState, primaryByItem } = promoteVariantToPrimary(variants, tag, oldPrimaryByItem);
+    if (nextState === variants) return; // Not a current author variant — nothing to promote.
+
+    const main = primaryByItem[MAIN_ITEM_ID];
+    if (main) {
+      setPostContent(main.text);
+      setMediaIds(main.media);
+      setArticle(main.article);
+    }
+    setThreadItems((prev) =>
+      prev.map((item) => {
+        const next = primaryByItem[item.id];
+        return next ? { ...item, text: next.text, mediaIds: next.media, article: next.article } : item;
+      }),
+    );
+    // The reducer recomputes the same swap from the same inputs; the buffer and the
+    // composer's primary state land on one consistent promotion.
+    promoteLanguage(tag, oldPrimaryByItem);
+  }, [variants, postContent, mediaIds, article, threadItems, setPostContent, setMediaIds, setArticle, setThreadItems, promoteLanguage]);
+
+  /**
    * The language picker. With no `currentTag` it ADDS a language; on an existing
    * tab it changes that tab's language — re-tagging a rendition in place, so the
-   * author's work survives — and offers to remove it.
+   * author's work survives — and, for a non-primary tab, offers to make it the
+   * main language or remove it.
    */
   const openLanguagePicker = useCallback((currentTag?: string) => {
     const isPrimary = currentTag === variants.primaryTag;
+    const isSecondaryTab = currentTag !== undefined && !isPrimary;
     bottomSheet.setBottomSheetContent(
       <Suspense fallback={null}>
         <LanguagePickerSheet
@@ -1500,13 +1577,14 @@ const ComposeScreenBody = () => {
               renameLanguage(currentTag, tag);
             }
           }}
-          onRemove={currentTag !== undefined && !isPrimary ? () => removeLanguage(currentTag) : undefined}
+          onMakeMain={isSecondaryTab ? () => promoteToPrimary(currentTag) : undefined}
+          onRemove={isSecondaryTab ? () => removeLanguage(currentTag) : undefined}
           onClose={() => bottomSheet.openBottomSheet(false)}
         />
       </Suspense>
     );
     bottomSheet.openBottomSheet(true);
-  }, [bottomSheet, variants, addLanguage, removeLanguage, renameLanguage, setPrimaryLanguage]);
+  }, [bottomSheet, variants, addLanguage, removeLanguage, renameLanguage, setPrimaryLanguage, promoteToPrimary]);
 
   const handleAddLanguage = useCallback(() => openLanguagePicker(), [openLanguagePicker]);
   const handleEditLanguage = useCallback(

--- a/packages/frontend/app/(app)/settings/fediverse.tsx
+++ b/packages/frontend/app/(app)/settings/fediverse.tsx
@@ -12,7 +12,11 @@ import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { RowIcon } from '@/components/settings/RowIcon';
 import { showFediverseInfo } from '@/components/Fediverse/FediverseInfoDialog';
+import LanguagePickerSheet from '@/components/Compose/LanguagePickerSheet';
+import { BottomSheetContext } from '@/context/BottomSheetContext';
 import { useSafeBack } from '@/hooks/useSafeBack';
+import { useFediversePreferredLanguage } from '@/hooks/useFediversePreferredLanguage';
+import { describeContentLanguage } from '@/constants/contentLanguages';
 import { confirmDialog } from '@/utils/alerts';
 import { api } from '@/utils/api';
 import { WEB_BASE_URL } from '@/config';
@@ -29,9 +33,46 @@ const logger = createScopedLogger('FediverseSettings');
 function FediverseSharingBody() {
   const { t } = useTranslation();
   const { user, oxyServices } = useAuth();
+  const bottomSheet = React.useContext(BottomSheetContext);
+  const { preferredLanguage, updatePreferredLanguage } = useFediversePreferredLanguage();
 
   const [sharing, setSharing] = useState<boolean>(user?.fediverseSharing !== false);
   const [pending, setPending] = useState(false);
+
+  const preferredLabel = preferredLanguage
+    ? describeContentLanguage(preferredLanguage).nativeName
+    : t('fediverse.settings.preferredLanguage.automatic', { defaultValue: 'Automatic' });
+
+  const applyPreferred = useCallback(
+    async (tag: string | null) => {
+      try {
+        await updatePreferredLanguage(tag);
+      } catch (error) {
+        logger.error('Failed to update fediverse preferred language', { error });
+        toast(
+          t('fediverse.settings.updateFailed', {
+            defaultValue: "Couldn't update fediverse sharing. Please try again.",
+          }),
+          { type: 'error' },
+        );
+      }
+    },
+    [updatePreferredLanguage, t],
+  );
+
+  const openPreferredLanguagePicker = useCallback(() => {
+    bottomSheet.setBottomSheetContent(
+      <LanguagePickerSheet
+        usedTags={[]}
+        currentTag={preferredLanguage ?? undefined}
+        removeLabel={t('fediverse.settings.preferredLanguage.clear', { defaultValue: 'Use automatic' })}
+        onRemove={preferredLanguage ? () => { void applyPreferred(null); } : undefined}
+        onSelect={(tag: string) => { void applyPreferred(tag); }}
+        onClose={() => bottomSheet.openBottomSheet(false)}
+      />,
+    );
+    bottomSheet.openBottomSheet(true);
+  }, [bottomSheet, preferredLanguage, applyPreferred, t]);
 
   const federatedHandle = user?.username
     ? `@${user.username}@${new URL(WEB_BASE_URL).host}`
@@ -112,6 +153,20 @@ function FediverseSharingBody() {
           rightElement={
             <Switch value={sharing} onValueChange={onToggle} disabled={pending} />
           }
+        />
+      </SettingsListGroup>
+
+      <SettingsListGroup
+        footer={t('fediverse.settings.preferredLanguage.description', {
+          defaultValue:
+            'The main language your posts are written in. It becomes the primary version shown across the fediverse; leave it automatic to let it be detected per post.',
+        })}
+      >
+        <SettingsListItem
+          icon={<RowIcon name="language-outline" />}
+          title={t('fediverse.settings.preferredLanguage.title', { defaultValue: 'Preferred language' })}
+          description={preferredLabel}
+          onPress={openPreferredLanguagePicker}
         />
       </SettingsListGroup>
 

--- a/packages/frontend/components/Compose/LanguagePickerSheet.tsx
+++ b/packages/frontend/components/Compose/LanguagePickerSheet.tsx
@@ -18,6 +18,13 @@ interface LanguagePickerSheetProps {
   currentTag?: string;
   /** Offered only when an existing NON-PRIMARY tab is being edited. */
   onRemove?: () => void;
+  /** Overrides the remove button's label (e.g. "Use automatic" in settings). */
+  removeLabel?: string;
+  /**
+   * Promotes this NON-PRIMARY language to the post's primary. Offered next to
+   * Remove when an existing secondary tab is being edited.
+   */
+  onMakeMain?: () => void;
   onSelect: (tag: string) => void;
   onClose: () => void;
 }
@@ -32,6 +39,8 @@ const LanguagePickerSheet = memo(function LanguagePickerSheet({
   usedTags,
   currentTag,
   onRemove,
+  removeLabel,
+  onMakeMain,
   onSelect,
   onClose,
 }: LanguagePickerSheetProps) {
@@ -62,6 +71,11 @@ const LanguagePickerSheet = memo(function LanguagePickerSheet({
     onRemove?.();
     onClose();
   }, [onRemove, onClose]);
+
+  const handleMakeMain = useCallback(() => {
+    onMakeMain?.();
+    onClose();
+  }, [onMakeMain, onClose]);
 
   const renderItem = useCallback(
     ({ item }: { item: ContentLanguage }) => {
@@ -126,16 +140,31 @@ const LanguagePickerSheet = memo(function LanguagePickerSheet({
         }
       />
 
-      {onRemove ? (
-        <TouchableOpacity
-          onPress={handleRemove}
-          className="flex-row items-center justify-center py-3 rounded-full mt-2 mx-4 border border-border"
-          activeOpacity={0.85}
-        >
-          <Text className="text-sm font-semibold" style={{ color: theme.colors.error }}>
-            {t('compose.languages.remove', { defaultValue: 'Remove this language' })}
-          </Text>
-        </TouchableOpacity>
+      {onMakeMain || onRemove ? (
+        <View className="mt-2 mx-4 gap-2">
+          {onMakeMain ? (
+            <TouchableOpacity
+              onPress={handleMakeMain}
+              className="flex-row items-center justify-center py-3 rounded-full border border-border"
+              activeOpacity={0.85}
+            >
+              <Text className="text-sm font-semibold text-primary">
+                {t('compose.languages.makeMain', { defaultValue: 'Make main language' })}
+              </Text>
+            </TouchableOpacity>
+          ) : null}
+          {onRemove ? (
+            <TouchableOpacity
+              onPress={handleRemove}
+              className="flex-row items-center justify-center py-3 rounded-full border border-border"
+              activeOpacity={0.85}
+            >
+              <Text className="text-sm font-semibold" style={{ color: theme.colors.error }}>
+                {removeLabel ?? t('compose.languages.remove', { defaultValue: 'Remove this language' })}
+              </Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
       ) : null}
     </View>
   );

--- a/packages/frontend/hooks/useComposeVariants.ts
+++ b/packages/frontend/hooks/useComposeVariants.ts
@@ -8,6 +8,7 @@ import {
   variantsStateFromPost,
   type ComposeVariantArticle,
   type ComposeVariantsState,
+  type PromotablePrimary,
 } from '@/utils/composeVariants';
 
 /**
@@ -31,6 +32,11 @@ export const useComposeVariants = (defaultPrimaryTag: string) => {
     [],
   );
   const setPrimaryLanguage = useCallback((tag: string) => dispatch({ type: 'set-primary-language', tag }), []);
+  const promoteLanguage = useCallback(
+    (tag: string, oldPrimaryByItem: Record<string, PromotablePrimary>) =>
+      dispatch({ type: 'promote-to-primary', tag, oldPrimaryByItem }),
+    [],
+  );
 
   const setVariantText = useCallback(
     (tag: string, itemId: string, text: string) => dispatch({ type: 'set-text', tag, itemId, text }),
@@ -99,6 +105,7 @@ export const useComposeVariants = (defaultPrimaryTag: string) => {
       removeLanguage,
       renameLanguage,
       setPrimaryLanguage,
+      promoteLanguage,
       setVariantText,
       setVariantMediaAlt,
       appendVariantMedia,
@@ -118,6 +125,7 @@ export const useComposeVariants = (defaultPrimaryTag: string) => {
       removeLanguage,
       renameLanguage,
       setPrimaryLanguage,
+      promoteLanguage,
       setVariantText,
       setVariantMediaAlt,
       appendVariantMedia,

--- a/packages/frontend/hooks/useFediversePreferredLanguage.ts
+++ b/packages/frontend/hooks/useFediversePreferredLanguage.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback } from 'react';
+import { authenticatedClient, isUnauthorizedError, isNotFoundError } from '@/utils/api';
+import { useAuth } from '@oxyhq/services';
+import { createScopedLogger } from '@/lib/logger';
+import type { UserSettingsResponse } from '@/hooks/usePrivacySettings';
+
+const logger = createScopedLogger('useFediversePreferredLanguage');
+
+/**
+ * The author's default PRIMARY content language — a Mention `UserSettings` field
+ * (`fediversePreferredLanguage`, canonical BCP-47) read from `GET /profile/settings/me`
+ * and written to `PUT /profile/settings`. It seeds the composer's primary language
+ * and is what a post federates as (`content.variants[0]`).
+ *
+ * `preferredLanguage`: `undefined` while the setting is still resolving, `null`
+ * once resolved with no preference set, or the tag string. Reads are gated on
+ * `canUsePrivateApi` (the SSO cold-boot window) so they never fire a 401.
+ */
+export function useFediversePreferredLanguage() {
+  const { isAuthenticated, isAuthResolved, canUsePrivateApi, isPrivateApiPending, user } = useAuth();
+  const viewerId = user?.id;
+  const [preferredLanguage, setPreferredLanguage] = useState<string | null | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    if (!isAuthResolved || isPrivateApiPending) {
+      return;
+    }
+    if (!canUsePrivateApi) {
+      setPreferredLanguage(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const response = await authenticatedClient.get<UserSettingsResponse>('/profile/settings/me');
+      setPreferredLanguage(response.data?.fediversePreferredLanguage ?? null);
+    } catch (error: unknown) {
+      if (!isUnauthorizedError(error) && !isNotFoundError(error)) {
+        logger.debug('Could not load fediverse preferred language', { error });
+      }
+      setPreferredLanguage(null);
+    } finally {
+      setLoading(false);
+    }
+    // `isAuthenticated` is a dependency so the per-user setting loads once the SSO
+    // session resolves on cold boot — keying on it alone would fetch while anon and
+    // never recover.
+  }, [canUsePrivateApi, isAuthResolved, isAuthenticated, isPrivateApiPending]);
+
+  /** Writes the preference. Pass `null` to clear it (fall back to detection). */
+  const updatePreferredLanguage = useCallback(
+    async (tag: string | null): Promise<void> => {
+      if (!canUsePrivateApi) {
+        throw new Error('Sign in to update your preferred language');
+      }
+      const response = await authenticatedClient.put<UserSettingsResponse>('/profile/settings', {
+        fediversePreferredLanguage: tag,
+      });
+      setPreferredLanguage(response.data?.fediversePreferredLanguage ?? tag ?? null);
+    },
+    [canUsePrivateApi],
+  );
+
+  useEffect(() => {
+    load();
+    // `viewerId` covers account switches; `load` re-runs the fetch when the auth
+    // session resolves (its identity changes with `isAuthenticated`).
+  }, [load, viewerId]);
+
+  return { preferredLanguage, loading, updatePreferredLanguage, reload: load };
+}

--- a/packages/frontend/hooks/usePrivacySettings.ts
+++ b/packages/frontend/hooks/usePrivacySettings.ts
@@ -64,6 +64,13 @@ export interface UserSettingsResponse {
     feedSettings?: FeedSettings;
     notificationPreferences?: NotificationPreferences;
     externalEmbeds?: ExternalEmbedsSettings;
+    /**
+     * The author's default PRIMARY content language (canonical BCP-47), applied
+     * as `content.variants[0]` — the rendition that federates and is the post's
+     * "face". Absent ⇒ no global preference; the composer opens on the UI locale
+     * and leaves detection to the server.
+     */
+    fediversePreferredLanguage?: string;
     createdAt?: string;
     updatedAt?: string;
 }

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -530,6 +530,10 @@
   "fediverse.sheet.cancel": "Cancel",
   "fediverse.settings.title": "Fediverse sharing",
   "fediverse.settings.description": "Share your profile and posts across the fediverse",
+  "fediverse.settings.preferredLanguage.title": "Preferred language",
+  "fediverse.settings.preferredLanguage.description": "The main language your posts are written in. It becomes the primary version shown across the fediverse; leave it automatic to let it be detected per post.",
+  "fediverse.settings.preferredLanguage.automatic": "Automatic",
+  "fediverse.settings.preferredLanguage.clear": "Use automatic",
   "fediverse.settings.share": "Share to the fediverse",
   "fediverse.settings.whatIs": "What is the fediverse?",
   "fediverse.settings.disableConfirm.title": "Turn off fediverse sharing?",
@@ -1571,5 +1575,6 @@
   },
   "user": {
     "unknown": "Unknown user"
-  }
+  },
+  "compose.languages.makeMain": "Make main language"
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -498,6 +498,10 @@
   "fediverse.sheet.cancel": "Cancelar",
   "fediverse.settings.title": "Compartir en el fediverso",
   "fediverse.settings.description": "Comparte tu perfil y tus publicaciones en el fediverso",
+  "fediverse.settings.preferredLanguage.title": "Idioma principal",
+  "fediverse.settings.preferredLanguage.description": "El idioma principal en el que escribes tus publicaciones. Será la versión principal que se muestra en el fediverso; déjalo en automático para detectarlo en cada publicación.",
+  "fediverse.settings.preferredLanguage.automatic": "Automático",
+  "fediverse.settings.preferredLanguage.clear": "Usar automático",
   "fediverse.settings.share": "Compartir en el fediverso",
   "fediverse.settings.whatIs": "¿Qué es el fediverso?",
   "fediverse.settings.disableConfirm.title": "¿Desactivar el compartir en el fediverso?",
@@ -1587,5 +1591,6 @@
   },
   "user": {
     "unknown": "Usuario desconocido"
-  }
+  },
+  "compose.languages.makeMain": "Establecer como idioma principal"
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -465,6 +465,10 @@
   "fediverse.sheet.cancel": "Annulla",
   "fediverse.settings.title": "Condivisione nel fediverso",
   "fediverse.settings.description": "Condividi il tuo profilo e i tuoi post nel fediverso",
+  "fediverse.settings.preferredLanguage.title": "Lingua principale",
+  "fediverse.settings.preferredLanguage.description": "La lingua principale in cui scrivi i tuoi post. Diventa la versione principale mostrata nel fediverso; lasciala in automatico per rilevarla per ogni post.",
+  "fediverse.settings.preferredLanguage.automatic": "Automatico",
+  "fediverse.settings.preferredLanguage.clear": "Usa automatico",
   "fediverse.settings.share": "Condividi nel fediverso",
   "fediverse.settings.whatIs": "Cos'è il fediverso?",
   "fediverse.settings.disableConfirm.title": "Disattivare la condivisione nel fediverso?",
@@ -1367,5 +1371,6 @@
   },
   "user": {
     "unknown": "Utente sconosciuto"
-  }
+  },
+  "compose.languages.makeMain": "Imposta come lingua principale"
 }

--- a/packages/frontend/utils/composeVariants.ts
+++ b/packages/frontend/utils/composeVariants.ts
@@ -181,6 +181,12 @@ export type ComposeVariantsAction =
   /** Re-tags a rendition IN PLACE — the author's work in that tab survives. */
   | { type: 'rename-language'; from: string; to: string }
   | { type: 'set-primary-language'; tag: string }
+  /**
+   * Promotes a secondary language to primary. The old primary moves into the
+   * author variants; because the primary's content lives in the composer's own
+   * state (not this buffer), the outgoing primary's per-item content is handed in.
+   */
+  | { type: 'promote-to-primary'; tag: string; oldPrimaryByItem: Record<string, PromotablePrimary> }
   | { type: 'set-text'; tag: string; itemId: string; text: string }
   /** Writes the alt of ONE image, into whichever arm the rendition is in. */
   | { type: 'set-media-alt'; tag: string; itemId: string; mediaId: string; alt: string }
@@ -267,6 +273,9 @@ export function variantsReducer(
       };
     }
 
+    case 'promote-to-primary':
+      return promoteVariantToPrimary(state, action.tag, action.oldPrimaryByItem).state;
+
     case 'set-text':
       return withItem(state, action.tag, action.itemId, (item) => ({ ...item, text: action.text }));
 
@@ -343,6 +352,159 @@ export function variantsReducer(
     case 'reset':
       return createVariantsState(action.primaryTag);
   }
+}
+
+// ── Promotion ────────────────────────────────────────────────────────────────
+
+/**
+ * The primary rendition of ONE composer item as it lives in the composer's own
+ * state (`postContent`/`mediaIds`/`article`, or a thread item's fields). The
+ * primary is not held in this buffer, so promoting a variant to primary must be
+ * handed the outgoing primary's content per item.
+ */
+export interface PromotablePrimary {
+  text: string;
+  media: ComposerMediaItem[];
+  article: ComposeVariantArticle | null;
+}
+
+/**
+ * Promoting a variant returns the new buffer PLUS the content to write back into
+ * the composer's own primary state, per item. Only items the promoted language
+ * actually rendered appear in `primaryByItem`: an item that language never
+ * translated keeps its primary body and inherits, exactly as before the promote.
+ */
+export interface PromotionOutcome {
+  state: ComposeVariantsState;
+  primaryByItem: Record<string, PromotablePrimary>;
+}
+
+/** The alt descriptions carried on a media set, as an inherit variant's map. */
+function sharedAltMap(media: readonly ComposerMediaItem[]): Record<string, string> {
+  const alt: Record<string, string> = {};
+  for (const item of media) {
+    const value = item.alt?.trim();
+    if (value) alt[item.id] = value;
+  }
+  return alt;
+}
+
+/** The shared images re-based to carry only `localized` alt (the old alt is dropped). */
+function withLocalizedAlt(
+  media: readonly ComposerMediaItem[],
+  localized: Record<string, string>,
+): ComposerMediaItem[] {
+  return media.map((item) => {
+    const alt = localized[item.id]?.trim();
+    return alt ? { id: item.id, type: item.type, alt } : { id: item.id, type: item.type };
+  });
+}
+
+/** The promoted variant, resolved to the concrete primary content it becomes. */
+function resolvePromotedPrimary(
+  variant: ComposeVariantItem,
+  oldPrimary: PromotablePrimary,
+): PromotablePrimary {
+  const media =
+    variant.media.mode === 'override'
+      ? variant.media.media
+      : withLocalizedAlt(oldPrimary.media, variant.media.alt);
+  return { text: variant.text, media, article: variant.article ?? oldPrimary.article };
+}
+
+/** The outgoing primary, captured as the variant it becomes. */
+function demotePrimary(
+  oldPrimary: PromotablePrimary,
+  promoted: ComposeVariantItem,
+): ComposeVariantItem {
+  const media: ComposeVariantMedia =
+    promoted.media.mode === 'override'
+      ? { mode: 'override', media: oldPrimary.media }
+      : { mode: 'inherit', alt: sharedAltMap(oldPrimary.media) };
+  return {
+    text: oldPrimary.text,
+    media,
+    article: promoted.article !== null ? oldPrimary.article : null,
+  };
+}
+
+/**
+ * Another author language, re-based when the shared media/article it INHERITS is
+ * about to change under it (the promoted language overrode it). A variant that
+ * already overrode is untouched — it never depended on the shared set.
+ */
+function rebaseInheritingVariant(
+  other: ComposeVariantItem,
+  oldPrimary: PromotablePrimary,
+  promoted: ComposeVariantItem,
+): ComposeVariantItem {
+  const media: ComposeVariantMedia =
+    promoted.media.mode === 'override' && other.media.mode === 'inherit'
+      ? { mode: 'override', media: withLocalizedAlt(oldPrimary.media, other.media.alt) }
+      : other.media;
+  const article =
+    promoted.article !== null && other.article === null ? oldPrimary.article : other.article;
+  return { ...other, media, article };
+}
+
+/**
+ * Promote a secondary language to primary.
+ *
+ * The old primary moves into the author variants, taking the promoted tab's slot,
+ * and every language keeps rendering exactly what it did: the promoted one becomes
+ * the post's face (`variants[0]`), the old primary becomes one rendition among the
+ * rest, and any language that was inheriting a media/article set that just changed
+ * is pinned to the old one. Returns the SAME state reference unchanged when the tag
+ * is not a current author variant, so callers can detect the no-op by identity.
+ */
+export function promoteVariantToPrimary(
+  state: ComposeVariantsState,
+  tag: string,
+  oldPrimaryByItem: Record<string, PromotablePrimary>,
+): PromotionOutcome {
+  const promotedTag = canonicalizeLanguageTag(tag);
+  if (promotedTag === null || !state.variantTags.includes(promotedTag)) {
+    return { state, primaryByItem: {} };
+  }
+
+  const oldPrimaryTag = state.primaryTag;
+  const promotedEntries = state.entries[promotedTag] ?? {};
+
+  const primaryByItem: Record<string, PromotablePrimary> = {};
+  const demotedEntries: Record<string, ComposeVariantItem> = {};
+  for (const [itemId, variant] of Object.entries(promotedEntries)) {
+    const oldPrimary = oldPrimaryByItem[itemId];
+    if (!oldPrimary || !hasVariantContent(variant)) continue;
+    primaryByItem[itemId] = resolvePromotedPrimary(variant, oldPrimary);
+    demotedEntries[itemId] = demotePrimary(oldPrimary, variant);
+  }
+
+  const entries: ComposeVariantsState['entries'] = {};
+  for (const [entryTag, items] of Object.entries(state.entries)) {
+    if (entryTag === promotedTag) continue; // Becomes the primary; its content moves out.
+    const rebased: Record<string, ComposeVariantItem> = {};
+    for (const [itemId, item] of Object.entries(items)) {
+      const promoted = promotedEntries[itemId];
+      const oldPrimary = oldPrimaryByItem[itemId];
+      rebased[itemId] =
+        promoted && oldPrimary && hasVariantContent(promoted)
+          ? rebaseInheritingVariant(item, oldPrimary, promoted)
+          : item;
+    }
+    entries[entryTag] = rebased;
+  }
+  entries[oldPrimaryTag] = demotedEntries;
+
+  return {
+    state: {
+      primaryTag: promotedTag,
+      variantTags: state.variantTags.map((t) => (t === promotedTag ? oldPrimaryTag : t)),
+      activeTag: promotedTag,
+      entries,
+      primaryChosen: true,
+    },
+    primaryByItem,
+  };
 }
 
 // ── Payload ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Mastodon shows only one language per post (from `contentMap`'s first key), so a bilingual Mention post federated with a Spanish primary variant is unreadable to English followers, and duplicating per-language posts would spam timelines and fragment engagement. This lets the author control which composer variant is primary (`variants[0]`) — the single "face" that federation, app display, and the MTN signed record all already read.
- Backend: new `UserSettings.fediversePreferredLanguage` (canonical BCP-47), read/written through `PUT /profile/settings` with server-side validation.
- Frontend: the composer seeds its default primary language from that preference, and a new "Make main language" gesture in the language picker lets the author promote any secondary variant to primary (previously impossible). No AP Note-builder changes were needed.

## Test plan
- [x] Backend `bunx tsc --noEmit` — 0 errors
- [x] Backend `bun run test` — 220 files / 2318 tests passed
- [x] Frontend `bun run typecheck` — 0 errors
- [x] Frontend `bun run test` — 19 suites / 356 tests passed
- [x] `bun run build:backend` (shared-types + backend) — succeeds
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)