### PR TITLE
feat(search): paginate feeds/hashtags/lists tabs + fix lists search filter

### DIFF
--- a/packages/backend/src/__tests__/routes/customFeedsSearchPagination.test.ts
+++ b/packages/backend/src/__tests__/routes/customFeedsSearchPagination.test.ts
@@ -1,0 +1,131 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type Doc, makeQuery, matchCondition } from './fakeMongo';
+
+/**
+ * Route coverage for the `GET /feeds` discovery list (`customFeeds.routes`):
+ *  - opt-in offset pagination (`?limit` ⇒ paged with a stable
+ *    `{ updatedAt desc, _id desc }` sort + `hasMore`; absent ⇒ the full set), and
+ *  - `?search=` still narrows the results.
+ *
+ * The route runs for real against a small in-memory CustomFeed (find + count);
+ * every heavy collaborator it imports (feed engine, hydration, Oxy client) is
+ * stubbed so importing the router stays isolated.
+ */
+
+const { find, countDocuments } = vi.hoisted(() => ({ find: vi.fn(), countDocuments: vi.fn() }));
+
+vi.mock('../../models/CustomFeed', () => ({ default: { find, countDocuments } }));
+vi.mock('../../models/FeedLike', () => ({
+  default: {
+    aggregate: vi.fn().mockResolvedValue([]),
+    find: vi.fn(() => ({ lean: () => Promise.resolve([]) })),
+  },
+}));
+vi.mock('../../models/FeedGenerator', () => ({ FeedGenerator: {} }));
+vi.mock('../../models/FeedReview', () => ({ default: {} }));
+
+// Heavy collaborators imported at module load but unused by GET /feeds.
+vi.mock('../../services/PostHydrationService', () => ({
+  resolveUserSummaries: vi.fn().mockResolvedValue(new Map()),
+  degradedActorSummary: (oxyUserId: string) => ({ id: oxyUserId, username: '', name: { displayName: 'Unknown user' } }),
+}));
+vi.mock('../../utils/oxyHelpers', () => ({ getServiceOxyClient: vi.fn() }));
+vi.mock('../../mtn/feed/definitions/customFeedDefinition', () => ({ buildCustomFeedDefinition: vi.fn() }));
+vi.mock('../../mtn/feed/feedContext', () => ({ loadViewerFeedContext: vi.fn() }));
+vi.mock('../../mtn/feed/engine/FeedEngine', () => ({ feedEngine: { run: vi.fn() } }));
+
+import customFeedsRoutes from '../../routes/customFeeds.routes';
+
+const OWNER = 'owner-1';
+
+// A 24-hex _id so the route's `new mongoose.Types.ObjectId(item._id)` is valid.
+function feedId(i: number): string {
+  return `aaaaaaaaaaaaaaaaaaaaaaa${i}`;
+}
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (req as express.Request & { user?: { id: string } }).user = { id: 'viewer-1' };
+  next();
+});
+app.use('/feeds', customFeedsRoutes);
+
+function seed(docs: Doc[]): void {
+  find.mockImplementation((q: Record<string, unknown> = {}) =>
+    makeQuery(docs.filter((d) => matchCondition(d, q))),
+  );
+  countDocuments.mockImplementation((q: Record<string, unknown> = {}) =>
+    Promise.resolve(docs.filter((d) => matchCondition(d, q)).length),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /feeds — search filter', () => {
+  beforeEach(() => {
+    seed([
+      { _id: feedId(0), ownerOxyUserId: OWNER, isPublic: true, title: 'World news', description: '', memberOxyUserIds: [], keywords: [], updatedAt: 3 },
+      { _id: feedId(1), ownerOxyUserId: OWNER, isPublic: true, title: 'Breaking news', description: '', memberOxyUserIds: [], keywords: [], updatedAt: 2 },
+      { _id: feedId(2), ownerOxyUserId: OWNER, isPublic: true, title: 'Cat photos', description: '', memberOxyUserIds: [], keywords: [], updatedAt: 1 },
+    ]);
+  });
+
+  it('returns only public feeds whose title matches the query', async () => {
+    const res = await request(app).get('/feeds').query({ publicOnly: true, search: 'news' }).expect(200);
+    const titles = (res.body.items as Array<{ title: string }>).map((f) => f.title);
+    expect(titles).toEqual(['World news', 'Breaking news']);
+  });
+});
+
+describe('GET /feeds — offset pagination', () => {
+  const feeds: Doc[] = Array.from({ length: 5 }, (_, i) => ({
+    _id: feedId(i),
+    ownerOxyUserId: OWNER,
+    isPublic: true,
+    title: `Daily ${i}`,
+    description: 'digest',
+    memberOxyUserIds: [],
+    keywords: [],
+    updatedAt: 100 - i,
+  }));
+
+  beforeEach(() => seed(feeds));
+
+  it('pages with a stable order, reports hasMore, and never repeats a row', async () => {
+    const seen: string[] = [];
+    let offset = 0;
+    let guard = 0;
+
+    for (;;) {
+      const res = await request(app).get('/feeds').query({ publicOnly: true, search: 'daily', limit: 2, offset }).expect(200);
+      const titles = (res.body.items as Array<{ title: string }>).map((f) => f.title);
+      seen.push(...titles);
+      if (!res.body.pagination.hasMore) break;
+      expect(titles).toHaveLength(2);
+      offset = res.body.pagination.offset + res.body.pagination.limit;
+      if (++guard > 10) throw new Error('pagination did not terminate');
+    }
+
+    expect(seen).toEqual(['Daily 0', 'Daily 1', 'Daily 2', 'Daily 3', 'Daily 4']);
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  it('reports the accurate total and hasMore on a paged request', async () => {
+    const res = await request(app).get('/feeds').query({ publicOnly: true, search: 'daily', limit: 2, offset: 0 }).expect(200);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.pagination).toMatchObject({ offset: 0, limit: 2, hasMore: true });
+    expect(res.body.total).toBe(5);
+  });
+
+  it('returns everything with hasMore=false when unbounded (no limit)', async () => {
+    const res = await request(app).get('/feeds').query({ publicOnly: true, search: 'daily' }).expect(200);
+    expect(res.body.items).toHaveLength(5);
+    expect(res.body.pagination.hasMore).toBe(false);
+  });
+});

--- a/packages/backend/src/__tests__/routes/fakeMongo.ts
+++ b/packages/backend/src/__tests__/routes/fakeMongo.ts
@@ -1,0 +1,78 @@
+/**
+ * A tiny in-memory stand-in for the sliver of Mongoose the search list routes
+ * use — `Model.find(q).sort().skip().limit().lean()` and `countDocuments(q)`.
+ *
+ * It is NOT a general query engine: it implements only the operators these
+ * handlers actually build (`$or`, `$and`, field equality, and a `RegExp` value
+ * on a string field), which is exactly enough to exercise the real
+ * visibility-gate + search-filter + offset-pagination behaviour against seeded
+ * documents. Pure (no vitest import) so a `vi.mock` factory can wire it through
+ * `mockImplementation` at test time.
+ */
+
+export type Doc = Record<string, unknown>;
+export type Query = Record<string, unknown>;
+
+function isQuery(value: unknown): value is Query {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Whether a document satisfies a Mongo-style query condition. */
+export function matchCondition(doc: Doc, query: Query): boolean {
+  return Object.entries(query).every(([key, cond]) => {
+    if (key === '$or') {
+      return Array.isArray(cond) && cond.some((sub) => isQuery(sub) && matchCondition(doc, sub));
+    }
+    if (key === '$and') {
+      return Array.isArray(cond) && cond.every((sub) => isQuery(sub) && matchCondition(doc, sub));
+    }
+    const value = doc[key];
+    if (cond instanceof RegExp) {
+      return typeof value === 'string' && cond.test(value);
+    }
+    return value === cond;
+  });
+}
+
+type SortSpec = Record<string, 1 | -1>;
+
+function compareValues(a: unknown, b: unknown): number {
+  if (a === b) return 0;
+  if (a === undefined) return -1;
+  if (b === undefined) return 1;
+  if (typeof a === 'number' && typeof b === 'number') return a < b ? -1 : 1;
+  return String(a) < String(b) ? -1 : 1;
+}
+
+/** A chainable query builder over an already-filtered set of documents. */
+export function makeQuery(docs: Doc[]) {
+  let sortSpec: SortSpec = {};
+  let skipN = 0;
+  let limitN: number | undefined;
+  const builder = {
+    sort(spec: SortSpec) {
+      sortSpec = spec;
+      return builder;
+    },
+    skip(n: number) {
+      skipN = n;
+      return builder;
+    },
+    limit(n: number) {
+      limitN = n;
+      return builder;
+    },
+    lean() {
+      const sorted = [...docs].sort((a, b) => {
+        for (const [key, dir] of Object.entries(sortSpec)) {
+          const c = compareValues(a[key], b[key]);
+          if (c !== 0) return c * dir;
+        }
+        return 0;
+      });
+      const end = limitN === undefined ? undefined : skipN + limitN;
+      return Promise.resolve(sorted.slice(skipN, end));
+    },
+  };
+  return builder;
+}

--- a/packages/backend/src/__tests__/routes/hashtagSearchPagination.test.ts
+++ b/packages/backend/src/__tests__/routes/hashtagSearchPagination.test.ts
@@ -1,0 +1,82 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Route coverage for `GET /hashtags/search` offset pagination.
+ *
+ * The handler was hard-capped at 5 tags with no offset. It now over-fetches one
+ * row past `limit` to detect `hasMore` and pages via `$skip`/`$limit` on a stable
+ * `{ count desc, tag asc }` sort. The aggregation is mocked to a fixed, already
+ * ranked result set so the test asserts the handler's window + `hasMore` logic
+ * (and that the offset/limit actually reach the pipeline).
+ */
+
+const { aggregate } = vi.hoisted(() => ({ aggregate: vi.fn() }));
+
+vi.mock('../../models/Post', () => ({ default: { aggregate } }));
+
+import hashtagsRoutes from '../../routes/hashtags';
+
+const app = express();
+app.use(express.json());
+app.use('/hashtags', hashtagsRoutes);
+
+// Ranked tags the aggregation would return (count desc). The mock applies only the
+// pipeline's $skip/$limit — every seeded tag is treated as matching the query.
+const RANKED = Array.from({ length: 5 }, (_, i) => ({ tag: `tag${i}`, count: 100 - i }));
+
+function pipelineStage(pipeline: Array<Record<string, unknown>>, op: string): Record<string, unknown> | undefined {
+  return pipeline.find((stage) => op in stage);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  aggregate.mockImplementation((pipeline: Array<Record<string, unknown>>) => {
+    const skip = Number(pipelineStage(pipeline, '$skip')?.$skip ?? 0);
+    const limit = Number(pipelineStage(pipeline, '$limit')?.$limit ?? RANKED.length);
+    return Promise.resolve(RANKED.slice(skip, skip + limit));
+  });
+});
+
+describe('GET /hashtags/search — pagination', () => {
+  it('rejects a missing query with 400', async () => {
+    await request(app).get('/hashtags/search').expect(400);
+  });
+
+  it('over-fetches to report hasMore and returns exactly `limit` rows on a full page', async () => {
+    const res = await request(app).get('/hashtags/search').query({ query: 'tag', limit: 2, offset: 0 }).expect(200);
+
+    expect(res.body.hashtags.map((h: { tag: string }) => h.tag)).toEqual(['tag0', 'tag1']);
+    expect(res.body.pagination).toMatchObject({ offset: 0, limit: 2, hasMore: true });
+
+    // The over-fetch (`limit + 1`) and the offset both reach the aggregation.
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(pipelineStage(pipeline, '$skip')).toEqual({ $skip: 0 });
+    expect(pipelineStage(pipeline, '$limit')).toEqual({ $limit: 3 });
+    expect(pipelineStage(pipeline, '$sort')).toEqual({ $sort: { count: -1, _id: 1 } });
+  });
+
+  it('pages with a stable order and never repeats a tag', async () => {
+    const seen: string[] = [];
+    let offset = 0;
+    let guard = 0;
+
+    for (;;) {
+      const res = await request(app).get('/hashtags/search').query({ query: 'tag', limit: 2, offset }).expect(200);
+      seen.push(...res.body.hashtags.map((h: { tag: string }) => h.tag));
+      if (!res.body.pagination.hasMore) break;
+      offset = res.body.pagination.offset + res.body.pagination.limit;
+      if (++guard > 10) throw new Error('pagination did not terminate');
+    }
+
+    expect(seen).toEqual(['tag0', 'tag1', 'tag2', 'tag3', 'tag4']);
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  it('reports hasMore=false when the result set fits within the default page', async () => {
+    const res = await request(app).get('/hashtags/search').query({ query: 'tag' }).expect(200);
+    expect(res.body.hashtags).toHaveLength(5);
+    expect(res.body.pagination.hasMore).toBe(false);
+  });
+});

--- a/packages/backend/src/__tests__/routes/searchListsPagination.test.ts
+++ b/packages/backend/src/__tests__/routes/searchListsPagination.test.ts
@@ -1,0 +1,150 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type Doc, makeQuery, matchCondition } from './fakeMongo';
+
+/**
+ * Route coverage for `GET /lists`:
+ *  - the FIX: `?search=` now actually filters by name/description (it was ignored,
+ *    so the search tab received every accessible list), while the visibility gate
+ *    (own + public) still holds — a private list a non-owner matches never leaks.
+ *  - opt-in offset pagination: `?limit` pages the results with a stable
+ *    `{ updatedAt desc, _id desc }` sort, reports `hasMore`, and never repeats a
+ *    row across pages; without `?limit` the full accessible set is returned.
+ *
+ * The route runs for real against a small in-memory AccountList (find + count);
+ * only the heavy collaborators it imports are stubbed.
+ */
+
+const { find, countDocuments } = vi.hoisted(() => ({ find: vi.fn(), countDocuments: vi.fn() }));
+
+vi.mock('../../models/AccountList', () => ({ default: { find, countDocuments } }));
+
+// Imported at module load but never touched by GET /lists — stub so importing the
+// router never drags in the feed controller / Oxy service / Redis chain.
+vi.mock('../../models/Post', () => ({ Post: {} }));
+vi.mock('../../controllers/feed.controller', () => ({ feedController: {} }));
+vi.mock('../../services/EndorsementSignalService', () => ({
+  endorsementSignalService: {
+    syncScope: vi.fn().mockResolvedValue(undefined),
+    syncScopeMembershipChange: vi.fn().mockResolvedValue(undefined),
+    syncScopeRemoval: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+vi.mock('../../middleware/security', () => ({
+  feedIPRateLimiter: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  feedRateLimiter: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+import listsRoutes from '../../routes/lists';
+
+const VIEWER = 'viewer-1';
+const OTHER = 'other-1';
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (req as express.Request & { user?: { id: string } }).user = { id: VIEWER };
+  next();
+});
+app.use('/lists', listsRoutes);
+
+/** Seed the in-memory collection and wire find/countDocuments to it. */
+function seed(docs: Doc[]): void {
+  find.mockImplementation((q: Record<string, unknown> = {}) =>
+    makeQuery(docs.filter((d) => matchCondition(d, q))),
+  );
+  countDocuments.mockImplementation((q: Record<string, unknown> = {}) =>
+    Promise.resolve(docs.filter((d) => matchCondition(d, q)).length),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /lists — search filter (the bug) + visibility gate', () => {
+  beforeEach(() => {
+    seed([
+      { _id: 'l1', ownerOxyUserId: VIEWER, isPublic: true, title: 'Sports fans', description: 'athletes', updatedAt: 6 },
+      { _id: 'l2', ownerOxyUserId: VIEWER, isPublic: false, title: 'My sport picks', description: '', updatedAt: 5 },
+      { _id: 'l3', ownerOxyUserId: OTHER, isPublic: true, title: 'Sporting goods', description: '', updatedAt: 4 },
+      // Matches "sport" but is PRIVATE and owned by someone else → must stay hidden.
+      { _id: 'l4', ownerOxyUserId: OTHER, isPublic: false, title: 'Secret sports', description: '', updatedAt: 3 },
+      { _id: 'l5', ownerOxyUserId: VIEWER, isPublic: true, title: 'Cooking', description: 'recipes', updatedAt: 2 },
+      { _id: 'l6', ownerOxyUserId: OTHER, isPublic: true, title: 'Gardening', description: 'plants', updatedAt: 1 },
+    ]);
+  });
+
+  it('returns ONLY the accessible lists whose name/description match the query', async () => {
+    const res = await request(app).get('/lists').query({ search: 'sport' }).expect(200);
+    const titles = (res.body.items as Array<{ title: string }>).map((l) => l.title);
+
+    // l1/l2/l3 match and are visible; l5/l6 do not match; l4 matches but is gated.
+    expect(titles).toEqual(['Sports fans', 'My sport picks', 'Sporting goods']);
+    expect(titles).not.toContain('Cooking');
+    expect(titles).not.toContain('Secret sports');
+  });
+
+  it('is case-insensitive and matches on the description too', async () => {
+    const res = await request(app).get('/lists').query({ search: 'ATHLETES' }).expect(200);
+    const titles = (res.body.items as Array<{ title: string }>).map((l) => l.title);
+    expect(titles).toEqual(['Sports fans']);
+  });
+
+  it('still returns every accessible list when no search term is given', async () => {
+    const res = await request(app).get('/lists').expect(200);
+    const titles = (res.body.items as Array<{ title: string }>).map((l) => l.title);
+    // All except the other-owned private list (l4).
+    expect(titles).toEqual(['Sports fans', 'My sport picks', 'Sporting goods', 'Cooking', 'Gardening']);
+  });
+});
+
+describe('GET /lists — offset pagination', () => {
+  // Five public lists, all matching "team", newest-first by updatedAt.
+  const lists: Doc[] = Array.from({ length: 5 }, (_, i) => ({
+    _id: `t${i}`,
+    ownerOxyUserId: OTHER,
+    isPublic: true,
+    title: `Team ${i}`,
+    description: 'roster',
+    updatedAt: 100 - i,
+  }));
+
+  beforeEach(() => seed(lists));
+
+  it('pages with a stable order, reports hasMore, and never repeats a row', async () => {
+    const seen: string[] = [];
+    let offset = 0;
+    let guard = 0;
+
+    for (;;) {
+      const res = await request(app).get('/lists').query({ search: 'team', limit: 2, offset }).expect(200);
+      const titles = (res.body.items as Array<{ title: string }>).map((l) => l.title);
+      seen.push(...titles);
+
+      if (!res.body.pagination.hasMore) break;
+      expect(titles).toHaveLength(2); // a non-terminal page is always full
+      offset = res.body.pagination.offset + res.body.pagination.limit;
+      if (++guard > 10) throw new Error('pagination did not terminate');
+    }
+
+    // Every list seen exactly once, in the stable newest-first order.
+    expect(seen).toEqual(['Team 0', 'Team 1', 'Team 2', 'Team 3', 'Team 4']);
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  it('reports the accurate total and hasMore=false on the final page', async () => {
+    const res = await request(app).get('/lists').query({ search: 'team', limit: 2, offset: 4 }).expect(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.pagination).toMatchObject({ offset: 4, limit: 2, hasMore: false });
+    expect(res.body.total).toBe(5);
+  });
+
+  it('returns everything with hasMore=false when unbounded (no limit)', async () => {
+    const res = await request(app).get('/lists').query({ search: 'team' }).expect(200);
+    expect(res.body.items).toHaveLength(5);
+    expect(res.body.pagination.hasMore).toBe(false);
+  });
+});

--- a/packages/backend/src/routes/customFeeds.routes.ts
+++ b/packages/backend/src/routes/customFeeds.routes.ts
@@ -155,7 +155,21 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       }
     }
 
-    const items = await CustomFeed.find(q).sort({ updatedAt: -1 }).lean();
+    // Opt-in pagination: with `?limit` present, page the results (offset/limit,
+    // over-fetching one row to detect `hasMore`); without it, keep the historical
+    // "return every accessible feed" behaviour the feeds screen / profile tabs
+    // rely on. `_id` breaks `updatedAt` ties so offsets never shuffle rows.
+    const rawLimit = queryInt(req.query.limit);
+    const offset = Math.max(0, queryInt(req.query.offset) ?? 0);
+    let listQuery = CustomFeed.find(q).sort({ updatedAt: -1, _id: -1 });
+    let pageLimit: number | undefined;
+    if (rawLimit !== undefined) {
+      pageLimit = Math.min(Math.max(1, rawLimit), MAX_FEED_PAGE_SIZE);
+      listQuery = listQuery.skip(offset).limit(pageLimit + 1);
+    }
+    const fetched = await listQuery.lean();
+    const hasMore = pageLimit !== undefined && fetched.length > pageLimit;
+    const items = hasMore ? fetched.slice(0, pageLimit) : fetched;
 
     // Get like counts and isLiked status for all feeds
     const feedIds = items.map((item) => item._id);
@@ -215,7 +229,14 @@ router.get('/', async (req: AuthRequest, res: Response) => {
         topicCount: (item.keywords || []).length,
       };
     });
-    res.json({ items: normalizedItems, total: normalizedItems.length });
+    // When paging, `total` is the full match count (a countDocuments) so the
+    // client can size the result set; unbounded, the page IS the whole set.
+    const total = pageLimit !== undefined ? await CustomFeed.countDocuments(q) : normalizedItems.length;
+    res.json({
+      items: normalizedItems,
+      total,
+      pagination: { offset, limit: pageLimit ?? normalizedItems.length, hasMore },
+    });
   } catch (error) {
     logger.error('[CustomFeeds] List custom feeds error:', { userId: req.user?.id, error, query: req.query });
     res.status(500).json({ error: 'Failed to list feeds' });

--- a/packages/backend/src/routes/hashtags.ts
+++ b/packages/backend/src/routes/hashtags.ts
@@ -7,8 +7,17 @@ import { queryInt, queryString } from "../utils/queryParams";
 
 const router = express.Router();
 
-/** Max hashtag suggestions returned by either search endpoint. */
-const HASHTAG_SEARCH_LIMIT = 5;
+/** Default page size for `GET /hashtags/search` when `?limit` is absent. */
+const HASHTAG_SEARCH_DEFAULT_LIMIT = 20;
+
+/** Hard cap on the `GET /hashtags/search` page size — `?limit` can only narrow it. */
+const HASHTAG_SEARCH_MAX_LIMIT = 50;
+
+/**
+ * Suggestion cap for the LEGACY `POST /hashtags/search` (tag-names-only) response.
+ * Pinned to the historical value so pre-pagination clients see no change.
+ */
+const LEGACY_HASHTAG_SEARCH_LIMIT = 5;
 
 /** Upper bound on the raw query we turn into a regex. */
 const HASHTAG_QUERY_MAX_LENGTH = 64;
@@ -26,26 +35,41 @@ export interface HashtagSearchResult {
   count: number;
 }
 
+/** One page of hashtag matches plus whether a further page exists. */
+interface HashtagSearchPage {
+  results: HashtagSearchResult[];
+  hasMore: boolean;
+}
+
 /**
- * Matching public hashtags with the number of posts carrying each one.
+ * One page of matching public hashtags with the number of posts carrying each.
  *
  * The query is regex-ESCAPED before it reaches Mongo — a raw user string would
  * otherwise be interpreted as a pattern (regex injection / catastrophic
  * backtracking).
+ *
+ * Paging is a stable keyset: the `{ count desc, tag asc }` sort is fully
+ * deterministic (the grouped `_id` — the tag — breaks count ties), so `$skip`
+ * offsets never shuffle rows between pages. One extra row is over-fetched
+ * (`$limit: limit + 1`) purely to detect `hasMore` without a second count query.
  */
-async function searchHashtagsWithCounts(rawQuery: string): Promise<HashtagSearchResult[]> {
+async function searchHashtagsWithCounts(rawQuery: string, offset: number, limit: number): Promise<HashtagSearchPage> {
   const needle = escapeRegex(rawQuery.trim().toLowerCase().slice(0, HASHTAG_QUERY_MAX_LENGTH));
 
-  return Post.aggregate<HashtagSearchResult>([
+  const rows = await Post.aggregate<HashtagSearchResult>([
     { $match: { visibility: 'public', hashtags: { $exists: true, $ne: [] } } },
     { $unwind: '$hashtags' },
     { $project: { tag: { $toLower: '$hashtags' } } },
     { $match: { tag: { $regex: needle, $options: 'i' } } },
     { $group: { _id: '$tag', count: { $sum: 1 } } },
-    { $sort: { count: -1 } },
-    { $limit: HASHTAG_SEARCH_LIMIT },
+    { $sort: { count: -1, _id: 1 } },
+    { $skip: offset },
+    { $limit: limit + 1 },
     { $project: { _id: 0, tag: '$_id', count: 1 } }
   ]);
+
+  const hasMore = rows.length > limit;
+  return { results: hasMore ? rows.slice(0, limit) : rows, hasMore };
 }
 
 function parseSearchQuery(value: unknown): string | null {
@@ -182,7 +206,9 @@ router.get("/", async (req: Request, res: Response) => {
 });
 
 // Search hashtags — returns each matching tag WITH its post count, so a result
-// row can show "N posts" instead of a hardcoded zero.
+// row can show "N posts" instead of a hardcoded zero. Offset-paginated so the
+// search tab can load past the first page; `pagination.hasMore` drives the
+// infinite scroll, `offset`/`limit` echo the effective window.
 router.get('/search', async (req: Request, res: Response) => {
   const query = parseSearchQuery(req.query.query);
   if (!query) {
@@ -192,9 +218,15 @@ router.get('/search', async (req: Request, res: Response) => {
     });
   }
 
+  // Clamp to a bounded window: an unparseable/absent `?limit` falls back to the
+  // default; a negative/tampered `?offset` floors at 0. `$limit: offset + limit`
+  // stays sane no matter what the client sends.
+  const offset = Math.max(0, queryInt(req.query.offset) ?? 0);
+  const limit = Math.min(Math.max(1, queryInt(req.query.limit) || HASHTAG_SEARCH_DEFAULT_LIMIT), HASHTAG_SEARCH_MAX_LIMIT);
+
   try {
-    const hashtags = await searchHashtagsWithCounts(query);
-    return res.json({ hashtags });
+    const { results, hasMore } = await searchHashtagsWithCounts(query, offset, limit);
+    return res.json({ hashtags: results, pagination: { offset, limit, hasMore } });
   } catch (error) {
     logger.error('[Hashtags] Error searching hashtags:', { error, searchQuery: query });
     return res.status(500).json({
@@ -217,8 +249,8 @@ router.post('/search', async (req: Request, res: Response) => {
   }
 
   try {
-    const hashtags = await searchHashtagsWithCounts(query);
-    return res.json({ data: hashtags.map((hashtag) => hashtag.tag) });
+    const { results } = await searchHashtagsWithCounts(query, 0, LEGACY_HASHTAG_SEARCH_LIMIT);
+    return res.json({ data: results.map((hashtag) => hashtag.tag) });
   } catch (error) {
     logger.error('[Hashtags] Error in searchHashtags:', { error, searchQuery: query });
     return res.status(500).json({

--- a/packages/backend/src/routes/lists.ts
+++ b/packages/backend/src/routes/lists.ts
@@ -7,6 +7,7 @@ import { feedController } from '../controllers/feed.controller';
 import { endorsementSignalService } from '../services/EndorsementSignalService';
 import { logger } from '../utils/logger';
 import { queryInt, queryString } from '../utils/queryParams';
+import { escapeRegex } from '../utils/textProcessing';
 import { feedIPRateLimiter, feedRateLimiter } from '../middleware/security';
 
 const router = express.Router();
@@ -27,6 +28,9 @@ const timelineRateLimiters = process.env.NODE_ENV === 'production'
 /** List timeline page size (`GET /lists/:id/timeline`). */
 const DEFAULT_TIMELINE_PAGE_SIZE = 20;
 const MAX_TIMELINE_PAGE_SIZE = 100;
+
+/** Hard cap on the `GET /lists` page size — `?limit` can only narrow it. */
+const MAX_LIST_PAGE_SIZE = 100;
 
 /**
  * Fire-and-forget endorsement re-sync for a list whose membership changed.
@@ -88,7 +92,7 @@ router.post('/', async (req: AuthRequest, res: Response) => {
   }
 });
 
-// List lists (mine/public)
+// List lists (mine/public), optionally filtered by a search term.
 router.get('/', async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.user?.id;
@@ -97,10 +101,50 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     const q: Record<string, unknown> = {};
     if (mine === 'true') q.ownerOxyUserId = userId;
     if (publicOnly === 'true') q.isPublic = true;
+    // Visibility gate: without an explicit filter the viewer sees their OWN lists
+    // plus every public list. The search term (below) narrows within that gate —
+    // it never widens it, so a non-owner still can't reach a private list.
     if (!mine && !publicOnly) q.$or = [{ ownerOxyUserId: userId }, { isPublic: true }];
-    const items = await AccountList.find(q).sort({ updatedAt: -1 }).lean<LeanAccountList[]>();
-    const serialized = items.map(serializeList);
-    res.json({ items: serialized, total: serialized.length });
+
+    // Filter by `search` (name/description, case-insensitive). Previously ignored —
+    // the search tab received every accessible list unfiltered. Regex-ESCAPED so a
+    // raw query can't be interpreted as a pattern (regex injection / backtracking).
+    const search = queryString(req.query.search)?.trim();
+    if (search) {
+      const searchRegex = new RegExp(escapeRegex(search), 'i');
+      const searchCondition = { $or: [{ title: searchRegex }, { description: searchRegex }] };
+      if (q.$or) {
+        // Combine the visibility OR with the search OR under $and so both must hold.
+        q.$and = [{ $or: q.$or }, searchCondition];
+        delete q.$or;
+      } else {
+        q.$or = searchCondition.$or;
+      }
+    }
+
+    // Opt-in pagination: `?limit` present ⇒ page (offset/limit, over-fetching one
+    // row to detect `hasMore`); absent ⇒ the historical "return every accessible
+    // list" the lists screen / add-to-list sheet depend on. `_id` breaks
+    // `updatedAt` ties so offsets never shuffle rows between pages.
+    const rawLimit = queryInt(req.query.limit);
+    const offset = Math.max(0, queryInt(req.query.offset) ?? 0);
+    let listQuery = AccountList.find(q).sort({ updatedAt: -1, _id: -1 });
+    let pageLimit: number | undefined;
+    if (rawLimit !== undefined) {
+      pageLimit = Math.min(Math.max(1, rawLimit), MAX_LIST_PAGE_SIZE);
+      listQuery = listQuery.skip(offset).limit(pageLimit + 1);
+    }
+    const fetched = await listQuery.lean<LeanAccountList[]>();
+    const hasMore = pageLimit !== undefined && fetched.length > pageLimit;
+    const page = hasMore ? fetched.slice(0, pageLimit) : fetched;
+    const serialized = page.map(serializeList);
+
+    const total = pageLimit !== undefined ? await AccountList.countDocuments(q) : serialized.length;
+    res.json({
+      items: serialized,
+      total,
+      pagination: { offset, limit: pageLimit ?? serialized.length, hasMore },
+    });
   } catch (error) {
     res.status(500).json({ error: 'Failed to list lists' });
   }

--- a/packages/frontend/app/(app)/search/index.tsx
+++ b/packages/frontend/app/(app)/search/index.tsx
@@ -120,10 +120,10 @@ type SearchPageParam = string | number | null;
 
 /**
  * One page of results for the active tab, plus the param to request the NEXT page
- * (`undefined` ⇒ this tab is exhausted). The "all" tab and the tabs whose
- * endpoints return every match in one shot (feeds, hashtags, lists) always yield a
- * single terminal page; the paginated tabs — posts (cursor), users (offset),
- * saved (page) — yield a `nextPageParam` until their source runs out.
+ * (`undefined` ⇒ this tab is exhausted). The "all" tab yields a single terminal
+ * page (a one-shot fan-out overview); every single-category tab paginates until
+ * its source runs out — posts by an opaque cursor, users/feeds/hashtags/lists by
+ * an offset, saved by a page number.
  */
 interface SearchResultsPage {
     results: LocalSearchResults;
@@ -175,12 +175,21 @@ async function fetchSearchPage(
             const { posts, hasMore, nextPage } = await searchService.searchSavedPage(query, page);
             return { results: { ...EMPTY_RESULTS, saved: posts }, nextPageParam: hasMore ? nextPage : undefined };
         }
-        case "feeds":
-            return { results: { ...EMPTY_RESULTS, feeds: await searchService.searchFeeds(query) }, nextPageParam: undefined };
-        case "hashtags":
-            return { results: { ...EMPTY_RESULTS, hashtags: await searchService.searchHashtags(query) }, nextPageParam: undefined };
-        case "lists":
-            return { results: { ...EMPTY_RESULTS, lists: await searchService.searchLists(query) }, nextPageParam: undefined };
+        case "feeds": {
+            const offset = typeof pageParam === "number" ? pageParam : 0;
+            const { feeds, hasMore, nextOffset } = await searchService.searchFeedsPage(query, offset);
+            return { results: { ...EMPTY_RESULTS, feeds }, nextPageParam: hasMore ? nextOffset : undefined };
+        }
+        case "hashtags": {
+            const offset = typeof pageParam === "number" ? pageParam : 0;
+            const { hashtags, hasMore, nextOffset } = await searchService.searchHashtagsPage(query, offset);
+            return { results: { ...EMPTY_RESULTS, hashtags }, nextPageParam: hasMore ? nextOffset : undefined };
+        }
+        case "lists": {
+            const offset = typeof pageParam === "number" ? pageParam : 0;
+            const { lists, hasMore, nextOffset } = await searchService.searchListsPage(query, offset);
+            return { results: { ...EMPTY_RESULTS, lists }, nextPageParam: hasMore ? nextOffset : undefined };
+        }
     }
 }
 
@@ -405,7 +414,8 @@ export default function SearchIndex() {
         queryFn: ({ pageParam }) => fetchSearchPage(activeTab, trimmedDebounced, pageParam),
         initialPageParam: null as SearchPageParam,
         // Each tab reports its own "next page" token; `undefined` stops paging, so
-        // the single-shot tabs (all/feeds/hashtags/lists) settle after one page.
+        // the "all" overview settles after one page while every single-category tab
+        // pages until its source runs out.
         getNextPageParam: (lastPage) => lastPage.nextPageParam,
         enabled: trimmedDebounced.length > 0,
         staleTime: SEARCH_STALE_TIME,
@@ -700,9 +710,8 @@ export default function SearchIndex() {
     const rows = isIdle ? idleRows : resultRows;
 
     // Reaching the end of a results tab pulls its next page. The idle list and the
-    // single-shot tabs (all/feeds/hashtags/lists) report no next page, so this is a
-    // no-op there; the guard collapses overlapping end-reached events into one
-    // in-flight fetch.
+    // "all" overview report no next page, so this is a no-op there; the guard
+    // collapses overlapping end-reached events into one in-flight fetch.
     const handleEndReached = useCallback(() => {
         if (isIdle) return;
         if (hasNextPage && !isFetchingNextPage) void fetchNextPage();

--- a/packages/frontend/services/searchService.ts
+++ b/packages/frontend/services/searchService.ts
@@ -86,6 +86,20 @@ export interface SearchFilters {
 /** Page size for the paginated single-category search tabs. */
 export const SEARCH_PAGE_LIMIT = 20;
 
+/**
+ * Hashtag rows shown in the compact "All" overview (the multi-section fan-out),
+ * kept small so it stays a preview. The dedicated Hashtags tab pages at
+ * {@link SEARCH_PAGE_LIMIT} instead.
+ */
+const SEARCH_OVERVIEW_HASHTAG_LIMIT = 5;
+
+/** The offset-window echo every paginated Mention search endpoint returns. */
+interface SearchOffsetPagination {
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
 /** A page of post results plus the opaque cursor to request the next page. */
 export interface SearchPostsPage {
   posts: SearchPostResult[];
@@ -105,6 +119,27 @@ export interface SearchSavedPage {
   posts: SearchPostResult[];
   hasMore: boolean;
   nextPage: number;
+}
+
+/** A page of feed results plus the offset to request the next page. */
+export interface SearchFeedsPage {
+  feeds: SearchFeedResult[];
+  hasMore: boolean;
+  nextOffset: number;
+}
+
+/** A page of hashtag results plus the offset to request the next page. */
+export interface SearchHashtagsPage {
+  hashtags: SearchHashtagResult[];
+  hasMore: boolean;
+  nextOffset: number;
+}
+
+/** A page of list results plus the offset to request the next page. */
+export interface SearchListsPage {
+  lists: SearchListResult[];
+  hasMore: boolean;
+  nextOffset: number;
 }
 
 const SEARCH_HISTORY_KEY = 'mention_search_history';
@@ -222,7 +257,8 @@ class SearchService {
     }
   }
 
-  // Search feeds
+  // Search feeds — the compact "All" overview (returns every public match in one
+  // shot; the paginated tab uses `searchFeedsPage`).
   async searchFeeds(query: string): Promise<SearchFeedResult[]> {
     const res = await publicClient.get<{ items?: SearchFeedResult[] }>("/feeds", {
       params: { publicOnly: true, search: query }
@@ -230,7 +266,24 @@ class SearchService {
     return res.data.items || [];
   }
 
-  // Search lists
+  // Paginated feeds search — `GET /feeds` offset-paginates once `limit` is
+  // supplied (`{ items, pagination: { offset, limit, hasMore } }`) on a stable
+  // `{ updatedAt desc, _id desc }` sort, so offset paging never repeats a row.
+  // Drives the infinite Feeds tab.
+  async searchFeedsPage(query: string, offset = 0): Promise<SearchFeedsPage> {
+    const res = await publicClient.get<{ items?: SearchFeedResult[]; pagination?: SearchOffsetPagination }>("/feeds", {
+      params: { publicOnly: true, search: query, limit: SEARCH_PAGE_LIMIT, offset },
+    });
+    const pagination = res.data.pagination;
+    return {
+      feeds: res.data.items ?? [],
+      hasMore: pagination?.hasMore ?? false,
+      nextOffset: (pagination?.offset ?? offset) + (pagination?.limit ?? SEARCH_PAGE_LIMIT),
+    };
+  }
+
+  // Search lists — the compact "All" overview (returns every accessible match in
+  // one shot; the paginated tab uses `searchListsPage`).
   async searchLists(query: string): Promise<SearchListResult[]> {
     try {
       const res = await authenticatedClient.get<{ items?: SearchListResult[] }>("/lists", {
@@ -242,13 +295,55 @@ class SearchService {
     }
   }
 
+  // Paginated lists search — `GET /lists` filters by `search` (name/description)
+  // and offset-paginates (`{ items, pagination: { offset, limit, hasMore } }`) on a
+  // stable `{ updatedAt desc, _id desc }` sort. Auth-gated: a signed-out viewer
+  // 401s → empty (this source has nothing), which is not a search failure. Drives
+  // the infinite Lists tab.
+  async searchListsPage(query: string, offset = 0): Promise<SearchListsPage> {
+    try {
+      const res = await authenticatedClient.get<{ items?: SearchListResult[]; pagination?: SearchOffsetPagination }>("/lists", {
+        params: { search: query, limit: SEARCH_PAGE_LIMIT, offset },
+      });
+      const pagination = res.data.pagination;
+      return {
+        lists: res.data.items ?? [],
+        hasMore: pagination?.hasMore ?? false,
+        nextOffset: (pagination?.offset ?? offset) + (pagination?.limit ?? SEARCH_PAGE_LIMIT),
+      };
+    } catch (error) {
+      return {
+        lists: emptyIfSignedOut<SearchListResult>(error, "lists"),
+        hasMore: false,
+        nextOffset: offset + SEARCH_PAGE_LIMIT,
+      };
+    }
+  }
+
   // Search hashtags — `GET /hashtags/search` answers with each matching tag and
   // the number of posts carrying it, so the result row can show a real count.
+  // Compact "All" overview; the paginated tab uses `searchHashtagsPage`.
   async searchHashtags(query: string): Promise<SearchHashtagResult[]> {
     const res = await authenticatedClient.get<{ hashtags?: SearchHashtagResult[] }>("/hashtags/search", {
-      params: { query }
+      params: { query, limit: SEARCH_OVERVIEW_HASHTAG_LIMIT }
     });
     return res.data.hashtags ?? [];
+  }
+
+  // Paginated hashtag search — `GET /hashtags/search` offset-paginates
+  // (`{ hashtags, pagination: { offset, limit, hasMore } }`) on a stable
+  // `{ count desc, tag asc }` sort, so offset paging never repeats a row. Drives
+  // the infinite Hashtags tab.
+  async searchHashtagsPage(query: string, offset = 0): Promise<SearchHashtagsPage> {
+    const res = await authenticatedClient.get<{ hashtags?: SearchHashtagResult[]; pagination?: SearchOffsetPagination }>("/hashtags/search", {
+      params: { query, limit: SEARCH_PAGE_LIMIT, offset },
+    });
+    const pagination = res.data.pagination;
+    return {
+      hashtags: res.data.hashtags ?? [],
+      hasMore: pagination?.hasMore ?? false,
+      nextOffset: (pagination?.offset ?? offset) + (pagination?.limit ?? SEARCH_PAGE_LIMIT),
+    };
   }
 
   // Search saved posts


### PR DESCRIPTION
Completes infinite scroll on ALL search tabs and fixes a real bug.

Backend (offset/limit + hasMore alongside existing keys, so current callers unchanged):
- **GET /hashtags/search** — was hard-capped at 5; now paginated (default 20, cap 50) over a stable {count desc, tag asc} keyset, overfetch+1 for hasMore. Legacy POST /search keeps its 5-tag response.
- **GET /feeds** / **GET /lists** — opt-in pagination (?limit ⇒ paged with real total + hasMore; absent ⇒ full set, so the feeds/profile/home screens are unchanged), stable {updatedAt desc, _id desc}.
- **GET /lists search FIX** — it ignored `search` entirely (tab showed every accessible list). Now filters title/description via an escaped regex combined under `$and` with the own+public visibility `$or` — the gate is never widened.

Frontend:
- searchFeedsPage/searchHashtagsPage/searchListsPage in searchService; feeds/hashtags/lists tabs routed through them so onEndReached loads page 2+ and stops. `all` overview unchanged.

Verified: backend tsc+build clean, 2611 tests (14 new: lists filters while the gate holds, all three paginate stable with no dup rows); frontend tsc+build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)