### PR TITLE
feat(federation): federate quote posts + ingest inbound @mentions

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
@@ -29,6 +29,8 @@ const mocks = vi.hoisted(() => ({
   resolveMentionContextByPost: vi.fn(),
   resolvePollContext: vi.fn(),
   resolvePollContextByPost: vi.fn(),
+  resolveQuoteContext: vi.fn(),
+  resolveQuoteContextByPost: vi.fn(),
   userSettingsFindOne: vi.fn(),
   postFind: vi.fn(),
   postCountDocuments: vi.fn(),
@@ -54,6 +56,8 @@ vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
     resolveMentionContextByPost: (...args: unknown[]) => mocks.resolveMentionContextByPost(...args),
     resolvePollContext: (...args: unknown[]) => mocks.resolvePollContext(...args),
     resolvePollContextByPost: (...args: unknown[]) => mocks.resolvePollContextByPost(...args),
+    resolveQuoteContext: (...args: unknown[]) => mocks.resolveQuoteContext(...args),
+    resolveQuoteContextByPost: (...args: unknown[]) => mocks.resolveQuoteContextByPost(...args),
     fetchPublicKey: vi.fn(),
     processInboxActivity: vi.fn(),
   },
@@ -123,6 +127,10 @@ beforeEach(() => {
   // the single-post dereference resolver returns null (serves a plain Note).
   mocks.resolvePollContext.mockResolvedValue(null);
   mocks.resolvePollContextByPost.mockResolvedValue(new Map());
+  // Default: no post is a quote — the batch resolver returns an empty map and the
+  // single-post dereference resolver returns null (serves a Note with no quote).
+  mocks.resolveQuoteContext.mockResolvedValue(null);
+  mocks.resolveQuoteContextByPost.mockResolvedValue(new Map());
 });
 
 describe('GET /ap/users/:username — actor image (banner)', () => {
@@ -189,9 +197,10 @@ describe('GET /ap/users/:username/outbox?page=true — reuses buildCreateNoteAct
       .expect(200);
 
     expect(mocks.buildCreateNoteActivity).toHaveBeenCalledTimes(2);
-    // The outbox passes NO reply context and the per-post mention + poll contexts
-    // (both undefined here — the batch resolvers returned empty maps) as args 3-5.
-    expect(mocks.buildCreateNoteActivity).toHaveBeenNthCalledWith(1, posts[0], 'alice', undefined, undefined, undefined);
+    // The outbox passes NO reply context and the per-post mention + poll + quote
+    // contexts (all undefined here — the batch resolvers returned empty maps) as
+    // args 3-6.
+    expect(mocks.buildCreateNoteActivity).toHaveBeenNthCalledWith(1, posts[0], 'alice', undefined, undefined, undefined, undefined);
     expect(res.body.type).toBe('OrderedCollectionPage');
     expect(res.body.orderedItems).toEqual([
       { type: 'Create', object: { id: 'https://mention.earth/ap/users/alice/posts/p1' } },
@@ -228,9 +237,36 @@ describe('GET /ap/users/:username/outbox?page=true — reuses buildCreateNoteAct
       .set('Accept', AP_ACCEPT)
       .expect(200);
 
-    // The batch-resolved poll context is passed as the 5th arg for its post.
-    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(posts[0], 'alice', undefined, undefined, pollContext);
+    // The batch-resolved poll context is passed as the 5th arg for its post (the
+    // 6th quote arg is undefined — no quote resolved for this post).
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(posts[0], 'alice', undefined, undefined, pollContext, undefined);
     expect(res.body.orderedItems).toEqual([{ type: 'Create', object: { type: 'Question' } }]);
+  });
+
+  it('threads the resolved quote context into the builder as the 6th arg for a quote post', async () => {
+    mocks.resolveOxyUser.mockResolvedValue({ _id: 'u1' });
+    mocks.postCountDocuments.mockResolvedValue(1);
+    const posts = [{ _id: 'quote-post' }];
+    mocks.postFind.mockReturnValue({
+      sort: () => ({ limit: () => ({ lean: async () => posts }) }),
+    });
+    const quoteContext = { uri: 'https://remote.example/users/bob/statuses/99' };
+    mocks.resolveQuoteContextByPost.mockResolvedValue(new Map([['quote-post', quoteContext]]));
+    mocks.buildCreateNoteActivity.mockImplementation(
+      (post: { _id: string }) => ({ type: 'Create', object: { id: `x/${post._id}` } }),
+    );
+
+    await request(app).get('/ap/users/alice/outbox?page=true').set('Accept', AP_ACCEPT).expect(200);
+
+    // The batch-resolved quote context is passed as the 6th arg for its post.
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(
+      posts[0],
+      'alice',
+      undefined,
+      undefined,
+      undefined,
+      quoteContext,
+    );
   });
 });
 
@@ -588,8 +624,29 @@ describe('GET /ap/users/:username/posts/:id — dereference', () => {
     // into the pure Note builder as the third argument.
     expect(mocks.resolveReplyContext).toHaveBeenCalledWith(replyDoc);
     // The dereference route threads the resolved reply context + (null →) undefined
-    // mention + poll contexts into the Note builder.
-    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(replyDoc, 'alice', replyContext, undefined, undefined);
+    // mention + poll + quote contexts into the Note builder.
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(replyDoc, 'alice', replyContext, undefined, undefined, undefined);
+  });
+
+  it('passes the resolved quote context into the Note builder for a quote post', async () => {
+    const quoteDoc = { _id: VALID_ID, content: { text: 'quoting this' }, quoteOf: 'quoted-1' };
+    mocks.postFindOne.mockReturnValue({ lean: async () => quoteDoc });
+    const quoteContext = { uri: 'https://remote.example/users/bob/statuses/99' };
+    mocks.resolveQuoteContext.mockResolvedValue(quoteContext);
+
+    await request(app).get(`/ap/users/alice/posts/${VALID_ID}`).set('Accept', AP_ACCEPT).expect(200);
+
+    // The route resolves the quote reference from the served post and threads it
+    // into the pure Note builder as the sixth argument.
+    expect(mocks.resolveQuoteContext).toHaveBeenCalledWith(quoteDoc);
+    expect(mocks.buildCreateNoteActivity).toHaveBeenCalledWith(
+      quoteDoc,
+      'alice',
+      undefined,
+      undefined,
+      undefined,
+      quoteContext,
+    );
   });
 
   it('404s a malformed post id without touching the database', async () => {

--- a/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
@@ -45,6 +45,8 @@ const mocks = vi.hoisted(() => ({
   resolveMentionContextByPost: vi.fn(),
   resolvePollContext: vi.fn(),
   resolvePollContextByPost: vi.fn(),
+  resolveQuoteContext: vi.fn(),
+  resolveQuoteContextByPost: vi.fn(),
   userSettingsFindOne: vi.fn(),
   postFind: vi.fn(),
   postCountDocuments: vi.fn(),
@@ -75,6 +77,8 @@ vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
     resolveMentionContextByPost: (...args: unknown[]) => mocks.resolveMentionContextByPost(...args),
     resolvePollContext: (...args: unknown[]) => mocks.resolvePollContext(...args),
     resolvePollContextByPost: (...args: unknown[]) => mocks.resolvePollContextByPost(...args),
+    resolveQuoteContext: (...args: unknown[]) => mocks.resolveQuoteContext(...args),
+    resolveQuoteContextByPost: (...args: unknown[]) => mocks.resolveQuoteContextByPost(...args),
     fetchPublicKey: vi.fn(),
     processInboxActivity: vi.fn().mockResolvedValue(undefined),
   },
@@ -180,6 +184,9 @@ beforeEach(() => {
   // plain Notes.
   mocks.resolvePollContext.mockResolvedValue(null);
   mocks.resolvePollContextByPost.mockResolvedValue(new Map());
+  // The gate tests serve non-quote posts — default to "no quote".
+  mocks.resolveQuoteContext.mockResolvedValue(null);
+  mocks.resolveQuoteContextByPost.mockResolvedValue(new Map());
   mocks.verifyHttpSignature.mockResolvedValue({
     verified: true,
     actorUri: 'https://remote.example/users/bob',

--- a/packages/backend/src/__tests__/connectors/activitypub/inboundMentionIngestion.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/inboundMentionIngestion.test.ts
@@ -1,0 +1,317 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Inbound federated @mention ingestion.
+ *
+ * A federated Note carries its @mentions in the content HTML (a Mastodon-style
+ * `<a class="u-url mention" href="…">@user</a>` anchor) AND in a machine-readable
+ * `tag` array (`{ type:'Mention', href:<actorUri>, name:'@user@host' }`). The
+ * inbox must resolve each tag's actor to the synced federated/local Oxy user id and
+ * rewrite the matching anchor into the internal `[mention:<oxyUserId>]` placeholder
+ * so hydration renders `@user@host` linking to that user — instead of the anchor
+ * being stripped to dead `@user` text.
+ *
+ * These pin, on `handleCreate`:
+ *   - a Mention tag → the stored body carries `[mention:<oxyUserId>]` (NOT `@user`)
+ *     and `post.mentions` holds the resolved id (the one `getOrFetchActor` returns);
+ *   - a LOCAL mentioned user gets a `type:'mention'` notification (via the SAME
+ *     `createMentionNotifications` util the native path calls);
+ *   - a redelivered Create (activityId already stored) never re-notifies;
+ *   - a note with NO Mention tags is stored unchanged (empty `mentions`, no notify).
+ *
+ * Drives the REAL `InboxProcessingService` with the sibling
+ * `inboundEngagementNotifications.test.ts` mocking convention: mock the models +
+ * notification util + `services/fediverseSharing`, let `actor.service.ts` +
+ * `constants.ts` (mention resolution) run for real against the mocked
+ * `FederatedActor` model / Oxy client, and mock `outbox.service.ts` wholesale.
+ */
+
+const REMOTE = 'https://remote.example';
+const AUTHOR_URI = `${REMOTE}/users/carol`;
+const AUTHOR_OXY_ID = 'oxy_carol';
+
+// A FEDERATED mentioned actor: Mastodon-style — its in-content anchor points at the
+// human profile URL (`/@bob`), its `Mention` tag href at the actor URI (`/users/bob`).
+const FED_MENTION_URI = `${REMOTE}/users/bob`;
+const FED_MENTION_PROFILE = `${REMOTE}/@bob`;
+const FED_MENTION_OXY_ID = 'oxy_fed_bob';
+
+// A LOCAL mentioned user: the tag href is our own actor URI, the anchor our profile URL.
+const LOCAL_MENTION_ACTOR_URI = 'https://mention.earth/ap/users/alice';
+const LOCAL_MENTION_PROFILE = 'https://mention.earth/@alice';
+const LOCAL_MENTION_OXY_ID = 'oxy_alice_local';
+
+const CREATED_POST_ID = 'created_post_1';
+
+const mocks = vi.hoisted(() => ({
+  actorFindOne: vi.fn(),
+  followExists: vi.fn(),
+  postFindOne: vi.fn(),
+  postExists: vi.fn(),
+  postUpdateOne: vi.fn(),
+  postCreatorCreate: vi.fn(),
+  ensureFederatedReplyLink: vi.fn(),
+  isFediverseSharingEnabled: vi.fn(),
+  getProfileByUsername: vi.fn(),
+  searchProfiles: vi.fn(),
+  createMentionNotifications: vi.fn(),
+  createPostAuthorNotifications: vi.fn(),
+  createNotification: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerError: vi.fn(),
+  loggerDebug: vi.fn(),
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: {
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError,
+    debug: mocks.loggerDebug,
+    fatal: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock('../../../connectors/activitypub/crypto', () => ({
+  getPublicKey: vi.fn(),
+  signViaOxy: vi.fn(),
+  signRequest: vi.fn(),
+}));
+
+vi.mock('../../../models/FederatedActor', () => ({
+  default: { findOne: mocks.actorFindOne },
+}));
+
+vi.mock('../../../models/FederatedFollow', () => ({
+  default: { exists: mocks.followExists },
+}));
+
+vi.mock('../../../models/FederationDeliveryQueue', () => ({
+  default: {},
+  getNextRetryTime: vi.fn(),
+}));
+
+vi.mock('../../../models/Post', () => ({
+  POST_CLASSIFICATION_PENDING: 'pending',
+  Post: {
+    findOne: mocks.postFindOne,
+    exists: mocks.postExists,
+    updateOne: mocks.postUpdateOne,
+    deleteOne: vi.fn(),
+  },
+}));
+
+vi.mock('../../../models/Like', () => ({
+  default: { create: vi.fn(), findOneAndDelete: vi.fn() },
+}));
+
+vi.mock('../../../models/UserSettings', () => ({
+  default: { updateOne: vi.fn() },
+}));
+
+vi.mock('../../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    getProfileByUsername: mocks.getProfileByUsername,
+    searchProfiles: mocks.searchProfiles,
+  }),
+}));
+
+vi.mock('../../../services/mediaCache/cacheWorker', () => ({
+  persistRemoteMediaForFederatedOwnerDetailed: vi.fn(),
+}));
+
+vi.mock('../../../services/mediaCache/cacheStore', () => ({
+  recordAccessAndMaybeEnqueue: vi.fn(),
+}));
+
+vi.mock('../../../services/serviceRegistry', () => ({
+  getPostCreator: () => ({ create: mocks.postCreatorCreate }),
+  registerPostFederator: vi.fn(),
+  registerPostCreator: vi.fn(),
+  getPostFederator: vi.fn(),
+}));
+
+vi.mock('../../../services/fediverseSharing', () => ({
+  isFediverseSharingEnabled: (...args: unknown[]) => mocks.isFediverseSharingEnabled(...args),
+}));
+
+// Notification utils are imported LAZILY inside the handlers (to avoid the load-time
+// server cycle); this module mock intercepts that dynamic import too.
+vi.mock('../../../utils/notificationUtils', () => ({
+  createMentionNotifications: mocks.createMentionNotifications,
+  createPostAuthorNotifications: mocks.createPostAuthorNotifications,
+  createNotification: mocks.createNotification,
+  createWelcomeNotification: vi.fn(),
+  createBatchNotifications: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/outbox.service', () => ({
+  outboxSyncService: {
+    ensureFederatedReplyLink: (...args: unknown[]) => mocks.ensureFederatedReplyLink(...args),
+    importAnnounce: vi.fn(),
+    syncOutboxPosts: vi.fn(),
+  },
+}));
+
+import { inboxProcessingService } from '../../../connectors/activitypub/inbox.service';
+
+/** Map each actor URI (author + federated mentions) to its resolved Oxy id. */
+function stubActors(byUri: Record<string, string>): void {
+  mocks.actorFindOne.mockImplementation((filter: { uri?: string }) => ({
+    lean: async () => {
+      const oxyUserId = filter.uri ? byUri[filter.uri] : undefined;
+      return oxyUserId ? { uri: filter.uri, oxyUserId, lastFetchedAt: new Date() } : null;
+    },
+  }));
+}
+
+/** The captured `create()` params of the single stored post. */
+function createdPost(): {
+  mentions?: string[];
+  content?: { variants?: Array<{ text: string }> };
+} {
+  return mocks.postCreatorCreate.mock.calls[0]?.[0] as {
+    mentions?: string[];
+    content?: { variants?: Array<{ text: string }> };
+  };
+}
+
+function primaryVariantText(): string {
+  return createdPost().content?.variants?.[0]?.text ?? '';
+}
+
+/** A Create(Note) with the given content HTML and Mention tags. */
+function createActivity(
+  content: string,
+  tag: Array<{ type: string; href: string; name: string }>,
+): Record<string, unknown> {
+  return {
+    id: `${AUTHOR_URI}/statuses/1/activity`,
+    type: 'Create',
+    actor: AUTHOR_URI,
+    object: {
+      id: `${AUTHOR_URI}/statuses/1`,
+      type: 'Note',
+      attributedTo: AUTHOR_URI,
+      content,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      tag,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.followExists.mockResolvedValue({ _id: 'follow_1' });
+  mocks.postExists.mockResolvedValue(null);
+  mocks.postUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  mocks.postCreatorCreate.mockResolvedValue({ _id: CREATED_POST_ID });
+  mocks.ensureFederatedReplyLink.mockResolvedValue(null);
+  mocks.isFediverseSharingEnabled.mockResolvedValue(true);
+  mocks.postFindOne.mockReturnValue({ lean: async () => null });
+  stubActors({ [AUTHOR_URI]: AUTHOR_OXY_ID, [FED_MENTION_URI]: FED_MENTION_OXY_ID });
+});
+
+describe('handleCreate — inbound @mention ingestion', () => {
+  it('rewrites a FEDERATED mention anchor to a [mention:<oxyUserId>] placeholder and stores post.mentions', async () => {
+    const content =
+      '<p>hey <span class="h-card"><a href="https://remote.example/@bob" class="u-url mention">@<span>bob</span></a></span> look</p>';
+    const activity = createActivity(content, [
+      { type: 'Mention', href: FED_MENTION_URI, name: '@bob@remote.example' },
+    ]);
+
+    await inboxProcessingService.processInboxActivity(activity, AUTHOR_URI);
+
+    expect(mocks.postCreatorCreate).toHaveBeenCalledTimes(1);
+    // The resolved id is the one getOrFetchActor returns for the tag's actor URI.
+    expect(createdPost().mentions).toEqual([FED_MENTION_OXY_ID]);
+    // Body carries the placeholder, never the bare visible handle.
+    expect(primaryVariantText()).toContain(`[mention:${FED_MENTION_OXY_ID}]`);
+    expect(primaryVariantText()).not.toContain('@bob');
+    // A federated mention has no Mention inbox → no notification.
+    expect(mocks.createMentionNotifications).not.toHaveBeenCalled();
+  });
+
+  it('notifies a LOCAL mentioned user with type:"mention" (native util) and stores the local id', async () => {
+    mocks.getProfileByUsername.mockResolvedValue({ _id: LOCAL_MENTION_OXY_ID, username: 'alice' });
+    const content =
+      '<p>cc <span class="h-card"><a href="https://mention.earth/@alice" class="u-url mention">@<span>alice</span></a></span></p>';
+    const activity = createActivity(content, [
+      { type: 'Mention', href: LOCAL_MENTION_ACTOR_URI, name: '@alice@mention.earth' },
+    ]);
+
+    await inboxProcessingService.processInboxActivity(activity, AUTHOR_URI);
+
+    expect(createdPost().mentions).toEqual([LOCAL_MENTION_OXY_ID]);
+    expect(primaryVariantText()).toContain(`[mention:${LOCAL_MENTION_OXY_ID}]`);
+    // Same util the native compose path calls: (recipients, postId, actorId, entityType).
+    expect(mocks.createMentionNotifications).toHaveBeenCalledWith(
+      [LOCAL_MENTION_OXY_ID],
+      CREATED_POST_ID,
+      AUTHOR_OXY_ID,
+      'post',
+    );
+  });
+
+  it('does NOT notify a local mention when that user has fediverse sharing off', async () => {
+    mocks.getProfileByUsername.mockResolvedValue({ _id: LOCAL_MENTION_OXY_ID, username: 'alice' });
+    mocks.isFediverseSharingEnabled.mockResolvedValue(false);
+    const content =
+      '<p>cc <a href="https://mention.earth/@alice" class="u-url mention">@<span>alice</span></a></p>';
+    const activity = createActivity(content, [
+      { type: 'Mention', href: LOCAL_MENTION_ACTOR_URI, name: '@alice@mention.earth' },
+    ]);
+
+    await inboxProcessingService.processInboxActivity(activity, AUTHOR_URI);
+
+    // The mention is still ingested (stored + placeholder), only the notify is gated.
+    expect(createdPost().mentions).toEqual([LOCAL_MENTION_OXY_ID]);
+    expect(mocks.createMentionNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT re-notify on a redelivered Create (activityId already stored)', async () => {
+    mocks.getProfileByUsername.mockResolvedValue({ _id: LOCAL_MENTION_OXY_ID, username: 'alice' });
+    mocks.postExists.mockResolvedValue({ _id: 'already_here' });
+    const content =
+      '<p>cc <a href="https://mention.earth/@alice" class="u-url mention">@<span>alice</span></a></p>';
+    const activity = createActivity(content, [
+      { type: 'Mention', href: LOCAL_MENTION_ACTOR_URI, name: '@alice@mention.earth' },
+    ]);
+
+    await inboxProcessingService.processInboxActivity(activity, AUTHOR_URI);
+
+    expect(mocks.postCreatorCreate).not.toHaveBeenCalled();
+    expect(mocks.createMentionNotifications).not.toHaveBeenCalled();
+  });
+
+  it('leaves a note with NO Mention tags unchanged (empty mentions, no notify)', async () => {
+    const activity = createActivity('<p>just some plain text</p>', []);
+
+    await inboxProcessingService.processInboxActivity(activity, AUTHOR_URI);
+
+    expect(mocks.postCreatorCreate).toHaveBeenCalledTimes(1);
+    expect(createdPost().mentions).toEqual([]);
+    expect(primaryVariantText()).toBe('just some plain text');
+    expect(primaryVariantText()).not.toContain('[mention:');
+    expect(mocks.createMentionNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does NOT rewrite an anchor whose href matches no resolved mention (degrades gracefully)', async () => {
+    // An unresolvable mention actor (getOrFetchActor returns no oxyUserId): the
+    // anchor stays, no placeholder, no stored mention — the prior bare-text behavior.
+    stubActors({ [AUTHOR_URI]: AUTHOR_OXY_ID });
+    const content =
+      '<p>hi <a href="https://remote.example/@ghost" class="u-url mention">@<span>ghost</span></a></p>';
+    const activity = createActivity(content, [
+      { type: 'Mention', href: `${REMOTE}/users/ghost`, name: '@ghost@remote.example' },
+    ]);
+
+    await inboxProcessingService.processInboxActivity(activity, AUTHOR_URI);
+
+    expect(createdPost().mentions).toEqual([]);
+    expect(primaryVariantText()).not.toContain('[mention:');
+    expect(mocks.createMentionNotifications).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/activitypub/inboundUpdateSecurity.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/inboundUpdateSecurity.test.ts
@@ -159,10 +159,11 @@ describe('handleUpdate — NoSQL-injection safety + ownership scope', () => {
   it('recovers a contentMap-only edit and scopes both queries to the sending actor', async () => {
     await inboxProcessingService.processInboxActivity(updateActivity(), ACTOR_URI);
 
-    // The lookup is scoped by BOTH the activity id and the sending actor.
+    // The lookup is scoped by BOTH the activity id and the sending actor (and reads
+    // the fields the edit needs: owner id, prior mentions, and reply-ness).
     expect(mocks.postFindOne).toHaveBeenCalledWith(
       { 'federation.activityId': EDITED_NOTE_ID, 'federation.actorUri': ACTOR_URI },
-      { oxyUserId: 1 },
+      { oxyUserId: 1, mentions: 1, parentPostId: 1 },
     );
 
     expect(mocks.postUpdateOne).toHaveBeenCalledTimes(1);

--- a/packages/backend/src/__tests__/connectors/activitypub/quoteFederation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/quoteFederation.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Outbound QUOTE-POST federation: a Mention quote post is a normal Note (its own
+ * commentary in `content`) PLUS a reference to the quoted post. These pin two
+ * things:
+ *
+ *  1. the PURE builder (`buildCreateNoteActivity` with a resolved quote context):
+ *     it emits the quoted object's canonical AP id under the modern
+ *     `quote`/`quoteUri` (FEP-044f / Mastodon 4.4+) AND legacy
+ *     `_misskey_quote`/`quoteUrl` (Misskey/Pleroma) fields, PLUS the FEP-e232
+ *     `Link` quote tag — and does NOT append the quoted URL into `content` (that
+ *     would double-render on quote-aware servers). A non-quote post emits none of
+ *     these, and a boost never carries a quote context.
+ *  2. the DB-read resolver (`resolveQuoteContext` / `resolveQuoteContextByPost`):
+ *     it reuses `resolveFederationTarget` to turn the local `quoteOf` id into the
+ *     quoted object's canonical AP uri — a FEDERATED quoted post → its remote
+ *     `federation.activityId`; a LOCAL quoted post → its minted
+ *     `/ap/users/<owner>/posts/<id>` uri; deduped across a batch.
+ *
+ * The builder's transitive deps are stubbed so `FollowService` imports in
+ * isolation; `Post`/`FederatedActor`/the Oxy client are stubbed with controllable
+ * lean output.
+ */
+
+vi.mock('../../../connectors/activitypub/actor.service', () => ({ actorService: {} }));
+vi.mock('../../../connectors/activitypub/crypto', () => ({ getPublicKey: vi.fn(), signRequest: vi.fn() }));
+vi.mock('../../../queue/producers', () => ({ enqueueDelivery: vi.fn(), enqueueInboxActivity: vi.fn() }));
+vi.mock('../../../models/FederationDeliveryQueue', () => ({ default: {} }));
+vi.mock('../../../models/FederatedFollow', () => ({ default: {} }));
+vi.mock('../../../models/Poll', () => ({ default: {} }));
+vi.mock('../../../utils/safeUpstreamFetch', () => ({ fetchUpstreamSingleHop: vi.fn() }));
+vi.mock('../../../utils/ssrfGuard', () => ({ assertSafePublicUrl: vi.fn() }));
+vi.mock('../../../utils/mediaResolver', () => ({
+  resolveMediaRef: (ref: string) => ({ url: `https://cloud.oxy.so/${ref}` }),
+}));
+
+const { postFindByIdLean, federatedActorFindOneLean, getUserById } = vi.hoisted(() => ({
+  postFindByIdLean: vi.fn(),
+  federatedActorFindOneLean: vi.fn(),
+  getUserById: vi.fn(),
+}));
+
+vi.mock('../../../models/Post', () => ({
+  Post: {
+    findById: () => ({ select: () => ({ lean: () => postFindByIdLean() }) }),
+  },
+}));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    findOne: () => ({ lean: () => federatedActorFindOneLean() }),
+  },
+}));
+vi.mock('../../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({ getUserById }),
+}));
+
+import type { PostContent } from '@mention/shared-types';
+import { followService } from '../../../connectors/activitypub/follow.service';
+
+const ISO = '2024-01-02T03:04:05.000Z';
+const QUOTED_URI = 'https://remote.example/users/bob/statuses/99';
+const QUOTE_LINK_REL = 'https://misskey-hub.net/ns#_misskey_quote';
+
+function body(text: string): PostContent {
+  return { variants: [{ source: 'author', text }] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  federatedActorFindOneLean.mockResolvedValue(null);
+});
+
+describe('buildCreateNoteActivity — quote → FEP-044f / FEP-e232 quote fields + Link tag', () => {
+  it('emits quote/quoteUri/quoteUrl/_misskey_quote = the quoted canonical id and a Link tag', () => {
+    const activity = followService.buildCreateNoteActivity(
+      { _id: 'q1', content: body('check this out'), createdAt: ISO },
+      'alice',
+      undefined,
+      undefined,
+      undefined,
+      { uri: QUOTED_URI },
+    );
+    const object = activity.object as Record<string, unknown>;
+
+    // All four quote surfaces carry the SAME quoted-object canonical id.
+    expect(object.quote).toBe(QUOTED_URI);
+    expect(object.quoteUri).toBe(QUOTED_URI);
+    expect(object.quoteUrl).toBe(QUOTED_URI);
+    expect(object._misskey_quote).toBe(QUOTED_URI);
+
+    // The FEP-e232 quote Link tag points at the quoted object as AP JSON.
+    const tags = object.tag as Array<Record<string, string>>;
+    expect(tags).toContainEqual({
+      type: 'Link',
+      mediaType: 'application/activity+json',
+      href: QUOTED_URI,
+      name: `RE: ${QUOTED_URI}`,
+      rel: QUOTE_LINK_REL,
+    });
+
+    // The commentary is a normal Note body; the quoted URL is NOT appended into
+    // `content` (structured fields only — no double-render on quote-aware servers).
+    expect(object.content).toBe('<p>check this out</p>');
+    expect(String(object.content)).not.toContain(QUOTED_URI);
+
+    // It is still a plain Note (a quote is not a poll).
+    expect(object.type).toBe('Note');
+  });
+
+  it('a non-quote post emits NONE of the quote fields and no Link tag', () => {
+    const activity = followService.buildCreateNoteActivity(
+      { _id: 'p1', content: body('just a post'), createdAt: ISO },
+      'alice',
+    );
+    const object = activity.object as Record<string, unknown>;
+
+    expect(object.quote).toBeUndefined();
+    expect(object.quoteUri).toBeUndefined();
+    expect(object.quoteUrl).toBeUndefined();
+    expect(object._misskey_quote).toBeUndefined();
+
+    const tags = (object.tag as Array<Record<string, string>> | undefined) ?? [];
+    expect(tags.some((t) => t.type === 'Link')).toBe(false);
+  });
+});
+
+describe('resolveQuoteContext — reuses resolveFederationTarget', () => {
+  it('resolves a FEDERATED quoted post to its remote federation.activityId', async () => {
+    postFindByIdLean.mockResolvedValue({ federation: { activityId: QUOTED_URI } });
+
+    const context = await followService.resolveQuoteContext({
+      _id: 'q1',
+      content: body('quoting a remote post'),
+      createdAt: ISO,
+      quoteOf: 'quoted-remote-id',
+    });
+
+    expect(context).toEqual({ uri: QUOTED_URI });
+    // A federated quoted post never needs an Oxy username lookup.
+    expect(getUserById).not.toHaveBeenCalled();
+  });
+
+  it('resolves a LOCAL quoted post to its minted /ap/users/<owner>/posts/<id> uri', async () => {
+    // No `federation` → local original; the owner username is resolved via Oxy.
+    postFindByIdLean.mockResolvedValue({ oxyUserId: 'owner1' });
+    getUserById.mockResolvedValue({ username: 'bob' });
+
+    const context = await followService.resolveQuoteContext({
+      _id: 'q1',
+      content: body('quoting a local post'),
+      createdAt: ISO,
+      quoteOf: 'local-post-1',
+    });
+
+    expect(context).toEqual({
+      uri: 'https://mention.earth/ap/users/bob/posts/local-post-1',
+    });
+    expect(getUserById).toHaveBeenCalledWith('owner1');
+  });
+
+  it('returns null (no DB read) when the post is not a quote', async () => {
+    const context = await followService.resolveQuoteContext({
+      _id: 'p1',
+      content: body('no quote here'),
+      createdAt: ISO,
+    });
+
+    expect(context).toBeNull();
+    expect(postFindByIdLean).not.toHaveBeenCalled();
+  });
+
+  it('returns null (no quote context) for a boost — a boost carries boostOf, never quoteOf', async () => {
+    const context = await followService.resolveQuoteContext({
+      _id: 'b1',
+      content: body(''),
+      createdAt: ISO,
+      boostOf: 'original-1',
+    });
+
+    expect(context).toBeNull();
+    expect(postFindByIdLean).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the quoted post is unresolvable (fail-soft, still federate the commentary)', async () => {
+    postFindByIdLean.mockResolvedValue(null);
+
+    const context = await followService.resolveQuoteContext({
+      _id: 'q1',
+      content: body('quoting a deleted post'),
+      createdAt: ISO,
+      quoteOf: 'gone',
+    });
+
+    expect(context).toBeNull();
+  });
+});
+
+describe('resolveQuoteContextByPost — batched + deduped', () => {
+  it('keys each quote context by post id, dedupes a shared quoted post, and omits non-quote posts', async () => {
+    // Both quote posts reference the SAME quoted original → resolved ONCE.
+    postFindByIdLean.mockResolvedValue({ federation: { activityId: QUOTED_URI } });
+
+    const map = await followService.resolveQuoteContextByPost([
+      { _id: 'q1', content: body('quote a'), createdAt: ISO, quoteOf: 'shared' },
+      { _id: 'q2', content: body('quote b'), createdAt: ISO, quoteOf: 'shared' },
+      { _id: 'p3', content: body('plain post'), createdAt: ISO },
+    ]);
+
+    expect(map.get('q1')).toEqual({ uri: QUOTED_URI });
+    expect(map.get('q2')).toEqual({ uri: QUOTED_URI });
+    expect(map.has('p3')).toBe(false);
+    // Deduped: the shared quoted id was resolved exactly once.
+    expect(postFindByIdLean).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty map (no DB read) when no post is a quote', async () => {
+    const map = await followService.resolveQuoteContextByPost([
+      { _id: 'p1', content: body('a'), createdAt: ISO },
+      { _id: 'p2', content: body('b'), createdAt: ISO },
+    ]);
+
+    expect(map.size).toBe(0);
+    expect(postFindByIdLean).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -11,7 +11,7 @@ import type {
 import { resolveOxyExternalUser } from '../identity';
 import { isAbsoluteHttpUrl } from '../shared/url';
 import { actorService } from './actor.service';
-import { followService, type NoteSourcePost, type NoteReplyContext, type NoteMentionContext, type NotePollContext } from './follow.service';
+import { followService, type NoteSourcePost, type NoteReplyContext, type NoteMentionContext, type NotePollContext, type NoteQuoteContext } from './follow.service';
 import { outboxSyncService } from './outbox.service';
 import { inboxProcessingService } from './inbox.service';
 import { FEDERATION_ENABLED, isBlockedDomain } from './constants';
@@ -291,8 +291,9 @@ class ActivityPubConnector implements NetworkConnector {
     reply?: NoteReplyContext,
     mentions?: NoteMentionContext,
     poll?: NotePollContext,
+    quote?: NoteQuoteContext,
   ): Record<string, unknown> {
-    return followService.buildCreateNoteActivity(post, username, reply, mentions, poll);
+    return followService.buildCreateNoteActivity(post, username, reply, mentions, poll, quote);
   }
 
   /**
@@ -342,6 +343,26 @@ class ActivityPubConnector implements NetworkConnector {
    */
   resolvePollContextByPost(posts: NoteSourcePost[]): Promise<Map<string, NotePollContext>> {
     return followService.resolvePollContextByPost(posts);
+  }
+
+  /**
+   * Resolve a single post's quote reference (the quoted object's canonical AP id →
+   * the FEP-044f/FEP-e232 quote fields + Link tag) for a PULL surface (the per-post
+   * dereference route). Null when the post is not a quote or the quoted post is
+   * unresolvable. The push path resolves this internally in
+   * {@link FollowService.federateNewPost}.
+   */
+  resolveQuoteContext(post: NoteSourcePost): Promise<NoteQuoteContext | null> {
+    return followService.resolveQuoteContext(post);
+  }
+
+  /**
+   * Batch-resolve quote references for MANY posts (the outbox page / featured
+   * collection), deduping the unique quoted post ids. Keyed by post id; a
+   * non-quote post is absent from the map.
+   */
+  resolveQuoteContextByPost(posts: NoteSourcePost[]): Promise<Map<string, NoteQuoteContext>> {
+    return followService.resolveQuoteContextByPost(posts);
   }
 
   federateNewPost(

--- a/packages/backend/src/connectors/activitypub/apMentions.ts
+++ b/packages/backend/src/connectors/activitypub/apMentions.ts
@@ -1,0 +1,266 @@
+import { logger } from '../../utils/logger';
+import { actorService } from './actor.service';
+import { getApContentMap } from './apLanguage';
+import { primaryApType } from './apSchemas';
+import { isBlockedDomain, resolveOxyUser } from './constants';
+
+/**
+ * INBOUND @mention ingestion for federated ActivityPub Notes.
+ *
+ * A remote Note carries its @mentions in TWO parallel places:
+ *   1. the visible content HTML — a Mastodon-style anchor,
+ *      `<span class="h-card"><a href="…" class="u-url mention">@<span>alice</span></a></span>`;
+ *   2. the machine-readable `tag` array — one `{ type:'Mention', href:<actorUri>,
+ *      name:'@alice@host' }` per mention.
+ *
+ * The `tag` array is authoritative (it carries the actor URI); the anchor is what
+ * the reader sees. Left untouched, {@link htmlToPlainText} strips the anchor to the
+ * bare visible text `@alice` — no domain, no link — and the `tag` array is ignored,
+ * so the mention renders as dead plain text.
+ *
+ * This module resolves each `Mention` tag's actor URI to the synced federated (or
+ * local) Oxy user id, then rewrites the matching content anchor into Mention's
+ * internal `[mention:<oxyUserId>]` placeholder — the SAME placeholder the native
+ * composer and the outbound Note builder use. Once stored as a placeholder,
+ * {@link PostHydrationService} renders it back into `@alice@host` linking to that
+ * user's profile via `getNormalizedUserHandle`, exactly like a native mention.
+ *
+ * Anchor↔tag matching is BY HREF (never the ambiguous bare `@username` text): the
+ * anchor's `href` is compared against two deterministic candidates per resolved
+ * tag — the actor URI itself (Pleroma, and our own round-tripped posts) and the
+ * reconstructed human profile URL `https://<domain>/@<user>` derived from the tag
+ * `name` (Mastodon/Misskey, whose in-content anchor points at the profile page,
+ * not the actor URI). An anchor that matches neither is left untouched and degrades
+ * to the prior bare-text behavior rather than mis-linking.
+ */
+
+/** One `Mention` entry extracted from an AP object's `tag` array. */
+export interface InboundMentionTag {
+  /** The mentioned actor's URI (the tag's `href`). */
+  href: string;
+  /** The `@user@domain` handle (the tag's `name`), when present. */
+  name?: string;
+}
+
+/** The resolved mentions of a single inbound Note. */
+export interface ResolvedInboundMentions {
+  /**
+   * Every resolved mentioned Oxy user id (federated AND local), deduped — stored
+   * verbatim as the post's `mentions` allowlist so hydration can render each
+   * `[mention:<id>]` placeholder.
+   */
+  ids: string[];
+  /**
+   * The subset of {@link ids} that are LOCAL Mention users — the only mention
+   * recipients with a Mention inbox, and thus the only notification targets.
+   */
+  localIds: string[];
+  /**
+   * Normalized candidate anchor `href` → mentioned Oxy user id, consumed by
+   * {@link applyMentionPlaceholders} to rewrite in-content anchors. Empty when no
+   * tag resolved (the common no-mention case), which makes the rewrite a no-op.
+   */
+  anchorMap: Map<string, string>;
+}
+
+/** Matches a whole `<a …>…</a>` anchor, capturing its `href`. Anchors never nest. */
+const MENTION_ANCHOR_REGEX = /<a\b[^>]*?\bhref="([^"]*)"[^>]*>.*?<\/a>/gis;
+
+/**
+ * Canonicalize an actor/profile href for equality matching: drop the fragment and
+ * any trailing slash and lowercase the whole thing, so `https://Host/@Alice#x/` and
+ * `https://host/@alice` compare equal. Both sides of every comparison run through
+ * this, so lowercasing the path (usernames are matched case-insensitively) is safe.
+ */
+function normalizeActorHref(href: string): string {
+  try {
+    const url = new URL(href);
+    url.hash = '';
+    let normalized = url.toString().toLowerCase();
+    if (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+    return normalized;
+  } catch {
+    return href.trim().toLowerCase().replace(/#.*$/, '').replace(/\/$/, '');
+  }
+}
+
+/**
+ * Reconstruct the human profile URL (`https://<domain>/@<user>`) from a tag `name`
+ * of the form `@user@domain`. This is the in-content anchor href Mastodon and
+ * Misskey emit (their anchor points at the profile page, not the actor URI), so it
+ * is the candidate that lets those servers' anchors match their own `Mention` tag.
+ * Returns `undefined` when the name is absent or not a `user@domain` handle.
+ */
+function reconstructProfileHref(name: string | undefined): string | undefined {
+  if (!name) return undefined;
+  const cleaned = name.replace(/^@+/, '');
+  const at = cleaned.indexOf('@');
+  if (at <= 0 || at === cleaned.length - 1) return undefined;
+  const local = cleaned.slice(0, at);
+  const domain = cleaned.slice(at + 1);
+  if (!local || !domain) return undefined;
+  return `https://${domain}/@${local}`;
+}
+
+/**
+ * Extract the local username from an href that points at one of OUR OWN users —
+ * either our minted actor URI (`/ap/users/<username>`) or our human profile URL
+ * (`/@<username>`). Returns `undefined` for any other shape.
+ */
+function extractLocalUsername(href: string): string | undefined {
+  let pathname: string;
+  try {
+    pathname = new URL(href).pathname;
+  } catch {
+    return undefined;
+  }
+  const actorMatch = pathname.match(/^\/ap\/users\/([^/]+)\/?$/);
+  if (actorMatch) return actorMatch[1];
+  const profileMatch = pathname.match(/^\/@([^/]+)\/?$/);
+  if (profileMatch) return profileMatch[1];
+  return undefined;
+}
+
+/** Parse the `Mention` entries out of an AP object's `tag` array. Pure. */
+export function extractMentionTags(object: Record<string, unknown>): InboundMentionTag[] {
+  const tag = object.tag;
+  if (!Array.isArray(tag)) return [];
+
+  const tags: InboundMentionTag[] = [];
+  for (const entry of tag) {
+    if (!entry || typeof entry !== 'object') continue;
+    const record = entry as { type?: unknown; href?: unknown; name?: unknown };
+    if (primaryApType(record.type as string | string[] | undefined) !== 'Mention') continue;
+    if (typeof record.href !== 'string' || record.href.trim().length === 0) continue;
+    tags.push({
+      href: record.href.trim(),
+      name: typeof record.name === 'string' ? record.name.trim() : undefined,
+    });
+  }
+  return tags;
+}
+
+/**
+ * Resolve one mentioned actor URI to its Oxy user id.
+ *
+ * An href on one of our own domains (or the Oxy identity apex) is a LOCAL user:
+ * resolve it through Oxy by username — NEVER fetch it as a remote actor (that path
+ * rejects own/blocked domains). Any other href is a genuine remote actor, resolved
+ * (and synced/created if new) through {@link ActorService.getOrFetchActor}. Returns
+ * `null` when the actor cannot be resolved to an Oxy user, so the caller leaves the
+ * anchor as bare text rather than minting a broken link.
+ */
+async function resolveMentionOxyId(
+  href: string,
+): Promise<{ oxyUserId: string; isLocal: boolean } | null> {
+  let host: string;
+  try {
+    host = new URL(href).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+
+  if (isBlockedDomain(host)) {
+    const username = extractLocalUsername(href);
+    if (!username) return null;
+    const user = await resolveOxyUser(username);
+    const oxyUserId = user ? String(user._id ?? user.id ?? '') : '';
+    return oxyUserId ? { oxyUserId, isLocal: true } : null;
+  }
+
+  const actor = await actorService.getOrFetchActor(href);
+  return actor?.oxyUserId ? { oxyUserId: String(actor.oxyUserId), isLocal: false } : null;
+}
+
+/**
+ * Resolve every `Mention` tag on an inbound Note to its Oxy user id, batched (each
+ * distinct actor href is resolved AT MOST once — no N+1). Fail-soft per mention: a
+ * tag that fails to resolve is simply absent from the result, leaving its anchor as
+ * bare text. Returns empty maps/arrays when the Note carries no `Mention` tags.
+ */
+export async function resolveInboundMentions(
+  object: Record<string, unknown>,
+): Promise<ResolvedInboundMentions> {
+  const tags = extractMentionTags(object);
+  if (tags.length === 0) return { ids: [], localIds: [], anchorMap: new Map() };
+
+  // Dedupe by actor href so a user mentioned twice is resolved once.
+  const byHref = new Map<string, InboundMentionTag>();
+  for (const tag of tags) {
+    if (!byHref.has(tag.href)) byHref.set(tag.href, tag);
+  }
+
+  const anchorMap = new Map<string, string>();
+  const ids = new Set<string>();
+  const localIds = new Set<string>();
+
+  await Promise.all(
+    [...byHref.values()].map(async (tag) => {
+      try {
+        const resolved = await resolveMentionOxyId(tag.href);
+        if (!resolved) return;
+        ids.add(resolved.oxyUserId);
+        if (resolved.isLocal) localIds.add(resolved.oxyUserId);
+        // Map BOTH candidate anchor hrefs (actor URI + reconstructed profile URL)
+        // to this id so the content anchor matches regardless of which form the
+        // origin server used.
+        anchorMap.set(normalizeActorHref(tag.href), resolved.oxyUserId);
+        const profileHref = reconstructProfileHref(tag.name);
+        if (profileHref) anchorMap.set(normalizeActorHref(profileHref), resolved.oxyUserId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`[Federation] failed to resolve inbound mention ${tag.href}: ${message}`);
+      }
+    }),
+  );
+
+  return { ids: [...ids], localIds: [...localIds], anchorMap };
+}
+
+/**
+ * Replace every in-content mention anchor whose `href` matches a resolved mention
+ * with the internal `[mention:<oxyUserId>]` placeholder. Anchors that match no
+ * resolved mention (hashtag anchors, bare links, an unresolved mention) are left
+ * untouched — {@link htmlToPlainText} handles those downstream. Pure.
+ */
+export function rewriteMentionAnchors(
+  html: string,
+  anchorMap: ReadonlyMap<string, string>,
+): string {
+  if (!html || anchorMap.size === 0) return html;
+  return html.replace(MENTION_ANCHOR_REGEX, (match, href: string) => {
+    const oxyUserId = anchorMap.get(normalizeActorHref(href));
+    return oxyUserId ? `[mention:${oxyUserId}]` : match;
+  });
+}
+
+/**
+ * Return a shallow copy of an AP Note object whose HTML bodies (`content` and every
+ * `contentMap` variant) have had their mention anchors rewritten to
+ * `[mention:<id>]` placeholders. The original object is never mutated; when the
+ * anchor map is empty the object is returned unchanged (zero cost for the common
+ * no-mention case). Every body is rewritten with the SAME map so the primary body
+ * and its `contentMap` counterpart stay byte-consistent for the language extractor.
+ */
+export function applyMentionPlaceholders(
+  object: Record<string, unknown>,
+  anchorMap: ReadonlyMap<string, string>,
+): Record<string, unknown> {
+  if (anchorMap.size === 0) return object;
+
+  const rewritten: Record<string, unknown> = { ...object };
+  if (typeof object.content === 'string') {
+    rewritten.content = rewriteMentionAnchors(object.content, anchorMap);
+  }
+
+  const contentMap = getApContentMap(object);
+  if (contentMap) {
+    const rewrittenMap: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(contentMap)) {
+      rewrittenMap[key] = typeof value === 'string' ? rewriteMentionAnchors(value, anchorMap) : value;
+    }
+    rewritten.contentMap = rewrittenMap;
+  }
+
+  return rewritten;
+}

--- a/packages/backend/src/connectors/activitypub/constants.ts
+++ b/packages/backend/src/connectors/activitypub/constants.ts
@@ -58,10 +58,25 @@ export const AP_CONTEXT = [
   // emits and reads. Without the declaration a JSON-LD consumer drops it. The
   // `Question`/`oneOf`/`anyOf`/`endTime`/`closed` poll terms are all AS2 core, so
   // they need no extra declaration here.
+  //
+  // Quote-post interop (FEP-044f / FEP-e232). A quote post carries the quoted
+  // object's canonical AP id under FOUR terms so the widest set of servers
+  // renders the inline quote: `quote` (FEP-044f, Mastodon 4.4+), `quoteUri`
+  // (Fedibird), `_misskey_quote` (Misskey) and `quoteUrl` (Pleroma/Akkoma). Each
+  // is typed `@id` (an IRI, not a literal); the `misskey`/`fedibird` namespaces
+  // and the AS2 `Link` type back the FEP-e232 `Link` quote tag. Without these
+  // declarations a strict JSON-LD consumer DROPS the quote fields.
   {
     sensitive: 'as:sensitive',
     toot: 'http://joinmastodon.org/ns#',
     votersCount: 'toot:votersCount',
+    misskey: 'https://misskey-hub.net/ns#',
+    fedibird: 'http://fedibird.com/ns#',
+    quote: { '@id': 'https://w3id.org/fep/044f#quote', '@type': '@id' },
+    quoteUri: { '@id': 'fedibird:quoteUri', '@type': '@id' },
+    quoteUrl: { '@id': 'as:quoteUrl', '@type': '@id' },
+    _misskey_quote: { '@id': 'misskey:_misskey_quote', '@type': '@id' },
+    Link: 'as:Link',
   },
 ];
 

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -164,6 +164,16 @@ export interface NoteSourcePost {
    * builder. Absent for a top-level post.
    */
   parentPostId?: string | null;
+  /**
+   * The local Post `_id` of the QUOTED post when this post is a quote. A quote
+   * post is a normal Note (its own commentary in `content`) PLUS a reference to
+   * the quoted object: the federation caller resolves the quoted post's canonical
+   * AP object uri via {@link FollowService.resolveQuoteContext} and passes it into
+   * the pure Note builder, which emits the FEP-044f/FEP-e232 quote fields. Absent
+   * for a non-quote post. (A pure boost carries `boostOf`, never `quoteOf`, and
+   * federates as an `Announce` — never as a quote.)
+   */
+  quoteOf?: string | null;
 }
 
 /**
@@ -236,6 +246,20 @@ export interface NotePollContext {
   endTime: Date;
   closed: boolean;
   votersCount: number;
+}
+
+/**
+ * The quote reference a Note carries when the post quotes another post: the
+ * quoted object's canonical AP object id. Resolved by the async federation caller
+ * (a DB lookup reusing {@link FollowService.resolveFederationTarget}) and passed
+ * into the PURE Note builder so {@link FollowService.buildCreateNoteActivity}
+ * never touches the database. The one `uri` feeds every emitted quote surface —
+ * the modern `quote`/`quoteUri` (FEP-044f / Mastodon 4.4+), the legacy
+ * `_misskey_quote`/`quoteUrl`, and the FEP-e232 `Link` quote tag.
+ */
+export interface NoteQuoteContext {
+  /** Canonical AP object id of the quoted post — the value of every quote field. */
+  uri: string;
 }
 
 /** The Poll fields {@link buildPollContext} reads from a lean `Poll` document. */
@@ -635,6 +659,7 @@ export class FollowService {
     reply?: NoteReplyContext,
     mentions?: NoteMentionContext,
     poll?: NotePollContext,
+    quote?: NoteQuoteContext,
   ): Record<string, unknown> {
     const actor = actorUrl(username);
     const postId = String(post._id);
@@ -662,6 +687,19 @@ export class FollowService {
     if (reply?.mention) pushMentionTag(reply.mention.href, reply.mention.name);
     if (mentions) {
       for (const tag of mentions.tags) pushMentionTag(tag.href, tag.name);
+    }
+    // FEP-e232 quote `Link` tag: a machine-readable pointer to the quoted object
+    // (`mediaType: application/activity+json`) so a quote-aware server (Mastodon
+    // 4.4+/Misskey) renders the inline quote. Emitted only for a real quote post —
+    // a boost never reaches this Create builder.
+    if (quote) {
+      tags.push({
+        type: 'Link',
+        mediaType: AP_CONTENT_TYPE,
+        href: quote.uri,
+        name: `RE: ${quote.uri}`,
+        rel: 'https://misskey-hub.net/ns#_misskey_quote',
+      });
     }
 
     // The primary rendition: its body, its media (shared or overridden, alt
@@ -727,6 +765,17 @@ export class FollowService {
       // Only present on a reply — undefined is dropped by JSON serialization,
       // so a top-level Note carries no `inReplyTo`.
       inReplyTo: reply?.inReplyTo,
+      // Quote reference — the quoted object's canonical AP id under both the
+      // modern (`quote`/`quoteUri`, FEP-044f / Mastodon 4.4+) and legacy
+      // (`_misskey_quote`/`quoteUrl`, Misskey/Pleroma) terms so a quote-aware
+      // server renders the inline quote. Structured fields ONLY — the quoted URL
+      // is deliberately NOT appended to `content` (that would double-render). All
+      // undefined (dropped by JSON) for a non-quote post; the matching FEP-e232
+      // `Link` tag is added to `tag` above.
+      quote: quote?.uri,
+      quoteUri: quote?.uri,
+      quoteUrl: quote?.uri,
+      _misskey_quote: quote?.uri,
       url: `https://${FEDERATION_DOMAIN}/@${username}/posts/${postId}`,
       sensitive,
       content: primaryContent,
@@ -802,7 +851,11 @@ export class FollowService {
       // A poll post federates as a `Question` (options + current tallies); a
       // non-poll post resolves to null and federates as a plain Note.
       const poll = await this.resolvePollContext(post);
-      const activity = this.buildCreateNoteActivity(post, senderUsername, reply?.context, mentions ?? undefined, poll ?? undefined);
+      // A quote post carries the quoted object's canonical AP id in the quote
+      // fields (+ FEP-e232 Link tag); a non-quote post resolves to null. Fail-soft:
+      // an unresolvable quoted post federates the commentary without quote fields.
+      const quote = await this.resolveQuoteContext(post);
+      const activity = this.buildCreateNoteActivity(post, senderUsername, reply?.context, mentions ?? undefined, poll ?? undefined, quote ?? undefined);
       await this.deliverToFollowers(activity, senderOxyUserId, senderUsername, {
         extraInboxes: [
           ...(reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : []),
@@ -1072,6 +1125,68 @@ export class FollowService {
   }
 
   /**
+   * Resolve a single post's {@link NoteQuoteContext} — the push-delivery, edit
+   * and per-post dereference entry point. A quote post links to the quoted post by
+   * `quoteOf`; this reuses {@link resolveFederationTarget} to turn that local id
+   * into the quoted object's canonical AP object uri (a federated quoted post →
+   * its remote `federation.activityId`; a local quoted post → its minted
+   * `/ap/users/<owner>/posts/<id>` uri). Returns null when the post is not a quote
+   * OR the quoted post is unresolvable — the post then federates as a normal Note
+   * carrying its own commentary, just without the quote fields. Fail-soft: any
+   * error is logged and resolves to null rather than breaking delivery.
+   */
+  async resolveQuoteContext(post: NoteSourcePost): Promise<NoteQuoteContext | null> {
+    const quoteId = post.quoteOf ? String(post.quoteOf) : undefined;
+    if (!quoteId) return null;
+    try {
+      const target = await this.resolveFederationTarget(quoteId);
+      return target ? { uri: target.objectUri } : null;
+    } catch (err) {
+      logger.warn(`[FedDeliver] failed to resolve quote context for quoted post ${quoteId}:`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Batch-resolve the {@link NoteQuoteContext} for MANY posts (the outbox page /
+   * featured collection). The unique set of quoted post ids is resolved once each —
+   * reusing {@link resolveFederationTarget}, in parallel and deduped so two posts
+   * quoting the same original share one resolution — then each quote post is keyed
+   * to its context. A non-quote post (or one whose quoted post is unresolvable) is
+   * absent from the map; the Note builder then serializes it without quote fields.
+   * Fail-soft per quoted post: a resolution error logs and yields no entry.
+   */
+  async resolveQuoteContextByPost(posts: NoteSourcePost[]): Promise<Map<string, NoteQuoteContext>> {
+    const result = new Map<string, NoteQuoteContext>();
+    const quoteIdToPostIds = new Map<string, string[]>();
+
+    for (const post of posts) {
+      const quoteId = post.quoteOf ? String(post.quoteOf) : undefined;
+      if (!quoteId) continue;
+      const postId = String(post._id);
+      const bucket = quoteIdToPostIds.get(quoteId);
+      if (bucket) bucket.push(postId);
+      else quoteIdToPostIds.set(quoteId, [postId]);
+    }
+    if (quoteIdToPostIds.size === 0) return result;
+
+    await Promise.all(
+      [...quoteIdToPostIds.entries()].map(async ([quoteId, postIds]) => {
+        let target: FederationTarget | null = null;
+        try {
+          target = await this.resolveFederationTarget(quoteId);
+        } catch (err) {
+          logger.warn(`[FedDeliver] failed to resolve quote context for quoted post ${quoteId}:`, err);
+          return;
+        }
+        if (!target) return;
+        for (const postId of postIds) result.set(postId, { uri: target.objectUri });
+      }),
+    );
+    return result;
+  }
+
+  /**
    * Resolve the canonical ActivityPub object id of a boosted/replied/liked
    * ORIGINAL post (plus, for a federated original, its author's remote inbox).
    *
@@ -1328,8 +1443,9 @@ export class FollowService {
     reply?: NoteReplyContext,
     mentions?: NoteMentionContext,
     poll?: NotePollContext,
+    quote?: NoteQuoteContext,
   ): Record<string, unknown> {
-    const created = this.buildCreateNoteActivity(post, username, reply, mentions, poll);
+    const created = this.buildCreateNoteActivity(post, username, reply, mentions, poll, quote);
     const note = created.object as Record<string, unknown>;
 
     const now = new Date();
@@ -1376,7 +1492,9 @@ export class FollowService {
       const mentions = await this.resolveMentionContext(post);
       // Re-federate a poll post as an Update(Question) carrying its CURRENT tallies.
       const poll = await this.resolvePollContext(post);
-      const activity = this.buildUpdateNoteActivity(post, editorUsername, reply?.context, mentions ?? undefined, poll ?? undefined);
+      // A quote post re-federates its quote reference; a non-quote post → null.
+      const quote = await this.resolveQuoteContext(post);
+      const activity = this.buildUpdateNoteActivity(post, editorUsername, reply?.context, mentions ?? undefined, poll ?? undefined, quote ?? undefined);
       await this.deliverToFollowers(activity, editorOxyUserId, editorUsername, {
         extraInboxes: [
           ...(reply?.parentAuthorInbox ? [reply.parentAuthorInbox] : []),

--- a/packages/backend/src/connectors/activitypub/inbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/inbox.service.ts
@@ -28,6 +28,8 @@ import {
   resolvePostIdFromObjectUri,
 } from './helpers';
 import { buildFederatedNoteContent, buildFederatedNoteContentForEdit } from './apPostContent';
+import { applyMentionPlaceholders, resolveInboundMentions } from './apMentions';
+import { normalizeMentionIds } from '../../utils/textProcessing';
 import { getRemoteHost } from '../shared/url';
 import { parseInboundActivity, parseNote, primaryApType } from './apSchemas';
 import type { z } from 'zod';
@@ -225,6 +227,49 @@ export class InboxProcessingService {
       const message = err instanceof Error ? err.message : String(err);
       logger.warn(
         `[Federation] ${type} notification failed for post ${postId} from actor ${actorOxyUserId}: ${message}`,
+      );
+    }
+  }
+
+  /**
+   * Best-effort: notify LOCAL users @mentioned by an inbound federated post,
+   * mirroring the NATIVE compose/reply path (`createMentionNotifications` — the
+   * SAME util `posts.controller` and `PostCreationService` call) so a Mastodon
+   * mention of a Mention user reaches their notifications exactly like a native one.
+   *
+   * `localMentionIds` are already narrowed to LOCAL users (federated mentions are
+   * stored on the post for rendering but have no Mention inbox to notify). Each is
+   * gated on THAT user's own fediverse-sharing consent: a mention is inbound
+   * engagement directed at the mentioned user, so a user with sharing off does not
+   * receive fediverse-originated mention notifications — the same rule the inbound
+   * Follow/reply/Like/Announce paths apply to their target. Fails OPEN per user on
+   * an Oxy outage, like every other consent read on this inbound path.
+   *
+   * `actorOxyUserId` is the post AUTHOR (who did the mentioning); `entityId` is the
+   * mentioning post. NEVER throws — a notification failure must not fail (and thus
+   * retry) the inbox activity. Lazy import for the same load-time-cycle reason as
+   * the sibling notify helpers.
+   */
+  private async notifyLocalMentionedUsers(
+    localMentionIds: string[],
+    actorOxyUserId: string,
+    entityId: string,
+    entityType: 'post' | 'reply',
+  ): Promise<void> {
+    try {
+      const consented = (
+        await Promise.all(
+          localMentionIds.map(async (id) => ((await isFediverseSharingEnabled(id)) ? id : null)),
+        )
+      ).filter((id): id is string => id !== null);
+      if (consented.length === 0) return;
+
+      const { createMentionNotifications } = await import('../../utils/notificationUtils');
+      await createMentionNotifications(consented, entityId, actorOxyUserId, entityType);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        `[Federation] mention notification failed for post ${entityId} from actor ${actorOxyUserId}: ${message}`,
       );
     }
   }
@@ -574,12 +619,22 @@ export class InboxProcessingService {
     const actor = await actorService.getOrFetchActor(actorUri);
     const authorOxyUserId = requireActorOxyUserId(actor, actorUri, `Create ${object.id}`);
 
+    // Resolve the Note's @mentions BEFORE building the body: each `Mention` tag's
+    // actor URI is resolved (and synced/created) to a federated or local Oxy user
+    // id, then the matching in-content anchor is rewritten to Mention's internal
+    // `[mention:<oxyUserId>]` placeholder so hydration renders it as a real link
+    // (`@user@domain`) instead of dead `@user` text. Batched — each distinct actor
+    // is resolved once. Runs after the dedup gate above, so a redelivered Create
+    // never repeats the resolution.
+    const mentionResult = await resolveInboundMentions(object);
+    const noteObject = applyMentionPlaceholders(object, mentionResult.anchorMap);
+
     // Extract the body (with contentMap fallback), normalize hashtags, and
     // materialize media through the shared builder — the SAME path the outbox
     // backfill and boost/ancestor import use. A Note that carries nothing
     // storable (no text, no surviving media, no content-warning) is dropped
     // instead of persisted as a blank post.
-    const built = await buildFederatedNoteContent(object, authorOxyUserId, {
+    const built = await buildFederatedNoteContent(noteObject, authorOxyUserId, {
       activityId: object.id,
       actorUri,
     });
@@ -638,6 +693,10 @@ export class InboxProcessingService {
       },
       visibility: mapApVisibility(object.to, object.cc),
       hashtags,
+      // Resolved @mention Oxy user ids (federated + local) — the SAME allowlist the
+      // native path stores, keyed by the `[mention:<id>]` placeholders now in the
+      // body, so hydration renders each as a real profile link.
+      mentions: mentionResult.ids,
       // AP-derived language so Mastodon/Pleroma posts carry their REAL language
       // (and feed the Stage-A classifier) instead of defaulting to 'en'. The
       // singular `language` sets the top-level `post.language` (primary); the full
@@ -671,6 +730,19 @@ export class InboxProcessingService {
         'reply',
         String(createdPost._id),
         'reply',
+      );
+    }
+
+    // Notify LOCAL @mentioned users exactly like a native mention. Only reached on
+    // a genuinely-new Create (the dedup gate returns early on a redelivery), so a
+    // redelivered Create never re-notifies. Federated mentions are stored on the
+    // post but not notified (no Mention inbox).
+    if (mentionResult.localIds.length > 0) {
+      await this.notifyLocalMentionedUsers(
+        mentionResult.localIds,
+        authorOxyUserId,
+        String(createdPost._id),
+        threadLink?.parentPostId ? 'reply' : 'post',
       );
     }
 
@@ -886,10 +958,20 @@ export class InboxProcessingService {
         'federation.actorUri': actorUri,
       };
 
-      const existingPost = await Post.findOne(editFilter, { oxyUserId: 1 }).lean<
-        { oxyUserId?: string | null } | null
+      const existingPost = await Post.findOne(editFilter, {
+        oxyUserId: 1,
+        mentions: 1,
+        parentPostId: 1,
+      }).lean<
+        { _id: mongoose.Types.ObjectId; oxyUserId?: string | null; mentions?: unknown; parentPostId?: string | null } | null
       >();
       const ownerOxyUserId = existingPost?.oxyUserId ?? (await actorService.getOrFetchActor(actorUri))?.oxyUserId ?? null;
+
+      // Re-resolve the edited Note's @mentions the SAME way as fresh ingest so an
+      // edit's mentions stay correct: each `Mention` tag → federated/local Oxy user
+      // id, the in-content anchors rewritten to `[mention:<id>]` placeholders.
+      const mentionResult = await resolveInboundMentions(object);
+      const noteObject = applyMentionPlaceholders(object, mentionResult.anchorMap);
 
       // Extract the edited body through the SAME shared logic as fresh ingest —
       // contentMap fallback, hashtag normalization, media materialization, and
@@ -898,7 +980,7 @@ export class InboxProcessingService {
       // Create: NO empty-note guard here — an Update applies its consistently
       // extracted fields (set when present, unset when the edit removed them),
       // never skips/deletes.
-      const built = await buildFederatedNoteContentForEdit(object, ownerOxyUserId, {
+      const built = await buildFederatedNoteContentForEdit(noteObject, ownerOxyUserId, {
         activityId: objectActivityId,
         actorUri,
       });
@@ -931,10 +1013,32 @@ export class InboxProcessingService {
       if (built.variants.length > 0) setOps['content.variants'] = built.variants;
       else unsetOps['content.variants'] = '';
 
+      // The edit's mention allowlist REPLACES the old one wholesale, mirroring the
+      // body: dropping a mention from the text drops it from `mentions` too, so the
+      // stored ids always match the `[mention:<id>]` placeholders now in the body.
+      setOps.mentions = mentionResult.ids;
+
       const update: Record<string, unknown> = { $set: setOps };
       if (Object.keys(unsetOps).length > 0) update.$unset = unsetOps;
       await Post.updateOne(editFilter, update);
       logger.debug(`Updated federated post: ${objectActivityId}`);
+
+      // Notify only NEWLY-added local mentions (diff against the post's prior
+      // mentions), so a redelivered/unchanged Update never re-notifies while an
+      // edit that adds a mention still reaches that user. Only meaningful when the
+      // post already exists locally and has a resolved author.
+      if (existingPost && ownerOxyUserId && mentionResult.localIds.length > 0) {
+        const priorMentionIds = new Set(normalizeMentionIds(existingPost.mentions));
+        const newLocalIds = mentionResult.localIds.filter((id) => !priorMentionIds.has(id));
+        if (newLocalIds.length > 0) {
+          await this.notifyLocalMentionedUsers(
+            newLocalIds,
+            ownerOxyUserId,
+            String(existingPost._id),
+            existingPost.parentPostId ? 'reply' : 'post',
+          );
+        }
+      }
     } else if (object.type === 'Person' || object.type === 'Service' || object.type === 'Application') {
       // Profile update — re-fetch the actor to get updated data
       await actorService.fetchRemoteActor(actorUri);

--- a/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
+++ b/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
@@ -316,6 +316,10 @@ router.get('/users/:username/outbox', async (req: Request, res: Response) => {
     // Poll posts serialize as `Question`; batch-resolve their tallies for the whole
     // page in one Poll read (non-poll posts are absent → plain Note).
     const pollContexts = await activityPubConnector.resolvePollContextByPost(pagePosts);
+    // Quote posts carry the quoted object's canonical AP id (FEP-044f quote fields
+    // + FEP-e232 Link tag); batch-resolve the whole page's quote references, deduped
+    // (non-quote posts are absent → plain Note).
+    const quoteContexts = await activityPubConnector.resolveQuoteContextByPost(pagePosts);
     const items = pagePosts.map((post) =>
       activityPubConnector.buildCreateNoteActivity(
         post,
@@ -323,6 +327,7 @@ router.get('/users/:username/outbox', async (req: Request, res: Response) => {
         undefined,
         mentionContexts.get(String(post._id)),
         pollContexts.get(String(post._id)),
+        quoteContexts.get(String(post._id)),
       ),
     );
 
@@ -409,6 +414,7 @@ router.get('/users/:username/collections/featured', async (req: Request, res: Re
     // them).
     const mentionContexts = await activityPubConnector.resolveMentionContextByPost(pinnedPosts);
     const pollContexts = await activityPubConnector.resolvePollContextByPost(pinnedPosts);
+    const quoteContexts = await activityPubConnector.resolveQuoteContextByPost(pinnedPosts);
     const items = pinnedPosts.map(
       (post) =>
         activityPubConnector.buildCreateNoteActivity(
@@ -417,6 +423,7 @@ router.get('/users/:username/collections/featured', async (req: Request, res: Re
           undefined,
           mentionContexts.get(String(post._id)),
           pollContexts.get(String(post._id)),
+          quoteContexts.get(String(post._id)),
         ).object as Record<string, unknown>,
     );
 
@@ -500,6 +507,11 @@ router.get('/users/:username/posts/:id', async (req: Request, res: Response) => 
     // null for a non-poll post, which serves a plain Note.
     const pollContext = await activityPubConnector.resolvePollContext(post);
 
+    // A quote post carries the quoted object's canonical AP id (FEP-044f quote
+    // fields + FEP-e232 Link tag); null for a non-quote post or an unresolvable
+    // quoted post, which serves the Note without quote fields.
+    const quoteContext = await activityPubConnector.resolveQuoteContext(post);
+
     // Build via the shared Note path, then unwrap the Create envelope: a
     // dereferenced Note/Question is the `object`, carrying its own top-level
     // `@context`.
@@ -509,6 +521,7 @@ router.get('/users/:username/posts/:id', async (req: Request, res: Response) => 
       replyContext ?? undefined,
       mentionContext ?? undefined,
       pollContext ?? undefined,
+      quoteContext ?? undefined,
     );
     const note = activity.object as Record<string, unknown>;
 


### PR DESCRIPTION
## Summary
- **Outbound quote federation**: a quote post (`quoteOf`) now emits the modern + legacy AP quote fields (`quote`/`quoteUri`/`quoteUrl`/`_misskey_quote` + a FEP-e232 `Link` tag) resolved to the quoted post's canonical AP id, so Mastodon 4.4+/Misskey render the inline quote instead of losing it.
- **Inbound @mention ingestion**: a federated post's `@mentions` are now parsed from its AP `Mention` tags, resolved by `href` to the synced `FederatedActor`, and rewritten to `[mention:<id>]` placeholders so they render as `@user@domain` linking to the real profile instead of a broken bare `@username`. Local mentioned users get an idempotent, consent-gated mention notification.

## Test plan
- [x] `cd packages/backend && bunx tsc --noEmit` — clean
- [x] `cd packages/backend && bun run test` — 229 files / 2416 tests passed
- [x] `bun run build:backend` (shared-types + backend) — succeeds
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)