### PR TITLE
style(profile): fully round the 'Follows you' chip

### DIFF
--- a/packages/frontend/components/Profile/ProfileContent.tsx
+++ b/packages/frontend/components/Profile/ProfileContent.tsx
@@ -62,7 +62,7 @@ export const ProfileContent = memo(function ProfileContent({
   // out visitor has no "you") and is never shown on the viewer's own profile.
   const followsYouTag =
     !isOwnProfile && isAuthenticated && profileData.followsYou ? (
-      <View className="bg-secondary px-1.5 py-0.5 rounded">
+      <View className="bg-secondary px-2 py-0.5 rounded-full">
         <Text className="text-muted-foreground text-xs font-medium" numberOfLines={1}>
           {t('profile.followsYou', { defaultValue: 'Follows you' })}
         </Text>


### PR DESCRIPTION
Make the 'Follows you' chip a full pill (`rounded` → `rounded-full`), + slightly more horizontal padding so the text isn't cramped against the round ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)