### PR TITLE
feat(federation): Phase 2 — HTTP signatures into @oxyhq/federation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "@mention/shared-types": "file:../shared-types",
         "@oxyhq/contracts": "^0.16.0",
         "@oxyhq/core": "^12.4.1",
-        "@oxyhq/federation": "^0.1.0",
+        "@oxyhq/federation": "^0.2.0",
         "@oxyhq/protocol": "^0.1.5",
         "@socket.io/redis-adapter": "^8.3.0",
         "@syra.fm/sdk": "^0.7.0",
@@ -713,7 +713,7 @@
 
     "@oxyhq/expo-oxy-identity": ["@oxyhq/expo-oxy-identity@0.1.0", "", { "peerDependencies": { "expo": ">=51.0.0", "expo-modules-core": "*", "react": ">=18.0.0", "react-native": ">=0.74.0" } }, "sha512-erMlS8dF1BIggOuu44impWjZDns8yjuQzRIvYnIjMzpD+Flc7V6HtufhzGTDEvmEYV/utZEiwo213IfGM5Uiyw=="],
 
-    "@oxyhq/federation": ["@oxyhq/federation@0.1.0", "", { "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-zurrip1PSczRr9P/ZoHXJg98kwrwkMxEhf+QjnvhUTId0AUH3FGmcqJCPzwONT5dH76iH+7YyVWXdjuZP7NsTw=="],
+    "@oxyhq/federation": ["@oxyhq/federation@0.2.0", "", { "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-hZvtTaXSDnqhidOrLxlZ/KmOWFSSkeixph1RRXDKjvl0h8Vxj6PdyC5cxFlblxDjCcxoi/VldVJXH8yIHR+NTA=="],
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.5", "", { "dependencies": { "@oxyhq/contracts": "^0.13.2", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-modules-core": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-iHrHLg1qnkjlcj2dES5sT/4zA5wmVU0PcvhpTIT+acTD6Oqip1EibiM6x1fYDMouAHoK+C4OKmHJ45Usg9nDrw=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,7 +20,7 @@
     "@mention/shared-types": "file:../shared-types",
     "@oxyhq/contracts": "^0.16.0",
     "@oxyhq/core": "^12.4.1",
-    "@oxyhq/federation": "^0.1.0",
+    "@oxyhq/federation": "^0.2.0",
     "@oxyhq/protocol": "^0.1.5",
     "@socket.io/redis-adapter": "^8.3.0",
     "@syra.fm/sdk": "^0.7.0",

--- a/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/fediverseSharingGates.test.ts
@@ -85,9 +85,16 @@ vi.mock('../../../connectors/activitypub/ActivityPubConnector', () => ({
 }));
 
 vi.mock('../../../connectors/activitypub/crypto', () => ({
-  verifyHttpSignature: (...args: unknown[]) => mocks.verifyHttpSignature(...args),
   getPublicKey: (...args: unknown[]) => mocks.getPublicKey(...args),
 }));
+
+// The pure HTTP-signature crypto now lives in @oxyhq/federation; the inbox route
+// (ap.routes.ts) imports verifyHttpSignature from there. Keep the rest of the
+// package (connector types, signRequest) real and stub only the verify seam.
+vi.mock('@oxyhq/federation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@oxyhq/federation')>();
+  return { ...actual, verifyHttpSignature: (...args: unknown[]) => mocks.verifyHttpSignature(...args) };
+});
 
 vi.mock('../../../connectors/activitypub/constants', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../connectors/activitypub/constants')>();

--- a/packages/backend/src/__tests__/connectors/activitypub/outboxValidation.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/outboxValidation.test.ts
@@ -21,7 +21,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getPublicKey: vi.fn(),
-  signRequest: vi.fn(),
+  signViaOxy: vi.fn(),
   actorFind: vi.fn(),
   actorFindOne: vi.fn(),
   findOneAndUpdate: vi.fn(),
@@ -41,9 +41,13 @@ const mocks = vi.hoisted(() => ({
   assertSafePublicUrl: vi.fn(),
 }));
 
+// `signedFetch` (helpers.ts) is built from @oxyhq/federation's createSignedFetch,
+// which signs via Mention's injected `signViaOxy` (crypto.ts) and derives the
+// instance keyId from `getPublicKey('instance')`. The package's real signRequest
+// composes the Signature header; only the private-key custody is stubbed here.
 vi.mock('../../../connectors/activitypub/crypto', () => ({
   getPublicKey: mocks.getPublicKey,
-  signRequest: mocks.signRequest,
+  signViaOxy: mocks.signViaOxy,
 }));
 
 // `signedFetch` performs its GET via the IP-pinned `fetchUpstreamSingleHop`
@@ -175,11 +179,7 @@ beforeEach(() => {
     keyId: 'https://mention.earth/ap/users/instance#main-key',
     publicKeyPem: 'public',
   });
-  mocks.signRequest.mockResolvedValue({
-    Host: 'mastodon.social',
-    Date: 'Thu, 18 Jun 2026 00:00:00 GMT',
-    Signature: 'signature',
-  });
+  mocks.signViaOxy.mockResolvedValue('c2lnbmF0dXJl'); // base64 stub signature
   mocks.findOneAndUpdate.mockImplementation(async (_query, update) => ({ _id: 'actor_1', ...update.$set }));
   mocks.updateOne.mockResolvedValue({ modifiedCount: 1 });
   mocks.actorFind.mockReturnValue({ lean: vi.fn().mockResolvedValue([]) });

--- a/packages/backend/src/__tests__/utils/httpSignature.test.ts
+++ b/packages/backend/src/__tests__/utils/httpSignature.test.ts
@@ -5,11 +5,13 @@ const ACTOR_URI = 'https://mastodon.social/users/alice';
 const KEY_ID = `${ACTOR_URI}#main-key`;
 const INBOX_URL = 'https://mention.earth/ap/inbox';
 
-// crypto.ts signs via Oxy's `/federation/sign` (the private key never leaves
-// Oxy). Stub the service client so `signViaOxy` performs the RSA signature
-// locally with the test private key — preserving an end-to-end sign/verify
-// round-trip without pulling in the real Oxy client graph or network. Uses
-// `vi.hoisted` so the holder exists before the hoisted `vi.mock` factory runs;
+// Integration test of Mention's federation SIGNING wiring: the pure HTTP-signature
+// crypto now lives in `@oxyhq/federation`, and Mention supplies the private-key
+// custody via `signViaOxy` (crypto.ts), which signs via Oxy's `/federation/sign`.
+// Stub the service client so `signViaOxy` performs the RSA signature locally with
+// the test private key — preserving an end-to-end sign/verify round-trip through
+// the REAL adapter (crypto.ts → @oxyhq/federation) without the Oxy client/network.
+// Uses `vi.hoisted` so the holder exists before the hoisted `vi.mock` factory runs;
 // `beforeAll` fills in the generated private key.
 const signing = vi.hoisted(() => ({ privateKeyPem: '' }));
 
@@ -28,7 +30,8 @@ vi.mock('../../utils/oxyHelpers', () => ({
   }),
 }));
 
