### PR TITLE
feat(federation): emit sensitive flag, media dimensions and source on AP notes

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/buildCreateNoteActivity.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/buildCreateNoteActivity.test.ts
@@ -297,3 +297,103 @@ describe('buildCreateNoteActivity — the PRIMARY rendition is what federates', 
     ]);
   });
 });
+
+describe('buildCreateNoteActivity — sensitive flag', () => {
+  it('emits sensitive:true when the author flagged the post sensitive', () => {
+    const { note } = noteFor({
+      _id: 'p1',
+      content: body('behind a warning'),
+      createdAt: ISO,
+      metadata: { isSensitive: true },
+    });
+
+    expect(note.sensitive).toBe(true);
+    // Boolean-only toggle → never a `summary` (there is no CW text to carry).
+    expect(note.summary).toBeUndefined();
+  });
+
+  it('emits sensitive:false for a normal post (no metadata, or the flag unset)', () => {
+    const { note } = noteFor({ _id: 'p1', content: body('safe'), createdAt: ISO });
+    expect(note.sensitive).toBe(false);
+
+    const { note: explicit } = noteFor({
+      _id: 'p2',
+      content: body('safe'),
+      createdAt: ISO,
+      metadata: { isSensitive: false },
+    });
+    expect(explicit.sensitive).toBe(false);
+  });
+});
+
+describe('buildCreateNoteActivity — media width/height', () => {
+  it('emits width and height on an attachment when both are present on the item', () => {
+    const { note } = noteFor({
+      _id: 'p1',
+      content: { ...body('sized'), media: [{ id: 'file-abc', type: 'image', width: 1200, height: 800 }] },
+      createdAt: ISO,
+    });
+
+    expect(note.attachment).toEqual([
+      { type: 'Document', mediaType: 'image/jpeg', url: 'https://cloud.oxy.so/file-abc', width: 1200, height: 800 },
+    ]);
+  });
+
+  it('omits the width/height keys entirely when the item carries no dimensions', () => {
+    const { note } = noteFor({
+      _id: 'p1',
+      content: { ...body('unsized'), media: [{ id: 'file-abc', type: 'image' }] },
+      createdAt: ISO,
+    });
+
+    const [attachment] = note.attachment as Array<Record<string, unknown>>;
+    expect(attachment).not.toHaveProperty('width');
+    expect(attachment).not.toHaveProperty('height');
+    expect(attachment).toEqual({
+      type: 'Document',
+      mediaType: 'image/jpeg',
+      url: 'https://cloud.oxy.so/file-abc',
+    });
+  });
+
+  it('emits only the present dimension and never a zero placeholder', () => {
+    const { note } = noteFor({
+      _id: 'p1',
+      content: { ...body('half sized'), media: [{ id: 'file-abc', type: 'image', width: 640, height: 0 }] },
+      createdAt: ISO,
+    });
+
+    expect(note.attachment).toEqual([
+      { type: 'Document', mediaType: 'image/jpeg', url: 'https://cloud.oxy.so/file-abc', width: 640 },
+    ]);
+  });
+});
+
+describe('buildCreateNoteActivity — source plaintext', () => {
+  it('carries the RAW primary body as source (text/plain), NOT the HTML content', () => {
+    const { note } = noteFor({ _id: 'p1', content: body('line one\nline two'), createdAt: ISO });
+
+    // `content` is HTML (the newline became a <br>); `source.content` is the
+    // author's raw plaintext, so an edit-fetching client recovers the original.
+    expect(note.content).toBe('<p>line one<br>line two</p>');
+    expect(note.source).toEqual({ content: 'line one\nline two', mediaType: 'text/plain' });
+  });
+
+  it('omits source for an empty body (a boost)', () => {
+    const { note } = noteFor({ _id: 'p1', content: { variants: [] }, createdAt: ISO });
+    expect(note.source).toBeUndefined();
+  });
+});
+
+describe('buildUpdateNoteActivity — inherits sensitive + source from the Note', () => {
+  it('the embedded Update object carries the same sensitive flag and raw source body', () => {
+    const activity = followService.buildUpdateNoteActivity(
+      { _id: 'p1', content: body('edited body'), createdAt: ISO, metadata: { isSensitive: true } },
+      'alice',
+    );
+    const note = activity.object as Record<string, unknown>;
+
+    expect(note.sensitive).toBe(true);
+    expect(note.source).toEqual({ content: 'edited body', mediaType: 'text/plain' });
+  });
+});

