### PR TITLE
fix(frontend): seed follow buttons so they don't flash Follow->Following

### DIFF
--- a/packages/frontend/components/Profile/ProfileHeader.tsx
+++ b/packages/frontend/components/Profile/ProfileHeader.tsx
@@ -18,8 +18,10 @@ import { PrivateBadge } from './PrivateBadge';
 import { PresenceIndicator } from '@/components/PresenceIndicator';
 import { usePoke } from './hooks/usePoke';
 import { useFederatedFollowSync } from './hooks/useFederatedFollowSync';
+import { useViewerFollowingSet } from '@/hooks/useViewerFollowing';
 import { LAYOUT } from './types';
 import type {
+  FollowButtonComponent as FollowButtonComponentType,
   ProfileHeaderDefaultProps,
   ProfileHeaderMinimalistProps,
   UserNameComponent,
@@ -54,6 +56,10 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
   const canPoke = !isFederated;
   const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || Boolean(isFederated));
   useFederatedFollowSync(profileId, isFederated, actorUri);
+  // Seed the follow button from the viewer's cached following set so a profile
+  // the viewer already follows renders "Following" on mount instead of flashing
+  // "Follow" until the status fetch resolves.
+  const followingSet = useViewerFollowingSet();
 
   // Normalized 0 → 1 collapse driver for the avatar shrink, derived on the UI
   // thread from the shared scroll offset (fed by both the native ScrollView and
@@ -164,7 +170,10 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
                 />
               </TouchableOpacity>
             )}
-            <FollowButtonComponent userId={profileId} />
+            <FollowButtonComponent
+              userId={profileId}
+              initiallyFollowing={followingSet.has(profileId)}
+            />
           </View>
         ) : null}
       </View>
