### PR TITLE
fix(frontend): verified icon in suggested-user cards + web stale-chunk reload recovery

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -18,6 +18,13 @@ suppressRnwTextNodeWarning();
 import { initLiveKit } from '@/lib/livekit';
 initLiveKit();
 
+// WEB-only: recover from a stale lazy-route chunk 404'ing after a deploy by
+// reloading once onto the fresh bundle (loop-guarded via sessionStorage).
+// Platform-split — chunkReload.native.ts is a no-op. Registered at module scope
+// so the listeners are live before any route lazily imports its chunk.
+import { registerChunkErrorRecovery } from '@/lib/chunkReload';
+registerChunkErrorRecovery();
+
 import NetInfo from '@react-native-community/netinfo';
 import { focusManager, onlineManager } from '@tanstack/react-query';
 import { Redirect, Slot, Stack, useRouter, useSegments } from "expo-router";

--- a/packages/frontend/components/ProfileCard.tsx
+++ b/packages/frontend/components/ProfileCard.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from 'react';
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { FollowButton } from '@oxyhq/services';
@@ -7,13 +7,29 @@ import { Avatar } from '@oxyhq/bloom/avatar';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { ThemedText } from './ThemedText';
-import { RemoteActorBadge } from '@/components/Fediverse/FediverseBadge';
-import { AgentIcon } from '@/assets/icons/agent-icon';
-import { AutomatedIcon } from '@/assets/icons/automated-icon';
-import { displayNameOrHandle } from '@/utils/displayName';
+import UserName from './UserName';
 import { getUserPlaceholderColor } from '@/utils/userPlaceholderColor';
 import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types';
 import { cn } from '@/lib/utils';
