### PR TITLE
perf(backend): bounded concurrency for Bluesky reingest + gone-actor prune sweeps

### DIFF
--- a/packages/backend/src/__tests__/scripts/mapWithConcurrency.test.ts
+++ b/packages/backend/src/__tests__/scripts/mapWithConcurrency.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapWithConcurrency,
+  DEFAULT_CONCURRENCY,
+  MAX_CONCURRENCY,
+} from '../../scripts/mapWithConcurrency';
+
+/**
+ * The bounded-concurrency pool that both one-shot repair sweeps
+ * (`reingestBlueskyPosts`, `pruneGoneFederatedActors`) run their per-page work
+ * through. The properties that matter for a live prod sweep:
+ *
+ *  - it never runs more than `concurrency` workers at once (that cap is the only
+ *    thing keeping the sweep from hammering oxy-api / the remote servers);
+ *  - every item is processed exactly once, and the results stay index-aligned
+ *    with the input (the scan tallies counters off `results[i]`);
+ *  - a single throwing worker surfaces as THAT item's failure and never aborts
+ *    the batch (one bad post/actor must not sink the whole page);
+ *  - combined with the caller pre-slicing each page to the remaining `--limit`,
+ *    the pool processes exactly the items handed to it — no overshoot.
+ */
+
+/** A deferred that lets a test hold a worker "in flight" until it chooses to release it. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('mapWithConcurrency', () => {
+  it('never exceeds the concurrency cap and processes every item exactly once', async () => {
+    const items = Array.from({ length: 25 }, (_, i) => i);
+    const CONCURRENCY = 4;
+
+    let inFlight = 0;
+    let peak = 0;
+    const startCount = new Map<number, number>();
+
+    const results = await mapWithConcurrency(items, CONCURRENCY, async (item) => {
+      startCount.set(item, (startCount.get(item) ?? 0) + 1);
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      // Yield across a microtask boundary so overlapping workers actually overlap.
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight -= 1;
+      return item * 2;
+    });
+
+    // Cap respected: at no point were more than CONCURRENCY workers in flight.
+    expect(peak).toBeLessThanOrEqual(CONCURRENCY);
+    expect(peak).toBe(CONCURRENCY); // ...and the pool actually saturated.
+
+    // Every item processed exactly once.
+    expect(startCount.size).toBe(items.length);
+    for (const item of items) expect(startCount.get(item)).toBe(1);
+
+    // Results are index-aligned with the input.
+    expect(results).toHaveLength(items.length);
+    for (let i = 0; i < items.length; i++) {
+      const settled = results[i];
+      expect(settled.status).toBe('fulfilled');
+      if (settled.status === 'fulfilled') expect(settled.value).toBe(items[i] * 2);
+    }
+  });
+
+  it('holds the pool at exactly `concurrency` in flight until slots free up', async () => {
+    const gates = [deferred(), deferred(), deferred(), deferred()];
+    let started = 0;
+
+    const run = mapWithConcurrency(gates, 2, async (gate) => {
+      started += 1;
+      await gate.promise;
+      return 'ok' as const;
+    });
+
+    // Two workers should be running; the other two blocked behind the cap.
+    await Promise.resolve();
+    expect(started).toBe(2);
+
+    // Releasing one in-flight worker frees exactly one slot.
+    gates[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toBe(3);
+
+    gates[1].resolve();
+    gates[2].resolve();
+    gates[3].resolve();
+    const results = await run;
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(started).toBe(4);
+  });
+
+  it('surfaces a per-item rejection as that item’s failure without aborting the batch', async () => {
+    const items = [0, 1, 2, 3, 4];
+    const boom = new Error('item 2 blew up');
+
+    const results = await mapWithConcurrency(items, 3, async (item) => {
+      if (item === 2) throw boom;
+      return item;
+    });
+
+    expect(results).toHaveLength(items.length);
+    for (const item of items) {
+      const settled = results[item];
+      if (item === 2) {
+        expect(settled.status).toBe('rejected');
+        if (settled.status === 'rejected') expect(settled.reason).toBe(boom);
+      } else {
+        expect(settled.status).toBe('fulfilled');
+        if (settled.status === 'fulfilled') expect(settled.value).toBe(item);
+      }
+    }
+  });
+
+  it('processes exactly the items it is given — the caller pre-slices to the --limit budget', async () => {
+    // The scan loop slices each page to `min(PAGE_SIZE, remaining)` BEFORE calling
+    // the pool, so a budget of 3 hands the pool a 3-item page and the pool touches
+    // no more than those 3 — never overshooting by up to `concurrency`.
+    const remainingBudget = 3;
+    const fullPage = [10, 11, 12, 13, 14, 15, 16, 17];
+    const page = fullPage.slice(0, remainingBudget);
+
+    const processed: number[] = [];
+    const results = await mapWithConcurrency(page, 8, async (item) => {
+      processed.push(item);
+      return item;
+    });
+
+    expect(processed.sort((a, b) => a - b)).toEqual([10, 11, 12]);
+    expect(results).toHaveLength(remainingBudget);
+  });
+
+  it('handles an empty batch without spawning any worker', async () => {
+    let calls = 0;
+    const results = await mapWithConcurrency<number, number>([], 8, async (item) => {
+      calls += 1;
+      return item;
+    });
+    expect(calls).toBe(0);
+    expect(results).toEqual([]);
+  });
+
+  it('caps the pool at the item count when concurrency exceeds it', async () => {
+    const items = [1, 2];
+    let inFlight = 0;
+    let peak = 0;
+    await mapWithConcurrency(items, 16, async (item) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return item;
+    });
+    // Only 2 items exist, so the pool must never spawn more than 2 workers.
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  it('exposes conservative default and max concurrency constants', () => {
+    expect(DEFAULT_CONCURRENCY).toBe(8);
+    expect(MAX_CONCURRENCY).toBe(32);
+  });
+});

--- a/packages/backend/src/scripts/mapWithConcurrency.ts
+++ b/packages/backend/src/scripts/mapWithConcurrency.ts
@@ -1,0 +1,63 @@
+/**
+ * A minimal, dependency-free bounded-concurrency map shared by the one-shot
+ * repair sweeps (`reingestBlueskyPosts`, `pruneGoneFederatedActors`).
+ *
+ * WHY
+ *   Those sweeps are almost entirely I/O-bound — each item does a remote signed
+ *   fetch plus oxy-api media/archive round-trips, so processing one item at a
+ *   time leaves the CPU idle waiting on the network. Overlapping a small pool of
+ *   items recovers roughly an order of magnitude of wall-clock time while keeping
+ *   the load on the remote/oxy-api endpoints bounded.
+ */
+
+/** Default in-flight pool size — conservative so a sweep never hammers oxy-api. */
+export const DEFAULT_CONCURRENCY = 8;
+
+/** Upper bound the `--concurrency` flag is clamped to (guards against a fat-finger). */
+export const MAX_CONCURRENCY = 32;
+
+/**
+ * Run `worker` over `items` with at most `concurrency` calls in flight at once,
+ * resolving once EVERY item has settled. A simple index-cursor promise pool: it
+ * starts `min(concurrency, items.length)` worker loops that each pull the next
+ * index off a shared cursor and process it until the list is drained, so the
+ * number of concurrent `worker` calls never exceeds `concurrency`. The returned
+ * array is index-aligned with `items`.
+ *
+ * Robust like `Promise.allSettled`: a `worker` that REJECTS never aborts the
+ * batch or the other in-flight items — its rejection is captured as that item's
+ * `{ status: 'rejected', reason }` slot, and every other item still runs to
+ * completion. Callers that already convert their own failures into a value never
+ * see a rejected slot; callers that let the worker throw get a per-item failure
+ * they can classify.
+ *
+ * Reading and advancing the shared cursor is a synchronous, await-free critical
+ * section, so in single-threaded JS each index is dispatched exactly once.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array<PromiseSettledResult<R>>(items.length);
+  let cursor = 0;
+
+  const runWorker = async (): Promise<void> => {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      try {
+        results[index] = { status: 'fulfilled', value: await worker(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  };
+
+  const poolSize = Math.min(Math.max(1, concurrency), items.length);
+  const pool: Promise<void>[] = [];
+  for (let i = 0; i < poolSize; i++) pool.push(runWorker());
+  await Promise.all(pool);
+  return results;
+}

--- a/packages/backend/src/scripts/pruneGoneFederatedActors.ts
+++ b/packages/backend/src/scripts/pruneGoneFederatedActors.ts
@@ -47,6 +47,11 @@
  *   --limit N          cap the number of actors processed (a canary budget).
  *   --actor <uri>      restrict to one actor by its stored `FederatedActor.uri`.
  *   --all              scan every non-atproto actor, not just `postsCount: 0`.
+ *   --concurrency N    how many actors to probe in parallel (default 8, clamped to
+ *                      32). The sweep is I/O-bound (signed actor re-fetch + the
+ *                      oxy-api actor-gone round-trip), so a small pool overlaps the
+ *                      network waits for ~8-10x wall-clock. Keep it conservative to
+ *                      avoid hammering oxy-api's actor-gone endpoint.
  *
  * Idempotent + forward-only: batched by a stable ASCENDING `_id` cursor; a
  * tombstoned actor re-fetched on a second run 410s again and re-applies the same
@@ -72,6 +77,7 @@ import { actorService } from '../connectors/activitypub/actor.service';
 import { signedFetch } from '../connectors/activitypub/helpers';
 import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
 import { logger } from '../utils/logger';
+import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from './mapWithConcurrency';
 
 /** Actors scanned per page (stable `_id` cursor pagination). */
 const PAGE_SIZE = 500;
