### PR TITLE
fix(backend): make Bluesky re-ingest hang-proof + ghost-safe

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/apMentionsBridgy.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apMentionsBridgy.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   getOrFetchActor: vi.fn(),
   isBlockedDomain: vi.fn(() => false),
   resolveOxyUser: vi.fn(),
+  findExistingActor: vi.fn(),
 }));
 
 vi.mock('../../../connectors/activitypub/actor.service', () => ({
@@ -28,11 +29,18 @@ vi.mock('../../../connectors/activitypub/constants', () => ({
   isBlockedDomain: mocks.isBlockedDomain,
   resolveOxyUser: mocks.resolveOxyUser,
 }));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: { findOne: mocks.findExistingActor },
+}));
 vi.mock('../../../utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
-import { applyMentionPlaceholders, resolveInboundMentions } from '../../../connectors/activitypub/apMentions';
+import {
+  applyMentionPlaceholders,
+  resolveInboundMentions,
+  resolveInboundMentionsExisting,
+} from '../../../connectors/activitypub/apMentions';
 
 const DID = 'did:plc:reu7q3altx5gsonhu5nxcfp6';
 const HANDLE = 'alice.bsky.social';
@@ -41,6 +49,7 @@ const BRIDGED_OXY_ID = 'oxy_bridged_alice';
 
 beforeEach(() => {
   mocks.getOrFetchActor.mockReset();
+  mocks.findExistingActor.mockReset();
   mocks.isBlockedDomain.mockReturnValue(false);
 });
 
@@ -81,5 +90,51 @@ describe('inbound brid.gy @mention resolution', () => {
     const resolved = await resolveInboundMentions(object);
     const rewritten = applyMentionPlaceholders(object, resolved.anchorMap);
     expect(rewritten.content).toBe('<p>[mention:oxy_bob]</p>');
+  });
+});
+
+/**
+ * Lookup-only mention resolution — the ghost-safe path the one-shot repair uses.
+ * A repair must NEVER fetch or create a `FederatedActor`: it resolves each mention
+ * against already-stored actors only, and leaves an unknown mention as raw text
+ * rather than minting a 0-post ghost user.
+ */
+describe('lookup-only inbound @mention resolution (repair path)', () => {
+  it('resolves an already-stored federated actor without fetching/creating one', async () => {
+    mocks.findExistingActor.mockReturnValue({
+      lean: () => Promise.resolve({ oxyUserId: 'oxy_bob' }),
+    });
+    const object = {
+      content: '<p><a href="https://mastodon.social/@bob" class="u-url mention">@bob</a></p>',
+      tag: [{ type: 'Mention', href: 'https://mastodon.social/users/bob', name: '@bob@mastodon.social' }],
+    };
+
+    const resolved = await resolveInboundMentionsExisting(object);
+    expect(resolved.ids).toContain('oxy_bob');
+    expect(mocks.getOrFetchActor).not.toHaveBeenCalled();
+    expect(mocks.findExistingActor).toHaveBeenCalledWith(
+      { uri: 'https://mastodon.social/users/bob' },
+      { oxyUserId: 1 },
+    );
+
+    const rewritten = applyMentionPlaceholders(object, resolved.anchorMap);
+    expect(rewritten.content).toBe('<p>[mention:oxy_bob]</p>');
+  });
+
+  it('skips an unknown actor: leaves the raw anchor and never fetches/creates one', async () => {
+    mocks.findExistingActor.mockReturnValue({ lean: () => Promise.resolve(null) });
+    const content = `<p>hi <a href="https://bsky.app/profile/${HANDLE}">@${HANDLE}</a></p>`;
+    const object = {
+      content,
+      tag: [{ type: 'Mention', href: BRIDGY_ACTOR, name: `@${HANDLE}@bsky.brid.gy` }],
+    };
+
+    const resolved = await resolveInboundMentionsExisting(object);
+    expect(resolved.ids).toEqual([]);
+    expect(resolved.anchorMap.size).toBe(0);
+    expect(mocks.getOrFetchActor).not.toHaveBeenCalled();
+
+    const rewritten = applyMentionPlaceholders(object, resolved.anchorMap);
+    expect(rewritten.content).toBe(content);
   });
 });

