### PR TITLE
feat(search): infinite scroll on paginating search tabs

### DIFF
--- a/packages/frontend/app/(app)/search/index.tsx
+++ b/packages/frontend/app/(app)/search/index.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from "@/lib/SafeAreaViewInterop";
 import { Ionicons } from "@expo/vector-icons";
 import { useTranslation } from "react-i18next";
 import { router, useLocalSearchParams } from "expo-router";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@oxyhq/services";
 import { getNormalizedUserHandle } from "@oxyhq/core";
 import { useSafeBack } from "@/hooks/useSafeBack";
@@ -110,18 +110,28 @@ type SearchRow =
     | { kind: "hashtag"; key: string; hashtag: SearchHashtagResult }
     | { kind: "list"; key: string; list: SearchListResult };
 
-/** Per-category fetchers, one for each single-category tab. */
-const RESULT_FETCHERS = {
-    posts: (query: string) => searchService.searchPosts(query),
-    users: (query: string) => searchService.searchUsers(query),
-    feeds: (query: string) => searchService.searchFeeds(query),
-    hashtags: (query: string) => searchService.searchHashtags(query),
-    lists: (query: string) => searchService.searchLists(query),
-    saved: (query: string) => searchService.searchSaved(query),
-} satisfies Record<ResultTab, (query: string) => Promise<LocalSearchResults[ResultTab]>>;
+/**
+ * A page cursor for the active tab's infinite query. Its meaning depends on the
+ * tab — an opaque post cursor (string), a user offset or saved-posts page number
+ * (number), or `null` for the first page — but the query key pins the tab, so
+ * only one interpretation is ever live at a time.
+ */
+type SearchPageParam = string | number | null;
 
 /**
- * Fetch one tab's results — the `queryFn` behind the search query.
+ * One page of results for the active tab, plus the param to request the NEXT page
+ * (`undefined` ⇒ this tab is exhausted). The "all" tab and the tabs whose
+ * endpoints return every match in one shot (feeds, hashtags, lists) always yield a
+ * single terminal page; the paginated tabs — posts (cursor), users (offset),
+ * saved (page) — yield a `nextPageParam` until their source runs out.
+ */
+interface SearchResultsPage {
+    results: LocalSearchResults;
+    nextPageParam: SearchPageParam | undefined;
+}
+
+/**
+ * Fetch one page for a tab — the `queryFn` behind the infinite search query.
  *
  * The "all" tab fans out over every source via `searchAll`, whose `allSettled`
  * keeps the "one flaky source degrades that section, a total failure errors"
@@ -130,20 +140,48 @@ const RESULT_FETCHERS = {
  * the public client), so a hanging source REJECTS rather than stalling the
  * screen — which is what lets React Query settle loading deterministically.
  */
