### PR TITLE
fix(layout): remove doubled safe-area top padding (hashtag/trend) + pin edges

### DIFF
--- a/packages/frontend/app/(app)/feeds.tsx
+++ b/packages/frontend/app/(app)/feeds.tsx
@@ -359,7 +359,7 @@ const FeedsScreen: React.FC = () => {
   return (
     <>
       <SEO title={t('seo.feeds.title')} description={t('seo.feeds.description')} />
-      <SafeAreaView className="flex-1 bg-background relative flex-col">
+      <SafeAreaView className="flex-1 bg-background relative flex-col" edges={['top']}>
         <Header
           options={{
             title: t('Feeds'),

--- a/packages/frontend/app/(app)/hashtag/[tag].tsx
+++ b/packages/frontend/app/(app)/hashtag/[tag].tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useSafeBack } from '@/hooks/useSafeBack';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SafeAreaView } from '@/lib/SafeAreaViewInterop';
 import { ThemedText } from '@/components/ThemedText';
 import { Header } from '@/components/Header';
@@ -17,7 +16,6 @@ import { PanelStickyHeader } from '@/components/shell/PanelChrome';
 export default function HashtagScreen() {
     const { tag } = useLocalSearchParams<{ tag: string }>();
     const safeBack = useSafeBack();
-    const insets = useSafeAreaInsets();
     const { t } = useTranslation();
 
     const hashtag = tag?.replace(/^#/, '') || '';
@@ -26,7 +24,7 @@ export default function HashtagScreen() {
     const filters = useMemo(() => ({ hashtag }), [hashtag]);
 
     const listHeader = useMemo(() => (
-        <View className="px-4 pb-2" style={{ paddingTop: insets.top }}>
+        <View className="px-4 pb-2">
             <View className="flex-row items-center justify-between">
                 <ThemedText type="title" className="text-[28px] font-bold mb-1 font-primary flex-1">
                     {displayTag}
@@ -34,10 +32,10 @@ export default function HashtagScreen() {
                 <EntityFollowButton entityType="hashtag" entityId={hashtag} label="Subscribe" followingLabel="Subscribed" />
             </View>
         </View>
-    ), [displayTag, hashtag, insets.top]);
+    ), [displayTag, hashtag]);
 
     return (
-        <SafeAreaView className="flex-1" edges={['top', 'bottom']}>
+        <SafeAreaView className="flex-1" edges={['top']}>
             <SEO
                 title={t('seo.hashtag.title', { hashtag: displayTag, defaultValue: `${displayTag} - Mention` })}
                 description={t('seo.hashtag.description', {

--- a/packages/frontend/app/(app)/live-rooms/[id].tsx
+++ b/packages/frontend/app/(app)/live-rooms/[id].tsx
@@ -243,7 +243,7 @@ const RoomDetailScreen = () => {
         title={room?.title ?? t('agora.room')}
         description={room?.description || 'Join this room'}
       />
-      <SafeAreaView className="flex-1 bg-background">
+      <SafeAreaView className="flex-1 bg-background" edges={['top']}>
         <Header
           options={{
             title: room ? '' : t('agora.room'),

--- a/packages/frontend/app/(app)/live-rooms/index.tsx
+++ b/packages/frontend/app/(app)/live-rooms/index.tsx
@@ -187,7 +187,7 @@ const LiveRoomsScreen = () => {
   return (
     <>
       <SEO title="Live Rooms" description="Join live audio conversations" />
-      <SafeAreaView className="flex-1 bg-background">
+      <SafeAreaView className="flex-1 bg-background" edges={['top']}>
         <Header
           options={{
             title: t('agora.title'),

--- a/packages/frontend/app/(app)/trend/[name].tsx
+++ b/packages/frontend/app/(app)/trend/[name].tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { useSafeBack } from '@/hooks/useSafeBack';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SafeAreaView } from '@/lib/SafeAreaViewInterop';
 import { ThemedText } from '@/components/ThemedText';
 import { Header } from '@/components/Header';
@@ -20,7 +19,6 @@ export default function TrendScreen() {
         type?: string;
     }>();
     const safeBack = useSafeBack();
-    const insets = useSafeAreaInsets();
     const { t } = useTranslation();
 
     const topicName = name || '';
@@ -34,7 +32,7 @@ export default function TrendScreen() {
         : t('trend.typeTopic', { defaultValue: 'Topic' });
 
     const listHeader = useMemo(() => (
-        <View className="px-4 pb-2" style={{ paddingTop: insets.top }}>
+        <View className="px-4 pb-2">
             <ThemedText className="text-xs text-muted-foreground font-medium uppercase tracking-wide mb-1 font-primary">
                 {t('trend.trendingLabel', { defaultValue: `Trending ${typeLabel}` })}
             </ThemedText>
@@ -47,10 +45,10 @@ export default function TrendScreen() {
                 </ThemedText>
             ) : null}
         </View>
-    ), [topicName, topicDescription, typeLabel, insets.top, t]);
+    ), [topicName, topicDescription, typeLabel, t]);
 
     return (
-        <SafeAreaView className="flex-1" edges={['top', 'bottom']}>
+        <SafeAreaView className="flex-1" edges={['top']}>
             <SEO
                 title={t('seo.trend.title', { topic: topicName, defaultValue: `${topicName} - Mention` })}
                 description={t('seo.trend.description', {


### PR DESCRIPTION
Hashtag + Trend screens applied the top inset TWICE — `SafeAreaView edges={['top','bottom']}` already pads `insets.top`, and the Feed listHeader View re-added `paddingTop: insets.top` → the title was pushed down by `2×insets.top` on device (invisible on web where insets≈0). Removed the duplicate paddingTop + dead `useSafeAreaInsets`, `edges`→`['top']`. Also pinned `feeds.tsx`/`live-rooms` SafeAreaView to `edges={['top']}` so the bottom inset is owned once by the panel. Matches the canonical `saved.tsx` pattern. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)