### PR TITLE
chore(frontend): bump @oxyhq/bloom to 0.35.1 (cluster avatar sizing fixes)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.35.0",
+        "@oxyhq/bloom": "^0.35.1",
         "@oxyhq/contracts": "^0.15.0",
         "@oxyhq/core": "^12.2.1",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.35.0",
+        "@oxyhq/bloom": "^0.35.1",
         "@oxyhq/core": "^12.2.1",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
         "@oxyhq/services": "^22.2.0",
@@ -208,7 +208,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.35.0",
+    "@oxyhq/bloom": "^0.35.1",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/services": "^22.2.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -702,7 +702,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.35.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-wW4mcICMo/roaoN/2sI/ZN9yEnQoAOc09iX929RnNfkBYAxi0sXrobamTcsr+XciBRI7yIJBDGeY5Xra31PuhQ=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.35.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-6apM2haiC7K81a2sDvwmRFXzNAHFqwHvlfkXt5odJgqt9bYNqNj0jT4GKGiAWvOwF95l9v1iyZ9N1Jzv2ZbrTg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.15.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-2UsyiRw+dxlwKa3rY50iJvBtsbSslUJwvfA27EmB1+DM4fSXS5raNoxzZ7FBeug1A0l4TQE1qd0PjpII2uDavA=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.35.0",
+    "@oxyhq/bloom": "^0.35.1",
     "@oxyhq/contracts": "^0.15.0",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.35.0",
+    "@oxyhq/bloom": "^0.35.1",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/services": "^22.2.0",
     "mongoose": "^8.17.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.35.0",
+    "@oxyhq/bloom": "^0.35.1",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
     "@oxyhq/services": "^22.2.0",


### PR DESCRIPTION
## Summary
- Pure dependency bump, no code changes.
- Picks up @oxyhq/bloom's AvatarGroup cluster layout fixes: the 2-avatar case now renders equal sizes, and 4+ packs densely with near-equal sizes filling the box.
- Bumped in all three places where `@oxyhq/bloom` is pinned: `packages/frontend/package.json` dependencies, root `package.json` dependencies, and root `package.json` `overrides`.

## Test plan
- [x] `bun install --frozen-lockfile` passes (no lockfile drift)
- [x] `cd packages/frontend && bun run typecheck` — 0 errors
- [x] `cd packages/frontend && bun run test` — 20 suites / 358 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)