+
+/**
+ * The identity line is the shared {@link UserName} — display name plus the
+ * verified / federated / agent / automated markers, rendered exactly as every
+ * other user surface renders them — typed to this row's own scale (text-base
+ * semibold name, text-sm muted `@handle`). Defined at module scope so the
+ * memoized `UserName` keeps a stable `style` reference across renders.
+ */
+const IDENTITY_TEXT_STYLES = StyleSheet.create({
+  name: { fontSize: 16, fontWeight: '600', lineHeight: 20 },
+  handle: { fontSize: 14, lineHeight: 18 },
+  column: { gap: 2 },
+});
+
+const IDENTITY_STYLE = {
+  name: IDENTITY_TEXT_STYLES.name,
+  handle: IDENTITY_TEXT_STYLES.handle,
+  container: IDENTITY_TEXT_STYLES.column,
+};
 
 /**
  * ProfileCard — THE user row.
@@ -106,15 +122,14 @@ export function ProfileCard({
   // pressable (no `/@<id>` links).
   const handle = getNormalizedUserHandle(profile) ?? '';
   const displayName = profile.name?.displayName?.trim();
-  const hasName = Boolean(displayName);
-  // A real display name is the bold primary with the muted @handle below; with no
-  // display name the @handle becomes the bold primary, shown ONCE.
-  const showHandleLine = hasName && handle.length > 0;
   const canPress = Boolean(onPress) || handle.length > 0;
-  const primaryLabel = displayNameOrHandle(
-    displayName,
-    handle ? `@${handle}` : t('user.unknown', { defaultValue: 'Unknown user' }),
-  );
+  // `UserName` owns the "display name else @handle, shown once" rule and the
+  // handle line beneath it. Hand it the degraded "Unknown user" label ONLY when
+  // there is neither a name nor a handle, so an unresolved profile never leaks
+  // its raw id as a handle.
+  const nameLabel =
+    displayName ??
+    (handle.length > 0 ? undefined : t('user.unknown', { defaultValue: 'Unknown user' }));
 
   const handlePress = () => {
     if (onPress) {
@@ -123,8 +138,6 @@ export function ProfileCard({
       router.push(`/@${handle}`);
     }
   };
-
-  const federatedBadge = profile.isFederated ? <RemoteActorBadge size={13} /> : null;
 
   return (
     <View
@@ -146,28 +159,18 @@ export function ProfileCard({
           placeholderColor={getUserPlaceholderColor(profile)}
         />
         <View className="flex-1 gap-0.5">
-          <View className="flex-row items-center gap-1">
-            <ThemedText
-              className="shrink text-base font-semibold leading-5"
-              numberOfLines={1}>
-              {primaryLabel}
-            </ThemedText>
-            {/* The fediverse marker always sits next to the line carrying the
-                handle — which is the primary line when there is no display name. */}
-            {!showHandleLine && federatedBadge}
-            {profile.isAgent && <AgentIcon size={14} className="text-muted-foreground" />}
-            {profile.isAutomated && <AutomatedIcon size={14} className="text-muted-foreground" />}
-          </View>
-          {showHandleLine && (
-            <View className="flex-row items-center gap-1">
-              <ThemedText
-                className="shrink text-sm leading-[18px] text-muted-foreground"
-                numberOfLines={1}>
-                @{handle}
-              </ThemedText>
-              {federatedBadge}
-            </View>
-          )}
+          {/* Identity line via the shared UserName: the name + verified /
+              federated / agent / automated markers and the muted @handle line,
+              consistent with every other user surface. */}
+          <UserName
+            name={nameLabel}
+            handle={handle || undefined}
+            verified={profile.verified}
+            isFederated={profile.isFederated}
+            isAgent={profile.isAgent}
+            isAutomated={profile.isAutomated}
+            style={IDENTITY_STYLE}
+          />
           {meta ? (
             <ThemedText
               className="text-sm leading-[18px] text-muted-foreground"

--- a/packages/frontend/components/suggestions/SuggestedUserCard.tsx
+++ b/packages/frontend/components/suggestions/SuggestedUserCard.tsx
@@ -12,6 +12,7 @@ interface SuggestedUserData {
   name: { displayName: string; first?: string; last?: string; full?: string };
   avatar?: string;
   bio?: string;
+  verified?: boolean;
   isFederated?: boolean;
   isAgent?: boolean;
   isAutomated?: boolean;
@@ -46,6 +47,7 @@ export const SuggestedUserCard = memo(function SuggestedUserCard({
     name: user.name,
     avatar: user.avatar || cachedUser?.avatar,
     color: cachedUser?.color,
+    verified: user.verified,
     description: user.bio,
     isFederated: user.isFederated,
     isAgent: user.isAgent,

--- a/packages/frontend/lib/chunkReload.native.ts
+++ b/packages/frontend/lib/chunkReload.native.ts
@@ -1,0 +1,10 @@
+/**
+ * Native no-op for the web-only stale-chunk recovery.
+ *
+ * Native builds ship a single embedded JS bundle — there are no hashed async
+ * route chunks that can go stale, so there is nothing to recover. See
+ * `chunkReload.web.ts` for the web implementation.
+ */
+export function registerChunkErrorRecovery(): void {
+  // intentionally empty on native
+}

--- a/packages/frontend/lib/chunkReload.ts
+++ b/packages/frontend/lib/chunkReload.ts
@@ -1,0 +1,3 @@
+// Base module for ESLint / tsc import resolution.
+// At build time, bundlers resolve chunkReload.native.ts or chunkReload.web.ts instead.
+export { registerChunkErrorRecovery } from './chunkReload.web';

--- a/packages/frontend/lib/chunkReload.web.ts
+++ b/packages/frontend/lib/chunkReload.web.ts
@@ -1,0 +1,145 @@
+/**
+ * Web-only recovery from a stale lazy-route chunk failing to load.
+ *
+ * expo-router code-splits each route into a hashed async chunk. After a web
+ * deploy the previously-loaded bundle's chunk hashes no longer exist on the
+ * host, which serves `index.html` (text/html) for the missing `*.js`. Metro's
+ * async require then rejects with an `AsyncRequireError` ("Loading module …
+ * failed"), so tapping into a not-yet-loaded route (e.g. an Explore topic) dies
+ * with no recovery.
+ *
+ * This registers a one-shot, loop-guarded listener that reloads the page onto
+ * the fresh bundle when it sees that failure. The loop guard is a short-lived
+ * `sessionStorage` timestamp: a second failure within the cooldown is treated as
+ * a genuinely-broken chunk (not merely stale) and is logged instead of reloading
+ * forever.
+ *
+ * The module is platform-split — `chunkReload.native.ts` is a no-op.
+ */
+
+import { logger } from '@/lib/logger';
+
+/** sessionStorage key holding the epoch-ms of the last recovery reload. */
+const RELOAD_STAMP_KEY = 'mention:chunkReloadAt';
+/** A second chunk failure within this window is a real break, not a stale hash. */
+const RELOAD_COOLDOWN_MS = 10_000;
+/** Metro serves the web route chunks from this path prefix. */
+const EXPO_CHUNK_PATH = '/_expo/static/js/';
+
+let registered = false;
+
+/** Read an error-like value's `name`/`message` as plain strings (metadata-safe). */
+function describeError(value: unknown): { name: string; message: string } {
+  const named = value as { name?: unknown; message?: unknown } | null | undefined;
+  const name = typeof named?.name === 'string' ? named.name : '';
+  const message =
+    typeof named?.message === 'string' ? named.message : typeof value === 'string' ? value : '';
+  return { name, message };
+}
+
+function isChunkLoadError(value: unknown): boolean {
+  if (!value) return false;
+  const { name, message } = describeError(value);
+  return (
+    name === 'AsyncRequireError' ||
+    name === 'ChunkLoadError' ||
+    /Loading module .* failed/i.test(message) ||
+    /Loading chunk \S+ failed/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Failed to fetch dynamically imported module/i.test(message)
+  );
+}
+
+function readStamp(): number {
+  try {
+    const raw = window.sessionStorage.getItem(RELOAD_STAMP_KEY);
+    const parsed = raw ? Number.parseInt(raw, 10) : 0;
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch {
+    // sessionStorage can throw in private mode / sandboxed frames.
+    return 0;
+  }
+}
+
+function writeStamp(value: number): boolean {
+  try {
+    window.sessionStorage.setItem(RELOAD_STAMP_KEY, String(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearStamp(): void {
+  try {
+    window.sessionStorage.removeItem(RELOAD_STAMP_KEY);
+  } catch {
+    // Nothing to clear when storage is unavailable.
+  }
+}
+
+function recover(error: unknown): void {
+  const now = Date.now();
+  const lastReloadAt = readStamp();
+
+  if (lastReloadAt && now - lastReloadAt < RELOAD_COOLDOWN_MS) {
+    // We already reloaded moments ago and a chunk still failed: it is broken, not
+    // merely stale. Surface it rather than reload in a loop.
+    logger.error('Route chunk still failing after a recovery reload; not reloading again', {
+      error: describeError(error),
+    });
+    return;
+  }
+
+  if (!writeStamp(now)) {
+    // Without a persisted guard a reload risks an infinite loop — refuse.
+    logger.error('Stale route chunk detected but the reload guard is unavailable; not reloading', {
+      error: describeError(error),
+    });
+    return;
+  }
+
+  logger.warn('Stale route chunk failed to load; reloading onto the fresh bundle', {
+    error: describeError(error),
+  });
+  window.location.reload();
+}
+
+export function registerChunkErrorRecovery(): void {
+  if (registered) return;
+  registered = true;
+
+  // A stable prior load means any earlier recovery succeeded: drop an expired
+  // stamp so a future deploy gets a fresh single-reload budget. A stamp still
+  // inside the cooldown is kept, so an immediate re-failure is caught by
+  // `recover`'s loop guard rather than reloading again.
+  const lastReloadAt = readStamp();
+  if (lastReloadAt && Date.now() - lastReloadAt >= RELOAD_COOLDOWN_MS) {
+    clearStamp();
+  }
+
+  // Primary path: Metro's async require rejects the dynamic import, surfacing as
+  // an unhandled promise rejection. We never preventDefault — this is additive.
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason: unknown = event.reason;
+    if (isChunkLoadError(reason)) recover(reason);
+  });
+
+  // Fallback path: a dynamic-import `<script>` failing fires an `error` event
+  // that does NOT bubble, so it is only observable in the capture phase. Scope
+  // recovery to Expo's own chunk scripts so unrelated resource errors (images,
+  // third-party scripts) never trigger a reload.
+  window.addEventListener(
+    'error',
+    (event) => {
+      const target = event.target;
+      if (target instanceof HTMLScriptElement && target.src.includes(EXPO_CHUNK_PATH)) {
+        recover(new Error(`Route chunk script failed to load: ${target.src}`));
+        return;
+      }
+      const err: unknown = event.error;
+      if (isChunkLoadError(err)) recover(err);
+    },
+    true,
+  );
+}


### PR DESCRIPTION
**Verified icon** missing in who-to-follow / suggestions: ProfileCard hand-rolled its name row and never rendered the verified check (data was present). Now renders via the shared `UserName` component (verified + federated + agent + automated, consistent app-wide); SuggestedUserCard threads `verified` too. Others already passed it → inherit the fix.
**AsyncRequireError** on Explore topic tap = stale lazy-route chunk after a deploy (old hash → SPA HTML fallback → import fails). Added a web-only, loop-guarded boot handler that reloads the fresh bundle on async-chunk failure; native no-op (platform split).

tsc clean; 55/55 tests. No useEffect fetch / as any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)