### PR TITLE
fix(federation): render post line breaks as HTML in AP content

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/buildCreateNoteActivity.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/buildCreateNoteActivity.test.ts
@@ -66,7 +66,8 @@ describe('buildCreateNoteActivity — canonical url + hashtag tags', () => {
     expect(activity.id).toBe('https://mention.earth/ap/users/alice/posts/post123/activity');
     expect(note.id).toBe('https://mention.earth/ap/users/alice/posts/post123');
     expect(note.url).toBe('https://mention.earth/@alice/posts/post123');
-    expect(note.content).toBe('hello world');
+    // AP `content` is HTML — a single-line body is one `<p>`, no `<br>`.
+    expect(note.content).toBe('<p>hello world</p>');
 
     expect(note.tag).toEqual([
       { type: 'Hashtag', href: 'https://mention.earth/hashtag/news', name: '#news' },
@@ -111,10 +112,13 @@ describe('buildCreateNoteActivity — language + contentMap', () => {
     // body) but takes the status LANGUAGE from `contentMap.keys.first`. So the
     // key order is not cosmetic: put the primary anywhere but first and the
     // status is labelled with the wrong language.
-    expect(note.content).toBe('hola mundo');
+    expect(note.content).toBe('<p>hola mundo</p>');
     expect(Object.keys(note.contentMap as Record<string, string>)).toEqual(['es-ES', 'en-US']);
-    expect(note.contentMap).toEqual({ 'es-ES': 'hola mundo', 'en-US': 'hello world' });
+    // Every contentMap value is AP HTML — the localized bodies are wrapped too.
+    expect(note.contentMap).toEqual({ 'es-ES': '<p>hola mundo</p>', 'en-US': '<p>hello world</p>' });
     expect(note.language).toBe('es-ES');
+    // `content` and the primary contentMap key are the SAME string byte-for-byte.
+    expect((note.contentMap as Record<string, string>)['es-ES']).toBe(note.content);
   });
 
   it('NEVER federates a machine translation — only author variants reach the wire', () => {
@@ -129,14 +133,14 @@ describe('buildCreateNoteActivity — language + contentMap', () => {
       createdAt: ISO,
     });
 
-    expect(note.contentMap).toEqual({ es: 'hola' });
-    expect(note.content).toBe('hola');
+    expect(note.contentMap).toEqual({ es: '<p>hola</p>' });
+    expect(note.content).toBe('<p>hola</p>');
   });
 
   it('emits a single-key contentMap for a monolingual post — the only way Mastodon learns the language', () => {
     const { note } = noteFor({ _id: 'p1', content: body('just english', 'en'), createdAt: ISO });
 
-    expect(note.contentMap).toEqual({ en: 'just english' });
+    expect(note.contentMap).toEqual({ en: '<p>just english</p>' });
     expect(note.language).toBe('en');
   });
 
@@ -147,7 +151,7 @@ describe('buildCreateNoteActivity — language + contentMap', () => {
     // Mastodon would then display as fact.
     const { note } = noteFor({ _id: 'p1', content: body('+1'), createdAt: ISO });
 
-    expect(note.content).toBe('+1');
+    expect(note.content).toBe('<p>+1</p>');
     expect(note.contentMap).toBeUndefined();
     expect(note.language).toBeUndefined();
   });
@@ -174,8 +178,39 @@ describe('buildCreateNoteActivity — language + contentMap', () => {
 
     // An invalid BCP-47 key gets a Mastodon status rejected wholesale, so it
     // never reaches the wire.
-    expect(note.contentMap).toEqual({ 'es-ES': 'hola' });
+    expect(note.contentMap).toEqual({ 'es-ES': '<p>hola</p>' });
     expect(note.language).toBe('es-ES');
+  });
+});
+
+describe('buildCreateNoteActivity — plain-text body → AP HTML content', () => {
+  it('wraps blank-line-separated paragraphs in <p> so Mastodon preserves them (regression)', () => {
+    // The bug: raw `\n\n` is insignificant whitespace in HTML, so Mastodon
+    // collapsed the author's blank lines and the paragraphs ran together.
+    const { note } = noteFor({
+      _id: 'p1',
+      content: body('hola mundo.\n\nAhora otra cosa.\n\nPorque sí.', 'es'),
+      createdAt: ISO,
+    });
+
+    expect(note.content).toBe('<p>hola mundo.</p><p>Ahora otra cosa.</p><p>Porque sí.</p>');
+    // The single contentMap value is the same HTML, byte-for-byte.
+    expect((note.contentMap as Record<string, string>).es).toBe(note.content);
+  });
+
+  it('converts a single newline inside a paragraph to <br>', () => {
+    const { note } = noteFor({ _id: 'p1', content: body('line one\nline two'), createdAt: ISO });
+    expect(note.content).toBe('<p>line one<br>line two</p>');
+  });
+
+  it('HTML-escapes < & > in the body so they never mis-render as markup', () => {
+    const { note } = noteFor({ _id: 'p1', content: body('a < b && c > d'), createdAt: ISO });
+    expect(note.content).toBe('<p>a &lt; b &amp;&amp; c &gt; d</p>');
+  });
+
+  it('keeps an empty-bodied post (a boost) empty — no stray tags', () => {
+    const { note } = noteFor({ _id: 'p1', content: { variants: [] }, createdAt: ISO });
+    expect(note.content).toBe('');
   });
 });
 

--- a/packages/backend/src/__tests__/connectors/activitypub/replyFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/replyFederation.test.ts
@@ -158,7 +158,8 @@ describe('federateNewPost — reply to a FEDERATED parent', () => {
     const note = deliveredNote();
     expect(note.type).toBe('Note');
     expect(note.inReplyTo).toBe('https://remote.example/users/bob/statuses/9');
-    expect(note.content).toBe('threaded response');
+    // AP `content` is HTML — the plain-text body is wrapped in a paragraph.
+    expect(note.content).toBe('<p>threaded response</p>');
 
     // The Mention tag threads + notifies the remote author (href resolves it;
     // name is the human-readable @user@domain from the stored acct).

--- a/packages/backend/src/__tests__/connectors/activitypub/updateFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/updateFederation.test.ts
@@ -145,7 +145,8 @@ describe('federateUpdate — top-level edit', () => {
 
     const note = deliveredNote();
     expect(note.type).toBe('Note');
-    expect(note.content).toBe('edited body');
+    // AP `content` is HTML — the plain-text body is wrapped in a paragraph.
+    expect(note.content).toBe('<p>edited body</p>');
     expect(note.inReplyTo).toBeUndefined();
     // The Note carries the SAME `updated` marker as the envelope.
     expect(note.updated).toBe(activity.updated);

--- a/packages/backend/src/__tests__/utils/plainTextToApHtml.test.ts
+++ b/packages/backend/src/__tests__/utils/plainTextToApHtml.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { plainTextToApHtml } from '../../utils/federation/plainTextToApHtml';
+
+/**
+ * The OUTBOUND plain-text → ActivityPub `content` HTML transform — the inverse of
+ * {@link htmlToPlainText}. ActivityPub `content` is HTML, where a bare newline is
+ * insignificant whitespace: emitting a stored plain-text body raw dropped the
+ * author's blank lines and line breaks the moment Mastodon rendered it. This
+ * converter wraps paragraphs in `<p>`, turns single newlines into `<br>`, and
+ * HTML-escapes the body so `<`/`&` never mis-render.
+ */
+describe('plainTextToApHtml', () => {
+  it('wraps a single-line body in one <p>, no <br>', () => {
+    expect(plainTextToApHtml('hello world')).toBe('<p>hello world</p>');
+  });
+
+  it('splits blank-line-separated paragraphs into <p> blocks', () => {
+    expect(plainTextToApHtml('hola mundo.\n\nAhora\n\nPorque')).toBe(
+      '<p>hola mundo.</p><p>Ahora</p><p>Porque</p>',
+    );
+  });
+
+  it('converts a single newline inside a paragraph to <br>', () => {
+    expect(plainTextToApHtml('line one\nline two')).toBe('<p>line one<br>line two</p>');
+  });
+
+  it('mixes paragraph breaks and line breaks', () => {
+    expect(plainTextToApHtml('a\nb\n\nc\nd')).toBe('<p>a<br>b</p><p>c<br>d</p>');
+  });
+
+  it('HTML-escapes &, < and > (and escapes & first, never double-escaping)', () => {
+    expect(plainTextToApHtml('a < b && c > d')).toBe('<p>a &lt; b &amp;&amp; c &gt; d</p>');
+    expect(plainTextToApHtml('<script>alert(1)</script>')).toBe('<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>');
+    // An ampersand-led entity in the source must not be re-escaped into `&amp;amp;`.
+    expect(plainTextToApHtml('AT&T & Co')).toBe('<p>AT&amp;T &amp; Co</p>');
+  });
+
+  it('returns an empty string for empty or whitespace-only input', () => {
+    expect(plainTextToApHtml('')).toBe('');
+    expect(plainTextToApHtml('   ')).toBe('');
+    expect(plainTextToApHtml('\n\n  \n')).toBe('');
+  });
+
+  it('collapses 3+ consecutive newlines to a single paragraph break — no empty <p>', () => {
+    expect(plainTextToApHtml('uno\n\n\n\ndos')).toBe('<p>uno</p><p>dos</p>');
+  });
+
+  it('tolerates horizontal whitespace on the blank line between paragraphs', () => {
+    // A "blank" line that holds spaces still separates paragraphs.
+    expect(plainTextToApHtml('uno\n   \n   \ndos')).toBe('<p>uno</p><p>dos</p>');
+  });
+
+  it('normalizes CRLF and lone CR before processing', () => {
+    expect(plainTextToApHtml('uno\r\n\r\ndos')).toBe('<p>uno</p><p>dos</p>');
+    expect(plainTextToApHtml('uno\rdos')).toBe('<p>uno<br>dos</p>');
+  });
+
+  it('trims leading/trailing blank lines so it never opens with an empty <p> or a stray <br>', () => {
+    expect(plainTextToApHtml('\n\nhola\n\n')).toBe('<p>hola</p>');
+    expect(plainTextToApHtml('hola\n')).toBe('<p>hola</p>');
+  });
+
+  it('does NOT linkify URLs, hashtags or mentions (out of scope — carried by AP tags)', () => {
+    expect(plainTextToApHtml('see https://example.com/x #news @bob')).toBe(
+      '<p>see https://example.com/x #news @bob</p>',
+    );
+  });
+});

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -25,6 +25,7 @@ import { actorService } from './actor.service';
 import { fetchUpstreamSingleHop } from '../../utils/safeUpstreamFetch';
 import { assertSafePublicUrl } from '../../utils/ssrfGuard';
 import { resolveMediaRef } from '../../utils/mediaResolver';
+import { plainTextToApHtml } from '../../utils/federation/plainTextToApHtml';
 import { isAbsoluteHttpUrl } from '../shared/url';
 
 const DELIVER_ACTIVITY_TIMEOUT_MS = 15000;
@@ -169,11 +170,14 @@ export interface NoteReplyContext {
  * The primary key is inserted before the rest are walked, so it leads the map
  * unconditionally — the ordering is what Mastodon derives the status language
  * from, and it must not depend on the shape of the data. Its value is the
- * RESOLVED primary body, the same string that goes out as `content`, so the two
- * can never disagree.
+ * already-converted primary body (`primaryContent`), the exact string that goes
+ * out as `content`, so the two can never disagree byte-for-byte.
  *
- * Only AUTHOR variants are emitted. A machine translation is derived content: it
- * is not the author's writing and it does not federate.
+ * Every value is AP `content` HTML: each author variant's plain-text body is run
+ * through {@link plainTextToApHtml} so a localized body's blank lines and line
+ * breaks survive rendering exactly like the primary. Only AUTHOR variants are
+ * emitted — a machine translation is derived content: it is not the author's
+ * writing and it does not federate.
  *
  * Returns `undefined` when the post declares no language — an UNTAGGED primary
  * variant (a body too short to detect, a remote Note that declared none) has no
@@ -184,16 +188,16 @@ export interface NoteReplyContext {
 function buildNoteContentMap(
   post: NoteSourcePost,
   primaryTag: string | undefined,
-  primaryBody: string,
+  primaryContent: string,
 ): Record<string, string> | undefined {
   const contentMap: Record<string, string> = {};
 
-  if (primaryTag) contentMap[primaryTag] = primaryBody;
+  if (primaryTag) contentMap[primaryTag] = primaryContent;
 
   for (const variant of authorVariants(post.content)) {
     const tag = canonicalizeLanguageTag(variant.tag);
     if (tag === null || tag in contentMap) continue;
-    contentMap[tag] = variant.text;
+    contentMap[tag] = plainTextToApHtml(variant.text);
   }
 
   return Object.keys(contentMap).length > 0 ? contentMap : undefined;
@@ -492,9 +496,14 @@ export class FollowService {
           .filter((a): a is Record<string, unknown> => a !== undefined)
       : [];
 
-    const primaryBody = primary.text;
+    // AP `content` is HTML: convert the resolved plain-text primary body ONCE and
+    // thread the result through both `content` and the primary `contentMap` key so
+    // they stay byte-for-byte identical (Mastodon reads `content` and only falls
+    // back to `contentMap`, but the two must never disagree). This preserves the
+    // author's blank lines and line breaks, which HTML would otherwise collapse.
+    const primaryContent = plainTextToApHtml(primary.text);
     const language = canonicalizeLanguageTag(primary.tag) ?? undefined;
-    const contentMap = buildNoteContentMap(post, language, primaryBody);
+    const contentMap = buildNoteContentMap(post, language, primaryContent);
 
     // The public collection stays in `to`; the mentioned parent author joins the
     // followers collection in `cc` so a public reply is delivered/attributed to
@@ -519,7 +528,7 @@ export class FollowService {
         // so a top-level Note carries no `inReplyTo`.
         inReplyTo: reply?.inReplyTo,
         url: `https://${FEDERATION_DOMAIN}/@${username}/posts/${postId}`,
-        content: primaryBody,
+        content: primaryContent,
         contentMap,
         language,
         published,

--- a/packages/backend/src/scripts/backfillFederatedPostHtml.ts
+++ b/packages/backend/src/scripts/backfillFederatedPostHtml.ts
@@ -1,0 +1,346 @@
+/**
+ * One-shot admin backfill: re-emit AP `Update(Note)` for a SINGLE local user's
+ * ALREADY-federated original posts so remote instances (Mastodon et al.)
+ * re-render them with the now-corrected HTML body.
+ *
+ * Context: for months the outbound Note builder emitted the plain-text body as-is,
+ * so Mastodon collapsed the author's blank lines / line breaks into a single run.
+ * That is now fixed (`plainTextToApHtml` + the `buildCreateNoteActivity` /
+ * `buildNoteContentMap` change), so `buildUpdateNoteActivity` already produces the
+ * right HTML. A re-`Create` cannot repair the historical posts — Mastodon dedupes
+ * an incoming object by its `id` and ignores a second Create for one it already has
+ * — but an `Update` IS processed as an edit and re-renders the status. This script
+ * pushes exactly that Update for the affected posts.
+ *
+ * It reuses the SAME delivery path the live edit flow calls
+ * (`followService.federateUpdate`, which builds the `Update(Note)` via
+ * `buildUpdateNoteActivity` and delivers via `deliverToFollowers`), so behavior is
+ * byte-identical to a real edit — no hand-rolled Update/signing/delivery path.
+ *
+ * SELECTION (in order):
+ *  1. The same base scope as `redeliverUserPosts`: the owner's local-origin,
+ *     published, PUBLIC, top-level (non-reply) ORIGINAL posts — no boosts — sorted
+ *     OLDEST-FIRST and capped at `BACKFILL_MAX` (overflow skipped, never blasted).
+ *  2. THEN, of that capped set, ONLY the posts whose PRIMARY author-variant body
+ *     contains a line break (`\n`). A single-line post renders identically whether
+ *     it federates as raw text or as `<p>text</p>`, so Updating it would add a
+ *     pointless "edited" mark on Mastodon for zero visible change. The primary body
+ *     is read through the SAME resolver the Note builder uses (`resolveVariant`),
+ *     never by hand-indexing `variants[0]`.
+ *
+ * SAFETY (in order):
+ *  1. The target user id is REQUIRED (`BACKFILL_OXY_USER_ID` env or argv[2]).
+ *     Missing/empty → exit(1) BEFORE any DB connect. NEVER defaults to all users.
+ *  2. `BACKFILL_DRY_RUN` defaults to `'true'` (safe): logs what WOULD be updated
+ *     and sends nothing. Only `BACKFILL_DRY_RUN=false` delivers.
+ *  3. `BACKFILL_MAX` (default 500) caps the base set; overflow is skipped.
+ *  4. Refuses to run when `FEDERATION_ENABLED` is false or the owner's
+ *     `fediverseSharing` consent is off.
+ *
+ * Runnable as a Fargate one-shot:
+ *   BACKFILL_OXY_USER_ID=6981c9178fcdefaf81988ffb \
+ *   BACKFILL_DRY_RUN=false \
+ *   bun packages/backend/dist/src/scripts/backfillFederatedPostHtml.js
+ */
+
+import mongoose from 'mongoose';
+import { Post } from '../models/Post';
+import FederatedFollow from '../models/FederatedFollow';
+import FederatedActor from '../models/FederatedActor';
+import { followService, type NoteSourcePost } from '../connectors/activitypub/follow.service';
+import { FEDERATION_ENABLED } from '../connectors/activitypub/constants';
+import { isFediverseSharingEnabled } from '../services/fediverseSharing';
+import { getServiceOxyClient } from '../utils/oxyHelpers';
+import { resolveVariant } from '../services/postVariants';
+import { PostVisibility } from '@mention/shared-types';
+import { logger } from '../utils/logger';
+
+/** Default delay between deliveries (ms) — throttles the blast to avoid tripping mastodon.social rate limits. */
+const DEFAULT_DELAY_MS = 2000;
+
+/** Default safety cap on how many posts a single run may scan/update. */
+const DEFAULT_MAX = 500;
+
+/**
+ * Grace period to let the awaited-but-detached delivery/enqueue work flush before
+ * the process disconnects and exits. `federateUpdate` awaits its follower enqueue,
+ * so a short settle is plenty; mirrors the other one-shot federation scripts.
+ */
+const DELIVERY_SETTLE_MS = 5000;
+
+/** Characters of the primary body echoed in dry-run / per-post log lines. */
+const SNIPPET_MAX_CHARS = 80;
+
+/** The lean Post shape delivery needs — structurally satisfies `federateUpdate`. */
+type BackfillablePost = NoteSourcePost & { visibility: string };
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Parse a strictly-positive integer env value, falling back on absent/invalid input. */
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * The post's PRIMARY plain-text body, resolved through the EXACT resolver the Note
+ * builder uses (`resolveVariant(post.content)` → `.text`, the string that becomes
+ * `content` after `plainTextToApHtml`). Never hand-indexes `variants[0]`. Returns
+ * `''` if the body cannot be resolved (defensive — such a post has no detectable
+ * line break and is simply excluded).
+ */
+function primaryBodyOf(post: BackfillablePost): string {
+  try {
+    return resolveVariant(post.content).text ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Whether an Update would actually change how the post renders on Mastodon: only
+ * true when the primary body carries a line break. A single-line body is identical
+ * as raw text and as `<p>text</p>`, so Updating it only stamps a spurious edit.
+ */
+function hasMeaningfulLineBreak(post: BackfillablePost): boolean {
+  return primaryBodyOf(post).includes('\n');
+}
+
+/** One-line body preview (whitespace collapsed, truncated) for logging. */
+function snippetOf(post: BackfillablePost): string {
+  const collapsed = primaryBodyOf(post).replace(/\s+/g, ' ').trim();
+  return collapsed.length > SNIPPET_MAX_CHARS ? `${collapsed.slice(0, SNIPPET_MAX_CHARS)}…` : collapsed;
+}
+
+/** ISO timestamp for logging, tolerant of a Date or string `createdAt`. */
+function formatCreatedAt(createdAt: string | Date): string {
+  const date = createdAt instanceof Date ? createdAt : new Date(createdAt);
+  return Number.isNaN(date.getTime()) ? String(createdAt) : date.toISOString();
+}
+
+/**
+ * Resolve the target's remote follower inboxes for REPORTING only (the header and
+ * dry-run output). This mirrors the exact ownership query `deliverToFollowers`
+ * uses — accepted inbound `FederatedFollow`s → `FederatedActor` shared/personal
+ * inbox, deduped by shared inbox — but never sends anything itself. Actual
+ * delivery goes through `federateUpdate` (which re-runs this resolution). Not a
+ * second delivery/signing path; purely read-only enumeration for the operator.
+ */
+async function resolveFollowerInboxes(
+  oxyUserId: string,
+): Promise<{ followerCount: number; inboxes: string[] }> {
+  const follows = await FederatedFollow.find(
+    { localUserId: oxyUserId, direction: 'inbound', status: 'accepted' },
+    { remoteActorUri: 1 },
+  ).lean<{ remoteActorUri: string }[]>();
+
+  const actorUris = follows.map((f) => f.remoteActorUri);
+  const actors =
+    actorUris.length > 0
+      ? await FederatedActor.find(
+          { uri: { $in: actorUris } },
+          { uri: 1, sharedInboxUrl: 1, inboxUrl: 1 },
+        ).lean<{ uri: string; sharedInboxUrl?: string; inboxUrl?: string }[]>()
+      : [];
+
+  const seen = new Set<string>();
+  const inboxes: string[] = [];
+  for (const actor of actors) {
+    const inbox = actor.sharedInboxUrl || actor.inboxUrl;
+    if (inbox && !seen.has(inbox)) {
+      seen.add(inbox);
+      inboxes.push(inbox);
+    }
+  }
+  return { followerCount: follows.length, inboxes };
+}
+
+async function backfillFederatedPostHtml(): Promise<void> {
+  const startedAt = Date.now();
+
+  // 1. PRIMARY SAFETY: an explicit target is mandatory. Never default to a broad
+  //    or unscoped run.
+  const targetUserId = (process.env.BACKFILL_OXY_USER_ID || process.argv[2] || '').trim();
+  if (!targetUserId) {
+    logger.error(
+      '[backfillFederatedPostHtml] BACKFILL_OXY_USER_ID is required (or pass the id as argv). Refusing to run unscoped.',
+    );
+    process.exit(1);
+  }
+
+  // Federation off → `federateUpdate` no-ops, so there is nothing to re-emit. Fail
+  // loudly rather than silently "succeeding" on zero work.
+  if (!FEDERATION_ENABLED) {
+    logger.error('[backfillFederatedPostHtml] FEDERATION_ENABLED is false; nothing to update. Aborting.');
+    process.exit(1);
+  }
+
+  const dryRun = process.env.BACKFILL_DRY_RUN !== 'false';
+  const delayMs = parsePositiveInt(process.env.BACKFILL_DELAY_MS, DEFAULT_DELAY_MS);
+  const maxPosts = parsePositiveInt(process.env.BACKFILL_MAX, DEFAULT_MAX);
+
+  const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/mention';
+  const dbName = `mention-${process.env.NODE_ENV || 'development'}`;
+
+  await mongoose.connect(mongoUri, { dbName });
+  logger.info(`[backfillFederatedPostHtml] connected to MongoDB (${dbName})`);
+
+  try {
+    // Resolve the owner username SERVER-SIDE from the authoritative oxyUserId (the
+    // same mechanism the live delivery path uses). No username → cannot build a
+    // canonical actor/Note; refuse.
+    const owner = await getServiceOxyClient().getUserById(targetUserId);
+    const username = owner.username?.trim();
+    if (!username) {
+      throw new Error(`no resolvable Oxy username for user ${targetUserId}; cannot federate`);
+    }
+
+    // Respect the owner's fediverse-sharing consent — never blast when sharing is
+    // off. (`federateUpdate` re-checks this too; we refuse up-front so the whole
+    // run is a clear no-op instead of silently dropping every post.)
+    const sharingEnabled = await isFediverseSharingEnabled(targetUserId);
+    if (!sharingEnabled) {
+      throw new Error(
+        `fediverseSharing is OFF for ${targetUserId} (@${username}); refusing to update posts`,
+      );
+    }
+
+    // Follower inboxes (reporting only). Zero remote inboxes → genuinely nothing to
+    // deliver to; report and exit cleanly.
+    const { followerCount, inboxes } = await resolveFollowerInboxes(targetUserId);
+    if (inboxes.length === 0) {
+      logger.warn(
+        `[backfillFederatedPostHtml] @${username} (${targetUserId}) has no remote follower inboxes; nothing to update. Done.`,
+      );
+      return;
+    }
+
+    // 2. BASE SCOPE: the owner's local-origin, published, PUBLIC, top-level
+    //    (non-reply) ORIGINAL posts — no boosts. Identical to the redeliver script.
+    const postFilter = {
+      oxyUserId: targetUserId,
+      federation: null, // local origin (missing or null federation subdoc)
+      status: 'published',
+      visibility: PostVisibility.PUBLIC,
+      parentPostId: null, // top-level only — EXCLUDE replies
+      boostOf: null, // not a boost (mirrors native repost exclusion)
+      type: { $ne: 'boost' },
+    } as const;
+
+    const totalMatched = await Post.countDocuments(postFilter);
+
+    // SAFETY CAP: never scan an unbounded set. Take the OLDEST `maxPosts`; the rest
+    // (the newest) are skipped by the cap and reported.
+    const willScan = Math.min(totalMatched, maxPosts);
+    const cappedSkipped = totalMatched - willScan;
+    if (cappedSkipped > 0) {
+      logger.warn(
+        `[backfillFederatedPostHtml] matched ${totalMatched} posts exceeds BACKFILL_MAX=${maxPosts}; scanning the oldest ${maxPosts}, skipping ${cappedSkipped}.`,
+      );
+    }
+
+    const scanned = await Post.find(postFilter)
+      .sort({ createdAt: 1, _id: 1 })
+      .limit(maxPosts)
+      .lean<BackfillablePost[]>();
+
+    // LINE-BREAK FILTER: of the scanned set, keep only posts whose primary body
+    // actually has a line break — the ONLY posts whose rendering an Update fixes.
+    const posts = scanned.filter(hasMeaningfulLineBreak);
+    const excludedNoLineBreak = scanned.length - posts.length;
+
+    // Header.
+    logger.info('[backfillFederatedPostHtml] ===== HTML re-render (Update) plan =====');
+    logger.info(`[backfillFederatedPostHtml] target user:       ${targetUserId} (@${username})`);
+    logger.info(`[backfillFederatedPostHtml] remote followers:  ${followerCount} (${inboxes.length} distinct inboxes)`);
+    for (const inbox of inboxes) {
+      logger.info(`[backfillFederatedPostHtml]   inbox: ${inbox}`);
+    }
+    logger.info(`[backfillFederatedPostHtml] mode:              ${dryRun ? 'DRY-RUN (sending nothing)' : 'LIVE (delivering)'}`);
+    logger.info(`[backfillFederatedPostHtml] delay between:     ${delayMs}ms`);
+    logger.info(`[backfillFederatedPostHtml] cap:               ${maxPosts}`);
+    logger.info(
+      `[backfillFederatedPostHtml] matched w/ breaks: ${posts.length} of ${scanned.length} scanned ` +
+        `(${excludedNoLineBreak} excluded: no line break, ${cappedSkipped} skipped by cap of ${totalMatched} matched)`,
+    );
+    logger.info('[backfillFederatedPostHtml] ========================================');
+
+    let updated = 0;
+    let failed = 0;
+
+    for (let i = 0; i < posts.length; i++) {
+      const post = posts[i];
+      const postId = String(post._id);
+      const position = `${i + 1}/${posts.length}`;
+      const createdAt = formatCreatedAt(post.createdAt);
+      const snippet = snippetOf(post);
+
+      if (dryRun) {
+        logger.info(
+          `[backfillFederatedPostHtml] [${position}] WOULD update post ${postId} (createdAt=${createdAt}) → ${inboxes.length} inbox(es) | "${snippet}"`,
+        );
+        continue;
+      }
+
+      try {
+        // Reuse the EXACT live edit path: builds the `Update(Note)` via
+        // `buildUpdateNoteActivity` (with the corrected HTML body) and delivers via
+        // `deliverToFollowers`. It re-gates on FEDERATION_ENABLED + sharing +
+        // non-boost + PUBLIC internally, so behavior is identical to a real edit.
+        await followService.federateUpdate(post, targetUserId, username);
+        updated += 1;
+        logger.info(
+          `[backfillFederatedPostHtml] [${position}] updated post ${postId} (createdAt=${createdAt}) | "${snippet}"`,
+        );
+      } catch (err) {
+        // Count and CONTINUE — one bad post never aborts the whole run.
+        failed += 1;
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`[backfillFederatedPostHtml] [${position}] FAILED post ${postId}: ${message}`);
+      }
+
+      // Throttle between deliveries (never after the last).
+      if (i < posts.length - 1) {
+        await sleep(delayMs);
+      }
+    }
+
+    if (!dryRun && updated > 0) {
+      // Let the awaited-but-detached follower enqueue/delivery work flush before
+      // tearing down the connection.
+      await sleep(DELIVERY_SETTLE_MS);
+    }
+
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    if (dryRun) {
+      logger.info(
+        `[backfillFederatedPostHtml] DRY-RUN done: ${posts.length} posts WOULD be updated to ${inboxes.length} inbox(es); ` +
+          `${excludedNoLineBreak} excluded (no line break), ${cappedSkipped} skipped by cap (${elapsedSeconds}s). ` +
+          'Set BACKFILL_DRY_RUN=false to actually deliver.',
+      );
+    } else {
+      logger.info(
+        `[backfillFederatedPostHtml] done: updated ${updated}, failed ${failed}, ` +
+          `excluded ${excludedNoLineBreak} (no line break), skipped ${cappedSkipped} by cap ` +
+          `of ${totalMatched} matched (${elapsedSeconds}s).`,
+      );
+    }
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+if (require.main === module) {
+  // Exit deterministically: imported singletons (BullMQ Redis connection, media
+  // cache workers) keep the event loop alive, so the process would otherwise sit
+  // RUNNING after the work completes. Mirrors the other federation one-shots.
+  backfillFederatedPostHtml()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error('[backfillFederatedPostHtml] unhandled failure', error);
+      process.exit(1);
+    });
+}
+
+export default backfillFederatedPostHtml;

--- a/packages/backend/src/utils/federation/plainTextToApHtml.ts
+++ b/packages/backend/src/utils/federation/plainTextToApHtml.ts
@@ -1,0 +1,61 @@
+/**
+ * HTML-escape the three characters that are significant inside HTML element text
+ * content. `&` is escaped FIRST so that the `&` this function introduces into
+ * `&lt;` / `&gt;` is never re-escaped — the canonical, double-escape-safe order.
+ *
+ * Only `&`, `<` and `>` matter here: the output is placed between `<p>…</p>` (as
+ * text content), never inside an attribute value, so `"`/`'` need no escaping.
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Convert an author-written PLAIN-TEXT post body into the safe ActivityPub
+ * `content` HTML fragment — the OUTBOUND inverse of {@link htmlToPlainText}.
+ *
+ * ActivityPub `content` (and every `contentMap` value) is an HTML string: every
+ * fediverse server — Mastodon included — renders it as HTML, where a run of
+ * whitespace collapses and a bare newline is insignificant. Emitting a stored
+ * plain-text body raw therefore DROPS the author's blank lines and line breaks the
+ * moment it is rendered, and leaves any literal `<`/`&` to be mis-parsed as markup.
+ *
+ * The transform mirrors how Mastodon itself serializes a status body:
+ *   1. Normalize line endings (`\r\n` and lone `\r` → `\n`).
+ *   2. HTML-escape the text (`&` first, then `<`/`>`).
+ *   3. Split on blank-line boundaries into paragraphs, each wrapped in `<p>…</p>`.
+ *   4. Convert every remaining single newline inside a paragraph to `<br>`.
+ *
+ * URLs, hashtags and mentions are deliberately NOT linkified here — that is a
+ * separate concern (the machine-readable references travel in the AP `tag` array).
+ * This helper is strictly the plain-text → line-break-preserving HTML transform.
+ *
+ * An empty or whitespace-only body returns `''`: an empty-bodied post (e.g. a
+ * boost, whose body is intentionally empty) must never grow stray `<p>` tags, and
+ * every caller already handles an empty `content`.
+ */
+export function plainTextToApHtml(text: string): string {
+  // Normalize line endings so paragraph/line-break detection is single-newline
+  // based, and drop leading/trailing whitespace so the body never opens or closes
+  // with an empty paragraph or a stray `<br>`.
+  const normalized = text.replace(/\r\n?/g, '\n').trim();
+  if (normalized.length === 0) return '';
+
+  const escaped = escapeHtml(normalized);
+
+  // A paragraph boundary is a run of two or more newlines. Horizontal whitespace
+  // on the "blank" line(s) is tolerated — a line that holds only spaces still
+  // separates paragraphs — and a run of 3+ newlines collapses to a single
+  // boundary, because HTML has no empty paragraph to render.
+  const paragraphs = escaped.split(/\n[ \t]*(?:\n[ \t]*)+/);
+
+  return paragraphs
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0)
+    // A single newline that survives inside a paragraph is an author line break.
+    .map((paragraph) => `<p>${paragraph.replace(/\n/g, '<br>')}</p>`)
+    .join('');
+}


### PR DESCRIPTION
## Summary
- The AP `Note.content` field is parsed as HTML by Mastodon, but Mention was emitting raw plaintext with literal newlines, so blank lines and line breaks collapsed into one run-on paragraph on federated timelines.
- New `plainTextToApHtml` helper escapes text and converts blank lines to `<p>` paragraphs / single newlines to `<br>`, applied to `content` and every `contentMap` locale variant so they stay in sync. Also fixes posts containing `<` or `&` that previously mis-rendered.
- Adds a one-shot `backfillFederatedPostHtml` script (dry-run by default) that re-sends `Update(Note)` for a user's already-federated posts containing line breaks, so historical statuses re-render correctly on Mastodon without duplicating (an Update is processed as an edit, unlike a re-Create which is deduped by id).

## Test plan
- [x] `bunx tsc --noEmit` — clean, 0 errors
- [x] `bun run test` (backend) — 221 files / 2333 tests passed
- [x] `bun run build:backend` — succeeds; `dist/src/scripts/backfillFederatedPostHtml.js` present
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)