### PR TITLE
fix(federation): comprehensive Bluesky/brid.gy federation fixes

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/apMentionsBridgy.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apMentionsBridgy.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Inbound Bridgy Fed (brid.gy) @mention resolution.
+ *
+ * A bridged Bluesky mention's `Mention` tag carries the brid.gy actor URI
+ * (`https://bsky.brid.gy/ap/<did>`) as `href` and `@<handle>@bsky.brid.gy` as
+ * `name`, but the anchor INSIDE the content points at the Bluesky WEB profile —
+ * `https://bsky.app/profile/<did|handle>` — which matched neither the actor URI
+ * nor the reconstructed profile URL, so the mention fell through to bare text.
+ * These pin that both bsky.app anchor forms now resolve to the internal
+ * `[mention:<oxyUserId>]` placeholder, and that the Mastodon path still resolves.
+ *
+ * `actor.service` and `constants` are mocked so no network / DB / Oxy I/O runs;
+ * the rest of the module graph (`bridgy`, `apLanguage`, `apSchemas`) is pure.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getOrFetchActor: vi.fn(),
+  isBlockedDomain: vi.fn(() => false),
+  resolveOxyUser: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/actor.service', () => ({
+  actorService: { getOrFetchActor: mocks.getOrFetchActor },
+}));
+vi.mock('../../../connectors/activitypub/constants', () => ({
+  isBlockedDomain: mocks.isBlockedDomain,
+  resolveOxyUser: mocks.resolveOxyUser,
+}));
+vi.mock('../../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { applyMentionPlaceholders, resolveInboundMentions } from '../../../connectors/activitypub/apMentions';
+
+const DID = 'did:plc:reu7q3altx5gsonhu5nxcfp6';
+const HANDLE = 'alice.bsky.social';
+const BRIDGY_ACTOR = `https://bsky.brid.gy/ap/${DID}`;
+const BRIDGED_OXY_ID = 'oxy_bridged_alice';
+
+beforeEach(() => {
+  mocks.getOrFetchActor.mockReset();
+  mocks.isBlockedDomain.mockReturnValue(false);
+});
+
+describe('inbound brid.gy @mention resolution', () => {
+  it('rewrites a bsky.app/profile/<handle> mention anchor to the placeholder', async () => {
+    mocks.getOrFetchActor.mockResolvedValue({ oxyUserId: BRIDGED_OXY_ID });
+    const object = {
+      content: `<p>hi <a href="https://bsky.app/profile/${HANDLE}">@${HANDLE}</a></p>`,
+      tag: [{ type: 'Mention', href: BRIDGY_ACTOR, name: `@${HANDLE}@bsky.brid.gy` }],
+    };
+
+    const resolved = await resolveInboundMentions(object);
+    expect(resolved.ids).toContain(BRIDGED_OXY_ID);
+
+    const rewritten = applyMentionPlaceholders(object, resolved.anchorMap);
+    expect(rewritten.content).toBe(`<p>hi [mention:${BRIDGED_OXY_ID}]</p>`);
+  });
+
+  it('rewrites a bsky.app/profile/<did> mention anchor to the placeholder', async () => {
+    mocks.getOrFetchActor.mockResolvedValue({ oxyUserId: BRIDGED_OXY_ID });
+    const object = {
+      content: `<p><a href="https://bsky.app/profile/${DID}">@${HANDLE}</a> hello</p>`,
+      tag: [{ type: 'Mention', href: BRIDGY_ACTOR, name: `@${HANDLE}@bsky.brid.gy` }],
+    };
+
+    const resolved = await resolveInboundMentions(object);
+    const rewritten = applyMentionPlaceholders(object, resolved.anchorMap);
+    expect(rewritten.content).toBe(`<p>[mention:${BRIDGED_OXY_ID}] hello</p>`);
+  });
+
+  it('still resolves a Mastodon mention (regression): actor-URI tag href, profile-page anchor', async () => {
+    mocks.getOrFetchActor.mockResolvedValue({ oxyUserId: 'oxy_bob' });
+    const object = {
+      content: '<p><a href="https://mastodon.social/@bob" class="u-url mention">@bob</a></p>',
+      tag: [{ type: 'Mention', href: 'https://mastodon.social/users/bob', name: '@bob@mastodon.social' }],
+    };
+
+    const resolved = await resolveInboundMentions(object);
+    const rewritten = applyMentionPlaceholders(object, resolved.anchorMap);
+    expect(rewritten.content).toBe('<p>[mention:oxy_bob]</p>');
+  });
+});

--- a/packages/backend/src/__tests__/connectors/activitypub/apPostContent.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apPostContent.test.ts
@@ -30,6 +30,7 @@ import {
   buildFederatedNoteContentForEdit,
   extractApContentHtml,
   extractApSummary,
+  rewriteHashtagAnchors,
 } from '../../../connectors/activitypub/apPostContent';
 
 beforeEach(() => {
@@ -93,7 +94,47 @@ describe('extractApSummary', () => {
   });
 });
 
+describe('rewriteHashtagAnchors', () => {
+  it('rewrites a Bridgy Fed hashtag anchor (plain-text child, bsky.app search href) to #tag', () => {
+    const html =
+      '<p>Climate news <a class="hashtag" rel="tag" href="https://bsky.app/search?q=%23ClimateCrisis">#ClimateCrisis</a></p>';
+    expect(rewriteHashtagAnchors(html)).toBe('<p>Climate news #ClimateCrisis</p>');
+  });
+
+  it('rewrites a Mastodon hashtag anchor (inner span) to #tag — unchanged from prior behavior', () => {
+    const html = '<a href="https://mastodon.social/tags/art" class="mention hashtag" rel="tag">#<span>art</span></a>';
+    expect(rewriteHashtagAnchors(html)).toBe('#art');
+  });
+
+  it('leaves a non-hashtag link untouched', () => {
+    const html = '<a href="https://example.com/page">example.com/page</a>';
+    expect(rewriteHashtagAnchors(html)).toBe(html);
+  });
+
+  it('leaves a mention anchor untouched', () => {
+    const html = '<a href="https://m.example/@alice" class="u-url mention">@alice</a>';
+    expect(rewriteHashtagAnchors(html)).toBe(html);
+  });
+
+  it('is a no-op for content with no anchors', () => {
+    expect(rewriteHashtagAnchors('<p>plain text</p>')).toBe('<p>plain text</p>');
+  });
+});
+
 describe('buildFederatedNoteContent', () => {
+  it('stores a Bridgy Fed hashtag as visible #tag text (not the bsky.app search URL) and in hashtags[]', async () => {
+    const note = {
+      content:
+        '<p>Climate news <a class="hashtag" rel="tag" href="https://bsky.app/search?q=%23ClimateCrisis">#ClimateCrisis</a></p>',
+      tag: [{ type: 'Hashtag', name: '#ClimateCrisis', href: 'https://bsky.app/search?q=%23ClimateCrisis' }],
+    };
+    const built = await buildFederatedNoteContent(note, 'owner-1', {});
+    if (built.skip) throw new Error('expected content');
+    expect(built.text).toBe('Climate news #ClimateCrisis');
+    expect(built.text).not.toContain('bsky.app/search');
+    expect(built.hashtags).toContain('climatecrisis');
+  });
+
   it('normalizes the whitespace of a pretty-printed remote body', async () => {
     // The bug this whole change exists for: the indented markup a remote server
     // emits left a blank line and an indent in the stored body, which the client

--- a/packages/backend/src/__tests__/connectors/activitypub/apQuoteExtraction.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apQuoteExtraction.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { extractApQuoteUri } from '../../../connectors/activitypub/helpers';
+
+/**
+ * Inbound quote extraction. A federated Note advertises the post it QUOTES across
+ * several interoperating terms — the modern `quote`/`quoteUri` (FEP-044f /
+ * Mastodon 4.4+), the legacy `_misskey_quote`/`quoteUrl` (Misskey/Pleroma), and
+ * the FEP-e232 `Link` quote tag. Bridgy Fed bridges a Bluesky quote through these
+ * same fields, pointing at the quoted post's wrapped brid.gy object URL. The
+ * caller resolves the returned URI to a local Post via `resolvePostIdFromObjectUri`.
+ */
+
+const DID = 'did:plc:reu7q3altx5gsonhu5nxcfp6';
+const QUOTED = `https://bsky.brid.gy/convert/ap/at://${DID}/app.bsky.feed.post/3quotedrkey`;
+
+describe('extractApQuoteUri', () => {
+  it('reads the FEP-044f `quote` field', () => {
+    expect(extractApQuoteUri({ quote: QUOTED })).toBe(QUOTED);
+  });
+
+  it('reads `quoteUri`, `quoteUrl`, and `_misskey_quote`', () => {
+    expect(extractApQuoteUri({ quoteUri: QUOTED })).toBe(QUOTED);
+    expect(extractApQuoteUri({ quoteUrl: QUOTED })).toBe(QUOTED);
+    expect(extractApQuoteUri({ _misskey_quote: QUOTED })).toBe(QUOTED);
+  });
+
+  it('reads an embedded object under a quote field (`{id}` / `{href}`)', () => {
+    expect(extractApQuoteUri({ quote: { id: QUOTED } })).toBe(QUOTED);
+    expect(extractApQuoteUri({ quoteUrl: { href: QUOTED } })).toBe(QUOTED);
+  });
+
+  it('reads a FEP-e232 `Link` quote tag by the misskey quote rel', () => {
+    const object = {
+      tag: [
+        { type: 'Mention', href: 'https://bsky.brid.gy/ap/did:plc:someone', name: '@a@bsky.brid.gy' },
+        {
+          type: 'Link',
+          mediaType: 'application/activity+json',
+          href: QUOTED,
+          name: `RE: ${QUOTED}`,
+          rel: 'https://misskey-hub.net/ns#_misskey_quote',
+        },
+      ],
+    };
+    expect(extractApQuoteUri(object)).toBe(QUOTED);
+  });
+
+  it('reads a FEP-e232 `Link` quote tag by the AP mediaType alone', () => {
+    const object = {
+      tag: [{ type: 'Link', mediaType: 'application/activity+json', href: QUOTED }],
+    };
+    expect(extractApQuoteUri(object)).toBe(QUOTED);
+  });
+
+  it('prefers a structured quote field over the tag', () => {
+    const other = `https://bsky.brid.gy/convert/ap/at://${DID}/app.bsky.feed.post/3othertag`;
+    const object = {
+      quoteUrl: QUOTED,
+      tag: [{ type: 'Link', mediaType: 'application/activity+json', href: other }],
+    };
+    expect(extractApQuoteUri(object)).toBe(QUOTED);
+  });
+
+  it('ignores a non-quote Link tag (e.g. a plain web link)', () => {
+    const object = {
+      tag: [{ type: 'Link', mediaType: 'text/html', href: 'https://example.com/page' }],
+    };
+    expect(extractApQuoteUri(object)).toBeUndefined();
+  });
+
+  it('returns undefined for a note that quotes nothing', () => {
+    expect(extractApQuoteUri({ content: '<p>no quote here</p>' })).toBeUndefined();
+    expect(extractApQuoteUri({})).toBeUndefined();
+  });
+
+  it('ignores a non-http quote value', () => {
+    expect(extractApQuoteUri({ quote: `at://${DID}/app.bsky.feed.post/x` })).toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/atproto/postMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/postMapper.test.ts
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   postFind: vi.fn(),
   create: vi.fn(),
   materialize: vi.fn(),
+  federatedActorFindOne: vi.fn(),
+  fetchProfile: vi.fn(),
 }));
 
 vi.mock('../../../connectors/atproto/xrpcClient', () => ({ xrpcGet: mocks.xrpcGet }));
@@ -23,6 +25,16 @@ vi.mock('../../../connectors/atproto/xrpcClient', () => ({ xrpcGet: mocks.xrpcGe
 vi.mock('../../../models/Post', () => ({
   POST_CLASSIFICATION_PENDING: 'pending',
   Post: { find: mocks.postFind },
+}));
+
+vi.mock('../../../models/FederatedActor', () => ({
+  default: { findOne: mocks.federatedActorFindOne },
+}));
+
+// Mention resolution goes through the atproto profile path; mocked so the mapper's
+// mention/quote/reply resolution never reaches the heavy identity chain.
+vi.mock('../../../connectors/atproto/profile.mapper', () => ({
+  fetchAndUpsertAtprotoProfile: mocks.fetchProfile,
 }));
 
 vi.mock('../../../services/serviceRegistry', () => ({
@@ -78,6 +90,8 @@ beforeEach(() => {
   mocks.postFind.mockReturnValue({ select: () => ({ lean: async () => [] }) });
   mocks.create.mockResolvedValue({ _id: 'created1' });
   mocks.materialize.mockImplementation(async (media: unknown, attachments: unknown) => ({ media, attachments }));
+  mocks.federatedActorFindOne.mockReturnValue({ select: () => ({ lean: async () => null }) });
+  mocks.fetchProfile.mockResolvedValue(null);
 });
 
 describe('mapPostViewToNormalizedPost', () => {
@@ -159,6 +173,125 @@ describe('mapPostViewToNormalizedPost', () => {
     expect(post?.media).toEqual([{ id: 'https://cdn/playlist.m3u8', type: 'video', remoteUrl: 'https://cdn/playlist.m3u8' }]);
   });
 
+  it('replaces a #link facet display text with the full URL (byte-indexed)', () => {
+    // Bluesky stores the truncated display URL in `text` but the FULL url in the
+    // facet feature — the Gothamist bug. The facet byte range covers the display.
+    const text = 'Read gothamist.com/news/lo…'; // '…' is a 3-byte UTF-8 char
+    const byteEnd = Buffer.byteLength(text, 'utf8');
+    const post = mapPostViewToNormalizedPost(
+      postView('lnk', text, {
+        record: {
+          facets: [
+            {
+              index: { byteStart: 5, byteEnd },
+              features: [{ $type: 'app.bsky.richtext.facet#link', uri: 'https://gothamist.com/news/long-article' }],
+            },
+          ],
+        },
+      }),
+      DID,
+    );
+    expect(post?.text).toBe('Read https://gothamist.com/news/long-article');
+  });
+
+  it('handles multiple #link facets with a multibyte emoji before them', () => {
+    // '👋' is 4 UTF-8 bytes: a JS-string (UTF-16) index would mis-target the facet.
+    const text = '👋 foo.co and bar.co';
+    const post = mapPostViewToNormalizedPost(
+      postView('multi', text, {
+        record: {
+          facets: [
+            {
+              index: { byteStart: 5, byteEnd: 11 }, // 'foo.co'
+              features: [{ $type: 'app.bsky.richtext.facet#link', uri: 'https://foo.co/full' }],
+            },
+            {
+              index: { byteStart: 16, byteEnd: 22 }, // 'bar.co'
+              features: [{ $type: 'app.bsky.richtext.facet#link', uri: 'https://bar.co/full' }],
+            },
+          ],
+        },
+      }),
+      DID,
+    );
+    expect(post?.text).toBe('👋 https://foo.co/full and https://bar.co/full');
+  });
+
+  it('replaces a resolved #mention facet with a [mention:<id>] placeholder and collects it', () => {
+    const MENTION_DID = 'did:plc:bob00000000000000000000';
+    const post = mapPostViewToNormalizedPost(
+      postView('mp', 'hi @bob.bsky.social!', {
+        record: {
+          facets: [
+            {
+              index: { byteStart: 3, byteEnd: 19 }, // '@bob.bsky.social'
+              features: [{ $type: 'app.bsky.richtext.facet#mention', did: MENTION_DID }],
+            },
+          ],
+        },
+      }),
+      DID,
+      new Map([[MENTION_DID, 'oxy-bob']]),
+    );
+    expect(post?.text).toBe('hi [mention:oxy-bob]!');
+    expect(post?.mentions).toEqual(['oxy-bob']);
+  });
+
+  it('leaves an unresolved #mention as bare @handle text (no placeholder, no mentions)', () => {
+    const post = mapPostViewToNormalizedPost(
+      postView('um', 'hi @ghost.bsky.social!', {
+        record: {
+          facets: [
+            {
+              index: { byteStart: 3, byteEnd: 21 }, // '@ghost.bsky.social'
+              features: [{ $type: 'app.bsky.richtext.facet#mention', did: 'did:plc:ghost0000000000000000000' }],
+            },
+          ],
+        },
+      }),
+      DID,
+      new Map(), // nothing resolved
+    );
+    expect(post?.text).toBe('hi @ghost.bsky.social!');
+    expect(post?.mentions).toBeUndefined();
+  });
+
+  it('maps an embedded record#view quote to quotedUri', () => {
+    const QUOTED_URI = 'at://did:plc:q/app.bsky.feed.post/qk';
+    const post = mapPostViewToNormalizedPost(
+      postView('q', 'nice', {
+        embed: {
+          $type: 'app.bsky.embed.record#view',
+          record: { $type: 'app.bsky.embed.record#viewRecord', uri: QUOTED_URI },
+        },
+      }),
+      DID,
+    );
+    expect(post?.quotedUri).toBe(QUOTED_URI);
+  });
+
+  it('maps a recordWithMedia#view quote to quotedUri and keeps the media', () => {
+    const QUOTED_URI = 'at://did:plc:q/app.bsky.feed.post/qk';
+    const post = mapPostViewToNormalizedPost(
+      postView('qm', 'nice pic', {
+        embed: {
+          $type: 'app.bsky.embed.recordWithMedia#view',
+          record: {
+            $type: 'app.bsky.embed.record#view',
+            record: { $type: 'app.bsky.embed.record#viewRecord', uri: QUOTED_URI },
+          },
+          media: {
+            $type: 'app.bsky.embed.images#view',
+            images: [{ fullsize: 'https://cdn/q.jpg', alt: 'pic' }],
+          },
+        },
+      }),
+      DID,
+    );
+    expect(post?.quotedUri).toBe(QUOTED_URI);
+    expect(post?.media).toEqual([{ id: 'https://cdn/q.jpg', type: 'image', remoteUrl: 'https://cdn/q.jpg', alt: 'pic' }]);
+  });
+
   it('rejects a non-feed-post record, a wrong author, and a non-AT-URI', () => {
     // Wrong collection (a like, not a post).
     expect(
@@ -227,5 +360,95 @@ describe('importAuthorFeed', () => {
     expect(result.posts).toEqual([]);
     expect(mocks.xrpcGet).not.toHaveBeenCalled();
     expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('stamps parentPostId + threadId when the reply parent is imported locally', async () => {
+    const PARENT_URI = 'at://did:plc:parent/app.bsky.feed.post/root';
+    mocks.xrpcGet.mockResolvedValue({
+      feed: [{ post: postView('reply', 'a reply', { record: { reply: { parent: { uri: PARENT_URI } } } }) }],
+    });
+    // The dedup query selects only the activityId; the thread/quote resolver
+    // selects `_id threadId federation.activityId` — branch on that to return the
+    // parent for the resolver but nothing for the dedup.
+    mocks.postFind.mockImplementation(() => ({
+      select: (fields: string) => ({
+        lean: async () =>
+          fields === 'federation.activityId'
+            ? []
+            : [{ _id: 'parent1', threadId: 'root1', federation: { activityId: PARENT_URI } }],
+      }),
+    }));
+
+    await importAuthorFeed(ACTOR);
+
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        federation: expect.objectContaining({ inReplyTo: PARENT_URI }),
+        parentPostId: 'parent1',
+        threadId: 'root1',
+      }),
+    );
+  });
+
+  it('resolves an embedded quote to a local quoteOf when the quoted post is imported', async () => {
+    const QUOTED_URI = 'at://did:plc:quoted/app.bsky.feed.post/qkey';
+    mocks.xrpcGet.mockResolvedValue({
+      feed: [
+        {
+          post: postView('quoter', 'check this', {
+            embed: {
+              $type: 'app.bsky.embed.record#view',
+              record: { $type: 'app.bsky.embed.record#viewRecord', uri: QUOTED_URI },
+            },
+          }),
+        },
+      ],
+    });
+    mocks.postFind.mockImplementation(() => ({
+      select: (fields: string) => ({
+        lean: async () =>
+          fields === 'federation.activityId' ? [] : [{ _id: 'quoted1', federation: { activityId: QUOTED_URI } }],
+      }),
+    }));
+
+    await importAuthorFeed(ACTOR);
+
+    expect(mocks.create).toHaveBeenCalledWith(expect.objectContaining({ quoteOf: 'quoted1' }));
+  });
+
+  it('resolves a mention facet (via the synced FederatedActor) into a placeholder + post.mentions', async () => {
+    const MENTION_DID = 'did:plc:mentioned00000000000000';
+    mocks.xrpcGet.mockResolvedValue({
+      feed: [
+        {
+          post: postView('m', 'hi @bob.bsky.social!', {
+            record: {
+              facets: [
+                {
+                  index: { byteStart: 3, byteEnd: 19 },
+                  features: [{ $type: 'app.bsky.richtext.facet#mention', did: MENTION_DID }],
+                },
+              ],
+            },
+          }),
+        },
+      ],
+    });
+    // The mentioned DID is already a synced actor → resolved from the cache (no
+    // network fetch through `fetchAndUpsertAtprotoProfile`).
+    mocks.federatedActorFindOne.mockReturnValue({
+      select: () => ({ lean: async () => ({ oxyUserId: 'oxy-bob' }) }),
+    });
+
+    await importAuthorFeed(ACTOR);
+
+    expect(mocks.federatedActorFindOne).toHaveBeenCalledWith({ uri: MENTION_DID });
+    expect(mocks.fetchProfile).not.toHaveBeenCalled();
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mentions: ['oxy-bob'],
+        content: expect.objectContaining({ text: 'hi [mention:oxy-bob]!' }),
+      }),
+    );
   });
 });

--- a/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getNormalizedUserHandle } from '@oxyhq/core';
 
 /**
  * atproto profile mapping: `app.bsky.actor.getProfile` → normalized actor →
@@ -94,10 +95,35 @@ describe('mapProfileToNormalizedActor', () => {
     expect(actor?.bio).toBeUndefined();
   });
 
-  it('derives the instance domain from a bare custom-domain handle', () => {
-    const actor = mapProfileToNormalizedActor({ ...PROFILE, handle: 'example.com' });
-    expect(actor?.federatedUsername).toBe('example.com@example.com');
-    expect(actor?.instanceDomain).toBe('example.com');
+  it('keys an apex custom-domain handle to the Bluesky network host (no doubled domain)', () => {
+    // A 2-label apex handle (`gothamist.com`) has no strippable parent domain.
+    // Using the handle itself as the instance rendered the doubled
+    // `@gothamist.com@gothamist.com`; it now keys to the network host so
+    // `getNormalizedUserHandle` renders the clean `@gothamist.com@bsky.social`.
+    const actor = mapProfileToNormalizedActor({ ...PROFILE, handle: 'gothamist.com' });
+    expect(actor?.federatedUsername).toBe('gothamist.com@bsky.social');
+    expect(actor?.instanceDomain).toBe('bsky.social');
+
+    const rendered = getNormalizedUserHandle({
+      username: actor?.handle,
+      isFederated: true,
+      federation: { domain: actor?.instanceDomain },
+    });
+    expect(rendered).toBe('gothamist.com@bsky.social');
+    expect(rendered).not.toBe('gothamist.com@gothamist.com');
+  });
+
+  it('leaves a normal `.bsky.social` handle rendering unchanged', () => {
+    const actor = mapProfileToNormalizedActor({ ...PROFILE, handle: 'georgemonbiot.bsky.social' });
+    expect(actor?.federatedUsername).toBe('georgemonbiot.bsky.social@bsky.social');
+    expect(actor?.instanceDomain).toBe('bsky.social');
+
+    const rendered = getNormalizedUserHandle({
+      username: actor?.handle,
+      isFederated: true,
+      federation: { domain: actor?.instanceDomain },
+    });
+    expect(rendered).toBe('georgemonbiot.bsky.social@bsky.social');
   });
 
   it('returns null when did or handle is missing', () => {

--- a/packages/backend/src/__tests__/connectors/bridgyActorUri.test.ts
+++ b/packages/backend/src/__tests__/connectors/bridgyActorUri.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Bridgy Fed identity derivation. Bridgy Fed bridges a Bluesky user onto
+ * ActivityPub at the DETERMINISTIC actor URI `https://bsky.brid.gy/ap/<did>` and
+ * wraps a post's AT-URI as `https://bsky.brid.gy/convert/ap/at://<did>/...`. A
+ * legacy orphan that stored only the wrapped object URL can therefore recover its
+ * author's actor URI with no network round trip.
+ */
+
+import { deriveBridgyActorUri } from '../../connectors/activitypub/bridgy';
+import { didFromAtUri } from '../../connectors/atproto/constants';
+
+const DID = 'did:plc:reu7q3altx5gsonhu5nxcfp6';
+const CONVERT_URL = `https://bsky.brid.gy/convert/ap/at://${DID}/app.bsky.feed.post/3moysdeqo3c2r`;
+
+describe('didFromAtUri', () => {
+  it('extracts the DID from a bare AT-URI', () => {
+    expect(didFromAtUri(`at://${DID}/app.bsky.feed.post/3moysdeqo3c2r`)).toBe(DID);
+  });
+
+  it('extracts the DID embedded in a wrapped brid.gy object URL', () => {
+    expect(didFromAtUri(CONVERT_URL)).toBe(DID);
+  });
+
+  it('extracts a did:web authority', () => {
+    expect(didFromAtUri('at://did:web:example.com/app.bsky.feed.post/abc')).toBe('did:web:example.com');
+  });
+
+  it('rejects a handle authority (no stable DID)', () => {
+    expect(didFromAtUri('at://alice.bsky.social/app.bsky.feed.post/abc')).toBeUndefined();
+  });
+
+  it('returns undefined when no at:// DID is present', () => {
+    expect(didFromAtUri('https://mastodon.online/@alice/12345')).toBeUndefined();
+  });
+});
+
+describe('deriveBridgyActorUri', () => {
+  it('derives the canonical actor URI from a wrapped brid.gy object URL', () => {
+    expect(deriveBridgyActorUri(CONVERT_URL)).toBe(`https://bsky.brid.gy/ap/${DID}`);
+  });
+
+  it('tries each candidate in order (activityId, then url)', () => {
+    expect(deriveBridgyActorUri(undefined, CONVERT_URL)).toBe(`https://bsky.brid.gy/ap/${DID}`);
+  });
+
+  it('rejects a non-brid.gy host even when it carries an at:// DID', () => {
+    expect(deriveBridgyActorUri(`https://example.com/convert/ap/at://${DID}/app.bsky.feed.post/x`)).toBeUndefined();
+  });
+
+  it('rejects a bare at:// URI (no brid.gy host to build from)', () => {
+    expect(deriveBridgyActorUri(`at://${DID}/app.bsky.feed.post/x`)).toBeUndefined();
+  });
+
+  it('returns undefined for a non-federated Mastodon URL', () => {
+    expect(deriveBridgyActorUri('https://mastodon.online/@alice/12345')).toBeUndefined();
+  });
+
+  it('returns undefined for empty / undefined input', () => {
+    expect(deriveBridgyActorUri(undefined, undefined)).toBeUndefined();
+    expect(deriveBridgyActorUri()).toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/bridgyActorUri.test.ts
+++ b/packages/backend/src/__tests__/connectors/bridgyActorUri.test.ts
@@ -8,11 +8,16 @@ import { describe, it, expect } from 'vitest';
  * author's actor URI with no network round trip.
  */
 
-import { deriveBridgyActorUri } from '../../connectors/activitypub/bridgy';
+import {
+  bridgedMentionAnchorHrefs,
+  deriveBridgyActorUri,
+  didFromBridgyActorUri,
+} from '../../connectors/activitypub/bridgy';
 import { didFromAtUri } from '../../connectors/atproto/constants';
 
 const DID = 'did:plc:reu7q3altx5gsonhu5nxcfp6';
 const CONVERT_URL = `https://bsky.brid.gy/convert/ap/at://${DID}/app.bsky.feed.post/3moysdeqo3c2r`;
+const BRIDGY_ACTOR = `https://bsky.brid.gy/ap/${DID}`;
 
 describe('didFromAtUri', () => {
   it('extracts the DID from a bare AT-URI', () => {
@@ -60,5 +65,51 @@ describe('deriveBridgyActorUri', () => {
   it('returns undefined for empty / undefined input', () => {
     expect(deriveBridgyActorUri(undefined, undefined)).toBeUndefined();
     expect(deriveBridgyActorUri()).toBeUndefined();
+  });
+});
+
+describe('didFromBridgyActorUri', () => {
+  it('extracts the DID from a brid.gy actor URI', () => {
+    expect(didFromBridgyActorUri(BRIDGY_ACTOR)).toBe(DID);
+  });
+
+  it('extracts a did:web authority', () => {
+    expect(didFromBridgyActorUri('https://bsky.brid.gy/ap/did:web:example.com')).toBe('did:web:example.com');
+  });
+
+  it('rejects a non-brid.gy host', () => {
+    expect(didFromBridgyActorUri(`https://example.com/ap/${DID}`)).toBeUndefined();
+  });
+
+  it('rejects a brid.gy URL whose path is not /ap/<did>', () => {
+    expect(didFromBridgyActorUri(CONVERT_URL)).toBeUndefined();
+    expect(didFromBridgyActorUri('https://bsky.brid.gy/ap/not-a-did')).toBeUndefined();
+  });
+
+  it('returns undefined for a non-URL', () => {
+    expect(didFromBridgyActorUri('not a url')).toBeUndefined();
+  });
+});
+
+describe('bridgedMentionAnchorHrefs', () => {
+  it('derives both bsky.app profile forms from a brid.gy Mention tag (did + handle)', () => {
+    expect(
+      bridgedMentionAnchorHrefs({ href: BRIDGY_ACTOR, name: '@alice.bsky.social@bsky.brid.gy' }),
+    ).toEqual([
+      `https://bsky.app/profile/${DID}`,
+      'https://bsky.app/profile/alice.bsky.social',
+    ]);
+  });
+
+  it('derives only the did form when the tag carries no name', () => {
+    expect(bridgedMentionAnchorHrefs({ href: BRIDGY_ACTOR })).toEqual([
+      `https://bsky.app/profile/${DID}`,
+    ]);
+  });
+
+  it('returns [] for a non-brid.gy mention tag', () => {
+    expect(
+      bridgedMentionAnchorHrefs({ href: 'https://mastodon.social/users/bob', name: '@bob@mastodon.social' }),
+    ).toEqual([]);
   });
 });

--- a/packages/backend/src/__tests__/services/postHydrationOrphanBridgy.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationOrphanBridgy.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Legacy brid.gy/Bluesky "orphan" federated posts carry no `oxyUserId` AND no
+ * `federation.actorUri` — only the wrapped AP object URL
+ * (`https://bsky.brid.gy/convert/ap/at://<did>/app.bsky.feed.post/<rkey>`). Their
+ * author previously degraded to "Unknown user" because the FederatedActor lookup
+ * keyed on the missing `actorUri`. `resolveOrphanFederatedAuthors` now DERIVES the
+ * deterministic Bridgy Fed actor URI (`https://bsky.brid.gy/ap/<did>`) from the
+ * object URL and (a) resolves the real handle when the actor is already synced, or
+ * (b) fires a fail-soft, non-blocking on-demand actor sync and degrades with the
+ * bridge origin this pass so the DTO self-heals on the next load.
+ */
+
+const { federatedActorFind, getOrFetchActor } = vi.hoisted(() => ({
+  federatedActorFind: vi.fn(),
+  getOrFetchActor: vi.fn(),
+}));
+
+// PostHydrationService touches these at module load — stub them so importing the
+// module never starts the server, hits the network, or opens Redis/Mongo.
+vi.mock('../../../server', () => ({
+  oxy: {
+    getUserById: vi.fn(async () => ({})),
+    getUserFollowing: vi.fn(async () => []),
+    getUserFollowers: vi.fn(async () => []),
+  },
+}));
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    getUsersByIds: vi.fn(async () => []),
+    getLinkPreviews: vi.fn(async () => ({})),
+    getFileDownloadUrl: (id: string) => id,
+  }),
+}));
+vi.mock('../../utils/privacyHelpers', () => ({
+  getBlockedUserIds: vi.fn(async () => []),
+  getRestrictedUserIds: vi.fn(async () => []),
+  extractFollowingIds: vi.fn(() => []),
+  extractFollowersIds: vi.fn(() => []),
+}));
+
+function chainable(rows: unknown[]) {
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.lean = async () => rows;
+  return q;
+}
+
+vi.mock('../../models/Post', () => ({ Post: { find: () => chainable([]), findOne: () => chainable([]) } }));
+vi.mock('../../models/Poll', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/Like', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/Bookmark', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/UserSettings', () => ({ UserSettings: { find: () => chainable([]), findOne: () => chainable([]) } }));
+vi.mock('../../models/StarterPack', () => ({
+  StarterPack: { aggregate: async () => [] },
+  default: { aggregate: async () => [] },
+}));
+vi.mock('../../services/userSummaryCache', () => ({
+  mget: vi.fn(async () => new Map()),
+  mset: vi.fn(async () => undefined),
+  invalidate: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../models/FederatedActor', () => ({
+  FederatedActor: { find: (...args: unknown[]) => ({ select: () => ({ lean: () => federatedActorFind(...args) }) }) },
+  default: { find: (...args: unknown[]) => ({ select: () => ({ lean: () => federatedActorFind(...args) }) }) },
+}));
+
+// Replace the ActivityPub actor service so importing PostHydrationService never
+// loads its network/identity stack, and so the lazy on-demand sync is observable.
+vi.mock('../../connectors/activitypub/actor.service', () => ({
+  actorService: { getOrFetchActor: (...args: unknown[]) => getOrFetchActor(...args) },
+  default: { getOrFetchActor: (...args: unknown[]) => getOrFetchActor(...args) },
+}));
+
+import { resolveOrphanFederatedAuthors } from '../../services/PostHydrationService';
+
+const DID = 'did:plc:reu7q3altx5gsonhu5nxcfp6';
+const OBJECT_URL = `https://bsky.brid.gy/convert/ap/at://${DID}/app.bsky.feed.post/3moysdeqo3c2r`;
+const DERIVED_ACTOR_URI = `https://bsky.brid.gy/ap/${DID}`;
+const POST_ID = '6a3c2de8002520aa8c254a7f';
+
+describe('resolveOrphanFederatedAuthors — brid.gy derivation', () => {
+  beforeEach(() => {
+    federatedActorFind.mockReset();
+    getOrFetchActor.mockReset();
+    federatedActorFind.mockResolvedValue([]);
+    getOrFetchActor.mockResolvedValue(null);
+  });
+
+  it('resolves the real author from the DERIVED actor URI when the actor is already synced', async () => {
+    federatedActorFind.mockResolvedValue([
+      {
+        uri: DERIVED_ACTOR_URI,
+        username: 'americanfietser.bsky.social',
+        acct: 'americanfietser.bsky.social@bsky.brid.gy',
+        domain: 'bsky.brid.gy',
+        avatarUrl: 'https://bsky.brid.gy/a.png',
+        oxyUserId: '6a38fbdd272930c46a785b1f',
+      },
+    ]);
+
+    const result = await resolveOrphanFederatedAuthors([
+      { postId: POST_ID, federation: { activityId: OBJECT_URL, url: OBJECT_URL } },
+    ]);
+    const user = result.get(POST_ID);
+
+    // The FederatedActor lookup was keyed on the DERIVED actor URI.
+    expect(federatedActorFind).toHaveBeenCalledWith({ uri: { $in: [DERIVED_ACTOR_URI] } });
+    expect(user?.username).toBe('americanfietser.bsky.social');
+    expect(user?.isFederated).toBe(true);
+    expect(user?.instance).toBe('bsky.brid.gy');
+    expect(user?.federation?.domain).toBe('bsky.brid.gy');
+    expect(user?.avatar).toBe('https://bsky.brid.gy/a.png');
+    // Never invent a display name — the FederatedActor has none.
+    expect(user?.name.displayName).toBeUndefined();
+    // The actor already exists → no on-demand sync.
+    expect(getOrFetchActor).not.toHaveBeenCalled();
+  });
+
+  it('degrades with the bridge origin AND fires a fail-soft on-demand sync when the actor is not yet synced', async () => {
+    federatedActorFind.mockResolvedValue([]);
+
+    const result = await resolveOrphanFederatedAuthors([
+      { postId: POST_ID, federation: { url: OBJECT_URL } },
+    ]);
+    const user = result.get(POST_ID);
+
+    // Degraded this pass, but marked federated with the bridge origin so the
+    // content renders and no fabricated handle is emitted.
+    expect(user?.username).toBe('');
+    expect(user?.name.displayName).toBe('Unknown user');
+    expect(user?.isFederated).toBe(true);
+    expect(user?.instance).toBe('bsky.brid.gy');
+    // The DERIVED actor URI is synced off the request path so it self-heals.
+    expect(getOrFetchActor).toHaveBeenCalledTimes(1);
+    expect(getOrFetchActor).toHaveBeenCalledWith(DERIVED_ACTOR_URI);
+  });
+
+  it('does NOT sync — and stays degraded — for a truly underivable orphan', async () => {
+    const result = await resolveOrphanFederatedAuthors([
+      { postId: POST_ID, federation: { url: 'https://mastodon.online/@alice/12345' } },
+    ]);
+    const user = result.get(POST_ID);
+
+    expect(user?.username).toBe('');
+    expect(user?.name.displayName).toBe('Unknown user');
+    expect(user?.instance).toBe('mastodon.online');
+    // Non-brid.gy, no derivable DID → no lookup, no on-demand sync.
+    expect(federatedActorFind).not.toHaveBeenCalled();
+    expect(getOrFetchActor).not.toHaveBeenCalled();
+  });
+
+  it('leaves the actorUri-present path unchanged (no derivation, no sync)', async () => {
+    const STORED_URI = 'https://mastodon.online/users/alice';
+    federatedActorFind.mockResolvedValue([
+      { uri: STORED_URI, username: 'alice', domain: 'mastodon.online', avatarUrl: null, oxyUserId: 'oxy-alice' },
+    ]);
+
+    const result = await resolveOrphanFederatedAuthors([
+      { postId: POST_ID, federation: { actorUri: STORED_URI, url: 'https://mastodon.online/@alice/1' } },
+    ]);
+    const user = result.get(POST_ID);
+
+    expect(federatedActorFind).toHaveBeenCalledWith({ uri: { $in: [STORED_URI] } });
+    expect(user?.username).toBe('alice');
+    expect(user?.instance).toBe('mastodon.online');
+    expect(getOrFetchActor).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/utils/apMedia.test.ts
+++ b/packages/backend/src/__tests__/utils/apMedia.test.ts
@@ -159,6 +159,48 @@ describe('resolveApAttachment', () => {
     });
   });
 
+  describe('Bridgy Fed AP-type fallback (no mediaType, extensionless getBlob URL)', () => {
+    const GETBLOB =
+      'https://morel.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:abc123&cid=bafyxyz';
+
+    it('classifies a type:Image attachment with no mediaType/extension as image', () => {
+      const att: ApAttachment = { type: 'Image', width: 1000, height: 750, url: GETBLOB };
+      expect(resolveApAttachment(att)).toEqual({ href: GETBLOB, type: 'image' });
+    });
+
+    it('classifies a type:Video attachment with no mediaType/extension as video', () => {
+      const att: ApAttachment = { type: 'Video', url: GETBLOB };
+      expect(resolveApAttachment(att)).toEqual({ href: GETBLOB, type: 'video' });
+    });
+
+    it('classifies a MIME-less type:Audio attachment as video (no dedicated audio media kind)', () => {
+      const att: ApAttachment = { type: 'Audio', url: GETBLOB };
+      expect(resolveApAttachment(att)).toEqual({ href: GETBLOB, type: 'video' });
+    });
+
+    it('classifies a MIME-less Document with image dimensions as image', () => {
+      const att: ApAttachment = { type: 'Document', width: 800, height: 600, url: GETBLOB };
+      expect(resolveApAttachment(att)).toEqual({ href: GETBLOB, type: 'image' });
+    });
+
+    it('does not classify a MIME-less Document that carries a duration (not clearly an image)', () => {
+      const att: ApAttachment = { type: 'Document', duration: 30, url: GETBLOB };
+      expect(resolveApAttachment(att)).toBeNull();
+    });
+
+    it('respects an explicit non-media MIME over the AP type (MIME-first preserved)', () => {
+      // `type` says Image but the server explicitly declared a PDF MIME — the MIME
+      // wins, so the attachment is skipped rather than mis-stored as an image.
+      const att: ApAttachment = { type: 'Image', mediaType: 'application/pdf', url: 'https://example/file' };
+      expect(resolveApAttachment(att)).toBeNull();
+    });
+
+    it('still resolves a declared image MIME normally (Mastodon path unchanged)', () => {
+      const att: ApAttachment = { type: 'Document', mediaType: 'image/jpeg', url: 'https://m.example/x.jpg' };
+      expect(resolveApAttachment(att)).toEqual({ href: 'https://m.example/x.jpg', type: 'image' });
+    });
+  });
+
   describe('malformed / empty entries', () => {
     it('returns null for null/undefined attachment', () => {
       expect(resolveApAttachment(null)).toBeNull();
@@ -276,6 +318,22 @@ describe('extractApMediaFromNote', () => {
         { type: 'media', id: 'https://example/720.mp4', mediaType: 'video' },
       ],
     });
+  });
+
+  it('recovers a Bridgy Fed image attachment (no mediaType, extensionless getBlob URL)', () => {
+    const GETBLOB = 'https://cdn.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:z&cid=b';
+    const note = {
+      attachment: [{ type: 'Image', width: 1200, height: 800, url: GETBLOB }],
+    };
+    const out = extractApMediaFromNote(note);
+    expect(out.media[0]).toMatchObject({
+      id: GETBLOB,
+      type: 'image',
+      width: 1200,
+      height: 800,
+      orientation: 'landscape',
+    });
+    expect(out.attachments).toEqual([{ type: 'media', id: GETBLOB, mediaType: 'image' }]);
   });
 
   it('matches the legacy Mastodon string behavior with no regression', () => {

--- a/packages/backend/src/connectors/activitypub/apMedia.ts
+++ b/packages/backend/src/connectors/activitypub/apMedia.ts
@@ -107,6 +107,46 @@ function classify(resolved: ResolvedUrl): ApMediaType | null {
 }
 
 /**
+ * Classify an attachment from its AP `type` discriminator — the LAST-RESORT
+ * signal used only when neither the MIME type nor a file extension resolves.
+ *
+ * Bridgy Fed (brid.gy) bridges Bluesky media as
+ * `{ type:'Image'|'Video', width, height, url:'https://…bsky.network/xrpc/com.atproto.sync.getBlob?did=…&cid=…' }`:
+ * NO `mediaType`, and the `getBlob` URL carries no extension, so the AP object
+ * `type` is the only remaining evidence of the medium. Mastodon/Pleroma always
+ * send a MIME, so their MIME-first path never reaches this.
+ */
+function classifyFromApType(attachment: ApAttachment): ApMediaType | null {
+  const apType = typeof attachment.type === 'string' ? attachment.type : undefined;
+  switch (apType) {
+    case 'Image':
+      return 'image';
+    case 'Video':
+      return 'video';
+    case 'Audio':
+      // The Post media model has no dedicated audio kind; an audio attachment is
+      // stored as a video item so it stays playable through the video pipeline
+      // rather than being dropped.
+      return 'video';
+    case 'Document':
+      // A generic `Document` with no MIME is only treated as an image when it
+      // carries still-image dimensions and no playback duration (a duration would
+      // imply audio/video, which cannot be assumed from `Document` alone).
+      return isImageIshDocument(attachment) ? 'image' : null;
+    default:
+      return null;
+  }
+}
+
+/** True when a MIME-less `Document` looks like a still image: has pixel dimensions and no duration. */
+function isImageIshDocument(attachment: ApAttachment): boolean {
+  const hasDuration = attachment.duration !== undefined && attachment.duration !== null;
+  const width = typeof attachment.width === 'number' ? attachment.width : 0;
+  const height = typeof attachment.height === 'number' ? attachment.height : 0;
+  return !hasDuration && (width > 0 || height > 0);
+}
+
+/**
  * Rank a video candidate for "most broadly playable":
  *  0 — progressive `video/mp4` (best `expo-video`/web `<video>` compatibility)
  *  1 — any other `video/*` (webm, quicktime, etc.)
@@ -179,6 +219,17 @@ export function resolveApAttachment(
   // Otherwise take the first valid image.
   if (images.length > 0) {
     return { href: images[0].href, type: 'image' };
+  }
+
+  // Nothing classified by MIME or extension. When NO MIME was declared at all —
+  // the Bridgy Fed shape (`type:'Image'`/`'Video'`, extensionless getBlob URL, no
+  // `mediaType`) — fall back to the AP `type` discriminator. A candidate that DID
+  // declare a MIME we don't recognize (e.g. `application/pdf`) is a deliberate
+  // non-media type and stays skipped, so Mastodon's MIME-first path is preserved.
+  const undeclared = resolved.find((r) => normalizeMime(r.mimeType).length === 0);
+  if (undeclared) {
+    const apType = classifyFromApType(attachment);
+    if (apType) return { href: undeclared.href, type: apType };
   }
 
   return null;

--- a/packages/backend/src/connectors/activitypub/apMentions.ts
+++ b/packages/backend/src/connectors/activitypub/apMentions.ts
@@ -2,6 +2,7 @@ import { logger } from '../../utils/logger';
 import { actorService } from './actor.service';
 import { getApContentMap } from './apLanguage';
 import { primaryApType } from './apSchemas';
+import { bridgedMentionAnchorHrefs } from './bridgy';
 import { isBlockedDomain, resolveOxyUser } from './constants';
 
 /**
@@ -201,12 +202,18 @@ export async function resolveInboundMentions(
         if (!resolved) return;
         ids.add(resolved.oxyUserId);
         if (resolved.isLocal) localIds.add(resolved.oxyUserId);
-        // Map BOTH candidate anchor hrefs (actor URI + reconstructed profile URL)
-        // to this id so the content anchor matches regardless of which form the
-        // origin server used.
+        // Map every candidate anchor href to this id so the content anchor
+        // matches regardless of which form the origin server used: the actor URI
+        // (Pleroma / our own posts), the reconstructed `https://<domain>/@<user>`
+        // profile URL (Mastodon/Misskey), and — for a bridged Bluesky mention —
+        // the `https://bsky.app/profile/<did|handle>` web-profile forms Bridgy Fed
+        // uses in-content.
         anchorMap.set(normalizeActorHref(tag.href), resolved.oxyUserId);
         const profileHref = reconstructProfileHref(tag.name);
         if (profileHref) anchorMap.set(normalizeActorHref(profileHref), resolved.oxyUserId);
+        for (const bridged of bridgedMentionAnchorHrefs(tag)) {
+          anchorMap.set(normalizeActorHref(bridged), resolved.oxyUserId);
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.warn(`[Federation] failed to resolve inbound mention ${tag.href}: ${message}`);

--- a/packages/backend/src/connectors/activitypub/apPostContent.ts
+++ b/packages/backend/src/connectors/activitypub/apPostContent.ts
@@ -85,6 +85,74 @@ export interface SkippedFederatedNoteContent {
 }
 
 /**
+ * Any `<a …>…</a>` anchor, capturing its attribute string and inner HTML
+ * separately. Anchors do not nest in AP content HTML, so the non-greedy `.*?`
+ * (dotall) inner match is safe.
+ */
+const AP_ANCHOR_REGEX = /<a\b([^>]*)>(.*?)<\/a>/gis;
+
+/**
+ * Marks an anchor as a HASHTAG link: Mastodon emits `class="mention hashtag"`
+ * with `rel="tag"`; Bridgy Fed emits `class="hashtag"` with `rel="tag"`. Either
+ * attribute signals a hashtag anchor.
+ */
+const HASHTAG_ANCHOR_ATTR_REGEX = /\bclass="[^"]*\bhashtag\b[^"]*"|\brel="[^"]*\btag\b[^"]*"/i;
+
+/**
+ * Rewrite hashtag anchors to their visible `#name` text BEFORE the generic
+ * {@link htmlToPlainText} runs.
+ *
+ * Mastodon wraps the tag text in an inner `<span>`
+ * (`<a … class="mention hashtag" rel="tag">#<span>tag</span></a>`), so
+ * `htmlToPlainText`'s link-to-URL rule (which only matches anchors with a
+ * text-only child) already leaves it as `#tag`. Bridgy Fed uses a PLAIN-TEXT
+ * child with a `bsky.app/search` href
+ * (`<a class="hashtag" rel="tag" href="https://bsky.app/search?q=%23Tag">#Tag</a>`),
+ * which that same rule turns into the raw search URL — wrecking the body. This
+ * collapses both shapes to the anchor's visible text (tags stripped), so the
+ * `#tag` survives regardless of origin. Non-hashtag anchors (mentions, plain
+ * links) are left untouched for the downstream converter. Pure.
+ */
+export function rewriteHashtagAnchors(html: string): string {
+  if (!html || !html.includes('<a')) return html;
+  return html.replace(AP_ANCHOR_REGEX, (match, attrs: string, inner: string) => {
+    if (!HASHTAG_ANCHOR_ATTR_REGEX.test(attrs)) return match;
+    const text = inner.replace(/<[^>]+>/g, '').trim();
+    return text.length > 0 ? text : match;
+  });
+}
+
+/**
+ * Return a shallow copy of an AP object whose HTML bodies (`content` and every
+ * `contentMap` variant) have had their hashtag anchors rewritten to the visible
+ * `#name` text. Mirrors {@link applyMentionPlaceholders}: the original object is
+ * never mutated, both the primary body and its `contentMap` counterpart are
+ * rewritten with the SAME rule so they stay consistent for the language
+ * extractor, and the object is returned unchanged (zero cost) when no anchors are
+ * present.
+ */
+function rewriteHashtagAnchorsInObject(object: Record<string, unknown>): Record<string, unknown> {
+  const content = object.content;
+  const contentMap = getApContentMap(object);
+  const contentHasAnchor = typeof content === 'string' && content.includes('<a');
+  const mapHasAnchor =
+    contentMap !== undefined &&
+    Object.values(contentMap).some((value) => typeof value === 'string' && value.includes('<a'));
+  if (!contentHasAnchor && !mapHasAnchor) return object;
+
+  const rewritten: Record<string, unknown> = { ...object };
+  if (typeof content === 'string') rewritten.content = rewriteHashtagAnchors(content);
+  if (contentMap) {
+    const rewrittenMap: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(contentMap)) {
+      rewrittenMap[key] = typeof value === 'string' ? rewriteHashtagAnchors(value) : value;
+    }
+    rewritten.contentMap = rewrittenMap;
+  }
+  return rewritten;
+}
+
+/**
  * Extract the HTML content body from an AP object, falling back to a
  * `contentMap` localized variant when the top-level `content` is empty.
  *
@@ -274,7 +342,14 @@ async function assembleFederatedNoteContent(
   ownerOxyUserId: string | null | undefined,
   ctx: BuildFederatedNoteContentContext,
 ): Promise<BuiltFederatedNoteContent> {
-  const primaryHtml = extractApContentHtml(object);
+  // Rewrite hashtag anchors to their visible `#name` text before ANY body
+  // extraction, so a Bridgy Fed hashtag anchor is not turned into its raw
+  // `bsky.app/search?q=%23Tag` href by the generic HTML→text converter. Applies
+  // to `content` and every `contentMap` variant; every reader below (primary
+  // body, author variants, primary-tag resolution) sees the rewritten bodies.
+  const source = rewriteHashtagAnchorsInObject(object);
+
+  const primaryHtml = extractApContentHtml(source);
   const rawText = htmlToPlainText(primaryHtml);
 
   // Run the centralized hashtag normalizer on every path so an all-hashtag post
@@ -309,9 +384,10 @@ async function assembleFederatedNoteContent(
 
   // The localized bodies — the post's only body storage. `text` is handed in as
   // the primary rendition, so the body the guard/classifier see and the body
-  // stored in `variants[0]` are the same string by construction.
-  const primaryTag = resolveApPrimaryTag(object, primaryHtml);
-  const variants = buildApAuthorVariants(object, primaryTag, text, media.length > 0);
+  // stored in `variants[0]` are the same string by construction. Both read from
+  // `source` so `contentMap` values match the rewritten `primaryHtml`.
+  const primaryTag = resolveApPrimaryTag(source, primaryHtml);
+  const variants = buildApAuthorVariants(source, primaryTag, text, media.length > 0);
 
   return { text, media, attachments, hashtags, summary, sensitive, variants };
 }

--- a/packages/backend/src/connectors/activitypub/bridgy.ts
+++ b/packages/backend/src/connectors/activitypub/bridgy.ts
@@ -14,7 +14,7 @@
  * which is exactly what hydration needs to resolve such an orphan's real author.
  */
 
-import { didFromAtUri } from '../atproto/constants';
+import { ANY_DID_RE, BSKY_APP_ORIGIN, didFromAtUri } from '../atproto/constants';
 
 /** Bridgy Fed's Bluesky↔fediverse bridge host (where the `/ap/<did>` scheme lives). */
 const BRIDGY_FED_BSKY_HOST = 'bsky.brid.gy';
@@ -42,4 +42,51 @@ export function deriveBridgyActorUri(...candidateUrls: Array<string | undefined>
     if (did) return `https://${BRIDGY_FED_BSKY_HOST}/ap/${did}`;
   }
   return undefined;
+}
+
+/**
+ * The atproto DID of a Bridgy Fed actor URI (`https://bsky.brid.gy/ap/<did>`) —
+ * the inverse of {@link deriveBridgyActorUri}. Returns undefined for any
+ * non-brid.gy URL or one whose path is not exactly `/ap/<did>`. Pure and
+ * synchronous; used to recognise a bridged mention and derive its Bluesky web
+ * profile URL.
+ */
+export function didFromBridgyActorUri(actorUri: string): string | undefined {
+  let url: URL;
+  try {
+    url = new URL(actorUri);
+  } catch {
+    return undefined;
+  }
+  if (url.host.toLowerCase() !== BRIDGY_FED_BSKY_HOST) return undefined;
+  const did = url.pathname.match(/^\/ap\/(did:(?:plc|web):[^/]+)$/i)?.[1];
+  return did && ANY_DID_RE.test(did) ? did : undefined;
+}
+
+/**
+ * The in-content profile-anchor hrefs a Bridgy Fed (brid.gy) @mention can use.
+ *
+ * Bridgy's `Mention` tag carries the bridged actor URI
+ * (`https://bsky.brid.gy/ap/<did>`) as `href` and `@<handle>@bsky.brid.gy` as
+ * `name`, but the anchor INSIDE the content points at the Bluesky WEB profile —
+ * `https://bsky.app/profile/<did>` OR `https://bsky.app/profile/<handle>` — which
+ * matches neither the actor URI nor the reconstructed `https://bsky.brid.gy/@<handle>`
+ * profile URL the generic mention resolver derives. Emitting both bsky.app forms
+ * as extra anchor candidates lets a bridged mention resolve to the internal
+ * `[mention:<id>]` placeholder exactly like a Mastodon mention does. Returns `[]`
+ * for a non-brid.gy tag (zero cost). Pure and synchronous.
+ */
+export function bridgedMentionAnchorHrefs(tag: { href: string; name?: string }): string[] {
+  const did = didFromBridgyActorUri(tag.href);
+  if (!did) return [];
+  const hrefs = [`${BSKY_APP_ORIGIN}/profile/${did}`];
+
+  // `name` is `@<handle>@bsky.brid.gy`; the handle is everything between the
+  // leading `@` and the trailing `@<domain>` (a Bluesky handle has no `@`).
+  const cleaned = (tag.name ?? '').replace(/^@+/, '');
+  const lastAt = cleaned.lastIndexOf('@');
+  const handle = lastAt > 0 ? cleaned.slice(0, lastAt) : '';
+  if (handle) hrefs.push(`${BSKY_APP_ORIGIN}/profile/${handle}`);
+
+  return hrefs;
 }

--- a/packages/backend/src/connectors/activitypub/bridgy.ts
+++ b/packages/backend/src/connectors/activitypub/bridgy.ts
@@ -1,0 +1,45 @@
+/**
+ * Bridgy Fed (brid.gy) — deterministic identity derivation for INBOUND bridged
+ * atproto (Bluesky) content.
+ *
+ * Bridgy Fed is an ActivityPub bridge: a Bluesky user is represented to the
+ * fediverse at a DETERMINISTIC actor URI derived from the user's atproto DID —
+ * `https://bsky.brid.gy/ap/<did>` — and a Bluesky post's AT-URI is wrapped as the
+ * AP object URL `https://bsky.brid.gy/convert/ap/at://<did>/app.bsky.feed.post/<rkey>`.
+ *
+ * A cohort of LEGACY orphan posts stored only that object URL
+ * (`federation.url` / `federation.activityId`) and never the author's
+ * `federation.actorUri`. Because the actor URI is a pure function of the DID
+ * embedded in the object URL, it can be RECOVERED with NO network round trip —
+ * which is exactly what hydration needs to resolve such an orphan's real author.
+ */
+
+import { didFromAtUri } from '../atproto/constants';
+
+/** Bridgy Fed's Bluesky↔fediverse bridge host (where the `/ap/<did>` scheme lives). */
+const BRIDGY_FED_BSKY_HOST = 'bsky.brid.gy';
+
+/**
+ * Derive the canonical Bridgy Fed ActivityPub actor URI
+ * (`https://bsky.brid.gy/ap/<did>`) for a bridged Bluesky post, given the post's
+ * federation object URLs (`activityId` and/or `url`, tried in order).
+ *
+ * Returns undefined unless a candidate is a `bsky.brid.gy`-hosted URL carrying an
+ * atproto DID — a non-brid.gy URL, or one with no `at://<did>`, is left for the
+ * caller to degrade gracefully. Pure and synchronous.
+ */
+export function deriveBridgyActorUri(...candidateUrls: Array<string | undefined>): string | undefined {
+  for (const candidate of candidateUrls) {
+    if (!candidate) continue;
+    let host: string;
+    try {
+      host = new URL(candidate).host.toLowerCase();
+    } catch {
+      continue;
+    }
+    if (host !== BRIDGY_FED_BSKY_HOST) continue;
+    const did = didFromAtUri(candidate);
+    if (did) return `https://${BRIDGY_FED_BSKY_HOST}/ap/${did}`;
+  }
+  return undefined;
+}

--- a/packages/backend/src/connectors/activitypub/helpers.ts
+++ b/packages/backend/src/connectors/activitypub/helpers.ts
@@ -451,6 +451,57 @@ export function extractInReplyToUri(inReplyTo: unknown): string | undefined {
 }
 
 /**
+ * Extract the canonical AP object URI of the post a Note QUOTES, or `undefined`
+ * when it quotes nothing.
+ *
+ * A quote is advertised across several interoperating terms — the SAME set the
+ * outbound Note builder emits ({@link FollowService.buildCreateNoteActivity}): the
+ * modern `quote`/`quoteUri` (FEP-044f / Mastodon 4.4+), the legacy
+ * `_misskey_quote`/`quoteUrl` (Misskey/Pleroma/Akkoma), and the FEP-e232 `Link`
+ * quote tag (`rel: …#_misskey_quote` and/or `mediaType: application/activity+json`).
+ * Bridgy Fed publishes a bridged Bluesky quote through these same fields, pointing
+ * at the quoted post's wrapped brid.gy object URL
+ * (`https://bsky.brid.gy/convert/ap/at://…`).
+ *
+ * The structured fields win over the tag; each candidate is normalized through
+ * {@link activityPubLinkUrl} (string / `{id}` / `{href}`) and must be an absolute
+ * http(s) URL. Pure / no I/O — the caller resolves the URI to a local Post via
+ * {@link resolvePostIdFromObjectUri}.
+ */
+export function extractApQuoteUri(object: Record<string, unknown>): string | undefined {
+  for (const key of ['quote', 'quoteUri', 'quoteUrl', '_misskey_quote'] as const) {
+    const uri = activityPubLinkUrl(object[key]);
+    if (uri) return uri;
+  }
+
+  const tags = object.tag;
+  if (Array.isArray(tags)) {
+    for (const entry of tags) {
+      if (!entry || typeof entry !== 'object') continue;
+      const record = entry as { type?: unknown; rel?: unknown; mediaType?: unknown; href?: unknown };
+      const isLink =
+        record.type === 'Link' || (Array.isArray(record.type) && record.type.includes('Link'));
+      if (!isLink) continue;
+
+      const rel = Array.isArray(record.rel)
+        ? record.rel.join(' ')
+        : typeof record.rel === 'string'
+          ? record.rel
+          : '';
+      const isQuoteRel = rel.includes('_misskey_quote');
+      const isApLink =
+        typeof record.mediaType === 'string' && record.mediaType.toLowerCase().includes('activity+json');
+      if (!isQuoteRel && !isApLink) continue;
+
+      const href = typeof record.href === 'string' ? record.href.trim() : '';
+      if (href && isAbsoluteHttpUrl(href)) return href;
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Extract media attachments from an AP Note object.
  * Returns media items and attachment descriptors for the Post model.
  *

--- a/packages/backend/src/connectors/activitypub/inbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/inbox.service.ts
@@ -21,6 +21,7 @@ import { followService } from './follow.service';
 import { getServiceOxyClient } from '../../utils/oxyHelpers';
 import {
   extractAnnouncedObjectUri,
+  extractApQuoteUri,
   extractInReplyToUri,
   isDuplicateKeyError,
   mapApVisibility,
@@ -672,6 +673,16 @@ export class InboxProcessingService {
       return;
     }
 
+    // When this Note QUOTES another post, link it to the local quoted Post so
+    // hydration embeds the quoted original (mirrors the native quote shape). The
+    // quote URI is read from the standard AP quote surfaces (Bridgy Fed bridges a
+    // Bluesky quote through them, pointing at the quoted post's brid.gy object
+    // URL). Resolved only when the quoted post is ALREADY imported here — a
+    // not-yet-imported quoted post leaves `quoteOf` null rather than blocking the
+    // Create; it will link on a later pass once the original is ingested.
+    const quoteUri = extractApQuoteUri(object);
+    const quoteOf = quoteUri ? await resolvePostIdFromObjectUri(quoteUri) : null;
+
     const createdPost = await getPostCreator().create({
       oxyUserId: authorOxyUserId,
       federation: {
@@ -684,6 +695,7 @@ export class InboxProcessingService {
       },
       parentPostId: threadLink?.parentPostId ?? null,
       threadId: threadLink?.threadId ?? null,
+      quoteOf,
       content: {
         // The body lives ONLY in the variants — a `contentMap` is one body PER
         // LANGUAGE, not a fallback for one. `variants[0]` is the primary.

--- a/packages/backend/src/connectors/atproto/constants.ts
+++ b/packages/backend/src/connectors/atproto/constants.ts
@@ -78,6 +78,21 @@ export function isAtUri(subject: string): boolean {
 }
 
 /**
+ * The atproto DID authority of an AT-URI, whether the URI is bare
+ * (`at://did:plc:.../app.bsky.feed.post/<rkey>`) or embedded in a larger URL
+ * (Bridgy Fed wraps it as `https://bsky.brid.gy/convert/ap/at://<did>/...`).
+ *
+ * Returns the DID only when the authority is a supported atproto DID; a handle
+ * authority (`at://alice.bsky.social/...`) is deliberately rejected, because
+ * callers need a STABLE did to derive a deterministic bridged actor URI. Returns
+ * undefined when no `at://<did>` appears in the input.
+ */
+export function didFromAtUri(value: string): string | undefined {
+  const did = value.match(/at:\/\/(did:(?:plc|web):[^/\s?#]+)/i)?.[1];
+  return did && ANY_DID_RE.test(did) ? did : undefined;
+}
+
+/**
  * True when `subject` looks like an atproto handle (a bare DNS name with no `@`
  * and no URL scheme). `*.bsky.social` and any other registrable domain qualify.
  */

--- a/packages/backend/src/connectors/atproto/constants.ts
+++ b/packages/backend/src/connectors/atproto/constants.ts
@@ -31,6 +31,16 @@ export const PLC_DIRECTORY = process.env.ATPROTO_PLC_DIRECTORY || 'plc.directory
 /** Bluesky's web app origin — the canonical web URL for a post / profile. */
 export const BSKY_APP_ORIGIN = 'https://bsky.app';
 
+/**
+ * The Bluesky network's canonical host, used as the federated instance domain for
+ * an APEX custom handle — a 2-label domain like `gothamist.com` whose first label
+ * cannot be stripped without leaving a bare TLD (`com`). A regular handle derives
+ * its instance from its parent domain (`alice.bsky.social` → `bsky.social`); an
+ * apex handle has none, so it keys to the network host and renders cleanly as
+ * `@gothamist.com@bsky.social` instead of the doubled `@gothamist.com@gothamist.com`.
+ */
+export const BSKY_NETWORK_DOMAIN = 'bsky.social';
+
 /** The atproto record collection that holds a feed post. */
 export const POST_COLLECTION = 'app.bsky.feed.post';
 

--- a/packages/backend/src/connectors/atproto/post.mapper.ts
+++ b/packages/backend/src/connectors/atproto/post.mapper.ts
@@ -2,12 +2,14 @@ import { PostVisibility } from '@mention/shared-types';
 import { normalizeMultilineText } from '@oxyhq/core';
 import { logger } from '../../utils/logger';
 import { Post } from '../../models/Post';
+import FederatedActor from '../../models/FederatedActor';
 import { normalizeAlt } from '../../services/MediaMetadataService';
 import { getPostCreator } from '../../services/serviceRegistry';
 import { materializeFederatedMedia, type ExtractedMediaAttachment } from '../shared/federatedMedia';
 import type { MediaItem } from '@mention/shared-types';
 import type { NormalizedExternalActor, NormalizedExternalMedia, NormalizedExternalPost } from '../types';
 import { xrpcGet } from './xrpcClient';
+import { fetchAndUpsertAtprotoProfile } from './profile.mapper';
 import { BSKY_APP_ORIGIN, POST_COLLECTION, PUBLIC_APPVIEW } from './constants';
 
 /**
@@ -31,7 +33,13 @@ interface AtprotoFacetFeature {
   uri?: string;
   did?: string;
 }
+/** Byte (UTF-8) offsets into the record `text` a facet annotates. */
+interface AtprotoFacetIndex {
+  byteStart?: number;
+  byteEnd?: number;
+}
 interface AtprotoFacet {
+  index?: AtprotoFacetIndex;
   features?: AtprotoFacetFeature[];
 }
 interface AtprotoReplyRef {
@@ -54,6 +62,17 @@ interface AtprotoEmbedImage {
   alt?: string;
   aspectRatio?: { width: number; height: number };
 }
+/**
+ * A hydrated record embed view. Self-referential so it covers both nesting levels:
+ * a top-level `app.bsky.embed.record#view` whose `.record` is the quoted
+ * `#viewRecord` (carrying its `uri`), and the `app.bsky.embed.recordWithMedia#view`
+ * whose `.record` is a nested `#view` whose `.record` is that `#viewRecord`.
+ */
+interface AtprotoEmbedRecordView {
+  $type?: string;
+  uri?: string;
+  record?: AtprotoEmbedRecordView;
+}
 interface AtprotoEmbedView {
   $type?: string;
   images?: AtprotoEmbedImage[];
@@ -61,6 +80,7 @@ interface AtprotoEmbedView {
   thumbnail?: string;
   aspectRatio?: { width: number; height: number };
   media?: AtprotoEmbedView;
+  record?: AtprotoEmbedRecordView;
 }
 interface AtprotoPostView {
   uri?: string;
@@ -111,6 +131,116 @@ function extractHashtags(record: AtprotoPostRecord): string[] {
     }
   }
   return Array.from(tags);
+}
+
+/** Every atproto DID referenced by a record's richtext `#mention` facets. Pure. */
+function extractMentionDids(record: AtprotoPostRecord | undefined): string[] {
+  if (!record) return [];
+  const dids: string[] = [];
+  for (const facet of record.facets ?? []) {
+    for (const feature of facet.features ?? []) {
+      if (feature?.$type === 'app.bsky.richtext.facet#mention' && typeof feature.did === 'string' && feature.did) {
+        dids.push(feature.did);
+      }
+    }
+  }
+  return dids;
+}
+
+/** A single byte-range text replacement derived from a richtext facet. */
+interface FacetReplacement {
+  byteStart: number;
+  byteEnd: number;
+  replacement: string;
+}
+
+/**
+ * Build the byte-range text replacements + resolved mention ids for a record's
+ * richtext facets:
+ *   - `#link`: replace the (truncated) display text with the feature's FULL `uri`
+ *     — this is what surfaces `gothamist.com/news/long-arti…` as the real URL so
+ *     the link is never broken and the link-preview pipeline can unfurl it.
+ *   - `#mention`: replace the `@handle` display text with the internal
+ *     `[mention:<oxyUserId>]` placeholder when the DID resolved (from `mentionMap`);
+ *     when it did not, emit no op so the bare `@handle` text is left in place.
+ *   - `#tag`: left untouched — the `#tag` text renders as-is and the normalized
+ *     tag set comes from {@link extractHashtags}.
+ * Pure.
+ */
+function buildFacetReplacements(
+  record: AtprotoPostRecord,
+  mentionMap: ReadonlyMap<string, string>,
+): { ops: FacetReplacement[]; mentionIds: string[] } {
+  const ops: FacetReplacement[] = [];
+  const mentionIds = new Set<string>();
+  for (const facet of record.facets ?? []) {
+    const byteStart = facet.index?.byteStart;
+    const byteEnd = facet.index?.byteEnd;
+    if (typeof byteStart !== 'number' || typeof byteEnd !== 'number') continue;
+    for (const feature of facet.features ?? []) {
+      if (feature?.$type === 'app.bsky.richtext.facet#link' && typeof feature.uri === 'string' && feature.uri) {
+        ops.push({ byteStart, byteEnd, replacement: feature.uri });
+        break; // one replacement per facet byte range
+      }
+      if (feature?.$type === 'app.bsky.richtext.facet#mention' && typeof feature.did === 'string' && feature.did) {
+        const oxyUserId = mentionMap.get(feature.did);
+        if (oxyUserId) {
+          ops.push({ byteStart, byteEnd, replacement: `[mention:${oxyUserId}]` });
+          mentionIds.add(oxyUserId);
+        }
+        break;
+      }
+    }
+  }
+  return { ops, mentionIds: [...mentionIds] };
+}
+
+/**
+ * Apply byte-range replacements to `text`. atproto facet indices are UTF-8 BYTE
+ * offsets (not JS UTF-16 string indices), so the splice runs over a UTF-8 byte
+ * buffer and decodes back — multibyte text (emoji, accents) before a facet does
+ * not shift its target. Replacements are applied in DESCENDING `byteStart` order
+ * so an earlier splice never shifts a later (leftward) range; overlapping or
+ * out-of-range facets are skipped. Pure.
+ */
+function applyFacetReplacements(text: string, ops: FacetReplacement[]): string {
+  if (ops.length === 0) return text;
+  const buffer = Buffer.from(text, 'utf8');
+  const ordered = ops
+    .filter((op) => op.byteStart >= 0 && op.byteStart < op.byteEnd && op.byteEnd <= buffer.length)
+    .sort((a, b) => b.byteStart - a.byteStart);
+
+  let out = buffer;
+  // The start of the nearest already-applied range to the right; a facet that
+  // ends past it overlaps and is skipped (facets never legally overlap).
+  let nextStart = buffer.length;
+  for (const op of ordered) {
+    if (op.byteEnd > nextStart) continue;
+    out = Buffer.concat([out.subarray(0, op.byteStart), Buffer.from(op.replacement, 'utf8'), out.subarray(op.byteEnd)]);
+    nextStart = op.byteStart;
+  }
+  return out.toString('utf8');
+}
+
+/**
+ * The quoted post's AT-URI from a hydrated record embed
+ * (`app.bsky.embed.record#view`, or the record half of
+ * `app.bsky.embed.recordWithMedia#view`) — but ONLY when the quoted record is a
+ * real, viewable feed post (`#viewRecord` of `app.bsky.feed.post`). A blocked /
+ * detached / not-found / feed-generator / list embed yields no quote. Pure.
+ */
+function extractQuotedUri(embed: AtprotoEmbedView | undefined): string | undefined {
+  const recordView =
+    embed?.$type === 'app.bsky.embed.record#view'
+      ? embed.record
+      : embed?.$type === 'app.bsky.embed.recordWithMedia#view'
+        ? embed.record?.record
+        : undefined;
+  if (recordView?.$type === 'app.bsky.embed.record#viewRecord' && typeof recordView.uri === 'string') {
+    const parsed = parseAtUri(recordView.uri);
+    if (parsed && parsed.collection === POST_COLLECTION) return recordView.uri;
+  }
+  return undefined;
 }
 
 /** Normalize `record.langs` to ISO 639-1 primary subtags (deduped, capped at 3). */
@@ -208,6 +338,7 @@ function extractMediaFromEmbed(embed: AtprotoEmbedView | undefined): NormalizedE
 export function mapPostViewToNormalizedPost(
   postView: AtprotoPostView | undefined,
   expectedAuthorDid: string,
+  mentionMap: ReadonlyMap<string, string> = new Map(),
 ): NormalizedExternalPost | null {
   if (!postView || typeof postView.uri !== 'string') return null;
   const parsed = parseAtUri(postView.uri);
@@ -225,6 +356,17 @@ export function mapPostViewToNormalizedPost(
   const langs = normalizeLangs(record.langs);
   const media = extractMediaFromEmbed(postView.embed);
   const inReplyTo = typeof record.reply?.parent?.uri === 'string' ? record.reply.parent.uri : undefined;
+  const quotedUri = extractQuotedUri(postView.embed);
+
+  // Rewrite richtext facets over the RAW body FIRST, then normalize whitespace:
+  // the facet indices are byte offsets into `record.text`, so they must be applied
+  // before normalization shifts the bytes. `#link` display text becomes the full
+  // URL; resolved `#mention`s become `[mention:<oxyUserId>]` placeholders.
+  const rawText = typeof record.text === 'string' ? record.text : '';
+  const { ops, mentionIds } = buildFacetReplacements(record, mentionMap);
+  // The post body is third-party text: the author's line breaks are meaningful and
+  // survive, but the surrounding whitespace noise is normalized away.
+  const text = normalizeMultilineText(applyFacetReplacements(rawText, ops));
 
   return {
     network: 'atproto',
@@ -232,13 +374,13 @@ export function mapPostViewToNormalizedPost(
     actorUri: did,
     url,
     inReplyTo,
+    quotedUri,
     sensitive: hasAdultLabel(record),
     authorOxyUserId: undefined,
-    // The post body is third-party text: the author's line breaks are meaningful
-    // and survive, but the surrounding whitespace noise is normalized away.
-    text: typeof record.text === 'string' ? normalizeMultilineText(record.text) : '',
+    text,
     media: media.length > 0 ? media : undefined,
     hashtags: extractHashtags(record),
+    mentions: mentionIds.length > 0 ? mentionIds : undefined,
     language: langs[0],
     languages: langs.length > 0 ? langs : undefined,
     createdAt: parseCreatedAt(record.createdAt),
@@ -248,6 +390,82 @@ export function mapPostViewToNormalizedPost(
 /** True for a MongoDB duplicate-key (E11000) error — a concurrent import race. */
 function isDuplicateKeyError(err: unknown): boolean {
   return Boolean(err && typeof err === 'object' && (err as { code?: number }).code === 11000);
+}
+
+/**
+ * Resolve a mentioned atproto DID to its Oxy user id. Prefers an already-synced
+ * `FederatedActor` (no network round trip); otherwise resolves + mints the actor
+ * through the shared atproto profile path (`fetchAndUpsertAtprotoProfile`). Returns
+ * undefined (fail-soft) when the DID cannot be resolved to an Oxy user — the caller
+ * then leaves the bare `@handle` display text rather than minting a broken link.
+ */
+async function resolveAtprotoMentionOxyId(did: string): Promise<string | undefined> {
+  try {
+    const existing = await FederatedActor.findOne({ uri: did })
+      .select('oxyUserId')
+      .lean<{ oxyUserId?: string } | null>();
+    if (existing?.oxyUserId) return String(existing.oxyUserId);
+  } catch (err) {
+    logger.warn(`[atproto] mention actor lookup failed for ${did}`, err);
+  }
+  const actor = await fetchAndUpsertAtprotoProfile(did);
+  return actor?.oxyUserId ? String(actor.oxyUserId) : undefined;
+}
+
+/**
+ * Batch-resolve every mentioned DID in an author feed to its Oxy user id (deduped,
+ * parallel, fail-soft). The returned map feeds the pure mapper so it can splice
+ * `[mention:<oxyUserId>]` placeholders in the same byte pass as `#link` facets.
+ * Unresolvable DIDs are simply absent from the map.
+ */
+async function resolveMentionDids(dids: Set<string>): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  if (dids.size === 0) return map;
+  await Promise.all(
+    [...dids].map(async (did) => {
+      const oxyUserId = await resolveAtprotoMentionOxyId(did);
+      if (oxyUserId) map.set(did, oxyUserId);
+    }),
+  );
+  return map;
+}
+
+/**
+ * Resolve a federated atproto post's `inReplyTo` / quoted AT-URIs to LOCAL thread +
+ * quote links by matching each against an imported post's `federation.activityId`.
+ * Mirrors the ActivityPub inbox reply rule (`threadId = parent.threadId ??
+ * parent._id`). Best-effort: a parent / quoted post not yet imported is left
+ * unlinked (a later re-ingest resolves it once that post exists locally).
+ */
+async function resolveThreadAndQuoteLinks(
+  inReplyTo: string | undefined,
+  quotedUri: string | undefined,
+): Promise<{ parentPostId?: string; threadId?: string; quoteOf?: string }> {
+  const uris = [inReplyTo, quotedUri].filter((uri): uri is string => typeof uri === 'string' && uri.length > 0);
+  if (uris.length === 0) return {};
+
+  const docs = await Post.find({ 'federation.activityId': { $in: uris } })
+    .select('_id threadId federation.activityId')
+    .lean<Array<{ _id: unknown; threadId?: string; federation?: { activityId?: string } }>>();
+  const byUri = new Map<string, { _id: unknown; threadId?: string }>();
+  for (const doc of docs) {
+    const uri = doc.federation?.activityId;
+    if (uri) byUri.set(uri, doc);
+  }
+
+  const links: { parentPostId?: string; threadId?: string; quoteOf?: string } = {};
+  if (inReplyTo) {
+    const parent = byUri.get(inReplyTo);
+    if (parent) {
+      links.parentPostId = String(parent._id);
+      links.threadId = parent.threadId ? String(parent.threadId) : String(parent._id);
+    }
+  }
+  if (quotedUri) {
+    const quoted = byUri.get(quotedUri);
+    if (quoted) links.quoteOf = String(quoted._id);
+  }
+  return links;
 }
 
 /**
@@ -283,6 +501,10 @@ async function createPostFromNormalized(
     actorUri: did,
   });
 
+  // Resolve reply-parent + quoted AT-URIs to local thread/quote links (best-effort;
+  // a not-yet-imported parent/quote is left unlinked).
+  const links = await resolveThreadAndQuoteLinks(post.inReplyTo, post.quotedUri);
+
   try {
     await getPostCreator().create({
       oxyUserId: ownerOxyUserId,
@@ -293,6 +515,9 @@ async function createPostFromNormalized(
         url: post.url,
         sensitive: post.sensitive ?? false,
       },
+      parentPostId: links.parentPostId ?? null,
+      threadId: links.threadId ?? null,
+      quoteOf: links.quoteOf ?? null,
       content: {
         text: post.text,
         media: materialized.media.length > 0 ? materialized.media : undefined,
@@ -300,6 +525,9 @@ async function createPostFromNormalized(
       },
       visibility: PostVisibility.PUBLIC,
       hashtags: post.hashtags,
+      // Resolved @mention Oxy user ids, keyed by the `[mention:<id>]` placeholders
+      // now in the body, so hydration renders each as a real profile link.
+      mentions: post.mentions,
       language: post.language,
       languages: post.languages,
       instanceDomain,
@@ -353,10 +581,21 @@ export async function importAuthorFeed(
   }
 
   const items = Array.isArray(feed?.feed) ? feed.feed : [];
+
+  // Pre-resolve every mentioned DID across the batch (deduped, fail-soft) so the
+  // pure mapper can splice `[mention:<oxyUserId>]` placeholders in the same byte
+  // pass as `#link` facets. Reposts are skipped here exactly as in the map loop.
+  const mentionDids = new Set<string>();
+  for (const item of items) {
+    if (item?.reason) continue;
+    for (const mentionedDid of extractMentionDids(item.post?.record)) mentionDids.add(mentionedDid);
+  }
+  const mentionMap = await resolveMentionDids(mentionDids);
+
   const normalized: NormalizedExternalPost[] = [];
   for (const item of items) {
     if (item?.reason) continue; // skip reposts in C2
-    const mapped = mapPostViewToNormalizedPost(item.post, did);
+    const mapped = mapPostViewToNormalizedPost(item.post, did, mentionMap);
     if (mapped) normalized.push({ ...mapped, authorOxyUserId: ownerOxyUserId });
   }
 

--- a/packages/backend/src/connectors/atproto/profile.mapper.ts
+++ b/packages/backend/src/connectors/atproto/profile.mapper.ts
@@ -4,7 +4,7 @@ import FederatedActor, { IFederatedActor } from '../../models/FederatedActor';
 import { resolveOxyExternalUser } from '../identity';
 import type { NormalizedExternalActor } from '../types';
 import { xrpcGet } from './xrpcClient';
-import { PUBLIC_APPVIEW } from './constants';
+import { BSKY_NETWORK_DOMAIN, PUBLIC_APPVIEW } from './constants';
 
 /**
  * Maps an `app.bsky.actor.getProfile` response into a network-neutral actor,
@@ -32,17 +32,19 @@ export interface AtprotoProfileView {
  * A Bluesky handle is a bare DNS name. Its instance domain is the handle minus
  * its first label — but ONLY when that leaves a real ≥2-label domain:
  *   - `alice.bsky.social` (3 labels) → instance `bsky.social`.
- *   - `example.com` (a 2-label apex custom domain) is its OWN instance — stripping
- *     would leave the bare TLD `com`, so the full handle stays the domain.
+ *   - `gothamist.com` (a 2-label apex custom domain) has no strippable parent —
+ *     stripping would leave the bare TLD `com`, and using the handle itself as the
+ *     domain renders the doubled `@gothamist.com@gothamist.com`. It keys to the
+ *     Bluesky network host instead (`bsky.social`), rendering `@gothamist.com@bsky.social`.
  * The federated Oxy username is `<handle>@<instance-domain>`
- * (`alice.bsky.social@bsky.social`, `example.com@example.com`) — the exact form
+ * (`alice.bsky.social@bsky.social`, `gothamist.com@bsky.social`) — the exact form
  * oxy-api's `PUT /users/resolve` binds (username domain must equal `domain`).
  */
 function splitHandle(handle: string): { username: string; domain: string; federatedUsername: string } {
   const dot = handle.indexOf('.');
   // Strip the first label only if the remainder is still a multi-label domain.
   const parent = dot > 0 ? handle.slice(dot + 1) : handle;
-  const domain = parent.includes('.') ? parent : handle;
+  const domain = parent.includes('.') ? parent : BSKY_NETWORK_DOMAIN;
   return { username: handle, domain, federatedUsername: `${handle}@${domain}` };
 }
 

--- a/packages/backend/src/connectors/types.ts
+++ b/packages/backend/src/connectors/types.ts
@@ -89,6 +89,18 @@ export interface NormalizedExternalPost {
   text: string;
   media?: NormalizedExternalMedia[];
   hashtags?: string[];
+  /**
+   * Resolved @mention Oxy user ids — the stored `mentions` allowlist, keyed by the
+   * `[mention:<id>]` placeholders the connector rewrote into {@link text}.
+   */
+  mentions?: string[];
+  /**
+   * The quoted post's external URI (an atproto `at://` URI / an AP quote uri) when
+   * this post quotes another. Resolved to a local `quoteOf` Post id at import time
+   * by matching an imported post's `federation.activityId`; left unresolved (no
+   * quote link) when the quoted post is not imported locally.
+   */
+  quotedUri?: string;
   language?: string;
   languages?: string[];
   createdAt?: Date;

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -6,6 +6,9 @@ import Like from '../models/Like';
 import Bookmark from '../models/Bookmark';
 import { FederatedActor } from '../models/FederatedActor';
 import { UserSettings } from '../models/UserSettings';
+import { actorService } from '../connectors/activitypub/actor.service';
+import { FEDERATION_ENABLED } from '../connectors/activitypub/constants';
+import { deriveBridgyActorUri } from '../connectors/activitypub/bridgy';
 import { oxy as defaultOxyClient } from '../../server';
 import { getServiceOxyClient } from '../utils/oxyHelpers';
 import { extractUrls } from '../utils/extractUrls';
@@ -467,6 +470,44 @@ function federatedHost(...urls: Array<string | undefined>): string | undefined {
 }
 
 /**
+ * Actor URIs currently being lazily resolved out of {@link resolveOrphanFederatedAuthors}.
+ * Collapses the repeated hydrations of a hot feed onto ONE detached fetch per
+ * actor so a re-rendering orphan cohort never storms the remote.
+ */
+const inFlightOrphanActorSyncs = new Set<string>();
+
+/**
+ * Fire-and-forget: lazily resolve (fetch + create) the FederatedActor + Oxy
+ * federated user for a set of actor URIs DERIVED from legacy brid.gy/Bluesky
+ * orphan posts. This is the SAME on-demand sync the inbound Like/Announce/mention
+ * paths use ({@link actorService.getOrFetchActor}), run DETACHED so it never
+ * blocks feed hydration; the resolved actor lands in Mongo, so the NEXT hydration
+ * of the same orphan renders the real `@handle@bsky.brid.gy` (self-healing).
+ *
+ * Bounded to the unique derivable actors in one hydration batch and deduped by an
+ * in-flight guard. Fail-soft: every error is swallowed (logged at debug) — an
+ * orphan simply stays degraded until a later pass succeeds.
+ */
+function scheduleOrphanActorSync(actorUris: Set<string>): void {
+  if (!FEDERATION_ENABLED || actorUris.size === 0) return;
+  for (const actorUri of actorUris) {
+    if (inFlightOrphanActorSyncs.has(actorUri)) continue;
+    inFlightOrphanActorSyncs.add(actorUri);
+    void actorService
+      .getOrFetchActor(actorUri)
+      .catch((error) => {
+        logger.debug('[PostHydration] Orphan actor lazy sync failed', {
+          actorUri,
+          reason: error instanceof Error ? error.message : 'unknown',
+        });
+      })
+      .finally(() => {
+        inFlightOrphanActorSyncs.delete(actorUri);
+      });
+  }
+}
+
+/**
  * Build the author {@link PostUser} for FEDERATED posts whose Oxy author link is
  * missing — legacy "orphans" ingested before the federated-actor → Oxy-user link
  * was enforced, so `oxyUserId` is null. Such a post is NOT dropped: its CONTENT
@@ -475,36 +516,60 @@ function federatedHost(...urls: Array<string | undefined>): string | undefined {
  * federation data + Mention's own {@link FederatedActor} record, NEVER from a raw
  * id (the ghost-handle rule):
  *
- *  1. If a {@link FederatedActor} exists for the post's `federation.actorUri`,
- *     use its authoritative `username@domain` + avatar — the SAME enrichment
+ *  1. Resolve each orphan's author actor URI: the stored `federation.actorUri`,
+ *     or — for a brid.gy/Bluesky orphan that stored only the object URL — the
+ *     actor URI deterministically {@link deriveBridgyActorUri | derived} from the
+ *     atproto DID embedded in `federation.activityId`/`federation.url` (no network).
+ *  2. If a {@link FederatedActor} exists for that URI, use its authoritative
+ *     `username@domain` + avatar — the SAME enrichment
  *     {@link enrichDegradedFederatedUsers} applies, keyed here by actor URI since
  *     there is no `oxyUserId`. It NEVER invents a `name.displayName`.
- *  2. Otherwise fall back to {@link degradedActorSummary} ("Unknown user", empty
+ *  3. If the URI was DERIVED and has no FederatedActor row yet (the common brid.gy
+ *     case — the actor was never synced), kick a fire-and-forget
+ *     {@link scheduleOrphanActorSync} that mints the actor + Oxy user off the
+ *     request path, and degrade WITH the bridge origin this pass so the DTO
+ *     self-heals to the real handle on the next load.
+ *  4. Otherwise fall back to {@link degradedActorSummary} ("Unknown user", empty
  *     handle), marked federated with the origin `instance` when a host is
  *     derivable. The empty handle suppresses the `@handle` line and the profile
  *     link, so no misleading handle is ever emitted.
  *
  * Batched (single FederatedActor query), best-effort, and never cached — the DTO
- * self-heals once the post's `oxyUserId` is backfilled and normal Oxy resolution
- * takes over. Keyed by post id (orphans have no `oxyUserId` to key on).
+ * self-heals once the actor resolves or the post's `oxyUserId` is backfilled and
+ * normal Oxy resolution takes over. Keyed by post id (orphans have no `oxyUserId`
+ * to key on).
  */
-async function resolveOrphanFederatedAuthors(
+export async function resolveOrphanFederatedAuthors(
   orphans: Array<{ postId: string; federation: PostFederationData }>,
 ): Promise<Map<string, PostUser>> {
   const result = new Map<string, PostUser>();
   if (orphans.length === 0) return result;
 
-  const actorUris = Array.from(
-    new Set(orphans.map((o) => o.federation.actorUri).filter((uri): uri is string => Boolean(uri))),
-  );
+  // Resolve each orphan's effective author actor URI up front: the stored one, or
+  // — when absent — the brid.gy actor URI derived from the atproto DID in the
+  // object URL. Track which post used a DERIVED URI so only those (never a
+  // stored-actorUri orphan) trigger the lazy on-demand actor sync below.
+  const derivedByPost = new Map<string, string>();
+  const lookupUris = new Set<string>();
+  for (const { postId, federation } of orphans) {
+    if (federation.actorUri) {
+      lookupUris.add(federation.actorUri);
+      continue;
+    }
+    const derivedUri = deriveBridgyActorUri(federation.activityId, federation.url);
+    if (derivedUri) {
+      derivedByPost.set(postId, derivedUri);
+      lookupUris.add(derivedUri);
+    }
+  }
 
   const actorByUri = new Map<
     string,
     { username?: string; acct?: string; domain?: string; avatarUrl?: string; oxyUserId?: string }
   >();
-  if (actorUris.length > 0) {
+  if (lookupUris.size > 0) {
     try {
-      const actors = await FederatedActor.find({ uri: { $in: actorUris } })
+      const actors = await FederatedActor.find({ uri: { $in: Array.from(lookupUris) } })
         .select('uri username acct domain avatarUrl oxyUserId')
         .lean();
       for (const actor of actors) {
@@ -513,14 +578,19 @@ async function resolveOrphanFederatedAuthors(
       }
     } catch (error) {
       logger.warn('[PostHydration] Orphan federated author lookup failed', {
-        count: actorUris.length,
+        count: lookupUris.size,
         reason: error instanceof Error ? error.message : 'unknown',
       });
     }
   }
 
+  // Derived brid.gy actors that have no local row yet — resolved off the request
+  // path after the loop so the next hydration renders the real handle.
+  const lazyResolveUris = new Set<string>();
+
   for (const { postId, federation } of orphans) {
-    const actorUri = federation.actorUri;
+    const derivedUri = federation.actorUri ? undefined : derivedByPost.get(postId);
+    const actorUri = federation.actorUri ?? derivedUri;
     const actor = actorUri ? actorByUri.get(actorUri) : undefined;
     const username = actor?.username || (actor?.acct ? actor.acct.split('@')[0] : '');
 
@@ -541,8 +611,15 @@ async function resolveOrphanFederatedAuthors(
       continue;
     }
 
-    // No knowable handle: a neutral "Unknown user", still marked federated with
-    // the origin host so the CONTENT (not a fabricated handle) is what renders.
+    // A brid.gy actor we derived but have never synced: mint it in the background
+    // so the NEXT hydration resolves the real handle.
+    if (derivedUri) {
+      lazyResolveUris.add(derivedUri);
+    }
+
+    // No knowable handle THIS pass: a neutral "Unknown user", still marked
+    // federated with the origin host so the CONTENT (not a fabricated handle) is
+    // what renders.
     const instance = federatedHost(actorUri, federation.url, federation.activityId);
     result.set(postId, {
       ...degradedActorSummary(actorUri || federation.url || federation.activityId || postId),
@@ -550,6 +627,8 @@ async function resolveOrphanFederatedAuthors(
       ...(instance ? { instance, federation: { domain: instance, ...(actorUri ? { actorUri } : {}) } } : {}),
     });
   }
+
+  scheduleOrphanActorSync(lazyResolveUris);
 
   return result;
 }


### PR DESCRIPTION
Fixes the cluster of Bluesky-federation defects (audit: 2 ingest paths — direct atproto + Bridgy-Fed AP).

**Authors:** orphan brid.gy posts no longer render "Unknown user" (derive actor URI from the DID + lazy self-healing sync).

**Direct atproto (post.mapper/profile.mapper):**
- Resolve `#link` facets → full URLs (fixes truncated/broken links, e.g. Gothamist).
- `#mention` facets → `[mention:id]`; thread replies; quote posts → `quoteOf`; apex handles render `@handle@bsky.social` (not doubled).

**Bridgy-Fed AP (apMedia/apPostContent/apMentions):**
- Classify images by the AP `type` discriminator → **recovers ~1,456 posts whose images were silently dropped**.
- Rewrite Bluesky hashtag anchors to `#tags` (not `bsky.app/search` URLs).
- Resolve `bsky.app/profile` mention anchors → `[mention:id]`; map brid.gy quote surfaces → `quoteOf`.

Ingest-only — existing posts need a re-ingest (follow-up one-shot). tsc clean, 2477 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)