@@ -93,6 +99,7 @@ interface Flags {
   limit?: number;
   actor?: string;
   all: boolean;
+  concurrency: number;
 }
 
 /** The lean `FederatedActor` fields the sweep reads. */
@@ -137,7 +144,18 @@ function parseFlags(argv: string[]): Flags {
   }
 
   const actor = readFlagValue(argv, '--actor')?.trim() || undefined;
-  return { dryRun, limit, actor, all };
+
+  const rawConcurrency = readFlagValue(argv, '--concurrency');
+  let concurrency = DEFAULT_CONCURRENCY;
+  if (rawConcurrency !== undefined) {
+    const parsed = Number.parseInt(rawConcurrency, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--concurrency must be a positive integer (got "${rawConcurrency}")`);
+    }
+    concurrency = Math.min(parsed, MAX_CONCURRENCY);
+  }
+
+  return { dryRun, limit, actor, all, concurrency };
 }
 
 // --- per-actor probe ---------------------------------------------------------
@@ -243,7 +261,7 @@ async function pruneGoneFederatedActors(): Promise<void> {
     const scope = flags.actor ? `actor ${flags.actor}` : flags.all ? 'all' : 'postsCount:0';
     logger.info(
       `[pruneGoneFederatedActors] connected — mode: ${flags.dryRun ? 'DRY-RUN' : 'LIVE'}, ` +
-        `scope: ${scope}` +
+        `scope: ${scope}, concurrency: ${flags.concurrency}` +
         `${flags.limit !== undefined ? `, limit: ${flags.limit}` : ''}`,
     );
 
@@ -266,17 +284,31 @@ async function pruneGoneFederatedActors(): Promise<void> {
         .lean<ActorRow[]>();
       if (page.length === 0) break;
 
-      for (const actor of page) {
+      // The page is already sliced to at most the remaining budget (`pageLimit`), so
+      // probing the WHOLE page in a bounded pool can never overshoot `--limit`. Each
+      // actor's work stays wrapped in its per-actor hard timeout, so one hung remote
+      // still cannot stall the pool beyond `ACTOR_PROBE_TIMEOUT_MS`.
+      const settledResults = await mapWithConcurrency(page, flags.concurrency, (actor) =>
+        withActorTimeout(processActor(actor, flags), ACTOR_PROBE_TIMEOUT_MS),
+      );
+
+      // Tally sequentially in `_id` order AFTER the pool drains: every counter and
+      // the shared budget are mutated exactly once per actor on a single call
+      // stack, so no concurrent update can race or double-count.
+      for (let i = 0; i < page.length; i++) {
+        const actor = page[i];
         counters.scanned += 1;
         if (remaining !== undefined) remaining -= 1;
 
+        const settled = settledResults[i];
         let outcome: ScanOutcome;
-        try {
-          outcome = await withActorTimeout(processActor(actor, flags), ACTOR_PROBE_TIMEOUT_MS);
-        } catch (err) {
+        if (settled.status === 'fulfilled') {
+          outcome = settled.value;
+        } else {
           // One bad actor never aborts the sweep; treat it as transient so a later
           // run can still reconcile it. A timeout is the defence-in-depth guard
           // against an unbounded await hanging the whole run.
+          const err = settled.reason;
           if (err instanceof ActorProbeTimeoutError) {
             logger.warn(
               `[pruneGoneFederatedActors] actor ${actor.uri} probe timed out after ${ACTOR_PROBE_TIMEOUT_MS}ms — skipping`,

--- a/packages/backend/src/scripts/reingestBlueskyPosts.ts
+++ b/packages/backend/src/scripts/reingestBlueskyPosts.ts
@@ -68,6 +68,11 @@
  *   --path atproto|bridgy|all   which ingest path(s) to repair (default: all).
  *   --actor <uri>          restrict to one actor (AP actor URI for bridgy, or the
  *                          `did:` for atproto), matched on `federation.actorUri`.
+ *   --concurrency N        how many posts to repair in parallel (default 8, clamped
+ *                          to 32). The sweep is I/O-bound (signed fetch + oxy-api
+ *                          media round-trips), so a small pool overlaps the network
+ *                          waits for ~8-10x wall-clock. Keep it conservative to
+ *                          avoid hammering oxy-api's media-cache endpoints.
  *
  * Idempotent + forward-only: batched by a stable ASCENDING `_id` cursor; a repaired
  * post re-maps to the same fields on a second run (no change ⇒ no write), so
@@ -98,6 +103,7 @@ import { signedFetch } from '../connectors/activitypub/helpers';
 import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
 import { refetchAtprotoPostForRepair } from '../connectors/atproto/post.mapper';
 import { fetchAndUpsertAtprotoProfile, splitHandle } from '../connectors/atproto/profile.mapper';
+import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from './mapWithConcurrency';
 
 /** Posts scanned per page (stable `_id` cursor pagination). */
 const PAGE_SIZE = 500;
@@ -131,6 +137,7 @@ interface Flags {
   limit?: number;
   path: RepairPath;
   actor?: string;
+  concurrency: number;
 }
 
 /** The lean Post fields the repair reads for both paths. */
@@ -229,7 +236,18 @@ function parseFlags(argv: string[]): Flags {
   }
 
   const actor = readFlagValue(argv, '--actor')?.trim() || undefined;
-  return { dryRun, limit, path: rawPath, actor };
+
+  const rawConcurrency = readFlagValue(argv, '--concurrency');
+  let concurrency = DEFAULT_CONCURRENCY;
+  if (rawConcurrency !== undefined) {
+    const parsed = Number.parseInt(rawConcurrency, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--concurrency must be a positive integer (got "${rawConcurrency}")`);
+    }
+    concurrency = Math.min(parsed, MAX_CONCURRENCY);
+  }
+
+  return { dryRun, limit, path: rawPath, actor, concurrency };
 }
 
 // --- pure diff helpers -------------------------------------------------------
