### PR TITLE
fix(atproto): strip .bsky.social suffix for default Bluesky handles (@skylee1@bsky.social)

### DIFF
--- a/packages/backend/src/__tests__/connectors/atproto/postMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/postMapper.test.ts
@@ -80,7 +80,7 @@ const ACTOR: NormalizedExternalActor = {
   network: 'atproto',
   externalId: DID,
   handle: 'alice.bsky.social',
-  federatedUsername: 'alice.bsky.social@bsky.social',
+  federatedUsername: 'alice@bsky.social',
   instanceDomain: 'bsky.social',
   oxyUserId: 'oxy-alice',
 };

--- a/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
+++ b/packages/backend/src/__tests__/connectors/atproto/profileMapper.test.ts
@@ -63,9 +63,10 @@ describe('mapProfileToNormalizedActor', () => {
       network: 'atproto',
       externalId: DID,
       handle: 'alice.bsky.social',
-      // The canonical `local@domain` Oxy username + the handle's parent domain —
-      // exactly what oxy-api's `PUT /users/resolve` binds for an atproto actor.
-      federatedUsername: 'alice.bsky.social@bsky.social',
+      // The canonical `local@domain` Oxy username: a default Bluesky handle drops its
+      // redundant `.bsky.social` suffix (`alice.bsky.social` → `alice`) — the exact
+      // value oxy-api's `PUT /users/resolve` binds for an atproto actor.
+      federatedUsername: 'alice@bsky.social',
       instanceDomain: 'bsky.social',
       displayName: 'Alice',
       avatarUrl: PROFILE.avatar,
@@ -96,30 +97,38 @@ describe('mapProfileToNormalizedActor', () => {
     expect(actor?.bio).toBeUndefined();
   });
 
-  // Every atproto handle — a normal `.bsky.social` handle, an apex custom domain,
-  // and a multi-label custom domain — keys to the Bluesky network host, with the
-  // FULL handle as the username. Deriving the instance from the handle's own parent
-  // domain was the bug: `mayor.nyc.gov` rendered `@mayor.nyc.gov@nyc.gov` instead of
-  // `@mayor.nyc.gov@bsky.social` (apex handles only escaped it because a bare TLD
-  // like `com` has no dot).
+  // Every atproto handle keys to the Bluesky network host. A DEFAULT Bluesky handle
+  // drops its redundant `.bsky.social` suffix from the username (so it renders
+  // `@skylee1@bsky.social`, not the doubled `@skylee1.bsky.social@bsky.social`); a
+  // CUSTOM domain keeps its whole handle as the username (`.bsky.team`/`.app`/apex
+  // are NOT `.bsky.social`, so they are kept in full). The `handle` field always
+  // preserves the actor's real atproto handle. Deriving the instance from the
+  // handle's own parent domain was the original bug: `mayor.nyc.gov` rendered
+  // `@mayor.nyc.gov@nyc.gov` instead of `@mayor.nyc.gov@bsky.social`.
   it.each([
-    'alice.bsky.social',
-    'carnage4life.bsky.social',
-    'gothamist.com',
-    'mayor.nyc.gov',
-    'jay.bsky.team',
-  ])('keys handle %s to the Bluesky network host with the full handle as username', (handle) => {
+    { handle: 'skylee1.bsky.social', username: 'skylee1', rendered: 'skylee1@bsky.social' },
+    { handle: 'carnage4life.bsky.social', username: 'carnage4life', rendered: 'carnage4life@bsky.social' },
+    { handle: 'gothamist.com', username: 'gothamist.com', rendered: 'gothamist.com@bsky.social' },
+    { handle: 'mayor.nyc.gov', username: 'mayor.nyc.gov', rendered: 'mayor.nyc.gov@bsky.social' },
+    { handle: 'jay.bsky.team', username: 'jay.bsky.team', rendered: 'jay.bsky.team@bsky.social' },
+    { handle: 'bsky.app', username: 'bsky.app', rendered: 'bsky.app@bsky.social' },
+  ])('keys handle $handle to $rendered on the Bluesky network host', ({ handle, username, rendered: expected }) => {
     const actor = mapProfileToNormalizedActor({ ...PROFILE, handle });
+    // The `handle` field always preserves the real atproto handle (full DNS name).
     expect(actor?.handle).toBe(handle);
     expect(actor?.instanceDomain).toBe('bsky.social');
-    expect(actor?.federatedUsername).toBe(`${handle}@bsky.social`);
+    // `federatedUsername` carries the stored `local@domain` — the exact rendered
+    // handle, with a default handle's `.bsky.social` suffix already stripped.
+    expect(actor?.federatedUsername).toBe(expected);
 
+    // Rendering from the stored username + instance domain (the shape hydration
+    // reads off the Oxy user) reproduces the same handle.
     const rendered = getNormalizedUserHandle({
-      username: actor?.handle,
+      username,
       isFederated: true,
       federation: { domain: actor?.instanceDomain },
     });
-    expect(rendered).toBe(`${handle}@bsky.social`);
+    expect(rendered).toBe(expected);
     // The pre-fix doubled/bogus instance must never re-appear.
     expect(rendered).not.toBe(`${handle}@${handle}`);
   });
@@ -131,19 +140,32 @@ describe('mapProfileToNormalizedActor', () => {
 });
 
 describe('splitHandle', () => {
-  // The instance domain for an atproto actor is ALWAYS the Bluesky network domain,
-  // and the whole handle is the username — regardless of label count or custom
-  // domain. These are the exact prod actors the old parent-stripping mis-derived.
+  // The instance domain for an atproto actor is ALWAYS the Bluesky network domain.
+  // A DEFAULT Bluesky handle drops its redundant `.bsky.social` suffix from the
+  // username; a CUSTOM domain (apex, `.bsky.team`, `.app`, or multi-label) keeps its
+  // whole handle. These are the exact prod actors the old derivations mis-rendered.
   it.each([
-    { handle: 'alice.bsky.social', domain: 'bsky.social' },
-    { handle: 'mayor.nyc.gov', domain: 'bsky.social' },
-    { handle: 'jay.bsky.team', domain: 'bsky.social' },
-    { handle: 'gothamist.com', domain: 'bsky.social' },
-  ])('derives $handle → instance $domain with the full handle as username', ({ handle, domain }) => {
+    { handle: 'skylee1.bsky.social', username: 'skylee1' },
+    { handle: 'carnage4life.bsky.social', username: 'carnage4life' },
+    { handle: 'mayor.nyc.gov', username: 'mayor.nyc.gov' },
+    { handle: 'gothamist.com', username: 'gothamist.com' },
+    { handle: 'jay.bsky.team', username: 'jay.bsky.team' },
+    { handle: 'bsky.app', username: 'bsky.app' },
+  ])('derives $handle → username $username on the Bluesky network host', ({ handle, username }) => {
     expect(splitHandle(handle)).toEqual({
-      username: handle,
-      domain,
-      federatedUsername: `${handle}@${domain}`,
+      username,
+      domain: 'bsky.social',
+      federatedUsername: `${username}@bsky.social`,
+    });
+  });
+
+  // Guard the degenerate case: the bare network domain would strip to an empty
+  // username, so it is kept whole.
+  it('keeps the bare network domain whole rather than stripping to an empty username', () => {
+    expect(splitHandle('bsky.social')).toEqual({
+      username: 'bsky.social',
+      domain: 'bsky.social',
+      federatedUsername: 'bsky.social@bsky.social',
     });
   });
 });
@@ -175,7 +197,7 @@ describe('fetchAndUpsertAtprotoProfile', () => {
     expect(mocks.resolveOxyExternalUser).toHaveBeenCalledWith(
       expect.objectContaining({
         externalId: DID,
-        federatedUsername: 'alice.bsky.social@bsky.social',
+        federatedUsername: 'alice@bsky.social',
         instanceDomain: 'bsky.social',
         avatarUrl: PROFILE.avatar,
         bannerUrl: PROFILE.banner,

--- a/packages/backend/src/connectors/atproto/constants.ts
+++ b/packages/backend/src/connectors/atproto/constants.ts
@@ -34,11 +34,13 @@ export const BSKY_APP_ORIGIN = 'https://bsky.app';
 /**
  * The Bluesky network's canonical host. It is the federated instance domain for
  * EVERY atproto actor: a Bluesky handle is a whole DNS name that identifies the
- * account (`alice.bsky.social`, the apex `gothamist.com`, the multi-label custom
+ * account (`skylee1.bsky.social`, the apex `gothamist.com`, the multi-label custom
  * domain `mayor.nyc.gov`), and the account lives on the Bluesky network in every
- * case. So the full handle is the username and this is always the instance domain,
- * rendering `@mayor.nyc.gov@bsky.social` — never a bogus instance derived from the
- * handle's own parent domain (the old bug rendered `@mayor.nyc.gov@nyc.gov`).
+ * case — so this is always the instance domain. A DEFAULT Bluesky handle drops its
+ * now-redundant `.bsky.social` suffix from the username (rendering `@skylee1@bsky.social`,
+ * not the doubled `@skylee1.bsky.social@bsky.social`); a CUSTOM domain keeps its whole
+ * handle as the username (`@mayor.nyc.gov@bsky.social`). Never a bogus instance derived
+ * from the handle's own parent domain (the old bug rendered `@mayor.nyc.gov@nyc.gov`).
  */
 export const BSKY_NETWORK_DOMAIN = 'bsky.social';
 

--- a/packages/backend/src/connectors/atproto/profile.mapper.ts
+++ b/packages/backend/src/connectors/atproto/profile.mapper.ts
@@ -33,33 +33,50 @@ export interface AtprotoProfileView {
  * domain (`bsky.social`): a Bluesky handle is a whole DNS name that identifies the
  * account, not a `local@host` address, and the account lives on the Bluesky
  * network regardless of how many labels the handle has or whether it is a custom
- * domain. The username is the FULL handle in every case:
- *   - `alice.bsky.social` → username `alice.bsky.social`, instance `bsky.social`.
- *   - `gothamist.com`      → username `gothamist.com`,      instance `bsky.social`.
- *   - `mayor.nyc.gov`      → username `mayor.nyc.gov`,      instance `bsky.social`.
+ * domain.
  *
- * Deriving the instance from the handle's own parent domain was the bug: a
- * multi-label custom domain (`mayor.nyc.gov`) produced the bogus instance
+ * The username is the DEFAULT-Bluesky-handle base: because the instance domain is
+ * already `bsky.social`, the `.bsky.social` suffix on a default handle is
+ * redundant, so it is stripped from the username to avoid the doubled
+ * `@skylee1.bsky.social@bsky.social`. A CUSTOM domain handle is not a
+ * `.bsky.social` handle, so its whole handle stays the username:
+ *   - `skylee1.bsky.social` → username `skylee1`,       instance `bsky.social`.
+ *   - `gothamist.com`       → username `gothamist.com`,  instance `bsky.social`.
+ *   - `mayor.nyc.gov`       → username `mayor.nyc.gov`,  instance `bsky.social`.
+ *   - `jay.bsky.team`       → username `jay.bsky.team`,  instance `bsky.social`
+ *                             (`.bsky.team` is NOT `.bsky.social` — kept).
+ *
+ * Deriving the instance from the handle's own parent domain was the ORIGINAL bug:
+ * a multi-label custom domain (`mayor.nyc.gov`) produced the bogus instance
  * `nyc.gov`, rendering `@mayor.nyc.gov@nyc.gov` instead of the correct
- * `@mayor.nyc.gov@bsky.social` (apex handles like `gothamist.com` only avoided it
- * by accident, because the bare TLD `com` has no dot).
+ * `@mayor.nyc.gov@bsky.social`. That is now fixed (instance is always
+ * `bsky.social`); the `.bsky.social` strip is the follow-up that also drops the
+ * redundant suffix on default handles.
  *
- * The federated Oxy username is `<handle>@bsky.social`
- * (`alice.bsky.social@bsky.social`, `mayor.nyc.gov@bsky.social`) — the exact form
- * oxy-api's `PUT /users/resolve` binds (username domain must equal `domain`).
+ * The federated Oxy username is `<username>@bsky.social`
+ * (`skylee1@bsky.social`, `mayor.nyc.gov@bsky.social`) — the exact form oxy-api's
+ * `PUT /users/resolve` binds (username domain must equal `domain`).
  *
- * Exported so the re-derive repair script can DETECT a stored actor whose
- * `FederatedActor.domain` no longer equals `splitHandle(acct).domain` without
- * re-fetching the profile, using the SAME derivation the upsert path uses.
+ * Exported so the re-derive repair scripts can DETECT a stored actor whose
+ * re-derived `federatedUsername` no longer equals `${stored.username}@${stored.domain}`
+ * without re-fetching the profile — a stored `.bsky.social` actor keeps the same
+ * `domain` (`bsky.social`) but its `username` changes, so the scripts must compare
+ * the full `local@domain`, not the domain alone.
  */
 export function splitHandle(handle: string): { username: string; domain: string; federatedUsername: string } {
-  // The instance domain for every atproto actor is the Bluesky network host and the
-  // whole handle is the username — a handle is a DNS name identifying the account,
-  // so it has no separable per-instance host to derive from its parent domain.
+  // For a default Bluesky handle (`<username>.bsky.social`) the `.bsky.social`
+  // suffix is redundant once the instance domain is already `bsky.social`, so the
+  // username is the handle with that suffix stripped. A custom domain handle is not
+  // a `.bsky.social` handle, so its whole handle stays the username. Guard the
+  // degenerate `handle === 'bsky.social'` (stripping would leave an empty username)
+  // by keeping the full handle in that case.
+  const suffix = `.${BSKY_NETWORK_DOMAIN}`;
+  const username =
+    handle !== BSKY_NETWORK_DOMAIN && handle.endsWith(suffix) ? handle.slice(0, -suffix.length) : handle;
   return {
-    username: handle,
+    username,
     domain: BSKY_NETWORK_DOMAIN,
-    federatedUsername: `${handle}@${BSKY_NETWORK_DOMAIN}`,
+    federatedUsername: `${username}@${BSKY_NETWORK_DOMAIN}`,
   };
 }
 

--- a/packages/backend/src/connectors/types.ts
+++ b/packages/backend/src/connectors/types.ts
@@ -33,9 +33,11 @@ export interface NormalizedExternalActor {
    * The canonical `local@domain` username this actor is stored under in Oxy — the
    * exact value passed to `PUT /users/resolve`. Each connector derives it for its
    * own protocol so the shared identity bridge never has to guess: AP uses the
-   * acct (`user@domain`); atproto synthesizes `<handle>@<instance-domain>` (e.g.
-   * `alice.bsky.social@bsky.social`). It MUST equal `instanceDomain` after the
-   * `@` so oxy-api's username↔domain binding holds.
+   * acct (`user@domain`); atproto synthesizes `<username>@<instance-domain>`, where
+   * a default Bluesky handle drops the redundant `.bsky.social` suffix
+   * (`skylee1.bsky.social` → `skylee1@bsky.social`) and a custom domain keeps its
+   * whole handle (`mayor.nyc.gov` → `mayor.nyc.gov@bsky.social`). It MUST equal
+   * `instanceDomain` after the `@` so oxy-api's username↔domain binding holds.
    */
   federatedUsername: string;
   /**

--- a/packages/backend/src/scripts/reingestBlueskyPosts.ts
+++ b/packages/backend/src/scripts/reingestBlueskyPosts.ts
@@ -33,9 +33,11 @@
  *      `post.mapper` (`refetchAtprotoPostForRepair`), folding in the #439 fixes:
  *      `#link`/`#mention` facet resolution (UTF-8 byte-indexed), reply threading
  *      (`parentPostId`/`threadId`), and quote posts (`quoteOf`). The actor
- *      HANDLE fix (`splitHandle`: apex `gothamist.com` → `@gothamist.com@bsky.social`,
- *      not doubled) lives on the `FederatedActor` doc, so it is repaired ONCE per
- *      distinct actor (deduped), not per post.
+ *      HANDLE fix (`splitHandle`: a default handle drops its redundant suffix,
+ *      `skylee1.bsky.social` → `@skylee1@bsky.social`, while a custom domain keeps
+ *      its whole handle, `gothamist.com` → `@gothamist.com@bsky.social`) lives on
+ *      the `FederatedActor` doc, so it is repaired ONCE per distinct actor
+ *      (deduped), not per post.
  *
  * HOW EACH PATH RE-FETCHES + RE-MAPS + DIFFS
  *   Both paths re-derive the SAME storable fields fresh ingest would produce, then
@@ -516,12 +518,15 @@ async function repairAtprotoPost(post: StoredPostRow, flags: Flags): Promise<Rep
 // --- actor handle repair (atproto only, deduped per distinct DID) ------------
 
 /**
- * Repair the doubled-handle bug on each distinct atproto actor referenced by the
+ * Repair the handle-rendering bugs on each distinct atproto actor referenced by the
  * scanned posts. The `splitHandle` fix lives on the `FederatedActor` doc, so this
- * runs ONCE per DID (deduped), never per post. Detection is a pure comparison of
- * the stored `domain` against `splitHandle(acct).domain`; the actual repair re-runs
- * the shared profile upsert (`fetchAndUpsertAtprotoProfile`), which re-derives the
- * handle AND re-resolves the Oxy user with the corrected `local@domain` username.
+ * runs ONCE per DID (deduped), never per post. Detection is a pure comparison of the
+ * stored `${username}@${domain}` against the re-derived `splitHandle(acct).federatedUsername`
+ * — comparing the domain ALONE would miss a `.bsky.social` actor, whose domain stays
+ * `bsky.social` while its username shortens (`skylee1.bsky.social` → `skylee1`). The
+ * actual repair re-runs the shared profile upsert (`fetchAndUpsertAtprotoProfile`),
+ * which re-derives the handle AND re-resolves the Oxy user with the corrected
+ * `local@domain` username.
  */
 async function repairActorHandles(
   dids: ReadonlySet<string>,
@@ -539,7 +544,7 @@ async function repairActorHandles(
     }
 
     const expected = splitHandle(actor.acct);
-    if (expected.domain === actor.domain) {
+    if (expected.federatedUsername === `${actor.username}@${actor.domain}`) {
       counters.unchanged += 1;
       continue;
     }

--- a/packages/backend/src/scripts/repairAtprotoActorHandles.ts
+++ b/packages/backend/src/scripts/repairAtprotoActorHandles.ts
@@ -1,26 +1,34 @@
 /**
- * One-shot REPAIR of stored atproto (Bluesky) actor handles that carry a bogus
- * federated instance domain.
+ * One-shot REPAIR of stored atproto (Bluesky) actor handles whose rendered
+ * `local@domain` no longer matches the current `splitHandle` derivation.
  *
  * WHY
- *   `splitHandle` (`connectors/atproto/profile.mapper.ts`) used to derive an actor's
- *   instance domain by stripping the first label off its handle — which is wrong for
- *   the atproto connector, where the instance domain is ALWAYS the Bluesky network
- *   host (`bsky.social`) and the whole handle is the username. A multi-label custom
- *   domain handle mis-derived its instance:
- *     - `mayor.nyc.gov`  → parent `nyc.gov` → stored domain `nyc.gov`   (WRONG)
- *     - `jay.bsky.team`  → parent `bsky.team` → stored domain `bsky.team` (WRONG)
- *     - `ronbronson.com` → parent `com`     → stored domain `com`       (WRONG)
- *   so the actor rendered as `@mayor.nyc.gov@nyc.gov` instead of the correct
- *   `@mayor.nyc.gov@bsky.social`. (Apex handles like `gothamist.com` happened to be
- *   correct only because a bare TLD has no dot to strip.) The ingest path is now
- *   fixed, but rows written before the fix keep their bogus `domain`/`acct` binding
- *   — this script re-derives and repairs them in place.
+ *   Two `splitHandle` (`connectors/atproto/profile.mapper.ts`) changes each left
+ *   stale rows behind:
+ *     1. It used to derive an actor's instance domain by stripping the first label
+ *        off its handle — wrong for the atproto connector, where the instance domain
+ *        is ALWAYS the Bluesky network host (`bsky.social`). A multi-label custom
+ *        domain handle mis-derived its instance:
+ *          - `mayor.nyc.gov`  → parent `nyc.gov`  → stored domain `nyc.gov`  (WRONG)
+ *          - `jay.bsky.team`  → parent `bsky.team` → stored domain `bsky.team` (WRONG)
+ *          - `ronbronson.com` → parent `com`      → stored domain `com`      (WRONG)
+ *        so the actor rendered as `@mayor.nyc.gov@nyc.gov` instead of the correct
+ *        `@mayor.nyc.gov@bsky.social`. (Apex handles like `gothamist.com` happened to
+ *        be correct only because a bare TLD has no dot to strip.)
+ *     2. It now also strips the redundant `.bsky.social` suffix from a DEFAULT handle
+ *        (the instance domain is already `bsky.social`), so `skylee1.bsky.social`
+ *        renders `@skylee1@bsky.social`, not the doubled `@skylee1.bsky.social@bsky.social`.
+ *        These rows keep their `domain` (`bsky.social`) but the `username` shortens.
+ *   The ingest path is now fixed, but rows written before each fix keep their stale
+ *   `username`/`domain`/`acct` binding — this script re-derives and repairs them in
+ *   place.
  *
  * WHAT IT DOES — per `FederatedActor` row with `protocol:'atproto'`:
  *   1. Cheaply detects whether the row needs repair WITHOUT any network I/O:
- *      `splitHandle(acct).domain !== stored.domain`. An already-correct actor is a
- *      no-op (logged `unchanged`, no fetch).
+ *      `splitHandle(acct).federatedUsername !== ${stored.username}@${stored.domain}`.
+ *      Comparing the domain ALONE would MISS a `.bsky.social` actor, whose domain is
+ *      unchanged while its username shortens. An already-correct actor is a no-op
+ *      (logged `unchanged`, no fetch).
  *   2. When it differs, repairs it by re-running the SAME sanctioned upsert the
  *      ingest path uses — `fetchAndUpsertAtprotoProfile(did)` — which recomputes the
  *      handle through the FIXED `splitHandle` AND updates BOTH sides consistently
@@ -43,8 +51,9 @@
  *                scanned in a stable ascending `_id` order so a limited run is
  *                deterministic.
  *
- * Idempotent + re-runnable: a repaired actor re-derives to the SAME domain on a
- * second run (`splitHandle(acct).domain === stored.domain`), so it is then a no-op.
+ * Idempotent + re-runnable: a repaired actor re-derives to the SAME `local@domain`
+ * on a second run (`splitHandle(acct).federatedUsername === ${stored.username}@${stored.domain}`),
+ * so it is then a no-op.
  *
  * RUN AS A FARGATE ONE-SHOT (post-deploy, in-VPC):
  *   bun packages/backend/dist/src/scripts/repairAtprotoActorHandles.js --dry-run
@@ -154,11 +163,13 @@ function withActorTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
 }
 
 /**
- * Repair one actor when its stored `domain` no longer matches the re-derived one.
- * Detection is a pure, network-free comparison; the actual repair re-runs the shared
- * profile upsert so the `FederatedActor` and the linked Oxy user stay consistent
- * through one code path. Fails soft: any error (or the per-actor timeout) is caught
- * by the caller and counted `failed` — the loop is never aborted.
+ * Repair one actor when its stored `${username}@${domain}` no longer matches the
+ * re-derived `splitHandle(acct).federatedUsername`. Detection is a pure, network-free
+ * comparison of the full `local@domain` (not the domain alone — a `.bsky.social`
+ * actor shortens only its username); the actual repair re-runs the shared profile
+ * upsert so the `FederatedActor` and the linked Oxy user stay consistent through one
+ * code path. Fails soft: any error (or the per-actor timeout) is caught by the caller
+ * and counted `failed` — the loop is never aborted.
  */
 async function repairActor(actor: ActorRow, flags: Flags): Promise<RepairOutcome> {
   if (!actor.acct) {
@@ -167,7 +178,7 @@ async function repairActor(actor: ActorRow, flags: Flags): Promise<RepairOutcome
   }
 
   const expected = splitHandle(actor.acct);
-  if (expected.domain === actor.domain) {
+  if (expected.federatedUsername === `${actor.username}@${actor.domain}`) {
     return 'unchanged';
   }
 


### PR DESCRIPTION
Default Bluesky handles rendered redundantly as `@skylee1.bsky.social@bsky.social`. Now `splitHandle` strips the `.bsky.social` suffix for default handles → `@skylee1@bsky.social`, while custom domains keep the full handle (`@mayor.nyc.gov@bsky.social`, `@gothamist.com@bsky.social`, `@jay.bsky.team@bsky.social`). Domain stays bsky.social. Degenerate `bsky.social` guarded.

Repair-script detection (reingestBlueskyPosts + repairAtprotoActorHandles) now compares the full `local@domain` (username OR domain change), since a .bsky.social actor keeps its domain but shortens its username — so a re-run migrates existing `@x.bsky.social@bsky.social` → `@x@bsky.social` in both Mention + Oxy.

tsc clean; 143 atproto tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)