### PR TITLE
fix(frontend): stop feed precache from stripping profile 'relationship' (Follows you)

### DIFF
--- a/packages/frontend/lib/__tests__/precacheProfiles.test.ts
+++ b/packages/frontend/lib/__tests__/precacheProfiles.test.ts
@@ -1,0 +1,128 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Unit tests for the profile precache helpers, focused on the one invariant the
+ * component tests can't reach: priming from a feed/list response must never
+ * DOWNGRADE the viewer-relative `relationship` that the authenticated
+ * single-profile fetch put on the by-username entry. That downgrade is the
+ * "Follows you tag vanishes when the feed loads" bug.
+ *
+ * The two SDK surfaces the helper touches are ported with the EXACT key shapes
+ * the real SDK uses (`@oxyhq/services` ships untranspiled TS source under jest),
+ * plus a controllable active viewer. A divergence between the seed key and the
+ * key `useUserByUsername` reads — e.g. re-introducing `.toLowerCase()` — would
+ * fail the casing test here rather than ship silently.
+ */
+let mockViewerId: string | null = 'viewer-1';
+jest.mock('@oxyhq/services', () => ({
+  queryKeys: {
+    users: {
+      detail: (id: string) => ['users', 'detail', id],
+      details: () => ['users', 'detail'],
+    },
+  },
+  useAuthStore: { getState: () => ({ user: mockViewerId === null ? null : { id: mockViewerId } }) },
+}));
+
+import { precacheProfileView, type CacheableUser } from '../precacheProfiles';
+
+/** The by-id identity key, exactly as the SDK's `useUserById` builds it. */
+function detailKey(id: string): unknown[] {
+  return ['users', 'detail', id];
+}
+
+/** The viewer-scoped by-username key, exactly as the SDK's `useUserByUsername` builds it. */
+function usernameKey(username: string, viewerId: string): unknown[] {
+  return ['users', 'detail', 'username', username, 'viewer', viewerId];
+}
+
+/** An authenticated single-profile fetch: carries the viewer `relationship`. */
+function authedProfile(overrides?: Partial<CacheableUser>): CacheableUser {
+  return {
+    id: 'u1',
+    username: 'alice',
+    name: { displayName: 'Alice' },
+    relationship: { isFollowing: false, followsYou: true },
+    ...overrides,
+  };
+}
+
+/** A feed/list user: public identity only, never a `relationship`. */
+function feedUser(overrides?: Partial<CacheableUser>): CacheableUser {
+  return { id: 'u1', username: 'alice', name: { displayName: 'Alice' }, ...overrides };
+}
+
+let qc: QueryClient;
+beforeEach(() => {
+  mockViewerId = 'viewer-1';
+  qc = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } });
+});
+afterEach(() => {
+  qc.clear();
+});
+
+describe('precacheProfileView — relationship preservation', () => {
+  it('PRESERVES a relationship-bearing by-username entry when a feed user is primed over it', () => {
+    // The profile page loaded Alice (who follows the viewer) into the cache.
+    qc.setQueryData(usernameKey('alice', 'viewer-1'), authedProfile());
+    const before = qc.getQueryState(usernameKey('alice', 'viewer-1'))?.dataUpdatedAt;
+
+    // The feed loads and Alice appears as a post author — a relationship-less user.
+    precacheProfileView(qc, feedUser());
+
+    const entry = qc.getQueryData<CacheableUser>(usernameKey('alice', 'viewer-1'));
+    // The "Follows you" tag survives: relationship is intact.
+    expect(entry?.relationship).toEqual({ isFollowing: false, followsYou: true });
+    // And the fresh authed entry was left untouched — NOT re-seeded stale (which
+    // would force a needless refetch).
+    expect(qc.getQueryState(usernameKey('alice', 'viewer-1'))?.dataUpdatedAt).toBe(before);
+  });
+
+  it('SEEDS an empty by-username slot as STALE so a cold navigation refetches the relationship', () => {
+    precacheProfileView(qc, feedUser());
+
+    const state = qc.getQueryState(usernameKey('alice', 'viewer-1'));
+    expect(qc.getQueryData<CacheableUser>(usernameKey('alice', 'viewer-1'))?.username).toBe('alice');
+    // Marked stale (updatedAt: 0) so `useUserByUsername` still fetches and pulls
+    // the viewer's `relationship` on first view.
+    expect(state?.dataUpdatedAt).toBe(0);
+  });
+
+  it('re-seeds over an existing relationship-LESS entry (nothing to preserve yet)', () => {
+    // A prior feed pass seeded a relationship-less entry.
+    precacheProfileView(qc, feedUser({ name: { displayName: 'Stale' } }));
+    // A later pass with fresher identity still seeds (no relationship to protect).
+    precacheProfileView(qc, feedUser({ name: { displayName: 'Fresh' } }));
+
+    const entry = qc.getQueryData<CacheableUser>(usernameKey('alice', 'viewer-1'));
+    expect(entry?.name).toEqual({ displayName: 'Fresh' });
+    expect(qc.getQueryState(usernameKey('alice', 'viewer-1'))?.dataUpdatedAt).toBe(0);
+  });
+
+  it('keeps the by-id identity entry FRESH (not viewer-scoped, carries no relationship)', () => {
+    precacheProfileView(qc, feedUser());
+
+    expect(qc.getQueryData<CacheableUser>(detailKey('u1'))?.username).toBe('alice');
+    // Fresh, not stale — cards read it instantly without a refetch.
+    expect(qc.getQueryState(detailKey('u1'))?.dataUpdatedAt).not.toBe(0);
+  });
+});
+
+describe('precacheProfileView — key casing matches the SDK exactly', () => {
+  it('writes the by-username entry under the RAW username, as `useUserByUsername` reads it', () => {
+    precacheProfileView(qc, feedUser({ username: 'AliceB' }));
+
+    // The SDK hook keys on the raw `username`, so the seed must too.
+    expect(qc.getQueryData<CacheableUser>(usernameKey('AliceB', 'viewer-1'))?.id).toBe('u1');
+    // A lowercased key would be a phantom the hook never reads.
+    expect(qc.getQueryData(usernameKey('aliceb', 'viewer-1'))).toBeUndefined();
+  });
+
+  it('scopes the seed to the active viewer, so an anon seed cannot satisfy an authed read', () => {
+    mockViewerId = null; // anonymous
+    precacheProfileView(qc, feedUser());
+
+    expect(qc.getQueryData<CacheableUser>(usernameKey('alice', ''))?.id).toBe('u1');
+    expect(qc.getQueryData(usernameKey('alice', 'viewer-1'))).toBeUndefined();
+  });
+});