@@ -629,7 +647,19 @@ async function scanPath(
       .lean<StoredPostRow[]>();
     if (page.length === 0) break;
 
-    for (const post of page) {
+    // The page is already sliced to at most the remaining budget (`pageLimit`), so
+    // repairing the WHOLE page in a bounded pool can never overshoot `--limit`.
+    // Each post's work stays wrapped in its per-post hard timeout, so one hung
+    // remote still cannot stall the pool beyond `REPAIR_TIMEOUT_MS`.
+    const settledResults = await mapWithConcurrency(page, flags.concurrency, (post) =>
+      withRepairTimeout(repair(post, flags), REPAIR_TIMEOUT_MS),
+    );
+
+    // Tally sequentially in `_id` order AFTER the pool drains: every counter,
+    // the shared budget, and the DID set are mutated exactly once per post on a
+    // single call stack, so no concurrent update can race or double-count.
+    for (let i = 0; i < page.length; i++) {
+      const post = page[i];
       counters.scanned += 1;
       if (budget.remaining !== undefined) budget.remaining -= 1;
 
@@ -637,13 +667,15 @@ async function scanPath(
         atprotoDids.add(post.federation.actorUri);
       }
 
+      const settled = settledResults[i];
       let outcome: RepairOutcome;
-      try {
-        outcome = await withRepairTimeout(repair(post, flags), REPAIR_TIMEOUT_MS);
-      } catch (err) {
+      if (settled.status === 'fulfilled') {
+        outcome = settled.value;
+      } else {
         // One bad post never aborts the run; treat it as a transient failure so a
         // later run can still recover it. A timeout is the defence-in-depth guard
         // against an unbounded await hanging the whole sweep.
+        const err = settled.reason;
         if (err instanceof RepairTimeoutError) {
           logger.warn(
             `[reingestBlueskyPosts] ${path} post ${String(post._id)} repair timed out after ${REPAIR_TIMEOUT_MS}ms — skipping`,
@@ -700,7 +732,7 @@ async function reingestBlueskyPosts(): Promise<void> {
     await mongoose.connect(mongoUri, { dbName });
     logger.info(
       `[reingestBlueskyPosts] connected to MongoDB (${dbName}) — mode: ${flags.dryRun ? 'DRY-RUN' : 'LIVE'}, ` +
-        `path: ${flags.path}${flags.limit !== undefined ? `, limit: ${flags.limit}` : ''}`,
+        `path: ${flags.path}, concurrency: ${flags.concurrency}${flags.limit !== undefined ? `, limit: ${flags.limit}` : ''}`,
     );
 
     if (flags.path === 'bridgy' || flags.path === 'all') {


### PR DESCRIPTION
Both one-shot sweeps processed items one-at-a-time. They're I/O-bound (remote signed fetches + oxy-api media/archive round-trips), so sequential wall-clock was ~8s/post → hours for the ~1,460 brid.gy posts. Overlapping the I/O with a small pool gives ~8-10x.

- New `mapWithConcurrency(items, n, worker)` — index-cursor promise pool (default 8, max 32), behaves like a bounded `Promise.allSettled` (a throwing worker becomes that item's rejected slot, never aborts the batch).
- `reingestBlueskyPosts` + `pruneGoneFederatedActors`: `--concurrency N` flag; each page is processed through the pool, then counters/budget/DID-set are tallied sequentially over settled results in `_id` order (no races), then the cursor advances. Per-item hard timeout preserved (wrapped as the pool worker). `--limit` stays exact (page pre-capped by remaining budget). Cursor/forward-only + page size unchanged. Default stays conservative (8) to not hammer oxy-api service limiters.

Tests: pool suite 7 + full scripts suite 66 pass. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)