### PR TITLE
fix(web): add non-deprecated mobile-web-app-capable meta tag

### DIFF
--- a/packages/frontend/app.config.js
+++ b/packages/frontend/app.config.js
@@ -116,6 +116,7 @@ return {
             meta: {
                 viewport: "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no",
                 themeColor: "#4F46E5",
+                mobileWebAppCapable: "yes",
                 appleMobileWebAppCapable: "yes",
                 appleMobileWebAppStatusBarStyle: "default",
                 appleMobileWebAppTitle: "Mention",


### PR DESCRIPTION
Chrome deprecates `apple-mobile-web-app-capable`; add the standard `mobile-web-app-capable` (kept the apple one for backward compat). Emitted via Expo web.meta (kebab-cased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)