### PR TITLE
fix(collab): reflect accept/decline in UI + propagate edited posts

### DIFF
--- a/packages/backend/src/__tests__/services/postCollaborationService.test.ts
+++ b/packages/backend/src/__tests__/services/postCollaborationService.test.ts
@@ -221,6 +221,21 @@ describe('PostCollaborationService', () => {
       await expect(postCollaborationService.accept('post-1', 'stranger')).rejects.toBeInstanceOf(CollabStateError);
       expect(federateNewPost).not.toHaveBeenCalled();
     });
+
+    it('marks the accepting user accepted on the returned post (co-authorship contract)', async () => {
+      // The controller hydrates and returns THIS post; the client reads the
+      // resulting `authors[]`/`viewerState.isCollaborator` to show the new
+      // collaboration everywhere. Guard that accept actually flips the entry.
+      const post = fakePost({ authorship: buildAuthorship('owner-1', ['c-1']) });
+      (Post.findById as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(post);
+
+      const result = await postCollaborationService.accept('post-1', 'c-1');
+
+      expect(result.authorship?.find((e) => e.oxyUserId === 'c-1')).toMatchObject({
+        role: 'collaborator',
+        status: 'accepted',
+      });
+    });
   });
 
   describe('decline — deferred federation gate', () => {
@@ -235,6 +250,20 @@ describe('PostCollaborationService', () => {
       await postCollaborationService.decline('post-1', 'c-1');
 
       expect(federateNewPost).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks the declining user declined on the returned post, leaving others pending', async () => {
+      // The controller hydrates and returns THIS post so the client can flip the
+      // invite row from actionable buttons to a resolved "You declined" state.
+      const post = fakePost({ authorship: buildAuthorship('owner-1', ['c-1', 'c-2']) });
+      (Post.findById as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(post);
+
+      const result = await postCollaborationService.decline('post-1', 'c-1');
+
+      expect(result.authorship?.find((e) => e.oxyUserId === 'c-1')?.status).toBe('declined');
+      expect(result.authorship?.find((e) => e.oxyUserId === 'c-2')?.status).toBe('pending');
+      // Another invite is still pending, so the deferred federation must NOT fire.
+      expect(federateNewPost).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -793,8 +793,20 @@ export const declineCollabInvite = async (req: AuthRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ message: 'Unauthorized' });
 
-    await postCollaborationService.decline(String(req.params.id), userId);
-    return res.status(200).json({ success: true });
+    const post = await postCollaborationService.decline(String(req.params.id), userId);
+    // Return the fully-hydrated post (same as accept/stop-sharing) so the client
+    // can update its cached copy: the viewer's authorship entry is now `declined`,
+    // which flips the invite notification from actionable buttons to a resolved
+    // state. For a private/followers-only post the decliner loses view access, so
+    // hydration yields no post and the client simply drops the actionable UI.
+    const [hydratedPost] = await postHydrationService.hydratePosts([post.toObject()], {
+      viewerId: userId,
+      oxyClient: createScopedOxyClient(req),
+      requestLanguages: requestLanguageCandidates(req),
+      maxDepth: 1,
+      includeLinkMetadata: true,
+    });
+    return res.status(200).json({ success: true, post: hydratedPost ?? null });
   } catch (error) {
     if (error instanceof CollabStateError) {
       return res.status(400).json({ message: error.message });

--- a/packages/frontend/app/(app)/compose.tsx
+++ b/packages/frontend/app/(app)/compose.tsx
@@ -182,7 +182,7 @@ const ComposeScreenBody = () => {
   const isScreenNotMobile = useIsScreenNotMobile();
   const keyboardVisible = useKeyboardVisibility();
   const bottomBarVisible = isAuthenticated && !isScreenNotMobile && !keyboardVisible;
-  const { createPost, createThread, createReply } = usePostsStore();
+  const { createPost, createThread, createReply, cachePosts } = usePostsStore();
   const { t, i18n } = useTranslation();
   const rawParams = useLocalSearchParams() as ComposeIntentRawParams;
   // Parse once per route entry. Re-running on every param tick would re-apply
@@ -987,7 +987,7 @@ const ComposeScreenBody = () => {
         // a whole post, so it has its own builder — which carries the renditions
         // too, or editing a multilingual post would strip every language but the
         // primary.
-        await feedService.editPost(editPostId, buildEditPost({
+        const updatedPost = await feedService.editPost(editPostId, buildEditPost({
           postContent,
           mediaIds,
           mentions: mainPost.mentions || [],
@@ -995,6 +995,11 @@ const ComposeScreenBody = () => {
           collaboratorIds: collaborators.map((c) => c.id),
           variantContent: mainVariantContent,
         }));
+        // Propagate the edited post to the shared post cache so the feed, profile
+        // and detail reflect the change immediately (the same store every new post
+        // flows through) — without this the edit is invisible until a manual
+        // refresh, since the detail only revalidates on its original mount.
+        cachePosts([updatedPost]);
       } else if (allPosts.length === 1) {
         await createPost(allPosts[0]);
       } else {

--- a/packages/frontend/components/notifications/NotificationItem.tsx
+++ b/packages/frontend/components/notifications/NotificationItem.tsx
@@ -29,6 +29,7 @@ import { POST_ITEM_SPACING } from '@/styles/shared';
 import { formatRelativeTimeLocalized } from '@/utils/dateUtils';
 import { BottomSheetContext } from '@/context/BottomSheetContext';
 import { feedService } from '@/services/feedService';
+import { usePostsStore } from '@/stores/postsStore';
 import { queryKeys } from '@/hooks/useOptimizedQuery';
 import { cn } from '@/lib/utils';
 import { createScopedLogger } from '@/lib/logger';
@@ -275,6 +276,11 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
   const theme = useTheme();
   const queryClient = useQueryClient();
   const bottomSheet = useContext(BottomSheetContext);
+  // Shared post cache (SQLite/memory) that every feed + the post detail read from.
+  // Accepting/declining an invite mutates the post's authorship, so the updated
+  // post must be propagated here — updating only the React Query post-detail cache
+  // leaves the timeline/profile rendering the pre-collaboration copy.
+  const cachePosts = usePostsStore((s) => s.cachePosts);
 
   const descriptor = getDescriptor(item.type);
   const primaryActor = item.actors[0];
@@ -319,6 +325,20 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
     enabled: isCollabInvite && !!postId,
     staleTime: 60_000,
   });
+
+  // Whether THIS viewer's invite is still actionable, read from the invited post's
+  // authoritative `viewerState` (derived server-side from the post's authorship —
+  // the single source of truth). While the post is loading, or once the viewer no
+  // longer has view access (a declined private post), none of these are true and
+  // the row shows no actionable UI. Accept/decline update the post cache below, so
+  // these flip reactively without a manual refresh.
+  const collabViewerState = collabPost?.viewerState;
+  const collabInvitePending = collabViewerState?.collabInvitePending === true;
+  const collabAccepted = collabViewerState?.isCollaborator === true;
+  // The viewer holds a collaborator entry that is neither pending nor accepted →
+  // they responded by declining the invite.
+  const collabDeclined =
+    collabViewerState?.viewerRole === 'collaborator' && !collabInvitePending && !collabAccepted;
 
   const badgeColor = theme.colors[descriptor.colorToken];
   const timeLabel = formatRelativeTimeLocalized(item.createdAt, t);
@@ -430,7 +450,14 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
     setActionLoading(true);
     try {
       const result = await feedService.acceptCollabInvite(postId);
-      if (result.post) queryClient.setQueryData(queryKeys.post(postId), result.post);
+      if (result.post) {
+        // Flip this row's own source of truth (drives the resolved state) AND
+        // propagate the newly-accepted co-authorship to every feed + the post
+        // detail via the shared posts store, so the collaboration shows
+        // everywhere without a manual refresh.
+        queryClient.setQueryData(queryKeys.post(postId), result.post);
+        cachePosts([result.post]);
+      }
       onMarkAsRead(item.notificationIds);
       bottomSheet.openBottomSheet(false);
       toast(t('collab.acceptedToast', { defaultValue: "You're now a collaborator on this post" }), { type: 'success' });
@@ -440,13 +467,20 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
     } finally {
       setActionLoading(false);
     }
-  }, [postId, queryClient, onMarkAsRead, item.notificationIds, bottomSheet, t]);
+  }, [postId, queryClient, cachePosts, onMarkAsRead, item.notificationIds, bottomSheet, t]);
 
   const runDecline = useCallback(async () => {
     if (!postId) return;
     setActionLoading(true);
     try {
-      await feedService.declineCollabInvite(postId);
+      const result = await feedService.declineCollabInvite(postId);
+      if (result.post) {
+        // Flip this row to the resolved state and reflect the declined status on
+        // any cached copy of the post (private posts return no post here, in which
+        // case the actionable UI is simply dropped — the viewer lost view access).
+        queryClient.setQueryData(queryKeys.post(postId), result.post);
+        cachePosts([result.post]);
+      }
       onMarkAsRead(item.notificationIds);
       bottomSheet.openBottomSheet(false);
     } catch (error) {
@@ -455,7 +489,7 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
     } finally {
       setActionLoading(false);
     }
-  }, [postId, onMarkAsRead, item.notificationIds, bottomSheet, t]);
+  }, [postId, queryClient, cachePosts, onMarkAsRead, item.notificationIds, bottomSheet, t]);
 
   const openAcceptSheet = useCallback(() => {
     bottomSheet.setBottomSheetContent(
@@ -574,7 +608,10 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
               </View>
             ) : null}
 
-            {isCollabInvite ? (
+            {/* Accept/Decline are shown ONLY while the invite is genuinely pending.
+                Once the viewer has responded, the row shows a resolved label
+                instead — so a handled invite is never actionable again. */}
+            {isCollabInvite && collabInvitePending ? (
               <View className="flex-row gap-2 mt-2">
                 <Button className="flex-1" onPress={openAcceptSheet} disabled={actionLoading}>
                   {t('collab.accept', { defaultValue: 'Accept' })}
@@ -582,6 +619,24 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
                 <Button variant="secondary" className="flex-1" onPress={runDecline} disabled={actionLoading}>
                   {t('collab.decline', { defaultValue: 'Decline' })}
                 </Button>
+              </View>
+            ) : null}
+
+            {isCollabInvite && collabAccepted ? (
+              <View className="flex-row items-center gap-1.5 mt-1">
+                <Ionicons name="checkmark-circle" size={16} color={theme.colors.success} />
+                <Text className="text-muted-foreground text-[15px] leading-5">
+                  {t('collab.youAccepted', { defaultValue: 'You accepted' })}
+                </Text>
+              </View>
+            ) : null}
+
+            {isCollabInvite && collabDeclined ? (
+              <View className="flex-row items-center gap-1.5 mt-1">
+                <Ionicons name="close-circle" size={16} color={theme.colors.textSecondary} />
+                <Text className="text-muted-foreground text-[15px] leading-5">
+                  {t('collab.youDeclined', { defaultValue: 'You declined' })}
+                </Text>
               </View>
             ) : null}
           </View>

--- a/packages/frontend/components/notifications/__tests__/NotificationItem.test.tsx
+++ b/packages/frontend/components/notifications/__tests__/NotificationItem.test.tsx
@@ -1,0 +1,344 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import TestRenderer, { act, type ReactTestInstance } from 'react-test-renderer';
+import { QueryClient, QueryClientProvider, notifyManager } from '@tanstack/react-query';
+import { PostVisibility, type HydratedPost, type PostViewerState } from '@mention/shared-types';
+import type { GroupedNotification } from '@/utils/groupNotifications';
+import type { TRawNotification } from '@/types/validation';
+import { queryKeys } from '@/hooks/useOptimizedQuery';
+
+/**
+ * The collaboration-invite notification row.
+ *
+ * The Accept/Decline buttons must be shown ONLY while THIS viewer's invite is
+ * genuinely pending — the single source of truth is the invited post's
+ * `viewerState` (derived server-side from its authorship). Once the viewer has
+ * responded, the row shows a resolved label ("You accepted" / "You declined")
+ * and is never actionable again. Acting also propagates the updated post to the
+ * shared posts store so the feed + detail reflect the new collaboration.
+ *
+ * These tests seed the post-detail query the row reads and assert what the row
+ * renders for each collaboration state, plus that declining propagates the
+ * returned post through `postsStore.cachePosts`.
+ */
+
+const POST_ID = 'post-1';
+const NOTIF_ID = 'notif-1';
+
+// ── Module boundaries ───────────────────────────────────────────────────────
+
+const mockAccept = jest.fn();
+const mockDecline = jest.fn();
+const mockGetPostById = jest.fn();
+jest.mock('@/services/feedService', () => ({
+  feedService: {
+    acceptCollabInvite: (...args: unknown[]) => mockAccept(...args),
+    declineCollabInvite: (...args: unknown[]) => mockDecline(...args),
+    getPostById: (...args: unknown[]) => mockGetPostById(...args),
+  },
+}));
+
+/** The shared post cache every feed + the post detail read from (Bug B path). */
+const mockCachePosts = jest.fn();
+jest.mock('@/stores/postsStore', () => ({
+  usePostsStore: (selector: (state: { cachePosts: unknown }) => unknown) =>
+    selector({ cachePosts: mockCachePosts }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+  }),
+}));
+
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
+jest.mock('expo-image', () => {
+  const { View: RNView } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { Image: () => <RNView /> };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const { View: RNView } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { Ionicons: () => <RNView /> };
+});
+
+jest.mock('@oxyhq/bloom/avatar', () => {
+  const { View: RNView } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { Avatar: () => <RNView /> };
+});
+
+jest.mock('@oxyhq/bloom/button', () => {
+  const { TouchableOpacity: RNTouchable, Text: RNText } =
+    jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    Button: ({
+      children,
+      onPress,
+      disabled,
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      disabled?: boolean;
+    }) => (
+      <RNTouchable onPress={onPress} disabled={disabled} accessibilityRole="button">
+        <RNText>{children}</RNText>
+      </RNTouchable>
+    ),
+  };
+});
+
+jest.mock('@oxyhq/bloom/subtle-hover', () => ({ SubtleHover: () => null }));
+
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      primary: '#1d4ed8',
+      success: '#16a34a',
+      warning: '#d97706',
+      error: '#dc2626',
+      text: '#000000',
+      textSecondary: '#666666',
+      border: '#dddddd',
+      background: '#ffffff',
+    },
+  }),
+}));
+
+jest.mock('@oxyhq/bloom/toast', () => ({ show: jest.fn() }));
+
+jest.mock('@oxyhq/services', () => ({
+  queryKeys: { users: { detail: (id: string) => ['users', id] } },
+}));
+
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user?: { username?: string | null } | null): string | null => {
+    const username = (user?.username ?? '').trim().replace(/^@/, '');
+    return username.length > 0 ? username : null;
+  },
+}));
+
+jest.mock('@/components/UserName', () => {
+  const { Text: RNText } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { __esModule: true, default: ({ name }: { name?: string }) => <RNText>{name}</RNText> };
+});
+
+jest.mock('@/components/common/LinkifiedText', () => {
+  const { Text: RNText } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { LinkifiedText: ({ text }: { text?: string }) => <RNText>{text}</RNText> };
+});
+
+jest.mock('@/components/Fediverse/FediverseBadge', () => ({ RemoteActorBadge: () => null }));
+jest.mock('@/components/Compose/CollabAcceptSheet', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/assets/icons/done-all-icon', () => ({ DoneAllIcon: () => null }));
+jest.mock('@/assets/icons/trash-icon', () => ({ TrashIcon: () => null }));
+
+jest.mock('../notificationDescriptors', () => ({
+  getDescriptor: () => ({
+    icon: 'people',
+    colorToken: 'primary',
+    hasPreview: true,
+    actionPhrase: () => 'invited you to collaborate on a post',
+  }),
+}));
+
+jest.mock('@/hooks/useCachedUser', () => ({ useUserById: () => undefined }));
+jest.mock('@/utils/dateUtils', () => ({ formatRelativeTimeLocalized: () => '1h' }));
+jest.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+jest.mock('@/context/BottomSheetContext', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  return {
+    BottomSheetContext: ReactActual.createContext({
+      openBottomSheet: jest.fn(),
+      setBottomSheetContent: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('@/lib/logger', () => ({
+  createScopedLogger: () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }),
+}));
+
+// The mocks above are hoisted, so the component below loads with every boundary
+// already swapped for its double.
+import { NotificationItem } from '../NotificationItem';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function viewerState(overrides: Partial<PostViewerState>): PostViewerState {
+  return {
+    isOwner: false,
+    isCollaborator: false,
+    isLiked: false,
+    isDownvoted: false,
+    isBoosted: false,
+    isSaved: false,
+    ...overrides,
+  };
+}
+
+const PENDING = viewerState({ collabInvitePending: true, viewerRole: 'collaborator' });
+const ACCEPTED = viewerState({ isCollaborator: true, viewerRole: 'collaborator' });
+const DECLINED = viewerState({ viewerRole: 'collaborator' });
+
+function collabPost(state: PostViewerState): HydratedPost {
+  return {
+    id: POST_ID,
+    content: { text: 'Collaboration post body' },
+    attachments: {},
+    user: { id: 'owner-1', username: 'owner', name: { displayName: 'Owner' } },
+    authors: [],
+    engagement: { likes: 0, downvotes: 0, boosts: 0, replies: 0 },
+    viewerState: state,
+    permissions: { canReply: true, canDelete: false, canPin: false, canViewSources: false },
+    metadata: {
+      visibility: PostVisibility.PUBLIC,
+      createdAt: '2026-07-16T00:00:00.000Z',
+      updatedAt: '2026-07-16T00:00:00.000Z',
+    },
+  };
+}
+
+function collabInviteItem(): GroupedNotification {
+  const lead: TRawNotification = {
+    _id: NOTIF_ID,
+    recipientId: 'viewer-1',
+    actorId: 'owner-1',
+    type: 'collab_invite',
+    entityId: POST_ID,
+    entityType: 'post',
+    read: false,
+    createdAt: '2026-07-16T00:00:00.000Z',
+    actorId_populated: { _id: 'owner-1', username: 'owner', name: { displayName: 'Owner' } },
+  };
+  return {
+    key: NOTIF_ID,
+    type: 'collab_invite',
+    entityId: POST_ID,
+    entityType: 'post',
+    hasUnread: true,
+    createdAt: '2026-07-16T00:00:00.000Z',
+    actors: [{ id: 'owner-1', name: 'Owner', username: 'owner' }],
+    totalActors: 1,
+    notificationIds: [NOTIF_ID],
+    leadNotification: lead,
+    isGroup: false,
+    expandable: false,
+  };
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+notifyManager.setScheduler((callback) => callback());
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderRow(state: PostViewerState): Promise<{
+  renderer: TestRenderer.ReactTestRenderer;
+  queryClient: QueryClient;
+}> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  });
+  // Seed the post-detail query the row reads. With the row's 60s staleTime the
+  // seeded (fresh) data is served synchronously and `getPostById` is never hit.
+  queryClient.setQueryData(queryKeys.post(POST_ID), collabPost(state));
+
+  let renderer!: TestRenderer.ReactTestRenderer;
+  await act(async () => {
+    renderer = TestRenderer.create(
+      <QueryClientProvider client={queryClient}>
+        <NotificationItem item={collabInviteItem()} onMarkAsRead={jest.fn()} onDelete={jest.fn()} />
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return { renderer, queryClient };
+}
+
+function texts(root: ReactTestInstance): string[] {
+  return root
+    .findAllByType(Text)
+    .flatMap((node) => {
+      const children = node.props.children;
+      return Array.isArray(children) ? children : [children];
+    })
+    .filter((child): child is string => typeof child === 'string')
+    .map((child) => child.trim());
+}
+
+function buttonByLabel(root: ReactTestInstance, label: string): ReactTestInstance | undefined {
+  return root.findAll((node) => {
+    if (node.type !== TouchableOpacity) return false;
+    const labels = node
+      .findAllByType(Text)
+      .flatMap((n) => (Array.isArray(n.props.children) ? n.props.children : [n.props.children]));
+    return labels.includes(label);
+  })[0];
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('NotificationItem — collaboration invite', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows Accept/Decline while the invite is pending, with no resolved label', async () => {
+    const { renderer } = await renderRow(PENDING);
+    const rendered = texts(renderer.root);
+
+    expect(rendered).toContain('Accept');
+    expect(rendered).toContain('Decline');
+    expect(rendered).not.toContain('You accepted');
+    expect(rendered).not.toContain('You declined');
+  });
+
+  it('hides the buttons and shows "You accepted" once the viewer is a collaborator', async () => {
+    const { renderer } = await renderRow(ACCEPTED);
+    const rendered = texts(renderer.root);
+
+    expect(rendered).toContain('You accepted');
+    expect(rendered).not.toContain('Accept');
+    expect(rendered).not.toContain('Decline');
+  });
+
+  it('hides the buttons and shows "You declined" once the viewer has declined', async () => {
+    const { renderer } = await renderRow(DECLINED);
+    const rendered = texts(renderer.root);
+
+    expect(rendered).toContain('You declined');
+    expect(rendered).not.toContain('Accept');
+    expect(rendered).not.toContain('Decline');
+  });
+
+  it('declining propagates the returned post to the shared store and flips the row to resolved', async () => {
+    mockDecline.mockResolvedValue({ success: true, post: collabPost(DECLINED) });
+
+    const { renderer } = await renderRow(PENDING);
+    const declineButton = buttonByLabel(renderer.root, 'Decline');
+    expect(declineButton).toBeDefined();
+
+    await act(async () => {
+      declineButton?.props.onPress();
+    });
+    await flush();
+
+    // The mutation ran, and its returned post was pushed into the shared cache
+    // (the same mechanism post edits/deletes use to refresh feed + detail).
+    expect(mockDecline).toHaveBeenCalledWith(POST_ID);
+    expect(mockCachePosts).toHaveBeenCalledWith([collabPost(DECLINED)]);
+
+    // The row is now resolved — no longer actionable.
+    const rendered = texts(renderer.root);
+    expect(rendered).toContain('You declined');
+    expect(rendered).not.toContain('Decline');
+  });
+});

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -154,6 +154,8 @@
   "collab.acceptedToast": "You're now a collaborator on this post",
   "collab.acceptFailed": "Failed to accept invite",
   "collab.declineFailed": "Failed to decline invite",
+  "collab.youAccepted": "You accepted",
+  "collab.youDeclined": "You declined",
   "collab.collaboratorsTitle": "Collaborators",
   "notification.mark_all_read": "Mark all as read",
   "notification.mark_read": "Mark as read",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -175,6 +175,8 @@
   "collab.acceptedToast": "Ahora eres colaborador en esta publicación",
   "collab.acceptFailed": "No se pudo aceptar la invitación",
   "collab.declineFailed": "No se pudo rechazar la invitación",
+  "collab.youAccepted": "Aceptaste",
+  "collab.youDeclined": "Rechazaste",
   "collab.collaboratorsTitle": "Colaboradores",
   "notification.mark_all_read": "Marcar todo como leído",
   "notification.mark_read": "Marcar como leído",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -564,6 +564,8 @@
   "collab.acceptedToast": "Ora sei un collaboratore su questo post",
   "collab.acceptFailed": "Impossibile accettare l'invito",
   "collab.declineFailed": "Impossibile rifiutare l'invito",
+  "collab.youAccepted": "Hai accettato",
+  "collab.youDeclined": "Hai rifiutato",
   "collab.collaboratorsTitle": "Collaboratori",
   "notifications": {
     "tabs": {

--- a/packages/frontend/services/feedService.ts
+++ b/packages/frontend/services/feedService.ts
@@ -583,9 +583,11 @@ class FeedService {
     return { success: true, post: response?.data?.post ?? null };
   }
 
-  async declineCollabInvite(postId: string): Promise<{ success: boolean }> {
-    await authenticatedClient.post(`/posts/${postId}/collaborators/decline`);
-    return { success: true };
+  async declineCollabInvite(postId: string): Promise<{ success: boolean; post: HydratedPost | null }> {
+    const response = await authenticatedClient.post<{ success?: boolean; post?: HydratedPost }>(
+      `/posts/${postId}/collaborators/decline`,
+    );
+    return { success: true, post: response?.data?.post ?? null };
   }
 
   async stopCollabSharing(postId: string): Promise<{ success: boolean; post: HydratedPost | null }> {


### PR DESCRIPTION
## Summary
- Collaboration invite Accept/Decline buttons in the notification stayed visible after resolution — gated on the invite's pending state (from `viewerState`) and shown as an accepted/declined label once resolved.
- Decline now returns the hydrated post too, and the accepted/declined post is propagated through the shared posts store so feed, profile, and detail all reflect the collaboration without a manual refresh.
- Fixed the edit flow, which discarded the updated post client-side after a successful edit, so changes weren't visible until a manual refresh.

## Test plan
- [x] Backend: `bunx tsc --noEmit` — 0 errors
- [x] Backend: `bun run test` — 229 files / 2418 tests passed
- [x] Frontend: `bun run typecheck` — 0 errors
- [x] Frontend: `bun run test` — 21 suites / 362 tests passed (includes new `NotificationItem.test.tsx`)
- [x] `bun run build:backend` — succeeds
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)