--- a/packages/backend/src/connectors/activitypub/apMentions.ts
+++ b/packages/backend/src/connectors/activitypub/apMentions.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../utils/logger';
+import FederatedActor from '../../models/FederatedActor';
 import { actorService } from './actor.service';
 import { getApContentMap } from './apLanguage';
 import { primaryApType } from './apSchemas';
@@ -142,17 +143,54 @@ export function extractMentionTags(object: Record<string, unknown>): InboundMent
 }
 
 /**
+ * Resolve a mentioned actor URI that is NOT one of our own/blocked domains — i.e.
+ * a genuine REMOTE actor — to its stored Oxy user id, or `null` when it cannot be
+ * resolved. The two mention paths differ ONLY here: the live inbox path
+ * fetches-and-creates the actor when unknown; the repair path looks it up without
+ * any network fetch or create.
+ */
+type RemoteMentionResolver = (href: string) => Promise<string | null>;
+
+/**
+ * Live-path remote resolver: resolve — and SYNC/CREATE if new — the remote actor
+ * through {@link ActorService.getOrFetchActor}. Used only by the inbox ingest path,
+ * where discovering a first-seen mentioned actor is desired.
+ */
+const fetchOrCreateRemoteActorOxyId: RemoteMentionResolver = async (href) => {
+  const actor = await actorService.getOrFetchActor(href);
+  return actor?.oxyUserId ? String(actor.oxyUserId) : null;
+};
+
+/**
+ * Repair-path remote resolver: resolve the remote actor against ALREADY-STORED
+ * `FederatedActor` rows ONLY (keyed by its URI, exactly as `getOrFetchActor` keys
+ * its own lookup). NEVER performs a network fetch and NEVER creates a row — an
+ * actor with no stored row (or a stored row not yet linked to an Oxy user)
+ * resolves to `null`, so the caller SKIPS it. That is what keeps a bulk one-shot
+ * repair from minting 0-post ghost federated actors for every account a legacy
+ * post happened to mention (including deleted/spam accounts that now 410 Gone).
+ */
+const lookupExistingRemoteActorOxyId: RemoteMentionResolver = async (href) => {
+  const actor = await FederatedActor.findOne({ uri: href }, { oxyUserId: 1 }).lean<{
+    oxyUserId?: string;
+  } | null>();
+  return actor?.oxyUserId ? String(actor.oxyUserId) : null;
+};
+
+/**
  * Resolve one mentioned actor URI to its Oxy user id.
  *
  * An href on one of our own domains (or the Oxy identity apex) is a LOCAL user:
  * resolve it through Oxy by username — NEVER fetch it as a remote actor (that path
  * rejects own/blocked domains). Any other href is a genuine remote actor, resolved
- * (and synced/created if new) through {@link ActorService.getOrFetchActor}. Returns
- * `null` when the actor cannot be resolved to an Oxy user, so the caller leaves the
- * anchor as bare text rather than minting a broken link.
+ * through the supplied {@link RemoteMentionResolver} — fetch-and-create for the
+ * live inbox path, lookup-only for the repair path. Returns `null` when the actor
+ * cannot be resolved to an Oxy user, so the caller leaves the anchor as bare text
+ * rather than minting a broken link.
  */
 async function resolveMentionOxyId(
   href: string,
+  resolveRemote: RemoteMentionResolver,
 ): Promise<{ oxyUserId: string; isLocal: boolean } | null> {
   let host: string;
   try {
@@ -169,18 +207,23 @@ async function resolveMentionOxyId(
     return oxyUserId ? { oxyUserId, isLocal: true } : null;
   }
 
-  const actor = await actorService.getOrFetchActor(href);
-  return actor?.oxyUserId ? { oxyUserId: String(actor.oxyUserId), isLocal: false } : null;
+  const oxyUserId = await resolveRemote(href);
+  return oxyUserId ? { oxyUserId, isLocal: false } : null;
 }
 
 /**
- * Resolve every `Mention` tag on an inbound Note to its Oxy user id, batched (each
- * distinct actor href is resolved AT MOST once — no N+1). Fail-soft per mention: a
- * tag that fails to resolve is simply absent from the result, leaving its anchor as
- * bare text. Returns empty maps/arrays when the Note carries no `Mention` tags.
+ * Shared engine behind {@link resolveInboundMentions} and
+ * {@link resolveInboundMentionsExisting}: extract the `Mention` tags, resolve each
+ * DISTINCT actor href AT MOST once (no N+1), and build the id/localId sets plus the
+ * candidate-anchor map. Fail-soft per mention (a tag that fails to resolve is
+ * simply absent, leaving its anchor as bare text). The ONLY behavioural difference
+ * between the two public callers is `resolveRemote` — whether an unknown remote
+ * actor is fetched-and-created or looked up read-only — so both cover the exact
+ * same set of anchor href forms.
  */
-export async function resolveInboundMentions(
+async function buildResolvedInboundMentions(
   object: Record<string, unknown>,
+  resolveRemote: RemoteMentionResolver,
 ): Promise<ResolvedInboundMentions> {
   const tags = extractMentionTags(object);
   if (tags.length === 0) return { ids: [], localIds: [], anchorMap: new Map() };
@@ -198,7 +241,7 @@ export async function resolveInboundMentions(
   await Promise.all(
     [...byHref.values()].map(async (tag) => {
       try {
-        const resolved = await resolveMentionOxyId(tag.href);
+        const resolved = await resolveMentionOxyId(tag.href, resolveRemote);
         if (!resolved) return;
         ids.add(resolved.oxyUserId);
         if (resolved.isLocal) localIds.add(resolved.oxyUserId);
@@ -222,6 +265,40 @@ export async function resolveInboundMentions(
   );
 
   return { ids: [...ids], localIds: [...localIds], anchorMap };
+}
+
+/**
+ * Resolve every `Mention` tag on an inbound Note to its Oxy user id, batched (each
+ * distinct actor href is resolved AT MOST once — no N+1). Fail-soft per mention: a
+ * tag that fails to resolve is simply absent from the result, leaving its anchor as
+ * bare text. Returns empty maps/arrays when the Note carries no `Mention` tags.
+ *
+ * This is the LIVE inbox path: an unknown remote actor is fetched-and-synced (a
+ * `FederatedActor` row is created) so a first-seen mention still links. For the
+ * one-shot repair use {@link resolveInboundMentionsExisting}, which never fetches
+ * or creates an actor.
+ */
+export async function resolveInboundMentions(
+  object: Record<string, unknown>,
+): Promise<ResolvedInboundMentions> {
+  return buildResolvedInboundMentions(object, fetchOrCreateRemoteActorOxyId);
+}
+
+/**
+ * Lookup-only variant of {@link resolveInboundMentions} for the one-shot repair
+ * path: resolve each mention against ALREADY-KNOWN identities only — local Oxy
+ * users and EXISTING `FederatedActor` rows — and NEVER fetch or create a remote
+ * actor. A mentioned actor that is not already stored is SKIPPED (its anchor is
+ * left as raw text), which is strictly better than minting a 0-post ghost
+ * federated actor for every account a legacy post happened to mention (deleted or
+ * spam Mastodon accounts that now 410 Gone included). Same
+ * {@link ResolvedInboundMentions} shape and same anchor-form coverage as the live
+ * path — the create-vs-lookup choice is the only difference.
+ */
+export async function resolveInboundMentionsExisting(
+  object: Record<string, unknown>,
+): Promise<ResolvedInboundMentions> {
+  return buildResolvedInboundMentions(object, lookupExistingRemoteActorOxyId);
 }
 
 /**

--- a/packages/backend/src/scripts/reingestBlueskyPosts.ts
+++ b/packages/backend/src/scripts/reingestBlueskyPosts.ts
@@ -15,13 +15,17 @@
  *   1. brid.gy ActivityPub path (`--path bridgy`) — posts whose `federation`
  *      object URL is on `bsky.brid.gy` (Bridgy Fed bridges Bluesky into the
  *      fediverse over ActivityPub). Re-fetches the source AP object with a signed
- *      GET and rebuilds body / media / hashtags / mentions through the EXACT fresh
- *      path the inbox `Update` uses — `resolveInboundMentions` +
- *      `applyMentionPlaceholders` + `buildFederatedNoteContentForEdit`. That folds
- *      in the #439 fixes: `rewriteHashtagAnchors` (brid.gy `#tag` anchors),
- *      `apMentions` (`bsky.app/profile` anchor → `[mention:<id>]`), and
+ *      GET and rebuilds body / media / hashtags / mentions through the fresh inbox
+ *      mapping — `resolveInboundMentionsExisting` (the LOOKUP-ONLY, never-create
+ *      mention resolver — see below) + `applyMentionPlaceholders` +
+ *      `buildFederatedNoteContentForEdit`. That folds in the #439 fixes:
+ *      `rewriteHashtagAnchors` (brid.gy `#tag` anchors), `apMentions`
+ *      (`bsky.app/profile` anchor → `[mention:<id>]`), and
  *      `apMedia.classifyFromApType` (recovers images the old MIME/extension check
- *      dropped).
+ *      dropped). Unlike the live inbox path (`resolveInboundMentions`), the repair
+ *      resolves mentions against ALREADY-STORED actors only: it never fetches or
+ *      mints a `FederatedActor`, so a bulk sweep can never pollute the federated
+ *      index with 0-post ghost users for every mentioned account.
  *
  *   2. direct atproto path (`--path atproto`) — posts whose `federation.activityId`
  *      is a bare `at://` URI (the read/discovery connector). Re-fetches the post's
@@ -52,13 +56,13 @@
  *
  * FLAGS (plain argv):
  *   --dry-run              log what WOULD change; write nothing to Mongo (neither
- *                          Post docs nor the FederatedActor handle repair). NOTE:
- *                          re-mapping still resolves the posts' referenced mentioned
- *                          actors through the shared connector path exactly as a
- *                          live re-map would (this is inseparable from reusing the
- *                          connector mapping), which can lazily sync a not-yet-known
- *                          MENTIONED actor. The scanned posts themselves are never
- *                          modified in dry-run.
+ *                          Post docs nor the FederatedActor handle repair). Mention
+ *                          resolution during the re-map is LOOKUP-ONLY
+ *                          (`resolveInboundMentionsExisting`): it matches each
+ *                          mentioned actor against already-stored identities and
+ *                          never fetches or creates a `FederatedActor`, so a repair
+ *                          run mints NO new actor rows in either mode. The scanned
+ *                          posts themselves are never modified in dry-run.
  *   --limit N              cap the number of posts processed (a canary budget,
  *                          shared across both paths).
  *   --path atproto|bridgy|all   which ingest path(s) to repair (default: all).
@@ -89,7 +93,7 @@ import { logger } from '../utils/logger';
 import { normalizePostHashtags } from '../utils/textProcessing';
 import type { ExtractedMediaAttachment } from '../connectors/shared/federatedMedia';
 import { buildFederatedNoteContentForEdit } from '../connectors/activitypub/apPostContent';
-import { applyMentionPlaceholders, resolveInboundMentions } from '../connectors/activitypub/apMentions';
+import { applyMentionPlaceholders, resolveInboundMentionsExisting } from '../connectors/activitypub/apMentions';
 import { signedFetch } from '../connectors/activitypub/helpers';
 import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
 import { refetchAtprotoPostForRepair } from '../connectors/atproto/post.mapper';
@@ -97,6 +101,15 @@ import { fetchAndUpsertAtprotoProfile, splitHandle } from '../connectors/atproto
 
 /** Posts scanned per page (stable `_id` cursor pagination). */
 const PAGE_SIZE = 500;
+
+/**
+ * Hard per-post wall-clock cap on a single post's repair. Defence-in-depth: every
+ * network await a repair issues (brid.gy `signedFetch`, the atproto AppView fetch,
+ * a mention lookup) is individually bounded, but a race against this timer
+ * guarantees ONE slow/unresponsive remote can never freeze the whole sweep. A
+ * timed-out post is counted `fetch-failed` and skipped; a later run recovers it.
+ */
+const REPAIR_TIMEOUT_MS = 45_000;
 
 /** HTTP statuses that mean the remote object is permanently gone. */
 const GONE_STATUS_CODES = new Set([404, 410]);
@@ -350,9 +363,12 @@ async function repairBridgyPost(post: StoredPostRow, flags: Flags): Promise<Repa
   if (fetched.kind === 'error') return 'fetch-failed';
   if (fetched.kind === 'gone') return 'gone'; // content-bearing — leave, never delete
 
-  // Fresh ingest recipe (identical to inbox `Update`): resolve mentions, splice the
-  // `[mention:<id>]` placeholders into the body, then extract the storable fields.
-  const mentionResult = await resolveInboundMentions(fetched.object);
+  // Fresh ingest recipe: resolve mentions, splice the `[mention:<id>]` placeholders
+  // into the body, then extract the storable fields. Mentions are resolved
+  // LOOKUP-ONLY (`resolveInboundMentionsExisting`) — a repair must never fetch or
+  // MINT a federated actor for a mentioned account, so an unknown mention is left
+  // as raw text rather than polluting the federated index with a ghost user.
+  const mentionResult = await resolveInboundMentionsExisting(fetched.object);
   const noteObject = applyMentionPlaceholders(fetched.object, mentionResult.anchorMap);
   const built = await buildFederatedNoteContentForEdit(noteObject, post.oxyUserId ?? null, {
     activityId: post.federation?.activityId,
@@ -552,6 +568,32 @@ interface Budget {
   remaining: number | undefined;
 }
 
+/** Distinct rejection raised by {@link withRepairTimeout} when a post exceeds the cap. */
+class RepairTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`repair exceeded ${ms}ms hard timeout`);
+    this.name = 'RepairTimeoutError';
+  }
+}
+
+/**
+ * Race one post's repair against a hard timeout so a single hung remote can never
+ * freeze the batch. The timer is ALWAYS cleared when the repair settles (win or
+ * lose the race), so no timer is leaked. Losing the race is safe: a repair writes
+ * its `Post.updateOne` only as the LAST step after every await resolves, so a
+ * genuinely-hung repair never reaches the write — the post is simply left untouched
+ * for a later run, exactly like any other `fetch-failed`.
+ */
+function withRepairTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new RepairTimeoutError(ms)), ms);
+  });
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
 /**
  * Scan one path with a stable ascending `_id` cursor and repair each post. Forward-
  * only: a repair only ever changes fields the filter does not select on, so no post
@@ -597,11 +639,19 @@ async function scanPath(
 
       let outcome: RepairOutcome;
       try {
-        outcome = await repair(post, flags);
+        outcome = await withRepairTimeout(repair(post, flags), REPAIR_TIMEOUT_MS);
       } catch (err) {
-        // One bad post never aborts the run; treat it as a transient failure.
-        const message = err instanceof Error ? err.message : String(err);
-        logger.warn(`[reingestBlueskyPosts] ${path} post ${String(post._id)} repair threw: ${message}`);
+        // One bad post never aborts the run; treat it as a transient failure so a
+        // later run can still recover it. A timeout is the defence-in-depth guard
+        // against an unbounded await hanging the whole sweep.
+        if (err instanceof RepairTimeoutError) {
+          logger.warn(
+            `[reingestBlueskyPosts] ${path} post ${String(post._id)} repair timed out after ${REPAIR_TIMEOUT_MS}ms — skipping`,
+          );
+        } else {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(`[reingestBlueskyPosts] ${path} post ${String(post._id)} repair threw: ${message}`);
+        }
         outcome = 'fetch-failed';
       }
 


### PR DESCRIPTION
The `reingestBlueskyPosts` one-shot (#441) hung mid-sweep and could mint ghost federated actors. Two fixes:

**1. Ghost-safe mention resolution (repair path).** `resolveInboundMentions` resolved each mention via `actorService.getOrFetchActor` — a network fetch that also CREATES a `FederatedActor`. In a bulk repair that (a) minted 0-post ghost actors for every mentioned account (incl. deleted/spam accounts now 410 Gone) and (b) hung the batch on one slow mentioned-actor fetch. Factored the shared batching/anchor-map into `buildResolvedInboundMentions(object, resolveRemote)`; added `resolveInboundMentionsExisting` (lookup-only: existing `FederatedActor` rows + local users, never fetch/create). The live inbox path (`resolveInboundMentions`) is unchanged. Repair now uses the lookup-only variant.

**2. Per-post hard timeout.** Each `repair(post)` races `withRepairTimeout(..., 45s)` (Promise.race + timer cleared in `.finally`). A timed-out post is logged, counted `fetch-failed`, and skipped (it never writes, since the update only fires after all awaits resolve) — a later run recovers it. Defense-in-depth against any unbounded await.

Idempotent as before → safe to re-run over the ~236 already-repaired posts.

Tests: 5 pass (3 live-path regressions + 2 new lookup-only cases). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)