### PR TITLE
refactor(frontend): statistics/insights/weekly_recap → React Query (fix cold-boot infinite spinner)

### DIFF
--- a/packages/frontend/app/(app)/insights.tsx
+++ b/packages/frontend/app/(app)/insights.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
     View,
     Text,
@@ -9,6 +9,7 @@ import {
     type ViewStyle,
     type TextStyle
 } from 'react-native';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { Loading } from '@oxyhq/bloom/loading';
 import { SafeAreaView } from '@/lib/SafeAreaViewInterop';
 import { router } from 'expo-router';
@@ -16,9 +17,9 @@ import { useSafeBack } from '@/hooks/useSafeBack';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme, type Theme } from '@oxyhq/bloom/theme';
 import { ThemedView } from '@/components/ThemedView';
-import { statisticsService, UserStatistics, EngagementRatios } from '@/services/statisticsService';
+import { statisticsService } from '@/services/statisticsService';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '@oxyhq/services';
+import { useAuth, OxyAuthPrompt } from '@oxyhq/services';
 import { usePostsStore } from '@/stores/postsStore';
 import PostItem from '@/components/Feed/PostItem';
 import { HydratedPost } from '@mention/shared-types';
@@ -121,70 +122,53 @@ const PeriodSelector: React.FC<PeriodSelectorProps> = ({ selected, onSelect, the
 const InsightsScreen: React.FC = () => {
     const { t } = useTranslation();
     const theme = useTheme();
-    const { user } = useAuth();
+    const { user, canUsePrivateApi, isPrivateApiPending } = useAuth();
     const safeBack = useSafeBack();
 
-    const [loading, setLoading] = useState(true);
     const [selectedPeriod, setSelectedPeriod] = useState(30);
     const [activeTab, setActiveTab] = useState<'overview' | 'engagement'>('overview');
-    const [cache, setCache] = useState<Record<number, { stats: UserStatistics; engagement: EngagementRatios; topPosts: HydratedPost[] }>>({});
 
     const { getPostById } = usePostsStore();
 
-    const stats = cache[selectedPeriod]?.stats ?? null;
-    const engagementRatios = cache[selectedPeriod]?.engagement ?? null;
-    const topPostsData = cache[selectedPeriod]?.topPosts ?? [];
-
-    const loadPeriod = useCallback(async (period: number) => {
-        if (!user) return;
-
-        try {
-            const [statsData, engagementData] = await Promise.all([
-                statisticsService.getUserStatistics(period),
-                statisticsService.getEngagementRatios(period)
+    // Stats + engagement + hydrated top posts for the selected period. Keyed on
+    // the auth identity AND period so it fires only once the session lands,
+    // auto-re-runs when `user?.id` arrives after SSO restore, and refetches per
+    // period. `keepPreviousData` keeps the previous period on screen while a new
+    // one loads, matching the original background-prefetch smoothness. Gated on
+    // `canUsePrivateApi` since /statistics/* are private endpoints.
+    const { data, isLoading } = useQuery({
+        queryKey: ['insights', user?.id, selectedPeriod],
+        queryFn: async () => {
+            const [stats, engagement] = await Promise.all([
+                statisticsService.getUserStatistics(selectedPeriod),
+                statisticsService.getEngagementRatios(selectedPeriod)
             ]);
 
             let topPosts: HydratedPost[] = [];
-            if (statsData.topPosts && statsData.topPosts.length > 0) {
-                try {
-                    const postsPromises = statsData.topPosts.slice(0, 5).map(async (postInfo) => {
-                        try {
-                            return await getPostById(postInfo.postId);
-                        } catch (error: unknown) {
+            if (stats.topPosts && stats.topPosts.length > 0) {
+                const posts = await Promise.all(
+                    stats.topPosts.slice(0, 5).map((postInfo) =>
+                        getPostById(postInfo.postId).catch((error: unknown) => {
                             const status = (error as { response?: { status?: number } })?.response?.status;
                             if (status !== 404) {
                                 logger.error(`Error loading post ${postInfo.postId}`, { error });
                             }
                             return null;
-                        }
-                    });
-                    const posts = await Promise.all(postsPromises);
-                    topPosts = posts.filter((p): p is HydratedPost => p !== null);
-                } catch (error) {
-                    logger.error('Error loading top posts', { error });
-                }
+                        })
+                    )
+                );
+                topPosts = posts.filter((p): p is HydratedPost => p !== null);
             }
 
-            setCache(prev => ({ ...prev, [period]: { stats: statsData, engagement: engagementData, topPosts } }));
-        } catch (error) {
-            logger.error('Error loading statistics', { error });
-        }
-    }, [user, getPostById]);
+            return { stats, engagement, topPosts };
+        },
+        enabled: canUsePrivateApi,
+        placeholderData: keepPreviousData,
+    });
 
-    useEffect(() => {
-        if (!user) return;
-
-        const loadAll = async () => {
-            setLoading(true);
-            // Load selected period first, then others in background
-            await loadPeriod(30);
-            setLoading(false);
-            // Pre-fetch remaining periods
-            Promise.all([loadPeriod(7), loadPeriod(90)]);
-        };
-
-        loadAll();
-    }, [user, loadPeriod]);
+    const stats = data?.stats ?? null;
+    const engagementRatios = data?.engagement ?? null;
+    const topPostsData = data?.topPosts ?? [];
 
     const handlePeriodChange = useCallback((val: number) => {
         if (val !== selectedPeriod) setSelectedPeriod(val);
@@ -442,10 +426,15 @@ const InsightsScreen: React.FC = () => {
                         />
                     </View>
 
-                    {loading ? (
+                    {isPrivateApiPending || isLoading ? (
                         <View className="flex-1 justify-center items-center">
                             <Loading className="text-primary" size="large" />
                         </View>
+                    ) : !canUsePrivateApi ? (
+                        <OxyAuthPrompt
+                            label={t('insights.signInRequired', { defaultValue: 'Sign in to see your insights' })}
+                            description={t('insights.signInRequiredDesc', { defaultValue: 'Your posts, views, and engagement stats will appear here once you sign in.' })}
+                        />
                     ) : (
                         activeTab === 'overview' ? renderOverviewTab() : renderEngagementTab()
                     )}

--- a/packages/frontend/app/(app)/insights/weekly_recap.tsx
+++ b/packages/frontend/app/(app)/insights/weekly_recap.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React from 'react';
 import {
     View,
     Text,
     ScrollView,
 } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
 import { Loading } from '@oxyhq/bloom/loading';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSafeBack } from '@/hooks/useSafeBack';
@@ -15,7 +16,7 @@ import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { statisticsService, UserStatistics } from '@/services/statisticsService';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '@oxyhq/services';
+import { useAuth, OxyAuthPrompt } from '@oxyhq/services';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types';
 import StatCard from '@/components/insights/StatCard';
@@ -37,13 +38,8 @@ const WeeklyRecapScreen: React.FC = () => {
     const { t } = useTranslation();
     const theme = useTheme();
     const insets = useSafeAreaInsets();
-    const { user } = useAuth();
+    const { user, canUsePrivateApi, isPrivateApiPending } = useAuth();
     const safeBack = useSafeBack();
-
-    const [loading, setLoading] = useState(true);
-    const [data, setData] = useState<WeeklyRecapData | null>(null);
-    const [summary, setSummary] = useState<string | null>(null);
-    const [summaryLoading, setSummaryLoading] = useState(true);
 
     const getWeekDates = (weekOffset: number = 0) => {
         const today = new Date();
@@ -119,12 +115,13 @@ const WeeklyRecapScreen: React.FC = () => {
         return `${startMonth} ${startDay} - ${endMonth} ${endDay}`;
     };
 
-    const loadWeeklyRecap = useCallback(async () => {
-        if (!user) return;
-
-        try {
-            setLoading(true);
-
+    // Weekly recap = 14 days of stats split into current/previous week + an
+    // AI summary. Keyed on the auth identity so it fires only once the session
+    // lands and auto-re-runs when `user?.id` arrives after SSO restore. Gated on
+    // `canUsePrivateApi` since /statistics/* are private endpoints.
+    const { data: result, isLoading } = useQuery({
+        queryKey: ['weekly-recap', user?.id],
+        queryFn: async () => {
             // Fetch statistics for both weeks
             // Fetch 14 days total, then split into current week (last 7) and previous week (first 7)
             const [combinedStats, followerChanges, summaryResult] = await Promise.all([
@@ -132,9 +129,6 @@ const WeeklyRecapScreen: React.FC = () => {
                 statisticsService.getFollowerChanges(14).catch(() => null),
                 statisticsService.getWeeklySummary().catch(() => ({ summary: null })),
             ]);
-
-            setSummary(summaryResult.summary);
-            setSummaryLoading(false);
 
             // Split daily breakdown into current and previous weeks
             const dailyBreakdown = combinedStats.dailyBreakdown || [];
@@ -196,45 +190,45 @@ const WeeklyRecapScreen: React.FC = () => {
                 previousFollowers = previousWeekChanges.reduce((sum, change) => sum + Math.max(0, change.change), 0);
             }
 
-            setData({
+            const recap: WeeklyRecapData = {
                 currentWeek: currentWeekStats,
                 previousWeek: previousWeekStats,
                 newFollowers,
                 previousFollowers
-            });
-        } catch (error) {
-            logger.error('Error loading weekly recap', { error });
-        } finally {
-            setLoading(false);
-        }
-    }, [user]);
+            };
 
-    useEffect(() => {
-        loadWeeklyRecap();
-    }, [loadWeeklyRecap]);
+            return { recap, summary: summaryResult.summary };
+        },
+        enabled: canUsePrivateApi,
+    });
 
+    const data = result?.recap ?? null;
+    const summary = result?.summary ?? null;
 
+    const renderHeader = () => (
+        <View style={{ paddingTop: insets.top }}>
+            <Header
+                options={{
+                    title: t('insights.weeklyRecap.title'),
+                    leftComponents: [
+                        <IconButton variant="icon"
+                            key="back"
+                            onPress={() => safeBack()}
+                        >
+                            <BackArrowIcon size={20} className="text-foreground" />
+                        </IconButton>,
+                    ],
+                }}
+                hideBottomBorder={true}
+                disableSticky={true}
+            />
+        </View>
+    );
 
-    if (loading) {
+    if (isPrivateApiPending || isLoading) {
         return (
             <ThemedView className="flex-1">
-                <View style={{ paddingTop: insets.top }}>
-                    <Header
-                        options={{
-                            title: t('insights.weeklyRecap.title'),
-                            leftComponents: [
-                                <IconButton variant="icon"
-                                    key="back"
-                                    onPress={() => safeBack()}
-                                >
-                                    <BackArrowIcon size={20} className="text-foreground" />
-                                </IconButton>,
-                            ],
-                        }}
-                        hideBottomBorder={true}
-                        disableSticky={true}
-                    />
-                </View>
+                {renderHeader()}
                 <View className="flex-1 items-center justify-center">
                     <Loading className="text-primary" size="large" />
                 </View>
@@ -242,26 +236,22 @@ const WeeklyRecapScreen: React.FC = () => {
         );
     }
 
+    if (!canUsePrivateApi) {
+        return (
+            <ThemedView className="flex-1">
+                {renderHeader()}
+                <OxyAuthPrompt
+                    label={t('insights.signInRequired', { defaultValue: 'Sign in to see your insights' })}
+                    description={t('insights.signInRequiredDesc', { defaultValue: 'Your posts, views, and engagement stats will appear here once you sign in.' })}
+                />
+            </ThemedView>
+        );
+    }
+
     if (!data) {
         return (
             <ThemedView className="flex-1">
-                <View style={{ paddingTop: insets.top }}>
-                    <Header
-                        options={{
-                            title: t('insights.weeklyRecap.title'),
-                            leftComponents: [
-                                <IconButton variant="icon"
-                                    key="back"
-                                    onPress={() => safeBack()}
-                                >
-                                    <BackArrowIcon size={20} className="text-foreground" />
-                                </IconButton>,
-                            ],
-                        }}
-                        hideBottomBorder={true}
-                        disableSticky={true}
-                    />
-                </View>
+                {renderHeader()}
                 <View className="flex-1 items-center justify-center p-6">
                     <AnalyticsIcon size={64} color={theme.colors.text + '60'} />
                     <Text className="text-base mt-3 text-muted-foreground">
@@ -334,16 +324,9 @@ const WeeklyRecapScreen: React.FC = () => {
                     <Text className="text-2xl font-bold mt-4 mb-2 text-foreground" style={{ letterSpacing: -0.3 }}>
                         {t('insights.weeklyRecap.pageTitle')}
                     </Text>
-                    {summaryLoading ? (
-                        <View className="gap-2 px-5 w-full items-center mt-1">
-                            <View className="h-3 rounded bg-muted-foreground/20 w-4/5" />
-                            <View className="h-3 rounded bg-muted-foreground/20 w-3/5" />
-                        </View>
-                    ) : (
-                        <Text className="text-sm text-center px-5 leading-5 text-muted-foreground">
-                            {summary || dateRange}
-                        </Text>
-                    )}
+                    <Text className="text-sm text-center px-5 leading-5 text-muted-foreground">
+                        {summary || dateRange}
+                    </Text>
                 </View>
 
                 {/* Stats Cards - Full Width, Stacked */}

--- a/packages/frontend/app/(app)/statistics.tsx
+++ b/packages/frontend/app/(app)/statistics.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import {
     View,
     Text,
@@ -8,6 +8,7 @@ import {
     Dimensions,
     Platform,
 } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
 import { Loading } from '@oxyhq/bloom/loading';
 import { SafeAreaView } from '@/lib/SafeAreaViewInterop';
 import { Ionicons } from '@expo/vector-icons';
@@ -15,9 +16,9 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { ThemedView } from '@/components/ThemedView';
 import { Header } from '@/components/Header';
 import { PanelStickyHeader } from '@/components/shell/PanelChrome';
-import { statisticsService, UserStatistics, EngagementRatios } from '@/services/statisticsService';
+import { statisticsService } from '@/services/statisticsService';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '@oxyhq/services';
+import { useAuth, OxyAuthPrompt } from '@oxyhq/services';
 import { usePostsStore } from '@/stores/postsStore';
 import PostItem from '@/components/Feed/PostItem';
 import { HydratedPost } from '@mention/shared-types';
@@ -37,61 +38,46 @@ const PERIOD_OPTIONS = [
 const InsightsScreen: React.FC = () => {
     const { t } = useTranslation();
     const theme = useTheme();
-    const { user } = useAuth();
+    const { user, canUsePrivateApi, isPrivateApiPending } = useAuth();
 
-    const [loading, setLoading] = useState(true);
-    const [stats, setStats] = useState<UserStatistics | null>(null);
-    const [engagementRatios, setEngagementRatios] = useState<EngagementRatios | null>(null);
     const [selectedPeriod, setSelectedPeriod] = useState(30);
     const [activeTab, setActiveTab] = useState<'overview' | 'engagement'>('overview');
-    const [topPostsData, setTopPostsData] = useState<HydratedPost[]>([]);
-    const [loadingTopPosts, setLoadingTopPosts] = useState(false);
 
     const { getPostById } = usePostsStore();
 
-    const loadStatistics = useCallback(async () => {
-        if (!user) return;
-
-        try {
-            setLoading(true);
-            const [statsData, engagementData] = await Promise.all([
+    // Overview + engagement metrics for the selected period. Keyed on the auth
+    // identity so it fires only once the session lands and auto-re-runs when
+    // `user?.id` arrives after SSO restore (fixes the cold-boot miss). Gated on
+    // `canUsePrivateApi` since /statistics/* are private endpoints.
+    const { data: statistics, isLoading } = useQuery({
+        queryKey: ['statistics', user?.id, selectedPeriod],
+        queryFn: async () => {
+            const [stats, engagementRatios] = await Promise.all([
                 statisticsService.getUserStatistics(selectedPeriod),
                 statisticsService.getEngagementRatios(selectedPeriod)
             ]);
-            setStats(statsData);
-            setEngagementRatios(engagementData);
+            return { stats, engagementRatios };
+        },
+        enabled: canUsePrivateApi,
+    });
 
-            // Load top posts data
-            if (statsData.topPosts && statsData.topPosts.length > 0) {
-                setLoadingTopPosts(true);
-                try {
-                    const postsPromises = statsData.topPosts.slice(0, 5).map(async (postInfo) => {
-                        try {
-                            return await getPostById(postInfo.postId);
-                        } catch (error) {
-                            return null;
-                        }
-                    });
-                    const posts = await Promise.all(postsPromises);
-                    setTopPostsData(posts.filter((p): p is HydratedPost => p !== null));
-                } catch (error) {
-                    // Silently ignore top posts loading errors
-                } finally {
-                    setLoadingTopPosts(false);
-                }
-            } else {
-                setTopPostsData([]);
-            }
-        } catch (error) {
-            // Silently ignore statistics loading errors
-        } finally {
-            setLoading(false);
-        }
-    }, [selectedPeriod, user, getPostById]);
+    const stats = statistics?.stats ?? null;
+    const engagementRatios = statistics?.engagementRatios ?? null;
 
-    useEffect(() => {
-        loadStatistics();
-    }, [loadStatistics]);
+    const topPostIds = stats?.topPosts?.slice(0, 5).map((p) => p.postId) ?? [];
+
+    // Top-post hydration is a dependent query (needs the ids from `statistics`),
+    // preserving the original per-section loading spinner.
+    const { data: topPostsData = [], isLoading: loadingTopPosts } = useQuery({
+        queryKey: ['statistics-top-posts', user?.id, topPostIds],
+        queryFn: async () => {
+            const posts = await Promise.all(
+                topPostIds.map((postId) => getPostById(postId).catch(() => null))
+            );
+            return posts.filter((p): p is HydratedPost => p !== null);
+        },
+        enabled: canUsePrivateApi && topPostIds.length > 0,
+    });
 
 
     const renderOverviewTab = () => {
@@ -572,10 +558,15 @@ const InsightsScreen: React.FC = () => {
                 {/* Content. WEB renders in normal document flow (no page-level
                     scroll container — the body is the scroller, matching
                     Home/Profile). NATIVE keeps a ScrollView as the screen scroller. */}
-                {loading ? (
+                {isPrivateApiPending || isLoading ? (
                     <View className="flex-1 items-center justify-center py-24">
                         <Loading className="text-primary" size="large" />
                     </View>
+                ) : !canUsePrivateApi ? (
+                    <OxyAuthPrompt
+                        label={t('insights.signInRequired', { defaultValue: 'Sign in to see your insights' })}
+                        description={t('insights.signInRequiredDesc', { defaultValue: 'Your posts, views, and engagement stats will appear here once you sign in.' })}
+                    />
                 ) : IS_WEB ? (
                     <View className="p-3">
                         {activeTab === 'overview' ? renderOverviewTab() : renderEngagementTab()}

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -686,6 +686,8 @@
   },
   "insights": {
     "posts": "Posts",
+    "signInRequired": "Sign in to see your insights",
+    "signInRequiredDesc": "Your posts, views, and engagement stats will appear here once you sign in.",
     "period": {
       "7days": "7 Days",
       "30days": "30 Days",


### PR DESCRIPTION
The trio bailed `if(!user) return` before clearing loading → permanent spinner during SSO restore/anon. Now useQuery keyed on user?.id + period, enabled:canUsePrivateApi (auto re-runs on auth landing). No useEffect fetch, no as any. tsc clean, 362 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)