### PR TITLE
fix(frontend): interests infinite-spinner → React Query + remove 7 banned non-null assertions

### DIFF
--- a/packages/frontend/app/(app)/settings/interests.tsx
+++ b/packages/frontend/app/(app)/settings/interests.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
 import { Loading } from '@oxyhq/bloom/loading';
 import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
@@ -29,50 +30,63 @@ export default function InterestsSettingsScreen() {
     const { t } = useTranslation();
     const safeBack = useSafeBack();
     const { colors } = useTheme();
-    const { canUsePrivateApi, isPrivateApiPending } = useAuth();
+    const { user, canUsePrivateApi, isPrivateApiPending } = useAuth();
     const mySettings = useAppearanceStore((state) => state.mySettings);
     const loadMySettings = useAppearanceStore((state) => state.loadMySettings);
-    const [loading, setLoading] = useState(true);
     const [isSaving, setIsSaving] = useState(false);
-    const [interests, setInterests] = useState<string[]>([]);
-    const [availableInterests, setAvailableInterests] = useState<Array<{ name: string; displayName: string }>>([]);
+
+    // The interest categories are served by an auth-gated endpoint, so the query
+    // is keyed on the viewer identity and gated on `canUsePrivateApi` (matching
+    // the sibling authed settings screens). `getCategories` resolves to `[]` on
+    // failure rather than throwing, so the query always settles — the spinner can
+    // never hang, and an error simply surfaces the empty state.
+    const categoriesQuery = useQuery({
+        queryKey: ['interests', 'categories', user?.id],
+        queryFn: () => topicService.getCategories(),
+        enabled: canUsePrivateApi,
+        staleTime: 5 * 60 * 1000,
+    });
+
+    // Drive the Zustand `loadMySettings` action declaratively through React Query
+    // (no data-fetching effect, no fire-and-forget `void`). The action swallows its
+    // own errors, so this query settles regardless of outcome — the spinner clears
+    // on success AND on failure, rather than waiting forever for `mySettings` to
+    // become truthy (the old permanent-spinner bug).
+    const mySettingsQuery = useQuery({
+        queryKey: ['appearance', 'mySettings', user?.id],
+        queryFn: async () => {
+            await loadMySettings(true);
+            return useAppearanceStore.getState().mySettings ?? null;
+        },
+        enabled: canUsePrivateApi,
+    });
+
+    const availableInterests = useMemo(
+        () => (categoriesQuery.data ?? []).map((c) => ({ name: c.slug, displayName: c.displayName })),
+        [categoriesQuery.data]
+    );
 
     const preselectedInterests = useMemo(
         () => mySettings?.interests?.tags || [],
         [mySettings?.interests?.tags]
     );
 
-    useEffect(() => {
-        // Wait out the token-pending SSO window; keep the initial `loading`
-        // spinner up rather than firing private reads that would 401.
-        if (isPrivateApiPending) {
-            return;
-        }
-        if (!canUsePrivateApi) {
-            setLoading(false);
-            return;
-        }
-        void loadMySettings(true);
+    // Loading is derived from the two queries' fetch state (never from data
+    // presence). Both `getCategories` and `loadMySettings` resolve to an
+    // empty/degraded result instead of throwing, so `isLoading` always returns to
+    // `false` — the error path ends the spinner and shows the empty state.
+    const isLoading = categoriesQuery.isLoading || mySettingsQuery.isLoading;
 
-        let cancelled = false;
-        topicService.getCategories().then(categories => {
-            if (cancelled) return;
-            setAvailableInterests(categories.map(c => ({ name: c.slug, displayName: c.displayName })));
-        }).catch((error) => {
-            if (cancelled) return;
-            logger.error('Failed to load interest categories', { error });
-            setAvailableInterests([]);
-        });
-
-        return () => { cancelled = true; };
-    }, [canUsePrivateApi, isPrivateApiPending, loadMySettings]);
-
-    useEffect(() => {
-        if (mySettings) {
-            setInterests(preselectedInterests);
-            setLoading(false);
-        }
-    }, [mySettings, preselectedInterests]);
+    // Seed the locally-editable selection from the loaded settings, re-syncing
+    // whenever the persisted tags change (React's "adjust state during render"
+    // pattern — no effect). `preselectedInterests` only changes reference when the
+    // stored `interests.tags` array does, so this fires once per real update.
+    const [interests, setInterests] = useState<string[]>(preselectedInterests);
+    const [syncedInterests, setSyncedInterests] = useState<string[]>(preselectedInterests);
+    if (syncedInterests !== preselectedInterests) {
+        setSyncedInterests(preselectedInterests);
+        setInterests(preselectedInterests);
+    }
 
     const saveInterests = useMemo(() => {
         return debounce(async (...args: unknown[]) => {
@@ -162,7 +176,7 @@ export default function InterestsSettingsScreen() {
         );
     }
 
-    if (loading) {
+    if (isLoading) {
         return (
             <ThemedView className="flex-1">
                 <Header

--- a/packages/frontend/components/BoostScreen.tsx
+++ b/packages/frontend/components/BoostScreen.tsx
@@ -67,14 +67,14 @@ const BoostScreen: React.FC = () => {
     const canBoost = !isOverLimit && !isSubmitting;
 
     const handleBoost = async () => {
-        if (!canBoost || !user || !originalPost) return;
+        if (!canBoost || !user || !originalPost || !postId) return;
 
         setIsSubmitting(true);
 
         try {
             // Create boost request
             const boostRequest: CreateBoostRequest = {
-                originalPostId: postId!,
+                originalPostId: postId,
                 content: content.trim() ? { text: content.trim() } : undefined,
                 mentions: [],
                 hashtags: []

--- a/packages/frontend/components/Post/PostArticleModal.tsx
+++ b/packages/frontend/components/Post/PostArticleModal.tsx
@@ -97,12 +97,12 @@ const PostArticleModal: React.FC<PostArticleModalProps> = ({
 
   // Fetch article data when modal becomes visible and articleId is provided
   useEffect(() => {
-    if (!visible || !needsFetch) return;
+    if (!visible || !needsFetch || !articleId) return;
 
     let isMounted = true;
     setIsLoading(true);
     setLoadError(null);
-    articleService.getArticle(articleId!)
+    articleService.getArticle(articleId)
       .then((article) => {
         if (!isMounted) return;
         setFetchedTitle(article.title || title);

--- a/packages/frontend/components/Profile/ProfileMeta.tsx
+++ b/packages/frontend/components/Profile/ProfileMeta.tsx
@@ -46,7 +46,7 @@ export const ProfileMeta = memo(function ProfileMeta({
         </View>
       )}
 
-      {hasJoinDate && (
+      {createdAt && (
         <TouchableOpacity
           className="flex-row items-center gap-1"
           onPress={() => {
@@ -59,7 +59,7 @@ export const ProfileMeta = memo(function ProfileMeta({
         >
           <CalendarIcon size={16} className="text-muted-foreground" />
           <Text className="text-muted-foreground text-[15px]">
-            {t('profile.joined')} {formatJoinDate(createdAt!)}
+            {t('profile.joined')} {formatJoinDate(createdAt)}
           </Text>
           <ChevronRightIcon size={16} className="text-muted-foreground" />
         </TouchableOpacity>

--- a/packages/frontend/components/ZoomableAvatar.tsx
+++ b/packages/frontend/components/ZoomableAvatar.tsx
@@ -175,10 +175,13 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
         }
         
         if (imageUri && (imageUri.startsWith('http') || imageUri.startsWith('https'))) {
+          // Capture the narrowed URI in a const so it stays `string` inside the
+          // Promise closure (a `let` widens back to `string | undefined` there).
+          const remoteUri = imageUri;
           // Remote image - use React Native's Image.getSize
           const { width, height } = await new Promise<{ width: number; height: number }>((resolve, reject) => {
             RNImage.getSize(
-              imageUri!,
+              remoteUri,
               (width, height) => resolve({ width, height }),
               reject
             );

--- a/packages/frontend/services/socketService.ts
+++ b/packages/frontend/services/socketService.ts
@@ -580,11 +580,11 @@ class SocketService {
 
     // Queue updates for batching
     const feedType = type as FeedType;
-    if (!this.feedUpdateQueue.has(feedType)) {
-      this.feedUpdateQueue.set(feedType, []);
+    const existingQueue = this.feedUpdateQueue.get(feedType);
+    const queue = existingQueue ?? [];
+    if (!existingQueue) {
+      this.feedUpdateQueue.set(feedType, queue);
     }
-    
-    const queue = this.feedUpdateQueue.get(feedType)!;
     queue.push(...postsArray);
     
     // Clear existing timer
@@ -625,10 +625,10 @@ class SocketService {
       // When a feed is loading, the fetch response will include the posts, so we don't need
       // socket updates to add them again (which would cause duplicates)
       if (feedUI.isLoading) {
-        // Keep posts in queue - they'll be processed after loading completes
-        // But limit queue size to prevent memory issues
-        const currentQueue = this.feedUpdateQueue.get(feedType)!;
-        if (currentQueue.length > this.MAX_BATCH_SIZE * 2) {
+        // Keep posts in queue - they'll be processed after loading completes.
+        // `posts` is this feed type's queued array (the forEach value), so it is
+        // the current queue — cap its size to prevent memory issues.
+        if (posts.length > this.MAX_BATCH_SIZE * 2) {
           this.feedUpdateQueue.set(feedType, posts.slice(-this.MAX_BATCH_SIZE)); // Keep last MAX_BATCH_SIZE items
         }
         return;
@@ -685,11 +685,11 @@ class SocketService {
    * Queue engagement update for batching
    */
   private queueEngagementUpdate(postId: string, type: 'like' | 'unlike' | 'boost' | 'unboost' | 'save' | 'unsave' | 'reply', data: EngagementEventData) {
-    if (!this.engagementUpdateQueue.has(postId)) {
-      this.engagementUpdateQueue.set(postId, []);
+    const existingQueue = this.engagementUpdateQueue.get(postId);
+    const queue = existingQueue ?? [];
+    if (!existingQueue) {
+      this.engagementUpdateQueue.set(postId, queue);
     }
-
-    const queue = this.engagementUpdateQueue.get(postId)!;
 
     // Limit queue size to prevent memory issues
     if (queue.length >= this.MAX_ENGAGEMENT_BATCH_SIZE) {


### PR DESCRIPTION
interests.tsx loading could hang (cleared only when data became truthy) → React Query; removed 7 `!` non-null assertions (ProfileMeta, PostArticleModal, BoostScreen, ZoomableAvatar, socketService×3) with proper guards. No useEffect fetch, no as any. tsc clean, 362 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)