--- a/packages/frontend/lib/precacheProfiles.ts
+++ b/packages/frontend/lib/precacheProfiles.ts
@@ -9,6 +9,14 @@
  * they stay in lockstep with `useUserById` (`queryKeys.users.detail(id)`) and
  * `useUserByUsername`
  * (`[...queryKeys.users.details(), 'username', username, 'viewer', viewerId]`).
+ * The by-username key uses the RAW `username`, exactly as the SDK hook builds it
+ * (`username || ''`) — it does NOT lowercase — so seed and read never diverge.
+ *
+ * The by-username entry alone carries the viewer-relative `relationship`
+ * (`followsYou`), fetched by the authenticated single-profile call. Feed/list
+ * users never carry it, so priming must never DOWNGRADE a relationship-bearing
+ * entry to a relationship-less one (that is the "Follows you tag vanishes when
+ * the feed loads" bug): a seed only fills an empty/relationship-less slot.
  */
 
 import type { QueryClient } from '@tanstack/react-query';
@@ -29,6 +37,10 @@ export interface CacheableUser {
   // Mirrors the SDK `User.avatar` (`string | null`): the projected user whitelist
   // stores avatar as a nullable column, so `null` is a legitimate cache value.
   avatar?: string | null;
+  // Viewer-relative follow relationship. Present ONLY on an authenticated
+  // single-profile fetch (`getProfileByUsername`); `null` for anon/self/bulk and
+  // absent on feed/list users. `followsYou` drives the profile "Follows you" tag.
+  relationship?: { isFollowing?: boolean; followsYou?: boolean } | null;
   [key: string]: unknown;
 }
 
@@ -40,6 +52,15 @@ function withId(user: CacheableUser): (CacheableUser & { id: string }) | null {
 }
 
 /**
+ * Whether a cache entry already carries a viewer relationship — i.e. it came
+ * from an authenticated single-profile fetch, not a list/feed/bulk response.
+ * Used to avoid overwriting such an entry with a relationship-less one.
+ */
+function hasViewerRelationship(user: CacheableUser | undefined): boolean {
+  return user?.relationship != null;
+}
+
+/**
  * Prime the React Query cache for a single user under both its id key and,
  * when a username is present, its username key.
  */
@@ -47,28 +68,33 @@ export function precacheProfileView(qc: QueryClient, user: CacheableUser): void 
   const normalized = withId(user);
   if (!normalized) return;
 
-  // By-id identity entry (viewer-independent) — read by cards via `useUserById`.
-  // Kept FRESH so those reads are satisfied instantly without a refetch.
+  // By-id identity entry — read by cards via `useUserById`. Its key is NOT
+  // viewer-scoped (the SDK hook keys on `queryKeys.users.detail(id)` alone), so
+  // it never carries a viewer `relationship`; kept FRESH so those reads are
+  // satisfied instantly without a refetch.
   qc.setQueryData(queryKeys.users.detail(normalized.id), normalized);
 
   const username = normalized.username;
   if (username) {
     // The by-username entry is what the profile page reads via
-    // `useUserByUsername`, whose key is viewer-scoped because an authenticated
-    // single-profile fetch embeds the viewer-relative `relationship`
-    // (`followsYou`). Seed under the SAME viewer-scoped key so navigating from a
-    // list/feed still paints identity instantly — but mark it STALE (`updatedAt:
-    // 0`) so react-query still refetches to pull the viewer's `relationship`.
-    // Precached list/feed objects carry public identity only, never
-    // `relationship`, so a fresh seed would suppress the fetch and the "Follows
-    // you" tag would never appear. Reading the active viewer imperatively keeps
-    // this in lockstep with `useUserByUsername`'s `useOxy().user?.id`.
+    // `useUserByUsername` (`hooks/useProfileData`), whose key is viewer-scoped
+    // because an authenticated single-profile fetch embeds the viewer-relative
+    // `relationship` (`followsYou`). Build the SAME key the SDK hook reads: the
+    // RAW `username` (the hook does not lowercase) and the active viewer id read
+    // imperatively — `useAuthStore` is the same store behind the hook's
+    // `useOxy().user?.id`, so the two stay in lockstep.
     const viewerId = useAuthStore.getState().user?.id ?? '';
-    qc.setQueryData(
-      [...queryKeys.users.details(), 'username', username.toLowerCase(), 'viewer', viewerId],
-      normalized,
-      { updatedAt: 0 },
-    );
+    const usernameKey = [...queryKeys.users.details(), 'username', username, 'viewer', viewerId];
+
+    // NEVER downgrade a relationship-bearing entry. If the profile page already
+    // loaded this profile, its entry carries `relationship`; a feed/list user
+    // does not, so overwriting would strip "Follows you" (and marking it stale
+    // would force a needless refetch). Leave it untouched. Only when nothing
+    // relationship-bearing is cached do we seed identity — STALE (`updatedAt: 0`)
+    // so react-query still refetches to pull the viewer's `relationship`.
+    if (!hasViewerRelationship(qc.getQueryData<CacheableUser>(usernameKey))) {
+      qc.setQueryData(usernameKey, normalized, { updatedAt: 0 });
+    }
   }
 }
 


### PR DESCRIPTION
The 'Follows you' tag disappeared when the feed loaded. `lib/precacheProfiles.ts` `precacheProfileView` unconditionally overwrote the viewer-scoped by-username cache entry (which the profile header reads via `useUserByUsername`, carrying viewer-relative `relationship.followsYou`) with a relationship-LESS feed/list user — fired by `precacheActorsFromPosts` whenever the profile's user appears as a post author in the feed. So `relationship` was stripped and the tag vanished.

- Adds `hasViewerRelationship(user)` (typed, no `as any`); precache only seeds the by-username key when nothing relationship-bearing is cached — a loaded authed entry is left completely untouched (no overwrite, no stale-marking).
- Fixes a latent casing bug: precache seeded `username.toLowerCase()` but the installed `useUserByUsername` keys on the RAW username (verified in the 22.4.1 tarball) — a mixed-case username wrote a phantom key. Now raw username, matching the SDK.
- Audit: `precacheProfileView` is the SOLE writer of that viewer-scoped key; every other setQueryData writes only by-id. Design not fragile — minimal preserve fix suffices; no SDK change needed.

Verified: tsc clean, build:frontend ok, new precacheProfiles test 6/6 + FeedInterstitial 55/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)