--- a/packages/backend/src/connectors/activitypub/constants.ts
+++ b/packages/backend/src/connectors/activitypub/constants.ts
@@ -48,6 +48,11 @@ const FEDERATION_BLOCKED_DOMAINS = new Set(
 export const AP_CONTEXT = [
   'https://www.w3.org/ns/activitystreams',
   'https://w3id.org/security/v1',
+  // The AS2 core context above defines the `as:` prefix
+  // (`as` → `https://www.w3.org/ns/activitystreams#`), so this maps the Note's
+  // `sensitive` boolean to `as:sensitive` — the exact term Mastodon defines for
+  // it. Without the term declaration a JSON-LD consumer drops `sensitive`.
+  { sensitive: 'as:sensitive' },
 ];
 
 export const AP_CONTENT_TYPE = 'application/activity+json';

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -121,6 +121,11 @@ function buildNoteAttachment(item: MediaItem | undefined | null): Record<string,
   const attachment: Record<string, unknown> = { type: 'Document', mediaType, url };
   // Alt text → AP `name` (accessibility description), when the author provided one.
   if (item?.alt) attachment.name = item.alt;
+  // Intrinsic pixel dimensions (persisted at ingest) — Mastodon uses them for
+  // aspect-ratio/layout. Emit each only when it is a real positive dimension;
+  // never advertise a `null`/`0` placeholder.
+  if (typeof item?.width === 'number' && item.width > 0) attachment.width = item.width;
+  if (typeof item?.height === 'number' && item.height > 0) attachment.height = item.height;
   return attachment;
 }
 
@@ -135,6 +140,14 @@ export interface NoteSourcePost {
   hashtags?: string[];
   mentions?: string[];
   createdAt: string | Date;
+  /**
+   * Post-level flags read at Note-build time. Only `isSensitive` (the author's
+   * CW/NSFW compose toggle) is federated — it becomes the Note's `sensitive`
+   * boolean so Mastodon blurs the media / hides the body behind a
+   * content-warning click. Absent/undefined ⇒ not sensitive. The toggle is
+   * boolean-only (there is no CW TEXT), so no `summary` is emitted.
+   */
+  metadata?: { isSensitive?: boolean } | null;
   /**
    * Set when the post is a boost. A boost has an intentionally empty body and
    * MUST federate as an `Announce`, never as a blank `Create(Note)` — the
@@ -586,6 +599,18 @@ export class FollowService {
     const language = canonicalizeLanguageTag(primary.tag) ?? undefined;
     const contentMap = buildNoteContentMap(post, language, primaryContent, linkifyOptions);
 
+    // The author's sensitive/NSFW flag → AP `sensitive` so a compatible instance
+    // blurs the media / hides the body behind a content-warning click. Boolean
+    // only: there is no CW TEXT to emit as `summary`.
+    const sensitive = post.metadata?.isSensitive === true;
+    // AP `source`: the RAW plaintext primary body (the same value linkified into
+    // `content` above). Now that `content` is HTML, Mastodon uses `source.content`
+    // for edit-fetch fidelity. Omitted for an empty body (e.g. a boost — which
+    // never reaches this Create path anyway).
+    const source = primary.text
+      ? { content: primary.text, mediaType: 'text/plain' }
+      : undefined;
+
     // The public collection stays in `to`; the mentioned parent author + every
     // REMOTE @mentioned actor join the followers collection in `cc` so a public
     // reply/mention is delivered/attributed to them (mirrors how the boost path
@@ -618,8 +643,12 @@ export class FollowService {
         // so a top-level Note carries no `inReplyTo`.
         inReplyTo: reply?.inReplyTo,
         url: `https://${FEDERATION_DOMAIN}/@${username}/posts/${postId}`,
+        sensitive,
         content: primaryContent,
         contentMap,
+        // Raw plaintext body, omitted (undefined dropped by JSON serialization)
+        // when the post has no body.
+        source,
         language,
         published,
         to: [AP_PUBLIC],


### PR DESCRIPTION
## Summary
- `sensitive`: `post.metadata.isSensitive` now federates as the AS2 `sensitive` flag so Mastodon blurs media on posts the author marked NSFW.
- Attachments carry `width`/`height` when known, improving remote layout rendering.
- `source: { content, mediaType: 'text/plain' }` carries the original plaintext for edit-fetch fidelity now that `content` is HTML.
- `@context` gains the `sensitive` term.

## Test plan
- [x] `bunx tsc --noEmit` — clean, exit 0
- [x] `bun run test` (packages/backend) — 224 test files passed, 2376 tests passed, 0 failures
- [x] `bun run build:backend` (shared-types + backend) — succeeded
- [x] New/updated unit tests in `buildCreateNoteActivity.test.ts` cover the sensitive flag, media dimensions, and source fields

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>