### PR TITLE
fix(federation): atproto instance domain is always bsky.social (custom-domain handles)

### DIFF
--- a/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
@@ -32,6 +32,7 @@ vi.mock('../../../connectors/identity', () => ({
 import {
   fetchAndUpsertAtprotoProfile,
   mapProfileToNormalizedActor,
+  splitHandle,
 } from '../../../connectors/atproto/profile.mapper';
 
 const DID = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz';
@@ -95,40 +96,55 @@ describe('mapProfileToNormalizedActor', () => {
     expect(actor?.bio).toBeUndefined();
   });
 
-  it('keys an apex custom-domain handle to the Bluesky network host (no doubled domain)', () => {
-    // A 2-label apex handle (`gothamist.com`) has no strippable parent domain.
-    // Using the handle itself as the instance rendered the doubled
-    // `@gothamist.com@gothamist.com`; it now keys to the network host so
-    // `getNormalizedUserHandle` renders the clean `@gothamist.com@bsky.social`.
-    const actor = mapProfileToNormalizedActor({ ...PROFILE, handle: 'gothamist.com' });
-    expect(actor?.federatedUsername).toBe('gothamist.com@bsky.social');
+  // Every atproto handle — a normal `.bsky.social` handle, an apex custom domain,
+  // and a multi-label custom domain — keys to the Bluesky network host, with the
+  // FULL handle as the username. Deriving the instance from the handle's own parent
+  // domain was the bug: `mayor.nyc.gov` rendered `@mayor.nyc.gov@nyc.gov` instead of
+  // `@mayor.nyc.gov@bsky.social` (apex handles only escaped it because a bare TLD
+  // like `com` has no dot).
+  it.each([
+    'alice.bsky.social',
+    'carnage4life.bsky.social',
+    'gothamist.com',
+    'mayor.nyc.gov',
+    'jay.bsky.team',
+  ])('keys handle %s to the Bluesky network host with the full handle as username', (handle) => {
+    const actor = mapProfileToNormalizedActor({ ...PROFILE, handle });
+    expect(actor?.handle).toBe(handle);
     expect(actor?.instanceDomain).toBe('bsky.social');
+    expect(actor?.federatedUsername).toBe(`${handle}@bsky.social`);
 
     const rendered = getNormalizedUserHandle({
       username: actor?.handle,
       isFederated: true,
       federation: { domain: actor?.instanceDomain },
     });
-    expect(rendered).toBe('gothamist.com@bsky.social');
-    expect(rendered).not.toBe('gothamist.com@gothamist.com');
-  });
-
-  it('leaves a normal `.bsky.social` handle rendering unchanged', () => {
-    const actor = mapProfileToNormalizedActor({ ...PROFILE, handle: 'georgemonbiot.bsky.social' });
-    expect(actor?.federatedUsername).toBe('georgemonbiot.bsky.social@bsky.social');
-    expect(actor?.instanceDomain).toBe('bsky.social');
-
-    const rendered = getNormalizedUserHandle({
-      username: actor?.handle,
-      isFederated: true,
-      federation: { domain: actor?.instanceDomain },
-    });
-    expect(rendered).toBe('georgemonbiot.bsky.social@bsky.social');
+    expect(rendered).toBe(`${handle}@bsky.social`);
+    // The pre-fix doubled/bogus instance must never re-appear.
+    expect(rendered).not.toBe(`${handle}@${handle}`);
   });
 
   it('returns null when did or handle is missing', () => {
     expect(mapProfileToNormalizedActor({ handle: 'a.b' })).toBeNull();
     expect(mapProfileToNormalizedActor({ did: DID })).toBeNull();
+  });
+});
+
+describe('splitHandle', () => {
+  // The instance domain for an atproto actor is ALWAYS the Bluesky network domain,
+  // and the whole handle is the username — regardless of label count or custom
+  // domain. These are the exact prod actors the old parent-stripping mis-derived.
+  it.each([
+    { handle: 'alice.bsky.social', domain: 'bsky.social' },
+    { handle: 'mayor.nyc.gov', domain: 'bsky.social' },
+    { handle: 'jay.bsky.team', domain: 'bsky.social' },
+    { handle: 'gothamist.com', domain: 'bsky.social' },
+  ])('derives $handle → instance $domain with the full handle as username', ({ handle, domain }) => {
+    expect(splitHandle(handle)).toEqual({
+      username: handle,
+      domain,
+      federatedUsername: `${handle}@${domain}`,
+    });
   });
 });
 

--- a/packages/backend/src/connectors/atproto/constants.ts
+++ b/packages/backend/src/connectors/atproto/constants.ts
@@ -32,12 +32,13 @@ export const PLC_DIRECTORY = process.env.ATPROTO_PLC_DIRECTORY || 'plc.directory
 export const BSKY_APP_ORIGIN = 'https://bsky.app';
 
 /**
- * The Bluesky network's canonical host, used as the federated instance domain for
- * an APEX custom handle — a 2-label domain like `gothamist.com` whose first label
- * cannot be stripped without leaving a bare TLD (`com`). A regular handle derives
- * its instance from its parent domain (`alice.bsky.social` → `bsky.social`); an
- * apex handle has none, so it keys to the network host and renders cleanly as
- * `@gothamist.com@bsky.social` instead of the doubled `@gothamist.com@gothamist.com`.
+ * The Bluesky network's canonical host. It is the federated instance domain for
+ * EVERY atproto actor: a Bluesky handle is a whole DNS name that identifies the
+ * account (`alice.bsky.social`, the apex `gothamist.com`, the multi-label custom
+ * domain `mayor.nyc.gov`), and the account lives on the Bluesky network in every
+ * case. So the full handle is the username and this is always the instance domain,
+ * rendering `@mayor.nyc.gov@bsky.social` — never a bogus instance derived from the
+ * handle's own parent domain (the old bug rendered `@mayor.nyc.gov@nyc.gov`).
  */
 export const BSKY_NETWORK_DOMAIN = 'bsky.social';
 

--- a/packages/backend/src/connectors/atproto/profile.mapper.ts
+++ b/packages/backend/src/connectors/atproto/profile.mapper.ts
@@ -29,27 +29,38 @@ export interface AtprotoProfileView {
  * Split an atproto handle (a DNS name) into its display username, instance
  * domain, and the canonical `local@domain` username Oxy stores it under.
  *
- * A Bluesky handle is a bare DNS name. Its instance domain is the handle minus
- * its first label — but ONLY when that leaves a real ≥2-label domain:
- *   - `alice.bsky.social` (3 labels) → instance `bsky.social`.
- *   - `gothamist.com` (a 2-label apex custom domain) has no strippable parent —
- *     stripping would leave the bare TLD `com`, and using the handle itself as the
- *     domain renders the doubled `@gothamist.com@gothamist.com`. It keys to the
- *     Bluesky network host instead (`bsky.social`), rendering `@gothamist.com@bsky.social`.
- * The federated Oxy username is `<handle>@<instance-domain>`
- * (`alice.bsky.social@bsky.social`, `gothamist.com@bsky.social`) — the exact form
+ * For the atproto connector the instance domain is ALWAYS the Bluesky network
+ * domain (`bsky.social`): a Bluesky handle is a whole DNS name that identifies the
+ * account, not a `local@host` address, and the account lives on the Bluesky
+ * network regardless of how many labels the handle has or whether it is a custom
+ * domain. The username is the FULL handle in every case:
+ *   - `alice.bsky.social` → username `alice.bsky.social`, instance `bsky.social`.
+ *   - `gothamist.com`      → username `gothamist.com`,      instance `bsky.social`.
+ *   - `mayor.nyc.gov`      → username `mayor.nyc.gov`,      instance `bsky.social`.
+ *
+ * Deriving the instance from the handle's own parent domain was the bug: a
+ * multi-label custom domain (`mayor.nyc.gov`) produced the bogus instance
+ * `nyc.gov`, rendering `@mayor.nyc.gov@nyc.gov` instead of the correct
+ * `@mayor.nyc.gov@bsky.social` (apex handles like `gothamist.com` only avoided it
+ * by accident, because the bare TLD `com` has no dot).
+ *
+ * The federated Oxy username is `<handle>@bsky.social`
+ * (`alice.bsky.social@bsky.social`, `mayor.nyc.gov@bsky.social`) — the exact form
  * oxy-api's `PUT /users/resolve` binds (username domain must equal `domain`).
  *
- * Exported so the reingest repair script can DETECT the pre-fix doubled-handle bug
- * (a stored `FederatedActor.domain` that no longer equals `splitHandle(acct).domain`)
- * without re-fetching the profile, using the SAME derivation the upsert path uses.
+ * Exported so the re-derive repair script can DETECT a stored actor whose
+ * `FederatedActor.domain` no longer equals `splitHandle(acct).domain` without
+ * re-fetching the profile, using the SAME derivation the upsert path uses.
  */
 export function splitHandle(handle: string): { username: string; domain: string; federatedUsername: string } {
-  const dot = handle.indexOf('.');
-  // Strip the first label only if the remainder is still a multi-label domain.
-  const parent = dot > 0 ? handle.slice(dot + 1) : handle;
-  const domain = parent.includes('.') ? parent : BSKY_NETWORK_DOMAIN;
-  return { username: handle, domain, federatedUsername: `${handle}@${domain}` };
+  // The instance domain for every atproto actor is the Bluesky network host and the
+  // whole handle is the username — a handle is a DNS name identifying the account,
+  // so it has no separable per-instance host to derive from its parent domain.
+  return {
+    username: handle,
+    domain: BSKY_NETWORK_DOMAIN,
+    federatedUsername: `${handle}@${BSKY_NETWORK_DOMAIN}`,
+  };
 }
 
 /** Map a getProfile response to the network-neutral actor shape (pure). */
@@ -69,8 +80,9 @@ export function mapProfileToNormalizedActor(profile: AtprotoProfileView): Normal
     network: 'atproto',
     externalId: did,
     handle,
-    // A DID carries no host, so the Oxy identity is keyed on the handle's parent
-    // domain. These are what the shared identity bridge sends to oxy-api.
+    // A DID carries no host and a handle is a whole DNS name, so an atproto actor's
+    // Oxy identity is keyed on the Bluesky network domain (`bsky.social`). These are
+    // what the shared identity bridge sends to oxy-api.
     federatedUsername,
     instanceDomain: domain,
     displayName: displayName || undefined,

--- a/packages/backend/src/scripts/repairAtprotoActorHandles.ts
+++ b/packages/backend/src/scripts/repairAtprotoActorHandles.ts
@@ -1,0 +1,276 @@
+/**
+ * One-shot REPAIR of stored atproto (Bluesky) actor handles that carry a bogus
+ * federated instance domain.
+ *
+ * WHY
+ *   `splitHandle` (`connectors/atproto/profile.mapper.ts`) used to derive an actor's
+ *   instance domain by stripping the first label off its handle — which is wrong for
+ *   the atproto connector, where the instance domain is ALWAYS the Bluesky network
+ *   host (`bsky.social`) and the whole handle is the username. A multi-label custom
+ *   domain handle mis-derived its instance:
+ *     - `mayor.nyc.gov`  → parent `nyc.gov` → stored domain `nyc.gov`   (WRONG)
+ *     - `jay.bsky.team`  → parent `bsky.team` → stored domain `bsky.team` (WRONG)
+ *     - `ronbronson.com` → parent `com`     → stored domain `com`       (WRONG)
+ *   so the actor rendered as `@mayor.nyc.gov@nyc.gov` instead of the correct
+ *   `@mayor.nyc.gov@bsky.social`. (Apex handles like `gothamist.com` happened to be
+ *   correct only because a bare TLD has no dot to strip.) The ingest path is now
+ *   fixed, but rows written before the fix keep their bogus `domain`/`acct` binding
+ *   — this script re-derives and repairs them in place.
+ *
+ * WHAT IT DOES — per `FederatedActor` row with `protocol:'atproto'`:
+ *   1. Cheaply detects whether the row needs repair WITHOUT any network I/O:
+ *      `splitHandle(acct).domain !== stored.domain`. An already-correct actor is a
+ *      no-op (logged `unchanged`, no fetch).
+ *   2. When it differs, repairs it by re-running the SAME sanctioned upsert the
+ *      ingest path uses — `fetchAndUpsertAtprotoProfile(did)` — which recomputes the
+ *      handle through the FIXED `splitHandle` AND updates BOTH sides consistently
+ *      through one code path: the Mention `FederatedActor` (domain / acct) and the
+ *      linked Oxy user (via the shared identity bridge's `/users/resolve`). The `did`
+ *      is the actor's stored `uri` (`did:plc:...` / `did:web:...`). We deliberately do
+ *      NOT hand-write the Oxy update, so the two stores never drift.
+ *
+ *   There are only ~18 atproto actors in prod, so this scans them in one pass (no
+ *   cursor batching), sequentially — the repair is one AppView fetch + one oxy-api
+ *   round-trip per actor, and running them one at a time keeps the load on both
+ *   trivial. Each repair is wrapped in a hard per-actor timeout so a single hung
+ *   remote can never freeze the run, and one actor's failure never aborts the loop.
+ *
+ * FLAGS (plain argv):
+ *   --dry-run    log what WOULD change (stored `domain` → re-derived `domain`) and
+ *                write nothing — the upsert is never called, so neither the
+ *                `FederatedActor` nor the linked Oxy user is touched.
+ *   --limit N    cap the number of actors processed (a canary budget). Actors are
+ *                scanned in a stable ascending `_id` order so a limited run is
+ *                deterministic.
+ *
+ * Idempotent + re-runnable: a repaired actor re-derives to the SAME domain on a
+ * second run (`splitHandle(acct).domain === stored.domain`), so it is then a no-op.
+ *
+ * RUN AS A FARGATE ONE-SHOT (post-deploy, in-VPC):
+ *   bun packages/backend/dist/src/scripts/repairAtprotoActorHandles.js --dry-run
+ *   bun packages/backend/dist/src/scripts/repairAtprotoActorHandles.js            # live repair
+ *
+ * RUN OVER THE SSM TUNNEL (prod Mongo forwarded to 127.0.0.1:47017):
+ *   MONGODB_URI='mongodb://127.0.0.1:47017/?directConnection=true' \
+ *   NODE_ENV=production \
+ *   bun packages/backend/src/scripts/repairAtprotoActorHandles.ts --dry-run
+ *   (NODE_ENV=production selects the `mention-production` DB; drop --dry-run to
+ *   write. The pool is ~18 actors, so the tunnel is fine.)
+ */
+
+import mongoose from 'mongoose';
+import FederatedActor from '../models/FederatedActor';
+import { connectToDatabase } from '../utils/database';
+import { fetchAndUpsertAtprotoProfile, splitHandle } from '../connectors/atproto/profile.mapper';
+import { logger } from '../utils/logger';
+
+/**
+ * Hard per-actor wall-clock cap on a single actor's repair. The upsert's network
+ * awaits (the Bluesky AppView `getProfile` fetch + the oxy-api resolve round-trip)
+ * are each internally bounded, but a race against this timer guarantees ONE
+ * slow/unresponsive remote can never freeze the run. A timed-out actor is counted
+ * `failed` and left untouched; a later run can still reconcile it.
+ */
+const ACTOR_REPAIR_TIMEOUT_MS = 30_000;
+
+/** Per-actor repair outcome. */
+type RepairOutcome = 'repaired' | 'unchanged' | 'failed';
+
+interface Flags {
+  dryRun: boolean;
+  limit?: number;
+}
+
+/** The lean `FederatedActor` fields the repair reads. */
+interface ActorRow {
+  _id: mongoose.Types.ObjectId;
+  uri: string;
+  acct: string;
+  username: string;
+  domain: string;
+}
+
+interface Counters {
+  scanned: number;
+  repaired: number;
+  unchanged: number;
+  failed: number;
+}
+
+// --- argv parsing (plain, mirrors the other one-shot scripts) ----------------
+
+/** Read the value of `--flag <value>` / `--flag=value` from argv. */
+function readFlagValue(argv: string[], name: string): string | undefined {
+  const prefix = `${name}=`;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === name) return argv[i + 1];
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  return undefined;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const dryRun = argv.includes('--dry-run');
+
+  const rawLimit = readFlagValue(argv, '--limit');
+  let limit: number | undefined;
+  if (rawLimit !== undefined) {
+    const parsed = Number.parseInt(rawLimit, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--limit must be a positive integer (got "${rawLimit}")`);
+    }
+    limit = parsed;
+  }
+
+  return { dryRun, limit };
+}
+
+// --- per-actor repair --------------------------------------------------------
+
+/** Distinct rejection raised by {@link withActorTimeout} when a repair exceeds the cap. */
+class ActorRepairTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`actor repair exceeded ${ms}ms hard timeout`);
+    this.name = 'ActorRepairTimeoutError';
+  }
+}
+
+/**
+ * Race one actor's repair against a hard timeout so a single hung remote can never
+ * freeze the run. The timer is ALWAYS cleared when the repair settles (win or lose
+ * the race), so no timer is leaked. Losing the race is safe: the upsert either
+ * completed its writes or it did not — a timed-out actor is simply reported `failed`
+ * and left for a later run.
+ */
+function withActorTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new ActorRepairTimeoutError(ms)), ms);
+  });
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/**
+ * Repair one actor when its stored `domain` no longer matches the re-derived one.
+ * Detection is a pure, network-free comparison; the actual repair re-runs the shared
+ * profile upsert so the `FederatedActor` and the linked Oxy user stay consistent
+ * through one code path. Fails soft: any error (or the per-actor timeout) is caught
+ * by the caller and counted `failed` — the loop is never aborted.
+ */
+async function repairActor(actor: ActorRow, flags: Flags): Promise<RepairOutcome> {
+  if (!actor.acct) {
+    logger.warn(`[repairAtprotoActorHandles] actor ${actor.uri} has no acct — cannot re-derive, skipping`);
+    return 'failed';
+  }
+
+  const expected = splitHandle(actor.acct);
+  if (expected.domain === actor.domain) {
+    return 'unchanged';
+  }
+
+  logger.info(
+    `[repairAtprotoActorHandles] ${flags.dryRun ? 'WOULD repair' : 'repairing'} actor ${actor.uri} handle: ` +
+      `${actor.username}@${actor.domain} → ${expected.federatedUsername}`,
+  );
+  if (flags.dryRun) return 'repaired';
+
+  const refreshed = await withActorTimeout(fetchAndUpsertAtprotoProfile(actor.uri), ACTOR_REPAIR_TIMEOUT_MS);
+  if (!refreshed) {
+    logger.warn(
+      `[repairAtprotoActorHandles] upsert for actor ${actor.uri} returned null (profile unfetchable) — left untouched`,
+    );
+    return 'failed';
+  }
+  return 'repaired';
+}
+
+// --- entrypoint --------------------------------------------------------------
+
+async function repairAtprotoActorHandles(): Promise<void> {
+  const startedAt = Date.now();
+  const flags = parseFlags(process.argv.slice(2));
+
+  const counters: Counters = { scanned: 0, repaired: 0, unchanged: 0, failed: 0 };
+
+  try {
+    await connectToDatabase();
+    logger.info(
+      `[repairAtprotoActorHandles] connected — mode: ${flags.dryRun ? 'DRY-RUN' : 'LIVE'}` +
+        `${flags.limit !== undefined ? `, limit: ${flags.limit}` : ''}`,
+    );
+
+    // There are only ~18 atproto actors, so a single ordered pass is enough. The
+    // stable ascending `_id` sort keeps a `--limit` run deterministic.
+    const query = FederatedActor.find(
+      { protocol: 'atproto' },
+      { _id: 1, uri: 1, acct: 1, username: 1, domain: 1 },
+    ).sort({ _id: 1 });
+    if (flags.limit !== undefined) query.limit(flags.limit);
+    const actors = await query.lean<ActorRow[]>();
+
+    logger.info(`[repairAtprotoActorHandles] ${actors.length} atproto actor(s) to scan`);
+
+    for (const actor of actors) {
+      counters.scanned += 1;
+
+      let outcome: RepairOutcome;
+      try {
+        outcome = await repairActor(actor, flags);
+      } catch (err) {
+        // One bad actor never aborts the run; the timeout is the defence-in-depth
+        // guard against an unbounded await hanging the whole sweep.
+        if (err instanceof ActorRepairTimeoutError) {
+          logger.warn(
+            `[repairAtprotoActorHandles] actor ${actor.uri} repair timed out after ${ACTOR_REPAIR_TIMEOUT_MS}ms — skipping`,
+          );
+        } else {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(`[repairAtprotoActorHandles] actor ${actor.uri} repair threw: ${message}`);
+        }
+        outcome = 'failed';
+      }
+
+      switch (outcome) {
+        case 'repaired':
+          counters.repaired += 1;
+          break;
+        case 'unchanged':
+          counters.unchanged += 1;
+          break;
+        case 'failed':
+          counters.failed += 1;
+          break;
+      }
+    }
+
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    logger.info(
+      `[repairAtprotoActorHandles] done (${flags.dryRun ? 'DRY-RUN' : 'LIVE'}, ${elapsedSeconds}s): ` +
+        `scanned ${counters.scanned}, repaired ${counters.repaired}, ` +
+        `unchanged ${counters.unchanged}, failed ${counters.failed}`,
+    );
+
+    await mongoose.disconnect();
+  } catch (error) {
+    logger.error('[repairAtprotoActorHandles] failed', error);
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  // Exit deterministically: imported singletons (BullMQ Redis connections, media
+  // cache workers) can keep the event loop alive, so the process would otherwise
+  // sit RUNNING after the work completes. Mirrors the other one-shot scripts.
+  repairAtprotoActorHandles()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error('[repairAtprotoActorHandles] unhandled failure', error);
+      process.exit(1);
+    });
+}
+
+export default repairAtprotoActorHandles;


### PR DESCRIPTION
`splitHandle` mis-derived the instance domain for multi-label custom-domain Bluesky handles: `mayor.nyc.gov` → `@mayor.nyc.gov@nyc.gov` (should be `@mayor.nyc.gov@bsky.social`). It stripped the first label and used the remaining multi-label parent as the domain (`nyc.gov`, `bsky.team`); bare `.com` apex handles only worked by luck.

For the atproto connector the instance is always the Bluesky network — `splitHandle` now returns `domain = BSKY_NETWORK_DOMAIN` always, full handle as username: `@gothamist.com@bsky.social`, `@mayor.nyc.gov@bsky.social`, `@carnage4life.bsky.social@bsky.social`.

Also `scripts/repairAtprotoActorHandles.ts`: re-derives all ~18 atproto actors, repairing the 6 with a wrong stored domain via `fetchAndUpsertAtprotoProfile` (updates both the Mention FederatedActor AND the linked Oxy user through one path). `--dry-run`, per-actor timeout.

Tests: 124 connector suite pass (splitHandle output pinned for 4 handles). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)