### PR TITLE
feat(federation): federate polls as AP Question with inbound votes

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
@@ -27,6 +27,8 @@ const mocks = vi.hoisted(() => ({
   resolveReplyContext: vi.fn(),
   resolveMentionContext: vi.fn(),
   resolveMentionContextByPost: vi.fn(),
+  resolvePollContext: vi.fn(),
+  resolvePollContextByPost: vi.fn(),
   userSettingsFindOne: vi.fn(),
   postFind: vi.fn(),
   postCountDocuments: vi.fn(),
@@ -50,6 +52,8 @@ vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
     resolveReplyContext: (...args: unknown[]) => mocks.resolveReplyContext(...args),
     resolveMentionContext: (...args: unknown[]) => mocks.resolveMentionContext(...args),
     resolveMentionContextByPost: (...args: unknown[]) => mocks.resolveMentionContextByPost(...args),
+    resolvePollContext: (...args: unknown[]) => mocks.resolvePollContext(...args),
+    resolvePollContextByPost: (...args: unknown[]) => mocks.resolvePollContextByPost(...args),
     fetchPublicKey: vi.fn(),
     processInboxActivity: vi.fn(),
   },
@@ -115,6 +119,10 @@ beforeEach(() => {
   // empty map and the single-post dereference resolver returns null.
   mocks.resolveMentionContext.mockResolvedValue(null);
   mocks.resolveMentionContextByPost.mockResolvedValue(new Map());
+  // Default: no post carries a poll — the batch resolver returns an empty map and
+  // the single-post dereference resolver returns null (serves a plain Note).
+  mocks.resolvePollContext.mockResolvedValue(null);
+  mocks.resolvePollContextByPost.mockResolvedValue(new Map());
 });
 
 describe('GET /ap/users/:username — actor image (banner)', () => {
@@ -181,9 +189,9 @@ describe('GET /ap/users/:username/outbox?page=true — reuses buildCreateNoteAct
       .expect(200);
 
     expect(mocks.buildCreateNoteActivity).toHaveBeenCalledTimes(2);
-    // The outbox passes NO reply context and the per-post mention context (undefined
-    // here — the batch resolver returned an empty map) as the 3rd/4th args.
-    expect(mocks.buildCreateNoteActivity).toHaveBeenNthCalledWith(1, posts[0], 'alice', undefined, undefined);
+    // The outbox passes NO reply context and the per-post mention + poll contexts
+    // (both undefined here — the batch resolvers returned empty maps) as args 3-5.
+    expect(mocks.buildCreateNoteActivity).toHaveBeenNthCalledWith(1, posts[0], 'alice', undefined, undefined, undefined);
     expect(res.body.type).toBe('OrderedCollectionPage');
     expect(res.body.orderedItems).toEqual([
       { type: 'Create', object: { id: 'https://mention.earth/ap/users/alice/posts/p1' } },
@@ -191,6 +199,38 @@ describe('GET /ap/users/:username/outbox?page=true — reuses buildCreateNoteAct
     ]);
     // A page that does not overfetch past the window has no further page.
     expect(res.body.next).toBeUndefined();
+  });
+
+  it('threads the resolved poll context into the builder so a poll post serializes as a Question', async () => {
+    mocks.resolveOxyUser.mockResolvedValue({ _id: 'u1' });
+    mocks.postCountDocuments.mockResolvedValue(1);
+    const posts = [{ _id: 'poll-post' }];
+    mocks.postFind.mockReturnValue({
+      sort: () => ({ limit: () => ({ lean: async () => posts }) }),
+    });
+    const pollContext = {
+      multiple: false,
+      options: [{ name: 'A', votes: 1 }],
+      endTime: new Date('2099-01-01T00:00:00.000Z'),
+      closed: false,
+      votersCount: 1,
+    };
+    mocks.resolvePollContextByPost.mockResolvedValue(new Map([['poll-post', pollContext]]));
+    mocks.buildCreateNoteActivity.mockImplementation(
+      (_post: unknown, _username: unknown, _reply: unknown, _mentions: unknown, poll: unknown) => ({
+        type: 'Create',
+        object: poll ? { type: 'Question' } : { type: 'Note' },
+      }),
+    );
+
+    const res = await request(app)
+      .get('/ap/users/alice/outbox?page=true')
+      .set('Accept', AP_ACCEPT)
+      .expect(200);
+
+    // The batch-resolved poll context is passed as the 5th arg for its post.
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(posts[0], 'alice', undefined, undefined, pollContext);
+    expect(res.body.orderedItems).toEqual([{ type: 'Create', object: { type: 'Question' } }]);
   });
 });
 
@@ -548,8 +588,8 @@ describe('GET /ap/users/:username/posts/:id — dereference', () => {
     // into the pure Note builder as the third argument.
     expect(mocks.resolveReplyContext).toHaveBeenCalledWith(replyDoc);
     // The dereference route threads the resolved reply context + (null →) undefined
-    // mention context into the Note builder.
-    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(replyDoc, 'alice', replyContext, undefined);
+    // mention + poll contexts into the Note builder.
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(replyDoc, 'alice', replyContext, undefined, undefined);
   });
 
   it('404s a malformed post id without touching the database', async () => {

--- a/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
@@ -43,6 +43,8 @@ const mocks = vi.hoisted(() => ({
   resolveReplyContext: vi.fn(),
   resolveMentionContext: vi.fn(),
   resolveMentionContextByPost: vi.fn(),
+  resolvePollContext: vi.fn(),
+  resolvePollContextByPost: vi.fn(),
   userSettingsFindOne: vi.fn(),
   postFind: vi.fn(),
   postCountDocuments: vi.fn(),
@@ -71,6 +73,8 @@ vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
     resolveReplyContext: (...args: unknown[]) => mocks.resolveReplyContext(...args),
     resolveMentionContext: (...args: unknown[]) => mocks.resolveMentionContext(...args),
     resolveMentionContextByPost: (...args: unknown[]) => mocks.resolveMentionContextByPost(...args),
+    resolvePollContext: (...args: unknown[]) => mocks.resolvePollContext(...args),
+    resolvePollContextByPost: (...args: unknown[]) => mocks.resolvePollContextByPost(...args),
     fetchPublicKey: vi.fn(),
     processInboxActivity: vi.fn().mockResolvedValue(undefined),
   },
@@ -172,6 +176,10 @@ beforeEach(() => {
   // gate tests mention nobody, so default to "no mentions".
   mocks.resolveMentionContext.mockResolvedValue(null);
   mocks.resolveMentionContextByPost.mockResolvedValue(new Map());
+  // The gate tests serve non-poll posts — default to "no poll" so the routes build
+  // plain Notes.
+  mocks.resolvePollContext.mockResolvedValue(null);
+  mocks.resolvePollContextByPost.mockResolvedValue(new Map());
   mocks.verifyHttpSignature.mockResolvedValue({
     verified: true,
     actorUri: 'https://remote.example/users/bob',

--- a/packages/backend/src/__tests__/connectors/activitypub/pollFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/pollFederation.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound POLL federation: a post that carries a poll federates as an
+ * ActivityPub `Question` instead of a `Note`. These pin two things:
+ *
+ *  1. the PURE builder (`buildCreateNoteActivity` with a resolved poll context):
+ *     a single-choice poll → `oneOf`, a multiple-choice poll → `anyOf`, each
+ *     option a `Note` whose `replies.totalItems` is that option's vote count;
+ *     `endTime` while open / `closed` once ended; `votersCount` (unique voters);
+ *     and that the SHARED object fields (attributedTo/content/url/…) are inherited
+ *     unchanged, so a non-poll post still emits a plain `Note`.
+ *  2. the DB-read resolver (`resolvePollContext` / `resolvePollContextByPost`):
+ *     it reads the linked `Poll` document and derives those fields, counting
+ *     UNIQUE voters across options.
+ *
+ * The builder's transitive deps are stubbed so `FollowService` imports in
+ * isolation; the `Poll` model is stubbed with controllable lean output.
+ */
+
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey: vi.fn(), signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery: vi.fn(), enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederatedActor', () => ({ default: {} }));
+vi.mock('../../../models/FederatedFollow', () => ({ default: {} }));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({ default: {} }));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn() }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+}));
+
+const { pollFindByIdLean, pollFindLean } = vi.hoisted(() => ({
+  pollFindByIdLean: vi.fn(),
+  pollFindLean: vi.fn(),
+}));
+
+vi.mock('../../../models/Poll', () => ({
+  default: {
+    findById: () => ({ select: () => ({ lean: () => pollFindByIdLean() }) }),
+    find: () => ({ select: () => ({ lean: () => pollFindLean() }) }),
+  },
+}));
+
+import type { PostContent } from '@mention/shared-types';
+import { followService, type NotePollContext } from '../../../connectors/activitypub/follow.service';
+
+const ISO = '2024-01-02T03:04:05.000Z';
+const FUTURE = new Date('2099-01-01T00:00:00.000Z');
+const PAST = new Date('2000-01-01T00:00:00.000Z');
+
+function body(text: string): PostContent {
+  return { variants: [{ source: 'author', text }] };
+}
+
+/** Build the Question `object` for a post carrying the given resolved poll context. */
+function questionFor(poll: NotePollContext, content: PostContent = body('vote now')) {
+  const activity = followService.buildCreateNoteActivity(
+    { _id: 'poll1', content, createdAt: ISO },
+    'alice',
+    undefined,
+    undefined,
+    poll,
+  );
+  return activity.object as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildCreateNoteActivity — poll → Question', () => {
+  it('emits a single-choice Question with oneOf, per-option replies.totalItems, endTime (open) and votersCount', () => {
+    const object = questionFor({
+      multiple: false,
+      options: [
+        { name: 'Red', votes: 3 },
+        { name: 'Blue', votes: 5 },
+      ],
+      endTime: FUTURE,
+      closed: false,
+      votersCount: 8,
+    });
+
+    expect(object.type).toBe('Question');
+    expect(object.oneOf).toEqual([
+      { type: 'Note', name: 'Red', replies: { type: 'Collection', totalItems: 3 } },
+      { type: 'Note', name: 'Blue', replies: { type: 'Collection', totalItems: 5 } },
+    ]);
+    expect(object.anyOf).toBeUndefined();
+    // Open poll → endTime present, closed absent.
+    expect(object.endTime).toBe(FUTURE.toISOString());
+    expect(object.closed).toBeUndefined();
+    expect(object.votersCount).toBe(8);
+
+    // The SHARED object fields are inherited unchanged from the Note assembly.
+    expect(object.attributedTo).toBe('https://mention.earth/ap/users/alice');
+    expect(object.id).toBe('https://mention.earth/ap/users/alice/posts/poll1');
+    expect(object.url).toBe('https://mention.earth/@alice/posts/poll1');
+    expect(object.content).toBe('<p>vote now</p>');
+  });
+
+  it('emits a multiple-choice Question with anyOf (not oneOf)', () => {
+    const object = questionFor({
+      multiple: true,
+      options: [
+        { name: 'A', votes: 1 },
+        { name: 'B', votes: 2 },
+      ],
+      endTime: FUTURE,
+      closed: false,
+      votersCount: 2,
+    });
+
+    expect(object.type).toBe('Question');
+    expect(object.anyOf).toEqual([
+      { type: 'Note', name: 'A', replies: { type: 'Collection', totalItems: 1 } },
+      { type: 'Note', name: 'B', replies: { type: 'Collection', totalItems: 2 } },
+    ]);
+    expect(object.oneOf).toBeUndefined();
+  });
+
+  it('emits `closed` (not `endTime`) once the poll has ended', () => {
+    const object = questionFor({
+      multiple: false,
+      options: [{ name: 'Yes', votes: 7 }],
+      endTime: PAST,
+      closed: true,
+      votersCount: 7,
+    });
+
+    expect(object.closed).toBe(PAST.toISOString());
+    expect(object.endTime).toBeUndefined();
+  });
+
+  it('a non-poll post still emits a plain Note (no poll fields)', () => {
+    const activity = followService.buildCreateNoteActivity(
+      { _id: 'p1', content: body('just a post'), createdAt: ISO },
+      'alice',
+    );
+    const object = activity.object as Record<string, unknown>;
+
+    expect(object.type).toBe('Note');
+    expect(object.oneOf).toBeUndefined();
+    expect(object.anyOf).toBeUndefined();
+    expect(object.votersCount).toBeUndefined();
+    expect(object.endTime).toBeUndefined();
+    expect(object.closed).toBeUndefined();
+  });
+});
+
+describe('resolvePollContext — reads the linked Poll document', () => {
+  it('derives the Question fields and counts UNIQUE voters across options', async () => {
+    pollFindByIdLean.mockResolvedValue({
+      _id: 'poll1',
+      // u2 voted on both options — counted ONCE in votersCount, but each option's
+      // own tally still reflects its full vote list.
+      options: [
+        { text: 'Red', votes: ['u1', 'u2'] },
+        { text: 'Blue', votes: ['u2', 'u3', 'u4'] },
+      ],
+      endsAt: FUTURE,
+      isMultipleChoice: true,
+    });
+
+    const context = await followService.resolvePollContext({
+      _id: 'p1',
+      content: { ...body('vote'), pollId: 'poll1' },
+      createdAt: ISO,
+    });
+
+    expect(context).toEqual({
+      multiple: true,
+      options: [
+        { name: 'Red', votes: 2 },
+        { name: 'Blue', votes: 3 },
+      ],
+      endTime: FUTURE,
+      closed: false,
+      votersCount: 4,
+    });
+  });
+
+  it('marks a poll whose deadline has passed as closed', async () => {
+    pollFindByIdLean.mockResolvedValue({
+      _id: 'poll1',
+      options: [{ text: 'Yes', votes: [] }],
+      endsAt: PAST,
+      isMultipleChoice: false,
+    });
+
+    const context = await followService.resolvePollContext({
+      _id: 'p1',
+      content: { ...body('vote'), pollId: 'poll1' },
+      createdAt: ISO,
+    });
+
+    expect(context?.closed).toBe(true);
+    expect(context?.votersCount).toBe(0);
+  });
+
+  it('returns null (no DB read) when the post carries no poll', async () => {
+    const context = await followService.resolvePollContext({
+      _id: 'p1',
+      content: body('no poll here'),
+      createdAt: ISO,
+    });
+
+    expect(context).toBeNull();
+    expect(pollFindByIdLean).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolvePollContextByPost — one batched Poll read for many posts', () => {
+  it('keys each poll context by post id and leaves non-poll posts absent', async () => {
+    pollFindLean.mockResolvedValue([
+      {
+        _id: 'pollA',
+        options: [{ text: 'A1', votes: ['x'] }],
+        endsAt: FUTURE,
+        isMultipleChoice: false,
+      },
+    ]);
+
+    const map = await followService.resolvePollContextByPost([
+      { _id: 'p1', content: { ...body('poll post'), pollId: 'pollA' }, createdAt: ISO },
+      { _id: 'p2', content: body('plain post'), createdAt: ISO },
+    ]);
+
+    expect(map.get('p1')).toEqual({
+      multiple: false,
+      options: [{ name: 'A1', votes: 1 }],
+      endTime: FUTURE,
+      closed: false,
+      votersCount: 1,
+    });
+    expect(map.has('p2')).toBe(false);
+  });
+});

--- a/packages/backend/src/__tests__/connectors/activitypub/pollVoteFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/pollVoteFederation.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Inbound POLL VOTE federation: a remote Mastodon user voting on a LOCAL Mention
+ * poll delivers a `Create(Note)` whose `name` is the chosen option, `inReplyTo`
+ * is our poll's Question, and which carries NO content. `handleCreate` must
+ * recognise that shape BEFORE the follower gate (a voter need not follow us) and
+ * record the vote through the shared `pollVoteService` — resolving the remote
+ * voter to a native Oxy user first (like `handleLike`).
+ *
+ * These pin:
+ *   - a valid vote → `recordVoteByOptionText(pollId, optionName, voter)`, and the
+ *     Create is CONSUMED (never materialized as a reply post);
+ *   - a duplicate / after-close vote is still consumed, never throws, never
+ *     creates a post (the shared service reports the reason);
+ *   - a sharing-OFF poll owner or an unresolved voter is skipped (no recording);
+ *   - a NON-vote Note (has content, or `inReplyTo` is not a poll) falls THROUGH to
+ *     the normal reply path (reaches the follower gate), unchanged.
+ *
+ * Drives the REAL `InboxProcessingService`; `pollVoteService`, the actor
+ * resolver, and the models are stubbed (same convention as the sibling
+ * `inboundSharingGates.test.ts`). `resolvePostIdFromObjectUri` (helpers) runs for
+ * real against the stubbed `Post` model.
+ */
+
+const ACTOR_URI = 'https://mastodon.social/users/bob';
+const TARGET_POST_ID = '507f1f77bcf86cd799439011';
+const TARGET_POST_URI = `https://mention.earth/ap/users/alice/posts/${TARGET_POST_ID}`;
+const POLL_ID = 'poll-123';
+const OWNER_OXY_ID = 'oxy_alice';
+const VOTER_OXY_ID = 'oxy_bob';
+
+const mocks = vi.hoisted(() => ({
+  resolveActorOxyUserId: vi.fn(),
+  getOrFetchActor: vi.fn(),
+  recordVoteByOptionText: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  followExists: vi.fn(),
+  postFindOne: vi.fn(),
+  postExists: vi.fn(),
+  postCreatorCreate: vi.fn(),
+  ensureFederatedReplyLink: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerError: vi.fn(),
+  loggerDebug: vi.fn(),
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: {
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError,
+    debug: mocks.loggerDebug,
+    fatal: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock('../../../connectors/activitypub/actor.service', () => ({
+  actorService: {
+    resolveActorOxyUserId: (...args: unknown[]) => mocks.resolveActorOxyUserId(...args),
+    getOrFetchActor: (...args: unknown[]) => mocks.getOrFetchActor(...args),
+    refreshActorInBackground: vi.fn(),
+    fetchRemoteActor: vi.fn(),
+  },
+}));
+
+vi.mock('../../../connectors/activitypub/crypto', () => ({
+  getPublicKey: vi.fn(),
+  signViaOxy: vi.fn(),
+  signRequest: vi.fn(),
+}));
+
+vi.mock('../../../services/PollVoteService', () => ({
+  pollVoteService: { recordVoteByOptionText: (...args: unknown[]) => mocks.recordVoteByOptionText(...args) },
+}));
+
+vi.mock('../../../models/FederatedActor', () => ({ default: { findOne: vi.fn() } }));
+vi.mock('../../../models/FederatedFollow', () => ({ default: { exists: mocks.followExists } }));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({ default: {}, getNextRetryTime: vi.fn() }));
+
+vi.mock('../../../models/Post', () => ({
+  POST_CLASSIFICATION_PENDING: 'pending',
+  Post: {
+    findOne: mocks.postFindOne,
+    exists: mocks.postExists,
+    updateOne: vi.fn(),
+    deleteOne: vi.fn(),
+  },
+}));
+
+vi.mock('../../../models/Like', () => ({ default: { create: vi.fn(), findOneAndDelete: vi.fn() } }));
+vi.mock('../../../models/UserSettings', () => ({ default: { updateOne: vi.fn() } }));
+vi.mock('../../../utils/oxyHelpers', () => ({ getServiceOxyClient: vi.fn() }));
+vi.mock('../../../services/mediaCache/cacheWorker', () => ({ persistRemoteMediaForFederatedOwnerDetailed: vi.fn() }));
+vi.mock('../../../services/mediaCache/cacheStore', () => ({ recordAccessAndMaybeEnqueue: vi.fn() }));
+
+vi.mock('../../../services/serviceRegistry', () => ({
+  getPostCreator: () => ({ create: mocks.postCreatorCreate }),
+  registerPostFederator: vi.fn(),
+  registerPostCreator: vi.fn(),
+  getPostFederator: vi.fn(),
+}));
+
+vi.mock('../../../services/fediverseSharing', () => ({
+  isFediverseSharingEnabled: (...args: unknown[]) => mocks.isFediverseSharingEnabled(...args),
+  isFediverseSharingEnabledFromUser: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/outbox.service', () => ({
+  outboxSyncService: {
+    ensureFederatedReplyLink: (...args: unknown[]) => mocks.ensureFederatedReplyLink(...args),
+    importAnnounce: vi.fn(),
+    syncOutboxPosts: vi.fn(),
+  },
+}));
+
+import { inboxProcessingService } from '../../../connectors/activitypub/inbox.service';
+
+/** A remote poll VOTE: a Note with `name` (chosen option), `inReplyTo` = our poll, no content. */
+function voteActivity(optionName = 'Blue') {
+  return {
+    id: `${ACTOR_URI}/statuses/500/activity`,
+    type: 'Create' as const,
+    actor: ACTOR_URI,
+    object: {
+      id: `${ACTOR_URI}/statuses/500`,
+      type: 'Note' as const,
+      attributedTo: ACTOR_URI,
+      name: optionName,
+      inReplyTo: TARGET_POST_URI,
+      to: ['https://mention.earth/ap/users/alice'],
+    },
+  };
+}
+
+/**
+ * Route every `Post.findOne` by (filter, projection):
+ *  - `resolvePostIdFromObjectUri` local-exists check (filter has `status`);
+ *  - `resolvePostIdFromObjectUri` imported-post check (filter has `federation.activityId`);
+ *  - `handlePollVote` pollId lookup (projection has `content.pollId`);
+ *  - `isLocalPostOwnerSharingEnabled` owner lookup (bare `_id`).
+ */
+function stubPostFindOne(options: {
+  localPostExists?: boolean;
+  pollId?: string | null;
+  owner?: { oxyUserId?: string | null; federation?: unknown } | null;
+} = {}): void {
+  const {
+    localPostExists = true,
+    pollId = POLL_ID,
+    owner = { oxyUserId: OWNER_OXY_ID, federation: null },
+  } = options;
+  mocks.postFindOne.mockImplementation((filter: Record<string, unknown>, projection?: Record<string, unknown>) => ({
+    lean: async () => {
+      if ('status' in filter) return localPostExists ? { _id: filter._id } : null;
+      if ('federation.activityId' in filter) return null;
+      if (projection && 'content.pollId' in projection) return { content: pollId ? { pollId } : {} };
+      return owner;
+    },
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolveActorOxyUserId.mockResolvedValue(VOTER_OXY_ID);
+  mocks.recordVoteByOptionText.mockResolvedValue({ ok: true, poll: { _id: POLL_ID } });
+  mocks.isFediverseSharingEnabled.mockResolvedValue(true);
+  mocks.followExists.mockResolvedValue(null);
+  mocks.postExists.mockResolvedValue(null);
+  mocks.postCreatorCreate.mockResolvedValue({ _id: 'created_post_1' });
+  mocks.ensureFederatedReplyLink.mockResolvedValue({ parentPostId: TARGET_POST_ID, threadId: TARGET_POST_ID });
+  stubPostFindOne();
+});
+
+describe('handlePollVote — recording a remote vote on a local poll', () => {
+  it('resolves the voter and records the vote by option name; the Create is consumed (no reply post)', async () => {
+    await inboxProcessingService.processInboxActivity(voteActivity('Blue'), ACTOR_URI);
+
+    expect(mocks.isFediverseSharingEnabled).toHaveBeenCalledWith(OWNER_OXY_ID);
+    expect(mocks.resolveActorOxyUserId).toHaveBeenCalledWith(ACTOR_URI);
+    expect(mocks.recordVoteByOptionText).toHaveBeenCalledWith(POLL_ID, 'Blue', VOTER_OXY_ID);
+    // A vote is never materialized as a reply post, and never reaches the follower gate.
+    expect(mocks.postCreatorCreate).not.toHaveBeenCalled();
+    expect(mocks.followExists).not.toHaveBeenCalled();
+  });
+
+  it('consumes a duplicate vote without error and without creating a post', async () => {
+    mocks.recordVoteByOptionText.mockResolvedValue({ ok: false, reason: 'already_voted' });
+
+    await inboxProcessingService.processInboxActivity(voteActivity('Blue'), ACTOR_URI);
+
+    expect(mocks.recordVoteByOptionText).toHaveBeenCalledWith(POLL_ID, 'Blue', VOTER_OXY_ID);
+    expect(mocks.postCreatorCreate).not.toHaveBeenCalled();
+    expect(mocks.loggerError).not.toHaveBeenCalled();
+  });
+
+  it('consumes a vote after the poll has closed (service reports poll_ended)', async () => {
+    mocks.recordVoteByOptionText.mockResolvedValue({ ok: false, reason: 'poll_ended' });
+
+    await inboxProcessingService.processInboxActivity(voteActivity('Blue'), ACTOR_URI);
+
+    expect(mocks.recordVoteByOptionText).toHaveBeenCalledTimes(1);
+    expect(mocks.postCreatorCreate).not.toHaveBeenCalled();
+  });
+
+  it('drops the vote (no recording, no actor resolution) when the poll owner has sharing disabled', async () => {
+    mocks.isFediverseSharingEnabled.mockResolvedValue(false);
+
+    await inboxProcessingService.processInboxActivity(voteActivity('Blue'), ACTOR_URI);
+
+    expect(mocks.resolveActorOxyUserId).not.toHaveBeenCalled();
+    expect(mocks.recordVoteByOptionText).not.toHaveBeenCalled();
+    expect(mocks.postCreatorCreate).not.toHaveBeenCalled();
+  });
+
+  it('skips the vote when the remote voter cannot be resolved to an Oxy user', async () => {
+    mocks.resolveActorOxyUserId.mockResolvedValue(null);
+
+    await inboxProcessingService.processInboxActivity(voteActivity('Blue'), ACTOR_URI);
+
+    expect(mocks.recordVoteByOptionText).not.toHaveBeenCalled();
+    expect(mocks.postCreatorCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('handlePollVote — non-vote Creates fall through unchanged', () => {
+  it('does not treat a normal reply (has content, no name) as a vote — reaches the follower gate', async () => {
+    const reply = {
+      id: `${ACTOR_URI}/statuses/900/activity`,
+      type: 'Create' as const,
+      actor: ACTOR_URI,
+      object: {
+        id: `${ACTOR_URI}/statuses/900`,
+        type: 'Note' as const,
+        attributedTo: ACTOR_URI,
+        content: '<p>nice poll</p>',
+        inReplyTo: TARGET_POST_URI,
+        to: ['https://www.w3.org/ns/activitystreams#Public'],
+      },
+    };
+
+    await inboxProcessingService.processInboxActivity(reply, ACTOR_URI);
+
+    expect(mocks.recordVoteByOptionText).not.toHaveBeenCalled();
+    // Fell through to normal handling: the follower gate was consulted.
+    expect(mocks.followExists).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not treat a named reply to a NON-poll post as a vote', async () => {
+    stubPostFindOne({ pollId: null }); // the referenced post carries no poll
+
+    await inboxProcessingService.processInboxActivity(voteActivity('Blue'), ACTOR_URI);
+
+    expect(mocks.recordVoteByOptionText).not.toHaveBeenCalled();
+    expect(mocks.followExists).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/__tests__/services/pollVoteService.test.ts
+++ b/packages/backend/src/__tests__/services/pollVoteService.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `PollVoteService` is the SINGLE authority for recording a poll vote, shared by
+ * the local HTTP vote route and the inbound ActivityPub poll-vote handler. These
+ * pin its contract: the ATOMIC dedup guard it issues (so a duplicate never
+ * double-counts), closed-poll rejection, unknown-option/poll handling, and the
+ * single-vs-multiple-choice branch — the same guarantees both callers rely on.
+ *
+ * The `Poll` model is stubbed with controllable output; assertions read the
+ * `findOneAndUpdate` filter to prove the dedup guard is present (MongoDB provides
+ * the atomicity).
+ */
+
+const { pollFindById, pollFindOneAndUpdate } = vi.hoisted(() => ({
+  pollFindById: vi.fn(),
+  pollFindOneAndUpdate: vi.fn(),
+}));
+
+vi.mock('../../models/Poll', () => ({
+  default: { findById: pollFindById, findOneAndUpdate: pollFindOneAndUpdate },
+  Poll: { findById: pollFindById, findOneAndUpdate: pollFindOneAndUpdate },
+}));
+
+import { pollVoteService } from '../../services/PollVoteService';
+
+const FUTURE = new Date('2099-01-01T00:00:00.000Z');
+const PAST = new Date('2000-01-01T00:00:00.000Z');
+
+/** A lean-ish poll doc; `_id`/option `_id` expose `.toString()` the service uses. */
+function poll(overrides: {
+  isMultipleChoice?: boolean;
+  endsAt?: Date;
+  options?: Array<{ id: string; text: string; votes: string[] }>;
+}) {
+  const options = (overrides.options ?? [
+    { id: 'opt-red', text: 'Red', votes: [] },
+    { id: 'opt-blue', text: 'Blue', votes: [] },
+  ]).map((o) => ({ _id: { toString: () => o.id }, text: o.text, votes: o.votes }));
+  return {
+    _id: { toString: () => 'poll1' },
+    isMultipleChoice: overrides.isMultipleChoice ?? false,
+    endsAt: overrides.endsAt ?? FUTURE,
+    options,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('recordVoteByOptionText — resolve option by name', () => {
+  it('records a single-choice vote with a dedup guard on the voter, and returns the updated poll', async () => {
+    pollFindById.mockResolvedValue(poll({}));
+    const updated = { _id: 'poll1' };
+    pollFindOneAndUpdate.mockResolvedValue(updated);
+
+    const result = await pollVoteService.recordVoteByOptionText('poll1', 'Blue', 'voter-1');
+
+    expect(result).toEqual({ ok: true, poll: updated });
+    // The atomic filter carries the one-per-voter dedup guard (voted on NO option yet).
+    expect(pollFindOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'poll1', 'options._id': 'opt-blue', 'options.votes': { $ne: 'voter-1' } },
+      { $push: { 'options.$.votes': 'voter-1' } },
+      { new: true },
+    );
+  });
+
+  it('is a no-op (already_voted) when the voter already voted — no double count', async () => {
+    // The snapshot shows the voter already on an option; the atomic update matches
+    // nothing (returns null) → the service reports already_voted, never re-pushing.
+    pollFindById.mockResolvedValue(poll({ options: [
+      { id: 'opt-red', text: 'Red', votes: ['voter-1'] },
+      { id: 'opt-blue', text: 'Blue', votes: [] },
+    ] }));
+    pollFindOneAndUpdate.mockResolvedValue(null);
+
+    const result = await pollVoteService.recordVoteByOptionText('poll1', 'Blue', 'voter-1');
+
+    expect(result).toEqual({ ok: false, reason: 'already_voted' });
+  });
+
+  it('rejects a vote after the poll has ended (no update issued)', async () => {
+    pollFindById.mockResolvedValue(poll({ endsAt: PAST }));
+
+    const result = await pollVoteService.recordVoteByOptionText('poll1', 'Blue', 'voter-1');
+
+    expect(result).toEqual({ ok: false, reason: 'poll_ended' });
+    expect(pollFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reports option_not_found when no option matches the name', async () => {
+    pollFindById.mockResolvedValue(poll({}));
+
+    const result = await pollVoteService.recordVoteByOptionText('poll1', 'Green', 'voter-1');
+
+    expect(result).toEqual({ ok: false, reason: 'option_not_found' });
+    expect(pollFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reports poll_not_found when the poll is gone', async () => {
+    pollFindById.mockResolvedValue(null);
+
+    const result = await pollVoteService.recordVoteByOptionText('poll1', 'Blue', 'voter-1');
+
+    expect(result).toEqual({ ok: false, reason: 'poll_not_found' });
+  });
+
+  it('uses the per-option $elemMatch dedup guard for a multiple-choice poll', async () => {
+    pollFindById.mockResolvedValue(poll({ isMultipleChoice: true }));
+    pollFindOneAndUpdate.mockResolvedValue({ _id: 'poll1' });
+
+    await pollVoteService.recordVoteByOptionText('poll1', 'Blue', 'voter-1');
+
+    expect(pollFindOneAndUpdate).toHaveBeenCalledWith(
+      {
+        _id: 'poll1',
+        'options._id': 'opt-blue',
+        options: { $not: { $elemMatch: { _id: 'opt-blue', votes: 'voter-1' } } },
+      },
+      { $push: { 'options.$.votes': 'voter-1' } },
+      { new: true },
+    );
+  });
+});
+
+describe('recordVoteByOptionId — resolve option by id (HTTP route)', () => {
+  it('records a vote resolved by the option id', async () => {
+    pollFindById.mockResolvedValue(poll({}));
+    pollFindOneAndUpdate.mockResolvedValue({ _id: 'poll1' });
+
+    const result = await pollVoteService.recordVoteByOptionId('poll1', 'opt-red', 'voter-9');
+
+    expect(result.ok).toBe(true);
+    expect(pollFindOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'poll1', 'options._id': 'opt-red', 'options.votes': { $ne: 'voter-9' } },
+      { $push: { 'options.$.votes': 'voter-9' } },
+      { new: true },
+    );
+  });
+});

--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -11,7 +11,7 @@ import type {
 import { resolveOxyExternalUser } from '../identity';
 import { isAbsoluteHttpUrl } from '../shared/url';
 import { actorService } from './actor.service';
-import { followService, type NoteSourcePost, type NoteReplyContext, type NoteMentionContext } from './follow.service';
+import { followService, type NoteSourcePost, type NoteReplyContext, type NoteMentionContext, type NotePollContext } from './follow.service';
 import { outboxSyncService } from './outbox.service';
 import { inboxProcessingService } from './inbox.service';
 import { FEDERATION_ENABLED, isBlockedDomain } from './constants';
@@ -290,8 +290,9 @@ class ActivityPubConnector implements NetworkConnector {
     username: string,
     reply?: NoteReplyContext,
     mentions?: NoteMentionContext,
+    poll?: NotePollContext,
   ): Record<string, unknown> {
-    return followService.buildCreateNoteActivity(post, username, reply, mentions);
+    return followService.buildCreateNoteActivity(post, username, reply, mentions, poll);
   }
 
   /**
@@ -323,6 +324,24 @@ class ActivityPubConnector implements NetworkConnector {
    */
   resolveMentionContextByPost(posts: NoteSourcePost[]): Promise<Map<string, NoteMentionContext>> {
     return followService.resolveMentionContextByPost(posts);
+  }
+
+  /**
+   * Resolve a single post's poll addressing (the AP `Question` fields) for a PULL
+   * surface (the per-post dereference route). Null when the post is not a poll.
+   * The push path resolves this internally in {@link FollowService.federateNewPost}.
+   */
+  resolvePollContext(post: NoteSourcePost): Promise<NotePollContext | null> {
+    return followService.resolvePollContext(post);
+  }
+
+  /**
+   * Batch-resolve poll addressing for MANY posts (the outbox page / featured
+   * collection) in ONE Poll read. Keyed by post id; a non-poll post is absent
+   * from the map.
+   */
+  resolvePollContextByPost(posts: NoteSourcePost[]): Promise<Map<string, NotePollContext>> {
+    return followService.resolvePollContextByPost(posts);
   }
 
   federateNewPost(

--- a/packages/backend/src/connectors/activitypub/constants.ts
+++ b/packages/backend/src/connectors/activitypub/constants.ts
@@ -52,7 +52,17 @@ export const AP_CONTEXT = [
   // (`as` → `https://www.w3.org/ns/activitystreams#`), so this maps the Note's
   // `sensitive` boolean to `as:sensitive` — the exact term Mastodon defines for
   // it. Without the term declaration a JSON-LD consumer drops `sensitive`.
-  { sensitive: 'as:sensitive' },
+  //
+  // `toot` is Mastodon's extension namespace; `votersCount` (the total unique
+  // voters on a poll `Question`) is `toot:votersCount` — the exact term Mastodon
+  // emits and reads. Without the declaration a JSON-LD consumer drops it. The
+  // `Question`/`oneOf`/`anyOf`/`endTime`/`closed` poll terms are all AS2 core, so
+  // they need no extra declaration here.
+  {
+    sensitive: 'as:sensitive',
+    toot: 'http://joinmastodon.org/ns#',
+    votersCount: 'toot:votersCount',
+  },
 ];
 
 export const AP_CONTENT_TYPE = 'application/activity+json';

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -4,6 +4,7 @@ import FederatedFollow from '../../models/FederatedFollow';
 import FederationDeliveryQueue from '../../models/FederationDeliveryQueue';
 import UserSettings from '../../models/UserSettings';
 import { Post } from '../../models/Post';
+import Poll from '../../models/Poll';
 import { signRequest, getPublicKey } from './crypto';
 import {
   FEDERATION_DOMAIN,
@@ -212,6 +213,93 @@ export interface NoteMentionContext {
   tags: Array<{ type: 'Mention'; href: string; name: string }>;
   cc: string[];
   inboxes: string[];
+}
+
+/**
+ * The resolved poll a post carries, in the shape the AP `Question` needs — the
+ * DB-read side ({@link FollowService.resolvePollContext}) yields this, and the
+ * PURE Note/Question builder consumes it so {@link FollowService.buildCreateNoteActivity}
+ * never touches the database. A poll post federates as a `Question` instead of a
+ * `Note`; everything else about the object (attributedTo/content/url/tag/media/…)
+ * is identical and shared.
+ *
+ *  - `multiple` picks `anyOf` (multiple-choice) vs `oneOf` (single-choice);
+ *  - `options` are the poll choices with each choice's current vote count;
+ *  - `endTime` is the poll deadline; `closed` says whether it has already passed
+ *    (Mastodon emits `closed` only once ended, `endTime` while still open);
+ *  - `votersCount` is the number of UNIQUE voters (a multiple-choice voter who
+ *    picked several options counts once).
+ */
+export interface NotePollContext {
+  multiple: boolean;
+  options: Array<{ name: string; votes: number }>;
+  endTime: Date;
+  closed: boolean;
+  votersCount: number;
+}
+
+/** The Poll fields {@link buildPollContext} reads from a lean `Poll` document. */
+interface PollContextSource {
+  _id: unknown;
+  options: Array<{ text: string; votes?: string[] }>;
+  endsAt: Date;
+  isMultipleChoice?: boolean;
+}
+
+/**
+ * Derive a {@link NotePollContext} from a lean `Poll` document. Pure. Per-option
+ * vote counts come straight off each option's `votes` set; `votersCount` is the
+ * UNION of voter ids across every option (so a multiple-choice voter is counted
+ * once), and `closed` is computed against the current time.
+ */
+function buildPollContext(poll: PollContextSource): NotePollContext {
+  const voters = new Set<string>();
+  const options = poll.options.map((option) => {
+    let votes = 0;
+    if (Array.isArray(option.votes)) {
+      for (const voter of option.votes) {
+        if (!voter) continue;
+        votes += 1;
+        voters.add(String(voter));
+      }
+    }
+    return { name: option.text, votes };
+  });
+
+  const endTime = poll.endsAt instanceof Date ? poll.endsAt : new Date(poll.endsAt);
+  return {
+    multiple: poll.isMultipleChoice === true,
+    options,
+    endTime,
+    closed: Date.now() > endTime.getTime(),
+    votersCount: voters.size,
+  };
+}
+
+/**
+ * Turn an already-assembled AP content object (a `Note`) into a Mastodon-compatible
+ * `Question` (poll), IN PLACE: flip `type`, add the option set (`oneOf`
+ * single-choice / `anyOf` multiple-choice, each option a `Note` whose
+ * `replies.totalItems` is its vote count), the deadline (`endTime` while open,
+ * `closed` once ended), and `votersCount`. Every other field
+ * (attributedTo/content/url/tag/attachment/…) is INHERITED unchanged from the
+ * shared Note assembly, so Note and Question never duplicate object-building.
+ */
+function applyPollFields(object: Record<string, unknown>, poll: NotePollContext): void {
+  object.type = 'Question';
+  const optionNotes = poll.options.map((option) => ({
+    type: 'Note',
+    name: option.name,
+    replies: { type: 'Collection', totalItems: option.votes },
+  }));
+  if (poll.multiple) object.anyOf = optionNotes;
+  else object.oneOf = optionNotes;
+
+  const deadline = poll.endTime.toISOString();
+  if (poll.closed) object.closed = deadline;
+  else object.endTime = deadline;
+
+  object.votersCount = poll.votersCount;
 }
 
 /**
@@ -546,6 +634,7 @@ export class FollowService {
     username: string,
     reply?: NoteReplyContext,
     mentions?: NoteMentionContext,
+    poll?: NotePollContext,
   ): Record<string, unknown> {
     const actor = actorUrl(username);
     const postId = String(post._id);
@@ -627,6 +716,34 @@ export class FollowService {
       for (const href of mentions.cc) pushCc(href);
     }
 
+    // The shared content object. A plain post serializes it as a `Note`; a poll
+    // post reuses this EXACT object and only adds the poll structure + flips
+    // `type` to `Question` (see {@link applyPollFields}), so Note and Question
+    // never duplicate the attributedTo/content/url/tag/attachment assembly.
+    const object: Record<string, unknown> = {
+      id: noteId,
+      type: 'Note',
+      attributedTo: actor,
+      // Only present on a reply — undefined is dropped by JSON serialization,
+      // so a top-level Note carries no `inReplyTo`.
+      inReplyTo: reply?.inReplyTo,
+      url: `https://${FEDERATION_DOMAIN}/@${username}/posts/${postId}`,
+      sensitive,
+      content: primaryContent,
+      contentMap,
+      // Raw plaintext body, omitted (undefined dropped by JSON serialization)
+      // when the post has no body.
+      source,
+      language,
+      published,
+      to: [AP_PUBLIC],
+      cc,
+      tag: tags.length > 0 ? tags : undefined,
+      attachment: attachments.length > 0 ? attachments : undefined,
+    };
+
+    if (poll) applyPollFields(object, poll);
+
     return {
       '@context': AP_CONTEXT,
       id: `${noteId}/activity`,
@@ -635,27 +752,7 @@ export class FollowService {
       published,
       to: [AP_PUBLIC],
       cc,
-      object: {
-        id: noteId,
-        type: 'Note',
-        attributedTo: actor,
-        // Only present on a reply — undefined is dropped by JSON serialization,
-        // so a top-level Note carries no `inReplyTo`.
-        inReplyTo: reply?.inReplyTo,
-        url: `https://${FEDERATION_DOMAIN}/@${username}/posts/${postId}`,
-        sensitive,
-        content: primaryContent,
-        contentMap,
-        // Raw plaintext body, omitted (undefined dropped by JSON serialization)
-        // when the post has no body.
-        source,
-        language,
-        published,
-        to: [AP_PUBLIC],
-        cc,
-        tag: tags.length > 0 ? tags : undefined,
-        attachment: attachments.length > 0 ? attachments : undefined,
-      },
+      object,
     };
   }
 
@@ -702,7 +799,10 @@ export class FollowService {
       // their instance receives + notifies the post. `null` when the post mentions
       // nobody; the linkifier still strips any stray placeholder.
       const mentions = await this.resolveMentionContext(post);
-      const activity = this.buildCreateNoteActivity(post, senderUsername, reply?.context, mentions ?? undefined);
+      // A poll post federates as a `Question` (options + current tallies); a
+      // non-poll post resolves to null and federates as a plain Note.
+      const poll = await this.resolvePollContext(post);
+      const activity = this.buildCreateNoteActivity(post, senderUsername, reply?.context, mentions ?? undefined, poll ?? undefined);
       await this.deliverToFollowers(activity, senderOxyUserId, senderUsername, {
         extraInboxes: [
           ...(reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : []),
@@ -905,6 +1005,70 @@ export class FollowService {
     const entries = await this.resolveMentionEntries(ids);
     const context = buildNoteMentionContext(ids, entries);
     return context.links.size > 0 ? context : null;
+  }
+
+  /**
+   * Resolve a single post's {@link NotePollContext} — the push-delivery and
+   * per-post dereference entry point. A poll post links to its `Poll` document by
+   * `content.pollId`; this reads that document and derives the AP `Question`
+   * fields (options + per-option vote counts, deadline, unique voters). Returns
+   * null when the post carries no poll or the poll document is gone (the post then
+   * federates as a plain Note). Fail-soft: a read error is logged and resolves to
+   * null rather than breaking delivery.
+   */
+  async resolvePollContext(post: NoteSourcePost): Promise<NotePollContext | null> {
+    const pollId = post.content?.pollId;
+    if (!pollId) return null;
+    try {
+      const poll = await Poll.findById(pollId)
+        .select('options endsAt isMultipleChoice')
+        .lean<PollContextSource | null>();
+      return poll ? buildPollContext(poll) : null;
+    } catch (err) {
+      logger.warn(`[FedDeliver] failed to resolve poll context for post ${String(post._id)}:`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Batch-resolve the {@link NotePollContext} for MANY posts (the outbox page /
+   * featured collection) in ONE `Poll` read — the union of every post's `pollId`
+   * is fetched at once, then each post that has one is keyed to its context. A
+   * post without a poll (or whose poll is gone) is absent from the map; the Note
+   * builder then serializes it as a plain Note. Fail-soft: a read error logs and
+   * yields an empty map.
+   */
+  async resolvePollContextByPost(posts: NoteSourcePost[]): Promise<Map<string, NotePollContext>> {
+    const result = new Map<string, NotePollContext>();
+    const pollIdToPostIds = new Map<string, string[]>();
+
+    for (const post of posts) {
+      const pollId = post.content?.pollId;
+      if (!pollId) continue;
+      const key = String(pollId);
+      const bucket = pollIdToPostIds.get(key);
+      if (bucket) bucket.push(String(post._id));
+      else pollIdToPostIds.set(key, [String(post._id)]);
+    }
+    if (pollIdToPostIds.size === 0) return result;
+
+    try {
+      const polls = await Poll.find({ _id: { $in: [...pollIdToPostIds.keys()] } })
+        .select('options endsAt isMultipleChoice')
+        .lean<PollContextSource[]>();
+      for (const poll of polls) {
+        const postIds = pollIdToPostIds.get(String(poll._id));
+        if (!postIds) continue;
+        const context = buildPollContext(poll);
+        for (const postId of postIds) result.set(postId, context);
+      }
+    } catch (err) {
+      logger.warn('[FedDeliver] batch poll-context resolution failed', {
+        count: pollIdToPostIds.size,
+        reason: err instanceof Error ? err.message : 'unknown',
+      });
+    }
+    return result;
   }
 
   /**
@@ -1163,8 +1327,9 @@ export class FollowService {
     username: string,
     reply?: NoteReplyContext,
     mentions?: NoteMentionContext,
+    poll?: NotePollContext,
   ): Record<string, unknown> {
-    const created = this.buildCreateNoteActivity(post, username, reply, mentions);
+    const created = this.buildCreateNoteActivity(post, username, reply, mentions, poll);
     const note = created.object as Record<string, unknown>;
 
     const now = new Date();
@@ -1209,7 +1374,9 @@ export class FollowService {
     try {
       const reply = await this.resolveReplyDelivery(post);
       const mentions = await this.resolveMentionContext(post);
-      const activity = this.buildUpdateNoteActivity(post, editorUsername, reply?.context, mentions ?? undefined);
+      // Re-federate a poll post as an Update(Question) carrying its CURRENT tallies.
+      const poll = await this.resolvePollContext(post);
+      const activity = this.buildUpdateNoteActivity(post, editorUsername, reply?.context, mentions ?? undefined, poll ?? undefined);
       await this.deliverToFollowers(activity, editorOxyUserId, editorUsername, {
         extraInboxes: [
           ...(reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : []),

--- a/packages/backend/src/connectors/activitypub/inbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/inbox.service.ts
@@ -12,6 +12,7 @@ import { PostType } from '@mention/shared-types';
 import type { PostAuthorshipEntry } from '@mention/shared-types';
 import { extractApLanguage, extractApLanguages } from './apLanguage';
 import { getPostCreator } from '../../services/serviceRegistry';
+import { pollVoteService } from '../../services/PollVoteService';
 import { isFediverseSharingEnabled, isFediverseSharingEnabledFromUser } from '../../services/fediverseSharing';
 import { actorService } from './actor.service';
 import { requireActorOxyUserId } from '../shared/ActorResolutionPendingError';
@@ -459,6 +460,68 @@ export class InboxProcessingService {
     logger.debug(`[Federation] undo Announce from ${actorUri} (boost ${String(boost._id)})`);
   }
 
+  /**
+   * Handle an inbound Create whose Note is actually a POLL VOTE.
+   *
+   * Mastodon delivers a vote as a `Create` wrapping a `Note` that carries the
+   * chosen option's TEXT in `name`, an `inReplyTo` pointing at the poll's
+   * `Question` (our poll post's canonical AP id), and NO content — addressed to
+   * the poll owner. This detects that shape and records the vote against the
+   * local `Poll` through the SAME shared, atomic, idempotent path a local vote
+   * uses ({@link pollVoteService}), so a redelivered/duplicate vote never
+   * double-counts, a vote after close is rejected, and single-vs-multiple-choice
+   * is honored.
+   *
+   * Returns `true` when the Create was a vote on one of OUR polls (whether or not
+   * it was ultimately recorded — an unresolved voter, a sharing-off owner, a
+   * closed poll, or an unknown option all still "consume" it so it never falls
+   * through to the reply/post path). Returns `false` when it is not a poll vote
+   * (missing `name`/`inReplyTo`, has real content, or the referenced post is not
+   * a local poll), leaving {@link handleCreate} to process it as a normal
+   * reply/post. Fail-soft is inherited from the shared helpers; nothing throws.
+   */
+  private async handlePollVote(object: Record<string, any>, actorUri: string): Promise<boolean> {
+    // Shape gate — cheap checks first, no DB until the shape is a plausible vote.
+    const name = typeof object.name === 'string' ? object.name.trim() : '';
+    if (!name) return false;
+    const inReplyToUri = extractInReplyToUri(object.inReplyTo);
+    if (!inReplyToUri) return false;
+    // A vote carries no body; a Note WITH content on a poll is a normal reply.
+    const content = typeof object.content === 'string' ? object.content.trim() : '';
+    if (content.length > 0) return false;
+
+    // The `inReplyTo` must resolve to a LOCAL post that actually carries a poll.
+    const postId = await resolvePostIdFromObjectUri(inReplyToUri);
+    if (!postId) return false;
+    const post = await Post.findOne({ _id: postId }, { 'content.pollId': 1 })
+      .lean<{ content?: { pollId?: string } } | null>();
+    const pollId = post?.content?.pollId;
+    if (!pollId) return false; // reply to a non-poll post → let the normal path handle it
+
+    // Unambiguously a vote on our poll from here — consume it regardless of outcome.
+
+    // The poll owner may have turned fediverse sharing off — drop it silently.
+    if (!(await this.isLocalPostOwnerSharingEnabled(postId))) {
+      logger.debug(`[Federation] dropping poll vote from ${actorUri} on ${postId} — poll owner has sharing disabled`);
+      return true;
+    }
+
+    // Resolve the remote voter to a native Oxy user (syncs the actor, like handleLike).
+    const voterOxyUserId = await actorService.resolveActorOxyUserId(actorUri);
+    if (!voterOxyUserId) {
+      logger.info(`[Federation] skipping poll vote from ${actorUri} on ${postId}: unresolved actor`);
+      return true;
+    }
+
+    const result = await pollVoteService.recordVoteByOptionText(String(pollId), name, voterOxyUserId);
+    if (result.ok) {
+      logger.debug(`[Federation] recorded poll vote from ${actorUri} on ${postId} (option="${name}")`);
+    } else {
+      logger.debug(`[Federation] poll vote from ${actorUri} on ${postId} not recorded (${result.reason})`);
+    }
+    return true;
+  }
+
   private async handleCreate(activity: Record<string, any>, actorUri: string): Promise<void> {
     const object = activity.object;
     if (!object || typeof object !== 'object') return;
@@ -474,6 +537,13 @@ export class InboxProcessingService {
       );
       return;
     }
+
+    // A remote poll VOTE arrives as a Create(Note) — chosen option in `name`,
+    // `inReplyTo` = our poll's Question id, no content — and must be recorded
+    // against the Poll BEFORE the follower gate below: a voter need not follow us.
+    // Returns true only when this WAS a vote on one of our polls (handled + stop);
+    // a genuine reply/post returns false and flows through unchanged.
+    if (await this.handlePollVote(object, actorUri)) return;
 
     // Only process if the actor is followed by at least one local user
     const hasFollower = await FederatedFollow.exists({

--- a/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
+++ b/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
@@ -313,8 +313,17 @@ router.get('/users/:username/outbox', async (req: Request, res: Response) => {
     // AND resolved @mention anchors/tags (never a raw `[mention:<id>]` placeholder).
     // Mentions are batch-resolved for the whole page in two reads.
     const mentionContexts = await activityPubConnector.resolveMentionContextByPost(pagePosts);
+    // Poll posts serialize as `Question`; batch-resolve their tallies for the whole
+    // page in one Poll read (non-poll posts are absent → plain Note).
+    const pollContexts = await activityPubConnector.resolvePollContextByPost(pagePosts);
     const items = pagePosts.map((post) =>
-      activityPubConnector.buildCreateNoteActivity(post, username, undefined, mentionContexts.get(String(post._id))),
+      activityPubConnector.buildCreateNoteActivity(
+        post,
+        username,
+        undefined,
+        mentionContexts.get(String(post._id)),
+        pollContexts.get(String(post._id)),
+      ),
     );
 
     const pageId = cursor
@@ -399,10 +408,16 @@ router.get('/users/:username/collections/featured', async (req: Request, res: Re
     // carrying no per-item `@context` (the collection's top-level `@context` covers
     // them).
     const mentionContexts = await activityPubConnector.resolveMentionContextByPost(pinnedPosts);
+    const pollContexts = await activityPubConnector.resolvePollContextByPost(pinnedPosts);
     const items = pinnedPosts.map(
       (post) =>
-        activityPubConnector.buildCreateNoteActivity(post, username, undefined, mentionContexts.get(String(post._id)))
-          .object as Record<string, unknown>,
+        activityPubConnector.buildCreateNoteActivity(
+          post,
+          username,
+          undefined,
+          mentionContexts.get(String(post._id)),
+          pollContexts.get(String(post._id)),
+        ).object as Record<string, unknown>,
     );
 
     res.set('Content-Type', AP_CONTENT_TYPE);
@@ -481,13 +496,19 @@ router.get('/users/:username/posts/:id', async (req: Request, res: Response) => 
     // nobody; the linkifier still strips any stray placeholder from the body.
     const mentionContext = await activityPubConnector.resolveMentionContext(post);
 
+    // A poll post is dereferenced as a `Question` (options + current tallies);
+    // null for a non-poll post, which serves a plain Note.
+    const pollContext = await activityPubConnector.resolvePollContext(post);
+
     // Build via the shared Note path, then unwrap the Create envelope: a
-    // dereferenced Note is the `object`, carrying its own top-level `@context`.
+    // dereferenced Note/Question is the `object`, carrying its own top-level
+    // `@context`.
     const activity = activityPubConnector.buildCreateNoteActivity(
       post,
       username,
       replyContext ?? undefined,
       mentionContext ?? undefined,
+      pollContext ?? undefined,
     );
     const note = activity.object as Record<string, unknown>;
 

--- a/packages/backend/src/controllers/polls.controller.ts
+++ b/packages/backend/src/controllers/polls.controller.ts
@@ -4,6 +4,7 @@ import Post from '../models/Post';
 import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { createError } from '../utils/error';
 import { logger } from '../utils/logger';
+import { pollVoteService } from '../services/PollVoteService';
 import mongoose from 'mongoose';
 
 class PollsController {
@@ -165,90 +166,23 @@ class PollsController {
         });
       }
 
-      const poll = await Poll.findById(id);
-      if (!poll) {
-        return res.status(404).json({
-          error: 'Not found',
-          message: 'Poll not found'
-        });
+      // Record the vote through the shared service (the SAME atomic dedup path the
+      // inbound ActivityPub poll-vote handler uses), then map its result to HTTP.
+      const result = await pollVoteService.recordVoteByOptionId(id, optionId, userId);
+      if (result.ok) {
+        return res.json({ success: true, data: this.sanitizePollResponse(result.poll) });
       }
 
-      // Check if poll has ended
-      if (new Date() > poll.endsAt) {
-        return res.status(400).json({
-          error: 'Invalid request',
-          message: 'This poll has ended'
-        });
+      switch (result.reason) {
+        case 'poll_not_found':
+          return res.status(404).json({ error: 'Not found', message: 'Poll not found' });
+        case 'poll_ended':
+          return res.status(400).json({ error: 'Invalid request', message: 'This poll has ended' });
+        case 'option_not_found':
+          return res.status(404).json({ error: 'Not found', message: 'Option not found' });
+        case 'already_voted':
+          return res.status(400).json({ error: 'Invalid request', message: 'You have already voted in this poll' });
       }
-
-      // Find the option
-      const option = poll.options.find(opt => opt._id.toString() === optionId);
-      if (!option) {
-        return res.status(404).json({
-          error: 'Not found',
-          message: 'Option not found'
-        });
-      }
-
-      // Use atomic findOneAndUpdate to prevent race conditions (double-vote)
-      if (!poll.isMultipleChoice) {
-        // Atomically check no vote exists and add vote in one operation
-        const updated = await Poll.findOneAndUpdate(
-          {
-            _id: id,
-            'options._id': optionId,
-            'options.votes': { $ne: userId } // Only if user hasn't voted on ANY option
-          },
-          {
-            $push: { 'options.$.votes': userId }
-          },
-          { new: true }
-        );
-
-        if (!updated) {
-          // Check if user already voted (vs option not found)
-          const hasVoted = poll.options.some(opt =>
-            opt.votes.some(vote => vote.toString() === userId)
-          );
-          if (hasVoted) {
-            return res.status(400).json({
-              error: 'Invalid request',
-              message: 'You have already voted in this poll'
-            });
-          }
-          return res.status(404).json({
-            error: 'Not found',
-            message: 'Option not found'
-          });
-        }
-
-        return res.json({ success: true, data: this.sanitizePollResponse(updated) });
-      }
-
-      // Multiple choice: atomically add vote to specific option if not already voted on it
-      const updated = await Poll.findOneAndUpdate(
-        {
-          _id: id,
-          'options._id': optionId,
-          'options': { $not: { $elemMatch: { _id: optionId, votes: userId } } }
-        },
-        {
-          $push: { 'options.$.votes': userId }
-        },
-        { new: true }
-      );
-
-      if (!updated) {
-        return res.status(400).json({
-          error: 'Invalid request',
-          message: 'You have already voted for this option'
-        });
-      }
-
-      res.json({
-        success: true,
-        data: this.sanitizePollResponse(updated)
-      });
     } catch (error) {
       logger.error('[Polls] Error voting in poll:', error);
       next(createError(500, 'Error voting in poll'));

--- a/packages/backend/src/services/PollVoteService.ts
+++ b/packages/backend/src/services/PollVoteService.ts
@@ -1,0 +1,108 @@
+import Poll, { IPoll, IPollOption } from '../models/Poll';
+
+/**
+ * Why a vote could not be recorded. Callers map these to their own surface: the
+ * HTTP controller to status codes, the ActivityPub inbox to a debug log + drop.
+ */
+export type PollVoteFailureReason =
+  | 'poll_not_found'
+  | 'poll_ended'
+  | 'option_not_found'
+  | 'already_voted';
+
+export type PollVoteResult =
+  | { ok: true; poll: IPoll }
+  | { ok: false; reason: PollVoteFailureReason };
+
+/**
+ * The SINGLE authority for recording a vote on a {@link Poll} — shared by the
+ * local HTTP vote route (`polls.controller`) and the inbound ActivityPub poll
+ * vote handler (`inbox.service` — a remote Mastodon `Create(Note)` with a `name`
+ * on our `Question`). Both resolve a voter and an option and then land here, so
+ * dedup/one-per-voter, closed-poll rejection, and single-vs-multiple-choice
+ * semantics live in ONE place and can never diverge between the two paths.
+ *
+ * Recording is a single ATOMIC `findOneAndUpdate` whose filter carries the
+ * dedup guard, so a concurrent double-vote (or a redelivered federated vote)
+ * can never double-count: the update matches only when the voter is not already
+ * in the relevant `votes` set.
+ */
+class PollVoteService {
+  /** Record a vote identified by the option's `_id` (the local HTTP vote route). */
+  async recordVoteByOptionId(pollId: string, optionId: string, voterId: string): Promise<PollVoteResult> {
+    const poll = await Poll.findById(pollId);
+    if (!poll) return { ok: false, reason: 'poll_not_found' };
+    if (this.hasEnded(poll)) return { ok: false, reason: 'poll_ended' };
+
+    const option = poll.options.find((opt) => opt._id.toString() === optionId);
+    if (!option) return { ok: false, reason: 'option_not_found' };
+
+    return this.applyVote(poll, option, voterId);
+  }
+
+  /**
+   * Record a vote identified by the option's TEXT (the inbound ActivityPub path:
+   * a Mastodon poll vote references the chosen option by `name`, not by our id).
+   */
+  async recordVoteByOptionText(pollId: string, optionText: string, voterId: string): Promise<PollVoteResult> {
+    const poll = await Poll.findById(pollId);
+    if (!poll) return { ok: false, reason: 'poll_not_found' };
+    if (this.hasEnded(poll)) return { ok: false, reason: 'poll_ended' };
+
+    const option = poll.options.find((opt) => opt.text === optionText);
+    if (!option) return { ok: false, reason: 'option_not_found' };
+
+    return this.applyVote(poll, option, voterId);
+  }
+
+  private hasEnded(poll: IPoll): boolean {
+    return new Date() > poll.endsAt;
+  }
+
+  /**
+   * Atomically push the voter onto the option's `votes` set, guarded so a
+   * duplicate never double-counts:
+   *  - single-choice: only when the voter has voted on NO option yet;
+   *  - multiple-choice: only when the voter has not voted on THIS option yet.
+   *
+   * `poll` is the pre-update snapshot used only to distinguish an already-voted
+   * miss from an unknown-option miss on the single-choice path (mirrors the
+   * original controller behavior).
+   */
+  private async applyVote(poll: IPoll, option: IPollOption, voterId: string): Promise<PollVoteResult> {
+    const pollId = String(poll._id);
+    const optionId = option._id.toString();
+
+    if (!poll.isMultipleChoice) {
+      const updated = await Poll.findOneAndUpdate(
+        {
+          _id: pollId,
+          'options._id': optionId,
+          'options.votes': { $ne: voterId }, // only if the voter has not voted on ANY option
+        },
+        { $push: { 'options.$.votes': voterId } },
+        { new: true },
+      );
+      if (!updated) {
+        const hasVoted = poll.options.some((opt) => opt.votes.some((vote) => vote.toString() === voterId));
+        return { ok: false, reason: hasVoted ? 'already_voted' : 'option_not_found' };
+      }
+      return { ok: true, poll: updated };
+    }
+
+    const updated = await Poll.findOneAndUpdate(
+      {
+        _id: pollId,
+        'options._id': optionId,
+        options: { $not: { $elemMatch: { _id: optionId, votes: voterId } } }, // not already on THIS option
+      },
+      { $push: { 'options.$.votes': voterId } },
+      { new: true },
+    );
+    if (!updated) return { ok: false, reason: 'already_voted' };
+    return { ok: true, poll: updated };
+  }
+}
+
+export const pollVoteService = new PollVoteService();
+export default pollVoteService;


### PR DESCRIPTION
## Summary
- Poll posts now federate as an AP `Question` (oneOf/anyOf options with per-option vote totals, endTime/closed, votersCount) instead of a plain `Note`, so the poll is votable from Mastodon and other AP servers.
- Note and Question object assembly is unified into one shared path.
- Inbound remote votes are recorded through a new `PollVoteService` (extracted from the local vote controller so there is a single authority for vote writes), atomic + idempotent, honoring single/multiple choice and poll close.
- `@context` gains the `toot:votersCount` term needed by the Question extension.

## Test plan
- [x] `bunx tsc --noEmit` in `packages/backend` — clean
- [x] `bun run test` in `packages/backend` — 227 files / 2399 tests passed
- [x] `bun run build:backend` — shared-types + backend build succeed
- [ ] CI green on this PR before merge

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>