### PR TITLE
fix(federation): organic self-heal of @mentions on outbox re-sync

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/outboxMentionSelfHeal.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/outboxMentionSelfHeal.test.ts
@@ -1,0 +1,317 @@
+import { PassThrough } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Organic SELF-HEAL of federated @mentions during outbox re-sync.
+ *
+ * The outbox mention fix resolves @mentions for NEW federated Note imports, but a
+ * post imported BEFORE that fix keeps its mentions as bare `@name` text — and the
+ * dedup pass (by `federation.activityId`) skips it on every re-sync, so it never
+ * heals. The self-heal closes that gap WITHOUT any extra fetch: the re-sync has
+ * already fetched the outbox page, so the original Note (with its `Mention` tags)
+ * is in hand; the matching EXISTING post is re-resolved from that in-hand note and
+ * its `[mention:<id>]` placeholders + `mentions` allowlist are written back.
+ *
+ * These pin:
+ *   - an existing post whose stored mentions never resolved gets its body variants
+ *     rewritten to `[mention:<id>]` placeholders and its `mentions` allowlist set,
+ *     with NO extra network fetch (only the single outbox GET);
+ *   - an ALREADY-resolved post is never touched (no resolution, no write);
+ *   - a resolve MISS (mentioned actor unresolvable) leaves the post as-is.
+ *
+ * The mock harness mirrors `outboxValidation.test.ts` (mocked `fetch` + models) and
+ * additionally stubs `actor.service` so the mentioned actor resolves from the
+ * (mocked) actor cache — proving the heal issues no network fetch of its own.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getPublicKey: vi.fn(),
+  signViaOxy: vi.fn(),
+  actorFind: vi.fn(),
+  actorFindOne: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+  updateOne: vi.fn(),
+  postFind: vi.fn(),
+  postFindOne: vi.fn(),
+  postFindById: vi.fn(),
+  postUpdateOne: vi.fn(),
+  postInsertMany: vi.fn(),
+  postExists: vi.fn(),
+  getServiceOxyClient: vi.fn(),
+  makeServiceRequest: vi.fn(),
+  persistRemoteMedia: vi.fn(),
+  recordAccess: vi.fn(),
+  postCreatorCreate: vi.fn(),
+  fetchUpstreamSingleHop: vi.fn(),
+  assertSafePublicUrl: vi.fn(),
+  getOrFetchActor: vi.fn(),
+  fetchRemoteActor: vi.fn(),
+}));
+
+vi.mock('../../../connectors/activitypub/crypto', () => ({
+  getPublicKey: mocks.getPublicKey,
+  signViaOxy: mocks.signViaOxy,
+}));
+
+// `signedFetch` performs its GET via the IP-pinned `fetchUpstreamSingleHop` (no
+// global `fetch`). Route it through the per-test stubbed global `fetch` so the
+// real validation/ingest logic runs; only the transport is adapted.
+vi.mock('../../../utils/safeUpstreamFetch', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../utils/safeUpstreamFetch')>();
+  return {
+    ...actual,
+    fetchUpstreamSingleHop: mocks.fetchUpstreamSingleHop,
+  };
+});
+
+vi.mock('@oxyhq/core/server', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@oxyhq/core/server')>()),
+  assertSafePublicUrl: mocks.assertSafePublicUrl,
+}));
+
+// Stub `actor.service` so the mentioned actor resolves from the actor cache — no
+// network fetch. The outbox owner is seeded from `actor.oxyUserId`, so
+// `fetchRemoteActor` is never reached here (provided only for completeness).
+vi.mock('../../../connectors/activitypub/actor.service', () => ({
+  actorService: {
+    getOrFetchActor: mocks.getOrFetchActor,
+    fetchRemoteActor: mocks.fetchRemoteActor,
+  },
+}));
+
+vi.mock('../../../models/FederatedActor', () => ({
+  default: {
+    findOne: mocks.actorFindOne,
+    find: mocks.actorFind,
+    findOneAndUpdate: mocks.findOneAndUpdate,
+    updateOne: mocks.updateOne,
+  },
+}));
+
+vi.mock('../../../models/Post', () => ({
+  // Mirror the real module's `pending` constant so the Stage-A baseline seed
+  // resolves it (vitest throws on undefined mock exports).
+  POST_CLASSIFICATION_PENDING: 'pending',
+  Post: {
+    find: mocks.postFind,
+    findOne: mocks.postFindOne,
+    findById: mocks.postFindById,
+    updateOne: mocks.postUpdateOne,
+    exists: mocks.postExists,
+    collection: {
+      insertMany: mocks.postInsertMany,
+    },
+  },
+}));
+
+vi.mock('../../../models/UserSettings', () => ({
+  default: {
+    updateOne: vi.fn(),
+  },
+}));
+
+vi.mock('../../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: mocks.getServiceOxyClient,
+}));
+
+vi.mock('../../../services/mediaCache/cacheWorker', () => ({
+  persistRemoteMediaForFederatedOwnerDetailed: mocks.persistRemoteMedia,
+}));
+
+vi.mock('../../../services/mediaCache/cacheStore', () => ({
+  recordAccessAndMaybeEnqueue: mocks.recordAccess,
+}));
+
+vi.mock('../../../services/serviceRegistry', () => ({
+  getPostCreator: () => ({ create: mocks.postCreatorCreate }),
+  registerPostFederator: vi.fn(),
+  registerPostCreator: vi.fn(),
+  getPostFederator: vi.fn(),
+}));
+
+import { outboxSyncService } from '../../../connectors/activitypub/outbox.service';
+
+const ACTOR_URI = 'https://mastodon.social/users/alice';
+const OUTBOX_URL = 'https://mastodon.social/users/alice/outbox';
+
+const BOB_URI = 'https://mastodon.example/users/bob';
+const BOB_PROFILE = 'https://mastodon.example/@bob';
+const BOB_OXY_ID = 'oxy_bob';
+
+/** The activity id (= note id) of the note that mentions @bob. */
+const MENTION_NOTE_ID = `${ACTOR_URI}/statuses/withmention`;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/activity+json' },
+    ...init,
+  });
+}
+
+/**
+ * A Mastodon-style `Create(Note)` authored by the outbox owner that mentions
+ * @bob: the `Mention` tag href is bob's actor URI, and the in-content anchor
+ * points at bob's profile page (the exact shape the resolver matches by href).
+ */
+function createNoteMentioningBob() {
+  return {
+    id: `${MENTION_NOTE_ID}/activity`,
+    type: 'Create',
+    actor: ACTOR_URI,
+    published: '2023-04-01T12:00:00Z',
+    object: {
+      id: MENTION_NOTE_ID,
+      type: 'Note',
+      attributedTo: ACTOR_URI,
+      content: `<p>hi <a href="${BOB_PROFILE}" class="u-url mention">@bob</a></p>`,
+      tag: [{ type: 'Mention', href: BOB_URI, name: '@bob@mastodon.example' }],
+      published: '2023-04-01T12:00:00Z',
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+    },
+  };
+}
+
+/** Stub the outbox so the whole collection (with inline items) resolves from ONE GET. */
+function stubOutbox(collection: unknown): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url === OUTBOX_URL) return jsonResponse(collection);
+    throw new Error(`unexpected fetch ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+/** Make the dedup query report an existing post for the mention note. */
+function stubExistingPost(mentions: string[]): void {
+  mocks.postFind.mockReturnValue({
+    lean: vi.fn().mockResolvedValue([
+      { federation: { activityId: MENTION_NOTE_ID }, mentions, content: {} },
+    ]),
+  });
+}
+
+function runSync() {
+  return outboxSyncService.syncOutboxPostsDetailed(
+    { uri: ACTOR_URI, acct: 'alice@mastodon.social', outboxUrl: OUTBOX_URL, oxyUserId: 'oxy_alice' },
+    { limit: 10, maxPages: 1 },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.getPublicKey.mockResolvedValue({
+    keyId: 'https://mention.earth/ap/users/instance#main-key',
+    publicKeyPem: 'public',
+  });
+  mocks.signViaOxy.mockResolvedValue('c2lnbmF0dXJl');
+  mocks.findOneAndUpdate.mockImplementation(async (_query, update) => ({ _id: 'actor_1', ...update.$set }));
+  mocks.updateOne.mockResolvedValue({ modifiedCount: 1 });
+  mocks.actorFind.mockReturnValue({ lean: vi.fn().mockResolvedValue([]) });
+  mocks.actorFindOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) });
+  mocks.postFind.mockReturnValue({ lean: vi.fn().mockResolvedValue([]) });
+  mocks.postFindOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) });
+  mocks.postFindById.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) });
+  mocks.postUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  mocks.postInsertMany.mockResolvedValue({ insertedCount: 0 });
+  mocks.postExists.mockResolvedValue(null);
+  mocks.persistRemoteMedia.mockResolvedValue({ ok: false, permanent: false });
+  mocks.recordAccess.mockResolvedValue(undefined);
+  mocks.postCreatorCreate.mockResolvedValue({ _id: 'created_post_1' });
+  mocks.makeServiceRequest.mockResolvedValue({ id: 'oxy_user_1' });
+  mocks.getServiceOxyClient.mockReturnValue({ makeServiceRequest: mocks.makeServiceRequest });
+  mocks.assertSafePublicUrl.mockResolvedValue({ ok: true, ip: '93.184.216.34', family: 4 });
+  mocks.fetchUpstreamSingleHop.mockImplementation(
+    async (url: string, options: { headers: Record<string, string> }) => {
+      const res: Response = await (globalThis.fetch as typeof fetch)(url, { headers: options.headers });
+      const bodyBuffer = Buffer.from(await res.arrayBuffer());
+      const headers: Record<string, string> = {};
+      res.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+      const stream = new PassThrough();
+      stream.end(bodyBuffer);
+      return { response: stream, status: res.status, headers };
+    },
+  );
+  // Default: @bob resolves from the actor cache (no network fetch).
+  mocks.getOrFetchActor.mockImplementation(async (uri: string) =>
+    uri === BOB_URI ? { oxyUserId: BOB_OXY_ID } : null,
+  );
+});
+
+describe('OutboxSyncService — @mention self-heal on re-sync', () => {
+  it('heals an existing post with bare-text mentions from the in-hand note, with NO extra fetch', async () => {
+    // The post already exists (deduped) but its stored mention allowlist is empty
+    // — a pre-fix import that never resolved @bob.
+    stubExistingPost([]);
+    const fetchMock = stubOutbox({
+      type: 'OrderedCollection',
+      totalItems: 1,
+      orderedItems: [createNoteMentioningBob()],
+    });
+
+    const result = await runSync();
+
+    // One existing post healed; nothing new inserted.
+    expect(result.healedMentionCount).toBe(1);
+    expect(result.newPostCount).toBe(0);
+    expect(mocks.postInsertMany).not.toHaveBeenCalled();
+
+    // The heal write rewrites the body variant to the `[mention:<id>]` placeholder
+    // and sets the `mentions` allowlist — in lockstep, like the inbox Update path.
+    const healCall = mocks.postUpdateOne.mock.calls.find(
+      ([filter]) =>
+        (filter as { 'federation.activityId'?: string })['federation.activityId'] === MENTION_NOTE_ID,
+    );
+    if (!healCall) throw new Error('expected a heal updateOne for the mention note');
+    const update = healCall[1] as {
+      $set: { mentions: string[]; 'content.variants': Array<{ text: string }> };
+    };
+    expect(update.$set.mentions).toEqual([BOB_OXY_ID]);
+    expect(update.$set['content.variants']).toHaveLength(1);
+    expect(update.$set['content.variants'][0].text).toContain(`[mention:${BOB_OXY_ID}]`);
+    expect(update.$set['content.variants'][0].text).not.toContain('<a');
+
+    // No extra network fetch: only the single outbox GET ran. The note was already
+    // in hand and @bob resolved from the (mocked) actor cache, not the network.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(OUTBOX_URL, expect.anything());
+  });
+
+  it('leaves an ALREADY-resolved post untouched (no resolution, no write)', async () => {
+    // Stored allowlist already covers the note's single mention → not a candidate.
+    stubExistingPost([BOB_OXY_ID]);
+    stubOutbox({
+      type: 'OrderedCollection',
+      totalItems: 1,
+      orderedItems: [createNoteMentioningBob()],
+    });
+
+    const result = await runSync();
+
+    expect(result.healedMentionCount).toBe(0);
+    // Never re-resolves and never rewrites an already-resolved post.
+    expect(mocks.getOrFetchActor).not.toHaveBeenCalled();
+    expect(mocks.postUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('leaves the post as-is on a resolve MISS (mentioned actor unresolvable)', async () => {
+    stubExistingPost([]);
+    stubOutbox({
+      type: 'OrderedCollection',
+      totalItems: 1,
+      orderedItems: [createNoteMentioningBob()],
+    });
+    // @bob cannot be resolved this run.
+    mocks.getOrFetchActor.mockResolvedValue(null);
+
+    const result = await runSync();
+
+    expect(result.healedMentionCount).toBe(0);
+    // The heal was attempted (bounded resolution ran) but wrote nothing.
+    expect(mocks.getOrFetchActor).toHaveBeenCalledWith(BOB_URI);
+    expect(mocks.postUpdateOne).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/connectors/activitypub/apPostContent.ts
+++ b/packages/backend/src/connectors/activitypub/apPostContent.ts
@@ -438,3 +438,36 @@ export async function buildFederatedNoteContentForEdit(
 ): Promise<BuiltFederatedNoteContent> {
   return assembleFederatedNoteContent(object, ownerOxyUserId, ctx);
 }
+
+/**
+ * Re-derive ONLY the localized author variants of a federated Note — the exact
+ * same text pipeline {@link assembleFederatedNoteContent} runs (hashtag-anchor
+ * rewrite, `contentMap` fallback, hashtag normalization, the all-hashtag "don't
+ * blank" restore, per-language variant assembly) but with **no media I/O**.
+ *
+ * This is the outbox @mention SELF-HEAL seam: a post imported before the outbox
+ * path resolved mentions kept its `@name` anchors as bare text, and the dedup pass
+ * never re-inserts it. The caller has the original Note in hand (already fetched by
+ * the outbox sync), applies the mention placeholders to it, then re-derives the
+ * body here to `$set content.variants` — WITHOUT re-materializing media (which
+ * would issue an extra remote fetch). The stored media state is reused via
+ * `hasMedia`, which only feeds the all-hashtag restore. Pure / no network fetch.
+ *
+ * Returns an EMPTY array for a note with no storable body (media-only / CW-only);
+ * the caller must never blank an existing post's body on an empty result.
+ */
+export function buildFederatedNoteVariants(
+  object: Record<string, unknown>,
+  hasMedia: boolean,
+): PostContentVariant[] {
+  const source = rewriteHashtagAnchorsInObject(object);
+  const primaryHtml = extractApContentHtml(source);
+  const rawText = htmlToPlainText(primaryHtml);
+  const { content: normalizedText } = normalizePostHashtags(rawText, extractApHashtags(object));
+  let text = normalizeMultilineText(normalizedText);
+  if (text.length === 0 && rawText.length > 0 && !hasMedia) {
+    text = rawText;
+  }
+  const primaryTag = resolveApPrimaryTag(source, primaryHtml);
+  return buildApAuthorVariants(source, primaryTag, text, hasMedia);
+}

--- a/packages/backend/src/connectors/activitypub/outbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/outbox.service.ts
@@ -8,7 +8,8 @@ import {
 } from './constants';
 import { PostVisibility } from '@mention/shared-types';
 import { extractApLanguage, extractApLanguages } from './apLanguage';
-import { buildFederatedNoteContent } from './apPostContent';
+import { buildFederatedNoteContent, buildFederatedNoteVariants } from './apPostContent';
+import { normalizeMentionIds } from '../../utils/textProcessing';
 import { getPostCreator } from '../../services/serviceRegistry';
 import { baselineContentClassifier } from '../../services/BaselineContentClassifier';
 import {
@@ -46,6 +47,7 @@ import {
 } from './apSchemas';
 import {
   applyMentionPlaceholders,
+  extractMentionTags,
   resolveInboundMentionsForNotes,
   type ResolvedInboundMentions,
 } from './apMentions';
@@ -71,6 +73,14 @@ const OUTBOX_ACTOR_RESOLVE_TIMEOUT_MS = 20 * 1000; // 20 seconds
  * parallelized in small batches rather than run strictly sequentially.
  */
 const OUTBOX_BOOST_IMPORT_CONCURRENCY = 4;
+
+/**
+ * Bounded concurrency for the existing-post @mention SELF-HEAL writes. Each heal is
+ * a single `updateOne` (no network fetch — the note is already in hand and its
+ * mentions were resolved in the same shared bounded pass as the new notes), so a
+ * small parallel batch keeps the write burst bounded without serializing.
+ */
+const OUTBOX_MENTION_HEAL_CONCURRENCY = 5;
 
 /**
  * Hard cap on how many untrusted outbox items a single page pass may inspect.
@@ -146,6 +156,12 @@ export interface OutboxSyncResult {
   newPostCount?: number;
   existingCount?: number;
   importedBoostCount?: number;
+  /**
+   * Existing posts whose bare-text @mentions were re-resolved and rewritten from
+   * the in-hand outbox notes this run (organic self-heal of pre-mention-fix
+   * imports). Zero on every page that carries no such posts.
+   */
+  healedMentionCount?: number;
   pagesFetched?: number;
   reachedEnd?: boolean;
   nextCursor?: {
@@ -550,15 +566,30 @@ export class OutboxSyncService {
         (c): c is Extract<OutboxCandidate, { kind: 'announce' }> => c.kind === 'announce',
       );
 
-      // Bulk dedup: single query instead of N queries
+      // Bulk dedup: single query instead of N queries. Also carries the fields the
+      // @mention self-heal below needs — the stored `mentions` allowlist and
+      // whether the post has media — so an existing post whose mentions were never
+      // resolved (imported before the outbox mention fix) can be repaired from the
+      // in-hand note without any extra query or fetch.
       const allActivityIds = candidates.map(c => c.activityId);
       const existingPosts = await Post.find(
         { 'federation.activityId': { $in: allActivityIds } },
-        { 'federation.activityId': 1 },
+        { 'federation.activityId': 1, mentions: 1, 'content.media': 1 },
       ).lean();
       const existingIds = new Set(
         existingPosts.map(p => (p.federation as { activityId?: string } | undefined)?.activityId),
       );
+      // activityId → the stored post's mention state, keyed for the self-heal pass.
+      const existingMentionStateByActivityId = new Map<string, { mentions: string[]; hasMedia: boolean }>();
+      for (const p of existingPosts) {
+        const activityId = (p.federation as { activityId?: string } | undefined)?.activityId;
+        if (!activityId) continue;
+        const media = (p as { content?: { media?: unknown[] } }).content?.media;
+        existingMentionStateByActivityId.set(activityId, {
+          mentions: normalizeMentionIds((p as { mentions?: unknown }).mentions),
+          hasMedia: Array.isArray(media) && media.length > 0,
+        });
+      }
 
       // Resolve actor URIs → Oxy User IDs (note authors only; announce authors
       // are always the outbox owner, resolved via actor.oxyUserId below).
@@ -603,22 +634,55 @@ export class OutboxSyncService {
 
       logger.debug(`[FedSync] ${candidates.length} candidates (${noteCandidates.length} notes, ${announceCandidates.length} announces), ${existingIds.size} already exist, actorOxyMap has ${actorOxyMap.size} entries`);
 
-      // Resolve the @mentions of every NEW note in this page ONCE, with bounded
-      // remote fan-out. Each DISTINCT mentioned actor across the page is
-      // fetched-and-created at most once, in capped-concurrency batches with a
-      // per-actor timeout (the SAME bounds this file already applies to note-author
-      // resolution), so a page carrying many first-seen mentions can never trigger
-      // the unbounded/serial actor fetch that once hung a re-ingest. Already-imported
-      // (deduped) notes are excluded so a re-sync never re-resolves. Consumed per
-      // note in the build loop below to rewrite each mention anchor into a
-      // `[mention:<id>]` placeholder BEFORE the body is derived and to set the
-      // post's `mentions` allowlist — mirroring the inbox Create path, which this
-      // raw `insertMany` cannot inherit because it bypasses that code path.
+      // NEW notes to import (not deduped) — their mentions are resolved for the
+      // build loop below to rewrite each anchor into a `[mention:<id>]` placeholder
+      // BEFORE the body is derived and to set the post's `mentions` allowlist,
+      // mirroring the inbox Create path (the raw `insertMany` bypasses that path).
       const pendingNoteCandidates = noteCandidates.filter(
         (c) => !existingIds.has(c.activityId),
       );
+
+      // SELF-HEAL candidates: notes that match an EXISTING post whose stored body
+      // still shows its @mentions as bare `@name` text. Such posts were imported
+      // before the outbox path resolved mentions, so their anchors were never
+      // rewritten — and the dedup pass above would otherwise skip them forever
+      // (they are never re-inserted). The outbox page just fetched carries each
+      // note's `Mention` tags, so those posts can be repaired with ZERO extra fetch.
+      // A post qualifies only when the in-hand note carries >=1 DISTINCT `Mention`
+      // tag AND the stored `mentions` allowlist is shorter than that (empty/short =>
+      // never fully resolved); an already-resolved post is never a candidate.
+      const mentionHealCandidates: Array<{
+        note: Record<string, unknown>;
+        activityId: string;
+        storedMentions: string[];
+        hasMedia: boolean;
+      }> = [];
+      for (const c of noteCandidates) {
+        if (!existingIds.has(c.activityId)) continue;
+        const stored = existingMentionStateByActivityId.get(c.activityId);
+        if (!stored) continue;
+        const distinctMentionHrefs = new Set(extractMentionTags(c.note).map((t) => t.href));
+        if (distinctMentionHrefs.size === 0) continue;
+        if (stored.mentions.length >= distinctMentionHrefs.size) continue;
+        mentionHealCandidates.push({
+          note: c.note,
+          activityId: c.activityId,
+          storedMentions: stored.mentions,
+          hasMedia: stored.hasMedia,
+        });
+      }
+
+      // Resolve the @mentions of the NEW notes AND the heal notes in ONE bounded
+      // pass. Each DISTINCT mentioned actor across the whole page is
+      // fetched-and-created at most once, in capped-concurrency batches with a
+      // per-actor timeout (the SAME bounds this file applies to note-author
+      // resolution), so a page carrying many first-seen mentions can never trigger
+      // the unbounded/serial actor fetch that once hung a re-ingest — and an actor
+      // mentioned by both a new and a healed note is fetched only once. The result
+      // map is keyed by the input note object reference and consumed with NO further
+      // I/O by both the build loop and the self-heal pass below.
       const mentionsByNote = await resolveInboundMentionsForNotes(
-        pendingNoteCandidates.map((c) => c.note),
+        [...pendingNoteCandidates.map((c) => c.note), ...mentionHealCandidates.map((h) => h.note)],
         {
           concurrency: OUTBOX_ACTOR_RESOLVE_CONCURRENCY,
           perActorTimeoutMs: OUTBOX_ACTOR_RESOLVE_TIMEOUT_MS,
@@ -846,6 +910,11 @@ export class OutboxSyncService {
         }
       }
 
+      // Organic self-heal: repair EXISTING posts whose @mentions were never
+      // resolved, using the in-hand notes (no extra fetch, mentions already
+      // resolved in the shared bounded pass above). Idempotent + fail-soft.
+      const healedMentionCount = await this.healExistingMentions(mentionHealCandidates, mentionsByNote);
+
       // Import boosts (Announce) attributed to the outbox owner. Each announce
       // ensures the boosted Note exists locally, then creates a boost Post that
       // mirrors native reposts (type=boost, boostOf=<local note _id>) with the
@@ -868,7 +937,7 @@ export class OutboxSyncService {
       }
 
       const synced = existingIds.size + newDocs.length + importedBoosts;
-      logger.debug(`Synced ${newDocs.length} new outbox posts and ${importedBoosts} boosts for ${actor.acct} (${existingIds.size} already existed)`);
+      logger.debug(`Synced ${newDocs.length} new outbox posts and ${importedBoosts} boosts for ${actor.acct} (${existingIds.size} already existed, ${healedMentionCount} mention self-heals)`);
       return {
         syncedCount: synced,
         shouldStampCooldown: !paginationFailed,
@@ -877,6 +946,7 @@ export class OutboxSyncService {
         newPostCount: newDocs.length,
         existingCount: existingIds.size,
         importedBoostCount: importedBoosts,
+        healedMentionCount,
         pagesFetched,
         reachedEnd,
         nextCursor,
@@ -885,6 +955,86 @@ export class OutboxSyncService {
       logger.warn(`Failed to sync outbox posts from ${actor.outboxUrl}:`, err);
       return { syncedCount: 0, shouldStampCooldown: false, reason: 'exception' };
     }
+  }
+
+  /**
+   * Organic self-heal of the @mentions of EXISTING federated posts whose stored
+   * body still shows its mentions as bare `@name` text — posts imported before the
+   * outbox path resolved mentions, which the dedup pass never re-inserts (so they
+   * would keep dead-text mentions forever). The in-hand outbox notes already carry
+   * the `Mention` tags, so each post is repaired with NO extra fetch beyond the
+   * bounded, shared mention resolution already performed for the page.
+   *
+   * Bounded batch of `updateOne`s. Idempotent + fail-soft: a note whose mentions
+   * did not resolve, or whose resolution adds nothing the stored allowlist already
+   * has, is a no-op — an already-resolved post is never rewritten. Historical posts
+   * are NEITHER re-notified NOR re-federated: this is a pure content-heal.
+   *
+   * @returns the number of posts actually rewritten this run.
+   */
+  private async healExistingMentions(
+    healCandidates: Array<{
+      note: Record<string, unknown>;
+      activityId: string;
+      storedMentions: string[];
+      hasMedia: boolean;
+    }>,
+    mentionsByNote: Map<Record<string, unknown>, ResolvedInboundMentions>,
+  ): Promise<number> {
+    if (healCandidates.length === 0) return 0;
+
+    let healed = 0;
+    for (let i = 0; i < healCandidates.length; i += OUTBOX_MENTION_HEAL_CONCURRENCY) {
+      const batch = healCandidates.slice(i, i + OUTBOX_MENTION_HEAL_CONCURRENCY);
+      const results = await Promise.all(
+        batch.map((candidate) => this.healOnePostMentions(candidate, mentionsByNote)),
+      );
+      healed += results.filter(Boolean).length;
+    }
+    return healed;
+  }
+
+  /**
+   * Repair ONE existing post's @mentions from its in-hand note. Returns true only
+   * when the post was actually rewritten. Guards on "unresolved" so a post whose
+   * mentions are already resolved is never touched (see {@link healExistingMentions}).
+   */
+  private async healOnePostMentions(
+    candidate: {
+      note: Record<string, unknown>;
+      activityId: string;
+      storedMentions: string[];
+      hasMedia: boolean;
+    },
+    mentionsByNote: Map<Record<string, unknown>, ResolvedInboundMentions>,
+  ): Promise<boolean> {
+    const resolved = mentionsByNote.get(candidate.note);
+    // Resolve miss (or the note carried no resolvable mention): leave the post as-is.
+    if (!resolved || resolved.ids.length === 0) return false;
+
+    // Only rewrite when the resolution ADDS a mention the stored allowlist lacks —
+    // a genuine improvement. When every resolved id is already stored (e.g. the
+    // remaining anchors point at now-unresolvable actors), the post is left
+    // untouched, so a partially-healed post is never rewritten on every re-sync.
+    const storedSet = new Set(candidate.storedMentions);
+    if (resolved.ids.every((id) => storedSet.has(id))) return false;
+
+    // Rewrite the in-hand note's mention anchors to `[mention:<id>]` placeholders,
+    // then re-derive ONLY the body variants (NO media I/O — the stored media state
+    // is reused via `hasMedia`) and `$set` them alongside the mention allowlist,
+    // keeping the stored body and `mentions` in lockstep exactly like the inbox
+    // Update path — without re-materializing media or re-fetching anything.
+    const noteObject = applyMentionPlaceholders(candidate.note, resolved.anchorMap);
+    const variants = buildFederatedNoteVariants(noteObject, candidate.hasMedia);
+    // A note that re-derives to an empty body (media-only / CW-only) must never
+    // blank an existing post's body — leave it untouched.
+    if (variants.length === 0) return false;
+
+    const result = await Post.updateOne(
+      { 'federation.activityId': candidate.activityId },
+      { $set: { 'content.variants': variants, mentions: resolved.ids } },
+    );
+    return ((result as { modifiedCount?: number }).modifiedCount ?? 0) > 0;
   }
 
   /**


### PR DESCRIPTION
Pre-#463 federated posts kept bare-text @mentions and never healed (re-sync deduped them). Now, during outbox re-sync — which already fetched the Note (tags in hand) — an existing post that never had its mention anchors rewritten is repaired with ZERO extra network fetch.

- Heal candidate only when the in-hand note has ≥1 distinct Mention tag AND the stored allowlist is shorter (never fully resolved); already-resolved posts never touched.
- New + heal notes resolved in ONE bounded pass (#463 batch resolver: distinct-href dedup, capped concurrency, per-actor timeout).
- Re-derives ONLY the body variants (new pure builder), reusing the stored hasMedia flag → never re-materializes media. $sets content.variants + mentions in lockstep. Idempotent, fail-soft, no re-notify/re-federate.

Verified: tsc clean, build clean, 2597 tests pass, focused test asserts a single outbox GET + already-resolved untouched + resolve-miss no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)