### PR TITLE
feat(backend): tombstone 410-Gone federated actors + prune one-shot

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/actorTombstone.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/actorTombstone.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Live "dead federated actor" tombstone: a definitive 410 Gone on the actor fetch
+ * marks the stored `FederatedActor` `suspended` and asks oxy-api to archive the
+ * linked identity (`reportFederatedActorGone`). Both best-effort and fail-soft —
+ * a 410 is authoritative, but the tombstone must never throw out of
+ * `fetchRemoteActor`, and a 404/5xx must NOT trigger it (only 410 is definitive).
+ */
+
+const mocks = vi.hoisted(() => ({
+  findOneAndUpdate: vi.fn(),
+  reportFederatedActorGone: vi.fn(),
+  signedFetch: vi.fn(),
+}));
+
+vi.mock('../../../models/FederatedActor', () => ({
+  default: { findOneAndUpdate: mocks.findOneAndUpdate },
+}));
+
+vi.mock('../../../connectors/identity', () => ({
+  reportFederatedActorGone: mocks.reportFederatedActorGone,
+  resolveOxyExternalUser: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/helpers', () => ({
+  signedFetch: mocks.signedFetch,
+  firstStringUrl: vi.fn(),
+  normalizeFederatedAcct: vi.fn(),
+  domainFromAcct: vi.fn(),
+}));
+
+import { actorService } from '../../../connectors/activitypub/actor.service';
+
+const ACTOR_URI = 'https://mastodon.social/users/ghost';
+
+/** A `findOneAndUpdate(...).lean()` result stub. */
+function leanReturning(value: unknown): { lean: () => Promise<unknown> } {
+  return { lean: () => Promise.resolve(value) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.reportFederatedActorGone.mockResolvedValue('archived');
+});
+
+describe('actorService.tombstoneGoneActor', () => {
+  it('suspends the stored row and reports the linked identity gone to Oxy', async () => {
+    mocks.findOneAndUpdate.mockReturnValue(leanReturning({ oxyUserId: 'oxy-ghost' }));
+
+    await actorService.tombstoneGoneActor(ACTOR_URI);
+
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledWith(
+      { uri: ACTOR_URI },
+      { $set: { suspended: true } },
+      expect.objectContaining({ returnDocument: 'after' }),
+    );
+    expect(mocks.reportFederatedActorGone).toHaveBeenCalledWith('oxy-ghost');
+  });
+
+  it('suspends but does NOT report when the actor has no linked Oxy identity', async () => {
+    mocks.findOneAndUpdate.mockReturnValue(leanReturning({ oxyUserId: undefined }));
+
+    await actorService.tombstoneGoneActor(ACTOR_URI);
+
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(mocks.reportFederatedActorGone).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op (no report) when no stored actor row matches', async () => {
+    mocks.findOneAndUpdate.mockReturnValue(leanReturning(null));
+
+    await actorService.tombstoneGoneActor(ACTOR_URI);
+
+    expect(mocks.reportFederatedActorGone).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the Mongo write fails (fail-soft)', async () => {
+    mocks.findOneAndUpdate.mockImplementation(() => {
+      throw new Error('mongo down');
+    });
+
+    await expect(actorService.tombstoneGoneActor(ACTOR_URI)).resolves.toBeUndefined();
+    expect(mocks.reportFederatedActorGone).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetchRemoteActor 410 detection', () => {
+  it('tombstones and returns null on a definitive 410 Gone', async () => {
+    mocks.signedFetch.mockResolvedValue(new Response('gone', { status: 410 }));
+    const tombstoneSpy = vi.spyOn(actorService, 'tombstoneGoneActor').mockResolvedValue(undefined);
+
+    const result = await actorService.fetchRemoteActor(ACTOR_URI);
+
+    expect(result).toBeNull();
+    expect(tombstoneSpy).toHaveBeenCalledWith(ACTOR_URI);
+    tombstoneSpy.mockRestore();
+  });
+
+  it('does NOT tombstone on a 404 (transient — not definitive gone)', async () => {
+    mocks.signedFetch.mockResolvedValue(new Response('not found', { status: 404 }));
+    const tombstoneSpy = vi.spyOn(actorService, 'tombstoneGoneActor').mockResolvedValue(undefined);
+
+    await actorService.fetchRemoteActor(ACTOR_URI);
+
+    expect(tombstoneSpy).not.toHaveBeenCalled();
+    tombstoneSpy.mockRestore();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/identity.test.ts
+++ b/packages/backend/src/__tests__/connectors/identity.test.ts
@@ -37,8 +37,13 @@ vi.mock('../../models/UserSettings', () => ({
   },
 }));
 
-import { resolveOxyExternalUser } from '../../connectors/identity';
+import { reportFederatedActorGone, resolveOxyExternalUser } from '../../connectors/identity';
 import type { NormalizedExternalActor } from '../../connectors/types';
+
+/** Build an HTTP-style rejection carrying the flat `.status` shape `getErrorStatus` reads. */
+function httpError(status: number, message = `HTTP ${status}`): Error {
+  return Object.assign(new Error(message), { status });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -183,5 +188,65 @@ describe('resolveOxyExternalUser', () => {
 
     expect(mocks.persistRemoteMedia).not.toHaveBeenCalled();
     expect(mocks.userSettingsUpdateOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportFederatedActorGone', () => {
+  it('posts to /federation/actor-gone with the oxyUserId and returns "archived"', async () => {
+    mocks.makeServiceRequest.mockResolvedValue({
+      oxyUserId: '6981c9178fcdefaf81988ffb',
+      accountStatus: 'archived',
+      alreadyArchived: false,
+    });
+
+    const outcome = await reportFederatedActorGone('6981c9178fcdefaf81988ffb');
+
+    expect(outcome).toBe('archived');
+    expect(mocks.makeServiceRequest).toHaveBeenCalledWith('POST', '/federation/actor-gone', {
+      oxyUserId: '6981c9178fcdefaf81988ffb',
+    });
+  });
+
+  it('returns "already" when Oxy reports the identity was already archived (idempotent 200)', async () => {
+    mocks.makeServiceRequest.mockResolvedValue({
+      oxyUserId: '6981c9178fcdefaf81988ffb',
+      accountStatus: 'archived',
+      alreadyArchived: true,
+    });
+
+    expect(await reportFederatedActorGone('6981c9178fcdefaf81988ffb')).toBe('already');
+  });
+
+  it('returns "skipped" without any network call for an empty id', async () => {
+    expect(await reportFederatedActorGone('   ')).toBe('skipped');
+    expect(mocks.makeServiceRequest).not.toHaveBeenCalled();
+  });
+
+  it.each([400, 403, 404, 409])(
+    'log-and-swallows the permanent %i to "skipped" (non-retryable)',
+    async (status) => {
+      mocks.makeServiceRequest.mockRejectedValue(httpError(status));
+      expect(await reportFederatedActorGone('6981c9178fcdefaf81988ffb')).toBe('skipped');
+    },
+  );
+
+  it.each([500, 502, 503])('surfaces the transient %i as "failed" (retryable)', async (status) => {
+    mocks.makeServiceRequest.mockRejectedValue(httpError(status));
+    expect(await reportFederatedActorGone('6981c9178fcdefaf81988ffb')).toBe('failed');
+  });
+
+  it.each([408, 429])('treats the retryable 4xx %i as "failed", not permanent', async (status) => {
+    mocks.makeServiceRequest.mockRejectedValue(httpError(status));
+    expect(await reportFederatedActorGone('6981c9178fcdefaf81988ffb')).toBe('failed');
+  });
+
+  it('treats a statusless network error as transient "failed"', async () => {
+    mocks.makeServiceRequest.mockRejectedValue(new Error('socket hang up'));
+    expect(await reportFederatedActorGone('6981c9178fcdefaf81988ffb')).toBe('failed');
+  });
+
+  it('never throws — a permanent rejection resolves to a discriminant instead', async () => {
+    mocks.makeServiceRequest.mockRejectedValue(httpError(409));
+    await expect(reportFederatedActorGone('6981c9178fcdefaf81988ffb')).resolves.toBe('skipped');
   });
 });

--- a/packages/backend/src/connectors/activitypub/actor.service.ts
+++ b/packages/backend/src/connectors/activitypub/actor.service.ts
@@ -18,7 +18,7 @@ import {
   domainFromAcct,
 } from './helpers';
 import { readBoundedResponseBody } from '../shared/httpBody';
-import { resolveOxyExternalUser } from '../identity';
+import { reportFederatedActorGone, resolveOxyExternalUser } from '../identity';
 import type { NormalizedExternalActor } from '../types';
 
 /**
@@ -166,6 +166,19 @@ export class ActorService {
       // Use signed fetch for servers that enforce authorized fetch (e.g., Threads)
       let res = await signedFetch(actorUri, AP_CONTENT_TYPE);
       if (!res.ok) {
+        // A definitive 410 Gone is authoritative: the actor was permanently
+        // DELETED upstream (Mastodon serves 410 for a deleted account). Tombstone
+        // it and stop — do NOT fall through to the WebFinger fallback below, which
+        // exists to recover from a STALE/wrong URI on a transient failure, not to
+        // second-guess a permanent removal. Only 410 does this; every other
+        // non-ok status keeps the unchanged fallback behavior. `actorUri` here is
+        // still the originally-requested (stored) URI — reassignment to a resolved
+        // URI only happens on a successful WebFinger fetch below.
+        if (res.status === 410) {
+          logger.info(`[FedSync] fetchRemoteActor 410 Gone for ${actorUri} — tombstoning actor`);
+          await this.tombstoneGoneActor(actorUri);
+          return null;
+        }
         const body = await res.text().catch(() => '');
         logger.info(`[FedSync] fetchRemoteActor HTTP ${res.status} ${res.statusText} for ${actorUri} body=${body.slice(0, 500)}`);
 
@@ -185,6 +198,16 @@ export class ActorService {
             if (res.ok) {
               actorUri = resolved;
             } else {
+              // A 410 on the WebFinger-RESOLVED URI is just as definitive as one
+              // on the direct URI — the account is gone at its canonical location.
+              // Tombstone against the stored `actorUri` (the row is keyed by the
+              // originally-requested URI, which is NOT reassigned on this failure
+              // branch), then stop.
+              if (res.status === 410) {
+                logger.info(`[FedSync] fetchRemoteActor 410 Gone for resolved ${resolved} — tombstoning actor ${actorUri}`);
+                await this.tombstoneGoneActor(actorUri);
+                return null;
+              }
               const body2 = await res.text().catch(() => '');
               logger.info(`[FedSync] fetchRemoteActor HTTP ${res.status} for resolved ${resolved} body=${body2.slice(0, 500)}`);
               return null;
@@ -356,6 +379,54 @@ export class ActorService {
     } catch (err) {
       logger.warn(`Failed to fetch remote actor ${actorUri}:`, err);
       return null;
+    }
+  }
+
+  /**
+   * Tombstone a remote actor that returned a definitive 410 Gone. Marks the stored
+   * `FederatedActor` as `suspended` (the schema's existing gone flag — a suspended
+   * actor is already excluded from active surfaces, and it carries the exact
+   * "no longer reachable upstream" meaning we need; a parallel `gone` field would
+   * be redundant) and, when the actor links to an Oxy identity, asks oxy-api to
+   * archive it via {@link reportFederatedActorGone} so it drops out of search.
+   *
+   * The `FederatedActor` document is NEVER deleted — posts, boosts and MTN records
+   * may still reference the actor (see the model doc); this is a tombstone, not a
+   * purge.
+   *
+   * Best-effort and fail-soft: a 410 is authoritative, but neither the Mongo write
+   * nor the Oxy archive call is allowed to throw out of the caller — a failure here
+   * only logs. Idempotent: re-running on an already-suspended actor re-sets the
+   * same flag and re-reports (oxy-api's actor-gone is itself idempotent). Shared by
+   * the live fetch path ({@link fetchRemoteActor}) and the one-shot
+   * `pruneGoneFederatedActors` sweep so there is exactly ONE tombstone
+   * implementation.
+   *
+   * @param actorUri - the stored `FederatedActor.uri` to tombstone. When no row
+   *   matches (a 410 for an actor we never tracked) this is a logged no-op — we do
+   *   not upsert a suspended row for an actor that isn't in our index.
+   */
+  async tombstoneGoneActor(actorUri: string): Promise<void> {
+    try {
+      const actor = await FederatedActor.findOneAndUpdate(
+        { uri: actorUri },
+        { $set: { suspended: true } },
+        { returnDocument: 'after', projection: { oxyUserId: 1 } },
+      ).lean<Pick<IFederatedActor, 'oxyUserId'>>();
+
+      if (!actor) {
+        logger.info(`[FedSync] 410 Gone for ${actorUri} — no stored actor row to tombstone`);
+        return;
+      }
+
+      logger.info(`[FedSync] tombstoned gone actor ${actorUri} (suspended)`);
+
+      if (actor.oxyUserId) {
+        const outcome = await reportFederatedActorGone(actor.oxyUserId);
+        logger.info(`[FedSync] actor-gone report for ${actorUri} (oxyUserId ${actor.oxyUserId}) → ${outcome}`);
+      }
+    } catch (err) {
+      logger.warn(`[FedSync] failed to tombstone gone actor ${actorUri}:`, err);
     }
   }
 

--- a/packages/backend/src/connectors/identity.ts
+++ b/packages/backend/src/connectors/identity.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage, getErrorStatus } from '@oxyhq/core';
 import { logger } from '../utils/logger';
 import { getServiceOxyClient } from '../utils/oxyHelpers';
 import UserSettings from '../models/UserSettings';
@@ -78,6 +79,98 @@ export async function resolveOxyExternalUser(
   } catch (resolveErr) {
     logger.warn(`Failed to resolve Oxy user for ${actor.externalId}:`, resolveErr);
     return null;
+  }
+}
+
+/**
+ * oxy-api service route this bridge posts to when a remote actor is permanently
+ * gone. Same service auth (scope `federation:write`) and same
+ * `getServiceOxyClient().makeServiceRequest` transport as the inbound-follow
+ * bridge (`inbox.service.ts` `bridgeFollowEdge` → `POST /federation/follow`).
+ */
+const ACTOR_GONE_PATH = '/federation/actor-gone';
+
+/** The `{ data }`-unwrapped body oxy-api returns for a 200 `POST /federation/actor-gone`. */
+interface ActorGoneResponse {
+  oxyUserId: string;
+  accountStatus: 'archived';
+  alreadyArchived: boolean;
+}
+
+/**
+ * Outcome discriminant of {@link reportFederatedActorGone}. NEVER thrown — both
+ * callers (the live 410 tombstone in `actor.service.ts` and the one-shot
+ * `pruneGoneFederatedActors` sweep) are fail-soft, so the transient/retryable
+ * case is surfaced as a value (`'failed'`) rather than an exception a sweep would
+ * have to catch to keep going.
+ *
+ *  - `archived` — Oxy archived a previously-active identity (removed from search).
+ *  - `already`  — the identity was already archived (idempotent no-op, still 200).
+ *  - `skipped`  — nothing to report, or oxy-api returned a PERMANENT client error
+ *                 (400 bad body / 403 missing scope / 404 no such user / 409 target
+ *                 not `type:'federated'`). Non-retryable — logged and swallowed.
+ *  - `failed`   — a genuinely transient failure (5xx, 408/429, network, or an
+ *                 unclassifiable transport error). Retryable: the caller may leave
+ *                 the actor for a later pass.
+ */
+export type ReportActorGoneOutcome = 'archived' | 'already' | 'skipped' | 'failed';
+
+/**
+ * Teardown counterpart of {@link resolveOxyExternalUser}: tell oxy-api that a
+ * federated actor is permanently gone so it archives the linked Oxy identity
+ * (`accountStatus:'archived'`, removing it from search). Idempotent on the Oxy
+ * side — a repeat call returns 200 with `alreadyArchived:true`.
+ *
+ * Mirrors the follow-bridge's exact client/auth pattern: the service-authed
+ * `getServiceOxyClient().makeServiceRequest('POST', '/federation/actor-gone', …)`
+ * under scope `federation:write`. `makeServiceRequest` unwraps the API's `{ data }`
+ * envelope, so the resolved value is the inner {@link ActorGoneResponse}.
+ *
+ * Error policy (see {@link ReportActorGoneOutcome}): PERMANENT 4xx responses
+ * (400/403/404/409 — all non-retryable per the contract) are logged and swallowed
+ * to `'skipped'` so a bulk sweep is never aborted by one dead actor; only
+ * genuinely transient failures (5xx, 408/429, network) surface as `'failed'` for
+ * the caller to retry. This function never throws.
+ */
+export async function reportFederatedActorGone(oxyUserId: string): Promise<ReportActorGoneOutcome> {
+  const id = oxyUserId.trim();
+  if (!id) return 'skipped';
+
+  try {
+    const data = await getServiceOxyClient().makeServiceRequest<ActorGoneResponse>(
+      'POST',
+      ACTOR_GONE_PATH,
+      { oxyUserId: id },
+    );
+    const alreadyArchived = data?.alreadyArchived === true;
+    logger.info(`[Federation] oxy-api archived gone actor ${id}`, { alreadyArchived });
+    return alreadyArchived ? 'already' : 'archived';
+  } catch (error) {
+    const httpStatus = getErrorStatus(error);
+    const reason = getErrorMessage(error);
+
+    // Permanent client errors (400 bad body, 403 missing scope, 404 no such user,
+    // 409 target not `type:'federated'`) are non-retryable per the contract. 408
+    // and 429 are excluded — those are transient and fall through to `'failed'`.
+    if (
+      httpStatus !== undefined &&
+      httpStatus >= 400 &&
+      httpStatus < 500 &&
+      httpStatus !== 408 &&
+      httpStatus !== 429
+    ) {
+      logger.warn(`[Federation] actor-gone report for ${id} rejected (HTTP ${httpStatus}, permanent)`, { reason });
+      return 'skipped';
+    }
+
+    // Everything else — 5xx, 408/429, a network failure, or an unclassifiable
+    // transport error — is transient. Surface as `'failed'` so the caller can
+    // leave the actor for a later pass instead of permanently skipping it.
+    logger.warn(`[Federation] actor-gone report for ${id} failed transiently; leaving for retry`, {
+      status: httpStatus,
+      reason,
+    });
+    return 'failed';
   }
 }
 

--- a/packages/backend/src/scripts/pruneGoneFederatedActors.ts
+++ b/packages/backend/src/scripts/pruneGoneFederatedActors.ts
@@ -1,0 +1,338 @@
+/**
+ * One-shot cleanup: TOMBSTONE `FederatedActor` rows whose remote actor is
+ * permanently gone (HTTP 410 Gone) upstream.
+ *
+ * WHY
+ *   Mention discovers a remote profile once and keeps its `FederatedActor` row
+ *   forever — there is no push when a remote account is DELETED. A deleted
+ *   Mastodon/fediverse account keeps surfacing in Mention (search, mentions,
+ *   its cached posts) even though it no longer exists. The live path now handles
+ *   this going forward: `ActorService.fetchRemoteActor` tombstones an actor the
+ *   moment its actor fetch returns a definitive 410 (marks the row `suspended`
+ *   and asks oxy-api to archive the linked identity via
+ *   `POST /federation/actor-gone`, dropping it from search). But that only fires
+ *   when the actor happens to be re-fetched. This script SWEEPS existing rows so
+ *   already-dead actors are reconciled without waiting for an incidental refetch.
+ *
+ * WHAT IT DOES — per scanned actor:
+ *   Re-fetches the actor via the SAME signed-fetch path the live code uses
+ *   (`signedFetch(uri, AP_CONTENT_TYPE)`), then:
+ *     - 410 Gone            → `tombstoned` (applies the SAME tombstone as the live
+ *                             path: `actorService.tombstoneGoneActor` — suspend the
+ *                             row + report-gone to oxy-api). Idempotent.
+ *     - 2xx OK              → `still-live` (left completely untouched).
+ *     - anything else       → `transient-failed` (404 [many servers 404 a live
+ *                             account transiently], 5xx, network error, or the
+ *                             per-actor timeout) — left untouched so a later run
+ *                             can still recover it. ONLY a 410 is treated as gone.
+ *   It NEVER deletes a `FederatedActor` document — posts, boosts and MTN records
+ *   may still reference the actor (see the model doc). This is a tombstone sweep,
+ *   not a purge (that is `purgeOwnDomainFederatedActors.ts`).
+ *
+ *   atproto (Bluesky) actors are excluded: a 410-on-actor-fetch is an
+ *   ActivityPub notion — an atproto actor is a DID with no AP actor endpoint to
+ *   return 410 — so the scan is scoped to `protocol != 'atproto'` (which also
+ *   catches legacy rows written before the `protocol` field existed).
+ *
+ * TARGETING (keep the first run cheap)
+ *   By default the scan is restricted to actors most likely to be dead:
+ *   `postsCount: 0` (or missing) — a profile we resolved but that has no content
+ *   is the cheapest, highest-signal candidate. Pass `--all` to scan every
+ *   (non-atproto) actor.
+ *
+ * FLAGS (plain argv):
+ *   --dry-run          log what WOULD be tombstoned; write nothing (no Mongo
+ *                      suspend, no oxy-api archive call). The re-fetch still runs
+ *                      so the summary is accurate.
+ *   --limit N          cap the number of actors processed (a canary budget).
+ *   --actor <uri>      restrict to one actor by its stored `FederatedActor.uri`.
+ *   --all              scan every non-atproto actor, not just `postsCount: 0`.
+ *
+ * Idempotent + forward-only: batched by a stable ASCENDING `_id` cursor; a
+ * tombstoned actor re-fetched on a second run 410s again and re-applies the same
+ * (idempotent) tombstone, so re-running is safe.
+ *
+ * RUN AS A FARGATE ONE-SHOT (post-deploy, in-VPC):
+ *   bun packages/backend/dist/src/scripts/pruneGoneFederatedActors.js --dry-run
+ *   bun packages/backend/dist/src/scripts/pruneGoneFederatedActors.js --limit 200
+ *   bun packages/backend/dist/src/scripts/pruneGoneFederatedActors.js --all      # full sweep
+ *
+ * RUN OVER THE SSM TUNNEL (prod Mongo forwarded to 127.0.0.1:47017):
+ *   MONGODB_URI='mongodb://127.0.0.1:47017/?directConnection=true' \
+ *   NODE_ENV=production \
+ *   bun packages/backend/src/scripts/pruneGoneFederatedActors.ts --dry-run --limit 50
+ *   (NODE_ENV=production selects the `mention-production` DB; drop --dry-run to
+ *   write. The tunnel is fine for this cursor-paged sweep.)
+ */
+
+import mongoose from 'mongoose';
+import FederatedActor from '../models/FederatedActor';
+import { connectToDatabase } from '../utils/database';
+import { actorService } from '../connectors/activitypub/actor.service';
+import { signedFetch } from '../connectors/activitypub/helpers';
+import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
+import { logger } from '../utils/logger';
+
+/** Actors scanned per page (stable `_id` cursor pagination). */
+const PAGE_SIZE = 500;
+
+/**
+ * Hard per-actor wall-clock cap on a single actor's re-fetch (+ tombstone). The
+ * signed fetch is already internally bounded, but a race against this timer
+ * guarantees ONE slow/unresponsive remote can never freeze the whole sweep. A
+ * timed-out actor is counted `transient-failed` and left untouched; a later run
+ * can still reconcile it.
+ */
+const ACTOR_PROBE_TIMEOUT_MS = 30_000;
+
+/** Per-actor re-fetch classification. Only `gone` (410) triggers a tombstone. */
+type ScanOutcome = 'gone' | 'live' | 'transient';
+
+interface Flags {
+  dryRun: boolean;
+  limit?: number;
+  actor?: string;
+  all: boolean;
+}
+
+/** The lean `FederatedActor` fields the sweep reads. */
+interface ActorRow {
+  _id: mongoose.Types.ObjectId;
+  uri: string;
+  acct: string;
+}
+
+interface Counters {
+  scanned: number;
+  tombstoned: number;
+  stillLive: number;
+  transientFailed: number;
+}
+
+// --- argv parsing (plain, mirrors reingestBlueskyPosts) ----------------------
+
+/** Read the value of `--flag <value>` / `--flag=value` from argv. */
+function readFlagValue(argv: string[], name: string): string | undefined {
+  const prefix = `${name}=`;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === name) return argv[i + 1];
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  return undefined;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const dryRun = argv.includes('--dry-run');
+  const all = argv.includes('--all');
+
+  const rawLimit = readFlagValue(argv, '--limit');
+  let limit: number | undefined;
+  if (rawLimit !== undefined) {
+    const parsed = Number.parseInt(rawLimit, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--limit must be a positive integer (got "${rawLimit}")`);
+    }
+    limit = parsed;
+  }
+
+  const actor = readFlagValue(argv, '--actor')?.trim() || undefined;
+  return { dryRun, limit, actor, all };
+}
+
+// --- per-actor probe ---------------------------------------------------------
+
+/** Distinct rejection raised by {@link withActorTimeout} when a probe exceeds the cap. */
+class ActorProbeTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`actor probe exceeded ${ms}ms hard timeout`);
+    this.name = 'ActorProbeTimeoutError';
+  }
+}
+
+/**
+ * Race one actor's probe against a hard timeout so a single hung remote can never
+ * freeze the batch. The timer is ALWAYS cleared when the probe settles (win or
+ * lose), so no timer is leaked. Losing the race is safe: the tombstone write only
+ * happens AFTER a definitive 410 is observed, so a hung probe never reaches it —
+ * the actor is simply left untouched for a later run, like any `transient-failed`.
+ */
+function withActorTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new ActorProbeTimeoutError(ms)), ms);
+  });
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/**
+ * Re-fetch the actor via the SAME signed-fetch path the live code uses and
+ * classify the result. ONLY a definitive 410 is `gone`; a 2xx is `live`; every
+ * other status (incl. 404), a network error, or a malformed URI is `transient`.
+ */
+async function probeActor(uri: string): Promise<ScanOutcome> {
+  let res: Response;
+  try {
+    res = await signedFetch(uri, AP_CONTENT_TYPE);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(`[pruneGoneFederatedActors] fetch error for ${uri}: ${message}`);
+    return 'transient';
+  }
+
+  if (res.status === 410) return 'gone';
+  if (res.ok) return 'live';
+
+  logger.info(
+    `[pruneGoneFederatedActors] non-gone status ${res.status} ${res.statusText} for ${uri} — left untouched`,
+  );
+  return 'transient';
+}
+
+/**
+ * Probe one actor and, on a definitive 410, apply the SAME tombstone as the live
+ * path (`actorService.tombstoneGoneActor`: suspend the row + report-gone to
+ * oxy-api). Dry-run reports the intended tombstone without writing.
+ */
+async function processActor(actor: ActorRow, flags: Flags): Promise<ScanOutcome> {
+  const outcome = await probeActor(actor.uri);
+  if (outcome !== 'gone') return outcome;
+
+  logger.info(
+    `[pruneGoneFederatedActors] ${flags.dryRun ? 'WOULD tombstone' : 'tombstoning'} gone actor ` +
+      `${actor.acct} (${actor.uri})`,
+  );
+  if (!flags.dryRun) {
+    await actorService.tombstoneGoneActor(actor.uri);
+  }
+  return 'gone';
+}
+
+// --- scan driver -------------------------------------------------------------
+
+/**
+ * Build the Mongo filter: always non-atproto actors (410-on-actor-fetch is an AP
+ * notion). An explicit `--actor <uri>` targets that one actor regardless of its
+ * post count; otherwise the scan is restricted to `postsCount: 0` (or missing) —
+ * the cheapest, highest-signal candidates — unless `--all` widens it to every
+ * (non-atproto) actor.
+ */
+function buildFilter(flags: Flags): Record<string, unknown> {
+  const filter: Record<string, unknown> = { protocol: { $ne: 'atproto' } };
+  if (flags.actor) {
+    filter.uri = flags.actor;
+    return filter;
+  }
+  if (!flags.all) {
+    filter.$or = [{ postsCount: 0 }, { postsCount: { $exists: false } }];
+  }
+  return filter;
+}
+
+async function pruneGoneFederatedActors(): Promise<void> {
+  const startedAt = Date.now();
+  const flags = parseFlags(process.argv.slice(2));
+
+  const counters: Counters = { scanned: 0, tombstoned: 0, stillLive: 0, transientFailed: 0 };
+  let remaining = flags.limit;
+
+  try {
+    await connectToDatabase();
+    const scope = flags.actor ? `actor ${flags.actor}` : flags.all ? 'all' : 'postsCount:0';
+    logger.info(
+      `[pruneGoneFederatedActors] connected — mode: ${flags.dryRun ? 'DRY-RUN' : 'LIVE'}, ` +
+        `scope: ${scope}` +
+        `${flags.limit !== undefined ? `, limit: ${flags.limit}` : ''}`,
+    );
+
+    const baseFilter = buildFilter(flags);
+    const total = await FederatedActor.countDocuments(baseFilter);
+    logger.info(`[pruneGoneFederatedActors] ${total} candidate actor(s) to scan`);
+
+    let lastId: mongoose.Types.ObjectId | null = null;
+
+    for (;;) {
+      if (remaining !== undefined && remaining <= 0) break;
+
+      const pageFilter: Record<string, unknown> = { ...baseFilter };
+      if (lastId) pageFilter._id = { $gt: lastId };
+
+      const pageLimit = remaining !== undefined ? Math.min(PAGE_SIZE, remaining) : PAGE_SIZE;
+      const page = await FederatedActor.find(pageFilter, { _id: 1, uri: 1, acct: 1 })
+        .sort({ _id: 1 })
+        .limit(pageLimit)
+        .lean<ActorRow[]>();
+      if (page.length === 0) break;
+
+      for (const actor of page) {
+        counters.scanned += 1;
+        if (remaining !== undefined) remaining -= 1;
+
+        let outcome: ScanOutcome;
+        try {
+          outcome = await withActorTimeout(processActor(actor, flags), ACTOR_PROBE_TIMEOUT_MS);
+        } catch (err) {
+          // One bad actor never aborts the sweep; treat it as transient so a later
+          // run can still reconcile it. A timeout is the defence-in-depth guard
+          // against an unbounded await hanging the whole run.
+          if (err instanceof ActorProbeTimeoutError) {
+            logger.warn(
+              `[pruneGoneFederatedActors] actor ${actor.uri} probe timed out after ${ACTOR_PROBE_TIMEOUT_MS}ms — skipping`,
+            );
+          } else {
+            const message = err instanceof Error ? err.message : String(err);
+            logger.warn(`[pruneGoneFederatedActors] actor ${actor.uri} probe threw: ${message}`);
+          }
+          outcome = 'transient';
+        }
+
+        switch (outcome) {
+          case 'gone':
+            counters.tombstoned += 1;
+            break;
+          case 'live':
+            counters.stillLive += 1;
+            break;
+          case 'transient':
+            counters.transientFailed += 1;
+            break;
+        }
+      }
+
+      lastId = page[page.length - 1]._id;
+      logger.info(
+        `[pruneGoneFederatedActors] progress: scanned ${counters.scanned}, tombstoned ${counters.tombstoned}, ` +
+          `still-live ${counters.stillLive}, transient-failed ${counters.transientFailed}`,
+      );
+    }
+
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    logger.info(
+      `[pruneGoneFederatedActors] done (${flags.dryRun ? 'DRY-RUN' : 'LIVE'}, ${elapsedSeconds}s): ` +
+        `scanned ${counters.scanned}, tombstoned ${counters.tombstoned}, ` +
+        `still-live ${counters.stillLive}, transient-failed ${counters.transientFailed}`,
+    );
+
+    await mongoose.disconnect();
+  } catch (error) {
+    logger.error('[pruneGoneFederatedActors] failed', error);
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  // Exit deterministically: imported singletons (BullMQ Redis connections, media
+  // cache workers) can keep the event loop alive, so the process would otherwise
+  // sit RUNNING after the work completes. Mirrors the other one-shot scripts.
+  pruneGoneFederatedActors()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error('[pruneGoneFederatedActors] unhandled failure', error);
+      process.exit(1);
+    });
+}
+
+export default pruneGoneFederatedActors;


### PR DESCRIPTION
Dead federated actors (remote account deleted → HTTP 410 Gone) linger as 0-post ghost profiles in search. Mention is the only component that talks to the fediverse, so it detects the death and tells Oxy to archive the identity (oxy-api #653 added `POST /federation/actor-gone` + search exclusion of `archived`).

- **Live tombstone:** `actor.service.fetchRemoteActor` now treats a definitive **410 Gone** (only 410 — not 404/5xx) on the direct OR WebFinger-resolved fetch as authoritative: `tombstoneGoneActor()` sets `FederatedActor.suspended=true` and, if the actor has an `oxyUserId`, calls `reportFederatedActorGone()` → oxy-api archives it → drops from search. Fail-soft, idempotent, never deletes the doc.
- **Helper** `reportFederatedActorGone` (connectors/identity.ts) mirrors the existing `makeServiceRequest` service-auth pattern (scope `federation:write`); never throws — permanent 4xx→skipped, transient→failed.
- **One-shot** `pruneGoneFederatedActors.ts`: `_id`-cursor sweep, re-fetches each actor (30s/actor timeout), 410→tombstone, everything else untouched. Defaults to `postsCount:0` candidates; `--all`, `--actor`, `--dry-run`, `--limit`.

Tests: 574 connector/script suites + 26 focused (identity 20, actorTombstone 6) pass. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)