### PR TITLE
fix(backend): allow wss://api.oxy.so in CSP (Oxy SDK socket blocked)

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -210,7 +210,7 @@ app.use(healthRoutes);
 const CSP_CONNECT_SRC = [
   "'self'", "blob:", "data:",
   "https://api.mention.earth", "wss://api.mention.earth", // Mention API + socket.io
-  "https://api.oxy.so",                                   // Oxy SDK (auth/profiles)
+  "https://api.oxy.so", "wss://api.oxy.so",               // Oxy SDK (auth/profiles/socket.io)
   "https://cloud.oxy.so",                                 // canonical media
   "https://api.syra.fm", "wss://api.syra.fm",             // Syra live rooms
   "https://livekit.oxy.so", "wss://livekit.oxy.so",       // LiveKit signaling


### PR DESCRIPTION
The Oxy SDK's socket.io connects to `wss://api.oxy.so`, but the CSP `connect-src` only allowed `https://api.oxy.so` (every other socket host had both https+wss) → browser blocked it. One-line fix: add `wss://api.oxy.so`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)