-async function fetchSearchResults(tab: SearchTab, query: string): Promise<LocalSearchResults> {
-    if (tab === "all") {
-        const all = await searchService.searchAll(query);
-        return {
-            posts: all.posts ?? [],
-            users: all.users ?? [],
-            feeds: all.feeds ?? [],
-            hashtags: all.hashtags ?? [],
-            lists: all.lists ?? [],
-            saved: all.saved ?? [],
-        };
+async function fetchSearchPage(
+    tab: SearchTab,
+    query: string,
+    pageParam: SearchPageParam,
+): Promise<SearchResultsPage> {
+    switch (tab) {
+        case "all": {
+            const all = await searchService.searchAll(query);
+            return {
+                results: {
+                    posts: all.posts ?? [],
+                    users: all.users ?? [],
+                    feeds: all.feeds ?? [],
+                    hashtags: all.hashtags ?? [],
+                    lists: all.lists ?? [],
+                    saved: all.saved ?? [],
+                },
+                nextPageParam: undefined,
+            };
+        }
+        case "posts": {
+            const cursor = typeof pageParam === "string" ? pageParam : undefined;
+            const { posts, hasMore, nextCursor } = await searchService.searchPostsPage(query, cursor);
+            return { results: { ...EMPTY_RESULTS, posts }, nextPageParam: hasMore ? nextCursor : undefined };
+        }
+        case "users": {
+            const offset = typeof pageParam === "number" ? pageParam : 0;
+            const { users, hasMore, nextOffset } = await searchService.searchUsersPage(query, offset);
+            return { results: { ...EMPTY_RESULTS, users }, nextPageParam: hasMore ? nextOffset : undefined };
+        }
+        case "saved": {
+            const page = typeof pageParam === "number" ? pageParam : 1;
+            const { posts, hasMore, nextPage } = await searchService.searchSavedPage(query, page);
+            return { results: { ...EMPTY_RESULTS, saved: posts }, nextPageParam: hasMore ? nextPage : undefined };
+        }
+        case "feeds":
+            return { results: { ...EMPTY_RESULTS, feeds: await searchService.searchFeeds(query) }, nextPageParam: undefined };
+        case "hashtags":
+            return { results: { ...EMPTY_RESULTS, hashtags: await searchService.searchHashtags(query) }, nextPageParam: undefined };
+        case "lists":
+            return { results: { ...EMPTY_RESULTS, lists: await searchService.searchLists(query) }, nextPageParam: undefined };
     }
-    const data = await RESULT_FETCHERS[tab](query);
-    return { ...EMPTY_RESULTS, [tab]: data };
 }
 
 function toProfileCardData(user: SearchUserResult): ProfileCardData | null {
@@ -354,42 +392,58 @@ export default function SearchIndex() {
     // `finally` only cleared loading when NOT stale, so an interleave could pin it
     // true forever) is gone.
     const {
-        data: results = EMPTY_RESULTS,
+        data: searchData,
         isPending,
         isFetching,
+        isFetchingNextPage,
+        hasNextPage,
+        fetchNextPage,
         isError: searchFailed,
         refetch: refetchSearch,
-    } = useQuery<LocalSearchResults>({
+    } = useInfiniteQuery({
         queryKey: ["search", activeTab, trimmedDebounced, isAuthenticated],
-        queryFn: () => fetchSearchResults(activeTab, trimmedDebounced),
+        queryFn: ({ pageParam }) => fetchSearchPage(activeTab, trimmedDebounced, pageParam),
+        initialPageParam: null as SearchPageParam,
+        // Each tab reports its own "next page" token; `undefined` stops paging, so
+        // the single-shot tabs (all/feeds/hashtags/lists) settle after one page.
+        getNextPageParam: (lastPage) => lastPage.nextPageParam,
         enabled: trimmedDebounced.length > 0,
         staleTime: SEARCH_STALE_TIME,
         gcTime: SEARCH_GC_TIME,
         // Fail fast to the error state (with a manual Retry) rather than stacking
         // React Query retries on top of the transport's own bounded retry+timeout.
         retry: false,
-        // A single-category tab already covered by a prior "all" search is served
-        // from that cached payload — derived straight from the query cache, no
-        // extra request. `undefined` (the "all" tab, or "all" never searched) lets
-        // the query fetch its own source normally.
-        initialData: (): LocalSearchResults | undefined => {
-            if (activeTab === "all") return undefined;
-            const all = queryClient.getQueryData<LocalSearchResults>([
-                "search",
-                "all",
-                trimmedDebounced,
-                isAuthenticated,
-            ]);
-            return all ? { ...EMPTY_RESULTS, [activeTab]: all[activeTab] } : undefined;
-        },
     });
 
-    // Loading spans BOTH the debounce wait and the fetch: while the box holds a
-    // query the results don't yet reflect, the query sits disabled with no data
-    // (`isPending`); the first fetch keeps `isPending`; a retry/refetch shows as
-    // `isFetching`. Every source request times out, so both settle deterministically
-    // — loading can never stick the way the old stale-guard could.
-    const loading = isPending || isFetching;
+    // Flatten every loaded page into ONE result set per category. Only the active
+    // tab's category actually grows across pages; the rest stay empty. The append
+    // is order-preserving, so the backend's native-first ordering renders exactly
+    // as returned — never re-sorted client-side — and appended pages never
+    // duplicate a prior page's rows (the cursor/offset sort is stable).
+    const results = useMemo<LocalSearchResults>(() => {
+        const pages = searchData?.pages;
+        if (!pages || pages.length === 0) return EMPTY_RESULTS;
+        return pages.reduce<LocalSearchResults>(
+            (acc, page) => ({
+                posts: acc.posts.concat(page.results.posts),
+                users: acc.users.concat(page.results.users),
+                feeds: acc.feeds.concat(page.results.feeds),
+                hashtags: acc.hashtags.concat(page.results.hashtags),
+                lists: acc.lists.concat(page.results.lists),
+                saved: acc.saved.concat(page.results.saved),
+            }),
+            EMPTY_RESULTS,
+        );
+    }, [searchData]);
+
+    // The full-screen loading state spans BOTH the debounce wait and the FIRST
+    // page fetch: while the box holds a query the results don't yet reflect, the
+    // query sits disabled with no data (`isPending`); the first fetch keeps
+    // `isPending`; a retry/refetch shows as `isFetching`. A next-page fetch is
+    // deliberately excluded — it keeps the existing rows on screen and shows the
+    // footer spinner instead. Every source request times out, so all settle
+    // deterministically — loading can never stick the way the old stale-guard could.
+    const loading = isPending || (isFetching && !isFetchingNextPage);
 
     const clearDebounce = useCallback(() => {
         if (debounceTimerRef.current) {
@@ -644,6 +698,15 @@ export default function SearchIndex() {
     }, [isIdle, loading, searchFailed, activeTab, results, externalActor, t]);
 
     const rows = isIdle ? idleRows : resultRows;
+
+    // Reaching the end of a results tab pulls its next page. The idle list and the
+    // single-shot tabs (all/feeds/hashtags/lists) report no next page, so this is a
+    // no-op there; the guard collapses overlapping end-reached events into one
+    // in-flight fetch.
+    const handleEndReached = useCallback(() => {
+        if (isIdle) return;
+        if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+    }, [isIdle, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
     const renderRow = useCallback(
         ({ item }: { item: SearchRow }): React.ReactElement | null => {
@@ -945,8 +1008,17 @@ export default function SearchIndex() {
                             keyboardShouldPersistTaps="handled"
                             keyboardDismissMode="on-drag"
                             showsVerticalScrollIndicator={false}
+                            onEndReached={handleEndReached}
+                            onEndReachedThreshold={0.5}
                             ListHeaderComponent={renderListHeader()}
                             ListEmptyComponent={renderListEmpty()}
+                            ListFooterComponent={
+                                isFetchingNextPage ? (
+                                    <View className="items-center justify-center py-4">
+                                        <Loading className="text-primary" size="small" />
+                                    </View>
+                                ) : null
+                            }
                         />
                     </View>
                 </SafeAreaView>

--- a/packages/frontend/services/searchService.ts
+++ b/packages/frontend/services/searchService.ts
@@ -83,6 +83,30 @@ export interface SearchFilters {
   limit?: number;
 }
 
+/** Page size for the paginated single-category search tabs. */
+export const SEARCH_PAGE_LIMIT = 20;
+
+/** A page of post results plus the opaque cursor to request the next page. */
+export interface SearchPostsPage {
+  posts: SearchPostResult[];
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
+/** A page of user results plus the offset to request the next page. */
+export interface SearchUsersPage {
+  users: SearchUserResult[];
+  hasMore: boolean;
+  nextOffset: number;
+}
+
+/** A page of saved-post results plus the page number to request next. */
+export interface SearchSavedPage {
+  posts: SearchPostResult[];
+  hasMore: boolean;
+  nextPage: number;
+}
+
 const SEARCH_HISTORY_KEY = 'mention_search_history';
 const MAX_SEARCH_HISTORY = 10;
 
@@ -135,6 +159,28 @@ class SearchService {
     }
   }
 
+  // Paginated posts search — `/search` keyset-paginates by `_id` behind an opaque
+  // `cursor`, returning `hasMore` + the `nextCursor` for the following page. The
+  // cursor sort (`createdAt desc`) makes paging stable, so appended pages never
+  // duplicate a prior page's rows. Drives the infinite Posts tab.
+  async searchPostsPage(query: string, cursor?: string): Promise<SearchPostsPage> {
+    try {
+      const params: Record<string, string> = { query, type: "posts" };
+      if (cursor) params.cursor = cursor;
+      const res = await authenticatedClient.get<{ posts?: SearchPostResult[]; hasMore?: boolean; nextCursor?: string }>(
+        "/search",
+        { params },
+      );
+      return {
+        posts: res.data.posts ?? [],
+        hasMore: res.data.hasMore ?? false,
+        nextCursor: res.data.nextCursor,
+      };
+    } catch (error) {
+      return { posts: emptyIfSignedOut<SearchPostResult>(error, "posts"), hasMore: false };
+    }
+  }
+
   // Search users via Oxy services
   async searchUsers(query: string): Promise<SearchUserResult[]> {
     try {
@@ -148,6 +194,31 @@ class SearchService {
       // A miss on the fallback is a real failure — let it propagate.
       const exactMatch = await oxyServices.getProfileByUsername(query);
       return exactMatch ? [exactMatch] : [];
+    }
+  }
+
+  // Paginated user search — Oxy's `GET /profiles/search` offset-paginates
+  // (`{ limit, offset }` → `{ data, pagination: { offset, limit, hasMore } }`) on
+  // a stable native-first sort, so offset paging never repeats a row. Drives the
+  // infinite People tab.
+  async searchUsersPage(query: string, offset = 0): Promise<SearchUsersPage> {
+    try {
+      const { data, pagination } = await oxyServices.searchProfiles(query, {
+        limit: SEARCH_PAGE_LIMIT,
+        offset,
+      });
+      return {
+        users: Array.isArray(data) ? data : [],
+        hasMore: pagination?.hasMore ?? false,
+        nextOffset: (pagination?.offset ?? offset) + (pagination?.limit ?? SEARCH_PAGE_LIMIT),
+      };
+    } catch (error) {
+      // The exact-username fallback only makes sense for the FIRST page — a deeper
+      // page has no single match to fall back to, so its failure is real.
+      if (offset > 0) throw error;
+      logger.warn("Profile search failed, falling back to exact username lookup", { error });
+      const exactMatch = await oxyServices.getProfileByUsername(query);
+      return { users: exactMatch ? [exactMatch] : [], hasMore: false, nextOffset: SEARCH_PAGE_LIMIT };
     }
   }
 
@@ -194,6 +265,19 @@ class SearchService {
         : [];
     } catch (error) {
       return emptyIfSignedOut<SearchPostResult>(error, "saved");
+    }
+  }
+
+  // Paginated saved-posts search — `GET /posts/saved` page-paginates
+  // (`{ page, limit }` → `{ posts, hasMore }`). Drives the infinite Saved tab.
+  async searchSavedPage(query: string, page = 1): Promise<SearchSavedPage> {
+    try {
+      const response = await feedService.getSavedPosts({ page, limit: SEARCH_PAGE_LIMIT, search: query });
+      const data = response.data;
+      const posts = isRecord(data) && Array.isArray(data.posts) ? data.posts.filter(isHydratedPost) : [];
+      return { posts, hasMore: isRecord(data) ? Boolean(data.hasMore) : false, nextPage: page + 1 };
+    } catch (error) {
+      return { posts: emptyIfSignedOut<SearchPostResult>(error, "saved"), hasMore: false, nextPage: page + 1 };
     }
   }
 


### PR DESCRIPTION
The search screen fetched only the first page per tab (no onEndReached, single useQuery). Now one useInfiniteQuery per tab with FlashList onEndReached + footer spinner.

- **posts** (cursor), **users** (offset — pairs with the oxy-api native-first stable sort), **saved** (page) now load page 2+ on scroll and stop when exhausted. Order-preserving append (backend native-first order rendered as-is), stable cursor/offset ⇒ no dup rows.
- **feeds / hashtags / lists / all** report no next page → onEndReached is a correct no-op (their backends return everything in one shot today).
- Removed the cross-tab initialData seed that would have frozen paging on a tab entered from 'all'.

Verified: tsc clean (rebased on 22.4.2), build:frontend ok.

Follow-up (separate, Mention backend): hashtags is hard-capped at 5, feeds/lists are unbounded one-shot, and GET /lists ignores its `search` param (pre-existing bug) — genuine load-more there needs offset/limit + the lists search fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)