### PR TITLE
feat(frontend): cluster avatar for collaborative posts (@oxyhq/bloom 0.35.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.34.3",
+        "@oxyhq/bloom": "^0.35.0",
         "@oxyhq/contracts": "^0.15.0",
         "@oxyhq/core": "^12.2.1",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.34.3",
+        "@oxyhq/bloom": "^0.35.0",
         "@oxyhq/core": "^12.2.1",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
         "@oxyhq/services": "^22.2.0",
@@ -208,7 +208,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.34.3",
+    "@oxyhq/bloom": "^0.35.0",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/services": "^22.2.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -702,7 +702,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.3", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-5Vz57ogXAn1wl+NxsSNDpAPmOQLnZmWWhj1ij3KD+cyDzC3WCGJaomWbo2vQ1j7M2tNWHhEbiUOe0kWsaXhqSw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.35.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-wW4mcICMo/roaoN/2sI/ZN9yEnQoAOc09iX929RnNfkBYAxi0sXrobamTcsr+XciBRI7yIJBDGeY5Xra31PuhQ=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.15.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-2UsyiRw+dxlwKa3rY50iJvBtsbSslUJwvfA27EmB1+DM4fSXS5raNoxzZ7FBeug1A0l4TQE1qd0PjpII2uDavA=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.34.3",
+    "@oxyhq/bloom": "^0.35.0",
     "@oxyhq/contracts": "^0.15.0",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.34.3",
+    "@oxyhq/bloom": "^0.35.0",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/services": "^22.2.0",
     "mongoose": "^8.17.0",

--- a/packages/frontend/components/Post/PostHeader.tsx
+++ b/packages/frontend/components/Post/PostHeader.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { Text, View, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { LiveAvatar } from '@/components/ui/LiveAvatar';
+import { AvatarGroup, type AvatarGroupItem } from '@oxyhq/bloom/avatar-group';
 
 import UserName from '../UserName';
 import { ProfileHoverCard } from '../ProfileHoverCard';
@@ -10,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { RemoteActorBadge } from '@/components/Fediverse/FediverseBadge';
 import { BoostIcon } from '@/assets/icons/boost-icon';
 import { formatTimeAgo } from '@/utils/dateUtils';
+import { displayNameOrHandle } from '@/utils/displayName';
 import type { HydratedAuthor } from '@mention/shared-types';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 
@@ -155,6 +157,25 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   const isCollabHeader = headerAuthors.length > 1;
   const hasDisplayName = !isCollabHeader && !!user.displayName?.trim();
 
+  // Collaborative posts render a single cluster of every author's avatar in the
+  // slot a solo post's avatar occupies. Each member's `avatar` (a bare Oxy file
+  // id OR an absolute federated URL) is routed straight into Bloom's `Avatar`
+  // source via the group's `uri` — the SAME ImageResolver plumbing the solo
+  // avatar uses (variant applied at the group level). `displayName`/`username`
+  // drive accessibility only. Empty for solo posts (the cluster is not rendered).
+  const collabAvatars = useMemo<AvatarGroupItem[]>(
+    () =>
+      isCollabHeader
+        ? (authors ?? []).map((a) => ({
+            id: a.id,
+            uri: a.avatar,
+            displayName: displayNameOrHandle(a.name?.displayName, getNormalizedUserHandle(a) ?? ''),
+            username: a.username,
+          }))
+        : [],
+    [authors, isCollabHeader],
+  );
+
   // `contextTop` rows are the first children of the flex-1 content column, so the
   // name row is pushed down by each fixed-height context row plus the column gap.
   // Offset the avatar + ⋯ menu by the same amount so they keep aligning with the
@@ -165,19 +186,39 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   return (
     <View style={{ paddingHorizontal }}>
       <View className="flex-row items-start justify-between">
-        <ProfileHoverCard username={user.handle}>
-          <LiveAvatar
-            userId={authorUserId}
-            source={avatarSource}
-            variant={avatarVariant}
-            size={avatarSize}
-            placeholderColor={placeholderColor}
-            // A collab post's avatar represents the group, so it opens the
-            // collaborators list; a solo post keeps its single-author behavior.
-            onPress={isCollabHeader && onPressCollaborators ? onPressCollaborators : onPressAvatar}
+        {isCollabHeader ? (
+          // The collab avatar represents the whole group: a magnetic bubble
+          // cluster of every author's avatar that opens the collaborators list
+          // on tap (the sheet lists each @username). `size` is the cluster box
+          // diameter, matched to the solo avatar so the layout never shifts.
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel={t('collab.viewCollaborators', { defaultValue: 'View collaborators' })}
+            disabled={!onPressCollaborators}
+            onPress={onPressCollaborators}
             style={{ marginTop: headerTopOffset, marginRight: 12 }}
-          />
-        </ProfileHoverCard>
+          >
+            <AvatarGroup
+              layout="cluster"
+              items={collabAvatars}
+              size={avatarSize}
+              variant={avatarVariant}
+              max={20}
+            />
+          </TouchableOpacity>
+        ) : (
+          <ProfileHoverCard username={user.handle}>
+            <LiveAvatar
+              userId={authorUserId}
+              source={avatarSource}
+              variant={avatarVariant}
+              size={avatarSize}
+              placeholderColor={placeholderColor}
+              onPress={onPressAvatar}
+              style={{ marginTop: headerTopOffset, marginRight: 12 }}
+            />
+          </ProfileHoverCard>
+        )}
         <View className="flex-1" style={{ gap: HEADER_CONTENT_GAP }}>
           {contextTop}
           <View className="flex-row items-end" style={{ gap: ROW_GAP }}>

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -129,6 +129,7 @@
   "notification.group.showAll": "Show all",
   "notification.group.showLess": "Show less",
   "collab.inviteCollaborators": "Invite collaborators",
+  "collab.viewCollaborators": "View collaborators",
   "collab.searchPlaceholder": "Search people to collaborate with",
   "collab.noResults": "No users found",
   "collab.and": " and ",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -150,6 +150,7 @@
   "notification.recommendation.activity": "Activo en tu red: {{actorName}}",
   "notification.post": "{{actorName}} publicó una nueva actualización",
   "collab.inviteCollaborators": "Invitar colaboradores",
+  "collab.viewCollaborators": "Ver colaboradores",
   "collab.searchPlaceholder": "Buscar personas para colaborar",
   "collab.noResults": "No se encontraron usuarios",
   "collab.and": " y ",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -539,6 +539,7 @@
   "common.goBack": "Torna indietro",
   "notification.post": "{{actorName}} ha pubblicato un nuovo aggiornamento",
   "collab.inviteCollaborators": "Invita collaboratori",
+  "collab.viewCollaborators": "Visualizza collaboratori",
   "collab.searchPlaceholder": "Cerca persone con cui collaborare",
   "collab.noResults": "Nessun utente trovato",
   "collab.and": " e ",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.34.3",
+    "@oxyhq/bloom": "^0.35.0",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
     "@oxyhq/services": "^22.2.0",


### PR DESCRIPTION
## Summary
- Bumps `@oxyhq/bloom` to 0.35.0 for the new `AvatarGroup` `cluster` layout.
- Wires it into `PostHeader` for collaborative posts: the author avatar is now an iMessage-style magnetic cluster of every collaborator's avatar; tapping it opens the collaborators bottom sheet.
- Solo posts are unchanged (still render a single `LiveAvatar`).
- Updates locale strings (en/es/it) for the new UI copy.

## Test plan
- [x] `bun install --frozen-lockfile` (with `BUN_TMPDIR`) — passed, no lockfile drift
- [x] `cd packages/frontend && bun run typecheck` — 0 errors
- [x] `cd packages/frontend && bun run test` — 20/20 suites, 358/358 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)