### PR TITLE
feat(federation): Phase 3 — actor model + remote-actor resolution into @oxyhq/federation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "@mention/shared-types": "file:../shared-types",
         "@oxyhq/contracts": "^0.16.0",
         "@oxyhq/core": "^12.4.1",
-        "@oxyhq/federation": "^0.2.0",
+        "@oxyhq/federation": "^0.3.0",
         "@oxyhq/protocol": "^0.1.5",
         "@socket.io/redis-adapter": "^8.3.0",
         "@syra.fm/sdk": "^0.7.0",
@@ -713,7 +713,7 @@
 
     "@oxyhq/expo-oxy-identity": ["@oxyhq/expo-oxy-identity@0.1.0", "", { "peerDependencies": { "expo": ">=51.0.0", "expo-modules-core": "*", "react": ">=18.0.0", "react-native": ">=0.74.0" } }, "sha512-erMlS8dF1BIggOuu44impWjZDns8yjuQzRIvYnIjMzpD+Flc7V6HtufhzGTDEvmEYV/utZEiwo213IfGM5Uiyw=="],
 
-    "@oxyhq/federation": ["@oxyhq/federation@0.2.0", "", { "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-hZvtTaXSDnqhidOrLxlZ/KmOWFSSkeixph1RRXDKjvl0h8Vxj6PdyC5cxFlblxDjCcxoi/VldVJXH8yIHR+NTA=="],
+    "@oxyhq/federation": ["@oxyhq/federation@0.3.0", "", { "dependencies": { "@oxyhq/core": "^12.5.0" }, "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-Y1ETfLTKtOYyC1jynXHVDubQZiygydP9bLLVh8CIaiZ5NC1XiSIwQlwcE1oIIRzJ0c2Ty4fZUK39t48B+FdDPQ=="],
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.5", "", { "dependencies": { "@oxyhq/contracts": "^0.13.2", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-modules-core": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-iHrHLg1qnkjlcj2dES5sT/4zA5wmVU0PcvhpTIT+acTD6Oqip1EibiM6x1fYDMouAHoK+C4OKmHJ45Usg9nDrw=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,7 +20,7 @@
     "@mention/shared-types": "file:../shared-types",
     "@oxyhq/contracts": "^0.16.0",
     "@oxyhq/core": "^12.4.1",
-    "@oxyhq/federation": "^0.2.0",
+    "@oxyhq/federation": "^0.3.0",
     "@oxyhq/protocol": "^0.1.5",
     "@socket.io/redis-adapter": "^8.3.0",
     "@syra.fm/sdk": "^0.7.0",

--- a/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/apRoutes.test.ts
@@ -95,7 +95,7 @@ vi.mock('../../../utils/oxyHelpers', () => ({
 }));
 
 import apRoutes from '../../../connectors/activitypub/routes/ap.routes';
-import { AP_CONTEXT } from '../../../connectors/activitypub/constants';
+import { AP_CONTEXT } from '@oxyhq/federation';
 
 const app = express();
 app.use(express.json());

--- a/packages/backend/src/__tests__/connectors/activitypub/sharingCleanup.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/sharingCleanup.test.ts
@@ -45,6 +45,13 @@ vi.mock('../../../utils/oxyHelpers', () => ({
 
 vi.mock('../../../connectors/activitypub/constants', () => ({
   actorUrl: (username: string) => `https://mention.earth/ap/users/${username}`,
+}));
+
+// `AP_CONTEXT` now lives in the shared engine; the service imports it directly.
+// Mock the engine's copy to the simplified 2-element context so the Delete(actor)
+// activity assertion below stays readable (the full term-declaration object is
+// exercised by the engine's own golden test).
+vi.mock('@oxyhq/federation', () => ({
   AP_CONTEXT: ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
 }));
 

--- a/packages/backend/src/__tests__/connectors/connectorsRoutesSharingGate.test.ts
+++ b/packages/backend/src/__tests__/connectors/connectorsRoutesSharingGate.test.ts
@@ -32,7 +32,22 @@ vi.mock('@oxyhq/core/server', () => ({
   getRequiredOxyUserId: () => 'local-user-1',
 }));
 
-vi.mock('../../connectors/activitypub/constants', () => ({ FEDERATION_ENABLED: true }));
+vi.mock('../../connectors/activitypub/constants', () => ({
+  FEDERATION_ENABLED: true,
+  // `actorObject.ts` / `actor.service.ts` bind the shared engine at module load, so
+  // they read these from constants when this module graph is imported.
+  isBlockedDomain: () => false,
+  FEDERATION_DOMAIN: 'mention.earth',
+  federationUrls: {
+    actor: (u: string) => `https://mention.earth/ap/users/${u}`,
+    inbox: (u: string) => `https://mention.earth/ap/users/${u}/inbox`,
+    outbox: (u: string) => `https://mention.earth/ap/users/${u}/outbox`,
+    featured: (u: string) => `https://mention.earth/ap/users/${u}/collections/featured`,
+    followers: (u: string) => `https://mention.earth/ap/users/${u}/followers`,
+    following: (u: string) => `https://mention.earth/ap/users/${u}/following`,
+    sharedInbox: () => 'https://mention.earth/ap/inbox',
+  },
+}));
 vi.mock('../../connectors/atproto/constants', () => ({ ATPROTO_ENABLED: false }));
 
 vi.mock('../../connectors/index', () => ({

--- a/packages/backend/src/__tests__/routes/federationFollowsDisplayName.test.ts
+++ b/packages/backend/src/__tests__/routes/federationFollowsDisplayName.test.ts
@@ -28,7 +28,22 @@ vi.mock('@oxyhq/core/server', () => ({
   getRequiredOxyUserId: () => 'local-user-1',
 }));
 
-vi.mock('../../connectors/activitypub/constants', () => ({ FEDERATION_ENABLED: true }));
+vi.mock('../../connectors/activitypub/constants', () => ({
+  FEDERATION_ENABLED: true,
+  // `actorObject.ts` / `actor.service.ts` bind the shared engine at module load, so
+  // they read these from constants when this module graph is imported.
+  isBlockedDomain: () => false,
+  FEDERATION_DOMAIN: 'mention.earth',
+  federationUrls: {
+    actor: (u: string) => `https://mention.earth/ap/users/${u}`,
+    inbox: (u: string) => `https://mention.earth/ap/users/${u}/inbox`,
+    outbox: (u: string) => `https://mention.earth/ap/users/${u}/outbox`,
+    featured: (u: string) => `https://mention.earth/ap/users/${u}/collections/featured`,
+    followers: (u: string) => `https://mention.earth/ap/users/${u}/followers`,
+    following: (u: string) => `https://mention.earth/ap/users/${u}/following`,
+    sharedInbox: () => 'https://mention.earth/ap/inbox',
+  },
+}));
 vi.mock('../../connectors/atproto/constants', () => ({ ATPROTO_ENABLED: false }));
 
 // The connector registry + resolve classifier pull the full connector graph;

--- a/packages/backend/src/connectors/activitypub/actor.service.ts
+++ b/packages/backend/src/connectors/activitypub/actor.service.ts
@@ -1,15 +1,17 @@
-import { logger } from '../../utils/logger';
 import sanitizeHtml from 'sanitize-html';
-import FederatedActor, { IFederatedActor } from '../../models/FederatedActor';
-import {
-  FEDERATION_ENABLED,
-  AP_CONTENT_TYPE,
-  AP_ACCEPT_TYPES,
-  isBlockedDomain,
-} from './constants';
-import { htmlToPlainText } from '../../utils/federation/htmlToPlainText';
 import { decode as decodeEntities } from 'he';
 import { normalizeInlineText } from '@oxyhq/core';
+import {
+  createActorResolver,
+  type FederatedActorStore,
+  type FederatedActorUpsert,
+  type WebFingerFetch,
+  type WebFingerJrd,
+} from '@oxyhq/federation/node';
+import { logger } from '../../utils/logger';
+import FederatedActor, { type IFederatedActor } from '../../models/FederatedActor';
+import { FEDERATION_ENABLED, isBlockedDomain } from './constants';
+import { htmlToPlainText } from '../../utils/federation/htmlToPlainText';
 import { fetchUpstreamSingleHop } from '../../utils/safeUpstreamFetch';
 import {
   signedFetch,
@@ -19,528 +21,105 @@ import {
 } from './helpers';
 import { readBoundedResponseBody } from '../shared/httpBody';
 import { reportFederatedActorGone, resolveOxyExternalUser } from '../identity';
-import type { NormalizedExternalActor } from '@oxyhq/federation';
-
-/**
- * Minimum interval between background actor refreshes for the same actor.
- * Prevents refresh storms when a profile is viewed repeatedly in a short window.
- */
-const ACTOR_REFRESH_MIN_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
-
-/**
- * Staleness threshold after which a cached actor is considered out of date and
- * eligible for a (background) re-fetch.
- */
-const ACTOR_STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-const WEBFINGER_TIMEOUT_MS = 10000;
-const WEBFINGER_MAX_BYTES = 256 * 1024;
-
-function sameOriginUrl(a: string, b: string): boolean {
-  try {
-    return new URL(a).origin.toLowerCase() === new URL(b).origin.toLowerCase();
-  } catch {
-    return false;
-  }
-}
-
-function actorPublicKeyIsSelfConsistent(actor: Record<string, any>): boolean {
-  const publicKey = actor.publicKey;
-  if (!publicKey || typeof publicKey !== 'object') return true;
-
-  const publicKeyId = typeof publicKey.id === 'string' ? publicKey.id : undefined;
-  if (publicKeyId && !sameOriginUrl(publicKeyId, actor.id)) return false;
-
-  const owner = typeof publicKey.owner === 'string' ? publicKey.owner : undefined;
-  if (owner && owner !== actor.id) return false;
-
-  return true;
-}
-
-/**
- * Read a single-line string field off a remote actor as normalized text.
- *
- * `preferredUsername`, `name` and the PropertyValue `name`/`value` pairs are
- * third-party text: they arrive with whatever whitespace the remote server's
- * markup happened to carry, and our clients render text faithfully (React Native
- * Web maps `Text` to `white-space: pre-wrap`), so an embedded newline or a run
- * of spaces would be VISIBLE in the UI. These values are conceptually one line,
- * so every whitespace run collapses to a single space.
- *
- * A remote can put anything in a JSON field, so a non-string collapses to `''`
- * and the caller applies its own fallback.
- */
-function inlineActorField(value: unknown): string {
-  return typeof value === 'string' ? normalizeInlineText(value) : '';
-}
-
-function acctMatchesActorHost(acct: string | undefined, actorHost: string): acct is string {
-  if (!acct) return false;
-  const domain = domainFromAcct(acct)?.toLowerCase();
-  if (!domain) return false;
-  const normalizedActorHost = actorHost.toLowerCase();
-  return domain === normalizedActorHost || normalizedActorHost === `www.${domain}`;
-}
 
 /**
  * Resolution, caching and refresh of remote ActivityPub actors.
  *
- * Extracted verbatim from the former monolithic FederationService — same behavior,
- * same public method signatures. This is the base sub-service: it depends only
- * on the shared low-level helpers and the Oxy service client, never on the other
- * federation sub-services, so it can be imported directly without a cycle.
+ * The PROTOCOL — webfinger resolution, the signed actor fetch + WebFinger
+ * fallback, the 410-Gone tombstone, the self-consistency/same-origin guards, the
+ * staleness/refresh policy — lives in `@oxyhq/federation`'s `createActorResolver`
+ * so every Oxy app backend resolves remote actors identically. This module is the
+ * Mention wiring: it supplies the FederatedActor CACHE store (bring-your-own-store,
+ * no data move), the actor↔Oxy-user identity bridge, the signed AP fetch + the
+ * SSRF-safe WebFinger fetch, and Mention's canonical text normalization.
  */
-export class ActorService {
-  /**
-   * Actor URIs with an in-flight background refresh. Guards against launching
-   * multiple concurrent `fetchRemoteActor` calls for the same actor (refresh
-   * storms) when a profile is viewed repeatedly while the first fetch is still
-   * running.
-   */
-  private readonly inFlightActorRefreshes = new Set<string>();
 
-  /**
-   * Resolve a WebFinger acct to an ActivityPub actor URI.
-   * @param acct - e.g. "alice@mastodon.social" or "@alice@mastodon.social"
-   */
-  async resolveWebFinger(acct: string): Promise<string | null> {
-    const cleaned = normalizeFederatedAcct(acct);
-    if (!cleaned) return null;
+const WEBFINGER_TIMEOUT_MS = 10000;
+const WEBFINGER_MAX_BYTES = 256 * 1024;
 
-    const domain = domainFromAcct(cleaned);
-    if (!domain) return null;
-    if (isBlockedDomain(domain)) return null;
+/**
+ * Mention's actor CACHE store: the AP-specific `FederatedActor` rows stay in
+ * Mention's Mongo, reached through this adapter. The exact Mongoose calls are
+ * unchanged from the previous `ActorService`.
+ */
+const store: FederatedActorStore<IFederatedActor> = {
+  findActorByUri: (uri) => FederatedActor.findOne({ uri }).lean<IFederatedActor>(),
+  upsertActor: (uri, update: FederatedActorUpsert) =>
+    FederatedActor.findOneAndUpdate(
+      { uri },
+      { $set: update },
+      { upsert: true, returnDocument: 'after', lean: true },
+    ) as Promise<IFederatedActor | null>,
+  findActorByPublicKeyId: (keyId) =>
+    FederatedActor.findOne({ publicKeyId: keyId }).lean<IFederatedActor>(),
+  setActorOxyUserId: async (actorId, oxyUserId) => {
+    await FederatedActor.updateOne({ _id: actorId }, { $set: { oxyUserId } });
+  },
+  tombstoneActor: (uri) =>
+    FederatedActor.findOneAndUpdate(
+      { uri },
+      { $set: { suspended: true } },
+      { returnDocument: 'after', projection: { oxyUserId: 1 } },
+    ).lean<Pick<IFederatedActor, 'oxyUserId'>>(),
+};
 
-    const resource = `acct:${cleaned}`;
-    const url = `https://${domain}/.well-known/webfinger?resource=${encodeURIComponent(resource)}`;
-
-    try {
-      const { response, status } = await fetchUpstreamSingleHop(url, {
-        headers: { Accept: 'application/jrd+json, application/json' },
-        signal: AbortSignal.timeout(WEBFINGER_TIMEOUT_MS),
-        headersTimeoutMs: WEBFINGER_TIMEOUT_MS,
-      });
-      if (status < 200 || status >= 300) {
-        response.destroy();
-        return null;
-      }
-
-      const body = await readBoundedResponseBody(response, WEBFINGER_MAX_BYTES);
-      const data = JSON.parse(Buffer.from(body).toString('utf8')) as {
-        links?: Array<{ rel?: string; type?: string; href?: string }>;
-      };
-      const link = data.links?.find(
-        (l) => l.rel === 'self' && l.type && AP_ACCEPT_TYPES.includes(l.type)
-      );
-      return link?.href || null;
-    } catch (err) {
-      logger.warn(`WebFinger resolution failed for ${acct}:`, err);
-      return null;
-    }
+/**
+ * SSRF-safe bounded WebFinger fetch. Validates + IP-pins the URL, enforces the
+ * 256 KiB cap, and returns the parsed JRD (or null on a non-2xx). A network /
+ * parse / size-limit failure throws and is treated by the resolver as a failed
+ * resolution.
+ */
+const fetchWebFinger: WebFingerFetch = async (url) => {
+  const { response, status } = await fetchUpstreamSingleHop(url, {
+    headers: { Accept: 'application/jrd+json, application/json' },
+    signal: AbortSignal.timeout(WEBFINGER_TIMEOUT_MS),
+    headersTimeoutMs: WEBFINGER_TIMEOUT_MS,
+  });
+  if (status < 200 || status >= 300) {
+    response.destroy();
+    return null;
   }
+  const body = await readBoundedResponseBody(response, WEBFINGER_MAX_BYTES);
+  return JSON.parse(Buffer.from(body).toString('utf8')) as WebFingerJrd;
+};
 
-  /**
-   * Fetch and store/update a remote ActivityPub actor by URI.
-   *
-   * @param actorUri - the remote actor URI to fetch.
-   * @param forceAvatarRefresh - when true, tells Oxy's `PUT /users/resolve` to
-   *   re-download and replace the federated avatar even if it already has a
-   *   stored file ID. Pass `true` from refresh paths (scheduled job, viewed
-   *   profile refresh) and `false` for first-time creation.
-   */
-  async fetchRemoteActor(actorUri: string, forceAvatarRefresh = false, acctHint?: string): Promise<IFederatedActor | null> {
-    try {
-      // Reject our own/blocked domains before any network I/O. Oxy's identity
-      // apex publishes every local user as `acct:<user>@<apex>` (DID layer), so
-      // resolving such an actor would create a duplicate FederatedActor row for
-      // a local user and POST `/users/resolve` against the platform's own
-      // identity. A malformed URI throws here and is handled by the catch below,
-      // matching the prior behaviour where `signedFetch` would have failed.
-      const requestedHost = new URL(actorUri).hostname.toLowerCase();
-      if (isBlockedDomain(requestedHost)) {
-        logger.info(`[FedSync] fetchRemoteActor skipping own/blocked domain ${requestedHost} for ${actorUri}`);
-        return null;
-      }
+/**
+ * The remote-actor resolver instance. Every consumer keeps using
+ * `actorService.resolveWebFinger / fetchRemoteActor / getOrFetchActor /
+ * tombstoneGoneActor / refreshActorInBackground / fetchPublicKey /
+ * resolveActorOxyUserId` unchanged.
+ */
+export const actorService = createActorResolver<IFederatedActor>({
+  federationEnabled: FEDERATION_ENABLED,
+  signedFetch,
+  fetchWebFinger,
+  isBlockedDomain,
+  normalizeFederatedAcct,
+  domainFromAcct,
+  firstStringUrl,
+  store,
+  identity: {
+    resolveExternalUser: (actor, opts) => resolveOxyExternalUser(actor, opts),
+    reportActorGone: (oxyUserId) => reportFederatedActorGone(oxyUserId),
+  },
+  text: {
+    inlineField: (value) => (typeof value === 'string' ? normalizeInlineText(value) : ''),
+    inlineDisplayName: (raw) => normalizeInlineText(decodeEntities(raw)),
+    // Sanitize BEFORE normalizing: the canonical normalizer collapses whitespace,
+    // it never strips markup — so the sanitizer must run first, on the raw value.
+    sanitizeFieldValue: (html) =>
+      normalizeInlineText(
+        sanitizeHtml(html, {
+          allowedTags: ['a', 'span'],
+          allowedAttributes: { a: ['href', 'rel'] },
+        }),
+      ),
+    htmlToPlainText: (html) => htmlToPlainText(html),
+  },
+  logger: {
+    info: (message) => logger.info(message),
+    warn: (message, detail) => logger.warn(message, detail),
+  },
+});
 
-      const canonicalAcctHint = normalizeFederatedAcct(acctHint);
-      // Use signed fetch for servers that enforce authorized fetch (e.g., Threads)
-      let res = await signedFetch(actorUri, AP_CONTENT_TYPE);
-      if (!res.ok) {
-        // A definitive 410 Gone is authoritative: the actor was permanently
-        // DELETED upstream (Mastodon serves 410 for a deleted account). Tombstone
-        // it and stop — do NOT fall through to the WebFinger fallback below, which
-        // exists to recover from a STALE/wrong URI on a transient failure, not to
-        // second-guess a permanent removal. Only 410 does this; every other
-        // non-ok status keeps the unchanged fallback behavior. `actorUri` here is
-        // still the originally-requested (stored) URI — reassignment to a resolved
-        // URI only happens on a successful WebFinger fetch below.
-        if (res.status === 410) {
-          logger.info(`[FedSync] fetchRemoteActor 410 Gone for ${actorUri} — tombstoning actor`);
-          await this.tombstoneGoneActor(actorUri);
-          return null;
-        }
-        const body = await res.text().catch(() => '');
-        logger.info(`[FedSync] fetchRemoteActor HTTP ${res.status} ${res.statusText} for ${actorUri} body=${body.slice(0, 500)}`);
-
-        // If direct fetch failed, try WebFinger to resolve the canonical actor URI.
-        // Some servers (e.g., Threads) use numeric IDs in AP URIs that differ from
-        // the username-based URI we may have stored.
-        const parsed = new URL(actorUri);
-        const pathUsername = parsed.pathname.split('/').filter(Boolean).pop();
-        const acct = canonicalAcctHint
-          || (pathUsername ? normalizeFederatedAcct(`${pathUsername}@${parsed.hostname}`) : undefined);
-        if (acct) {
-          logger.info(`[FedSync] attempting WebFinger fallback for ${acct}`);
-          const resolved = await this.resolveWebFinger(acct);
-          if (resolved && resolved !== actorUri) {
-            logger.info(`[FedSync] WebFinger resolved ${acct} → ${resolved}`);
-            res = await signedFetch(resolved, AP_CONTENT_TYPE);
-            if (res.ok) {
-              actorUri = resolved;
-            } else {
-              // A 410 on the WebFinger-RESOLVED URI is just as definitive as one
-              // on the direct URI — the account is gone at its canonical location.
-              // Tombstone against the stored `actorUri` (the row is keyed by the
-              // originally-requested URI, which is NOT reassigned on this failure
-              // branch), then stop.
-              if (res.status === 410) {
-                logger.info(`[FedSync] fetchRemoteActor 410 Gone for resolved ${resolved} — tombstoning actor ${actorUri}`);
-                await this.tombstoneGoneActor(actorUri);
-                return null;
-              }
-              const body2 = await res.text().catch(() => '');
-              logger.info(`[FedSync] fetchRemoteActor HTTP ${res.status} for resolved ${resolved} body=${body2.slice(0, 500)}`);
-              return null;
-            }
-          } else {
-            logger.info(`[FedSync] WebFinger returned ${resolved ?? 'null'} for ${acct}`);
-            return null;
-          }
-        } else {
-          return null;
-        }
-      }
-
-      const actor = await res.json() as Record<string, any>;
-      if (!actor.id || !actor.inbox) {
-        logger.info(`[FedSync] fetchRemoteActor missing fields for ${actorUri}: id=${!!actor.id} inbox=${!!actor.inbox} type=${actor.type} keys=${Object.keys(actor).join(',')}`);
-        return null;
-      }
-
-      if (!sameOriginUrl(actorUri, actor.id)) {
-        logger.warn(`[FedSync] rejecting actor ${actorUri}: fetched URI is not authoritative for claimed id ${actor.id}`);
-        return null;
-      }
-
-      if (!actorPublicKeyIsSelfConsistent(actor)) {
-        logger.warn(`[FedSync] rejecting actor ${actorUri}: publicKey is not self-consistent for claimed id ${actor.id}`);
-        return null;
-      }
-
-      const actorHost = new URL(actor.id).hostname.toLowerCase();
-      const username = inlineActorField(actor.preferredUsername) || inlineActorField(actor.name) || 'unknown';
-      const actorWebfinger = typeof actor.webfinger === 'string'
-        ? normalizeFederatedAcct(actor.webfinger)
-        : undefined;
-      const verifiedAcctHint = acctMatchesActorHost(canonicalAcctHint, actorHost)
-        ? canonicalAcctHint
-        : undefined;
-      const verifiedActorWebfinger = acctMatchesActorHost(actorWebfinger, actorHost)
-        ? actorWebfinger
-        : undefined;
-      const acct = verifiedAcctHint
-        || verifiedActorWebfinger
-        || normalizeFederatedAcct(`${username}@${actorHost}`)
-        || `${username.toLowerCase()}@${actorHost}`;
-      const domain = domainFromAcct(acct) || actorHost;
-      // Re-check against the RESOLVED host/acct (post-redirect / WebFinger), which
-      // can differ from the originally-requested URI host the early-return guard
-      // (~line 167, before any network I/O) already screened. WebFinger/redirects
-      // may land us on an own/blocked domain even when the requested URI did not —
-      // so this guard is NOT redundant with the early one and must stay.
-      if (isBlockedDomain(domain) || isBlockedDomain(actorHost)) {
-        logger.info(`[FedSync] fetchRemoteActor blocked domain ${domain} actorHost=${actorHost} for ${actorUri}`);
-        return null;
-      }
-
-      // Fetch collection counts (followers, following, posts) in parallel
-      const [followersCount, followingCount, postsCount] = await Promise.all([
-        this.fetchCollectionCount(actor.followers),
-        this.fetchCollectionCount(actor.following),
-        this.fetchCollectionCount(actor.outbox),
-      ]);
-
-      // Extract profile fields (PropertyValue attachments). Sanitize BEFORE
-      // normalizing: the canonical normalizer collapses whitespace, it never
-      // strips markup — so the sanitizer must run first, on the raw value.
-      const fields: { name: string; value: string; verifiedAt?: Date }[] = [];
-      if (Array.isArray(actor.attachment)) {
-        for (const att of actor.attachment) {
-          if (att?.type !== 'PropertyValue') continue;
-          const fieldName = inlineActorField(att.name);
-          const fieldValue = typeof att.value === 'string'
-            ? normalizeInlineText(sanitizeHtml(att.value, {
-              allowedTags: ['a', 'span'],
-              allowedAttributes: { a: ['href', 'rel'] },
-            }))
-            : '';
-          if (!fieldName || !fieldValue) continue;
-          fields.push({
-            name: fieldName,
-            value: fieldValue,
-            verifiedAt: att.verifiedAt ? new Date(att.verifiedAt) : undefined,
-          });
-        }
-      }
-
-      const avatarUrl = firstStringUrl(actor.icon);
-      const headerUrl = firstStringUrl(actor.image);
-      // `summary` is the actor's bio — a BODY, so its line breaks are the
-      // author's and must survive; `htmlToPlainText` normalizes it as multiline.
-      const summary = typeof actor.summary === 'string' ? htmlToPlainText(actor.summary) : '';
-      // The display name is one line. Entity-decode FIRST (an encoded `&#10;` or
-      // `&nbsp;` only becomes whitespace once decoded), THEN collapse.
-      const rawDisplayName = typeof actor.name === 'string' ? actor.name : '';
-      const displayName = normalizeInlineText(decodeEntities(rawDisplayName)) || username;
-
-      const update: Partial<IFederatedActor> = {
-        protocol: 'activitypub',
-        uri: actor.id,
-        username,
-        domain,
-        acct,
-        summary,
-        avatarUrl,
-        headerUrl,
-        inboxUrl: actor.inbox,
-        outboxUrl: actor.outbox || undefined,
-        sharedInboxUrl: actor.endpoints?.sharedInbox || undefined,
-        followersUrl: actor.followers || undefined,
-        followingUrl: actor.following || undefined,
-        publicKeyPem: actor.publicKey?.publicKeyPem || undefined,
-        publicKeyId: actor.publicKey?.id || undefined,
-        type: actor.type || 'Person',
-        manuallyApprovesFollowers: actor.manuallyApprovesFollowers || false,
-        discoverable: actor.discoverable !== false,
-        memorial: actor.memorial === true,
-        suspended: actor.suspended === true,
-        fields,
-        featuredUrl: actor.featured || undefined,
-        featuredTagsUrl: actor.featuredTags || undefined,
-        alsoKnownAs: Array.isArray(actor.alsoKnownAs) ? actor.alsoKnownAs : undefined,
-        remoteCreatedAt: actor.published ? new Date(actor.published) : undefined,
-        followersCount,
-        followingCount,
-        postsCount,
-        lastFetchedAt: new Date(),
-      };
-
-      const fedActor = await FederatedActor.findOneAndUpdate(
-        { uri: actor.id },
-        { $set: update },
-        { upsert: true, returnDocument: 'after', lean: true },
-      );
-
-      // Always upsert into Oxy so profile changes (avatar, name, bio) are synced.
-      // `resolveOxyExternalUser` (the network-neutral identity bridge shared with
-      // the atproto connector) creates the federated Oxy user if it does not
-      // exist, updates it when changed, and mirrors the banner — using a service
-      // token for `PUT /users/resolve`. This connector then stamps its own
-      // FederatedActor row with the resolved id.
-      if (fedActor) {
-        try {
-          const normalized: NormalizedExternalActor = {
-            network: 'activitypub',
-            externalId: actor.id,
-            handle: acct,
-            // For AP the acct IS the canonical `user@domain` Oxy username, and
-            // `domain` is its instance host — both already verified above.
-            federatedUsername: acct,
-            instanceDomain: domain,
-            displayName,
-            avatarUrl,
-            bannerUrl: headerUrl,
-            bio: summary || undefined,
-            followersCount,
-            followingCount,
-            postsCount,
-            oxyUserId: fedActor.oxyUserId ?? undefined,
-          };
-          const oxyId = await resolveOxyExternalUser(normalized, { forceAvatarRefresh });
-          if (oxyId && fedActor.oxyUserId !== oxyId) {
-            await FederatedActor.updateOne({ _id: fedActor._id }, { $set: { oxyUserId: oxyId } });
-          }
-        } catch (resolveErr) {
-          logger.warn(`Failed to resolve Oxy user for ${actorUri}:`, resolveErr);
-        }
-      }
-
-      return fedActor as IFederatedActor | null;
-    } catch (err) {
-      logger.warn(`Failed to fetch remote actor ${actorUri}:`, err);
-      return null;
-    }
-  }
-
-  /**
-   * Tombstone a remote actor that returned a definitive 410 Gone. Marks the stored
-   * `FederatedActor` as `suspended` (the schema's existing gone flag — a suspended
-   * actor is already excluded from active surfaces, and it carries the exact
-   * "no longer reachable upstream" meaning we need; a parallel `gone` field would
-   * be redundant) and, when the actor links to an Oxy identity, asks oxy-api to
-   * archive it via {@link reportFederatedActorGone} so it drops out of search.
-   *
-   * The `FederatedActor` document is NEVER deleted — posts, boosts and MTN records
-   * may still reference the actor (see the model doc); this is a tombstone, not a
-   * purge.
-   *
-   * Best-effort and fail-soft: a 410 is authoritative, but neither the Mongo write
-   * nor the Oxy archive call is allowed to throw out of the caller — a failure here
-   * only logs. Idempotent: re-running on an already-suspended actor re-sets the
-   * same flag and re-reports (oxy-api's actor-gone is itself idempotent). Shared by
-   * the live fetch path ({@link fetchRemoteActor}) and the one-shot
-   * `pruneGoneFederatedActors` sweep so there is exactly ONE tombstone
-   * implementation.
-   *
-   * @param actorUri - the stored `FederatedActor.uri` to tombstone. When no row
-   *   matches (a 410 for an actor we never tracked) this is a logged no-op — we do
-   *   not upsert a suspended row for an actor that isn't in our index.
-   */
-  async tombstoneGoneActor(actorUri: string): Promise<void> {
-    try {
-      const actor = await FederatedActor.findOneAndUpdate(
-        { uri: actorUri },
-        { $set: { suspended: true } },
-        { returnDocument: 'after', projection: { oxyUserId: 1 } },
-      ).lean<Pick<IFederatedActor, 'oxyUserId'>>();
-
-      if (!actor) {
-        logger.info(`[FedSync] 410 Gone for ${actorUri} — no stored actor row to tombstone`);
-        return;
-      }
-
-      logger.info(`[FedSync] tombstoned gone actor ${actorUri} (suspended)`);
-
-      if (actor.oxyUserId) {
-        const outcome = await reportFederatedActorGone(actor.oxyUserId);
-        logger.info(`[FedSync] actor-gone report for ${actorUri} (oxyUserId ${actor.oxyUserId}) → ${outcome}`);
-      }
-    } catch (err) {
-      logger.warn(`[FedSync] failed to tombstone gone actor ${actorUri}:`, err);
-    }
-  }
-
-  /**
-   * Fetch the totalItems count from an ActivityPub collection URL.
-   */
-  private async fetchCollectionCount(url?: string): Promise<number> {
-    if (!url) return 0;
-    try {
-      const res = await signedFetch(url, AP_CONTENT_TYPE);
-      if (!res.ok) return 0;
-      const col = await res.json() as Record<string, any>;
-      return typeof col.totalItems === 'number' ? col.totalItems : 0;
-    } catch {
-      return 0;
-    }
-  }
-
-  /**
-   * Get a cached actor or fetch if missing/stale (>24h).
-   *
-   * Never blocks on remote network I/O when a cached actor already exists: a
-   * stale cached actor is returned immediately and a background refresh is
-   * enqueued. Only a completely missing actor triggers a blocking fetch (the
-   * caller has nothing else to return).
-   */
-  async getOrFetchActor(actorUri: string): Promise<IFederatedActor | null> {
-    const existing = await FederatedActor.findOne({ uri: actorUri }).lean<IFederatedActor>();
-    if (existing) {
-      const isStale = !existing.lastFetchedAt || Date.now() - existing.lastFetchedAt.getTime() > ACTOR_STALE_MS;
-      if (isStale) {
-        // Refresh in the background — never block the caller on remote I/O.
-        this.refreshActorInBackground(actorUri, existing);
-      }
-      return existing;
-    }
-    return this.fetchRemoteActor(actorUri);
-  }
-
-  /**
-   * Enqueue a fire-and-forget full-actor refresh. Safe to call on a client
-   * request path: it returns synchronously and the fetch runs detached.
-   *
-   * Guards against refresh storms:
-   *  - an in-flight refresh for the same URI short-circuits;
-   *  - a recently-fetched actor (within ACTOR_REFRESH_MIN_INTERVAL_MS) is
-   *    skipped unless it is missing essential profile fields.
-   *
-   * The avatar refresh is forced only when refreshing an actor that already
-   * exists (so Oxy re-downloads/replaces it); first-time creation does not
-   * force, matching the upstream guard.
-   */
-  refreshActorInBackground(actorUri: string, existing?: IFederatedActor): void {
-    if (!FEDERATION_ENABLED) return;
-    if (this.inFlightActorRefreshes.has(actorUri)) return;
-
-    const missingProfile = !existing
-      || !existing.avatarUrl
-      || !existing.headerUrl;
-    const lastFetchedMs = existing?.lastFetchedAt?.getTime();
-    const refreshedRecently = typeof lastFetchedMs === 'number'
-      && Date.now() - lastFetchedMs < ACTOR_REFRESH_MIN_INTERVAL_MS;
-
-    // Skip if we refreshed recently AND the cached profile is already complete.
-    if (refreshedRecently && !missingProfile) return;
-
-    // Force avatar re-download only when the actor already exists (refresh),
-    // not on first-time creation.
-    const forceAvatarRefresh = Boolean(existing);
-
-    this.inFlightActorRefreshes.add(actorUri);
-    void (async () => {
-      try {
-        await this.fetchRemoteActor(actorUri, forceAvatarRefresh, existing?.acct);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        logger.warn(`[FedSync] background actor refresh failed for ${actorUri}: ${message}`);
-      } finally {
-        this.inFlightActorRefreshes.delete(actorUri);
-      }
-    })();
-  }
-
-  /**
-   * Resolve a remote actor URI to its listable Oxy user id (the federated user
-   * the actor already resolves to). Returns null when the actor cannot be
-   * resolved to an Oxy user — callers must then skip, because federated
-   * engagement is only ever recorded against a real, listable user.
-   */
-  async resolveActorOxyUserId(actorUri: string): Promise<string | null> {
-    const actor = await this.getOrFetchActor(actorUri);
-    return actor?.oxyUserId ?? null;
-  }
-
-  /**
-   * Fetch a public key by keyId (used for HTTP signature verification).
-   */
-  async fetchPublicKey(keyId: string): Promise<{ publicKeyPem: string; actorUri: string } | null> {
-    // keyId is typically the actor URI with #main-key appended
-    const actorUri = keyId.replace(/#.*$/, '');
-
-    // Check local cache first
-    const cached = await FederatedActor.findOne({ publicKeyId: keyId }).lean();
-    if (cached?.publicKeyPem) {
-      return { publicKeyPem: cached.publicKeyPem, actorUri: cached.uri };
-    }
-
-    // Fetch the actor to get the public key (uses 24h cache)
-    const actor = await this.getOrFetchActor(actorUri);
-    if (!actor?.publicKeyPem) return null;
-
-    return { publicKeyPem: actor.publicKeyPem, actorUri: actor.uri };
-  }
-}
-
-export const actorService = new ActorService();
 export default actorService;

--- a/packages/backend/src/connectors/activitypub/actorObject.ts
+++ b/packages/backend/src/connectors/activitypub/actorObject.ts
@@ -1,26 +1,18 @@
+import { createLocalActorBuilder, type ActorMediaResolver } from '@oxyhq/federation';
 import { logger } from '../../utils/logger';
 import { resolveAvatarUrl, resolveMediaRef } from '../../utils/mediaResolver';
-import {
-  FEDERATION_DOMAIN,
-  actorUrl,
-  inboxUrl,
-  outboxUrl,
-  featuredUrl,
-  followersUrl,
-  followingUrl,
-  sharedInboxUrl,
-} from './constants';
+import { FEDERATION_DOMAIN, federationUrls } from './constants';
 
 /**
  * The single builder of a LOCAL user's ActivityPub `Person` actor document.
  *
- * Shared by the GET actor route (`ap.routes.ts`, which serves it as a standalone
- * JSON-LD document) and the outbound `Update(Person)` broadcast
- * (`FollowService.federateActorUpdate`, which embeds it in an `Update` activity),
- * so a follower's Mastodon renders the same actor whether it was fetched or
- * pushed. Deliberately does NOT include the top-level `@context`: the GET route
- * and the `Update` envelope each own their JSON-LD context, and an embedded actor
- * object must not double-declare it.
+ * The byte-identical actor assembly (field set, ordering, `icon`/`image`
+ * absolute-URL invariant, `publicKey`) lives in `@oxyhq/federation` so every Oxy
+ * app federates identically; this module binds it to Mention's domain, URL
+ * builders, and canonical media chokepoint. It is shared by the GET actor route
+ * (which serves it as a standalone JSON-LD document) and the outbound
+ * `Update(Person)` broadcast, so a follower's Mastodon renders the same actor
+ * whether it was fetched or pushed.
  */
 
 /** Fields of the resolved Oxy user the actor document reads. */
@@ -33,150 +25,28 @@ export interface ActorUserView {
   createdAt?: string | null;
 }
 
-/** Map common image extensions to a MIME type for an actor image `mediaType`. */
-const IMAGE_MEDIA_TYPE_BY_EXT: Record<string, string> = {
-  png: 'image/png',
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  gif: 'image/gif',
-  webp: 'image/webp',
-  avif: 'image/avif',
+/**
+ * Mention's actor media adapter for the engine's actor builder. The avatar
+ * (`icon`) resolves through the canonical `resolveAvatarUrl` (Oxy file id →
+ * absolute CDN URL, external URL → proxied). The banner (`image`) — stored in
+ * Mention's own `UserSettings.profileHeaderImage` — resolves through
+ * `resolveMediaRef`. The engine enforces the absolute-URL invariant on both.
+ */
+const actorMedia: ActorMediaResolver = {
+  resolveAvatar: (ref) => resolveAvatarUrl(ref),
+  resolveBanner: (ref) => resolveMediaRef(ref).url,
 };
 
-/** True when `value` is an absolute `http(s)` URL. */
-function isAbsoluteHttpUrl(value: string): boolean {
-  try {
-    return /^https?:$/i.test(new URL(value).protocol);
-  } catch {
-    return false;
-  }
-}
-
 /**
- * Build an ActivityPub `Image` object from an already-absolute URL, deriving
- * `mediaType` from the URL extension when recognizable (a bare `Image` with a
- * `url` is spec-valid, so an unknown extension simply omits `mediaType` rather
- * than asserting a wrong one). Shared by the actor `icon` (avatar) and `image`
- * (profile banner) builders.
- */
-function apImageObject(url: string): { type: 'Image'; url: string; mediaType?: string } {
-  let extension: string | undefined;
-  try {
-    extension = new URL(url).pathname.split('.').pop()?.toLowerCase();
-  } catch {
-    extension = url.split('?')[0]?.split('.').pop()?.toLowerCase();
-  }
-  const mediaType = extension ? IMAGE_MEDIA_TYPE_BY_EXT[extension] : undefined;
-  return mediaType ? { type: 'Image', url, mediaType } : { type: 'Image', url };
-}
-
-/**
- * Build the actor `icon` (avatar) object for ActivityPub.
- *
- * The avatar reference stored on the Oxy user may be a raw Oxy file id (e.g.
- * `69b80c09a08af16d4b871195`) or an absolute URL. ActivityPub consumers such as
- * Mastodon validate that `icon.url` is an absolute URL and REJECT the entire
- * actor document when it is not — so a raw file id here makes the account
- * undiscoverable. We therefore resolve the reference through the same
- * server-authoritative `resolveAvatarUrl` mechanism the rest of the API uses
- * (Oxy file id → absolute Oxy asset stream URL; external URL → proxied through
- * our own origin), and only emit `icon` when that yields a real absolute URL.
- *
- * Returns undefined when there is no avatar or no absolute URL can be produced —
- * Mastodon is fine with an avatar-less actor, but a non-absolute url breaks it.
- */
-export function buildActorIcon(avatar: string | null | undefined): { type: 'Image'; url: string; mediaType?: string } | undefined {
-  if (!avatar) return undefined;
-
-  // Resolve a raw Oxy file id (or external URL) to a final, absolute URL. If the
-  // reference was already an absolute http(s) URL, `resolveAvatarUrl` returns an
-  // absolute URL too (verbatim for our own origins, proxied for external CDNs).
-  const resolved = resolveAvatarUrl(avatar);
-
-  // Guard the absolute-URL invariant: if resolution failed or degraded to a
-  // non-absolute passthrough (e.g. an unresolvable id), OMIT `icon` entirely
-  // rather than emit a value that would make Mastodon reject the actor.
-  if (!resolved || !isAbsoluteHttpUrl(resolved)) {
-    logger.warn(`[Federation] Omitting actor icon — avatar did not resolve to an absolute URL (ref: ${avatar})`);
-    return undefined;
-  }
-
-  return apImageObject(resolved);
-}
-
-/**
- * Build the actor `image` (profile banner/header) object for ActivityPub.
- *
- * Mastodon renders the AP `image` property as the profile HEADER banner — a
- * Mention user's banner is otherwise invisible across the fediverse. The banner
- * reference lives in Mention's own `UserSettings.profileHeaderImage` (a raw Oxy
- * file id or an absolute URL), the same field the profile-design endpoint reads
- * and `mirrorFederatedBanner` writes for the inbound direction. It is resolved
- * through the canonical media chokepoint (`resolveMediaRef`) to a final absolute
- * URL — an Oxy file id → CDN URL, an external URL → proxied through our origin —
- * mirroring {@link buildActorIcon}'s absolute-URL invariant.
- *
- * Returns undefined when there is no banner or none can be resolved to an
- * absolute URL, so callers omit the field cleanly.
- */
-export function buildActorImage(banner: string | null | undefined): { type: 'Image'; url: string; mediaType?: string } | undefined {
-  if (!banner) return undefined;
-
-  const resolved = resolveMediaRef(banner).url;
-  if (!resolved || !isAbsoluteHttpUrl(resolved)) {
-    logger.warn(`[Federation] Omitting actor image — banner did not resolve to an absolute URL (ref: ${banner})`);
-    return undefined;
-  }
-
-  return apImageObject(resolved);
-}
-
-/**
- * Assemble the LOCAL user's AP `Person` actor object (WITHOUT the top-level
+ * Assemble a LOCAL user's AP `Person` actor object (WITHOUT the top-level
  * `@context` — the caller owns that). `displayName` is the caller-resolved Oxy
  * `name.displayName` (falling back to the handle); it is never recomposed from
  * name parts here. The banner lives in Mention's own `UserSettings`, passed in as
  * `profileHeaderImage`.
  */
-export function buildLocalActorObject(params: {
-  username: string;
-  displayName: string;
-  bio?: string | null;
-  avatar?: string | null;
-  profileHeaderImage?: string | null;
-  publicKey: { keyId: string; publicKeyPem: string };
-  createdAt?: string | null;
-}): Record<string, unknown> {
-  const { username, displayName, bio, avatar, profileHeaderImage, publicKey, createdAt } = params;
-
-  const actorObject: Record<string, unknown> = {
-    id: actorUrl(username),
-    type: 'Person',
-    preferredUsername: username,
-    name: displayName,
-    summary: bio || '',
-    url: `https://${FEDERATION_DOMAIN}/@${username}`,
-    inbox: inboxUrl(username),
-    outbox: outboxUrl(username),
-    featured: featuredUrl(username),
-    followers: followersUrl(username),
-    following: followingUrl(username),
-    endpoints: { sharedInbox: sharedInboxUrl() },
-    discoverable: true,
-    manuallyApprovesFollowers: false,
-    icon: buildActorIcon(avatar),
-    image: buildActorImage(profileHeaderImage),
-    publicKey: {
-      id: publicKey.keyId,
-      owner: actorUrl(username),
-      publicKeyPem: publicKey.publicKeyPem,
-    },
-  };
-
-  // `published` (account creation date) is advertised when the API provides it.
-  if (createdAt) {
-    actorObject.published = new Date(createdAt).toISOString();
-  }
-
-  return actorObject;
-}
+export const buildLocalActorObject = createLocalActorBuilder({
+  domain: FEDERATION_DOMAIN,
+  urls: federationUrls,
+  media: actorMedia,
+  onWarn: (message) => logger.warn(message),
+});

--- a/packages/backend/src/connectors/activitypub/constants.ts
+++ b/packages/backend/src/connectors/activitypub/constants.ts
@@ -1,4 +1,5 @@
 import { registrableApex } from '@oxyhq/core';
+import { createDomainPolicy, createUrlBuilders } from '@oxyhq/federation';
 import { logger } from '../../utils/logger';
 import { getServiceOxyClient } from '../../utils/oxyHelpers';
 
@@ -45,41 +46,6 @@ const FEDERATION_BLOCKED_DOMAINS = new Set(
     .filter(Boolean)
 );
 
-export const AP_CONTEXT = [
-  'https://www.w3.org/ns/activitystreams',
-  'https://w3id.org/security/v1',
-  // The AS2 core context above defines the `as:` prefix
-  // (`as` → `https://www.w3.org/ns/activitystreams#`), so this maps the Note's
-  // `sensitive` boolean to `as:sensitive` — the exact term Mastodon defines for
-  // it. Without the term declaration a JSON-LD consumer drops `sensitive`.
-  //
-  // `toot` is Mastodon's extension namespace; `votersCount` (the total unique
-  // voters on a poll `Question`) is `toot:votersCount` — the exact term Mastodon
-  // emits and reads. Without the declaration a JSON-LD consumer drops it. The
-  // `Question`/`oneOf`/`anyOf`/`endTime`/`closed` poll terms are all AS2 core, so
-  // they need no extra declaration here.
-  //
-  // Quote-post interop (FEP-044f / FEP-e232). A quote post carries the quoted
-  // object's canonical AP id under FOUR terms so the widest set of servers
-  // renders the inline quote: `quote` (FEP-044f, Mastodon 4.4+), `quoteUri`
-  // (Fedibird), `_misskey_quote` (Misskey) and `quoteUrl` (Pleroma/Akkoma). Each
-  // is typed `@id` (an IRI, not a literal); the `misskey`/`fedibird` namespaces
-  // and the AS2 `Link` type back the FEP-e232 `Link` quote tag. Without these
-  // declarations a strict JSON-LD consumer DROPS the quote fields.
-  {
-    sensitive: 'as:sensitive',
-    toot: 'http://joinmastodon.org/ns#',
-    votersCount: 'toot:votersCount',
-    misskey: 'https://misskey-hub.net/ns#',
-    fedibird: 'http://fedibird.com/ns#',
-    quote: { '@id': 'https://w3id.org/fep/044f#quote', '@type': '@id' },
-    quoteUri: { '@id': 'fedibird:quoteUri', '@type': '@id' },
-    quoteUrl: { '@id': 'as:quoteUrl', '@type': '@id' },
-    _misskey_quote: { '@id': 'misskey:_misskey_quote', '@type': '@id' },
-    Link: 'as:Link',
-  },
-];
-
 export const AP_CONTENT_TYPE = 'application/activity+json';
 export const AP_ACCEPT_TYPES = [
   'application/activity+json',
@@ -101,9 +67,21 @@ export function isActivityPubAccept(accept: string | string[] | undefined): bool
   return lower.includes('activity+json') || lower.includes('ld+json');
 }
 
-export function actorUrl(username: string): string {
-  return `https://${ACTOR_DOMAIN}/ap/users/${username}`;
-}
+/**
+ * Per-instance ActivityPub URL builders, bound to Mention's FEDERATION_DOMAIN /
+ * ACTOR_DOMAIN via the shared `@oxyhq/federation` factory. The URL SHAPES live in
+ * the engine (so every Oxy app federates identically); this module owns only the
+ * domain configuration. `actorUrl` is `ACTOR_DOMAIN`-scoped; the rest are
+ * `FEDERATION_DOMAIN`-scoped — unchanged from the previous hand-written builders.
+ */
+export const federationUrls = createUrlBuilders(FEDERATION_DOMAIN, ACTOR_DOMAIN);
+export const actorUrl = federationUrls.actor;
+export const inboxUrl = federationUrls.inbox;
+export const outboxUrl = federationUrls.outbox;
+export const featuredUrl = federationUrls.featured;
+export const followersUrl = federationUrls.followers;
+export const followingUrl = federationUrls.following;
+export const sharedInboxUrl = federationUrls.sharedInbox;
 
 /**
  * Canonical href for a hashtag — the SINGLE shape shared by the Note's `Hashtag`
@@ -114,112 +92,23 @@ export function hashtagUrl(tag: string): string {
   return `https://${FEDERATION_DOMAIN}/hashtag/${encodeURIComponent(tag)}`;
 }
 
-export function inboxUrl(username: string): string {
-  return `https://${FEDERATION_DOMAIN}/ap/users/${username}/inbox`;
-}
-
-export function outboxUrl(username: string): string {
-  return `https://${FEDERATION_DOMAIN}/ap/users/${username}/outbox`;
-}
-
 /**
- * The actor's `featured` collection (pinned posts). Mastodon reads this URL from
- * the actor's `featured` property and fetches it on profile view — it is the ONLY
- * way a freshly-discovered account's posts populate its profile Posts tab
- * (Mastodon never backfills a remote timeline from the regular `outbox`). The
- * exact path only needs to be self-consistent with what the actor advertises;
- * this mirrors Mastodon's own `/collections/featured` convention under our
- * existing `/ap/users/:username` namespace.
+ * Mention's per-instance domain policy, bound via the shared `@oxyhq/federation`
+ * factory. `isBlockedDomain` rejects our own ActivityPub domains, the Oxy identity
+ * apex (both publish our own users), and any configured `FEDERATION_BLOCKED_DOMAINS`;
+ * `extractLocalPostId` recognises our own AP post URIs. The URI/domain LOGIC lives
+ * in the engine; this module owns the domain configuration.
  */
-export function featuredUrl(username: string): string {
-  return `https://${FEDERATION_DOMAIN}/ap/users/${username}/collections/featured`;
-}
-
-export function followersUrl(username: string): string {
-  return `https://${FEDERATION_DOMAIN}/ap/users/${username}/followers`;
-}
-
-export function followingUrl(username: string): string {
-  return `https://${FEDERATION_DOMAIN}/ap/users/${username}/following`;
-}
-
-export function sharedInboxUrl(): string {
-  return `https://${FEDERATION_DOMAIN}/ap/inbox`;
-}
-
-/**
- * Domains where WE mint ActivityPub URIs. Used to recognise our own post URIs
- * (see {@link extractLocalPostIdFromApUri}); the Oxy identity apex is NOT here
- * because Oxy does not mint Mention post URIs — it only publishes user DIDs.
- */
-const LOCAL_DOMAINS = new Set([
-  FEDERATION_DOMAIN.toLowerCase(),
-  ACTOR_DOMAIN.toLowerCase(),
-]);
-
-/**
- * Returns true if the domain should be rejected for federation.
- *
- * Includes our own ActivityPub domains AND Oxy's identity apex
- * ({@link OXY_IDENTITY_APEX}) — both publish our own users, so resolving an
- * actor there would create duplicate `FederatedActor` rows for local users —
- * plus any explicitly configured `FEDERATION_BLOCKED_DOMAINS`.
- */
-export function isBlockedDomain(domain: string): boolean {
-  const d = domain.toLowerCase();
-  return LOCAL_DOMAINS.has(d) || d === OXY_IDENTITY_APEX || FEDERATION_BLOCKED_DOMAINS.has(d);
-}
+const domainPolicy = createDomainPolicy({
+  domain: FEDERATION_DOMAIN,
+  actorDomain: ACTOR_DOMAIN,
+  identityApex: OXY_IDENTITY_APEX,
+  blockedDomains: FEDERATION_BLOCKED_DOMAINS,
+});
+export const isBlockedDomain = domainPolicy.isBlockedDomain;
+export const extractLocalPostIdFromApUri = domainPolicy.extractLocalPostId;
 
 export const USER_AGENT = `Mention/${FEDERATION_DOMAIN} (ActivityPub)`;
-
-/**
- * Extract a local Post id from an ActivityPub object URI that points at one of
- * our own posts. Local note URIs are minted as
- * `https://<our-domain>/ap/users/<username>/posts/<postId>` (see
- * `buildCreateNoteActivity` and the outbox route), so a remote Like/Announce
- * that targets one of our posts carries that URI as its `object`.
- *
- * Returns the trailing `<postId>` segment only when the URI host is one of our
- * own federation domains and the path matches the canonical scheme; otherwise
- * returns null (the object is a remote/imported post, resolved by
- * `federation.activityId` instead). Caller must still validate the id is a real
- * ObjectId before querying.
- */
-export function extractLocalPostIdFromApUri(objectUri: string): string | null {
-  let parsed: URL;
-  try {
-    parsed = new URL(objectUri);
-  } catch {
-    return null;
-  }
-  if (!LOCAL_DOMAINS.has(parsed.host.toLowerCase())) return null;
-  const match = parsed.pathname.match(/^\/ap\/users\/[^/]+\/posts\/([^/]+)\/?$/);
-  return match ? match[1] : null;
-}
-
-/** Path segments that typically separate an actor path from a post ID in ActivityPub URIs. */
-const POST_PATH_SEGMENTS = new Set(['statuses', 'posts', 'notes', 'objects', 'activities']);
-
-/**
- * Given an ActivityPub activity/object ID (URL), extract the actor URI by
- * trimming everything from the first recognised post-path segment onward.
- *
- * e.g. "https://mastodon.social/users/alice/statuses/12345"
- *    → "https://mastodon.social/users/alice"
- *
- * Returns null when the URL is malformed or no post-path segment is found.
- */
-export function extractActorUriFromActivityId(activityId: string): string | null {
-  try {
-    const url = new URL(activityId);
-    const segments = url.pathname.split('/').filter(Boolean);
-    const statusIdx = segments.findIndex(s => POST_PATH_SEGMENTS.has(s));
-    if (statusIdx < 1) return null;
-    return `${url.origin}/${segments.slice(0, statusIdx).join('/')}`;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Resolve an Oxy user by username (tries getUserByUsername, falls back to searchUsers).

--- a/packages/backend/src/connectors/activitypub/follow.service.ts
+++ b/packages/backend/src/connectors/activitypub/follow.service.ts
@@ -6,11 +6,10 @@ import UserSettings from '../../models/UserSettings';
 import { Post } from '../../models/Post';
 import Poll from '../../models/Poll';
 import { getPublicKey, signViaOxy } from './crypto';
-import { signRequest } from '@oxyhq/federation';
+import { AP_CONTEXT, signRequest } from '@oxyhq/federation';
 import {
   FEDERATION_DOMAIN,
   FEDERATION_ENABLED,
-  AP_CONTEXT,
   AP_CONTENT_TYPE,
   USER_AGENT,
   actorUrl,

--- a/packages/backend/src/connectors/activitypub/outbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/outbox.service.ts
@@ -1,10 +1,10 @@
 import { logger } from '../../utils/logger';
 import FederatedActor, { IFederatedActor } from '../../models/FederatedActor';
 import { Post } from '../../models/Post';
+import { extractActorUriFromActivityId } from '@oxyhq/federation';
 import {
   FEDERATION_MAX_CONTENT_LENGTH,
   AP_CONTENT_TYPE,
-  extractActorUriFromActivityId,
 } from './constants';
 import { PostVisibility } from '@mention/shared-types';
 import { extractApLanguage, extractApLanguages } from './apLanguage';

--- a/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
+++ b/packages/backend/src/connectors/activitypub/routes/ap.routes.ts
@@ -3,7 +3,7 @@ import { isValidObjectId } from 'mongoose';
 import { logger } from '../../../utils/logger';
 import { activityPubConnector } from '../ActivityPubConnector';
 import { getPublicKey } from '../crypto';
-import { verifyHttpSignature } from '@oxyhq/federation';
+import { AP_CONTEXT, verifyHttpSignature } from '@oxyhq/federation';
 import { Post } from '../../../models/Post';
 import UserSettings from '../../../models/UserSettings';
 import { getServiceOxyClient } from '../../../utils/oxyHelpers';
@@ -11,7 +11,6 @@ import type { User } from '@oxyhq/core';
 import {
   FEDERATION_DOMAIN,
   FEDERATION_ENABLED,
-  AP_CONTEXT,
   AP_CONTENT_TYPE,
   isActivityPubAccept,
   actorUrl,

--- a/packages/backend/src/connectors/activitypub/sharingCleanup.service.ts
+++ b/packages/backend/src/connectors/activitypub/sharingCleanup.service.ts
@@ -3,7 +3,8 @@ import FederatedActor from '../../models/FederatedActor';
 import FederatedFollow from '../../models/FederatedFollow';
 import { followService } from './follow.service';
 import { getServiceOxyClient } from '../../utils/oxyHelpers';
-import { actorUrl, AP_CONTEXT } from './constants';
+import { AP_CONTEXT } from '@oxyhq/federation';
+import { actorUrl } from './constants';
 import { getFediverseSharingStateById } from '../../services/fediverseSharing';
 
 /**

--- a/packages/backend/src/connectors/identity.ts
+++ b/packages/backend/src/connectors/identity.ts
@@ -1,279 +1,78 @@
-import { getErrorMessage, getErrorStatus } from '@oxyhq/core';
 import { logger } from '../utils/logger';
 import { getServiceOxyClient } from '../utils/oxyHelpers';
 import UserSettings from '../models/UserSettings';
 import { invalidate as invalidateUserSummaryCache } from '../services/userSummaryCache';
 import { persistRemoteMediaForFederatedOwnerDetailed } from '../services/mediaCache/cacheWorker';
 import { isAbsoluteHttpUrl, getRemoteHost } from './shared/url';
-import type { NormalizedExternalActor } from '@oxyhq/federation';
+import { createIdentityBridge, type ServiceRequest, type ServiceRequestMethod } from '@oxyhq/federation/node';
 
 /**
- * Network-neutral identity bridge: resolve a normalized external actor to its
- * Oxy user (`oxyUserId`) by upserting it through Oxy's service-scoped
- * `PUT /users/resolve`, and mirror its profile banner to Oxy.
+ * The network-neutral identity bridge: resolve a normalized external actor to its
+ * Oxy user (`PUT /users/resolve`), and archive/delete a permanently-gone actor's
+ * Oxy identity. The bridge LOGIC — the resolve body, the error classification, the
+ * outcome discriminants — lives in `@oxyhq/federation` so BOTH connectors
+ * (ActivityPub + atproto) and every Oxy app backend mint identities identically.
  *
- * Extracted verbatim from `ActivityPubConnector`'s actor-resolution path so BOTH
- * connectors (ActivityPub today, atproto next) mint Oxy identities through the
- * SAME helper — this is `NetworkConnector.mapIdentity`'s implementation. It is
- * deliberately protocol-agnostic: it reads only the normalized actor fields, so
- * the calling connector is responsible for stamping its own actor row with the
- * returned id.
+ * This module is the Mention wiring: it supplies the service-scoped oxy-api
+ * transport, the post-resolve user-summary cache invalidation, and the banner
+ * mirror (which uses Mention's own media cache — the one piece that stays
+ * app-side). `resolveOxyExternalUser` / `reportFederatedActorGone` /
+ * `deleteFederatedActorIdentity` keep their names + signatures for every caller.
  */
+
+/** Service-scoped oxy-api request, resolved at call time (the client is per-request). */
+const callOxyService: ServiceRequest = <T>(method: ServiceRequestMethod, path: string, body?: unknown): Promise<T> =>
+  getServiceOxyClient().makeServiceRequest<T>(method, path, body);
+
+const identityBridge = createIdentityBridge({
+  makeServiceRequest: callOxyService,
+  // A re-resolve can refresh the federated actor's display name / avatar in Oxy;
+  // evict any warm user-summary cache entry so the next feed hydration reads fresh.
+  onUserResolved: (oxyUserId) => invalidateUserSummaryCache([oxyUserId]),
+  // Best-effort banner mirror through Mention's own media cache (see below). It
+  // handles its own errors and never throws, so it can never drop a resolved user.
+  mirrorBanner: async (bannerUrl, oxyUserId, actorUri) => {
+    await mirrorFederatedBanner(bannerUrl, oxyUserId, actorUri);
+  },
+  logger: {
+    info: (message, meta) => logger.info(message, meta),
+    warn: (message, meta) => logger.warn(message, meta),
+  },
+});
 
 /**
- * Resolve/mint the Oxy user a normalized external actor maps to.
- *
- * Upserts the federated user via `PUT /users/resolve` (service-token scoped) so
- * profile changes (avatar, name, bio) stay synced — creating the user when it
- * does not exist. Returns the resolved Oxy user id, or `null` when Oxy is
- * unreachable / returns no id (callers must then skip, never persisting an
- * orphan). After resolution, the actor's banner is mirrored into a durable,
- * public Oxy asset via the SAME service-token media path as federated post media
- * (best-effort; failures are logged, not propagated).
- *
- * @param actor the normalized external actor.
- * @param opts.forceAvatarRefresh when true, tell Oxy to re-download and replace
- *   the federated avatar even if it already stored a file id (refresh paths).
+ * Resolve/mint the Oxy user a normalized external actor maps to (via
+ * `PUT /users/resolve`), then mirror its banner. Returns the resolved Oxy user id,
+ * or `null` when Oxy is unreachable / returns no id (callers must then skip, never
+ * persisting an orphan). This is `NetworkConnector.mapIdentity`'s implementation,
+ * shared by the ActivityPub and atproto connectors.
  */
-export async function resolveOxyExternalUser(
-  actor: NormalizedExternalActor,
-  opts: { forceAvatarRefresh?: boolean } = {},
-): Promise<string | null> {
-  const forceAvatarRefresh = opts.forceAvatarRefresh ?? false;
-  try {
-    const oxyClient = getServiceOxyClient();
-    // The connector owns deriving the canonical `local@domain` username and the
-    // instance domain for its protocol, so this bridge stays protocol-agnostic:
-    // it never has to guess a domain out of a bare atproto handle or a hostless
-    // DID. oxy-api binds the two (username domain must equal `domain`).
-    const oxyUser: { _id?: string; id?: string } | null = await oxyClient.makeServiceRequest('PUT', '/users/resolve', {
-      type: 'federated',
-      username: actor.federatedUsername,
-      actorUri: actor.externalId,
-      domain: actor.instanceDomain,
-      displayName: actor.displayName,
-      avatar: actor.avatarUrl,
-      bio: actor.bio,
-      // On refresh, tell Oxy to re-download and replace the avatar even if it
-      // already stored a file ID. Coordinated with oxy-api's
-      // `refresh` / `forceAvatarRefresh` flag on PUT /users/resolve.
-      refresh: forceAvatarRefresh,
-      forceAvatarRefresh,
-    });
-    const oxyId = String(oxyUser?._id || oxyUser?.id || '');
-    if (!oxyId) return null;
-
-    // A re-resolve can refresh the federated actor's display name / avatar in
-    // Oxy. Evict any warm user-summary cache entry so the next feed hydration
-    // reads the updated Oxy user instead of the stale 10-min cached copy.
-    await invalidateUserSummaryCache([oxyId]);
-
-    if (actor.bannerUrl) {
-      // Best-effort on the live path: the outcome (stored / transient / permanent)
-      // only matters to the one-shot backfill, which inspects the return to decide
-      // whether to retry. Failures here are already logged inside the helper.
-      await mirrorFederatedBanner(actor.bannerUrl, oxyId, actor.externalId);
-    }
-
-    return oxyId;
-  } catch (resolveErr) {
-    logger.warn(`Failed to resolve Oxy user for ${actor.externalId}:`, resolveErr);
-    return null;
-  }
-}
+export const resolveOxyExternalUser = identityBridge.resolveExternalUser;
 
 /**
- * oxy-api service route this bridge posts to when a remote actor is permanently
- * gone. Same service auth (scope `federation:write`) and same
- * `getServiceOxyClient().makeServiceRequest` transport as the inbound-follow
- * bridge (`inbox.service.ts` `bridgeFollowEdge` → `POST /federation/follow`).
+ * Teardown counterpart: tell oxy-api that a federated actor is permanently gone so
+ * it ARCHIVES the linked Oxy identity (removing it from search). Idempotent on the
+ * Oxy side. Never throws — a transient failure surfaces as the `'failed'` outcome.
  */
-const ACTOR_GONE_PATH = '/federation/actor-gone';
-
-/** The `{ data }`-unwrapped body oxy-api returns for a 200 `POST /federation/actor-gone`. */
-interface ActorGoneResponse {
-  oxyUserId: string;
-  accountStatus: 'archived';
-  alreadyArchived: boolean;
-}
+export const reportFederatedActorGone = identityBridge.reportActorGone;
 
 /**
- * Outcome discriminant of {@link reportFederatedActorGone}. NEVER thrown — both
- * callers (the live 410 tombstone in `actor.service.ts` and the one-shot
- * `pruneGoneFederatedActors` sweep) are fail-soft, so the transient/retryable
- * case is surfaced as a value (`'failed'`) rather than an exception a sweep would
- * have to catch to keep going.
- *
- *  - `archived` — Oxy archived a previously-active identity (removed from search).
- *  - `already`  — the identity was already archived (idempotent no-op, still 200).
- *  - `skipped`  — nothing to report, or oxy-api returned a PERMANENT client error
- *                 (400 bad body / 403 missing scope / 404 no such user / 409 target
- *                 not `type:'federated'`). Non-retryable — logged and swallowed.
- *  - `failed`   — a genuinely transient failure (5xx, 408/429, network, or an
- *                 unclassifiable transport error). Retryable: the caller may leave
- *                 the actor for a later pass.
+ * The irreversible counterpart of {@link reportFederatedActorGone}: ask oxy-api to
+ * HARD-DELETE the Oxy identity (User + follow edges/blocks) a permanently-gone
+ * actor maps to. Only the `purgeGoneFederatedActors` one-shot calls it, after
+ * re-confirming the remote actor still returns 410 Gone. Never throws.
  */
-export type ReportActorGoneOutcome = 'archived' | 'already' | 'skipped' | 'failed';
+export const deleteFederatedActorIdentity = identityBridge.deleteActorIdentity;
 
 /**
- * Teardown counterpart of {@link resolveOxyExternalUser}: tell oxy-api that a
- * federated actor is permanently gone so it archives the linked Oxy identity
- * (`accountStatus:'archived'`, removing it from search). Idempotent on the Oxy
- * side — a repeat call returns 200 with `alreadyArchived:true`.
- *
- * Mirrors the follow-bridge's exact client/auth pattern: the service-authed
- * `getServiceOxyClient().makeServiceRequest('POST', '/federation/actor-gone', …)`
- * under scope `federation:write`. `makeServiceRequest` unwraps the API's `{ data }`
- * envelope, so the resolved value is the inner {@link ActorGoneResponse}.
- *
- * Error policy (see {@link ReportActorGoneOutcome}): PERMANENT 4xx responses
- * (400/403/404/409 — all non-retryable per the contract) are logged and swallowed
- * to `'skipped'` so a bulk sweep is never aborted by one dead actor; only
- * genuinely transient failures (5xx, 408/429, network) surface as `'failed'` for
- * the caller to retry. This function never throws.
+ * Best-effort outcome of {@link mirrorFederatedBanner}. `permanent` distinguishes a
+ * transient failure (bad service credential, upstream 5xx, upload rejection — worth
+ * retrying) from a permanently-unavailable banner (dead/oversized/non-image — never
+ * retry), so the one-shot backfill caller can decide whether to back off and retry.
  */
-export async function reportFederatedActorGone(oxyUserId: string): Promise<ReportActorGoneOutcome> {
-  const id = oxyUserId.trim();
-  if (!id) return 'skipped';
-
-  try {
-    const data = await getServiceOxyClient().makeServiceRequest<ActorGoneResponse>(
-      'POST',
-      ACTOR_GONE_PATH,
-      { oxyUserId: id },
-    );
-    const alreadyArchived = data?.alreadyArchived === true;
-    logger.info(`[Federation] oxy-api archived gone actor ${id}`, { alreadyArchived });
-    return alreadyArchived ? 'already' : 'archived';
-  } catch (error) {
-    const httpStatus = getErrorStatus(error);
-    const reason = getErrorMessage(error);
-
-    // Permanent client errors (400 bad body, 403 missing scope, 404 no such user,
-    // 409 target not `type:'federated'`) are non-retryable per the contract. 408
-    // and 429 are excluded — those are transient and fall through to `'failed'`.
-    if (
-      httpStatus !== undefined &&
-      httpStatus >= 400 &&
-      httpStatus < 500 &&
-      httpStatus !== 408 &&
-      httpStatus !== 429
-    ) {
-      logger.warn(`[Federation] actor-gone report for ${id} rejected (HTTP ${httpStatus}, permanent)`, { reason });
-      return 'skipped';
-    }
-
-    // Everything else — 5xx, 408/429, a network failure, or an unclassifiable
-    // transport error — is transient. Surface as `'failed'` so the caller can
-    // leave the actor for a later pass instead of permanently skipping it.
-    logger.warn(`[Federation] actor-gone report for ${id} failed transiently; leaving for retry`, {
-      status: httpStatus,
-      reason,
-    });
-    return 'failed';
-  }
-}
-
-/**
- * oxy-api service route that HARD-DELETES a federated actor's Oxy identity — the
- * irreversible teardown counterpart of the (reversible) archive
- * {@link reportFederatedActorGone} performs. Same service auth (scope
- * `federation:write`) and same `getServiceOxyClient().makeServiceRequest`
- * transport as every other identity bridge (`/users/resolve`, `/federation/follow`,
- * `/federation/actor-gone`). Only the `purgeGoneFederatedActors` one-shot calls it,
- * after re-confirming the remote actor is STILL 410 Gone.
- */
-const ACTOR_DELETE_PATH = '/federation/actor-delete';
-
-/** The `{ data }`-unwrapped body oxy-api returns for a 200 `POST /federation/actor-delete`. */
-interface ActorDeleteResponse {
-  oxyUserId: string;
-  /** Whether an Oxy `User` actually existed and was deleted (false ⇒ idempotent no-op). */
-  deleted: boolean;
-  /** Follow edges removed on the Oxy side (both directions, counts repaired). */
-  followEdgesRemoved: number;
-}
-
-/**
- * Outcome discriminant of {@link deleteFederatedActorIdentity}. NEVER thrown — the
- * one-shot purge sweep is fail-soft, so the transient/retryable case is surfaced as
- * a value (`'failed'`) rather than an exception. Mirrors {@link ReportActorGoneOutcome}.
- *
- *  - `deleted` — oxy-api hard-deleted a live Oxy identity (+ its follow edges/blocks).
- *  - `absent`  — the identity was already gone (200 with `deleted:false`, idempotent).
- *                Like `deleted`, this CONFIRMS the Oxy side is clean — the purge may
- *                safely drop the `FederatedActor` anchor.
- *  - `skipped` — nothing to delete, or oxy-api returned a PERMANENT client error
- *                (400 bad body / 403 missing scope / 409 target not `type:'federated'`).
- *                Non-retryable — logged and swallowed. The identity is NOT confirmed
- *                gone, so the caller must KEEP the `FederatedActor` anchor.
- *  - `failed`  — a genuinely transient failure (5xx, 408/429, network). Retryable: the
- *                caller must KEEP the `FederatedActor` anchor so a later run finishes.
- */
-export type DeleteActorIdentityOutcome = 'deleted' | 'absent' | 'skipped' | 'failed';
-
-/**
- * Ask oxy-api to HARD-DELETE the Oxy identity a permanently-gone federated actor
- * maps to — the Oxy `User` plus all its Follow edges (both directions, counts
- * repaired), Blocks, and caches. Irreversible on the Oxy side; the caller
- * ({@link ../scripts/purgeGoneFederatedActors}) only invokes it after re-verifying
- * the remote actor still returns 410 Gone.
- *
- * Mirrors {@link reportFederatedActorGone} EXACTLY: the service-authed
- * `getServiceOxyClient().makeServiceRequest('POST', '/federation/actor-delete', …)`
- * under scope `federation:write`, `{ data }`-unwrapped to {@link ActorDeleteResponse}.
- *
- * Error policy (see {@link DeleteActorIdentityOutcome}): PERMANENT 4xx responses
- * (400/403/409 — all non-retryable per the contract) are logged and swallowed to
- * `'skipped'`; only genuinely transient failures (5xx, 408/429, network) surface as
- * `'failed'`. This function NEVER throws — a sweep over thousands of actors is never
- * aborted by one dead actor, and a `'skipped'`/`'failed'` tells the caller to keep
- * the `FederatedActor` row as a retry anchor (so a surviving Oxy user is never
- * orphaned without a record to reconcile it).
- */
-export async function deleteFederatedActorIdentity(oxyUserId: string): Promise<DeleteActorIdentityOutcome> {
-  const id = oxyUserId.trim();
-  if (!id) return 'skipped';
-
-  try {
-    const data = await getServiceOxyClient().makeServiceRequest<ActorDeleteResponse>(
-      'POST',
-      ACTOR_DELETE_PATH,
-      { oxyUserId: id },
-    );
-    const deleted = data?.deleted === true;
-    logger.info(
-      `[Federation] oxy-api ${deleted ? 'hard-deleted' : 'found no'} identity for gone actor ${id}`,
-      { followEdgesRemoved: data?.followEdgesRemoved ?? 0 },
-    );
-    return deleted ? 'deleted' : 'absent';
-  } catch (error) {
-    const httpStatus = getErrorStatus(error);
-    const reason = getErrorMessage(error);
-
-    // Permanent client errors (400 bad body, 403 missing scope, 409 target not
-    // `type:'federated'`) are non-retryable per the contract. 408 and 429 are
-    // excluded — those are transient and fall through to `'failed'`.
-    if (
-      httpStatus !== undefined &&
-      httpStatus >= 400 &&
-      httpStatus < 500 &&
-      httpStatus !== 408 &&
-      httpStatus !== 429
-    ) {
-      logger.warn(`[Federation] actor-delete for ${id} rejected (HTTP ${httpStatus}, permanent)`, { reason });
-      return 'skipped';
-    }
-
-    // Everything else — 5xx, 408/429, a network failure, or an unclassifiable
-    // transport error — is transient. Surface as `'failed'` so the caller keeps the
-    // actor's `FederatedActor` anchor and a later pass finishes the Oxy delete.
-    logger.warn(`[Federation] actor-delete for ${id} failed transiently; leaving for retry`, {
-      status: httpStatus,
-      reason,
-    });
-    return 'failed';
-  }
+export interface MirrorBannerResult {
+  ok: boolean;
+  permanent: boolean;
 }
 
 /**
@@ -284,29 +83,17 @@ export async function deleteFederatedActorIdentity(oxyUserId: string): Promise<D
  * (`persistRemoteMediaForFederatedOwnerDetailed` →
  * `POST /assets/service/federation`): SSRF-safe download → streamed upload as a
  * public, CDN-reachable file owned by the resolved federated user — the SAME
- * service-token flow that already mirrors federated post media and the avatar
- * (downloaded server-side by oxy-api). It deliberately does NOT use the SDK's
- * `uploadProfileBanner`, which routes through the USER-authenticated
- * `POST /assets/upload` and is rejected `401 UNAUTHORIZED` on the service client,
- * so the banner was never stored.
+ * service-token flow that already mirrors federated post media and the avatar. It
+ * deliberately does NOT use the SDK's `uploadProfileBanner`, which routes through
+ * the USER-authenticated `POST /assets/upload` and is rejected `401 UNAUTHORIZED`
+ * on the service client, so the banner was never stored.
  *
  * Best-effort: returns `{ ok: true }` when the banner was stored, otherwise
- * `{ ok: false, permanent }`. `permanent` distinguishes a transient failure
- * (bad service credential, upstream 5xx, upload rejection — worth retrying) from
- * a permanently-unavailable banner (dead/oversized/non-image — never retry), so
- * the backfill caller can decide whether to back off and retry. A non-http url is
- * `permanent: true` (it will never become valid). Transient failures are surfaced
- * at `warn`; permanent ones stay quiet, mirroring `materializeFederatedMedia`.
- *
- * Shared by the live actor-resolution path (`resolveOxyExternalUser`, which
- * ignores the result) and the one-shot `backfillFederatedBanners` script (which
- * inspects `permanent` to drive retry) so both go through ONE implementation.
+ * `{ ok: false, permanent }`. A non-http url is `permanent: true`. Transient
+ * failures are surfaced at `warn`; permanent ones stay quiet. Shared by the live
+ * actor-resolution path (the identity bridge above, which ignores the result) and
+ * the one-shot `backfillFederatedBanners` script (which inspects `permanent`).
  */
-export interface MirrorBannerResult {
-  ok: boolean;
-  permanent: boolean;
-}
-
 export async function mirrorFederatedBanner(
   bannerUrl: string,
   oxyUserId: string,
@@ -348,10 +135,8 @@ export async function mirrorFederatedBanner(
     return { ok: false, permanent: result.permanent };
   } catch (bannerErr) {
     // Honor the documented best-effort contract: a throw from the media persist or
-    // the `UserSettings` write must never propagate. On the live resolution path it
-    // would otherwise reach `resolveOxyExternalUser`'s outer catch and discard an
-    // already-successful user resolution. Treat it as a transient (retryable)
-    // failure so the backfill still retries, and swallow it.
+    // the `UserSettings` write must never propagate. Treat it as a transient
+    // (retryable) failure so the backfill still retries, and swallow it.
     logger.warn(`Failed to mirror banner for ${actorUri}`, {
       error: bannerErr,
       remoteHost,

--- a/packages/backend/src/scripts/purgeGoneFederatedActors.ts
+++ b/packages/backend/src/scripts/purgeGoneFederatedActors.ts
@@ -128,7 +128,7 @@ import MentionRepoHead from '../models/MentionRepoHead';
 import MentionSignedRecord from '../models/MentionSignedRecord';
 import MentionNodeIngestWitness from '../models/MentionNodeIngestWitness';
 import { deleteFederatedActorIdentity } from '../connectors/identity';
-import type { DeleteActorIdentityOutcome } from '../connectors/identity';
+import type { DeleteActorIdentityOutcome } from '@oxyhq/federation/node';
 import { signedFetch } from '../connectors/activitypub/helpers';
 import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
 import { logger } from '../utils/logger';


### PR DESCRIPTION
Phase 3 of the shared-federation-engine migration. Extracts the AP actor identity + remote-actor resolution into @oxyhq/federation@0.3.0 (domain-parameterized). Zero data movement — FederatedActor/FederatedFollow rows stay in Mention behind a bring-your-own-store adapter.

- Engine: `createUrlBuilders(domain)`, `AP_CONTEXT`, `createLocalActorBuilder` (media injected), `createActorResolver` (webfinger/fetch/getOrFetch/tombstone/fetchPublicKey over store + identity adapters + the Phase-2 signedFetch), `createIdentityBridge` (resolveExternalUser/reportGone/deleteIdentity → oxy-api).
- Mention: −841 lines; `actor.service.ts`/`actorObject.ts`/`constants.ts`/`identity.ts` now bind the engine with Mention's store, media chokepoint, domain. Clean cut.

Verified: golden actor test proves the Person JSON is byte-identical (id/type/preferredUsername/inbox/outbox/featured/followers/following/sharedInbox/icon/image/publicKey#main-key, @context, publicKey.id host == actor host). Backend tsc clean, 2594 tests pass, build ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)