### PR TITLE
feat(profile): Twitter-style 'Follows you' tag inline on the handle

### DIFF
--- a/packages/frontend/components/Profile/ProfileContent.tsx
+++ b/packages/frontend/components/Profile/ProfileContent.tsx
@@ -48,7 +48,7 @@ export const ProfileContent = memo(function ProfileContent({
   onLayout,
 }: ProfileContentProps) {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { user, isAuthenticated } = useAuth();
   const design = profileData.design;
   const minimalistMode = design.minimalistMode;
   // Own, non-federated profile opted into fediverse sharing (absent flag ⇒ on):
@@ -56,6 +56,17 @@ export const ProfileContent = memo(function ProfileContent({
   const fediverseBadge =
     isOwnProfile && !profileData.isFederated && user?.fediverseSharing !== false ? (
       <FediverseSharingBadge size={20} />
+    ) : undefined;
+  // Passive "Follows you" tag rendered inline to the right of the @handle when
+  // this profile follows the viewer. Requires an authenticated viewer (a signed-
+  // out visitor has no "you") and is never shown on the viewer's own profile.
+  const followsYouTag =
+    !isOwnProfile && isAuthenticated && profileData.followsYou ? (
+      <View className="bg-secondary px-1.5 py-0.5 rounded">
+        <Text className="text-muted-foreground text-xs font-medium" numberOfLines={1}>
+          {t('profile.followsYou', { defaultValue: 'Follows you' })}
+        </Text>
+      </View>
     ) : undefined;
   const profileHandle = getNormalizedUserHandle({
     username: profileData.username || username,
@@ -145,17 +156,13 @@ export const ProfileContent = memo(function ProfileContent({
             variant="default"
             style={userNameStyle}
             trailingBadge={fediverseBadge}
+            handleTrailing={followsYouTag}
           />
-          <View className="flex-row items-center gap-2 flex-wrap">
-            {isPrivate && <PrivateBadge privacySettings={profileData.privacy} />}
-            {!isOwnProfile && profileData.followsYou && (
-              <View className="bg-secondary px-1.5 py-0.5 rounded">
-                <Text className="text-muted-foreground text-xs font-medium">
-                  {t('profile.followsYou', { defaultValue: 'Follows you' })}
-                </Text>
-              </View>
-            )}
-          </View>
+          {isPrivate && (
+            <View className="flex-row items-center gap-2 flex-wrap">
+              <PrivateBadge privacySettings={profileData.privacy} />
+            </View>
+          )}
         </View>
       )}
 

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -46,8 +46,10 @@ export interface UserNameProps {
   };
   unifiedColors?: boolean;
   onPress?: () => void;
-  /** Extra element rendered inline after the verified/federated/agent icons. */
+  /** Extra element rendered inline after the verified/federated/agent icons (name line). */
   trailingBadge?: React.ReactNode;
+  /** Passive element rendered inline to the right of the `@handle` on the handle line (e.g. a "Follows you" tag). */
+  handleTrailing?: React.ReactNode;
 }
 
 export type UserNameComponent = React.ComponentType<UserNameProps>;

--- a/packages/frontend/components/UserName.tsx
+++ b/packages/frontend/components/UserName.tsx
@@ -9,7 +9,7 @@ import { AgentIcon } from '@/assets/icons/agent-icon';
 import { AutomatedIcon } from '@/assets/icons/automated-icon';
 import type { UserNameProps } from '@/components/Profile/types';
 
-const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated, isAgent, isAutomated, unifiedColors, onPress, variant = 'default', style, trailingBadge }) => {
+const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated, isAgent, isAutomated, unifiedColors, onPress, variant = 'default', style, trailingBadge, handleTrailing }) => {
     const theme = useTheme();
     const nameStyle = [styles.name, variant === 'small' && styles.nameSmall, style?.name];
 
@@ -40,6 +40,60 @@ const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated
     const primaryText = hasName ? name : (handle ? `@${handle}` : undefined);
     const showHandleLine = hasName && !!handle;
 
+    // Handle line: the muted `@handle`, optionally with a passive inline element
+    // (e.g. a "Follows you" tag) rendered to its right on the SAME line. When a
+    // trailing element is present the handle is wrapped in a row and the caller's
+    // bottom margin is relocated onto that row so the tag stays vertically
+    // centered with the handle text; the handle itself shrinks first so it stays
+    // primary. With no trailing element the original single-Text path is kept
+    // byte-for-byte, so every other caller is unaffected.
+    let handleLineNode: React.ReactNode = null;
+    if (showHandleLine) {
+        if (handleTrailing != null) {
+            const flatHandle = StyleSheet.flatten([styles.handle, style?.handle]) as TextStyle;
+            const { marginBottom: handleMarginBottom, ...handleTextStyle } = flatHandle;
+            const handleText = (
+                <Text
+                    className="text-muted-foreground"
+                    style={[handleTextStyle, styles.handleShrink]}
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                >
+                    @{handle}
+                </Text>
+            );
+            handleLineNode = (
+                <View
+                    className="gap-2"
+                    style={[styles.handleTrailingRow, handleMarginBottom != null ? { marginBottom: handleMarginBottom } : null]}
+                >
+                    {isFederated ? (
+                        <TouchableOpacity activeOpacity={0.7} onPress={handleCopyHandle} style={styles.handleShrink}>
+                            {handleText}
+                        </TouchableOpacity>
+                    ) : (
+                        handleText
+                    )}
+                    {handleTrailing}
+                </View>
+            );
+        } else if (isFederated) {
+            handleLineNode = (
+                <TouchableOpacity activeOpacity={0.7} onPress={handleCopyHandle}>
+                    <Text className="text-muted-foreground" style={[styles.handle, style?.handle]} numberOfLines={1} ellipsizeMode="tail">
+                        @{handle}
+                    </Text>
+                </TouchableOpacity>
+            );
+        } else {
+            handleLineNode = (
+                <Text className="text-muted-foreground" style={[styles.handle, style?.handle]} numberOfLines={1} ellipsizeMode="tail">
+                    @{handle}
+                </Text>
+            );
+        }
+    }
+
     const inner = (
         <>
             <View className="gap-1" style={styles.nameRow}>
@@ -62,19 +116,7 @@ const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated
                 )}
                 {trailingBadge}
             </View>
-            {showHandleLine ? (
-                isFederated ? (
-                    <TouchableOpacity activeOpacity={0.7} onPress={handleCopyHandle}>
-                        <Text className="text-muted-foreground" style={[styles.handle, style?.handle]} numberOfLines={1} ellipsizeMode="tail">
-                            @{handle}
-                        </Text>
-                    </TouchableOpacity>
-                ) : (
-                    <Text className="text-muted-foreground" style={[styles.handle, style?.handle]} numberOfLines={1} ellipsizeMode="tail">
-                        @{handle}
-                    </Text>
-                )
-            ) : null}
+            {handleLineNode}
         </>
     );
 
@@ -122,6 +164,17 @@ const styles = StyleSheet.create({
     handle: {
         fontSize: 15,
         lineHeight: 20,
+    },
+    // Row that holds the `@handle` plus an inline trailing tag; the handle keeps
+    // the flexible space and shrinks first so the tag never pushes it offscreen.
+    handleTrailingRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        minWidth: 0,
+    },
+    handleShrink: {
+        flexShrink: 1,
+        minWidth: 0,
     },
 });
 

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -197,6 +197,7 @@
   "profile.edit": "Edit profile",
   "profile.editProfile": "Edit Profile",
   "profile.chat": "Chat",
+  "profile.followsYou": "Follows you",
   "profile.tabs.posts": "Posts",
   "profile.tabs.replies": "Replies",
   "profile.tabs.media": "Media",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -222,6 +222,7 @@
   "profile.edit": "Editar perfil",
   "profile.editProfile": "Editar Perfil",
   "profile.chat": "Chat",
+  "profile.followsYou": "Te sigue",
   "profile.tabs.posts": "Publicaciones",
   "profile.tabs.replies": "Respuestas",
   "profile.tabs.media": "Medios",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -186,6 +186,7 @@
   "profile.edit": "Modifica profilo",
   "profile.editProfile": "Modifica Profilo",
   "profile.chat": "Chat",
+  "profile.followsYou": "Ti segue",
   "profile.tabs.posts": "Post",
   "profile.tabs.replies": "Risposte",
   "profile.tabs.media": "Media",


### PR DESCRIPTION
Small passive pill next to the @handle on a profile, shown only when `!isOwnProfile && isAuthenticated && followsYou`. Data already end-to-end (`ProfileData.followsYou` ← appearance ← `profileDesign.ts followsViewer`). Rendered via UserName's new `handleTrailing` prop (other callers byte-identical). i18n en/es/it, theme-aware, no useEffect/as any. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)