### PR TITLE
fix(frontend): mobile-web-app-capable meta + federated @handle navigation

### DIFF
--- a/packages/frontend/app.config.js
+++ b/packages/frontend/app.config.js
@@ -116,7 +116,6 @@ return {
             meta: {
                 viewport: "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no",
                 themeColor: "#4F46E5",
-                mobileWebAppCapable: "yes",
                 appleMobileWebAppCapable: "yes",
                 appleMobileWebAppStatusBarStyle: "default",
                 appleMobileWebAppTitle: "Mention",

--- a/packages/frontend/components/Profile/ProfileContent.tsx
+++ b/packages/frontend/components/Profile/ProfileContent.tsx
@@ -153,6 +153,7 @@ export const ProfileContent = memo(function ProfileContent({
             handle={profileData.username}
             verified={profileData.verified}
             isFederated={profileData.isFederated}
+            copyableHandle
             variant="default"
             style={userNameStyle}
             trailingBadge={fediverseBadge}

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -46,6 +46,12 @@ export interface UserNameProps {
   };
   unifiedColors?: boolean;
   onPress?: () => void;
+  /**
+   * Opt-in tap-to-copy for the `@handle`. Default off so the handle stays plain
+   * text inside navigable parents (e.g. who-to-follow cards), letting the parent
+   * receive the tap and navigate. Only the profile header enables it.
+   */
+  copyableHandle?: boolean;
   /** Extra element rendered inline after the verified/federated/agent icons (name line). */
   trailingBadge?: React.ReactNode;
   /** Passive element rendered inline to the right of the `@handle` on the handle line (e.g. a "Follows you" tag). */

--- a/packages/frontend/components/UserName.tsx
+++ b/packages/frontend/components/UserName.tsx
@@ -9,7 +9,7 @@ import { AgentIcon } from '@/assets/icons/agent-icon';
 import { AutomatedIcon } from '@/assets/icons/automated-icon';
 import type { UserNameProps } from '@/components/Profile/types';
 
-const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated, isAgent, isAutomated, unifiedColors, onPress, variant = 'default', style, trailingBadge, handleTrailing }) => {
+const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated, isAgent, isAutomated, unifiedColors, onPress, copyableHandle, variant = 'default', style, trailingBadge, handleTrailing }) => {
     const theme = useTheme();
     const nameStyle = [styles.name, variant === 'small' && styles.nameSmall, style?.name];
 
@@ -67,7 +67,7 @@ const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated
                     className="gap-2"
                     style={[styles.handleTrailingRow, handleMarginBottom != null ? { marginBottom: handleMarginBottom } : null]}
                 >
-                    {isFederated ? (
+                    {isFederated && copyableHandle ? (
                         <TouchableOpacity activeOpacity={0.7} onPress={handleCopyHandle} style={styles.handleShrink}>
                             {handleText}
                         </TouchableOpacity>
@@ -77,7 +77,7 @@ const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated
                     {handleTrailing}
                 </View>
             );
-        } else if (isFederated) {
+        } else if (isFederated && copyableHandle) {
             handleLineNode = (
                 <TouchableOpacity activeOpacity={0.7} onPress={handleCopyHandle}>
                     <Text className="text-muted-foreground" style={[styles.handle, style?.handle]} numberOfLines={1} ellipsizeMode="tail">

--- a/packages/frontend/public/index.html
+++ b/packages/frontend/public/index.html
@@ -6,6 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
     <!--
+      Standard PWA capability meta. Chrome deprecates the legacy
+      `apple-mobile-web-app-capable` (injected at runtime by `components/PwaHead.tsx`)
+      and asks for this standard companion. Baking it into the static shell keeps it
+      present from first parse, before the runtime apple-meta injection.
+    -->
+    <meta name="mobile-web-app-capable" content="yes" />
+
+    <!--
       Resource hints for the two cross-origin hosts the first screen hits before
       any JS-driven fetch can resolve DNS/TLS on its own:
         - the Mention API   (feed JSON + federated media proxy)


### PR DESCRIPTION
Two independent frontend UX fixes (verified, tsc clean).

## 1. Standard `mobile-web-app-capable` meta (c6a923e5)
Chrome deprecated `apple-mobile-web-app-capable`. The real static <head> is `public/index.html` (Expo custom template); `web.meta` in app.config is dead for the web DOM and PwaHead only injects the apple variant. Added the standard meta to the actual static template and dropped the dead `web.meta.mobileWebAppCapable` key. Verified present in `expo export -p web` output.

## 2. Federated @handle no longer hijacks profile navigation (f3b25632)
In who-to-follow (and any navigable user row), tapping a federated user's @handle copied it instead of navigating — a nested copy TouchableOpacity in `UserName` swallowed the parent card's tap. Made handle tap-to-copy opt-in (`copyableHandle`, default off); only the profile header opts in. All call sites reviewed; none other relied on copy-on-tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)