### PR TITLE
chore(frontend): bump @oxyhq/bloom to 0.35.2 (cluster 4-avatar 2x2 grid)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.35.1",
+        "@oxyhq/bloom": "^0.35.2",
         "@oxyhq/contracts": "^0.15.0",
         "@oxyhq/core": "^12.2.1",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.35.1",
+        "@oxyhq/bloom": "^0.35.2",
         "@oxyhq/core": "^12.2.1",
         "@oxyhq/expo-oxy-identity": "^0.1.0",
         "@oxyhq/services": "^22.2.0",
@@ -208,7 +208,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.35.1",
+    "@oxyhq/bloom": "^0.35.2",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/services": "^22.2.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -702,7 +702,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.35.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-6apM2haiC7K81a2sDvwmRFXzNAHFqwHvlfkXt5odJgqt9bYNqNj0jT4GKGiAWvOwF95l9v1iyZ9N1Jzv2ZbrTg=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.35.2", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-KY2yUneo9WaCaBkvoSTSmizKaHOVxf9vI+PjKiTDau3mPxqG5AjNJloawSNLU4f51lBz0IMm9VEb1nl6xGD2rA=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.15.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-2UsyiRw+dxlwKa3rY50iJvBtsbSslUJwvfA27EmB1+DM4fSXS5raNoxzZ7FBeug1A0l4TQE1qd0PjpII2uDavA=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.35.1",
+    "@oxyhq/bloom": "^0.35.2",
     "@oxyhq/contracts": "^0.15.0",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.35.1",
+    "@oxyhq/bloom": "^0.35.2",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/services": "^22.2.0",
     "mongoose": "^8.17.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.35.1",
+    "@oxyhq/bloom": "^0.35.2",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/expo-oxy-identity": "^0.1.0",
     "@oxyhq/services": "^22.2.0",


### PR DESCRIPTION
## Summary
- Pure dependency bump of `@oxyhq/bloom` from `^0.35.1` to `^0.35.2` (all 3 pins: root deps, root overrides, frontend deps)
- Picks up the cluster count=4 2x2 grid layout fix in Bloom
- No app code changes

## Test plan
- [x] `bun install --frozen-lockfile` passes
- [x] `packages/frontend` typecheck: 0 errors
- [x] `packages/frontend` test suite: 21 suites / 362 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)