### PR TITLE
feat(frontend): collaborators bottom sheet on collaborative posts

### DIFF
--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -26,6 +26,7 @@ const PostSourcesSheet = lazy(() => import('@/components/Post/PostSourcesSheet')
 const PostArticleModal = lazy(() => import('@/components/Post/PostArticleModal'));
 const PostInsightsSheet = lazy(() => import('@/components/Post/PostInsightsSheet'));
 const EngagementListSheet = lazy(() => import('@/components/Post/EngagementListSheet'));
+const CollaboratorsSheet = lazy(() => import('@/components/Post/CollaboratorsSheet'));
 import { BottomSheetContext } from '@/context/BottomSheetContext';
 import { useLiveRoom } from '@/context/LiveRoomContext';
 import { Ionicons } from '@expo/vector-icons';
@@ -445,6 +446,26 @@ const PostItem: React.FC<PostItemProps> = ({
         bottomSheet.openBottomSheet(true);
     }, [bottomSheet, viewPostId]);
 
+    // Owner + accepted collaborators, already hydrated on the post. A post is
+    // collaborative when it carries more than one author.
+    const collaborators = viewPost?.authors;
+    const isCollab = (collaborators?.length ?? 0) > 1;
+
+    // Open the collaborators list — the byline shows first names only, so this is
+    // where the full @usernames live. Content is already on the post (no fetch).
+    const openCollaboratorsSheet = useCallback(() => {
+        if (!collaborators || collaborators.length <= 1) return;
+        bottomSheet.setBottomSheetContent(
+            <Suspense fallback={null}>
+                <CollaboratorsSheet
+                    authors={collaborators}
+                    onClose={() => bottomSheet.openBottomSheet(false)}
+                />
+            </Suspense>
+        );
+        bottomSheet.openBottomSheet(true);
+    }, [bottomSheet, collaborators]);
+
     const roomId = roomContent?.roomId;
     const handleRoomPress = useCallback(() => {
         if (roomId) joinLiveRoom(roomId);
@@ -778,6 +799,7 @@ const PostItem: React.FC<PostItemProps> = ({
                         authorUserId={viewPost.user.id || undefined}
                         onPressUser={goToUser}
                         onPressAvatar={goToUser}
+                        onPressCollaborators={isCollab ? openCollaboratorsSheet : undefined}
                         onPressAuthor={goToAuthor}
                         onPressMenu={openMenu}
                         paddingHorizontal={isNested ? 0 : HPAD}

--- a/packages/frontend/components/Post/CollaboratorsSheet.tsx
+++ b/packages/frontend/components/Post/CollaboratorsSheet.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from 'react';
+import { View, FlatList } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Header } from '@/components/Header';
+import { IconButton } from '@/components/ui/Button';
+import { CloseIcon } from '@/assets/icons/close-icon';
+import { ProfileCard } from '@/components/ProfileCard';
+import { getNormalizedUserHandle } from '@oxyhq/core';
+import type { PostUser } from '@mention/shared-types';
+
+interface CollaboratorsSheetProps {
+  /**
+   * Owner + accepted collaborators, already hydrated on the post (`post.authors`).
+   * The sheet renders them directly — there is NO fetch here, unlike the
+   * likes/boosts {@link EngagementListSheet}.
+   */
+  authors: PostUser[];
+  onClose: () => void;
+}
+
+/**
+ * The collaborators of a multi-author post, as a bottom-sheet list. Surfaces each
+ * author's full identity — displayName + @username (federated authors render
+ * `@user@domain`) — which the compact byline (first names only) omits. Reuses
+ * {@link ProfileCard} for every row and the same `getNormalizedUserHandle` →
+ * `/@handle` navigation as {@link EngagementListSheet}.
+ */
+const CollaboratorsSheet: React.FC<CollaboratorsSheetProps> = ({ authors, onClose }) => {
+  const router = useRouter();
+  const { t } = useTranslation();
+
+  const handleUserPress = useCallback((user: PostUser) => {
+    onClose();
+    const profileHandle = getNormalizedUserHandle(user);
+    if (profileHandle) {
+      router.push(`/@${profileHandle}`);
+    }
+  }, [onClose, router]);
+
+  const renderUser = useCallback(({ item }: { item: PostUser }) => (
+    <ProfileCard
+      profile={{
+        id: item.id,
+        username: item.username,
+        name: item.name,
+        avatar: item.avatar,
+        verified: item.verified,
+        isFederated: item.isFederated,
+        instance: item.instance,
+        federation: item.federation,
+      }}
+      showFollowButton
+      onPress={() => handleUserPress(item)}
+    />
+  ), [handleUserPress]);
+
+  return (
+    <View className="flex-1 bg-background">
+      <Header
+        options={{
+          title: t('collab.collaboratorsTitle', { defaultValue: 'Collaborators' }),
+          rightComponents: [
+            <IconButton variant="icon"
+              key="close"
+              onPress={onClose}
+            >
+              <CloseIcon size={20} className="text-foreground" />
+            </IconButton>,
+          ],
+        }}
+        hideBottomBorder={true}
+        disableSticky={true}
+      />
+
+      <FlatList
+        data={authors}
+        renderItem={renderUser}
+        keyExtractor={(item) => item.id}
+      />
+    </View>
+  );
+};
+
+export default CollaboratorsSheet;

--- a/packages/frontend/components/Post/PostHeader.tsx
+++ b/packages/frontend/components/Post/PostHeader.tsx
@@ -93,6 +93,12 @@ interface PostHeaderProps {
   placeholderColor?: string;
   onPressUser?: () => void;
   onPressAvatar?: () => void;
+  /**
+   * Collaborative posts only (owner + ≥1 accepted collaborator): tapping the
+   * avatar — which represents the group — opens the collaborators list instead of
+   * a single profile. Ignored for solo posts, which keep {@link onPressAvatar}.
+   */
+  onPressCollaborators?: () => void;
   onPressMenu?: () => void;
   onPressAuthor?: (handle: string) => void;
 }
@@ -120,6 +126,7 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   placeholderColor,
   onPressUser,
   onPressAvatar,
+  onPressCollaborators,
   onPressMenu,
   onPressAuthor,
 }) => {
@@ -165,7 +172,9 @@ const PostHeader: React.FC<PostHeaderProps> = ({
             variant={avatarVariant}
             size={avatarSize}
             placeholderColor={placeholderColor}
-            onPress={onPressAvatar}
+            // A collab post's avatar represents the group, so it opens the
+            // collaborators list; a solo post keeps its single-author behavior.
+            onPress={isCollabHeader && onPressCollaborators ? onPressCollaborators : onPressAvatar}
             style={{ marginTop: headerTopOffset, marginRight: 12 }}
           />
         </ProfileHoverCard>

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -153,6 +153,7 @@
   "collab.acceptedToast": "You're now a collaborator on this post",
   "collab.acceptFailed": "Failed to accept invite",
   "collab.declineFailed": "Failed to decline invite",
+  "collab.collaboratorsTitle": "Collaborators",
   "notification.mark_all_read": "Mark all as read",
   "notification.mark_read": "Mark as read",
   "notification.delete": "Delete notification",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -174,6 +174,7 @@
   "collab.acceptedToast": "Ahora eres colaborador en esta publicación",
   "collab.acceptFailed": "No se pudo aceptar la invitación",
   "collab.declineFailed": "No se pudo rechazar la invitación",
+  "collab.collaboratorsTitle": "Colaboradores",
   "notification.mark_all_read": "Marcar todo como leído",
   "notification.mark_read": "Marcar como leído",
   "notification.delete": "Eliminar notificación",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -563,6 +563,7 @@
   "collab.acceptedToast": "Ora sei un collaboratore su questo post",
   "collab.acceptFailed": "Impossibile accettare l'invito",
   "collab.declineFailed": "Impossibile rifiutare l'invito",
+  "collab.collaboratorsTitle": "Collaboratori",
   "notifications": {
     "tabs": {
       "all": "Tutto",


### PR DESCRIPTION
## Summary
- The collab byline shows only first names, so @usernames weren't visible for collaborators on a post.
- Tapping a collaborative post's avatar now opens a bottom sheet listing every collaborator (avatar, display name, @username, verified badge, tappable to their profile).
- Reuses `ProfileCard` from the engagement-list sheet — no extra fetch, since authors are already present on the hydrated post.
- Per-name taps in the byline still navigate directly to that author's profile (unchanged).

## Test plan
- [x] `bun run typecheck` in `packages/frontend` — 0 errors
- [x] `bun run test` in `packages/frontend` — 20 suites / 358 tests passing
- [x] Frontend-only change; backend untouched, no backend build needed

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>