-import { signRequest, verifyHttpSignature } from '../../connectors/activitypub/crypto';
+import { signRequest, verifyHttpSignature } from '@oxyhq/federation';
+import { signViaOxy } from '../../connectors/activitypub/crypto';
 import { AP_CONTENT_TYPE } from '../../connectors/activitypub/constants';
 
 let publicKeyPem: string;
@@ -65,10 +68,10 @@ beforeAll(() => {
   signing.privateKeyPem = privateKey;
 });
 
-describe('verifyHttpSignature', () => {
+describe('verifyHttpSignature (via Mention signViaOxy adapter)', () => {
   it('verifies a valid signature produced by signRequest and returns the actor URI', async () => {
     const body = JSON.stringify({ type: 'Create', id: 'https://remote/a/1' });
-    const signed = await signRequest(KEY_ID, 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, KEY_ID, 'POST', INBOX_URL, body);
 
     const result = await verifyHttpSignature(
       {
@@ -95,7 +98,7 @@ describe('verifyHttpSignature', () => {
 
   it('rejects when the public key cannot be fetched', async () => {
     const body = JSON.stringify({ type: 'Create' });
-    const signed = await signRequest('https://other/key#main', 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, 'https://other/key#main', 'POST', INBOX_URL, body);
 
     const result = await verifyHttpSignature(
       { method: 'POST', path: new URL(INBOX_URL).pathname, headers: lowerHeaders(signed), body },
@@ -107,7 +110,7 @@ describe('verifyHttpSignature', () => {
 
   it('rejects when the body is tampered after signing (digest mismatch)', async () => {
     const body = JSON.stringify({ type: 'Create', id: 'https://remote/a/1' });
-    const signed = await signRequest(KEY_ID, 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, KEY_ID, 'POST', INBOX_URL, body);
 
     const result = await verifyHttpSignature(
       {
@@ -124,7 +127,7 @@ describe('verifyHttpSignature', () => {
 
   it('rejects when the signed string does not match (verify-failed)', async () => {
     const body = JSON.stringify({ type: 'Create', id: 'https://remote/a/1' });
-    const signed = await signRequest(KEY_ID, 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, KEY_ID, 'POST', INBOX_URL, body);
 
     // Change the request path so the reconstructed (request-target) differs from
     // what was signed — digest still matches, but the RSA verification fails.
@@ -143,7 +146,7 @@ describe('verifyHttpSignature', () => {
 
   it('rejects when the Date header is outside the allowed skew', async () => {
     const body = JSON.stringify({ type: 'Create', id: 'https://remote/a/1' });
-    const signed = await signRequest(KEY_ID, 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, KEY_ID, 'POST', INBOX_URL, body);
     const stale = lowerHeaders(signed);
     stale.date = new Date(Date.now() - 30 * 60 * 1000).toUTCString(); // 30 min ago
 
@@ -155,14 +158,14 @@ describe('verifyHttpSignature', () => {
     expect(result.reason).toBe('date-skew');
   });
 
-  // The sender signs over `host: mention.earth` (INBOX_URL host). Our edge (the
-  // CF Pages worker) rewrites the origin Host to api.mention.earth and forwards
-  // the ORIGINAL signed host in X-Forwarded-Host. The verifier must rebuild the
-  // `host` signing line from X-Forwarded-Host so the reconstructed string matches
-  // what was signed.
+  // The sender signs over `host: mention.earth` (INBOX_URL host). The apex is
+  // CF-proxied → ALB → backend, which rewrites the origin Host to
+  // api.mention.earth and forwards the ORIGINAL signed host in X-Forwarded-Host.
+  // Mention passes `trustForwardedHost: true` (as ap.routes.ts does in prod) so
+  // the verifier rebuilds the `host` signing line from X-Forwarded-Host.
   it('verifies when received via the origin host with x-forwarded-host carrying the signed apex', async () => {
     const body = JSON.stringify({ type: 'Create', id: 'https://remote/a/1' });
-    const signed = await signRequest(KEY_ID, 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, KEY_ID, 'POST', INBOX_URL, body);
 
     const headers = lowerHeaders(signed);
     headers.host = 'api.mention.earth';
@@ -171,6 +174,7 @@ describe('verifyHttpSignature', () => {
     const result = await verifyHttpSignature(
       { method: 'POST', path: new URL(INBOX_URL).pathname, headers, body },
       fetchPublicKey,
+      { trustForwardedHost: true },
     );
 
     expect(result.verified).toBe(true);
@@ -179,7 +183,7 @@ describe('verifyHttpSignature', () => {
 
   it('falls back to the host header when x-forwarded-host is absent (direct delivery)', async () => {
     const body = JSON.stringify({ type: 'Create', id: 'https://remote/a/1' });
-    const signed = await signRequest(KEY_ID, 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, KEY_ID, 'POST', INBOX_URL, body);
 
     const headers = lowerHeaders(signed);
     expect(headers['x-forwarded-host']).toBeUndefined();
@@ -187,6 +191,7 @@ describe('verifyHttpSignature', () => {
     const result = await verifyHttpSignature(
       { method: 'POST', path: new URL(INBOX_URL).pathname, headers, body },
       fetchPublicKey,
+      { trustForwardedHost: true },
     );
 
     expect(result.verified).toBe(true);
@@ -195,7 +200,7 @@ describe('verifyHttpSignature', () => {
 
   it('uses only the first token of a comma-separated x-forwarded-host list', async () => {
     const body = JSON.stringify({ type: 'Create', id: 'https://remote/a/1' });
-    const signed = await signRequest(KEY_ID, 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, KEY_ID, 'POST', INBOX_URL, body);
 
     const headers = lowerHeaders(signed);
     headers.host = 'api.mention.earth';
@@ -205,6 +210,7 @@ describe('verifyHttpSignature', () => {
     const result = await verifyHttpSignature(
       { method: 'POST', path: new URL(INBOX_URL).pathname, headers, body },
       fetchPublicKey,
+      { trustForwardedHost: true },
     );
 
     expect(result.verified).toBe(true);
@@ -213,7 +219,7 @@ describe('verifyHttpSignature', () => {
 
   it('fails verification when x-forwarded-host does not match the signed host', async () => {
     const body = JSON.stringify({ type: 'Create', id: 'https://remote/a/1' });
-    const signed = await signRequest(KEY_ID, 'POST', INBOX_URL, body);
+    const signed = await signRequest(signViaOxy, KEY_ID, 'POST', INBOX_URL, body);
 
     const headers = lowerHeaders(signed);
     headers.host = 'api.mention.earth';
@@ -222,6 +228,7 @@ describe('verifyHttpSignature', () => {
     const result = await verifyHttpSignature(
       { method: 'POST', path: new URL(INBOX_URL).pathname, headers, body },
       fetchPublicKey,
+      { trustForwardedHost: true },
     );
 
     expect(result.verified).toBe(false);

--- a/packages/backend/src/connectors/activitypub/crypto.ts
+++ b/packages/backend/src/connectors/activitypub/crypto.ts
@@ -1,7 +1,19 @@
-import crypto from 'crypto';
 import { logger } from '../../utils/logger';
-import { AP_CONTENT_TYPE, FEDERATION_DOMAIN } from './constants';
+import { FEDERATION_DOMAIN } from './constants';
 import { getServiceOxyClient } from '../../utils/oxyHelpers';
+
+/**
+ * Mention's federation KEYS ADAPTER.
+ *
+ * The pure HTTP-signature crypto (`signRequest` / `verifyHttpSignature`, incl.
+ * the X-Forwarded-Host host reconstruction) now lives in `@oxyhq/federation` —
+ * a byte-identical, app-agnostic extraction. This file is what stays app-side:
+ * the two adapters that bind Mention's private-key CUSTODY to that engine.
+ * `getPublicKey` and `signViaOxy` both call oxy-api (`GET /federation/public-key`
+ * / `POST /federation/sign`); the private key never enters Mention. Callers pass
+ * `signViaOxy` as the engine's injected signer and `getPublicKey` for the
+ * instance/actor keyId.
+ */
 
 /**
  * Public-key material for an actor, as advertised in its ActivityPub `publicKey`
@@ -203,191 +215,4 @@ export async function signViaOxy(keyId: string, signingString: string): Promise<
   }
 
   return response.signature;
-}
-
-/**
- * Build the HTTP Signature header per draft-cavage-http-signatures-12 and sign it
- * via Oxy (the private key never leaves Oxy).
- *
- * The spec-correct signing string is composed locally: (request-target), host,
- * date, and — for body-bearing requests — digest and content-type. The composed
- * string is sent to Oxy's `/federation/sign`, and the resulting signature is
- * assembled into the `Signature:` header.
- *
- * Returns the headers to attach to the outbound request (Host, Date, optional
- * Digest, and Signature). Content-Type is set by the deliverer's fetch.
- */
-export async function signRequest(
-  keyId: string,
-  method: string,
-  url: string,
-  body?: string,
-): Promise<Record<string, string>> {
-  const parsedUrl = new URL(url);
-  const date = new Date().toUTCString();
-  const headers: Record<string, string> = {
-    Host: parsedUrl.host,
-    Date: date,
-  };
-
-  const signedHeaderNames = ['(request-target)', 'host', 'date'];
-  const signingParts = [
-    `(request-target): ${method.toLowerCase()} ${parsedUrl.pathname}${parsedUrl.search}`,
-    `host: ${parsedUrl.host}`,
-    `date: ${date}`,
-  ];
-
-  if (body) {
-    const digest = crypto.createHash('sha256').update(body).digest('base64');
-    headers['Digest'] = `SHA-256=${digest}`;
-    signedHeaderNames.push('digest');
-    signingParts.push(`digest: SHA-256=${digest}`);
-    // Include content-type in signature (required by some servers like Threads)
-    signedHeaderNames.push('content-type');
-    signingParts.push(`content-type: ${AP_CONTENT_TYPE}`);
-  }
-
-  const signingString = signingParts.join('\n');
-  const signature = await signViaOxy(keyId, signingString);
-
-  headers['Signature'] = [
-    `keyId="${keyId}"`,
-    'algorithm="rsa-sha256"',
-    `headers="${signedHeaderNames.join(' ')}"`,
-    `signature="${signature}"`,
-  ].join(',');
-
-  return headers;
-}
-
-/**
- * Parse the Signature header from an incoming request.
- */
-function parseSignatureHeader(signatureHeader: string): {
-  keyId: string;
-  algorithm: string;
-  headers: string[];
-  signature: string;
-} | null {
-  const params: Record<string, string> = {};
-  const regex = /(\w+)="([^"]*)"/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(signatureHeader)) !== null) {
-    params[match[1]] = match[2];
-  }
-
-  if (!params.keyId || !params.signature) return null;
-
-  return {
-    keyId: params.keyId,
-    algorithm: params.algorithm || 'rsa-sha256',
-    headers: (params.headers || 'date').split(' '),
-    signature: params.signature,
-  };
-}
-
-/**
- * Verify the HTTP signature on an incoming request.
- * Returns the actor URI (key owner) if valid, null otherwise.
- */
-interface VerifyHttpRequest {
-  method: string;
-  path: string;
-  headers: Record<string, string | string[] | undefined>;
-  body?: unknown;
-}
-
-interface VerifyHttpResult {
-  verified: boolean;
-  actorUri?: string;
-  reason?: string;
-}
-
-type FetchPublicKey = (keyId: string) => Promise<{ publicKeyPem: string; actorUri: string } | null>;
-
-export async function verifyHttpSignature(
-  req: VerifyHttpRequest,
-  fetchPublicKey: FetchPublicKey,
-): Promise<VerifyHttpResult> {
-  const signatureHeader = req.headers['signature'] as string | undefined;
-  if (!signatureHeader) return { verified: false, reason: 'missing-signature' };
-
-  const parsed = parseSignatureHeader(signatureHeader);
-  if (!parsed) return { verified: false, reason: 'invalid-signature-header' };
-
-  const keyData = await fetchPublicKey(parsed.keyId);
-  if (!keyData) {
-    logger.debug(`Failed to fetch public key for keyId: ${parsed.keyId}`);
-    return { verified: false, reason: 'key-fetch-failed' };
-  }
-
-  const lowerHeaders = Object.fromEntries(
-    Object.entries(req.headers).map(([k, v]) => [k.toLowerCase(), v])
-  );
-
-  // Enforce Date skew (+/- 10 minutes) if present
-  const dateHeader = lowerHeaders['date'];
-  if (dateHeader) {
-    const dateVal = Array.isArray(dateHeader) ? dateHeader[0] : dateHeader;
-    const parsedDate = Date.parse(dateVal || '');
-    if (!Number.isNaN(parsedDate)) {
-      const skew = Math.abs(Date.now() - parsedDate);
-      if (skew > 10 * 60 * 1000) {
-        return { verified: false, reason: 'date-skew' };
-      }
-    }
-  }
-
-  // If Digest header is required in signature but missing/invalid, fail early
-  if (parsed.headers.includes('digest')) {
-    const digestHeader = lowerHeaders['digest'];
-    const bodyString = typeof req.body === 'string' ? req.body : req.body ? JSON.stringify(req.body) : '';
-    if (!digestHeader) {
-      return { verified: false, reason: 'missing-digest' };
-    }
-    const expectedDigest = `SHA-256=${crypto.createHash('sha256').update(bodyString).digest('base64')}`;
-    const digestVal = Array.isArray(digestHeader) ? digestHeader[0] : digestHeader;
-    if (digestVal !== expectedDigest) {
-      return { verified: false, reason: 'digest-mismatch' };
-    }
-  }
-
-  const signingParts = parsed.headers.map((header) => {
-    const name = header.toLowerCase();
-    if (name === '(request-target)') {
-      return `(request-target): ${req.method.toLowerCase()} ${req.path}`;
-    }
-    // Reconstruct the `host` line from `x-forwarded-host` when present. Our edge
-    // (the Cloudflare Pages worker) rewrites the origin Host to
-    // api.mention.earth and forwards the ORIGINAL host the sender signed over
-    // (mention.earth) in X-Forwarded-Host; a proxy chain may append a
-    // comma-separated list, whose FIRST token is the client-facing host. This
-    // grants a forger nothing: the signature cryptographically binds whatever
-    // host value the sender signed, so a bogus X-Forwarded-Host simply fails
-    // verification. Falls back to `host` when the header is absent (direct
-    // delivery), preserving the pre-proxy behavior.
-    if (name === 'host') {
-      const forwarded = lowerHeaders['x-forwarded-host'];
-      const forwardedValue = Array.isArray(forwarded) ? forwarded[0] : forwarded;
-      const firstToken = forwardedValue?.split(',')[0]?.trim();
-      if (firstToken) {
-        return `host: ${firstToken}`;
-      }
-    }
-    const value = lowerHeaders[name];
-    return `${name}: ${Array.isArray(value) ? value[0] : value}`;
-  });
-
-  const signingString = signingParts.join('\n');
-  const verifier = crypto.createVerify('sha256');
-  verifier.update(signingString);
-  verifier.end();
-
-  try {
-    const isValid = verifier.verify(keyData.publicKeyPem, parsed.signature, 'base64');
-    return { verified: isValid, actorUri: isValid ? keyData.actorUri : undefined, reason: isValid ? undefined : 'verify-failed' };
-  } catch (err) {
-    logger.debug('HTTP signature verification failed:', err);
-    return { verified: false, reason: err instanceof Error ? err.message : 'verify-exception' };
-  }
 }

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -5,7 +5,8 @@ import FederationDeliveryQueue from '../../models/FederationDeliveryQueue';
 import UserSettings from '../../models/UserSettings';
 import { Post } from '../../models/Post';
 import Poll from '../../models/Poll';
-import { signRequest, getPublicKey } from './crypto';
+import { getPublicKey, signViaOxy } from './crypto';
+import { signRequest } from '@oxyhq/federation';
 import {
   FEDERATION_DOMAIN,
   FEDERATION_ENABLED,
@@ -448,7 +449,7 @@ export class FollowService {
     try {
       const { keyId } = await getPublicKey(senderUsername);
       const body = JSON.stringify(activity);
-      const sigHeaders = await signRequest(keyId, 'POST', targetInbox, body);
+      const sigHeaders = await signRequest(signViaOxy, keyId, 'POST', targetInbox, body);
 
       const allHeaders: Record<string, string> = {
         'Content-Type': AP_CONTENT_TYPE,

--- a/packages/backend/src/connectors/activitypub/helpers.ts
+++ b/packages/backend/src/connectors/activitypub/helpers.ts
@@ -1,7 +1,8 @@
 import mongoose from 'mongoose';
 import { logger } from '../../utils/logger';
 import { Post } from '../../models/Post';
-import { signRequest, getPublicKey } from './crypto';
+import { createSignedFetch, type SignedFetch } from '@oxyhq/federation/node';
+import { getPublicKey, signViaOxy } from './crypto';
 import {
   AP_CONTENT_TYPE,
   USER_AGENT,
@@ -26,11 +27,9 @@ import { isAbsoluteHttpUrl } from '../shared/url';
  * `connectors/shared/url.ts` respectively.
  */
 
-const SIGNED_FETCH_TIMEOUT_MS = 10000;
-/** Bounded redirect budget for signed AP GETs; each hop is re-validated and re-signed. */
-const SIGNED_FETCH_MAX_REDIRECTS = 3;
+/** Bounded redirect budget for the stricter boost-import fetch; each hop re-validated. */
+const MAX_ACTIVITYPUB_REDIRECTS = 3;
 const REDIRECT_STATUS_CODES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]);
-const MAX_ACTIVITYPUB_REDIRECTS = SIGNED_FETCH_MAX_REDIRECTS;
 
 export function asRecord(value: unknown): Record<string, any> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -121,13 +120,6 @@ export function domainFromAcct(acct: string): string | undefined {
   return acct.substring(atIndex + 1).toLowerCase();
 }
 
-function requestInitHeaders(init: RequestInit): Record<string, string> {
-  if (!init.headers) return {};
-  if (init.headers instanceof Headers) return Object.fromEntries(init.headers.entries());
-  if (Array.isArray(init.headers)) return Object.fromEntries(init.headers);
-  return init.headers as Record<string, string>;
-}
-
 /**
  * Adapt the Node `IncomingMessage` stream returned by {@link fetchUpstreamSingleHop}
  * into a WHATWG `Response`, so every `signedFetch` caller keeps using the
@@ -168,92 +160,54 @@ async function singleHopToResponse(result: SingleHopResult): Promise<Response> {
   return new Response(Buffer.concat(chunks), { status: result.status, headers });
 }
 
+/** Resolve the Oxy-managed instance actor's keyId used to sign outbound AP GETs. */
+async function getInstanceKeyId(): Promise<string> {
+  const { keyId } = await getPublicKey('instance');
+  return keyId;
+}
+
+// Built lazily on first use so the adapters (`signViaOxy`, `USER_AGENT`) are read
+// at call time — NOT at module import — matching the original `signedFetch`'s
+// call-time evaluation (a module never reads federation credentials just to load).
+let signedFetchImpl: SignedFetch | null = null;
+function getSignedFetch(): SignedFetch {
+  if (!signedFetchImpl) {
+    signedFetchImpl = createSignedFetch({
+      sign: signViaOxy,
+      getInstanceKeyId,
+      fetchSingleHop: (url, init) =>
+        fetchUpstreamSingleHop(url, {
+          headers: init.headers,
+          signal: init.signal,
+          headersTimeoutMs: init.headersTimeoutMs,
+        }).then(singleHopToResponse),
+      userAgent: USER_AGENT,
+      logger: {
+        info: (message) => logger.info(message),
+        warn: (message) => logger.warn(message),
+      },
+    });
+  }
+  return signedFetchImpl;
+}
+
 /**
  * Sign a GET request using the instance actor key pair (managed by Oxy) and
  * perform it under the SSRF-safe contract.
  *
- * The connection is routed through {@link fetchUpstreamSingleHop}, which
+ * The signing + per-hop re-signing redirect policy lives in `@oxyhq/federation`
+ * (`createSignedFetch`); Mention supplies the private-key custody (`signViaOxy`,
+ * which calls oxy-api — the key never enters Mention), the instance keyId, and
+ * the SSRF-safe single-hop transport ({@link fetchUpstreamSingleHop}, which
  * validates the URL AND pins the TCP connection to the validated IP via a custom
- * DNS `lookup` — DNS is NOT re-resolved at connect time. This closes the
- * DNS-rebind TOCTOU window that a plain "validate-then-`fetch`" sequence leaves
- * open: a hostname could resolve to a public IP during an `assertSafePublicUrl`
- * check, then re-resolve to an internal IP when the global `fetch` connects.
- *
- * Redirects are followed manually (bounded by {@link SIGNED_FETCH_MAX_REDIRECTS}),
- * re-validating AND re-signing each hop — an HTTP signature is bound to the
- * `(request-target)`/`host` of a specific URL, so the signature must be
- * recomputed for the redirect target. When the caller passes
- * `init.redirect === 'manual'`, the redirect `Response` is returned directly so
- * the caller can apply its own stricter redirect policy (see
- * {@link fetchVerifiedAnnouncedNote}).
- *
- * Signed for servers that enforce authorized fetch (e.g., Threads). On a 5xx the
- * request is retried unsigned (same SSRF-safe path) as a fallback for public
- * resources.
+ * DNS `lookup` — DNS is NOT re-resolved at connect time, closing the DNS-rebind
+ * TOCTOU window). The engine re-validates AND re-signs each redirect hop, honours
+ * `init.redirect === 'manual'` (returning the redirect for a stricter per-hop
+ * policy — see {@link fetchVerifiedAnnouncedNote}), and retries unsigned on a 5xx
+ * for public resources.
  */
-export async function signedFetch(url: string, accept: string, init: RequestInit = {}): Promise<Response> {
-  const acceptHeader = `${accept}, application/ld+json; profile="https://www.w3.org/ns/activitystreams"`;
-  const { keyId } = await getPublicKey('instance');
-  const extraHeaders = requestInitHeaders(init);
-  const manualRedirect = init.redirect === 'manual';
-
-  const fetchOnce = async (targetUrl: string, signed: boolean): Promise<Response> => {
-    const sigHeaders = signed ? await signRequest(keyId, 'GET', targetUrl) : {};
-    const result = await fetchUpstreamSingleHop(targetUrl, {
-      headers: {
-        Accept: acceptHeader,
-        'User-Agent': USER_AGENT,
-        ...sigHeaders,
-        ...extraHeaders,
-      },
-      signal: init.signal ?? AbortSignal.timeout(SIGNED_FETCH_TIMEOUT_MS),
-      headersTimeoutMs: SIGNED_FETCH_TIMEOUT_MS,
-    });
-    return singleHopToResponse(result);
-  };
-
-  const fetchFollowingRedirects = async (initialUrl: string, signed: boolean): Promise<Response> => {
-    let currentUrl = initialUrl;
-    for (let hop = 0; hop <= SIGNED_FETCH_MAX_REDIRECTS; hop++) {
-      const res = await fetchOnce(currentUrl, signed);
-      if (!REDIRECT_STATUS_CODES.has(res.status)) {
-        return res;
-      }
-      // The caller asked to handle redirects itself (stricter per-hop policy).
-      if (manualRedirect) {
-        return res;
-      }
-      const location = res.headers.get('location');
-      if (hop === SIGNED_FETCH_MAX_REDIRECTS || !location) {
-        return res;
-      }
-      currentUrl = new URL(location, currentUrl).toString();
-    }
-    throw new Error('redirect loop exhausted');
-  };
-
-  const res = await fetchFollowingRedirects(url, true);
-
-  // If the remote server returns a 5xx (e.g. it can't resolve our keyId to verify
-  // the signature), retry without the signature as a fallback for public resources.
-  if (res.status >= 500) {
-    logger.info(`[FedSync] signedFetch got ${res.status} for ${url}, retrying unsigned`);
-    return fetchFollowingRedirects(url, false);
-  }
-
-  // A 401/403 on a signed request means the remote rejected OUR signature
-  // (e.g. it could not resolve/verify our keyId, or our instance key pair is
-  // missing/invalid because the service token could not be acquired). Without a
-  // log this silently yields zero results — surface it so the failure mode is
-  // observable in production. The caller still receives the response and decides
-  // how to proceed; we do not change control flow here.
-  if (res.status === 401 || res.status === 403) {
-    logger.warn(
-      `[FedSync] signedFetch got ${res.status} ${res.statusText} for ${url} — remote rejected our HTTP signature (check instance key pair / service token); returning the failed response so no posts are imported from this source`,
-    );
-  }
-
-  return res;
+export function signedFetch(url: string, accept: string, init: RequestInit = {}): Promise<Response> {
+  return getSignedFetch()(url, accept, init);
 }
 
 function sameOrigin(left: string, right: string): boolean {

--- a/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
+++ b/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
@@ -2,7 +2,8 @@ import { Router, Request, Response } from 'express';
 import { isValidObjectId } from 'mongoose';
 import { logger } from '../../../utils/logger';
 import { activityPubConnector } from '../ActivityPubConnector';
-import { verifyHttpSignature, getPublicKey } from '../crypto';
+import { getPublicKey } from '../crypto';
+import { verifyHttpSignature } from '@oxyhq/federation';
 import { Post } from '../../../models/Post';
 import UserSettings from '../../../models/UserSettings';
 import { getServiceOxyClient } from '../../../utils/oxyHelpers';
@@ -197,6 +198,13 @@ async function handleInbox(req: Request, res: Response): Promise<Response> {
         body: req.rawBody ?? req.body,
       },
       (keyId) => activityPubConnector.fetchPublicKey(keyId),
+      // The apex (mention.earth) is CF-proxied → ALB → backend, which rewrites the
+      // origin Host to api.mention.earth while Mastodon signs over mention.earth
+      // (forwarded in X-Forwarded-Host). Reconstruct the signed `host` line from it.
+      {
+        trustForwardedHost: true,
+        onDebug: (message, detail) => logger.debug(message, detail),
+      },
     );
 
     if (!verified || !actorUri) {


### PR DESCRIPTION
Phase 2 of the shared-federation-engine migration — the highest-risk phase, verified BYTE-IDENTICAL.

- Moves `signRequest`/`verifyHttpSignature` (pure draft-cavage crypto, incl. the load-bearing `X-Forwarded-Host` host reconstruction) into `@oxyhq/federation@0.2.0` (`.` entry), private-key custody injected (still oxy-api `/federation/sign`; key never enters the package). `signedFetch` → `./node` (`createSignedFetch`) over Mention's Phase-1 single-hop transport — deliberately NOT core `safeFetch` (which follows redirects + can't per-hop re-sign).
- Mention deletes its copies, imports from the package, supplies the sign/getPublicKey adapters + `trustForwardedHost:true`. Clean cut.

Verified: a parity harness proved byte-equality vs the original for a fixed key + frozen clock — identical signing string, covered-header order, `rsa-sha256`, digest, param assembly, and every X-Forwarded-Host case (incl. cross-direction OLD↔NEW verify). Full backend suite 2594 tests pass; tsc clean.

Post-deploy gate: confirm live Mastodon federation (inbound follow / webfinger / outbound) — signing bytes are proven unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)