### PR TITLE
feat(federation): sync Bluesky starter packs (functional) + feed generators (read-only refs)

### DIFF
--- a/packages/backend/src/__tests__/connectors/atproto/feedGenMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/feedGenMapper.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * atproto feed-generator mirroring (READ-ONLY references).
+ *
+ *  - `mapGeneratorToExternalFeed`: `app.bsky.feed.getActorFeeds` generatorView →
+ *    normalized external-feed reference (service DID, name, description, avatar,
+ *    like count, bsky.app deep link), rejecting non-generator URIs.
+ *  - `syncActorFeeds`: getActorFeeds → upsert each reference on its AT-URI. The
+ *    XRPC fetch and the ExternalFeed model are mocked.
+ */
+
+const mocks = vi.hoisted(() => ({
+  xrpcGet: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+}));
+
+vi.mock('../../../connectors/atproto/xrpcClient', () => ({ xrpcGet: mocks.xrpcGet }));
+
+vi.mock('../../../models/ExternalFeed', () => ({
+  default: { findOneAndUpdate: mocks.findOneAndUpdate },
+}));
+
+import { mapGeneratorToExternalFeed, syncActorFeeds } from '../../../connectors/atproto/feedgen.mapper';
+
+const CREATOR_DID = 'did:plc:creator0000000000000000';
+const OWNER = 'oxy-creator';
+
+function genUri(rkey: string): string {
+  return `at://${CREATOR_DID}/app.bsky.feed.generator/${rkey}`;
+}
+
+function generatorView(rkey: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    uri: genUri(rkey),
+    did: 'did:web:feeds.example.com',
+    displayName: 'Cool Feed',
+    description: 'A nice feed',
+    likeCount: 42,
+    creator: { did: CREATOR_DID, handle: 'creator.bsky.social' },
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.findOneAndUpdate.mockResolvedValue({ _id: 'feed-doc' });
+});
+
+describe('mapGeneratorToExternalFeed', () => {
+  it('maps a generator view to a read-only reference with a handle-based deep link', () => {
+    const feed = mapGeneratorToExternalFeed(generatorView('t-videogames'));
+    expect(feed).toEqual({
+      uri: genUri('t-videogames'),
+      serviceDid: 'did:web:feeds.example.com',
+      name: 'Cool Feed',
+      description: 'A nice feed',
+      avatar: undefined,
+      likeCount: 42,
+      webUrl: 'https://bsky.app/profile/creator.bsky.social/feed/t-videogames',
+    });
+  });
+
+  it('falls back to the creator DID for the deep link when no handle is present', () => {
+    const feed = mapGeneratorToExternalFeed(generatorView('f1', { creator: { did: CREATOR_DID } }));
+    expect(feed?.webUrl).toBe(`https://bsky.app/profile/${CREATOR_DID}/feed/f1`);
+  });
+
+  it('rejects a non-generator URI, a missing service DID, and a missing name', () => {
+    expect(mapGeneratorToExternalFeed({ uri: `at://${CREATOR_DID}/app.bsky.feed.post/x`, did: 'did:web:x', displayName: 'n' })).toBeNull();
+    expect(mapGeneratorToExternalFeed(generatorView('f', { did: undefined }))).toBeNull();
+    expect(mapGeneratorToExternalFeed(generatorView('f', { displayName: '   ' }))).toBeNull();
+    expect(mapGeneratorToExternalFeed(undefined)).toBeNull();
+  });
+});
+
+describe('syncActorFeeds', () => {
+  it('upserts each feed reference on its AT-URI', async () => {
+    mocks.xrpcGet.mockResolvedValue({
+      feeds: [generatorView('f1'), generatorView('f2', { displayName: 'Second', avatar: 'https://cdn/a.jpg' })],
+    });
+
+    const count = await syncActorFeeds(CREATOR_DID, OWNER);
+
+    expect(count).toBe(2);
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    const [filter, update, options] = mocks.findOneAndUpdate.mock.calls[0];
+    expect(filter).toEqual({ uri: genUri('f1') });
+    expect(options).toEqual({ upsert: true });
+    expect(update.$set).toMatchObject({
+      network: 'atproto',
+      ownerOxyUserId: OWNER,
+      serviceDid: 'did:web:feeds.example.com',
+      name: 'Cool Feed',
+      webUrl: 'https://bsky.app/profile/creator.bsky.social/feed/f1',
+    });
+    expect(update.$set.syncedAt).toBeInstanceOf(Date);
+  });
+
+  it('skips unmappable generator views', async () => {
+    mocks.xrpcGet.mockResolvedValue({
+      feeds: [generatorView('ok'), { uri: 'not-an-at-uri', displayName: 'x', did: 'did:web:y' }],
+    });
+    const count = await syncActorFeeds(CREATOR_DID, OWNER);
+    expect(count).toBe(1);
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops without a resolved Oxy owner and fails soft on a fetch error', async () => {
+    expect(await syncActorFeeds(CREATOR_DID, '')).toBe(0);
+    expect(mocks.xrpcGet).not.toHaveBeenCalled();
+
+    mocks.xrpcGet.mockRejectedValue(new Error('boom'));
+    expect(await syncActorFeeds(CREATOR_DID, OWNER)).toBe(0);
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/connectors/atproto/starterPackMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/starterPackMapper.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * atproto starter-pack mirroring.
+ *
+ *  - `extractStarterPackRefs` / `extractMemberDids`: pure extraction from the
+ *    AppView `getActorStarterPacks` / `getList` shapes (filtering + caps).
+ *  - `syncActorStarterPacks`: getActorStarterPacks → getList members → resolve each
+ *    member DID to an Oxy user (the shared profile path) → upsert a `StarterPack`
+ *    deduped on `source.uri`. The XRPC fetch, the StarterPack model, and the member
+ *    profile resolver are mocked; the real bounded-concurrency pool runs.
+ */
+
+const mocks = vi.hoisted(() => ({
+  xrpcGet: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+  fetchProfile: vi.fn(),
+}));
+
+vi.mock('../../../connectors/atproto/xrpcClient', () => ({ xrpcGet: mocks.xrpcGet }));
+
+vi.mock('../../../models/StarterPack', () => ({
+  default: { findOneAndUpdate: mocks.findOneAndUpdate },
+}));
+
+vi.mock('../../../connectors/atproto/profile.mapper', () => ({
+  fetchAndUpsertAtprotoProfile: mocks.fetchProfile,
+}));
+
+import {
+  extractMemberDids,
+  extractStarterPackRefs,
+  syncActorStarterPacks,
+} from '../../../connectors/atproto/starterpack.mapper';
+
+const DID = 'did:plc:owner0000000000000000000';
+const OWNER = 'oxy-owner';
+
+function packUri(rkey: string): string {
+  return `at://${DID}/app.bsky.graph.starterpack/${rkey}`;
+}
+function listUri(rkey: string): string {
+  return `at://${DID}/app.bsky.graph.list/${rkey}`;
+}
+
+/** Route the mocked XRPC by nsid so one mock serves both endpoints. */
+function routeXrpc(
+  handlers: { starterPacks?: unknown; list?: Record<string, unknown> },
+): void {
+  mocks.xrpcGet.mockImplementation((_host: string, nsid: string, params: Record<string, unknown>) => {
+    if (nsid === 'app.bsky.graph.getActorStarterPacks') return Promise.resolve(handlers.starterPacks ?? { starterPacks: [] });
+    if (nsid === 'app.bsky.graph.getList') {
+      const list = typeof params.list === 'string' ? params.list : '';
+      return Promise.resolve(handlers.list?.[list] ?? { items: [] });
+    }
+    return Promise.resolve({});
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.findOneAndUpdate.mockResolvedValue({ _id: 'pack-doc' });
+  mocks.fetchProfile.mockImplementation((did: string) =>
+    Promise.resolve({ network: 'atproto', externalId: did, handle: `${did}.h`, oxyUserId: `oxy-${did.slice(-2)}` }),
+  );
+});
+
+describe('extractStarterPackRefs', () => {
+  it('keeps packs with a valid uri + name + list ref, drops the rest', () => {
+    const refs = extractStarterPackRefs({
+      starterPacks: [
+        { uri: packUri('p1'), record: { name: 'Great moots', list: listUri('l1') } },
+        { uri: packUri('p2'), record: { name: '   ', list: listUri('l2') } }, // blank name
+        { uri: packUri('p3'), record: { name: 'No list' } }, // missing list
+        { uri: `at://${DID}/app.bsky.feed.post/x`, record: { name: 'Wrong collection', list: listUri('l4') } },
+        { record: { name: 'No uri', list: listUri('l5') } }, // missing uri
+      ],
+    });
+    expect(refs).toEqual([{ uri: packUri('p1'), name: 'Great moots', listUri: listUri('l1') }]);
+  });
+
+  it('returns [] for an empty / malformed response', () => {
+    expect(extractStarterPackRefs(undefined)).toEqual([]);
+    expect(extractStarterPackRefs({})).toEqual([]);
+    expect(extractStarterPackRefs({ starterPacks: [] })).toEqual([]);
+  });
+});
+
+describe('extractMemberDids', () => {
+  it('pulls subject DIDs in order and dedups', () => {
+    expect(
+      extractMemberDids({
+        items: [
+          { subject: { did: 'did:plc:a' } },
+          { subject: { did: 'did:plc:b' } },
+          { subject: { did: 'did:plc:a' } }, // dup
+          { subject: {} }, // no did
+        ],
+      }),
+    ).toEqual(['did:plc:a', 'did:plc:b']);
+  });
+});
+
+describe('syncActorStarterPacks', () => {
+  it('mirrors a pack to a StarterPack with resolved members, keyed on source.uri', async () => {
+    routeXrpc({
+      starterPacks: { starterPacks: [{ uri: packUri('p1'), record: { name: 'Great moots', list: listUri('l1') } }] },
+      list: {
+        [listUri('l1')]: {
+          items: [{ subject: { did: 'did:plc:m1' } }, { subject: { did: 'did:plc:m2' } }],
+        },
+      },
+    });
+    mocks.fetchProfile.mockImplementation((did: string) => {
+      const map: Record<string, string> = { 'did:plc:m1': 'oxy-m1', 'did:plc:m2': 'oxy-m2' };
+      return Promise.resolve(map[did] ? { network: 'atproto', externalId: did, handle: 'h', oxyUserId: map[did] } : null);
+    });
+
+    const count = await syncActorStarterPacks(DID, OWNER);
+
+    expect(count).toBe(1);
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    const [filter, update, options] = mocks.findOneAndUpdate.mock.calls[0];
+    expect(filter).toEqual({ 'source.uri': packUri('p1') });
+    expect(options).toEqual({ upsert: true });
+    expect(update.$set).toMatchObject({
+      ownerOxyUserId: OWNER,
+      name: 'Great moots',
+      memberOxyUserIds: ['oxy-m1', 'oxy-m2'],
+    });
+    expect(update.$set.source).toMatchObject({ network: 'atproto', uri: packUri('p1') });
+    expect(update.$set.source.syncedAt).toBeInstanceOf(Date);
+  });
+
+  it('drops members that do not resolve to an Oxy user (no orphan members)', async () => {
+    routeXrpc({
+      starterPacks: { starterPacks: [{ uri: packUri('p1'), record: { name: 'Pack', list: listUri('l1') } }] },
+      list: {
+        [listUri('l1')]: {
+          items: [{ subject: { did: 'did:plc:ok' } }, { subject: { did: 'did:plc:ghost' } }],
+        },
+      },
+    });
+    mocks.fetchProfile.mockImplementation((did: string) =>
+      did === 'did:plc:ok'
+        ? Promise.resolve({ network: 'atproto', externalId: did, handle: 'h', oxyUserId: 'oxy-ok' })
+        : Promise.resolve(null),
+    );
+
+    await syncActorStarterPacks(DID, OWNER);
+
+    expect(mocks.findOneAndUpdate.mock.calls[0][1].$set.memberOxyUserIds).toEqual(['oxy-ok']);
+  });
+
+  it('resolves each DISTINCT member DID once even when shared across packs', async () => {
+    routeXrpc({
+      starterPacks: {
+        starterPacks: [
+          { uri: packUri('p1'), record: { name: 'A', list: listUri('l1') } },
+          { uri: packUri('p2'), record: { name: 'B', list: listUri('l2') } },
+        ],
+      },
+      list: {
+        [listUri('l1')]: { items: [{ subject: { did: 'did:plc:shared' } }] },
+        [listUri('l2')]: { items: [{ subject: { did: 'did:plc:shared' } }] },
+      },
+    });
+    mocks.fetchProfile.mockResolvedValue({ network: 'atproto', externalId: 'did:plc:shared', handle: 'h', oxyUserId: 'oxy-shared' });
+
+    await syncActorStarterPacks(DID, OWNER);
+
+    // Two packs upserted, but the shared member resolved only once.
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    expect(mocks.fetchProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent — a re-sync upserts on the same source.uri, never creating a duplicate', async () => {
+    routeXrpc({
+      starterPacks: { starterPacks: [{ uri: packUri('p1'), record: { name: 'Pack', list: listUri('l1') } }] },
+      list: { [listUri('l1')]: { items: [{ subject: { did: 'did:plc:m1' } }] } },
+    });
+    mocks.fetchProfile.mockResolvedValue({ network: 'atproto', externalId: 'did:plc:m1', handle: 'h', oxyUserId: 'oxy-m1' });
+
+    await syncActorStarterPacks(DID, OWNER);
+    await syncActorStarterPacks(DID, OWNER);
+
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    // Both runs target the same document via the source-uri dedup key + upsert.
+    for (const call of mocks.findOneAndUpdate.mock.calls) {
+      expect(call[0]).toEqual({ 'source.uri': packUri('p1') });
+      expect(call[2]).toEqual({ upsert: true });
+    }
+  });
+
+  it('no-ops without a resolved Oxy owner (no orphan packs) and never fetches', async () => {
+    const count = await syncActorStarterPacks(DID, '');
+    expect(count).toBe(0);
+    expect(mocks.xrpcGet).not.toHaveBeenCalled();
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('fails soft when getActorStarterPacks throws', async () => {
+    mocks.xrpcGet.mockRejectedValue(new Error('appview 502'));
+    const count = await syncActorStarterPacks(DID, OWNER);
+    expect(count).toBe(0);
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/externalFeedModel.test.ts
+++ b/packages/backend/src/__tests__/externalFeedModel.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * The ExternalFeed model — a READ-ONLY reference to a remote (atproto) feed
+ * generator. Offline construct → validateSync → index-declaration checks (the repo
+ * has no mongodb-memory-server); no DB connection is opened.
+ */
+
+import ExternalFeed from '../models/ExternalFeed';
+
+describe('ExternalFeed model', () => {
+  it('round-trips a valid feed reference', () => {
+    const now = new Date();
+    const doc = new ExternalFeed({
+      network: 'atproto',
+      uri: 'at://did:plc:c/app.bsky.feed.generator/t-news',
+      ownerOxyUserId: 'oxy-creator',
+      serviceDid: 'did:web:feeds.example.com',
+      name: 'T - News',
+      description: 'hot news posts',
+      likeCount: 12,
+      webUrl: 'https://bsky.app/profile/creator.bsky.social/feed/t-news',
+      syncedAt: now,
+    });
+    expect(doc.validateSync()).toBeUndefined();
+    const obj = doc.toObject();
+    expect(obj.uri).toBe('at://did:plc:c/app.bsky.feed.generator/t-news');
+    expect(obj.serviceDid).toBe('did:web:feeds.example.com');
+    expect(obj.webUrl).toBe('https://bsky.app/profile/creator.bsky.social/feed/t-news');
+  });
+
+  it('requires the load-bearing reference fields', () => {
+    const doc = new ExternalFeed({ network: 'atproto' });
+    const error = doc.validateSync();
+    expect(error).toBeDefined();
+    // Missing the fields a reference card cannot render / dedup without.
+    for (const field of ['uri', 'ownerOxyUserId', 'serviceDid', 'name', 'webUrl', 'syncedAt']) {
+      expect(error?.errors[field]).toBeDefined();
+    }
+  });
+
+  it('declares a unique index on uri and an owner-lookup index', () => {
+    const indexes = ExternalFeed.schema.indexes();
+    const uriIndex = indexes.find(([keys]) => Object.prototype.hasOwnProperty.call(keys, 'uri'));
+    expect(uriIndex?.[1]).toMatchObject({ unique: true });
+    const ownerIndex = indexes.find(
+      ([keys]) => keys.ownerOxyUserId === 1 && Object.prototype.hasOwnProperty.call(keys, 'createdAt'),
+    );
+    expect(ownerIndex).toBeDefined();
+  });
+});

--- a/packages/backend/src/__tests__/migrations/federatedStarterPackSourceIndex.test.ts
+++ b/packages/backend/src/__tests__/migrations/federatedStarterPackSourceIndex.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+import { migrationFederatedStarterPackSourceIndex } from '../../migrations/0006-federated-starter-pack-source-index';
+
+/**
+ * Offline coverage for migration 0006 (federated starter-pack + external-feed
+ * indexes). `autoIndex`/`autoCreate` are OFF in production, so this migration is
+ * the only thing that creates the sparse-unique `source.uri` dedup index (without
+ * which re-sync would duplicate mirrored packs) and the `externalfeeds` indexes.
+ * The Mongo `Db` / collections are faked (createIndex captured) so the real branch
+ * logic runs without a database.
+ */
+
+function makeDb() {
+  const starterPacksCreateIndex = vi.fn().mockResolvedValue('idx');
+  const externalFeedsCreateIndex = vi.fn().mockResolvedValue('idx');
+  const collections: Record<string, { collectionName: string; createIndex: ReturnType<typeof vi.fn> }> = {
+    starterpacks: { collectionName: 'starterpacks', createIndex: starterPacksCreateIndex },
+    externalfeeds: { collectionName: 'externalfeeds', createIndex: externalFeedsCreateIndex },
+  };
+  const db = {
+    collection: vi.fn((name: string) => collections[name]),
+  } as unknown as mongoose.mongo.Db;
+  return { db, starterPacksCreateIndex, externalFeedsCreateIndex };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('migration 0006 — federated starter-pack + external-feed indexes', () => {
+  it('creates the sparse-unique source.uri index on starterpacks', async () => {
+    const { db, starterPacksCreateIndex } = makeDb();
+
+    await migrationFederatedStarterPackSourceIndex.run(db);
+
+    expect(starterPacksCreateIndex).toHaveBeenCalledWith({ 'source.uri': 1 }, { unique: true, sparse: true });
+  });
+
+  it('creates the unique uri + owner-lookup indexes on externalfeeds', async () => {
+    const { db, externalFeedsCreateIndex } = makeDb();
+
+    await migrationFederatedStarterPackSourceIndex.run(db);
+
+    expect(externalFeedsCreateIndex).toHaveBeenCalledWith({ uri: 1 }, { unique: true });
+    expect(externalFeedsCreateIndex).toHaveBeenCalledWith({ ownerOxyUserId: 1, createdAt: -1 });
+  });
+
+  it('resolves the collections from the models, not hardcoded names', async () => {
+    const { db } = makeDb();
+
+    await migrationFederatedStarterPackSourceIndex.run(db);
+
+    expect(db.collection).toHaveBeenCalledWith('starterpacks');
+    expect(db.collection).toHaveBeenCalledWith('externalfeeds');
+  });
+});

--- a/packages/backend/src/__tests__/routes/starterPacksFederatedGuard.test.ts
+++ b/packages/backend/src/__tests__/routes/starterPacksFederatedGuard.test.ts
@@ -1,0 +1,113 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A federated-source starter pack (mirrored from atproto) is read-only through
+ * Mention's write API: every mutation route rejects it with 403 BEFORE the
+ * ownership check, so a local user can never edit or delete an upstream-owned pack
+ * (its membership is re-synced in place and a local edit would be overwritten).
+ * Following its members (`POST /:id/use`) stays allowed. The model + the collaborator
+ * services are mocked so the router runs in isolation.
+ */
+
+const { findById } = vi.hoisted(() => ({ findById: vi.fn() }));
+
+vi.mock('../../models/StarterPack', () => ({
+  default: { findById },
+}));
+
+// Heavy collaborators the router imports — stubbed so importing it never drags in
+// the Oxy service chain / a server circular import.
+vi.mock('../../services/PostHydrationService', () => ({
+  resolveUserSummaries: vi.fn().mockResolvedValue(new Map()),
+  isFallbackUserSummary: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../services/userSummaryCache', () => ({ invalidate: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../services/EndorsementSignalService', () => ({
+  endorsementSignalService: {
+    syncScope: vi.fn().mockResolvedValue(undefined),
+    syncScopeMembershipChange: vi.fn().mockResolvedValue(undefined),
+    syncScopeRemoval: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import starterPacksRoutes from '../../routes/starterPacks';
+
+const READONLY_MESSAGE = 'This starter pack is mirrored from an external network and is read-only';
+
+let authUserId: string | undefined = 'viewer-1';
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (req as unknown as { user?: { id: string } }).user = authUserId ? { id: authUserId } : undefined;
+  next();
+});
+app.use('/starter-packs', starterPacksRoutes);
+
+function federatedPack(): Record<string, unknown> {
+  return {
+    _id: 'pack-fed',
+    ownerOxyUserId: 'oxy-federated-owner',
+    name: 'Bluesky pack',
+    memberOxyUserIds: ['a', 'b'],
+    source: { network: 'atproto', uri: 'at://did:plc:x/app.bsky.graph.starterpack/p1', syncedAt: new Date() },
+    save: vi.fn(),
+    deleteOne: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authUserId = 'viewer-1';
+});
+
+describe('federated starter pack is read-only', () => {
+  it.each([
+    ['put', '/starter-packs/pack-fed', { name: 'hacked' }],
+    ['post', '/starter-packs/pack-fed/members', { userIds: ['c'] }],
+    ['delete', '/starter-packs/pack-fed/members', { userIds: ['a'] }],
+    ['delete', '/starter-packs/pack-fed', {}],
+  ] as const)('rejects %s %s with 403 read-only', async (method, path, body) => {
+    const pack = federatedPack();
+    findById.mockResolvedValue(pack);
+
+    const res = await request(app)[method](path).send(body);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe(READONLY_MESSAGE);
+    // The mutation never happened.
+    expect(pack.save).not.toHaveBeenCalled();
+    expect(pack.deleteOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects the federated pack before the ownership check (even for a non-owner)', async () => {
+    authUserId = 'someone-else';
+    findById.mockResolvedValue(federatedPack());
+
+    const res = await request(app).put('/starter-packs/pack-fed').send({ name: 'x' });
+
+    // Read-only wins over "Not allowed" — the pack is never editable by anyone.
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe(READONLY_MESSAGE);
+  });
+});
+
+describe('native starter pack is unaffected by the federated guard', () => {
+  it('still applies the normal ownership check (403 Not allowed, not the read-only message)', async () => {
+    findById.mockResolvedValue({
+      _id: 'pack-native',
+      ownerOxyUserId: 'some-other-owner', // not the viewer
+      name: 'Native pack',
+      memberOxyUserIds: [],
+      // no `source` → not federated
+      save: vi.fn(),
+    });
+
+    const res = await request(app).put('/starter-packs/pack-native').send({ name: 'x' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Not allowed');
+  });
+});

--- a/packages/backend/src/__tests__/starterPackSourceModel.test.ts
+++ b/packages/backend/src/__tests__/starterPackSourceModel.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * The `source` provenance subfield on the StarterPack model: it marks a pack as
+ * mirrored from an external network (read-only) and is the sparse-unique dedup key
+ * for re-sync. Offline construct → validateSync → index-declaration checks (the
+ * repo has no mongodb-memory-server); no DB connection is opened.
+ */
+
+import StarterPack from '../models/StarterPack';
+
+describe('StarterPack model — external source', () => {
+  it('round-trips a valid atproto source subdoc', () => {
+    const now = new Date();
+    const doc = new StarterPack({
+      ownerOxyUserId: 'oxy-federated',
+      name: 'Mirrored pack',
+      memberOxyUserIds: ['m1', 'm2'],
+      source: { network: 'atproto', uri: 'at://did:plc:x/app.bsky.graph.starterpack/p1', syncedAt: now },
+    });
+    expect(doc.validateSync()).toBeUndefined();
+    const obj = doc.toObject();
+    expect(obj.source?.network).toBe('atproto');
+    expect(obj.source?.uri).toBe('at://did:plc:x/app.bsky.graph.starterpack/p1');
+    expect(obj.source?.syncedAt).toEqual(now);
+  });
+
+  it('still constructs a native pack with no source', () => {
+    const doc = new StarterPack({ ownerOxyUserId: 'oxy-1', name: 'Native', memberOxyUserIds: ['a'] });
+    expect(doc.validateSync()).toBeUndefined();
+    expect(doc.toObject().source).toBeUndefined();
+  });
+
+  it('rejects an unknown source network via schema validation', () => {
+    const doc = new StarterPack({
+      ownerOxyUserId: 'oxy-1',
+      name: 'Bad source',
+      source: { network: 'nostr', uri: 'x', syncedAt: new Date() },
+    });
+    const error = doc.validateSync();
+    expect(error).toBeDefined();
+    expect(error?.errors['source.network']).toBeDefined();
+  });
+
+  it('declares a sparse UNIQUE index on source.uri (the re-sync dedup key)', () => {
+    const indexes = StarterPack.schema.indexes();
+    const sourceIndex = indexes.find(([keys]) => Object.prototype.hasOwnProperty.call(keys, 'source.uri'));
+    expect(sourceIndex).toBeDefined();
+    const [, options] = sourceIndex ?? [{}, {}];
+    expect(options).toMatchObject({ unique: true, sparse: true });
+  });
+});

--- a/packages/backend/src/__tests__/utils/concurrency.test.ts
+++ b/packages/backend/src/__tests__/utils/concurrency.test.ts
@@ -4,12 +4,13 @@ import {
   mapWithConcurrency,
   DEFAULT_CONCURRENCY,
   MAX_CONCURRENCY,
-} from '../../scripts/mapWithConcurrency';
+} from '../../utils/concurrency';
 
 /**
- * The bounded-concurrency pool that both one-shot repair sweeps
- * (`reingestBlueskyPosts`, `pruneGoneFederatedActors`) run their per-page work
- * through. The properties that matter for a live prod sweep:
+ * The shared bounded-concurrency pool that the one-shot repair sweeps
+ * (`reingestBlueskyPosts`, `pruneGoneFederatedActors`, `syncBlueskyStarterPacks`)
+ * and the runtime atproto starter-pack member resolution run their work through.
+ * The properties that matter for a live prod sweep:
  *
  *  - it never runs more than `concurrency` workers at once (that cap is the only
  *    thing keeping the sweep from hammering oxy-api / the remote servers);

--- a/packages/backend/src/connectors/atproto/constants.ts
+++ b/packages/backend/src/connectors/atproto/constants.ts
@@ -45,6 +45,12 @@ export const BSKY_NETWORK_DOMAIN = 'bsky.social';
 /** The atproto record collection that holds a feed post. */
 export const POST_COLLECTION = 'app.bsky.feed.post';
 
+/** The atproto record collection that holds a starter pack. */
+export const STARTER_PACK_COLLECTION = 'app.bsky.graph.starterpack';
+
+/** The atproto record collection that holds a feed generator declaration. */
+export const FEED_GENERATOR_COLLECTION = 'app.bsky.feed.generator';
+
 /**
  * A `did:plc:` identifier: the literal prefix followed by 24 base32-sortable
  * characters (lowercase `a-z` + digits `2-7`).

--- a/packages/backend/src/connectors/atproto/feedgen.mapper.ts
+++ b/packages/backend/src/connectors/atproto/feedgen.mapper.ts
@@ -1,0 +1,146 @@
+import { normalizeInlineText, normalizeMultilineText } from '@oxyhq/core';
+import { logger } from '../../utils/logger';
+import ExternalFeed from '../../models/ExternalFeed';
+import { xrpcGet } from './xrpcClient';
+import { BSKY_APP_ORIGIN, FEED_GENERATOR_COLLECTION, PUBLIC_APPVIEW } from './constants';
+
+/**
+ * Mirrors a Bluesky actor's FEED GENERATORS (`app.bsky.feed.generator`) into
+ * Mention's `ExternalFeed` collection as READ-ONLY references.
+ *
+ * A Bluesky feed is a remote algorithmic SERVICE (`view.did` is a `did:web:` host
+ * that runs the ranking) — Mention CANNOT execute it, so this deliberately does
+ * NOT build a runnable Mention feed (`CustomFeed`/`FeedGenerator`). It stores only
+ * display metadata + a `webUrl` deep link so a synced profile can surface "feeds
+ * created by this user" as reference cards that open on Bluesky. Deduped on the
+ * feed's AT-URI; re-sync refreshes metadata in place.
+ */
+
+/** Max feed references mirrored per actor in one sync (a single AppView page). */
+const MAX_FEEDS_PER_ACTOR = 50;
+
+/** A `generatorView` from `app.bsky.feed.getActorFeeds` (only the read fields). */
+interface AtprotoGeneratorView {
+  /** The feed generator's AT-URI (`at://<creatorDid>/app.bsky.feed.generator/<rkey>`). */
+  uri?: string;
+  /** The DID of the remote service that RUNS the algorithm (never executed here). */
+  did?: string;
+  displayName?: string;
+  description?: string;
+  avatar?: string;
+  likeCount?: number;
+  creator?: { did?: string; handle?: string };
+}
+
+interface AtprotoGetActorFeedsResponse {
+  feeds?: AtprotoGeneratorView[];
+  cursor?: string;
+}
+
+/** A feed generator reduced to the read-only reference fields Mention stores. */
+export interface NormalizedExternalFeed {
+  uri: string;
+  serviceDid: string;
+  name: string;
+  description?: string;
+  avatar?: string;
+  likeCount: number;
+  webUrl: string;
+}
+
+/** Parse `at://<authority>/<collection>/<rkey>` into its parts. Pure. */
+function parseAtUri(uri: string): { authority: string; collection: string; rkey: string } | null {
+  const match = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/([^/]+)$/);
+  if (!match) return null;
+  return { authority: match[1], collection: match[2], rkey: match[3] };
+}
+
+/**
+ * Map a `getActorFeeds` generator view to a read-only external feed reference.
+ * Returns null for anything that is not a feed generator AT-URI or is missing the
+ * service DID / a display name. Pure.
+ */
+export function mapGeneratorToExternalFeed(view: AtprotoGeneratorView | undefined): NormalizedExternalFeed | null {
+  if (!view) return null;
+  const uri = typeof view.uri === 'string' ? view.uri : '';
+  const parsed = parseAtUri(uri);
+  if (!parsed || parsed.collection !== FEED_GENERATOR_COLLECTION) return null;
+
+  const serviceDid = typeof view.did === 'string' ? view.did : '';
+  const name = typeof view.displayName === 'string' ? normalizeInlineText(view.displayName) : '';
+  if (!serviceDid || !name) return null;
+
+  const description = typeof view.description === 'string' ? normalizeMultilineText(view.description) : '';
+  // Prefer the creator's handle for a human-friendly deep link; fall back to the
+  // AT-URI authority (the creator DID) which bsky.app also resolves.
+  const creatorRef =
+    (typeof view.creator?.handle === 'string' && view.creator.handle) || parsed.authority;
+  const webUrl = `${BSKY_APP_ORIGIN}/profile/${creatorRef}/feed/${parsed.rkey}`;
+
+  return {
+    uri,
+    serviceDid,
+    name,
+    description: description || undefined,
+    avatar: typeof view.avatar === 'string' && view.avatar ? view.avatar : undefined,
+    likeCount: typeof view.likeCount === 'number' ? view.likeCount : 0,
+    webUrl,
+  };
+}
+
+/**
+ * Sync an atproto actor's feed generators into `ExternalFeed` as read-only
+ * references. `ownerOxyUserId` is the ALREADY-RESOLVED Oxy user who created the
+ * feeds. Best-effort + bounded (a single capped AppView page); returns the number
+ * of references upserted; never throws.
+ */
+export async function syncActorFeeds(did: string, ownerOxyUserId: string): Promise<number> {
+  if (!ownerOxyUserId) {
+    logger.warn(`[atproto] syncActorFeeds called for ${did} without a resolved Oxy owner; skipping`);
+    return 0;
+  }
+
+  let response: AtprotoGetActorFeedsResponse;
+  try {
+    response = await xrpcGet<AtprotoGetActorFeedsResponse>(PUBLIC_APPVIEW, 'app.bsky.feed.getActorFeeds', {
+      actor: did,
+      limit: MAX_FEEDS_PER_ACTOR,
+    });
+  } catch (err) {
+    logger.debug(`[atproto] getActorFeeds failed for ${did}`, err);
+    return 0;
+  }
+
+  const views = Array.isArray(response?.feeds) ? response.feeds.slice(0, MAX_FEEDS_PER_ACTOR) : [];
+  let upserted = 0;
+  for (const view of views) {
+    const feed = mapGeneratorToExternalFeed(view);
+    if (!feed) continue;
+    try {
+      await ExternalFeed.findOneAndUpdate(
+        { uri: feed.uri },
+        {
+          $set: {
+            network: 'atproto',
+            ownerOxyUserId,
+            serviceDid: feed.serviceDid,
+            name: feed.name,
+            description: feed.description,
+            avatar: feed.avatar,
+            likeCount: feed.likeCount,
+            webUrl: feed.webUrl,
+            syncedAt: new Date(),
+          },
+        },
+        { upsert: true },
+      );
+      upserted += 1;
+    } catch (err) {
+      // A concurrent sync racing the same feed to an E11000 is benign; log + skip.
+      logger.warn(`[atproto] failed to upsert external feed ${feed.uri}`, err);
+    }
+  }
+
+  if (upserted > 0) logger.info(`[atproto] mirrored ${upserted} external feed references for ${did}`);
+  return upserted;
+}

--- a/packages/backend/src/connectors/atproto/profileGraph.ts
+++ b/packages/backend/src/connectors/atproto/profileGraph.ts
@@ -1,0 +1,32 @@
+import { logger } from '../../utils/logger';
+import { syncActorStarterPacks } from './starterpack.mapper';
+import { syncActorFeeds } from './feedgen.mapper';
+
+/**
+ * Sync an atproto actor's PROFILE GRAPH extras — its starter packs (functional
+ * mirror) and its feed-generator references (read-only) — in one call.
+ *
+ * This is the single entry point shared by the live sync-on-view path
+ * (`federatedProfileSync`) and the one-shot backfill (`syncBlueskyStarterPacks`),
+ * so both discover the same extras through one code path — mirroring how post
+ * backfill is the single discovery path for a profile's posts.
+ *
+ * `ownerOxyUserId` must already be resolved (the no-orphan invariant — the caller
+ * resolves the profile first). Each half is independently best-effort and never
+ * throws, so one failing does not skip the other; the whole call is fail-soft.
+ */
+export async function syncAtprotoProfileGraph(did: string, ownerOxyUserId: string): Promise<void> {
+  const [packs, feeds] = await Promise.allSettled([
+    syncActorStarterPacks(did, ownerOxyUserId),
+    syncActorFeeds(did, ownerOxyUserId),
+  ]);
+
+  if (packs.status === 'rejected') {
+    const message = packs.reason instanceof Error ? packs.reason.message : String(packs.reason);
+    logger.warn(`[atproto] starter-pack sync threw for ${did}: ${message}`);
+  }
+  if (feeds.status === 'rejected') {
+    const message = feeds.reason instanceof Error ? feeds.reason.message : String(feeds.reason);
+    logger.warn(`[atproto] feed-reference sync threw for ${did}: ${message}`);
+  }
+}

--- a/packages/backend/src/connectors/atproto/starterpack.mapper.ts
+++ b/packages/backend/src/connectors/atproto/starterpack.mapper.ts
@@ -1,0 +1,306 @@
+import { logger } from '../../utils/logger';
+import StarterPack from '../../models/StarterPack';
+import { mapWithConcurrency } from '../../utils/concurrency';
+import { xrpcGet } from './xrpcClient';
+import { fetchAndUpsertAtprotoProfile } from './profile.mapper';
+import { PUBLIC_APPVIEW, STARTER_PACK_COLLECTION } from './constants';
+
+/**
+ * Mirrors a Bluesky actor's STARTER PACKS (`app.bsky.graph.starterpack`) into
+ * Mention's own `StarterPack` collection as read-only, upstream-owned packs.
+ *
+ * A Bluesky starter pack is a named curation whose `record.list` points at an
+ * `app.bsky.graph.list` of member accounts. This module resolves each pack's
+ * member DIDs to Oxy users through the SAME sanctioned identity path post mentions
+ * use (`fetchAndUpsertAtprotoProfile` — creates the federated Oxy user if new),
+ * then upserts a `StarterPack` owned by the profile's Oxy user, deduped on the
+ * source AT-URI (`source.uri`) so a re-sync updates name + membership in place and
+ * never duplicates.
+ *
+ * Bounded + fail-soft by construction: a hard cap on packs, list pages, per-pack
+ * members and total member resolutions; each atproto GET is time-bounded by the
+ * XRPC client's request deadline; and one bad pack/member never aborts the rest.
+ */
+
+// --- caps (a power user can have many packs with many members) --------------
+
+/** Max starter packs mirrored per actor in one sync (a single AppView page). */
+const MAX_STARTER_PACKS_PER_ACTOR = 25;
+
+/** Max members mirrored per pack — matches the `StarterPack` route member cap. */
+const MAX_PACK_MEMBERS = 150;
+
+/** Members requested per `getList` page. */
+const GET_LIST_PAGE_SIZE = 100;
+
+/** Max `getList` pages walked per pack (`MAX_PACK_MEMBERS / page` + slack). */
+const MAX_LIST_PAGES = 3;
+
+/**
+ * Hard ceiling on the number of DISTINCT member DIDs resolved to Oxy users per
+ * actor sync. Each resolution mints/refreshes a federated Oxy user (a getProfile +
+ * `PUT /users/resolve`), so this bounds the oxy-api write load a single popular
+ * Bluesky account can trigger. Exceeding it warns (no silent truncation) and packs
+ * beyond the budget mirror with the members that resolved.
+ */
+const MAX_MEMBERS_RESOLVED_PER_ACTOR = 1000;
+
+/** How many packs to walk (`getList`) in parallel. */
+const PACK_CONCURRENCY = 4;
+
+/** How many member DIDs to resolve to Oxy users in parallel. */
+const MEMBER_CONCURRENCY = 6;
+
+// --- AppView response shapes (only the fields this connector reads) ----------
+
+/** The `record` of an `app.bsky.graph.starterpack` view. */
+interface AtprotoStarterPackRecord {
+  name?: string;
+  /** AT-URI of the `app.bsky.graph.list` holding the pack's members. */
+  list?: string;
+}
+
+/** An item of `app.bsky.graph.getActorStarterPacks` (`starterPackViewBasic`). */
+interface AtprotoStarterPackViewBasic {
+  uri?: string;
+  record?: AtprotoStarterPackRecord;
+}
+
+interface AtprotoGetActorStarterPacksResponse {
+  starterPacks?: AtprotoStarterPackViewBasic[];
+  cursor?: string;
+}
+
+/** A member row of `app.bsky.graph.getList` (`listItemView`). */
+interface AtprotoListItem {
+  subject?: { did?: string };
+}
+
+interface AtprotoGetListResponse {
+  items?: AtprotoListItem[];
+  cursor?: string;
+}
+
+/** A starter pack reduced to the fields Mention mirrors. */
+export interface NormalizedStarterPackRef {
+  /** The source starter-pack AT-URI (dedup key). */
+  uri: string;
+  name: string;
+  /** AT-URI of the member list to resolve. */
+  listUri: string;
+}
+
+// --- pure mappers (unit-tested) ---------------------------------------------
+
+/**
+ * Extract the mirrorable starter-pack refs from a `getActorStarterPacks` response:
+ * a pack must have its own AT-URI (of the starter-pack collection), a non-empty
+ * name, and a `record.list` member-list AT-URI. Capped at
+ * {@link MAX_STARTER_PACKS_PER_ACTOR}. Pure.
+ *
+ * Uses the basic view's `record.list` directly — it is the SAME authoritative list
+ * ref `getStarterPack` would return, so mirroring goes straight to `getList` and
+ * skips a redundant per-pack `getStarterPack` round trip.
+ */
+export function extractStarterPackRefs(
+  response: AtprotoGetActorStarterPacksResponse | undefined,
+): NormalizedStarterPackRef[] {
+  const packs = Array.isArray(response?.starterPacks) ? response.starterPacks : [];
+  const refs: NormalizedStarterPackRef[] = [];
+  for (const pack of packs) {
+    if (refs.length >= MAX_STARTER_PACKS_PER_ACTOR) break;
+    const uri = typeof pack?.uri === 'string' ? pack.uri : '';
+    if (!uri.includes(`/${STARTER_PACK_COLLECTION}/`)) continue;
+    const name = typeof pack.record?.name === 'string' ? pack.record.name.trim() : '';
+    const listUri = typeof pack.record?.list === 'string' ? pack.record.list : '';
+    if (!name || !listUri) continue;
+    refs.push({ uri, name, listUri });
+  }
+  return refs;
+}
+
+/** Extract the member DIDs from a `getList` page, in list order (deduped). Pure. */
+export function extractMemberDids(response: AtprotoGetListResponse | undefined): string[] {
+  const items = Array.isArray(response?.items) ? response.items : [];
+  const dids: string[] = [];
+  for (const item of items) {
+    const did = item?.subject?.did;
+    if (typeof did === 'string' && did && !dids.includes(did)) dids.push(did);
+  }
+  return dids;
+}
+
+// --- network + persistence ---------------------------------------------------
+
+/**
+ * Walk a pack's member list (`getList`, paginated) and return its member DIDs in
+ * list order, capped at {@link MAX_PACK_MEMBERS}. Fail-soft: a failed page stops
+ * the walk and returns what was collected so far.
+ */
+async function collectPackMemberDids(listUri: string): Promise<string[]> {
+  const dids: string[] = [];
+  const seen = new Set<string>();
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_LIST_PAGES && dids.length < MAX_PACK_MEMBERS; page++) {
+    let response: AtprotoGetListResponse;
+    try {
+      response = await xrpcGet<AtprotoGetListResponse>(PUBLIC_APPVIEW, 'app.bsky.graph.getList', {
+        list: listUri,
+        limit: GET_LIST_PAGE_SIZE,
+        cursor,
+      });
+    } catch (err) {
+      logger.debug(`[atproto] getList failed for ${listUri}`, err);
+      break;
+    }
+
+    for (const did of extractMemberDids(response)) {
+      if (dids.length >= MAX_PACK_MEMBERS) break;
+      if (!seen.has(did)) {
+        seen.add(did);
+        dids.push(did);
+      }
+    }
+
+    cursor = typeof response.cursor === 'string' && response.cursor ? response.cursor : undefined;
+    if (!cursor) break;
+  }
+
+  return dids;
+}
+
+/**
+ * Resolve a batch of member DIDs to Oxy user ids through the shared atproto profile
+ * path (mints the federated Oxy user if new), with bounded concurrency. Returns a
+ * `did → oxyUserId` map; DIDs that fail to resolve to an Oxy user are absent
+ * (fail-soft — a member we can't mint is simply dropped from the pack).
+ */
+async function resolveMemberOxyIds(dids: readonly string[]): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  if (dids.length === 0) return map;
+
+  const settled = await mapWithConcurrency(dids, MEMBER_CONCURRENCY, async (did) => {
+    const actor = await fetchAndUpsertAtprotoProfile(did);
+    return actor?.oxyUserId ? String(actor.oxyUserId) : undefined;
+  });
+
+  for (let i = 0; i < dids.length; i++) {
+    const result = settled[i];
+    if (result.status === 'fulfilled' && result.value) map.set(dids[i], result.value);
+  }
+  return map;
+}
+
+/**
+ * Upsert a single mirrored starter pack, keyed on its source AT-URI. Idempotent:
+ * re-sync updates name + membership + `syncedAt` in place (never a duplicate — the
+ * sparse-unique `source.uri` index is the backstop for a concurrent race).
+ * Fail-soft: a persistence failure is logged and the sync moves on.
+ */
+async function upsertMirroredPack(
+  ref: NormalizedStarterPackRef,
+  ownerOxyUserId: string,
+  memberOxyUserIds: string[],
+): Promise<boolean> {
+  try {
+    await StarterPack.findOneAndUpdate(
+      { 'source.uri': ref.uri },
+      {
+        $set: {
+          ownerOxyUserId,
+          name: ref.name,
+          memberOxyUserIds,
+          source: { network: 'atproto', uri: ref.uri, syncedAt: new Date() },
+        },
+      },
+      { upsert: true },
+    );
+    return true;
+  } catch (err) {
+    // A concurrent sync of the same pack can race the upsert to an E11000; that is
+    // benign (the other writer landed the same mirror), so it is not re-thrown.
+    logger.warn(`[atproto] failed to upsert mirrored starter pack ${ref.uri}`, err);
+    return false;
+  }
+}
+
+/**
+ * Sync an atproto actor's starter packs into Mention's `StarterPack` collection.
+ *
+ * `did` is the actor's DID; `ownerOxyUserId` is the ALREADY-RESOLVED Oxy user the
+ * packs are owned by (the no-orphan invariant — the caller resolves the profile
+ * first). Best-effort and bounded: returns the number of packs upserted; never
+ * throws.
+ */
+export async function syncActorStarterPacks(did: string, ownerOxyUserId: string): Promise<number> {
+  if (!ownerOxyUserId) {
+    logger.warn(`[atproto] syncActorStarterPacks called for ${did} without a resolved Oxy owner; skipping`);
+    return 0;
+  }
+
+  let response: AtprotoGetActorStarterPacksResponse;
+  try {
+    response = await xrpcGet<AtprotoGetActorStarterPacksResponse>(
+      PUBLIC_APPVIEW,
+      'app.bsky.graph.getActorStarterPacks',
+      { actor: did, limit: MAX_STARTER_PACKS_PER_ACTOR },
+    );
+  } catch (err) {
+    logger.debug(`[atproto] getActorStarterPacks failed for ${did}`, err);
+    return 0;
+  }
+
+  const refs = extractStarterPackRefs(response);
+  if (refs.length === 0) return 0;
+
+  // Phase 1 — collect each pack's member DIDs (bounded pool over packs; each pack's
+  // getList paging is individually bounded by the XRPC per-call deadline + caps).
+  const memberSettled = await mapWithConcurrency(refs, PACK_CONCURRENCY, (ref) =>
+    collectPackMemberDids(ref.listUri),
+  );
+  const packMemberDids: string[][] = memberSettled.map((result) =>
+    result.status === 'fulfilled' ? result.value : [],
+  );
+
+  // Phase 2 — resolve the DISTINCT member DIDs across all packs ONCE (a member in
+  // several packs is minted once), bounded by a hard per-actor ceiling.
+  const uniqueDids: string[] = [];
+  const seenDid = new Set<string>();
+  for (const dids of packMemberDids) {
+    for (const did of dids) {
+      if (!seenDid.has(did)) {
+        seenDid.add(did);
+        uniqueDids.push(did);
+      }
+    }
+  }
+  let didsToResolve = uniqueDids;
+  if (uniqueDids.length > MAX_MEMBERS_RESOLVED_PER_ACTOR) {
+    logger.warn(
+      `[atproto] ${did} starter-pack members (${uniqueDids.length}) exceed the per-actor resolve cap ` +
+        `(${MAX_MEMBERS_RESOLVED_PER_ACTOR}); mirroring only the first ${MAX_MEMBERS_RESOLVED_PER_ACTOR}`,
+    );
+    didsToResolve = uniqueDids.slice(0, MAX_MEMBERS_RESOLVED_PER_ACTOR);
+  }
+  const oxyIdByDid = await resolveMemberOxyIds(didsToResolve);
+
+  // Phase 3 — upsert each pack with its resolved members (list order preserved).
+  let upserted = 0;
+  for (let i = 0; i < refs.length; i++) {
+    const memberOxyUserIds: string[] = [];
+    const seenMember = new Set<string>();
+    for (const memberDid of packMemberDids[i]) {
+      const oxyId = oxyIdByDid.get(memberDid);
+      if (oxyId && !seenMember.has(oxyId)) {
+        seenMember.add(oxyId);
+        memberOxyUserIds.push(oxyId);
+      }
+    }
+    const ok = await upsertMirroredPack(refs[i], ownerOxyUserId, memberOxyUserIds);
+    if (ok) upserted += 1;
+  }
+
+  logger.info(`[atproto] mirrored ${upserted}/${refs.length} starter packs for ${did}`);
+  return upserted;
+}

--- a/packages/backend/src/connectors/federatedProfileSync.ts
+++ b/packages/backend/src/connectors/federatedProfileSync.ts
@@ -32,6 +32,7 @@ import {
   shouldForceUntrackedOutboxSync,
 } from './activitypub/outboxSyncCooldown';
 import { ATPROTO_ENABLED } from './atproto/constants';
+import { syncAtprotoProfileGraph } from './atproto/profileGraph';
 import { connectorRegistry } from './index';
 
 /**
@@ -126,6 +127,21 @@ class FederatedProfileSync {
                 const message = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
                 logger.warn(`[FedSync] atproto backfill failed for ${cachedActor.acct}: ${message}`);
               }
+            }
+
+            // Discover the actor's starter packs + external feed references the
+            // SAME way posts are discovered — on profile view, best-effort and
+            // DETACHED so it never delays or fails the (already-detached) post
+            // backfill or its cooldown stamp below. Gated on a resolved Oxy owner
+            // (no orphan): a re-resolved atproto actor carries `oxyUserId`; when it
+            // does not yet, the next view (after the backfill stamps it) picks it up.
+            if (ATPROTO_ENABLED && cachedActor.oxyUserId) {
+              const graphDid = cachedActor.uri;
+              const graphOwner = cachedActor.oxyUserId;
+              void syncAtprotoProfileGraph(graphDid, graphOwner).catch((err) => {
+                const message = err instanceof Error ? err.message : String(err);
+                logger.warn(`[FedSync] atproto graph sync failed for ${cachedActor.acct}: ${message}`);
+              });
             }
           }
           // Stamp the post-backfill time so `shouldReportPending` can clear. The

--- a/packages/backend/src/migrations/0006-federated-starter-pack-source-index.ts
+++ b/packages/backend/src/migrations/0006-federated-starter-pack-source-index.ts
@@ -1,0 +1,48 @@
+/**
+ * Migration 0006: indexes for the Bluesky (atproto) profile-graph import.
+ *
+ * Creates the indexes the schemas declare for mirrored starter packs + external
+ * feed references. `autoIndex`/`autoCreate` are OFF in production (see
+ * `utils/database.ts`), so a schema-declared index NEVER reaches production — this
+ * migration is the only thing that creates them.
+ *
+ *  - `starterpacks` SPARSE UNIQUE `{ 'source.uri': 1 }` — the dedup key for every
+ *    mirrored pack. WITHOUT it, re-syncing an actor's packs would DUPLICATE them on
+ *    every profile view (the upsert would never find the prior row). SPARSE so it
+ *    covers only packs that carry a `source`; the millions of native packs (no
+ *    `source` field) are excluded, so their uniqueness is unaffected.
+ *  - `externalfeeds` UNIQUE `{ uri: 1 }` — one row per remote feed generator (the
+ *    upsert dedup key) — and `{ ownerOxyUserId: 1, createdAt: -1 }` for the
+ *    "feeds created by this user" profile lookup.
+ *
+ * Idempotent: `createIndex` with an identical spec is a no-op, and it creates the
+ * `externalfeeds` collection on first run. Data-free — no backfill needed (there is
+ * no pre-existing mirrored data, so the unique constraints cannot conflict).
+ */
+
+import mongoose from 'mongoose';
+import { logger } from '../utils/logger';
+import { MIGRATION_FEDERATED_STARTER_PACK_SOURCE_INDEX } from './constants';
+import StarterPack from '../models/StarterPack';
+import ExternalFeed from '../models/ExternalFeed';
+import type { Migration } from './runner';
+
+export const migrationFederatedStarterPackSourceIndex: Migration = {
+  id: MIGRATION_FEDERATED_STARTER_PACK_SOURCE_INDEX,
+
+  async run(db: mongoose.mongo.Db): Promise<void> {
+    const starterPacks = db.collection(StarterPack.collection.collectionName);
+    await starterPacks.createIndex({ 'source.uri': 1 }, { unique: true, sparse: true });
+    logger.info(
+      `[migration] ensured sparse-unique index on ${starterPacks.collectionName} { 'source.uri': 1 }`,
+    );
+
+    const externalFeeds = db.collection(ExternalFeed.collection.collectionName);
+    await externalFeeds.createIndex({ uri: 1 }, { unique: true });
+    await externalFeeds.createIndex({ ownerOxyUserId: 1, createdAt: -1 });
+    logger.info(
+      `[migration] ensured indexes on ${externalFeeds.collectionName} ` +
+        `{ uri: 1 } (unique) + { ownerOxyUserId: 1, createdAt: -1 }`,
+    );
+  },
+};

--- a/packages/backend/src/migrations/constants.ts
+++ b/packages/backend/src/migrations/constants.ts
@@ -49,3 +49,14 @@ export const MIGRATION_NOTIFICATION_TTL_INDEX = '0004-notification-ttl-index';
  * See {@link ./0005-starter-pack-member-index}.
  */
 export const MIGRATION_STARTER_PACK_MEMBER_INDEX = '0005-starter-pack-member-index';
+
+/**
+ * One-shot creation of the indexes backing the Bluesky (atproto) profile-graph
+ * import: the SPARSE UNIQUE `{ 'source.uri': 1 }` dedup index on `starterpacks`
+ * (one Mention pack per mirrored remote pack) and the `externalfeeds` collection's
+ * unique `{ uri: 1 }` + owner-lookup `{ ownerOxyUserId: 1, createdAt: -1 }` indexes.
+ * `autoIndex`/`autoCreate` are OFF in production, so the schema-declared indexes are
+ * created here — without the sparse-unique index, re-sync would DUPLICATE mirrored
+ * packs. See {@link ./0006-federated-starter-pack-source-index}.
+ */
+export const MIGRATION_FEDERATED_STARTER_PACK_SOURCE_INDEX = '0006-federated-starter-pack-source-index';

--- a/packages/backend/src/migrations/runner.ts
+++ b/packages/backend/src/migrations/runner.ts
@@ -18,6 +18,7 @@ import { migrationLowercaseHashtags } from './0002-lowercase-hashtags';
 import { migrationTrendingTtlIndex } from './0003-trending-ttl-index';
 import { migrationNotificationTtlIndex } from './0004-notification-ttl-index';
 import { migrationStarterPackMemberIndex } from './0005-starter-pack-member-index';
+import { migrationFederatedStarterPackSourceIndex } from './0006-federated-starter-pack-source-index';
 
 export interface Migration {
   /** Stable, unique migration id recorded in the migrations collection. */
@@ -38,6 +39,7 @@ const MIGRATIONS: readonly Migration[] = [
   migrationTrendingTtlIndex,
   migrationNotificationTtlIndex,
   migrationStarterPackMemberIndex,
+  migrationFederatedStarterPackSourceIndex,
 ];
 
 /**

--- a/packages/backend/src/models/ExternalFeed.ts
+++ b/packages/backend/src/models/ExternalFeed.ts
@@ -1,0 +1,69 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * A READ-ONLY reference to an external network's feed GENERATOR (atproto today).
+ *
+ * A Bluesky feed (`app.bsky.feed.generator`) is a remote algorithmic service: its
+ * `serviceDid` (a `did:web:` / `did:plc:` record) is the host that actually RUNS
+ * the ranking algorithm. Mention CANNOT execute that algorithm, so — unlike
+ * {@link ../models/CustomFeed} and {@link ../models/FeedGenerator}, which are
+ * RUNNABLE Mention feeds the FeedEngine serves — this model is deliberately a
+ * plain metadata record with NO runnable definition and NO coupling to the feed
+ * engine. It exists only so a synced Bluesky profile can surface "feeds created by
+ * this user" as reference cards that DEEP-LINK to Bluesky (`webUrl`).
+ *
+ * Provenance/dedup: `uri` is the feed generator's canonical AT-URI and the unique
+ * upsert key, so re-sync mirrors the current metadata in place (one row per remote
+ * feed). Owned by `ownerOxyUserId` (the resolved federated Oxy user who created
+ * the feed) so a profile "feeds" surface can list them by owner.
+ *
+ * NOTE: `autoIndex`/`autoCreate` are OFF in production — the indexes below are
+ * created by migration `0006-federated-starter-pack-source-index`, not on load.
+ */
+export interface IExternalFeed extends Document {
+  /** The external network this feed reference was imported from. */
+  network: 'atproto';
+  /** The feed generator's canonical URI (`at://…/app.bsky.feed.generator/…`) — unique. */
+  uri: string;
+  /** The resolved federated Oxy user who created the feed (the profile owner). */
+  ownerOxyUserId: string;
+  /**
+   * The DID of the remote service that RUNS the algorithm (`did:web:…`). Stored for
+   * provenance only — Mention never dereferences or executes it.
+   */
+  serviceDid: string;
+  /** The feed's display name. */
+  name: string;
+  description?: string;
+  /** Remote (bsky CDN) avatar URL — a link-card thumbnail, not an Oxy-owned asset. */
+  avatar?: string;
+  /** The feed's like count on the source network (display only). */
+  likeCount: number;
+  /** Canonical web URL to open the feed on the source network. */
+  webUrl: string;
+  /** When this reference was last mirrored from the source network. */
+  syncedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ExternalFeedSchema = new Schema<IExternalFeed>({
+  network: { type: String, enum: ['atproto'], required: true },
+  uri: { type: String, required: true },
+  ownerOxyUserId: { type: String, required: true },
+  serviceDid: { type: String, required: true },
+  name: { type: String, required: true },
+  description: { type: String },
+  avatar: { type: String },
+  likeCount: { type: Number, default: 0 },
+  webUrl: { type: String, required: true },
+  syncedAt: { type: Date, required: true },
+}, { timestamps: true });
+
+// Unique upsert/dedup key — one row per remote feed generator.
+ExternalFeedSchema.index({ uri: 1 }, { unique: true });
+// Owner lookup for a profile "feeds created by this user" surface.
+ExternalFeedSchema.index({ ownerOxyUserId: 1, createdAt: -1 });
+
+export const ExternalFeed = mongoose.model<IExternalFeed>('ExternalFeed', ExternalFeedSchema);
+export default ExternalFeed;

--- a/packages/backend/src/models/StarterPack.ts
+++ b/packages/backend/src/models/StarterPack.ts
@@ -1,5 +1,25 @@
 import mongoose, { Schema, Document } from 'mongoose';
 
+/**
+ * Provenance for a starter pack MIRRORED from an external network (atproto today).
+ *
+ * A pack carrying a `source` is OWNED UPSTREAM and read-only through Mention's
+ * write API — its membership is a mirror of the remote list, re-synced in place on
+ * every profile view, so a local edit would be silently overwritten on the next
+ * sync and is therefore rejected (see `routes/starterPacks.ts`). `uri` is the
+ * source pack's canonical identifier (the atproto starter-pack AT-URI) and the
+ * dedup key for re-sync: a sparse UNIQUE index guarantees exactly one Mention pack
+ * per remote pack (see migration `0006-federated-starter-pack-source-index`).
+ */
+export interface StarterPackSource {
+  /** The external network this pack was imported from. */
+  network: 'atproto';
+  /** The source pack's canonical URI (e.g. `at://…/app.bsky.graph.starterpack/…`). */
+  uri: string;
+  /** When the pack was last mirrored from the source network. */
+  syncedAt: Date;
+}
+
 export interface IStarterPack extends Document {
   ownerOxyUserId: string;
   name: string;
@@ -7,9 +27,17 @@ export interface IStarterPack extends Document {
   memberOxyUserIds: string[];
   usedByOxyUserIds: string[];
   useCount: number;
+  /** Set only on packs mirrored from an external network — read-only, owned upstream. */
+  source?: StarterPackSource;
   createdAt: Date;
   updatedAt: Date;
 }
+
+const StarterPackSourceSchema = new Schema<StarterPackSource>({
+  network: { type: String, enum: ['atproto'], required: true },
+  uri: { type: String, required: true },
+  syncedAt: { type: Date, required: true },
+}, { _id: false });
 
 const StarterPackSchema = new Schema<IStarterPack>({
   ownerOxyUserId: { type: String, required: true, index: true },
@@ -18,6 +46,7 @@ const StarterPackSchema = new Schema<IStarterPack>({
   memberOxyUserIds: { type: [String], default: [] },
   usedByOxyUserIds: { type: [String], default: [] },
   useCount: { type: Number, default: 0 },
+  source: { type: StarterPackSourceSchema },
 }, { timestamps: true });
 
 StarterPackSchema.index({ ownerOxyUserId: 1, createdAt: -1 });
@@ -35,6 +64,21 @@ StarterPackSchema.index({ useCount: -1, createdAt: -1 });
  * migration `0005-starter-pack-member-index`, not on model load.
  */
 StarterPackSchema.index({ memberOxyUserIds: 1, useCount: -1 });
+
+/**
+ * SPARSE UNIQUE index on the external-source URI.
+ *
+ * The single dedup key for external imports: a starter pack mirrored from atproto
+ * is upserted on `source.uri`, so this index makes re-sync idempotent (one Mention
+ * pack per remote pack) and closes the concurrent-import race (E11000). SPARSE so
+ * it only covers packs that carry a `source` — native packs (the overwhelming
+ * majority) have no `source` field and are excluded entirely, so their uniqueness
+ * is unaffected.
+ *
+ * NOTE: `autoIndex`/`autoCreate` are OFF in production — this index is created by
+ * migration `0006-federated-starter-pack-source-index`, not on model load.
+ */
+StarterPackSchema.index({ 'source.uri': 1 }, { unique: true, sparse: true });
 
 export const StarterPack = mongoose.model<IStarterPack>('StarterPack', StarterPackSchema);
 export default StarterPack;

--- a/packages/backend/src/routes/starterPacks.ts
+++ b/packages/backend/src/routes/starterPacks.ts
@@ -64,6 +64,24 @@ const router = express.Router();
 
 const MAX_MEMBERS = 150;
 
+/**
+ * A pack MIRRORED from an external network (`source` set) is owned UPSTREAM and
+ * read-only through Mention's write API: its name + membership are re-synced in
+ * place on every profile view, so a local edit would be silently overwritten on
+ * the next sync. Every mutation route rejects it BEFORE the ownership check — a
+ * federated pack is never editable regardless of who asks (its owner is a
+ * federated Oxy user with no session, so the ownership check already blocks local
+ * users; this is defence-in-depth and a clearer 403 that states the real reason).
+ * Following the pack's members (`POST /:id/use`) stays allowed — that is a viewer
+ * action that never mutates the pack.
+ */
+const FEDERATED_PACK_READONLY_MESSAGE =
+  'This starter pack is mirrored from an external network and is read-only';
+
+function isFederatedPack(pack: Pick<IStarterPack, 'source'>): boolean {
+  return Boolean(pack.source);
+}
+
 /** Number of member avatars surfaced per pack in the list response. */
 const LIST_AVATAR_LIMIT = 8;
 
@@ -280,6 +298,7 @@ router.put('/:id', async (req: AuthRequest, res: Response) => {
     if (!userId) return res.status(401).json({ error: 'Authentication required' });
     const pack = await StarterPack.findById(req.params.id);
     if (!pack) return res.status(404).json({ error: 'Starter pack not found' });
+    if (isFederatedPack(pack)) return res.status(403).json({ error: FEDERATED_PACK_READONLY_MESSAGE });
     if (pack.ownerOxyUserId !== userId) return res.status(403).json({ error: 'Not allowed' });
 
     const { name, description, memberOxyUserIds } = req.body || {};
@@ -310,6 +329,7 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     if (!userId) return res.status(401).json({ error: 'Authentication required' });
     const pack = await StarterPack.findById(req.params.id);
     if (!pack) return res.status(404).json({ error: 'Starter pack not found' });
+    if (isFederatedPack(pack)) return res.status(403).json({ error: FEDERATED_PACK_READONLY_MESSAGE });
     if (pack.ownerOxyUserId !== userId) return res.status(403).json({ error: 'Not allowed' });
     // Capture members BEFORE delete so we can retract their endorsements.
     const ownerId = pack.ownerOxyUserId;
@@ -334,6 +354,7 @@ router.post('/:id/members', async (req: AuthRequest, res: Response) => {
     const { userIds } = req.body || {};
     const pack = await StarterPack.findById(req.params.id);
     if (!pack) return res.status(404).json({ error: 'Starter pack not found' });
+    if (isFederatedPack(pack)) return res.status(403).json({ error: FEDERATED_PACK_READONLY_MESSAGE });
     if (pack.ownerOxyUserId !== userId) return res.status(403).json({ error: 'Not allowed' });
 
     const previousMemberIds = [...(pack.memberOxyUserIds || [])];
@@ -357,6 +378,7 @@ router.delete('/:id/members', async (req: AuthRequest, res: Response) => {
     const { userIds } = req.body || {};
     const pack = await StarterPack.findById(req.params.id);
     if (!pack) return res.status(404).json({ error: 'Starter pack not found' });
+    if (isFederatedPack(pack)) return res.status(403).json({ error: FEDERATED_PACK_READONLY_MESSAGE });
     if (pack.ownerOxyUserId !== userId) return res.status(403).json({ error: 'Not allowed' });
 
     const previousMemberIds = [...(pack.memberOxyUserIds || [])];

--- a/packages/backend/src/scripts/pruneGoneFederatedActors.ts
+++ b/packages/backend/src/scripts/pruneGoneFederatedActors.ts
@@ -77,7 +77,7 @@ import { actorService } from '../connectors/activitypub/actor.service';
 import { signedFetch } from '../connectors/activitypub/helpers';
 import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
 import { logger } from '../utils/logger';
-import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from './mapWithConcurrency';
+import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from '../utils/concurrency';
 
 /** Actors scanned per page (stable `_id` cursor pagination). */
 const PAGE_SIZE = 500;

--- a/packages/backend/src/scripts/purgeGoneFederatedActors.ts
+++ b/packages/backend/src/scripts/purgeGoneFederatedActors.ts
@@ -132,7 +132,7 @@ import type { DeleteActorIdentityOutcome } from '../connectors/identity';
 import { signedFetch } from '../connectors/activitypub/helpers';
 import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
 import { logger } from '../utils/logger';
-import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from './mapWithConcurrency';
+import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from '../utils/concurrency';
 
 /** Actors scanned per page (stable `_id` cursor pagination). */
 const PAGE_SIZE = 500;

--- a/packages/backend/src/scripts/reingestBlueskyPosts.ts
+++ b/packages/backend/src/scripts/reingestBlueskyPosts.ts
@@ -103,7 +103,7 @@ import { signedFetch } from '../connectors/activitypub/helpers';
 import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
 import { refetchAtprotoPostForRepair } from '../connectors/atproto/post.mapper';
 import { fetchAndUpsertAtprotoProfile, splitHandle } from '../connectors/atproto/profile.mapper';
-import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from './mapWithConcurrency';
+import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from '../utils/concurrency';
 
 /** Posts scanned per page (stable `_id` cursor pagination). */
 const PAGE_SIZE = 500;

--- a/packages/backend/src/scripts/syncBlueskyStarterPacks.ts
+++ b/packages/backend/src/scripts/syncBlueskyStarterPacks.ts
@@ -1,0 +1,261 @@
+/**
+ * One-shot backfill: mirror existing atproto actors' PROFILE GRAPH extras — their
+ * starter packs (`app.bsky.graph.starterpack`, functional import) and their feed
+ * generators (`app.bsky.feed.generator`, read-only references) — into Mention.
+ *
+ * WHY
+ *   Starter-pack + feed sync is discovered on profile view (the same lifecycle as
+ *   post backfill — see `connectors/federatedProfileSync.ts`), so an atproto actor
+ *   Mention resolved BEFORE this feature shipped has no mirrored packs/feeds until
+ *   someone views their profile again. This sweep catches those actors up.
+ *
+ *   Despite the starter-pack-focused name, it runs the SAME orchestrator the live
+ *   path does (`syncAtprotoProfileGraph`), so it also refreshes each actor's
+ *   external feed references — the two are always discovered together.
+ *
+ * WHAT IT DOES
+ *   Iterates every atproto `FederatedActor` that already carries a resolved
+ *   `oxyUserId` (the no-orphan invariant — a pack/feed must be owned by a real Oxy
+ *   user) and calls `syncAtprotoProfileGraph(actor.uri, actor.oxyUserId)`. That
+ *   upserts each pack on `source.uri` (idempotent — re-running never duplicates)
+ *   and each feed reference on its AT-URI, minting any not-yet-seen member accounts
+ *   through the shared federated-identity path.
+ *
+ * FLAGS (plain argv):
+ *   --dry-run          enumerate the atproto actors that WOULD be synced (respecting
+ *                      --actor / --limit) and report the scope; perform NO network
+ *                      sync and write NOTHING (no upserts, no minted members).
+ *   --limit N          cap the number of actors processed.
+ *   --actor <did|handle>  restrict to one actor, matched on its `uri` (DID) or `acct`.
+ *   --concurrency N    how many actors to sync in parallel (default 8, clamped 32).
+ *
+ * Idempotent + forward-only: batched by a stable ASCENDING `_id` cursor; a re-sync
+ * upserts the same rows (no duplicates), so re-running is safe.
+ *
+ * RUN AS A FARGATE ONE-SHOT (post-deploy, in-VPC):
+ *   ATPROTO_ENABLED=true bun packages/backend/dist/src/scripts/syncBlueskyStarterPacks.js --dry-run
+ *   ATPROTO_ENABLED=true bun packages/backend/dist/src/scripts/syncBlueskyStarterPacks.js --limit 50
+ *   ATPROTO_ENABLED=true bun packages/backend/dist/src/scripts/syncBlueskyStarterPacks.js   # full sweep
+ *
+ * RUN OVER THE SSM TUNNEL (prod Mongo forwarded to 127.0.0.1:47017):
+ *   MONGODB_URI='mongodb://127.0.0.1:47017/?directConnection=true' NODE_ENV=production \
+ *   ATPROTO_ENABLED=true bun packages/backend/src/scripts/syncBlueskyStarterPacks.ts --dry-run --limit 20
+ */
+
+import mongoose from 'mongoose';
+import { logger } from '../utils/logger';
+import FederatedActor from '../models/FederatedActor';
+import { ATPROTO_ENABLED } from '../connectors/atproto/constants';
+import { syncAtprotoProfileGraph } from '../connectors/atproto/profileGraph';
+import { mapWithConcurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY } from '../utils/concurrency';
+
+/** Actors scanned per page (stable `_id` cursor pagination). */
+const PAGE_SIZE = 500;
+
+/**
+ * Hard per-actor wall-clock cap. Every network call inside the graph sync is
+ * individually bounded by the XRPC client, but this guarantees one slow actor can
+ * never freeze the sweep — a timed-out actor is counted `failed` and skipped.
+ */
+const ACTOR_TIMEOUT_MS = 120_000;
+
+interface Flags {
+  dryRun: boolean;
+  limit?: number;
+  actor?: string;
+  concurrency: number;
+}
+
+/** The lean `FederatedActor` fields the sweep reads. */
+interface AtprotoActorRow {
+  _id: mongoose.Types.ObjectId;
+  uri: string;
+  acct?: string;
+  oxyUserId?: string;
+}
+
+interface Counters {
+  scanned: number;
+  synced: number;
+  failed: number;
+}
+
+// --- argv parsing (plain, mirrors reingestBlueskyPosts) ----------------------
+
+/** Read the value of `--flag <value>` / `--flag=value` from argv. */
+function readFlagValue(argv: string[], name: string): string | undefined {
+  const prefix = `${name}=`;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === name) return argv[i + 1];
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  return undefined;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const dryRun = argv.includes('--dry-run');
+
+  const rawLimit = readFlagValue(argv, '--limit');
+  let limit: number | undefined;
+  if (rawLimit !== undefined) {
+    const parsed = Number.parseInt(rawLimit, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--limit must be a positive integer (got "${rawLimit}")`);
+    }
+    limit = parsed;
+  }
+
+  const actor = readFlagValue(argv, '--actor')?.trim() || undefined;
+
+  const rawConcurrency = readFlagValue(argv, '--concurrency');
+  let concurrency = DEFAULT_CONCURRENCY;
+  if (rawConcurrency !== undefined) {
+    const parsed = Number.parseInt(rawConcurrency, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`--concurrency must be a positive integer (got "${rawConcurrency}")`);
+    }
+    concurrency = Math.min(parsed, MAX_CONCURRENCY);
+  }
+
+  return { dryRun, limit, actor, concurrency };
+}
+
+/** Distinct rejection raised by {@link withActorTimeout} when an actor exceeds the cap. */
+class ActorTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`actor sync exceeded ${ms}ms hard timeout`);
+    this.name = 'ActorTimeoutError';
+  }
+}
+
+/**
+ * Race one actor's sync against a hard timeout so a single hung remote can never
+ * freeze the batch. The timer is ALWAYS cleared when the sync settles.
+ */
+function withActorTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new ActorTimeoutError(ms)), ms);
+  });
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/** Build the Mongo filter: atproto actors with a resolved Oxy owner (+ optional single-actor scope). */
+function buildFilter(actor: string | undefined): Record<string, unknown> {
+  const filter: Record<string, unknown> = {
+    protocol: 'atproto',
+    oxyUserId: { $exists: true, $ne: null },
+  };
+  if (actor) filter.$or = [{ uri: actor }, { acct: actor }];
+  return filter;
+}
+
+async function syncBlueskyStarterPacks(): Promise<void> {
+  const startedAt = Date.now();
+  const flags = parseFlags(process.argv.slice(2));
+
+  if (!ATPROTO_ENABLED) {
+    // The graph sync talks to the Bluesky AppView through the atproto connector,
+    // which is gated on ATPROTO_ENABLED — refuse loudly rather than silently no-op.
+    throw new Error('ATPROTO_ENABLED must be "true" to run the Bluesky starter-pack sync');
+  }
+
+  const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/mention';
+  const dbName = `mention-${process.env.NODE_ENV || 'development'}`;
+
+  const counters: Counters = { scanned: 0, synced: 0, failed: 0 };
+  let remaining = flags.limit;
+
+  try {
+    await mongoose.connect(mongoUri, { dbName });
+    const baseFilter = buildFilter(flags.actor);
+    const total = await FederatedActor.countDocuments(baseFilter);
+    logger.info(
+      `[syncBlueskyStarterPacks] connected to MongoDB (${dbName}) — mode: ${flags.dryRun ? 'DRY-RUN' : 'LIVE'}, ` +
+        `concurrency: ${flags.concurrency}${flags.limit !== undefined ? `, limit: ${flags.limit}` : ''}; ` +
+        `${total} atproto actor(s) with a resolved Oxy owner${flags.actor ? ` (actor ${flags.actor})` : ''}`,
+    );
+
+    let lastId: mongoose.Types.ObjectId | null = null;
+    for (;;) {
+      if (remaining !== undefined && remaining <= 0) break;
+
+      const pageFilter: Record<string, unknown> = { ...baseFilter };
+      if (lastId) pageFilter._id = { $gt: lastId };
+
+      const pageLimit = remaining !== undefined ? Math.min(PAGE_SIZE, remaining) : PAGE_SIZE;
+      const page = await FederatedActor.find(pageFilter, { _id: 1, uri: 1, acct: 1, oxyUserId: 1 })
+        .sort({ _id: 1 })
+        .limit(pageLimit)
+        .lean<AtprotoActorRow[]>();
+      if (page.length === 0) break;
+
+      if (flags.dryRun) {
+        // A dry-run only reports the SCOPE (which actors would be synced) — it runs
+        // no AppView reads, mints no members, and writes nothing.
+        for (const actor of page) {
+          counters.scanned += 1;
+          if (remaining !== undefined) remaining -= 1;
+          logger.info(
+            `[syncBlueskyStarterPacks] WOULD sync graph for ${actor.acct ?? actor.uri} (oxyUserId=${actor.oxyUserId})`,
+          );
+        }
+      } else {
+        const settled = await mapWithConcurrency(page, flags.concurrency, (actor) => {
+          const owner = actor.oxyUserId;
+          if (!owner) return Promise.resolve(false);
+          return withActorTimeout(syncAtprotoProfileGraph(actor.uri, owner), ACTOR_TIMEOUT_MS).then(() => true);
+        });
+
+        for (let i = 0; i < page.length; i++) {
+          const actor = page[i];
+          counters.scanned += 1;
+          if (remaining !== undefined) remaining -= 1;
+          const result = settled[i];
+          if (result.status === 'fulfilled' && result.value) {
+            counters.synced += 1;
+          } else if (result.status === 'rejected') {
+            const err = result.reason;
+            const message = err instanceof Error ? err.message : String(err);
+            logger.warn(`[syncBlueskyStarterPacks] sync failed for ${actor.acct ?? actor.uri}: ${message}`);
+            counters.failed += 1;
+          }
+        }
+      }
+
+      lastId = page[page.length - 1]._id;
+      logger.info(
+        `[syncBlueskyStarterPacks] progress: scanned ${counters.scanned}, synced ${counters.synced}, failed ${counters.failed}`,
+      );
+    }
+
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    logger.info(
+      `[syncBlueskyStarterPacks] done (${flags.dryRun ? 'DRY-RUN' : 'LIVE'}, ${elapsedSeconds}s): ` +
+        `scanned ${counters.scanned}, synced ${counters.synced}, failed ${counters.failed}`,
+    );
+
+    await mongoose.disconnect();
+  } catch (error) {
+    logger.error('[syncBlueskyStarterPacks] failed', error);
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  // Exit deterministically: imported singletons (BullMQ Redis connections, media
+  // cache workers) can keep the event loop alive, so the process would otherwise
+  // sit RUNNING after the work completes. Mirrors the other one-shot scripts.
+  syncBlueskyStarterPacks()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error('[syncBlueskyStarterPacks] unhandled failure', error);
+      process.exit(1);
+    });
+}
+
+export default syncBlueskyStarterPacks;

--- a/packages/backend/src/utils/concurrency.ts
+++ b/packages/backend/src/utils/concurrency.ts
@@ -1,13 +1,15 @@
 /**
- * A minimal, dependency-free bounded-concurrency map shared by the one-shot
- * repair sweeps (`reingestBlueskyPosts`, `pruneGoneFederatedActors`).
+ * A minimal, dependency-free bounded-concurrency map.
  *
  * WHY
- *   Those sweeps are almost entirely I/O-bound — each item does a remote signed
- *   fetch plus oxy-api media/archive round-trips, so processing one item at a
- *   time leaves the CPU idle waiting on the network. Overlapping a small pool of
- *   items recovers roughly an order of magnitude of wall-clock time while keeping
- *   the load on the remote/oxy-api endpoints bounded.
+ *   Shared by the I/O-bound one-shot repair sweeps (`reingestBlueskyPosts`,
+ *   `pruneGoneFederatedActors`, `syncBlueskyStarterPacks`) AND the runtime atproto
+ *   connector's starter-pack member resolution. Each item does a remote fetch plus
+ *   oxy-api round-trips, so processing one item at a time leaves the CPU idle
+ *   waiting on the network. Overlapping a small pool recovers roughly an order of
+ *   magnitude of wall-clock time while keeping the load on the remote / oxy-api
+ *   endpoints bounded (oxy-api's service endpoints are per-IP rate-limited, and
+ *   Mention's federation traffic egresses from one NAT IP).
  */
 
 /** Default in-flight pool size — conservative so a sweep never hammers oxy-api. */


### PR DESCRIPTION
Syncs an atproto actor's starter packs + feeds on profile view (same lifecycle as post backfill, detached + gated on ATPROTO_ENABLED).

- **Starter packs (functional):** `syncActorStarterPacks` imports a Bluesky user's packs → Mention `StarterPack` owned by the federated user, members resolved via the sanctioned `fetchAndUpsertAtprotoProfile`. New `source:{network,uri,syncedAt}` subdoc + sparse-unique index (migration 0006) → idempotent re-sync. Mutation routes 403 a federated-source pack (read-only, owned upstream); `/use` still allowed.
- **Feeds (read-only refs):** a Bluesky feed is an external `did:web` algorithm Mention can't run — NOT mirrored into the runnable FeedGenerator/CustomFeed. New non-executable `ExternalFeed` model stores metadata + a bsky.app link, owner-queryable (profile surface is a frontend follow-up).
- One-shot backfill `scripts/syncBlueskyStarterPacks.ts`.

tsc clean; 2569 tests (38 new). Bounded (caps + per-call deadlines), fail-soft per pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)