### PR TITLE
fix(federation): resolve @mentions in AP outbox-synced posts

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/outboxMentionResolution.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/outboxMentionResolution.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Batched, BOUNDED outbox @mention resolution (`resolveInboundMentionsForNotes`).
+ *
+ * The outbox backfill imports a whole PAGE of Notes in one raw `insertMany` pass,
+ * bypassing the inbox `Create` path — so it never ran the mention resolver and
+ * federated outbox-imported notes kept their @mentions as dead plain text. This
+ * batch resolver closes that gap while staying bounded: every DISTINCT mentioned
+ * actor across the page is fetched-and-created AT MOST once, in capped-concurrency
+ * batches, each remote resolution capped by a per-actor timeout. These pin:
+ *   - a mentioned actor shared by two notes is resolved ONCE (no per-note N+1);
+ *   - each note's content anchor is rewritten to the `[mention:<id>]` placeholder
+ *     and its `ids` allowlist carries the resolved id;
+ *   - a slow/unresponsive actor TIMES OUT → its mention stays bare text, and the
+ *     whole batch still resolves (never hangs — the prior re-ingest hang);
+ *   - a throwing resolve leaves that one mention unresolved without aborting the
+ *     rest of the batch.
+ *
+ * `actor.service` and `constants` are mocked so no network / DB / Oxy I/O runs;
+ * the rest of the module graph (`bridgy`, `apLanguage`, `apSchemas`, `helpers`
+ * `runWithTimeout`) is pure.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getOrFetchActor: vi.fn(),
+  isBlockedDomain: vi.fn(() => false),
+  resolveOxyUser: vi.fn(),
+  findExistingActor: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/actor.service', () => ({
+  actorService: { getOrFetchActor: mocks.getOrFetchActor },
+}));
+vi.mock('../../../connectors/activitypub/constants', () => ({
+  isBlockedDomain: mocks.isBlockedDomain,
+  resolveOxyUser: mocks.resolveOxyUser,
+}));
+vi.mock('../../../models/FederatedActor', () => ({
+  default: { findOne: mocks.findExistingActor },
+}));
+vi.mock('../../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  applyMentionPlaceholders,
+  resolveInboundMentionsForNotes,
+  type ResolvedInboundMentions,
+} from '../../../connectors/activitypub/apMentions';
+
+/** Assert the batch produced a resolution for `note` and return it (no `!`). */
+function resolutionFor(
+  byNote: Map<Record<string, unknown>, ResolvedInboundMentions>,
+  note: Record<string, unknown>,
+): ResolvedInboundMentions {
+  const resolved = byNote.get(note);
+  if (!resolved) throw new Error('expected a resolution entry for the note');
+  return resolved;
+}
+
+const REMOTE = 'https://mastodon.example';
+const BOB_URI = `${REMOTE}/users/bob`;
+const BOB_PROFILE = `${REMOTE}/@bob`;
+const BOB_OXY_ID = 'oxy_bob';
+const CAROL_URI = `${REMOTE}/users/carol`;
+const CAROL_PROFILE = `${REMOTE}/@carol`;
+const CAROL_OXY_ID = 'oxy_carol';
+
+/** A Mastodon-style Note: tag href = actor URI, in-content anchor = profile page. */
+function noteMentioning(actorUri: string, profileHref: string, name: string) {
+  return {
+    content: `<p>hi <a href="${profileHref}" class="u-url mention">${name}</a></p>`,
+    tag: [{ type: 'Mention', href: actorUri, name: `${name}@mastodon.example` }],
+  };
+}
+
+const OPTIONS = { concurrency: 3, perActorTimeoutMs: 20_000 };
+
+beforeEach(() => {
+  mocks.getOrFetchActor.mockReset();
+  mocks.findExistingActor.mockReset();
+  mocks.isBlockedDomain.mockReturnValue(false);
+});
+
+describe('resolveInboundMentionsForNotes (batched outbox mention resolution)', () => {
+  it('resolves a distinct mention actor ONCE across a page and rewrites each note', async () => {
+    mocks.getOrFetchActor.mockImplementation(async (uri: string) => {
+      if (uri === BOB_URI) return { oxyUserId: BOB_OXY_ID };
+      if (uri === CAROL_URI) return { oxyUserId: CAROL_OXY_ID };
+      return null;
+    });
+
+    // Two notes mention @bob, one mentions @carol → 2 distinct actors.
+    const noteA = noteMentioning(BOB_URI, BOB_PROFILE, '@bob');
+    const noteB = noteMentioning(BOB_URI, BOB_PROFILE, '@bob');
+    const noteC = noteMentioning(CAROL_URI, CAROL_PROFILE, '@carol');
+
+    const byNote = await resolveInboundMentionsForNotes([noteA, noteB, noteC], OPTIONS);
+
+    // Each DISTINCT actor fetched exactly once — never once per note.
+    expect(mocks.getOrFetchActor).toHaveBeenCalledTimes(2);
+    expect(mocks.getOrFetchActor).toHaveBeenCalledWith(BOB_URI);
+    expect(mocks.getOrFetchActor).toHaveBeenCalledWith(CAROL_URI);
+
+    // Per-note allowlist + placeholder rewrite.
+    const a = resolutionFor(byNote, noteA);
+    expect(a.ids).toEqual([BOB_OXY_ID]);
+    expect(applyMentionPlaceholders(noteA, a.anchorMap).content).toBe(
+      `<p>hi [mention:${BOB_OXY_ID}]</p>`,
+    );
+    expect(resolutionFor(byNote, noteB).ids).toEqual([BOB_OXY_ID]);
+    const c = resolutionFor(byNote, noteC);
+    expect(c.ids).toEqual([CAROL_OXY_ID]);
+    expect(applyMentionPlaceholders(noteC, c.anchorMap).content).toBe(
+      `<p>hi [mention:${CAROL_OXY_ID}]</p>`,
+    );
+  });
+
+  it('times out a slow/unresponsive actor: mention stays bare text, batch never hangs', async () => {
+    // @bob resolves fast; @carol never resolves → must be bounded by the timeout.
+    mocks.getOrFetchActor.mockImplementation((uri: string) => {
+      if (uri === BOB_URI) return Promise.resolve({ oxyUserId: BOB_OXY_ID });
+      return new Promise(() => {
+        /* never resolves — simulates an unresponsive remote instance */
+      });
+    });
+
+    const noteBob = noteMentioning(BOB_URI, BOB_PROFILE, '@bob');
+    const noteSlow = noteMentioning(CAROL_URI, CAROL_PROFILE, '@carol');
+
+    // A tiny per-actor timeout so the never-resolving fetch is abandoned quickly.
+    const byNote = await resolveInboundMentionsForNotes([noteBob, noteSlow], {
+      concurrency: 3,
+      perActorTimeoutMs: 10,
+    });
+
+    // @bob still resolved and rewrote; the unresponsive @carol is left bare text.
+    expect(resolutionFor(byNote, noteBob).ids).toEqual([BOB_OXY_ID]);
+    const slow = resolutionFor(byNote, noteSlow);
+    expect(slow.ids).toEqual([]);
+    expect(applyMentionPlaceholders(noteSlow, slow.anchorMap).content).toBe(noteSlow.content);
+  });
+
+  it('a throwing resolve leaves that mention unresolved without aborting the batch', async () => {
+    mocks.getOrFetchActor.mockImplementation(async (uri: string) => {
+      if (uri === BOB_URI) return { oxyUserId: BOB_OXY_ID };
+      throw new Error('remote actor fetch blew up');
+    });
+
+    const noteBob = noteMentioning(BOB_URI, BOB_PROFILE, '@bob');
+    const noteBad = noteMentioning(CAROL_URI, CAROL_PROFILE, '@carol');
+
+    const byNote = await resolveInboundMentionsForNotes([noteBob, noteBad], OPTIONS);
+
+    expect(resolutionFor(byNote, noteBob).ids).toEqual([BOB_OXY_ID]);
+    const bad = resolutionFor(byNote, noteBad);
+    expect(bad.ids).toEqual([]);
+    expect(applyMentionPlaceholders(noteBad, bad.anchorMap).content).toBe(noteBad.content);
+  });
+
+  it('returns an empty map for an empty page (no resolution work)', async () => {
+    const byNote = await resolveInboundMentionsForNotes([], OPTIONS);
+    expect(byNote.size).toBe(0);
+    expect(mocks.getOrFetchActor).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/connectors/activitypub/apMentions.ts
+++ b/packages/backend/src/connectors/activitypub/apMentions.ts
@@ -5,6 +5,7 @@ import { getApContentMap } from './apLanguage';
 import { primaryApType } from './apSchemas';
 import { bridgedMentionAnchorHrefs } from './bridgy';
 import { isBlockedDomain, resolveOxyUser } from './constants';
+import { runWithTimeout } from './helpers';
 
 /**
  * INBOUND @mention ingestion for federated ActivityPub Notes.
@@ -63,6 +64,14 @@ export interface ResolvedInboundMentions {
    * tag resolved (the common no-mention case), which makes the rewrite a no-op.
    */
   anchorMap: Map<string, string>;
+}
+
+/** A mentioned actor resolved to its Oxy user id and locality. */
+export interface MentionActorResolution {
+  /** The mentioned actor's Oxy user id (federated OR local). */
+  oxyUserId: string;
+  /** True when the actor is a LOCAL Mention user — the only notification target. */
+  isLocal: boolean;
 }
 
 /** Matches a whole `<a …>…</a>` anchor, capturing its `href`. Anchors never nest. */
@@ -191,7 +200,7 @@ const lookupExistingRemoteActorOxyId: RemoteMentionResolver = async (href) => {
 async function resolveMentionOxyId(
   href: string,
   resolveRemote: RemoteMentionResolver,
-): Promise<{ oxyUserId: string; isLocal: boolean } | null> {
+): Promise<MentionActorResolution | null> {
   let host: string;
   try {
     host = new URL(href).hostname.toLowerCase();
@@ -212,18 +221,29 @@ async function resolveMentionOxyId(
 }
 
 /**
- * Shared engine behind {@link resolveInboundMentions} and
- * {@link resolveInboundMentionsExisting}: extract the `Mention` tags, resolve each
- * DISTINCT actor href AT MOST once (no N+1), and build the id/localId sets plus the
- * candidate-anchor map. Fail-soft per mention (a tag that fails to resolve is
- * simply absent, leaving its anchor as bare text). The ONLY behavioural difference
- * between the two public callers is `resolveRemote` — whether an unknown remote
- * actor is fetched-and-created or looked up read-only — so both cover the exact
- * same set of anchor href forms.
+ * Resolve ONE extracted `Mention` tag to its mentioned actor, or `null` when it
+ * cannot be resolved (leaving its anchor as bare text). This is the single seam
+ * {@link buildResolvedInboundMentions} varies across its callers: the live inbox
+ * path resolves through {@link resolveMentionOxyId} with the fetch-and-create
+ * remote resolver, the one-shot repair path resolves lookup-only, and the batched
+ * outbox path resolves from a precomputed map with NO further I/O.
+ */
+type MentionTagResolver = (tag: InboundMentionTag) => Promise<MentionActorResolution | null>;
+
+/**
+ * Shared engine behind {@link resolveInboundMentions},
+ * {@link resolveInboundMentionsExisting} and {@link resolveInboundMentionsForNotes}:
+ * extract the `Mention` tags, resolve each DISTINCT actor href AT MOST once (no
+ * N+1), and build the id/localId sets plus the candidate-anchor map. Fail-soft per
+ * mention (a tag that fails to resolve is simply absent, leaving its anchor as bare
+ * text). The ONLY behavioural difference between the callers is `resolveTag` —
+ * whether an unknown remote actor is fetched-and-created, looked up read-only, or
+ * read from a precomputed batch map — so all cover the exact same set of anchor
+ * href forms.
  */
 async function buildResolvedInboundMentions(
   object: Record<string, unknown>,
-  resolveRemote: RemoteMentionResolver,
+  resolveTag: MentionTagResolver,
 ): Promise<ResolvedInboundMentions> {
   const tags = extractMentionTags(object);
   if (tags.length === 0) return { ids: [], localIds: [], anchorMap: new Map() };
@@ -241,7 +261,7 @@ async function buildResolvedInboundMentions(
   await Promise.all(
     [...byHref.values()].map(async (tag) => {
       try {
-        const resolved = await resolveMentionOxyId(tag.href, resolveRemote);
+        const resolved = await resolveTag(tag);
         if (!resolved) return;
         ids.add(resolved.oxyUserId);
         if (resolved.isLocal) localIds.add(resolved.oxyUserId);
@@ -281,7 +301,9 @@ async function buildResolvedInboundMentions(
 export async function resolveInboundMentions(
   object: Record<string, unknown>,
 ): Promise<ResolvedInboundMentions> {
-  return buildResolvedInboundMentions(object, fetchOrCreateRemoteActorOxyId);
+  return buildResolvedInboundMentions(object, (tag) =>
+    resolveMentionOxyId(tag.href, fetchOrCreateRemoteActorOxyId),
+  );
 }
 
 /**
@@ -298,7 +320,91 @@ export async function resolveInboundMentions(
 export async function resolveInboundMentionsExisting(
   object: Record<string, unknown>,
 ): Promise<ResolvedInboundMentions> {
-  return buildResolvedInboundMentions(object, lookupExistingRemoteActorOxyId);
+  return buildResolvedInboundMentions(object, (tag) =>
+    resolveMentionOxyId(tag.href, lookupExistingRemoteActorOxyId),
+  );
+}
+
+/** Tuning for {@link resolveInboundMentionsForNotes}'s bounded remote fan-out. */
+export interface BatchMentionResolveOptions {
+  /** Max distinct mention actors resolved in parallel per batch. */
+  concurrency: number;
+  /**
+   * Per-actor wall-clock budget. A remote actor fetch that exceeds it resolves to
+   * "unresolved" (its anchor stays bare text) rather than stalling the batch.
+   */
+  perActorTimeoutMs: number;
+}
+
+/**
+ * Batched, BOUNDED variant of {@link resolveInboundMentions} for the outbox
+ * backfill path, which imports a whole PAGE of Notes in one pass. Returns each
+ * note's {@link ResolvedInboundMentions}, keyed by the input object reference.
+ *
+ * The outbox path must resolve the UNION of the page's @mentions without either
+ * (a) re-resolving an actor several notes mention, or (b) fanning out one
+ * UNBOUNDED remote actor fetch per mention across the page — the exact failure
+ * mode that once hung a Bluesky re-ingest. So every DISTINCT mention actor across
+ * all notes is resolved AT MOST once, in batches of `concurrency`, each remote
+ * resolution capped by `perActorTimeoutMs`; a slow/dead/throwing actor yields
+ * `null` and its anchor stays bare text instead of stalling or aborting the page.
+ *
+ * Like {@link resolveInboundMentions} (and unlike the repair path), a first-seen
+ * mentioned actor IS fetched-and-created so its mention links. The per-note
+ * placeholder/id assembly then runs against the shared resolution map with NO
+ * further I/O, reusing the identical anchor-matching logic as the single-note
+ * paths via {@link buildResolvedInboundMentions}.
+ */
+export async function resolveInboundMentionsForNotes(
+  objects: ReadonlyArray<Record<string, unknown>>,
+  options: BatchMentionResolveOptions,
+): Promise<Map<Record<string, unknown>, ResolvedInboundMentions>> {
+  const byNote = new Map<Record<string, unknown>, ResolvedInboundMentions>();
+  if (objects.length === 0) return byNote;
+
+  // 1. Union of DISTINCT mention actor hrefs across every note in the page.
+  const distinctHrefs = new Set<string>();
+  for (const object of objects) {
+    for (const tag of extractMentionTags(object)) distinctHrefs.add(tag.href);
+  }
+
+  // 2. Resolve each distinct href AT MOST once (fetch-and-create) in bounded
+  //    batches, each capped by the per-actor timeout. A timeout, a null, or a
+  //    thrown error leaves the href unresolved — never aborts the batch.
+  const resolutions = new Map<string, MentionActorResolution>();
+  const hrefs = [...distinctHrefs];
+  const concurrency = Math.max(1, options.concurrency);
+  for (let i = 0; i < hrefs.length; i += concurrency) {
+    const batch = hrefs.slice(i, i + concurrency);
+    const resolved = await Promise.all(
+      batch.map((href) =>
+        runWithTimeout(
+          resolveMentionOxyId(href, fetchOrCreateRemoteActorOxyId),
+          options.perActorTimeoutMs,
+        ).catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(`[Federation] failed to resolve outbox mention ${href}: ${message}`);
+          return null;
+        }),
+      ),
+    );
+    for (let j = 0; j < batch.length; j++) {
+      const value = resolved[j];
+      if (value) resolutions.set(batch[j], value);
+    }
+  }
+
+  // 3. Assemble each note's placeholders/ids from the shared map — NO I/O, same
+  //    anchor-matching engine as the single-note paths.
+  for (const object of objects) {
+    byNote.set(
+      object,
+      await buildResolvedInboundMentions(object, (tag) =>
+        Promise.resolve(resolutions.get(tag.href) ?? null),
+      ),
+    );
+  }
+  return byNote;
 }
 
 /**

--- a/packages/backend/src/connectors/activitypub/outbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/outbox.service.ts
@@ -44,6 +44,11 @@ import {
   parseInboundActivity,
   parseNote,
 } from './apSchemas';
+import {
+  applyMentionPlaceholders,
+  resolveInboundMentionsForNotes,
+  type ResolvedInboundMentions,
+} from './apMentions';
 
 /**
  * Bounded concurrency for resolving unknown actor URIs during outbox backfill.
@@ -598,6 +603,31 @@ export class OutboxSyncService {
 
       logger.debug(`[FedSync] ${candidates.length} candidates (${noteCandidates.length} notes, ${announceCandidates.length} announces), ${existingIds.size} already exist, actorOxyMap has ${actorOxyMap.size} entries`);
 
+      // Resolve the @mentions of every NEW note in this page ONCE, with bounded
+      // remote fan-out. Each DISTINCT mentioned actor across the page is
+      // fetched-and-created at most once, in capped-concurrency batches with a
+      // per-actor timeout (the SAME bounds this file already applies to note-author
+      // resolution), so a page carrying many first-seen mentions can never trigger
+      // the unbounded/serial actor fetch that once hung a re-ingest. Already-imported
+      // (deduped) notes are excluded so a re-sync never re-resolves. Consumed per
+      // note in the build loop below to rewrite each mention anchor into a
+      // `[mention:<id>]` placeholder BEFORE the body is derived and to set the
+      // post's `mentions` allowlist — mirroring the inbox Create path, which this
+      // raw `insertMany` cannot inherit because it bypasses that code path.
+      const pendingNoteCandidates = noteCandidates.filter(
+        (c) => !existingIds.has(c.activityId),
+      );
+      const mentionsByNote = await resolveInboundMentionsForNotes(
+        pendingNoteCandidates.map((c) => c.note),
+        {
+          concurrency: OUTBOX_ACTOR_RESOLVE_CONCURRENCY,
+          perActorTimeoutMs: OUTBOX_ACTOR_RESOLVE_TIMEOUT_MS,
+        },
+      );
+      // Shared no-mention default for a note the map has no entry for (never
+      // mutated; `applyMentionPlaceholders` treats an empty anchor map as a no-op).
+      const emptyMentions: ResolvedInboundMentions = { ids: [], localIds: [], anchorMap: new Map() };
+
       // Build documents for batch insert. Raw insert docs (bypass Mongoose) — a
       // loose record shape since they are assembled field-by-field below and
       // inserted via `Post.collection.insertMany`.
@@ -642,13 +672,22 @@ export class OutboxSyncService {
           continue;
         }
 
+        // Rewrite this note's @mention anchors to internal `[mention:<id>]`
+        // placeholders using the shared page-level resolution, so hydration renders
+        // each mention as a real profile link instead of dead `@user` text. Must
+        // run BEFORE the builder derives the body (the raw `insertMany` bypasses
+        // Mongoose, so there is no later hook to do it). `applyMentionPlaceholders`
+        // returns the note unchanged when it has no resolved mentions (zero cost).
+        const mentionResult = mentionsByNote.get(note) ?? emptyMentions;
+        const noteObject = applyMentionPlaceholders(note, mentionResult.anchorMap);
+
         // Build the storable body via the shared builder: contentMap fallback,
         // the SAME hashtag normalization the inbox path runs (fixes the ingest
         // asymmetry), media materialization, and the empty-note guard. The raw
         // `insertMany` below bypasses Mongoose middleware, so the builder is the
         // single place that normalization/guarding happens for this path. A Note
         // that carries nothing storable is skipped rather than inserted blank.
-        const built = await buildFederatedNoteContent(note, resolvedOxyUserId, {
+        const built = await buildFederatedNoteContent(noteObject, resolvedOxyUserId, {
           activityId,
           actorUri: actorUri ?? undefined,
         });
@@ -712,6 +751,11 @@ export class OutboxSyncService {
           },
           visibility: mapApVisibility(note.to, note.cc),
           hashtags,
+          // Resolved @mention Oxy user ids (federated + local) — the SAME allowlist
+          // the inbox path stores, keyed by the `[mention:<id>]` placeholders now in
+          // the body so hydration renders each as a real profile link. Set
+          // explicitly because the raw `insertMany` bypasses the schema default.
+          ...(mentionResult.ids.length > 0 ? { mentions: mentionResult.ids } : {}),
           ...(primaryLanguage ? { language: primaryLanguage } : {}),
           status: 'published',
           // Engagement counters start at 0 and only ever move in lockstep with


### PR DESCRIPTION
Federated (Mastodon/AP) posts imported via OUTBOX sync (profile-view backfill) never resolved their @mentions — only the inbox-push path did. So mentions like `@babe` rendered as dead plain text (e.g. https://mention.earth/p/6a594a45a7adda635809baa8 from @phaysis@mastodon.coffee).

## Fix
- `apMentions.ts`: refactored the shared engine to vary on a single per-tag resolver seam (no duplication of inbox logic; inbox/repair behaviour byte-identical). Added `resolveInboundMentionsForNotes` — a batched, bounded resolver.
- `outbox.service.ts`: resolves the page's mentions once (deduped across notes), applies `[mention:<id>]` placeholders before the raw-insert body build, sets the `mentions` allowlist.

## Bounded (no repeat of the earlier re-ingest hang)
Dedup distinct actor hrefs across the page + concurrency cap (OUTBOX_ACTOR_RESOLVE_CONCURRENCY=3) + per-actor 20s timeout (→ null, never throws). One dead remote can't stall/abort the page.

## Verified
tsc clean; full backend suite 2584 tests pass incl. new `outboxMentionResolution.test.ts`.

## Follow-up (separate)
Existing already-imported posts are deduped on re-sync, so this only fixes NEW imports. A bounded Fargate one-shot backfill is needed to repair stored posts (lookup-only resolver, no ghost actors). Decision pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)