@@ -256,13 +265,14 @@ export const ProfileActions = memo(function ProfileActions({
   currentUsername?: string;
   profileUsername?: string;
   profileId?: string;
-  FollowButtonComponent: React.ComponentType<{ userId: string }>;
+  FollowButtonComponent: FollowButtonComponentType;
 }) {
   const theme = useTheme();
   const { t } = useTranslation();
   const canPoke = !isFederated;
   const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || Boolean(isFederated));
   useFederatedFollowSync(profileId, isFederated, actorUri);
+  const followingSet = useViewerFollowingSet();
 
   if (!isOwnProfile || currentUsername !== profileUsername) {
     if (!profileId) return null;
@@ -288,7 +298,10 @@ export const ProfileActions = memo(function ProfileActions({
             />
           </TouchableOpacity>
         )}
-        <FollowButtonComponent userId={profileId} />
+        <FollowButtonComponent
+          userId={profileId}
+          initiallyFollowing={followingSet.has(profileId)}
+        />
       </View>
     );
   }

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -24,6 +24,8 @@ export interface ProfileScreenProps {
 export interface FollowButtonProps {
   userId: string;
   size?: 'small' | 'medium' | 'large';
+  /** Seeds the button so a followed user renders "Following" on mount (no flash). */
+  initiallyFollowing?: boolean;
 }
 
 export type FollowButtonComponent = React.ComponentType<FollowButtonProps>;

--- a/packages/frontend/components/ProfileCard.tsx
+++ b/packages/frontend/components/ProfileCard.tsx
@@ -6,6 +6,7 @@ import { FollowButton } from '@oxyhq/services';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { getNormalizedUserHandle } from '@oxyhq/core';
+import { useViewerFollowingSet } from '@/hooks/useViewerFollowing';
 import { ThemedText } from './ThemedText';
 import { RemoteActorBadge } from '@/components/Fediverse/FediverseBadge';
 import { AgentIcon } from '@/assets/icons/agent-icon';
@@ -63,6 +64,15 @@ interface ProfileCardProps {
    */
   showFollowButton?: boolean;
   /**
+   * Seeds the follow button's initial state so a user the viewer already follows
+   * renders "Following" on mount instead of flashing "Follow" until the status
+   * fetch resolves. When omitted, it is derived from the viewer's cached
+   * following set ({@link useViewerFollowingSet}), so every list surface gets the
+   * seed for free; pass an explicit value only when the row already carries the
+   * relationship from its own DTO.
+   */
+  initiallyFollowing?: boolean;
+  /**
    * Called when the viewer follows or unfollows from this row's follow button.
    * The button owns the follow state (and the surfaces that show it own nothing),
    * so this is the only way a caller can learn the row was acted on — used by the
@@ -81,6 +91,7 @@ export function ProfileCard({
   profile,
   onPress,
   showFollowButton = false,
+  initiallyFollowing,
   onFollowChange,
   meta,
   accessory,
@@ -88,6 +99,7 @@ export function ProfileCard({
 }: ProfileCardProps) {
   const router = useRouter();
   const { t } = useTranslation();
+  const followingSet = useViewerFollowingSet();
 
   // A federated profile's canonical handle carries its instance (`user@domain`),
   // so the row never needs a separate "globe + instance" line. An unresolved
@@ -175,7 +187,12 @@ export function ProfileCard({
         </View>
       </TouchableOpacity>
       {showFollowButton && (
-        <FollowButton userId={profile.id} size="small" onFollowChange={onFollowChange} />
+        <FollowButton
+          userId={profile.id}
+          size="small"
+          initiallyFollowing={initiallyFollowing ?? followingSet.has(profile.id)}
+          onFollowChange={onFollowChange}
+        />
       )}
       {accessory}
     </View>

--- a/packages/frontend/hooks/useViewerFollowing.ts
+++ b/packages/frontend/hooks/useViewerFollowing.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@oxyhq/services';
+
+/** The viewer's following set stays fresh for 2 minutes — matches the SDK's own
+ *  `getViewerGraph()` cache TTL, so this query and the SDK cache expire together. */
+const VIEWER_FOLLOWING_STALE_TIME_MS = 2 * 60 * 1000;
+const VIEWER_FOLLOWING_GC_TIME_MS = 5 * 60 * 1000;
+
+/**
+ * The set of user ids the authenticated viewer follows.
+ *
+ * Sourced ONCE (per session, then cached) from the SDK's consolidated
+ * `getViewerGraph()` — an ids-only, server-bounded (`MAX_FOLLOWING_IDS`, 5000,
+ * most-recent first), 2-minute-cached payload. A single shared React Query owner
+ * keyed on the viewer id, so every surface that renders follow buttons reads ONE
+ * app-wide request instead of each button probing its own status first.
+ *
+ * Consumers use it to seed each {@link FollowButton}'s `initiallyFollowing`, so a
+ * user the viewer already follows renders "Following" on mount instead of
+ * flashing "Follow" until the per-button follow-status fetch resolves.
+ *
+ * Keyed on `viewerId` (and gated on `canUsePrivateApi`) so it stays empty while
+ * anonymous and reloads when the cold-boot session lands, per the app's
+ * auth-cold-boot reactivity rule.
+ */
+export function useViewerFollowingSet(): Set<string> {
+  const { oxyServices, user, canUsePrivateApi } = useAuth();
+  const viewerId = user?.id ?? '';
+
+  const { data } = useQuery({
+    queryKey: ['viewerFollowing', viewerId],
+    queryFn: () => oxyServices.getViewerGraph(),
+    enabled: canUsePrivateApi && viewerId.length > 0,
+    staleTime: VIEWER_FOLLOWING_STALE_TIME_MS,
+    gcTime: VIEWER_FOLLOWING_GC_TIME_MS,
+  });
+
+  return useMemo(() => new Set(data?.followingIds ?? []), [data]);
+}


### PR DESCRIPTION
The SDK FollowButton defaulted to "Follow" and corrected to "Following" only after a per-button follow-status fetch, so a followed user flashed on every list/profile. Seed each button's initiallyFollowing from the viewer's cached following set (one shared getViewerGraph query), so it renders the correct state on mount. One ProfileCard prop covers every list surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)