### PR TITLE
feat(federation): linkify content, federate @mentions, notify inbound engagement

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
@@ -25,6 +25,8 @@ const mocks = vi.hoisted(() => ({
   getPublicKey: vi.fn(),
   buildCreateNoteActivity: vi.fn(),
   resolveReplyContext: vi.fn(),
+  resolveMentionContext: vi.fn(),
+  resolveMentionContextByPost: vi.fn(),
   userSettingsFindOne: vi.fn(),
   postFind: vi.fn(),
   postCountDocuments: vi.fn(),
@@ -46,6 +48,8 @@ vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
   activityPubConnector: {
     buildCreateNoteActivity: (...args: unknown[]) => mocks.buildCreateNoteActivity(...args),
     resolveReplyContext: (...args: unknown[]) => mocks.resolveReplyContext(...args),
+    resolveMentionContext: (...args: unknown[]) => mocks.resolveMentionContext(...args),
+    resolveMentionContextByPost: (...args: unknown[]) => mocks.resolveMentionContextByPost(...args),
     fetchPublicKey: vi.fn(),
     processInboxActivity: vi.fn(),
   },
@@ -107,6 +111,10 @@ beforeEach(() => {
   // Default: not a reply (or unresolvable parent) — the dereference route serves
   // the Note with no `inReplyTo`. Individual tests override for a reply post.
   mocks.resolveReplyContext.mockResolvedValue(null);
+  // Default: no @mentions resolve — the outbox/featured batch resolver returns an
+  // empty map and the single-post dereference resolver returns null.
+  mocks.resolveMentionContext.mockResolvedValue(null);
+  mocks.resolveMentionContextByPost.mockResolvedValue(new Map());
 });
 
 describe('GET /ap/users/:username — actor image (banner)', () => {
@@ -173,7 +181,9 @@ describe('GET /ap/users/:username/outbox?page=true — reuses buildCreateNoteAct
       .expect(200);
 
     expect(mocks.buildCreateNoteActivity).toHaveBeenCalledTimes(2);
-    expect(mocks.buildCreateNoteActivity).toHaveBeenNthCalledWith(1, posts[0], 'alice');
+    // The outbox passes NO reply context and the per-post mention context (undefined
+    // here — the batch resolver returned an empty map) as the 3rd/4th args.
+    expect(mocks.buildCreateNoteActivity).toHaveBeenNthCalledWith(1, posts[0], 'alice', undefined, undefined);
     expect(res.body.type).toBe('OrderedCollectionPage');
     expect(res.body.orderedItems).toEqual([
       { type: 'Create', object: { id: 'https://mention.earth/ap/users/alice/posts/p1' } },
@@ -537,7 +547,9 @@ describe('GET /ap/users/:username/posts/:id — dereference', () => {
     // The route resolves the reply addressing from the served post and threads it
     // into the pure Note builder as the third argument.
     expect(mocks.resolveReplyContext).toHaveBeenCalledWith(replyDoc);
-    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(replyDoc, 'alice', replyContext);
+    // The dereference route threads the resolved reply context + (null →) undefined
+    // mention context into the Note builder.
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(replyDoc, 'alice', replyContext, undefined);
   });
 
   it('404s a malformed post id without touching the database', async () => {

--- a/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
@@ -41,6 +41,8 @@ const mocks = vi.hoisted(() => ({
   getPublicKey: vi.fn(),
   buildCreateNoteActivity: vi.fn(),
   resolveReplyContext: vi.fn(),
+  resolveMentionContext: vi.fn(),
+  resolveMentionContextByPost: vi.fn(),
   userSettingsFindOne: vi.fn(),
   postFind: vi.fn(),
   postCountDocuments: vi.fn(),
@@ -67,6 +69,8 @@ vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
   activityPubConnector: {
     buildCreateNoteActivity: (...args: unknown[]) => mocks.buildCreateNoteActivity(...args),
     resolveReplyContext: (...args: unknown[]) => mocks.resolveReplyContext(...args),
+    resolveMentionContext: (...args: unknown[]) => mocks.resolveMentionContext(...args),
+    resolveMentionContextByPost: (...args: unknown[]) => mocks.resolveMentionContextByPost(...args),
     fetchPublicKey: vi.fn(),
     processInboxActivity: vi.fn().mockResolvedValue(undefined),
   },
@@ -164,6 +168,10 @@ beforeEach(() => {
   // The dereference route resolves reply addressing before building the Note; the
   // gate tests serve a non-reply post, so default to "no reply context".
   mocks.resolveReplyContext.mockResolvedValue(null);
+  // The dereference/outbox/featured routes also resolve @mention addressing; the
+  // gate tests mention nobody, so default to "no mentions".
+  mocks.resolveMentionContext.mockResolvedValue(null);
+  mocks.resolveMentionContextByPost.mockResolvedValue(new Map());
   mocks.verifyHttpSignature.mockResolvedValue({
     verified: true,
     actorUri: 'https://remote.example/users/bob',

--- a/packages/backend/src/__tests__/connectors/activitypub/inboundEngagementNotifications.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/inboundEngagementNotifications.test.ts
@@ -1,0 +1,417 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Inbound federated engagement → LOCAL owner notification parity.
+ *
+ * A like/boost/reply from the fediverse on a LOCAL Mention post must reach the
+ * owner's notifications exactly like the native equivalent — the same
+ * `createPostAuthorNotifications` util the local `posts.controller` (like) and
+ * `PostCreationService` (reply/boost) paths call, mirroring
+ * `handleIncomingFollow`'s already-present follow notification.
+ *
+ * These pin, per handler:
+ *   - handleLike     → `type:'like'`  (entityId = the liked post)
+ *   - handleAnnounce → `type:'boost'` (entityId = the boosted post)
+ *   - handleCreate   → `type:'reply'` (entityId = the NEW reply post) to the parent owner
+ *
+ * and for each: the notification fires ONLY on genuinely-NEW engagement — never
+ * on a redelivered duplicate, never when the target owner has sharing OFF, and
+ * never when the remote actor is unresolved. A REMOTE-owned/mirrored target
+ * (`federation != null`) records the engagement but is never notified (no local
+ * inbox). A notification failure is fail-soft — it never fails the inbox job.
+ *
+ * Drives the REAL `InboxProcessingService` with the same mocking convention as
+ * the sibling `inboundSharingGates.test.ts`: mock the models + the notification
+ * util + `services/fediverseSharing`, let `actor.service.ts` run for real
+ * against the mocked `FederatedActor` model, and mock `outbox.service.ts`
+ * wholesale (its thread-link/boost-import logic has its own coverage).
+ */
+
+const ACTOR_URI = 'https://mastodon.social/users/bob';
+const TARGET_POST_ID = '507f1f77bcf86cd799439011';
+const TARGET_POST_URI = `https://mention.earth/ap/users/alice/posts/${TARGET_POST_ID}`;
+const CREATED_REPLY_ID = 'created_post_1';
+const OWNER_OXY_ID = 'oxy_alice';
+const ACTOR_OXY_ID = 'oxy_bob';
+const OWNER_AUTHORSHIP = [{ userId: OWNER_OXY_ID, role: 'owner', status: 'accepted' }];
+
+const mocks = vi.hoisted(() => ({
+  getPublicKey: vi.fn(),
+  signViaOxy: vi.fn(),
+  signRequest: vi.fn(),
+  actorFindOne: vi.fn(),
+  followExists: vi.fn(),
+  postFindOne: vi.fn(),
+  postExists: vi.fn(),
+  postUpdateOne: vi.fn(),
+  postDeleteOne: vi.fn(),
+  likeCreate: vi.fn(),
+  likeFindOneAndDelete: vi.fn(),
+  postCreatorCreate: vi.fn(),
+  ensureFederatedReplyLink: vi.fn(),
+  importAnnounce: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  createPostAuthorNotifications: vi.fn(),
+  createNotification: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerError: vi.fn(),
+  loggerDebug: vi.fn(),
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: {
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError,
+    debug: mocks.loggerDebug,
+    fatal: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock('../../../connectors/activitypub/crypto', () => ({
+  getPublicKey: mocks.getPublicKey,
+  signViaOxy: mocks.signViaOxy,
+  signRequest: mocks.signRequest,
+}));
+
+vi.mock('../../../models/FederatedActor', () => ({
+  default: { findOne: mocks.actorFindOne },
+}));
+
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { exists: mocks.followExists },
+}));
+
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: {},
+  getNextRetryTime: vi.fn(),
+}));
+
+vi.mock('../../../models/Post', () => ({
+  POST_CLASSIFICATION_PENDING: 'pending',
+  Post: {
+    findOne: mocks.postFindOne,
+    exists: mocks.postExists,
+    updateOne: mocks.postUpdateOne,
+    deleteOne: mocks.postDeleteOne,
+  },
+}));
+
+vi.mock('../../../models/Like', () => ({
+  default: {
+    create: mocks.likeCreate,
+    findOneAndDelete: mocks.likeFindOneAndDelete,
+  },
+}));
+
+vi.mock('../../../models/UserSettings', () => ({
+  default: { updateOne: vi.fn() },
+}));
+
+vi.mock('../../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: vi.fn(),
+}));
+
+vi.mock('../../../services/mediaCache/cacheWorker', () => ({
+  persistRemoteMediaForFederatedOwnerDetailed: vi.fn(),
+}));
+
+vi.mock('../../../services/mediaCache/cacheStore', () => ({
+  recordAccessAndMaybeEnqueue: vi.fn(),
+}));
+
+vi.mock('../../../services/serviceRegistry', () => ({
+  getPostCreator: () => ({ create: mocks.postCreatorCreate }),
+  registerPostFederator: vi.fn(),
+  registerPostCreator: vi.fn(),
+  getPostFederator: vi.fn(),
+}));
+
+vi.mock('../../../services/fediverseSharing', () => ({
+  isFediverseSharingEnabled: (...args: unknown[]) => mocks.isFediverseSharingEnabled(...args),
+}));
+
+// The notification util is imported LAZILY inside the handlers (to avoid the
+// load-time server cycle); this module mock intercepts that dynamic import too.
+vi.mock('../../../utils/notificationUtils', () => ({
+  createPostAuthorNotifications: mocks.createPostAuthorNotifications,
+  createNotification: mocks.createNotification,
+  createMentionNotifications: vi.fn(),
+  createWelcomeNotification: vi.fn(),
+  createBatchNotifications: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/outbox.service', () => ({
+  outboxSyncService: {
+    ensureFederatedReplyLink: (...args: unknown[]) => mocks.ensureFederatedReplyLink(...args),
+    importAnnounce: (...args: unknown[]) => mocks.importAnnounce(...args),
+    syncOutboxPosts: vi.fn(),
+  },
+}));
+
+import { inboxProcessingService } from '../../../connectors/activitypub/inbox.service';
+
+/** Stub the remote actor (liker/booster/reply-author) resolved via `FederatedActor.findOne`. */
+function stubRemoteActor(oxyUserId: string | null): void {
+  mocks.actorFindOne.mockReturnValue({
+    lean: vi.fn().mockResolvedValue(
+      oxyUserId
+        ? { uri: ACTOR_URI, oxyUserId, lastFetchedAt: new Date() }
+        : { uri: ACTOR_URI, lastFetchedAt: new Date() },
+    ),
+  });
+}
+
+/**
+ * Routes every `Post.findOne` call by its filter shape:
+ *  - `resolvePostIdFromObjectUri`'s local-post-exists check (`status` present)
+ *  - `isLocalPostOwnerSharingEnabled` (owner gate) AND
+ *    `notifyLocalPostOwnerOfEngagement` (owner notify) — both bare `{_id}`,
+ *    served by the same `owner` doc (gate reads oxyUserId/federation; notify
+ *    reads authorship/federation).
+ */
+function stubPostFindOne(options: {
+  localPostExists?: boolean;
+  owner?: { oxyUserId?: string | null; federation?: unknown; authorship?: unknown } | null;
+} = {}): void {
+  const {
+    localPostExists = true,
+    owner = { oxyUserId: OWNER_OXY_ID, federation: null, authorship: OWNER_AUTHORSHIP },
+  } = options;
+  mocks.postFindOne.mockImplementation((filter: Record<string, unknown>) => ({
+    lean: async () => {
+      if ('status' in filter) return localPostExists ? { _id: filter._id } : null;
+      return owner;
+    },
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.followExists.mockResolvedValue({ _id: 'follow_1' });
+  mocks.postExists.mockResolvedValue(null);
+  mocks.postUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  mocks.likeCreate.mockResolvedValue({ _id: 'like_1' });
+  mocks.postCreatorCreate.mockResolvedValue({ _id: CREATED_REPLY_ID });
+  mocks.ensureFederatedReplyLink.mockResolvedValue({ parentPostId: TARGET_POST_ID, threadId: TARGET_POST_ID });
+  mocks.importAnnounce.mockResolvedValue(true);
+  mocks.isFediverseSharingEnabled.mockResolvedValue(true);
+  mocks.createPostAuthorNotifications.mockResolvedValue(undefined);
+  stubRemoteActor(ACTOR_OXY_ID);
+  stubPostFindOne();
+});
+
+// ---------------------------------------------------------------------------
+// handleLike
+// ---------------------------------------------------------------------------
+
+describe('handleLike — local owner like notification', () => {
+  function likeActivity() {
+    return { id: `${ACTOR_URI}/likes/1`, type: 'Like' as const, actor: ACTOR_URI, object: TARGET_POST_URI };
+  }
+
+  it('notifies the owner (type:"like") on a NEW inbound like, mirroring the native shape', async () => {
+    await inboxProcessingService.processInboxActivity(likeActivity(), ACTOR_URI);
+
+    expect(mocks.likeCreate).toHaveBeenCalledWith({ userId: ACTOR_OXY_ID, postId: TARGET_POST_ID, value: 1 });
+    expect(mocks.createPostAuthorNotifications).toHaveBeenCalledWith(OWNER_AUTHORSHIP, {
+      actorId: ACTOR_OXY_ID,
+      type: 'like',
+      entityId: TARGET_POST_ID,
+      entityType: 'post',
+    });
+  });
+
+  it('does NOT notify on a redelivered duplicate like (duplicate-key insert)', async () => {
+    mocks.likeCreate.mockRejectedValueOnce(Object.assign(new Error('dup'), { code: 11000 }));
+
+    await inboxProcessingService.processInboxActivity(likeActivity(), ACTOR_URI);
+
+    expect(mocks.likeCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.postUpdateOne).not.toHaveBeenCalled();
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify when the owner has fediverse sharing off', async () => {
+    mocks.isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await inboxProcessingService.processInboxActivity(likeActivity(), ACTOR_URI);
+
+    expect(mocks.likeCreate).not.toHaveBeenCalled();
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify when the liker actor is unresolved', async () => {
+    stubRemoteActor(null);
+
+    await inboxProcessingService.processInboxActivity(likeActivity(), ACTOR_URI);
+
+    expect(mocks.likeCreate).not.toHaveBeenCalled();
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('records the like but does NOT notify for a REMOTE-owned/mirrored target (no local inbox)', async () => {
+    stubPostFindOne({
+      owner: { oxyUserId: 'remote_oxy_1', federation: { activityId: 'https://remote.example/1' }, authorship: OWNER_AUTHORSHIP },
+    });
+
+    await inboxProcessingService.processInboxActivity(likeActivity(), ACTOR_URI);
+
+    expect(mocks.likeCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('is fail-soft: a notification failure never fails the inbox activity', async () => {
+    mocks.createPostAuthorNotifications.mockRejectedValueOnce(new Error('notif backend down'));
+
+    await expect(
+      inboxProcessingService.processInboxActivity(likeActivity(), ACTOR_URI),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.likeCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.postUpdateOne).toHaveBeenCalledTimes(1);
+    expect(mocks.loggerWarn).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAnnounce
+// ---------------------------------------------------------------------------
+
+describe('handleAnnounce — local owner boost notification', () => {
+  function announceActivity() {
+    return {
+      id: `${ACTOR_URI}/announces/1`,
+      type: 'Announce' as const,
+      actor: ACTOR_URI,
+      object: TARGET_POST_URI,
+      published: new Date().toISOString(),
+    };
+  }
+
+  it('notifies the owner (type:"boost") when a NEW boost is imported', async () => {
+    await inboxProcessingService.processInboxActivity(announceActivity(), ACTOR_URI);
+
+    expect(mocks.importAnnounce).toHaveBeenCalledTimes(1);
+    expect(mocks.createPostAuthorNotifications).toHaveBeenCalledWith(OWNER_AUTHORSHIP, {
+      actorId: ACTOR_OXY_ID,
+      type: 'boost',
+      entityId: TARGET_POST_ID,
+      entityType: 'post',
+    });
+  });
+
+  it('does NOT notify on a redelivered Announce (importAnnounce reports no new boost)', async () => {
+    mocks.importAnnounce.mockResolvedValue(false);
+
+    await inboxProcessingService.processInboxActivity(announceActivity(), ACTOR_URI);
+
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify when the owner has fediverse sharing off', async () => {
+    mocks.isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await inboxProcessingService.processInboxActivity(announceActivity(), ACTOR_URI);
+
+    expect(mocks.importAnnounce).not.toHaveBeenCalled();
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify when the booster actor is unresolved', async () => {
+    stubRemoteActor(null);
+
+    await inboxProcessingService.processInboxActivity(announceActivity(), ACTOR_URI);
+
+    expect(mocks.importAnnounce).not.toHaveBeenCalled();
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('imports the boost but does NOT notify for a REMOTE-owned/mirrored target', async () => {
+    stubPostFindOne({
+      owner: { oxyUserId: 'remote_oxy_1', federation: { activityId: 'https://remote.example/1' }, authorship: OWNER_AUTHORSHIP },
+    });
+
+    await inboxProcessingService.processInboxActivity(announceActivity(), ACTOR_URI);
+
+    expect(mocks.importAnnounce).toHaveBeenCalledTimes(1);
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCreate (federated reply)
+// ---------------------------------------------------------------------------
+
+describe('handleCreate — reply notification to the local parent owner', () => {
+  function replyActivity() {
+    return {
+      id: `${ACTOR_URI}/statuses/900/activity`,
+      type: 'Create' as const,
+      actor: ACTOR_URI,
+      object: {
+        id: `${ACTOR_URI}/statuses/900`,
+        type: 'Note' as const,
+        attributedTo: ACTOR_URI,
+        content: '<p>nice post</p>',
+        to: ['https://www.w3.org/ns/activitystreams#Public'],
+        inReplyTo: TARGET_POST_URI,
+      },
+    };
+  }
+
+  it('notifies the parent owner (type:"reply", entityId = the new reply post) on a NEW reply', async () => {
+    await inboxProcessingService.processInboxActivity(replyActivity(), ACTOR_URI);
+
+    expect(mocks.postCreatorCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.createPostAuthorNotifications).toHaveBeenCalledWith(OWNER_AUTHORSHIP, {
+      actorId: ACTOR_OXY_ID,
+      type: 'reply',
+      entityId: CREATED_REPLY_ID,
+      entityType: 'reply',
+    });
+  });
+
+  it('does NOT notify on a redelivered reply (activityId already stored)', async () => {
+    mocks.postExists.mockResolvedValue({ _id: 'already_here' });
+
+    await inboxProcessingService.processInboxActivity(replyActivity(), ACTOR_URI);
+
+    expect(mocks.postCreatorCreate).not.toHaveBeenCalled();
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify when the parent owner has fediverse sharing off (reply dropped)', async () => {
+    mocks.isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await inboxProcessingService.processInboxActivity(replyActivity(), ACTOR_URI);
+
+    expect(mocks.postCreatorCreate).not.toHaveBeenCalled();
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify for a REMOTE-owned/mirrored parent (materialized but no local inbox)', async () => {
+    stubPostFindOne({
+      owner: { oxyUserId: 'remote_oxy_1', federation: { activityId: 'https://remote.example/1' }, authorship: OWNER_AUTHORSHIP },
+    });
+
+    await inboxProcessingService.processInboxActivity(replyActivity(), ACTOR_URI);
+
+    expect(mocks.postCreatorCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify for a non-reply top-level federated post (no parent)', async () => {
+    mocks.ensureFederatedReplyLink.mockResolvedValue(null);
+    const activity = replyActivity();
+    delete (activity.object as { inReplyTo?: unknown }).inReplyTo;
+
+    await inboxProcessingService.processInboxActivity(activity, ACTOR_URI);
+
+    expect(mocks.postCreatorCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.createPostAuthorNotifications).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/activitypub/mentionFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/mentionFederation.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound @mention federation: a Mention post stores mentions inline as internal
+ * `[mention:<oxyUserId>]` placeholders + a `mentions` id allowlist. The Note
+ * builder MUST resolve those to Mastodon mention anchors + `Mention` tags — never
+ * ship the raw placeholder — and, for REMOTE mentioned users, `cc` their actor and
+ * deliver to their inbox so their instance receives + notifies the post.
+ *
+ * These pin the ONE convergence point (`FollowService.federateNewPost` →
+ * `resolveMentionContext` → `buildCreateNoteActivity`):
+ *   - a post mentioning a REMOTE user → mention anchor in `content`, a `Mention`
+ *     tag, the remote actor in `cc`, and its inbox unioned into delivery;
+ *   - a post mentioning a LOCAL user → a local mention anchor/tag, NO cc, NO extra
+ *     inbox;
+ *   - the content NEVER contains a `[mention:` substring;
+ *   - a hashtag still emits its `Hashtag` tag alongside a mention;
+ *   - the reply-parent `Mention` is NOT duplicated when the parent is also @mentioned.
+ *
+ * The delivery/queue layer, the models, and the Oxy client are mocked so the real
+ * `FollowService` runs in isolation; assertions read the captured `enqueueDelivery`
+ * calls (mirroring the reply-federation test harness).
+ */
+
+const {
+  enqueueDelivery,
+  isFediverseSharingEnabled,
+  getUsersByIds,
+  getUserById,
+  followFindLean,
+  actorFindLean,
+  actorFindSelectLean,
+  actorFindOneLean,
+  postFindByIdLean,
+  insertMany,
+} = vi.hoisted(() => ({
+  enqueueDelivery: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  getUsersByIds: vi.fn(),
+  getUserById: vi.fn(),
+  followFindLean: vi.fn(),
+  actorFindLean: vi.fn(),
+  actorFindSelectLean: vi.fn(),
+  actorFindOneLean: vi.fn(),
+  postFindByIdLean: vi.fn(),
+  insertMany: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../connectors/activitypub/constants')>(
+    '../../../connectors/activitypub/constants',
+  );
+  return { ...actual, FEDERATION_ENABLED: true };
+});
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey: vi.fn(), signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery, enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    // `resolveMentionEntries` reads `find({ oxyUserId }).select(...).lean()`;
+    // `deliverToFollowers` reads `find({ uri }).lean()`; both chains are stubbed.
+    find: () => ({
+      select: () => ({ lean: () => actorFindSelectLean() }),
+      lean: () => actorFindLean(),
+    }),
+    findOne: () => ({ lean: () => actorFindOneLean() }),
+  },
+}));
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { find: () => ({ lean: () => followFindLean() }) },
+}));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: { insertMany, create: vi.fn() },
+}));
+vi.mock('../../../models/Post', () => ({
+  Post: { findById: () => ({ select: () => ({ lean: () => postFindByIdLean() }) }) },
+}));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+}));
+vi.mock('../../../services/fediverseSharing', () => ({ isFediverseSharingEnabled }));
+vi.mock('../../../utils/oxyHelpers', () => ({ getServiceOxyClient: () => ({ getUsersByIds, getUserById }) }));
+
+import { followService, type NoteMentionContext } from '../../../connectors/activitypub/follow.service';
+
+const ISO = '2024-05-06T07:08:09.000Z';
+const ALICE_ACTOR = 'https://mention.earth/ap/users/alice';
+const ALICE_FOLLOWERS = `${ALICE_ACTOR}/followers`;
+const AP_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
+
+/** A top-level post as the seam hands it to `federateNewPost`. */
+function mentionPost(text: string, mentions: string[], hashtags?: string[]): {
+  _id: string;
+  content: { variants: Array<{ source: 'author'; text: string; tag: string }> };
+  mentions: string[];
+  hashtags?: string[];
+  createdAt: string;
+  visibility: string;
+} {
+  return {
+    _id: 'post1',
+    content: { variants: [{ source: 'author', text, tag: 'en' }] },
+    mentions,
+    ...(hashtags ? { hashtags } : {}),
+    createdAt: ISO,
+    visibility: 'public',
+  };
+}
+
+function deliveredInboxes(): string[] {
+  return enqueueDelivery.mock.calls.map((c) => (c[0] as { targetInbox: string }).targetInbox);
+}
+function deliveredNote(): Record<string, unknown> {
+  const activity = (enqueueDelivery.mock.calls[0]?.[0] as { activityJson: Record<string, unknown> }).activityJson;
+  return activity.object as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueDelivery.mockResolvedValue(true);
+  isFediverseSharingEnabled.mockResolvedValue(true);
+  followFindLean.mockResolvedValue([{ remoteActorUri: 'https://foo.example/users/x' }]);
+  actorFindLean.mockResolvedValue([{ sharedInboxUrl: 'https://foo.example/inbox' }]);
+  actorFindSelectLean.mockResolvedValue([]);
+  actorFindOneLean.mockResolvedValue(null);
+  postFindByIdLean.mockResolvedValue(null);
+  getUsersByIds.mockResolvedValue([]);
+});
+
+describe('federateNewPost — mentions a REMOTE user', () => {
+  beforeEach(() => {
+    // The mentioned user resolves to a FederatedActor row (href + acct + inbox).
+    actorFindSelectLean.mockResolvedValue([
+      {
+        oxyUserId: 'remote-oxy-id',
+        uri: 'https://remote.social/users/bob',
+        acct: 'bob@remote.social',
+        sharedInboxUrl: 'https://remote.social/inbox',
+      },
+    ]);
+  });
+
+  it('emits a mention anchor + Mention tag + remote cc, and never leaks the placeholder', async () => {
+    await followService.federateNewPost(
+      mentionPost('hey [mention:remote-oxy-id] look', ['remote-oxy-id']),
+      'author-oxy',
+      'alice',
+    );
+
+    const note = deliveredNote();
+    // The body carries a resolved Mastodon mention anchor — NOT the raw placeholder.
+    expect(note.content).toBe(
+      '<p>hey <a href="https://remote.social/users/bob" class="u-url mention">@bob@remote.social</a> look</p>',
+    );
+    expect(String(note.content)).not.toContain('[mention:');
+
+    // A Mention tag threads + notifies the remote author.
+    expect(note.tag).toContainEqual({
+      type: 'Mention',
+      href: 'https://remote.social/users/bob',
+      name: '@bob@remote.social',
+    });
+
+    // The remote mentioned actor joins cc (public collection stays in `to`).
+    expect(note.cc).toEqual([ALICE_FOLLOWERS, 'https://remote.social/users/bob']);
+    expect(note.to).toEqual([AP_PUBLIC]);
+  });
+
+  it('unions the mentioned remote user inbox into delivery (deduped with followers)', async () => {
+    await followService.federateNewPost(
+      mentionPost('yo [mention:remote-oxy-id]', ['remote-oxy-id']),
+      'author-oxy',
+      'alice',
+    );
+
+    expect(deliveredInboxes().sort()).toEqual(
+      ['https://foo.example/inbox', 'https://remote.social/inbox'].sort(),
+    );
+  });
+});
+
+describe('federateNewPost — mentions a LOCAL user', () => {
+  it('emits a local mention anchor/tag, adds NO cc and NO extra inbox', async () => {
+    // No federated actor row → resolved as a local Oxy user via the bulk lookup.
+    actorFindSelectLean.mockResolvedValue([]);
+    getUsersByIds.mockResolvedValue([{ id: 'local-oxy-id', username: 'carol', name: { displayName: 'Carol' } }]);
+
+    await followService.federateNewPost(
+      mentionPost('hi [mention:local-oxy-id]', ['local-oxy-id']),
+      'author-oxy',
+      'alice',
+    );
+
+    const note = deliveredNote();
+    expect(note.content).toBe(
+      '<p>hi <a href="https://mention.earth/ap/users/carol" class="u-url mention">@carol</a></p>',
+    );
+    expect(note.tag).toContainEqual({
+      type: 'Mention',
+      href: 'https://mention.earth/ap/users/carol',
+      name: '@carol',
+    });
+    // A local mention is reached through the author's own followers — never cc'd
+    // to a remote collection, never an extra remote inbox.
+    expect(note.cc).toEqual([ALICE_FOLLOWERS]);
+    expect(deliveredInboxes()).toEqual(['https://foo.example/inbox']);
+  });
+});
+
+describe('federateNewPost — hashtag alongside a mention', () => {
+  it('still emits the Hashtag tag when the post also mentions someone', async () => {
+    getUsersByIds.mockResolvedValue([{ id: 'local-oxy-id', username: 'carol', name: { displayName: 'Carol' } }]);
+
+    await followService.federateNewPost(
+      mentionPost('hi [mention:local-oxy-id] #news', ['local-oxy-id'], ['news']),
+      'author-oxy',
+      'alice',
+    );
+
+    const tags = deliveredNote().tag as Array<Record<string, string>>;
+    expect(tags).toContainEqual({ type: 'Hashtag', href: 'https://mention.earth/hashtag/news', name: '#news' });
+    expect(tags).toContainEqual({
+      type: 'Mention',
+      href: 'https://mention.earth/ap/users/carol',
+      name: '@carol',
+    });
+  });
+});
+
+describe('buildCreateNoteActivity — mention/reply Mention dedup', () => {
+  it('does not duplicate the reply-parent Mention when the parent author is also @mentioned', () => {
+    // The reply parent AND the @mention resolve to the SAME actor href.
+    const sharedHref = 'https://remote.social/users/bob';
+    const reply = { inReplyTo: 'https://remote.social/users/bob/statuses/9', mention: { href: sharedHref, name: '@bob@remote.social' } };
+    const mentions: NoteMentionContext = {
+      links: new Map([['remote-oxy-id', { href: sharedHref, handle: 'bob@remote.social' }]]),
+      tags: [{ type: 'Mention', href: sharedHref, name: '@bob@remote.social' }],
+      cc: [sharedHref],
+      inboxes: ['https://remote.social/inbox'],
+    };
+
+    const activity = followService.buildCreateNoteActivity(
+      { _id: 'p1', content: { variants: [{ source: 'author', text: 'reply to [mention:remote-oxy-id]', tag: 'en' }] }, mentions: ['remote-oxy-id'], createdAt: ISO, parentPostId: 'parent1' },
+      'alice',
+      reply,
+      mentions,
+    );
+    const note = activity.object as Record<string, unknown>;
+
+    const mentionTags = (note.tag as Array<Record<string, string>>).filter((t) => t.type === 'Mention');
+    expect(mentionTags).toEqual([{ type: 'Mention', href: sharedHref, name: '@bob@remote.social' }]);
+    // cc carries the shared href exactly once.
+    expect(note.cc).toEqual([ALICE_FOLLOWERS, sharedHref]);
+  });
+});

--- a/packages/backend/src/__tests__/utils/linkifyApHtml.test.ts
+++ b/packages/backend/src/__tests__/utils/linkifyApHtml.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { linkifyApHtml, type ApMentionLink, type LinkifyApHtmlOptions } from '../../utils/federation/linkifyApHtml';
+
+/**
+ * The outbound plain-text → ActivityPub `content` HTML LINKIFIER: it turns
+ * `[mention:<id>]` placeholders into Mastodon mention anchors, `#tags` into
+ * hashtag anchors, and bare URLs into links — while preserving the paragraph/`<br>`
+ * structure of {@link plainTextToApHtml} and, critically, NEVER leaking the
+ * internal placeholder to the wire.
+ *
+ * These pin the SEGMENT/TOKEN escaping contract: only plain-text spans and the
+ * VISIBLE label of a link are HTML-escaped, every href is attribute-escaped, and
+ * nothing is escaped twice or corrupts an injected anchor.
+ */
+
+const MENTIONS: ReadonlyMap<string, ApMentionLink> = new Map([
+  ['u1', { href: 'https://mention.earth/ap/users/alice', handle: 'alice' }],
+  ['u2', { href: 'https://remote.social/users/bob', handle: 'bob@remote.social' }],
+]);
+
+// A hashtag href builder mirroring the real one (normalize → lowercase → encode)
+// so the anchor href matches the Note's `Hashtag` tag shape.
+const hashtagHref = (tag: string): string => `https://mention.earth/hashtag/${encodeURIComponent(tag.toLowerCase())}`;
+
+const opts: LinkifyApHtmlOptions = { mentions: MENTIONS, hashtagHref };
+
+describe('linkifyApHtml — @mentions', () => {
+  it('renders a LOCAL mention as a Mastodon mention anchor (@username)', () => {
+    expect(linkifyApHtml('hi [mention:u1]!', opts)).toBe(
+      '<p>hi <a href="https://mention.earth/ap/users/alice" class="u-url mention">@alice</a>!</p>',
+    );
+  });
+
+  it('renders a FEDERATED mention as @user@domain pointing at the remote actor uri', () => {
+    expect(linkifyApHtml('cc [mention:u2]', opts)).toBe(
+      '<p>cc <a href="https://remote.social/users/bob" class="u-url mention">@bob@remote.social</a></p>',
+    );
+  });
+
+  it('resolves every occurrence of a repeated placeholder and NEVER leaves a [mention: substring', () => {
+    const out = linkifyApHtml('[mention:u1] and again [mention:u1]', opts);
+    expect(out).toBe(
+      '<p><a href="https://mention.earth/ap/users/alice" class="u-url mention">@alice</a> and again ' +
+        '<a href="https://mention.earth/ap/users/alice" class="u-url mention">@alice</a></p>',
+    );
+    expect(out).not.toContain('[mention:');
+  });
+
+  it('DROPS an unresolved/undeclared placeholder — the internal id must never reach the wire', () => {
+    expect(linkifyApHtml('who is [mention:u9]?', opts)).toBe('<p>who is ?</p>');
+    // With no mentions map at all, every placeholder is dropped too; a trailing
+    // placeholder leaves no stray space (the paragraph trim cleans it).
+    expect(linkifyApHtml('gone [mention:u1]', { hashtagHref })).toBe('<p>gone</p>');
+  });
+});
+
+describe('linkifyApHtml — #hashtags', () => {
+  it('wraps a #tag, preserving case in the label but normalizing the href', () => {
+    expect(linkifyApHtml('big #News today', opts)).toBe(
+      '<p>big <a href="https://mention.earth/hashtag/news" class="mention hashtag" rel="tag">#News</a> today</p>',
+    );
+  });
+
+  it('leaves #tags as plain text when no hashtagHref is supplied', () => {
+    expect(linkifyApHtml('big #News', {})).toBe('<p>big #News</p>');
+  });
+});
+
+describe('linkifyApHtml — URLs', () => {
+  it('wraps a bare http(s) URL', () => {
+    expect(linkifyApHtml('see https://example.com/x', opts)).toBe(
+      '<p>see <a href="https://example.com/x">https://example.com/x</a></p>',
+    );
+  });
+
+  it('leaves trailing sentence punctuation OUTSIDE the link', () => {
+    expect(linkifyApHtml('go to https://example.com.', opts)).toBe(
+      '<p>go to <a href="https://example.com">https://example.com</a>.</p>',
+    );
+  });
+
+  it('escapes an ampersand in a query string in BOTH the href and the label (no double-escape)', () => {
+    expect(linkifyApHtml('https://x.com/a?b=1&c=2', opts)).toBe(
+      '<p><a href="https://x.com/a?b=1&amp;c=2">https://x.com/a?b=1&amp;c=2</a></p>',
+    );
+  });
+
+  it('keeps a balanced closing paren but trims an unbalanced one', () => {
+    expect(linkifyApHtml('(see https://en.wikipedia.org/wiki/Foo_(bar))', opts)).toBe(
+      '<p>(see <a href="https://en.wikipedia.org/wiki/Foo_(bar)">https://en.wikipedia.org/wiki/Foo_(bar)</a>)</p>',
+    );
+  });
+});
+
+describe('linkifyApHtml — escaping correctness', () => {
+  it('escapes < & > in surrounding text but never re-escapes the injected anchors', () => {
+    const out = linkifyApHtml('a < b && [mention:u1] <x>', opts);
+    expect(out).toBe(
+      '<p>a &lt; b &amp;&amp; <a href="https://mention.earth/ap/users/alice" class="u-url mention">@alice</a> &lt;x&gt;</p>',
+    );
+    // The anchor markup is intact (not turned into &lt;a&gt;), and no double-escape.
+    expect(out).not.toContain('&amp;lt;');
+    expect(out).not.toContain('&lt;a ');
+  });
+});
+
+describe('linkifyApHtml — composes with paragraphs / <br>', () => {
+  it('linkifies across paragraph and line breaks', () => {
+    expect(linkifyApHtml('hi [mention:u1]\nsecond line\n\nbye #tag', opts)).toBe(
+      '<p>hi <a href="https://mention.earth/ap/users/alice" class="u-url mention">@alice</a><br>second line</p>' +
+        '<p>bye <a href="https://mention.earth/hashtag/tag" class="mention hashtag" rel="tag">#tag</a></p>',
+    );
+  });
+
+  it('mixes a URL, a hashtag and two mentions in one body', () => {
+    expect(linkifyApHtml('[mention:u1] pinged [mention:u2] re https://ex.com #hi', opts)).toBe(
+      '<p><a href="https://mention.earth/ap/users/alice" class="u-url mention">@alice</a> pinged ' +
+        '<a href="https://remote.social/users/bob" class="u-url mention">@bob@remote.social</a> re ' +
+        '<a href="https://ex.com">https://ex.com</a> ' +
+        '<a href="https://mention.earth/hashtag/hi" class="mention hashtag" rel="tag">#hi</a></p>',
+    );
+  });
+
+  it('returns an empty string for an empty/whitespace-only body', () => {
+    expect(linkifyApHtml('', opts)).toBe('');
+    expect(linkifyApHtml('   \n\n ', opts)).toBe('');
+  });
+});

--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -11,7 +11,7 @@ import type {
 import { resolveOxyExternalUser } from '../identity';
 import { isAbsoluteHttpUrl } from '../shared/url';
 import { actorService } from './actor.service';
-import { followService, type NoteSourcePost, type NoteReplyContext } from './follow.service';
+import { followService, type NoteSourcePost, type NoteReplyContext, type NoteMentionContext } from './follow.service';
 import { outboxSyncService } from './outbox.service';
 import { inboxProcessingService } from './inbox.service';
 import { FEDERATION_ENABLED, isBlockedDomain } from './constants';
@@ -289,8 +289,9 @@ class ActivityPubConnector implements NetworkConnector {
     post: NoteSourcePost,
     username: string,
     reply?: NoteReplyContext,
+    mentions?: NoteMentionContext,
   ): Record<string, unknown> {
-    return followService.buildCreateNoteActivity(post, username, reply);
+    return followService.buildCreateNoteActivity(post, username, reply, mentions);
   }
 
   /**
@@ -302,6 +303,26 @@ class ActivityPubConnector implements NetworkConnector {
    */
   resolveReplyContext(post: NoteSourcePost): Promise<NoteReplyContext | null> {
     return followService.resolveReplyContext(post);
+  }
+
+  /**
+   * Resolve a single post's @mention addressing (mention anchors + `Mention` tags
+   * + remote `cc`) for a PULL surface (the per-post dereference route). Null when
+   * the post mentions nobody or nothing resolves. The push path resolves this
+   * internally in {@link FollowService.federateNewPost}, unioning mentioned remote
+   * users' inboxes into delivery.
+   */
+  resolveMentionContext(post: NoteSourcePost): Promise<NoteMentionContext | null> {
+    return followService.resolveMentionContext(post);
+  }
+
+  /**
+   * Batch-resolve @mention addressing for MANY posts by one author (the outbox
+   * page / featured collection) in the same two batched reads a single post costs.
+   * Keyed by post id; a post that mentions nobody is absent from the map.
+   */
+  resolveMentionContextByPost(posts: NoteSourcePost[]): Promise<Map<string, NoteMentionContext>> {
+    return followService.resolveMentionContextByPost(posts);
   }
 
   federateNewPost(

--- a/packages/backend/src/connectors/activitypub/constants.ts
+++ b/packages/backend/src/connectors/activitypub/constants.ts
@@ -75,6 +75,15 @@ export function actorUrl(username: string): string {
   return `https://${ACTOR_DOMAIN}/ap/users/${username}`;
 }
 
+/**
+ * Canonical href for a hashtag — the SINGLE shape shared by the Note's `Hashtag`
+ * `tag` entries and the body linkifier, so a `#tag` in the text and its
+ * machine-readable tag point at the same URL. Mirrors Mastodon's `/tags/:name`.
+ */
+export function hashtagUrl(tag: string): string {
+  return `https://${FEDERATION_DOMAIN}/hashtag/${encodeURIComponent(tag)}`;
+}
+
 export function inboxUrl(username: string): string {
   return `https://${FEDERATION_DOMAIN}/ap/users/${username}/inbox`;
 }

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -12,6 +12,7 @@ import {
   AP_CONTENT_TYPE,
   USER_AGENT,
   actorUrl,
+  hashtagUrl,
   resolveOxyUser,
 } from './constants';
 import { buildLocalActorObject, type ActorUserView } from './actorObject';
@@ -25,7 +26,9 @@ import { actorService } from './actor.service';
 import { fetchUpstreamSingleHop } from '../../utils/safeUpstreamFetch';
 import { assertSafePublicUrl } from '../../utils/ssrfGuard';
 import { resolveMediaRef } from '../../utils/mediaResolver';
-import { plainTextToApHtml } from '../../utils/federation/plainTextToApHtml';
+import { linkifyApHtml, type ApMentionLink, type LinkifyApHtmlOptions } from '../../utils/federation/linkifyApHtml';
+import { normalizeHashtag, normalizeMentionIds } from '../../utils/textProcessing';
+import { getNormalizedUserHandle, type User as OxyUser } from '@oxyhq/core';
 import { isAbsoluteHttpUrl } from '../shared/url';
 
 const DELIVER_ACTIVITY_TIMEOUT_MS = 15000;
@@ -165,6 +168,72 @@ export interface NoteReplyContext {
 }
 
 /**
+ * One resolved @mention of the post's declared `mentions` ids. `href` (a local
+ * minted actor URL or a remote actor URI) is the authoritative resolution key for
+ * both the body anchor and the `Mention` tag; `handle` (no leading `@`) is the
+ * human-readable label. `isRemote` marks a federated mention (added to `cc`), and
+ * `inbox` is its remote delivery inbox when known (unioned into delivery so the
+ * mentioned user's instance receives + notifies the post).
+ */
+interface ResolvedMentionEntry {
+  href: string;
+  handle: string;
+  isRemote: boolean;
+  inbox?: string;
+}
+
+/**
+ * The mention addressing a Note carries: everything resolved from the post's
+ * declared `mentions` (Oxy user ids → `[mention:<id>]` placeholders in the body).
+ * Resolved by the async federation caller (a batched `FederatedActor` read + one
+ * bulk Oxy lookup) and passed into the PURE Note builder so
+ * {@link FollowService.buildCreateNoteActivity} never touches the database.
+ *
+ *  - `links` feeds the linkifier: `[mention:<id>]` → a Mastodon mention anchor;
+ *  - `tags` are the Note's `Mention` `tag` entries (one per resolved mention);
+ *  - `cc` are the REMOTE mentioned actors' hrefs (added to the Note's `cc`);
+ *  - `inboxes` are the remote delivery inboxes unioned into the follower fan-out.
+ */
+export interface NoteMentionContext {
+  links: Map<string, ApMentionLink>;
+  tags: Array<{ type: 'Mention'; href: string; name: string }>;
+  cc: string[];
+  inboxes: string[];
+}
+
+/**
+ * Assemble a per-post {@link NoteMentionContext} from the post's own declared
+ * mention ids and the shared, batch-resolved id → {@link ResolvedMentionEntry}
+ * map. Pure. Deduped by actor `href` so a user mentioned twice (or a mention that
+ * coincides with the reply parent — deduped again in the Note builder) yields a
+ * single `Mention` tag / `cc` / inbox. `links` maps EVERY declared+resolved id
+ * (the linkifier keys on id, so both occurrences of a repeated mention linkify).
+ */
+function buildNoteMentionContext(
+  ids: string[],
+  entries: ReadonlyMap<string, ResolvedMentionEntry>,
+): NoteMentionContext {
+  const links = new Map<string, ApMentionLink>();
+  const tags: Array<{ type: 'Mention'; href: string; name: string }> = [];
+  const cc: string[] = [];
+  const inboxes: string[] = [];
+  const seenHref = new Set<string>();
+
+  for (const id of ids) {
+    const entry = entries.get(id);
+    if (!entry) continue;
+    if (!links.has(id)) links.set(id, { href: entry.href, handle: entry.handle });
+    if (seenHref.has(entry.href)) continue;
+    seenHref.add(entry.href);
+    tags.push({ type: 'Mention', href: entry.href, name: `@${entry.handle}` });
+    if (entry.isRemote) cc.push(entry.href);
+    if (entry.inbox) inboxes.push(entry.inbox);
+  }
+
+  return { links, tags, cc, inboxes };
+}
+
+/**
  * Build the AP `contentMap`: BCP-47 tag → localized body, PRIMARY KEY FIRST.
  *
  * The primary key is inserted before the rest are walked, so it leads the map
@@ -174,10 +243,12 @@ export interface NoteReplyContext {
  * out as `content`, so the two can never disagree byte-for-byte.
  *
  * Every value is AP `content` HTML: each author variant's plain-text body is run
- * through {@link plainTextToApHtml} so a localized body's blank lines and line
- * breaks survive rendering exactly like the primary. Only AUTHOR variants are
- * emitted — a machine translation is derived content: it is not the author's
- * writing and it does not federate.
+ * through {@link linkifyApHtml} (the SAME transform as the primary body) so a
+ * localized body's blank lines/line breaks survive rendering AND its @mentions,
+ * #hashtags and URLs linkify — and, critically, no localized variant ever ships an
+ * internal `[mention:<id>]` placeholder. Only AUTHOR variants are emitted — a
+ * machine translation is derived content: it is not the author's writing and it
+ * does not federate.
  *
  * Returns `undefined` when the post declares no language — an UNTAGGED primary
  * variant (a body too short to detect, a remote Note that declared none) has no
@@ -189,6 +260,7 @@ function buildNoteContentMap(
   post: NoteSourcePost,
   primaryTag: string | undefined,
   primaryContent: string,
+  linkifyOptions: LinkifyApHtmlOptions,
 ): Record<string, string> | undefined {
   const contentMap: Record<string, string> = {};
 
@@ -197,7 +269,7 @@ function buildNoteContentMap(
   for (const variant of authorVariants(post.content)) {
     const tag = canonicalizeLanguageTag(variant.tag);
     if (tag === null || tag in contentMap) continue;
-    contentMap[tag] = plainTextToApHtml(variant.text);
+    contentMap[tag] = linkifyApHtml(variant.text, linkifyOptions);
   }
 
   return Object.keys(contentMap).length > 0 ? contentMap : undefined;
@@ -460,6 +532,7 @@ export class FollowService {
     post: NoteSourcePost,
     username: string,
     reply?: NoteReplyContext,
+    mentions?: NoteMentionContext,
   ): Record<string, unknown> {
     const actor = actorUrl(username);
     const postId = String(post._id);
@@ -471,19 +544,22 @@ export class FollowService {
     const tags: Array<Record<string, string>> = [];
     if (post.hashtags) {
       for (const tag of post.hashtags) {
-        tags.push({
-          type: 'Hashtag',
-          href: `https://${FEDERATION_DOMAIN}/hashtag/${encodeURIComponent(tag)}`,
-          name: `#${tag}`,
-        });
+        tags.push({ type: 'Hashtag', href: hashtagUrl(tag), name: `#${tag}` });
       }
     }
-    // A reply addressed at the parent author: the `Mention` tag is what makes
-    // Mastodon thread the reply under the parent and notify its author. `href`
-    // (the actor uri) is the authoritative resolution key; `name` (`@user@domain`)
-    // is the human-readable handle.
-    if (reply?.mention) {
-      tags.push({ type: 'Mention', href: reply.mention.href, name: reply.mention.name });
+    // `Mention` tags: the reply-parent author (threads + notifies) PLUS every
+    // @mentioned user. `href` (the actor uri) is the authoritative resolution key;
+    // `name` (`@user` / `@user@domain`) is the human-readable handle. Deduped by
+    // href so a parent author who is ALSO @mentioned yields a single tag.
+    const seenMentionHref = new Set<string>();
+    const pushMentionTag = (href: string, name: string): void => {
+      if (!href || seenMentionHref.has(href)) return;
+      seenMentionHref.add(href);
+      tags.push({ type: 'Mention', href, name });
+    };
+    if (reply?.mention) pushMentionTag(reply.mention.href, reply.mention.name);
+    if (mentions) {
+      for (const tag of mentions.tags) pushMentionTag(tag.href, tag.name);
     }
 
     // The primary rendition: its body, its media (shared or overridden, alt
@@ -496,21 +572,35 @@ export class FollowService {
           .filter((a): a is Record<string, unknown> => a !== undefined)
       : [];
 
-    // AP `content` is HTML: convert the resolved plain-text primary body ONCE and
+    // AP `content` is HTML: linkify the resolved plain-text primary body ONCE
+    // (@mentions/#hashtags/URLs → anchors, internal placeholders resolved) and
     // thread the result through both `content` and the primary `contentMap` key so
     // they stay byte-for-byte identical (Mastodon reads `content` and only falls
-    // back to `contentMap`, but the two must never disagree). This preserves the
-    // author's blank lines and line breaks, which HTML would otherwise collapse.
-    const primaryContent = plainTextToApHtml(primary.text);
+    // back to `contentMap`, but the two must never disagree). Both go through the
+    // SAME linkify options so every rendition resolves mentions identically.
+    const linkifyOptions: LinkifyApHtmlOptions = {
+      mentions: mentions?.links,
+      hashtagHref: (tag) => hashtagUrl(normalizeHashtag(tag)),
+    };
+    const primaryContent = linkifyApHtml(primary.text, linkifyOptions);
     const language = canonicalizeLanguageTag(primary.tag) ?? undefined;
-    const contentMap = buildNoteContentMap(post, language, primaryContent);
+    const contentMap = buildNoteContentMap(post, language, primaryContent, linkifyOptions);
 
-    // The public collection stays in `to`; the mentioned parent author joins the
-    // followers collection in `cc` so a public reply is delivered/attributed to
-    // them (mirrors how the boost path cc's the boosted author). Same set on the
-    // Create envelope and the embedded Note.
+    // The public collection stays in `to`; the mentioned parent author + every
+    // REMOTE @mentioned actor join the followers collection in `cc` so a public
+    // reply/mention is delivered/attributed to them (mirrors how the boost path
+    // cc's the boosted author). Deduped, same set on the Create envelope + Note.
     const cc = [`${actor}/followers`];
-    if (reply?.mention) cc.push(reply.mention.href);
+    const seenCc = new Set(cc);
+    const pushCc = (href: string): void => {
+      if (!href || seenCc.has(href)) return;
+      seenCc.add(href);
+      cc.push(href);
+    };
+    if (reply?.mention) pushCc(reply.mention.href);
+    if (mentions) {
+      for (const href of mentions.cc) pushCc(href);
+    }
 
     return {
       '@context': AP_CONTEXT,
@@ -578,9 +668,17 @@ export class FollowService {
       // `null`, so the Note federates as a normal post (no `inReplyTo`) rather
       // than being dropped.
       const reply = await this.resolveReplyDelivery(post);
-      const activity = this.buildCreateNoteActivity(post, senderUsername, reply?.context);
+      // The post's @mentions: resolved to mention anchors + `Mention` tags, and —
+      // for REMOTE mentioned users — their inboxes are unioned into delivery so
+      // their instance receives + notifies the post. `null` when the post mentions
+      // nobody; the linkifier still strips any stray placeholder.
+      const mentions = await this.resolveMentionContext(post);
+      const activity = this.buildCreateNoteActivity(post, senderUsername, reply?.context, mentions ?? undefined);
       await this.deliverToFollowers(activity, senderOxyUserId, senderUsername, {
-        extraInboxes: reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : [],
+        extraInboxes: [
+          ...(reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : []),
+          ...(mentions?.inboxes ?? []),
+        ],
       });
     } catch (err) {
       logger.error('Failed to federate new post:', err);
@@ -647,6 +745,137 @@ export class FollowService {
       logger.warn(`[FedDeliver] failed to resolve reply delivery for parent ${parentId}:`, err);
       return null;
     }
+  }
+
+  /**
+   * Resolve a set of mentioned Oxy user ids to their per-mention addressing
+   * ({@link ResolvedMentionEntry}) in AT MOST two batched reads — no N+1 per
+   * mention:
+   *
+   *  1. ONE {@link FederatedActor} query resolves every FEDERATED mention at once,
+   *     yielding its actor URI (`href`), `acct` (`user@domain` handle) AND the
+   *     delivery inbox from the same row.
+   *  2. The remaining ids are LOCAL Oxy users (or a federated user whose actor row
+   *     is momentarily missing); ONE bulk `getUsersByIds` resolves their canonical
+   *     handle. A local user → our minted actor URL + bare `username`; a federated
+   *     user with a known `federation.actorUri` → that URI + `user@domain` (no
+   *     inbox, so tag/cc only).
+   *
+   * Fail-soft: an unresolvable id is simply absent from the map (the linkifier
+   * then DROPS its placeholder — never leaks `[mention:<id>]`). A degraded Oxy
+   * user (empty handle) is treated as unresolved. Best-effort — a lookup error is
+   * logged and yields no entries for that batch rather than throwing.
+   */
+  private async resolveMentionEntries(ids: string[]): Promise<Map<string, ResolvedMentionEntry>> {
+    const entries = new Map<string, ResolvedMentionEntry>();
+    const unique = [...new Set(ids)];
+    if (unique.length === 0) return entries;
+
+    // 1. Federated mentions — one read gives href (actor uri), handle (acct) and
+    //    the delivery inbox.
+    let federatedActors: Array<
+      Pick<IFederatedActor, 'oxyUserId' | 'uri' | 'acct' | 'sharedInboxUrl' | 'inboxUrl'>
+    > = [];
+    try {
+      federatedActors = await FederatedActor.find({ oxyUserId: { $in: unique } })
+        .select('oxyUserId uri acct sharedInboxUrl inboxUrl')
+        .lean<Array<Pick<IFederatedActor, 'oxyUserId' | 'uri' | 'acct' | 'sharedInboxUrl' | 'inboxUrl'>>>();
+    } catch (err) {
+      logger.warn('[FedDeliver] mention federated-actor lookup failed', {
+        count: unique.length,
+        reason: err instanceof Error ? err.message : 'unknown',
+      });
+    }
+
+    const federatedIds = new Set<string>();
+    for (const actor of federatedActors) {
+      const id = actor.oxyUserId ? String(actor.oxyUserId) : '';
+      if (!id || !actor.uri || !actor.acct) continue;
+      federatedIds.add(id);
+      entries.set(id, {
+        href: actor.uri,
+        handle: actor.acct,
+        isRemote: true,
+        inbox: actor.sharedInboxUrl ?? actor.inboxUrl ?? undefined,
+      });
+    }
+
+    // 2. The rest are local (or federated-without-a-row) — one bulk Oxy lookup.
+    const localIds = unique.filter((id) => !federatedIds.has(id));
+    if (localIds.length === 0) return entries;
+
+    let users: OxyUser[] = [];
+    try {
+      users = await getServiceOxyClient().getUsersByIds(localIds);
+    } catch (err) {
+      logger.warn('[FedDeliver] mention Oxy user lookup failed', {
+        count: localIds.length,
+        reason: err instanceof Error ? err.message : 'unknown',
+      });
+      return entries;
+    }
+
+    for (const user of users) {
+      const id = String(user.id ?? '');
+      if (!id) continue;
+      // Canonical handle: `username` (local) or `username@domain` (federated). An
+      // empty handle is a degraded/unresolved user — drop it, never emit a ghost.
+      const handle = getNormalizedUserHandle(user);
+      if (!handle) continue;
+      const isRemote = user.type === 'federated' || user.isFederated === true;
+      const href = isRemote
+        ? (typeof user.federation?.actorUri === 'string' && user.federation.actorUri.length > 0
+            ? user.federation.actorUri
+            : undefined)
+        : actorUrl(handle);
+      if (!href) continue; // federated user with no resolvable actor uri → drop.
+      entries.set(id, { href, handle, isRemote });
+    }
+
+    return entries;
+  }
+
+  /**
+   * Batch-resolve the {@link NoteMentionContext} for MANY posts by the same author
+   * (the outbox page / featured collection) in the SAME two batched reads a single
+   * post costs — the union of every post's declared mention ids is resolved once,
+   * then each post's context is assembled from the shared id → entry map. A post
+   * that mentions nobody (or whose mentions all fail to resolve) is absent from the
+   * returned map; the Note builder then simply linkifies without a mention context.
+   */
+  async resolveMentionContextByPost(posts: NoteSourcePost[]): Promise<Map<string, NoteMentionContext>> {
+    const result = new Map<string, NoteMentionContext>();
+    const perPostIds = new Map<string, string[]>();
+    const allIds: string[] = [];
+
+    for (const post of posts) {
+      const ids = normalizeMentionIds(post.mentions);
+      if (ids.length === 0) continue;
+      perPostIds.set(String(post._id), ids);
+      allIds.push(...ids);
+    }
+    if (allIds.length === 0) return result;
+
+    const entries = await this.resolveMentionEntries(allIds);
+    for (const [postId, ids] of perPostIds) {
+      const context = buildNoteMentionContext(ids, entries);
+      if (context.links.size > 0) result.set(postId, context);
+    }
+    return result;
+  }
+
+  /**
+   * Resolve a single post's {@link NoteMentionContext} — the push-delivery and
+   * per-post dereference entry point. Returns null when the post mentions nobody
+   * or nothing resolves (the linkifier still strips any stray placeholder). Never
+   * throws — {@link resolveMentionEntries} is fail-soft.
+   */
+  async resolveMentionContext(post: NoteSourcePost): Promise<NoteMentionContext | null> {
+    const ids = normalizeMentionIds(post.mentions);
+    if (ids.length === 0) return null;
+    const entries = await this.resolveMentionEntries(ids);
+    const context = buildNoteMentionContext(ids, entries);
+    return context.links.size > 0 ? context : null;
   }
 
   /**
@@ -904,8 +1133,9 @@ export class FollowService {
     post: NoteSourcePost,
     username: string,
     reply?: NoteReplyContext,
+    mentions?: NoteMentionContext,
   ): Record<string, unknown> {
-    const created = this.buildCreateNoteActivity(post, username, reply);
+    const created = this.buildCreateNoteActivity(post, username, reply, mentions);
     const note = created.object as Record<string, unknown>;
 
     const now = new Date();
@@ -949,9 +1179,13 @@ export class FollowService {
 
     try {
       const reply = await this.resolveReplyDelivery(post);
-      const activity = this.buildUpdateNoteActivity(post, editorUsername, reply?.context);
+      const mentions = await this.resolveMentionContext(post);
+      const activity = this.buildUpdateNoteActivity(post, editorUsername, reply?.context, mentions ?? undefined);
       await this.deliverToFollowers(activity, editorOxyUserId, editorUsername, {
-        extraInboxes: reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : [],
+        extraInboxes: [
+          ...(reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : []),
+          ...(mentions?.inboxes ?? []),
+        ],
       });
     } catch (err) {
       logger.error('Failed to federate post update:', err);

--- a/packages/backend/src/connectors/activitypub/inbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/inbox.service.ts
@@ -9,6 +9,7 @@ import {
   resolveOxyUser,
 } from './constants';
 import { PostType } from '@mention/shared-types';
+import type { PostAuthorshipEntry } from '@mention/shared-types';
 import { extractApLanguage, extractApLanguages } from './apLanguage';
 import { getPostCreator } from '../../services/serviceRegistry';
 import { isFediverseSharingEnabled, isFediverseSharingEnabledFromUser } from '../../services/fediverseSharing';
@@ -170,6 +171,61 @@ export class InboxProcessingService {
     ).lean<{ oxyUserId?: string | null; federation?: unknown } | null>();
     if (!post || post.federation != null || !post.oxyUserId) return true;
     return isFediverseSharingEnabled(post.oxyUserId);
+  }
+
+  /**
+   * Best-effort: notify the LOCAL owner (+ accepted collaborators) of `postId`
+   * about a NEW inbound federated engagement, mirroring the NATIVE
+   * like/boost/reply notification (`createPostAuthorNotifications` — the SAME
+   * util the local `posts.controller` like path and `PostCreationService`
+   * reply/boost path call) so a Mastodon like/boost/reply on a Mention post
+   * reaches the owner's notifications exactly like the local equivalent.
+   *
+   * No-op when the post is gone or REMOTE-owned/mirrored (`federation != null`):
+   * a mirrored post's "owner" is a federated actor with no Mention inbox, so the
+   * only meaningful recipient is a real local author. Consent and actor
+   * resolution are already enforced by every caller (this only ever runs after
+   * the engagement was recorded against a sharing-enabled local target by a
+   * resolved actor); self-notification is prevented by `createNotification`.
+   *
+   * NEVER throws — a notification failure must not fail (and thus retry) the
+   * inbox activity, mirroring {@link handleIncomingFollow}'s fail-soft notify.
+   * Uses the same lazy import as the follow path to avoid the load-time cycle
+   * (`notificationUtils` reaches the `server` singleton, and this connectors
+   * module is itself pulled in by `server`).
+   *
+   * `postId` is the post whose owner is notified (a like/boost target, or a
+   * reply's PARENT); `entityId` is what the notification points AT (the target
+   * post for like/boost, the new reply post for reply) — mirroring the native
+   * shapes exactly.
+   */
+  private async notifyLocalPostOwnerOfEngagement(
+    postId: string,
+    actorOxyUserId: string,
+    type: 'like' | 'boost' | 'reply',
+    entityId: string,
+    entityType: 'post' | 'reply',
+  ): Promise<void> {
+    try {
+      const post = await Post.findOne(
+        { _id: postId },
+        { authorship: 1, federation: 1 },
+      ).lean<{ authorship?: PostAuthorshipEntry[]; federation?: unknown } | null>();
+      if (!post || post.federation != null) return;
+
+      const { createPostAuthorNotifications } = await import('../../utils/notificationUtils');
+      await createPostAuthorNotifications(post.authorship, {
+        actorId: actorOxyUserId,
+        type,
+        entityId,
+        entityType,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        `[Federation] ${type} notification failed for post ${postId} from actor ${actorOxyUserId}: ${message}`,
+      );
+    }
   }
 
   private async handleIncomingFollow(activity: Record<string, any>, actorUri: string): Promise<void> {
@@ -491,7 +547,7 @@ export class InboxProcessingService {
       return;
     }
 
-    await getPostCreator().create({
+    const createdPost = await getPostCreator().create({
       oxyUserId: authorOxyUserId,
       federation: {
         activityId: object.id,
@@ -530,6 +586,23 @@ export class InboxProcessingService {
       skipFederationDelivery: true,
       ...(originalCreatedAt ? { createdAt: originalCreatedAt, updatedAt: originalCreatedAt } : {}),
     });
+
+    // A federated reply to a LOCAL post notifies the parent owner exactly like a
+    // native reply (`type:'reply'`, entityId = the new reply post). Only reached
+    // when this Create is genuinely new — the `federation.activityId` dedup above
+    // returns early on a redelivery, so a redelivery never re-notifies.
+    // `threadLink` is set only for replies, and the parent owner's sharing
+    // consent was already enforced above; the helper skips a mirrored remote
+    // parent (a federated author has no Mention inbox).
+    if (threadLink?.parentPostId) {
+      await this.notifyLocalPostOwnerOfEngagement(
+        threadLink.parentPostId,
+        authorOxyUserId,
+        'reply',
+        String(createdPost._id),
+        'reply',
+      );
+    }
 
     logger.debug(`Stored federated post from ${actorUri}: ${object.id}`);
   }
@@ -589,6 +662,11 @@ export class InboxProcessingService {
 
     await Post.updateOne({ _id: postId }, { $inc: { 'stats.likesCount': 1 } });
     logger.debug(`[Federation] recorded Like from ${actorUri} on ${postId}`);
+
+    // Notify the local owner exactly like a native like. Only reached after a
+    // NEW Like doc was inserted — a redelivered Like returns on the duplicate-key
+    // path above, so a redelivery never re-notifies.
+    await this.notifyLocalPostOwnerOfEngagement(postId, likerOxyUserId, 'like', postId, 'post');
   }
 
   /**
@@ -631,6 +709,16 @@ export class InboxProcessingService {
     const created = await outboxSyncService.importAnnounce(activity, announcedUri, boosterOxyUserId);
     if (created) {
       logger.debug(`Imported boost from ${actorUri} of ${announcedUri}`);
+
+      // Notify the local owner exactly like a native boost. Only reached when a
+      // NEW boost Post was created (`importAnnounce` returns false on a
+      // redelivered Announce), so a redelivery never re-notifies. `announcedPostId`
+      // is the pre-resolved LOCAL post id; when null the boosted object is remote
+      // (no local owner to notify), and the helper additionally skips mirrored
+      // remote posts.
+      if (announcedPostId) {
+        await this.notifyLocalPostOwnerOfEngagement(announcedPostId, boosterOxyUserId, 'boost', announcedPostId, 'post');
+      }
     }
   }
 

--- a/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
+++ b/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
@@ -309,9 +309,13 @@ router.get('/users/:username/outbox', async (req: Request, res: Response) => {
 
     // Reuse the SINGLE Note builder that push delivery uses, so outbox backfill
     // (Mastodon ≥4.4 imports up to 20 items on discovery) carries the same
-    // fidelity as pushed posts: canonical url, hashtag `tag`s, and media
-    // `attachment`s. One implementation for both paths.
-    const items = pagePosts.map((post) => activityPubConnector.buildCreateNoteActivity(post, username));
+    // fidelity as pushed posts: canonical url, hashtag `tag`s, media `attachment`s,
+    // AND resolved @mention anchors/tags (never a raw `[mention:<id>]` placeholder).
+    // Mentions are batch-resolved for the whole page in two reads.
+    const mentionContexts = await activityPubConnector.resolveMentionContextByPost(pagePosts);
+    const items = pagePosts.map((post) =>
+      activityPubConnector.buildCreateNoteActivity(post, username, undefined, mentionContexts.get(String(post._id))),
+    );
 
     const pageId = cursor
       ? `${outboxUrl(username)}?page=true&cursor=${encodeURIComponent(cursor)}`
@@ -389,11 +393,16 @@ router.get('/users/:username/collections/featured', async (req: Request, res: Re
       .limit(FEATURED_LIMIT)
       .lean();
 
-    // Build via the shared Note path, then unwrap the Create envelope: a featured
-    // collection contains bare Note OBJECTS, carrying no per-item `@context` (the
-    // collection's top-level `@context` covers them).
+    // Build via the shared Note path (batch-resolving @mentions for the whole
+    // collection so no pinned Note leaks a `[mention:<id>]` placeholder), then
+    // unwrap the Create envelope: a featured collection contains bare Note OBJECTS,
+    // carrying no per-item `@context` (the collection's top-level `@context` covers
+    // them).
+    const mentionContexts = await activityPubConnector.resolveMentionContextByPost(pinnedPosts);
     const items = pinnedPosts.map(
-      (post) => activityPubConnector.buildCreateNoteActivity(post, username).object as Record<string, unknown>,
+      (post) =>
+        activityPubConnector.buildCreateNoteActivity(post, username, undefined, mentionContexts.get(String(post._id)))
+          .object as Record<string, unknown>,
     );
 
     res.set('Content-Type', AP_CONTENT_TYPE);
@@ -467,9 +476,19 @@ router.get('/users/:username/posts/:id', async (req: Request, res: Response) => 
     // yields null, so the Note is served without `inReplyTo` rather than erroring.
     const replyContext = await activityPubConnector.resolveReplyContext(post);
 
+    // Resolve the post's @mentions so a pulled Note carries mention anchors + tags
+    // (never a raw `[mention:<id>]` placeholder). Fail-soft — null when it mentions
+    // nobody; the linkifier still strips any stray placeholder from the body.
+    const mentionContext = await activityPubConnector.resolveMentionContext(post);
+
     // Build via the shared Note path, then unwrap the Create envelope: a
     // dereferenced Note is the `object`, carrying its own top-level `@context`.
-    const activity = activityPubConnector.buildCreateNoteActivity(post, username, replyContext ?? undefined);
+    const activity = activityPubConnector.buildCreateNoteActivity(
+      post,
+      username,
+      replyContext ?? undefined,
+      mentionContext ?? undefined,
+    );
     const note = activity.object as Record<string, unknown>;
 
     res.set('Content-Type', AP_CONTENT_TYPE);

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -25,6 +25,7 @@ import {
   getViewerEntry,
   normalizeAuthorship,
 } from '../utils/postAuthorship';
+import { normalizeMentionIds } from '../utils/textProcessing';
 import {
   readerVariants,
   resolveVariant,
@@ -2089,24 +2090,11 @@ export class PostHydrationService {
       return text;
     }
 
-    // Normalize the current post's declared mention IDs. The per-request
-    // cache is intentionally shared across a hydration batch, so replacement
-    // must be scoped to this per-post allowlist rather than every cached user.
-    const declaredMentionIds = new Set<string>();
-    for (const mentionIdRaw of mentions) {
-      let mentionId: string;
-      if (typeof mentionIdRaw === 'string') {
-        mentionId = mentionIdRaw;
-      } else if (mentionIdRaw && typeof mentionIdRaw === 'object') {
-        const raw = mentionIdRaw as Record<string, unknown>;
-        mentionId = String(raw?.id || raw?._id || raw || '');
-      } else {
-        mentionId = String(mentionIdRaw || '');
-      }
-      if (mentionId) {
-        declaredMentionIds.add(mentionId);
-      }
-    }
+    // Normalize the current post's declared mention IDs via the shared coercion
+    // (the SAME parsing the federation Note builder uses). The per-request cache is
+    // intentionally shared across a hydration batch, so replacement must be scoped
+    // to this per-post allowlist rather than every cached user.
+    const declaredMentionIds = new Set<string>(normalizeMentionIds(mentions));
 
     // Collect declared mention placeholders present in the text but not yet in
     // the per-request cache. Only placeholders that actually appear are worth

--- a/packages/backend/src/utils/federation/linkifyApHtml.ts
+++ b/packages/backend/src/utils/federation/linkifyApHtml.ts
@@ -1,0 +1,146 @@
+import { escapeApHtml, escapeApHtmlAttr, normalizeApBody, wrapApParagraphs } from './plainTextToApHtml';
+
+/**
+ * A resolved @mention link: the actor `href` (the anchor target AND the Note's
+ * `Mention` tag href) and the visible handle WITHOUT the leading `@` (`alice` for
+ * a local user, `bob@remote.social` for a federated one). Built by the async
+ * caller (`FollowService.resolveMentionContext`) from the post's declared
+ * `mentions` ids; the pure linkifier only RENDERS it.
+ */
+export interface ApMentionLink {
+  /** Actor href — a local minted actor URL or a remote actor URI. */
+  href: string;
+  /** Visible handle, no leading `@`: `alice` (local) or `bob@remote.social` (federated). */
+  handle: string;
+}
+
+/** Options for {@link linkifyApHtml}. */
+export interface LinkifyApHtmlOptions {
+  /**
+   * Resolved mention links keyed by the placeholder's Oxy user id. A
+   * `[mention:<id>]` whose id is ABSENT here (undeclared, or unresolvable) is
+   * DROPPED — the internal placeholder must never survive into federated
+   * `content`. Omit the whole map to drop every placeholder.
+   */
+  mentions?: ReadonlyMap<string, ApMentionLink>;
+  /**
+   * Build the href for a `#hashtag` anchor from the RAW captured tag (no `#`). The
+   * caller supplies this so a content `#tag` and its machine-readable `Hashtag`
+   * tag point at the same URL (both go through the same `hashtagUrl` helper). When
+   * omitted, hashtags stay plain (escaped) text.
+   */
+  hashtagHref?: (rawTag: string) => string;
+}
+
+/**
+ * Left-to-right token scanner for the three inline reference kinds a Mention post
+ * body carries. URL is tried FIRST so a `#fragment` (or any trailing text) inside
+ * a link is consumed by the URL token and never re-matched as a hashtag.
+ *  - `url`       — a bare `http(s)://…` run (up to whitespace or `<`)
+ *  - `mentionId` — the id inside a `[mention:<id>]` placeholder
+ *  - `hashtag`   — the tag text after `#` (ASCII word chars, mirroring the stored
+ *                  hashtag extraction so a content `#tag` matches the `tag` array)
+ */
+const TOKEN_REGEX = /(?<url>https?:\/\/[^\s<]+)|\[mention:(?<mentionId>[^\]]+)\]|#(?<hashtag>[A-Za-z0-9_]+)/g;
+
+/**
+ * Sentence punctuation that is almost never part of a URL and should stay OUTSIDE
+ * the link. A closing paren is handled separately (only trimmed when unbalanced),
+ * so a Wikipedia-style `…_(disambiguation)` URL survives intact.
+ */
+const TRAILING_URL_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?', '"', "'", '’', '”', '»']);
+
+/**
+ * Split a raw matched URL run into the real URL and any trailing prose punctuation
+ * (`see https://x.com.` → the `.` is a sentence end, not part of the URL). The
+ * trimmed suffix is re-emitted as escaped plain text by the caller.
+ */
+function splitTrailingUrlPunctuation(raw: string): { url: string; trailing: string } {
+  let end = raw.length;
+  while (end > 0) {
+    const ch = raw[end - 1];
+    if (ch === ')') {
+      const head = raw.slice(0, end);
+      const opens = (head.match(/\(/g) ?? []).length;
+      const closes = (head.match(/\)/g) ?? []).length;
+      if (closes <= opens) break; // balanced → the ')' belongs to the URL
+    } else if (!TRAILING_URL_PUNCTUATION.has(ch)) {
+      break;
+    }
+    end -= 1;
+  }
+  return { url: raw.slice(0, end), trailing: raw.slice(end) };
+}
+
+/** Mastodon-compatible mention anchor. `href` is attribute-escaped, label is text-escaped. */
+function mentionAnchor(link: ApMentionLink): string {
+  return `<a href="${escapeApHtmlAttr(link.href)}" class="u-url mention">@${escapeApHtml(link.handle)}</a>`;
+}
+
+/** Mastodon-compatible hashtag anchor (`class="mention hashtag" rel="tag"`). */
+function hashtagAnchor(rawTag: string, href: string): string {
+  return `<a href="${escapeApHtmlAttr(href)}" class="mention hashtag" rel="tag">#${escapeApHtml(rawTag)}</a>`;
+}
+
+/** Bare-URL anchor — the same string is the (attribute-escaped) href and (text-escaped) label. */
+function urlAnchor(url: string): string {
+  return `<a href="${escapeApHtmlAttr(url)}">${escapeApHtml(url)}</a>`;
+}
+
+/**
+ * Convert an author-written PLAIN-TEXT post body into safe ActivityPub `content`
+ * HTML, LINKIFYING @mentions, #hashtags and bare URLs — the body transform the
+ * Note builder uses so a federated post never ships an internal `[mention:<id>]`
+ * placeholder (and so `#tags`/URLs render as links on Mastodon).
+ *
+ * ESCAPING (the correctness core — no naive chained replaces over escaped text):
+ * the raw body is tokenized into spans (plain text | mention placeholder | URL |
+ * hashtag). ONLY plain-text spans and the VISIBLE label of each link are
+ * HTML-escaped, and every `href` is attribute-escaped; the anchors are assembled
+ * from those already-safe pieces. Nothing is ever escaped twice, and an injected
+ * anchor is never re-escaped.
+ *
+ * PARAGRAPHING composes AROUND linkification: the escaped-and-linkified body is
+ * then run through the SAME `<p>`/`<br>` structuring as {@link plainTextToApHtml}
+ * (blank line → new paragraph, single newline → `<br>`). Anchors carry no newline,
+ * so the newline-based split only ever cuts at plain-text boundaries.
+ *
+ * Pure and side-effect free. An empty/whitespace-only body returns `''`.
+ */
+export function linkifyApHtml(text: string, options: LinkifyApHtmlOptions = {}): string {
+  const normalized = normalizeApBody(text);
+  if (normalized.length === 0) return '';
+
+  const { mentions, hashtagHref } = options;
+
+  let out = '';
+  let cursor = 0;
+
+  for (const match of normalized.matchAll(TOKEN_REGEX)) {
+    const index = match.index ?? 0;
+
+    // Plain text between the previous token and this one — escaped as element text.
+    if (index > cursor) out += escapeApHtml(normalized.slice(cursor, index));
+
+    const groups = match.groups ?? {};
+    if (groups.url !== undefined) {
+      const { url, trailing } = splitTrailingUrlPunctuation(groups.url);
+      out += urlAnchor(url);
+      if (trailing) out += escapeApHtml(trailing);
+    } else if (groups.mentionId !== undefined) {
+      // Resolved → a mention anchor. Undeclared/unresolvable → DROP: the internal
+      // `[mention:<id>]` placeholder must never leak to the wire.
+      const link = mentions?.get(groups.mentionId);
+      if (link) out += mentionAnchor(link);
+    } else if (groups.hashtag !== undefined) {
+      const href = hashtagHref?.(groups.hashtag);
+      out += href ? hashtagAnchor(groups.hashtag, href) : escapeApHtml(match[0]);
+    }
+
+    cursor = index + match[0].length;
+  }
+
+  if (cursor < normalized.length) out += escapeApHtml(normalized.slice(cursor));
+
+  return wrapApParagraphs(out);
+}

--- a/packages/backend/src/utils/federation/plainTextToApHtml.ts
+++ b/packages/backend/src/utils/federation/plainTextToApHtml.ts
@@ -5,12 +5,61 @@
  *
  * Only `&`, `<` and `>` matter here: the output is placed between `<p>…</p>` (as
  * text content), never inside an attribute value, so `"`/`'` need no escaping.
+ * For an ATTRIBUTE value (an anchor `href`), use {@link escapeApHtmlAttr}.
  */
-function escapeHtml(text: string): string {
+export function escapeApHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
+}
+
+/**
+ * HTML-escape a value placed inside a DOUBLE-QUOTED attribute (an anchor `href`).
+ * Everything {@link escapeApHtml} escapes, PLUS the `"` that would otherwise close
+ * the attribute — so a user-typed URL carrying `"`/`&`/`<`/`>` can never break out
+ * of the `href="…"`. `&` first (via `escapeApHtml`) keeps the order double-escape
+ * safe; the introduced entities contain no `"`, so the trailing `"` pass is clean.
+ */
+export function escapeApHtmlAttr(value: string): string {
+  return escapeApHtml(value).replace(/"/g, '&quot;');
+}
+
+/**
+ * Normalize a post body for AP HTML rendering: `\r\n` and lone `\r` → `\n`, and
+ * trim surrounding whitespace so the body never opens or closes with an empty
+ * paragraph or a stray `<br>`. Shared by the plain-text transform and the
+ * linkifier so both do line-break detection on the same single-newline basis.
+ */
+export function normalizeApBody(text: string): string {
+  return text.replace(/\r\n?/g, '\n').trim();
+}
+
+/**
+ * Wrap an ALREADY-SAFE body — escaped plain text, with any anchors already
+ * injected — into AP `content` paragraphs. Blank-line runs become paragraph
+ * boundaries (`<p>…</p>`); a single newline inside a paragraph becomes `<br>`.
+ *
+ * This is the paragraph structuring shared by {@link plainTextToApHtml} and the
+ * linkifier. It NEVER escapes (its input is already safe), so injected `<a>`
+ * anchors pass through intact — and because an anchor contains no newline, the
+ * newline-based paragraph/line-break split only ever cuts at plain-text
+ * boundaries. Input must already be normalized (see {@link normalizeApBody}).
+ */
+export function wrapApParagraphs(safeBody: string): string {
+  if (safeBody.length === 0) return '';
+
+  // A paragraph boundary is a run of two or more newlines. Horizontal whitespace
+  // on the "blank" line(s) is tolerated, and a run of 3+ newlines collapses to a
+  // single boundary, because HTML has no empty paragraph to render.
+  const paragraphs = safeBody.split(/\n[ \t]*(?:\n[ \t]*)+/);
+
+  return paragraphs
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0)
+    // A single newline that survives inside a paragraph is an author line break.
+    .map((paragraph) => `<p>${paragraph.replace(/\n/g, '<br>')}</p>`)
+    .join('');
 }
 
 /**
@@ -29,33 +78,17 @@ function escapeHtml(text: string): string {
  *   3. Split on blank-line boundaries into paragraphs, each wrapped in `<p>…</p>`.
  *   4. Convert every remaining single newline inside a paragraph to `<br>`.
  *
- * URLs, hashtags and mentions are deliberately NOT linkified here — that is a
- * separate concern (the machine-readable references travel in the AP `tag` array).
- * This helper is strictly the plain-text → line-break-preserving HTML transform.
+ * URLs, hashtags and mentions are deliberately NOT linkified here — that is the
+ * job of the linkifier (`linkifyApHtml`), which the Note builder uses for the
+ * post body. This helper is strictly the plain-text → line-break-preserving HTML
+ * transform, kept for any caller that has no linkification context.
  *
  * An empty or whitespace-only body returns `''`: an empty-bodied post (e.g. a
  * boost, whose body is intentionally empty) must never grow stray `<p>` tags, and
  * every caller already handles an empty `content`.
  */
 export function plainTextToApHtml(text: string): string {
-  // Normalize line endings so paragraph/line-break detection is single-newline
-  // based, and drop leading/trailing whitespace so the body never opens or closes
-  // with an empty paragraph or a stray `<br>`.
-  const normalized = text.replace(/\r\n?/g, '\n').trim();
+  const normalized = normalizeApBody(text);
   if (normalized.length === 0) return '';
-
-  const escaped = escapeHtml(normalized);
-
-  // A paragraph boundary is a run of two or more newlines. Horizontal whitespace
-  // on the "blank" line(s) is tolerated — a line that holds only spaces still
-  // separates paragraphs — and a run of 3+ newlines collapses to a single
-  // boundary, because HTML has no empty paragraph to render.
-  const paragraphs = escaped.split(/\n[ \t]*(?:\n[ \t]*)+/);
-
-  return paragraphs
-    .map((paragraph) => paragraph.trim())
-    .filter((paragraph) => paragraph.length > 0)
-    // A single newline that survives inside a paragraph is an author line break.
-    .map((paragraph) => `<p>${paragraph.replace(/\n/g, '<br>')}</p>`)
-    .join('');
+  return wrapApParagraphs(escapeApHtml(normalized));
 }

--- a/packages/backend/src/utils/textProcessing.ts
+++ b/packages/backend/src/utils/textProcessing.ts
@@ -165,6 +165,37 @@ export function extractMentionIds(text: string): string[] {
 }
 
 /**
+ * Normalize a post's declared `mentions` field into a deduped list of mentioned
+ * Oxy user ids — the SINGLE coercion both the hydration renderer
+ * ({@link PostHydrationService.replaceMentionPlaceholders}) and the federation
+ * Note builder read.
+ *
+ * The stored value is USUALLY a `string[]` of ids, but legacy rows and
+ * loosely-typed call sites can hold objects (`{ id }` / `{ _id }`). This coerces
+ * both shapes to the canonical id strings the `[mention:<id>]` placeholder is
+ * keyed by, trims them, and drops empties — so neither reader re-implements the
+ * (previously duplicated, subtly divergent) parsing.
+ */
+export function normalizeMentionIds(mentions: unknown): string[] {
+  if (!Array.isArray(mentions)) return [];
+  const ids = new Set<string>();
+  for (const raw of mentions) {
+    let id = '';
+    if (typeof raw === 'string') {
+      id = raw;
+    } else if (raw && typeof raw === 'object') {
+      const obj = raw as Record<string, unknown>;
+      id = String(obj.id ?? obj._id ?? '');
+    } else if (raw !== null && raw !== undefined) {
+      id = String(raw);
+    }
+    const trimmed = id.trim();
+    if (trimmed) ids.add(trimmed);
+  }
+  return [...ids];
+}
+
+/**
  * Escape special regex characters in a string for safe use in RegExp constructor.
  */
 export function escapeRegex(str: string): string {


### PR DESCRIPTION
## Summary
- **Outbound:** post content now linkifies URLs, `#hashtags`, and `@mentions` into `<a>` tags, and resolves the internal `[mention:<id>]` placeholder that was previously shipping raw to the fediverse. `@mentions` of remote users now emit an AP `Mention` tag, cc the actor, and deliver to their inbox so their instance receives and notifies them.
- **Inbound:** a Like / Announce(boost) / reply from the fediverse now notifies the local post owner (`type: like/boost/reply`), matching existing local-engagement and federated-follow notification behavior — idempotent (no re-notify on redelivery), fail-soft, consent-gated. Inbound `@mention` ingestion is a known separate gap, not addressed here.

## Test plan
- [x] `bunx tsc --noEmit` in `packages/backend` — 0 errors
- [x] `bun run test` in `packages/backend` — 224 files / 2368 tests passed
- [x] `bun run build:backend` from repo root — succeeds
- [ ] CI green on this PR