### PR TITLE
fix(federation): terminate infinite 'Loading posts…' on empty atproto profiles

### DIFF
--- a/packages/backend/src/__tests__/connectors/federatedProfileSync.test.ts
+++ b/packages/backend/src/__tests__/connectors/federatedProfileSync.test.ts
@@ -48,7 +48,15 @@ vi.mock('../../connectors/activitypub/ActivityPubConnector', () => ({
 
 vi.mock('../../connectors/activitypub/constants', () => ({ FEDERATION_ENABLED: true }));
 vi.mock('../../connectors/atproto/constants', () => ({ ATPROTO_ENABLED: false }));
-vi.mock('../../connectors/index', () => ({ connectorRegistry: { connectorFor: () => undefined } }));
+
+/** atproto backfill: the connector the registry hands back for an atproto URI. */
+const atprotoFetchPosts = vi.fn(async () => ({ posts: [] as unknown[] }));
+const connectorFor = vi.fn<(uri: string) => { fetchPosts: typeof atprotoFetchPosts } | undefined>(
+  () => undefined,
+);
+vi.mock('../../connectors/index', () => ({
+  connectorRegistry: { connectorFor: (...a: unknown[]) => connectorFor(...(a as [string])) },
+}));
 
 const getUserById = vi.fn(async () => ({ id: 'local1', type: 'user', username: 'local' }));
 vi.mock('../../utils/oxyHelpers', () => ({
@@ -70,6 +78,20 @@ function federatedActor(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/** A cached atproto (Bluesky) actor row: no AP outbox, keyed by DID. */
+function atprotoActor(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'atactor1',
+    protocol: 'atproto',
+    uri: 'did:plc:abc123',
+    acct: 'someone.bsky.social',
+    oxyUserId: 'at1',
+    postsCount: 0,
+    lastFetchedAt: new Date(),
+    ...overrides,
+  };
+}
+
 function mockActorLookup(actor: unknown) {
   actorFindOne.mockReturnValue({ lean: () => Promise.resolve(actor) });
 }
@@ -78,6 +100,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   releaseOutboxSync = undefined;
   fetchRemoteActor.mockResolvedValue(null);
+  connectorFor.mockReturnValue(undefined);
+  atprotoFetchPosts.mockResolvedValue({ posts: [] });
 });
 
 describe('federatedProfileSync.syncOnProfileView', () => {
@@ -154,5 +178,46 @@ describe('federatedProfileSync.syncOnProfileView', () => {
     actorFindOne.mockReturnValue({ lean: () => Promise.reject(new Error('mongo down')) });
 
     await expect(federatedProfileSync.syncOnProfileView('fed1')).resolves.toBe(false);
+  });
+
+  it('does NOT report pending for an atproto actor with zero upstream posts', async () => {
+    // A Bluesky account with genuinely 0 posts has nothing to import — reporting
+    // pending would make the client poll "Loading posts…" forever.
+    mockActorLookup(atprotoActor({ postsCount: 0 }));
+
+    const pending = await federatedProfileSync.syncOnProfileView('at1');
+
+    expect(pending).toBe(false);
+    // The AP outbox path must never run for an atproto actor.
+    expect(syncOutboxPostsDetailed).not.toHaveBeenCalled();
+  });
+
+  it('reports pending for an atproto actor with posts and no prior sync, then stamps the backfill', async () => {
+    connectorFor.mockReturnValue({ fetchPosts: atprotoFetchPosts });
+    mockActorLookup(atprotoActor({ postsCount: 5 }));
+
+    const pending = await federatedProfileSync.syncOnProfileView('at1');
+    expect(pending).toBe(true);
+
+    // The background task pulls the author feed, then stamps lastOutboxSyncAt so
+    // the next poll can clear — the stamp lands AFTER the import writes posts.
+    await vi.waitFor(() =>
+      expect(atprotoFetchPosts).toHaveBeenCalledWith('did:plc:abc123', { limit: 20 }),
+    );
+    await vi.waitFor(() =>
+      expect(actorUpdateOne).toHaveBeenCalledWith(
+        { _id: 'atactor1' },
+        { $set: { lastOutboxSyncAt: expect.any(Date) } },
+      ),
+    );
+    expect(syncOutboxPostsDetailed).not.toHaveBeenCalled();
+  });
+
+  it('clears pending for an atproto actor once the backfill has been stamped', async () => {
+    // postsCount > 0 skips the zero-post short-circuit; a recent stamp inside the
+    // cooldown window is what terminates the poll after the background import.
+    mockActorLookup(atprotoActor({ postsCount: 5, lastOutboxSyncAt: new Date() }));
+
+    await expect(federatedProfileSync.syncOnProfileView('at1')).resolves.toBe(false);
   });
 });

--- a/packages/backend/src/connectors/federatedProfileSync.ts
+++ b/packages/backend/src/connectors/federatedProfileSync.ts
@@ -118,9 +118,21 @@ class FederatedProfileSync {
           if (cachedActor.uri) {
             const connector = connectorRegistry.connectorFor(cachedActor.uri);
             if (connector) {
-              await connector.fetchPosts(cachedActor.uri, { limit: OUTBOX_SYNC_LIMIT });
+              try {
+                await connector.fetchPosts(cachedActor.uri, { limit: OUTBOX_SYNC_LIMIT });
+              } catch (fetchErr) {
+                // A failed backfill is still a COMPLETED sync attempt: stamp it
+                // below so the pending check can clear instead of polling forever.
+                const message = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+                logger.warn(`[FedSync] atproto backfill failed for ${cachedActor.acct}: ${message}`);
+              }
             }
           }
+          // Stamp the post-backfill time so `shouldReportPending` can clear. The
+          // atproto path never touches the ActivityPub outbox code that normally
+          // stamps `lastOutboxSyncAt`, so without this an atproto profile with an
+          // empty local feed would report `pending:true` on EVERY view forever.
+          await this.stampPostBackfill(cachedActor._id);
           return;
         }
 
@@ -291,6 +303,26 @@ class FederatedProfileSync {
     })();
   }
 
+  /**
+   * Stamp `lastOutboxSyncAt = now` on a federated actor after a post backfill.
+   *
+   * The field name is ActivityPub-flavoured, but `shouldReportPending` reads it
+   * as the single "when did we last try to import this actor's posts" signal for
+   * BOTH protocols. The atproto backfill (`fetchPosts`) never touches the AP
+   * outbox code that stamps it, so this is the atproto path's stamp point. An
+   * empty import is still a COMPLETED sync, so the caller stamps regardless of
+   * how many posts were imported. Fail-soft: a stamp failure only costs one more
+   * poll, never the detached task.
+   */
+  private async stampPostBackfill(actorId: IFederatedActor['_id']): Promise<void> {
+    try {
+      await FederatedActor.updateOne({ _id: actorId }, { $set: { lastOutboxSyncAt: new Date() } });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`[FedSync] failed to stamp post backfill for actor ${String(actorId)}: ${message}`);
+    }
+  }
+
   private shouldRefreshActorBeforeOutboxSync(actor: IFederatedActor): boolean {
     if (!actor.outboxUrl) return true;
     const fetchedAt = actor.lastFetchedAt?.getTime();
@@ -312,6 +344,13 @@ class FederatedProfileSync {
    * the empty profile instead of spinning.
    */
   private shouldReportPending(actor: IFederatedActor): boolean {
+    // An atproto actor with zero upstream posts has nothing to import, so it
+    // must never poll. Short-circuit the common empty case on the VERY first
+    // view — before the background backfill has stamped `lastOutboxSyncAt` — so
+    // a zero-post Bluesky profile renders empty immediately instead of spinning.
+    // (`postsCount` is populated from the Bluesky profile on actor upsert.)
+    if (actor.protocol === 'atproto' && (actor.postsCount ?? 0) === 0) return false;
+
     const outboxStatus = this.currentOutboxBackfillStatus(actor);
     if (outboxStatus === 'unavailable' || outboxStatus === 'complete') return false;
     if (outboxStatus === 'pending') return true;


### PR DESCRIPTION
Federated (Bluesky) profiles with no local posts showed "Loading posts…" forever. `shouldReportPending` returns `true` whenever `lastOutboxSyncAt` is unset, and the atproto `runInBackground` branch called `fetchPosts` but never stamped it (only the AP outbox path did) — so every atproto profile reported `pending:true` on every view, and an empty one (e.g. `nycimmigrants.bsky.social`, genuinely 0 posts upstream) polled forever.

- `runInBackground` atproto branch now stamps `lastOutboxSyncAt` after `fetchPosts` resolves (success or caught error) via a fail-soft `stampPostBackfill` — so a synced actor's pending clears on the next poll.
- `shouldReportPending` short-circuits `protocol==='atproto' && postsCount===0 → false`, so an account with zero upstream posts never polls (renders empty immediately).
- AP path + local-user path unchanged.

Tests: 11 pass (8 existing + 3 new). tsc clean. No useEffect/as any/ts-ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)