### PR TITLE
fix(feed): topic feed matches topicRefs (a trend with posts no longer shows empty)

### DIFF
--- a/packages/backend/src/__tests__/feedSources.test.ts
+++ b/packages/backend/src/__tests__/feedSources.test.ts
@@ -80,6 +80,35 @@ function makePost(n: number, extra: Record<string, unknown> = {}) {
   return { _id: oid(n), oxyUserId: `a${n}`, createdAt: new Date(), ...extra };
 }
 
+/**
+ * Evaluate the topic `$or` a source built against a fixture post — proving the
+ * query MATCHES the right documents, not merely that its shape looks right.
+ * Mirrors how Mongo applies the two-branch clause: a post is on the topic when
+ * EITHER a `postClassification.topicRefs[].name` OR a `postClassification.topics`
+ * slug equals the queried slug. The clause is nested under `$and`.
+ */
+function matchesTopicOr(match: Record<string, unknown>, post: Record<string, unknown>): boolean {
+  const and = (match.$and as Array<Record<string, unknown>> | undefined) ?? [];
+  const orClause = and
+    .map((clause) => clause.$or)
+    .find((value): value is Array<Record<string, string>> => Array.isArray(value));
+  if (!orClause) return false;
+  const classification = post.postClassification as
+    | { topics?: string[]; topicRefs?: Array<{ name: string }> }
+    | undefined;
+  return orClause.some((branch) => {
+    const refName = branch['postClassification.topicRefs.name'];
+    if (refName !== undefined) {
+      return (classification?.topicRefs ?? []).some((ref) => ref.name === refName);
+    }
+    const slug = branch['postClassification.topics'];
+    if (slug !== undefined) {
+      return (classification?.topics ?? []).includes(slug);
+    }
+    return false;
+  });
+}
+
 beforeEach(() => {
   findCalls.length = 0;
   sortCalls.length = 0;
@@ -120,12 +149,40 @@ describe('following source', () => {
 });
 
 describe('topic source', () => {
-  it('slug variant queries postClassification.topics with the lowercased slug', async () => {
+  it('slug variant matches topicRefs.name OR the slug-only topics (lowercased, public/published)', async () => {
     findRouter = () => [makePost(3)];
     await topicSource.gather({ currentUserId: 'viewer' }, { slug: 'Art' }, 31);
     const match = findCalls[0];
-    expect(match['postClassification.topics']).toBe('art');
+    // The topic OR is nested under `$and` so a cursor `$or` cannot clobber it.
+    const and = match.$and as Array<Record<string, unknown>>;
+    expect(and[0].$or).toEqual([
+      { 'postClassification.topicRefs.name': 'art' },
+      { 'postClassification.topics': 'art' },
+    ]);
     expect(match.visibility).toBe('public');
+    expect(match.status).toBe('published');
+  });
+
+  /**
+   * Regression: "a topic trends but its page shows no posts".
+   *
+   * TrendingService counts a topic from `postClassification.topicRefs` (Stage-B
+   * canonical) OR `postClassification.topics` (Stage-A slug). The topic feed used
+   * to match ONLY `postClassification.topics`, so a post classified with a
+   * canonical `topicRefs` "tech" but no "tech" slug in `topics` was counted as
+   * trending yet never returned by the feed. The feed must now return it too.
+   */
+  it('returns a post associated via topicRefs.name only, and excludes an unrelated post', async () => {
+    const techViaRefsOnly = makePost(3, {
+      postClassification: { topics: ['news'], topicRefs: [{ name: 'tech' }] },
+    });
+    const unrelated = makePost(4, {
+      postClassification: { topics: ['sports'], topicRefs: [{ name: 'sports' }] },
+    });
+    findRouter = (match) => [techViaRefsOnly, unrelated].filter((post) => matchesTopicOr(match, post));
+
+    const posts = await topicSource.gather({ currentUserId: 'viewer' }, { slug: 'tech' }, 31);
+    expect(posts.map((p) => String(p._id))).toEqual([oid(3).toString()]);
   });
 });
 

--- a/packages/backend/src/__tests__/utils/postTopicMatch.test.ts
+++ b/packages/backend/src/__tests__/utils/postTopicMatch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { buildTopicSlugMatch } from '../../utils/postTopicMatch';
+
+/**
+ * `buildTopicSlugMatch` is the ONE canonical "posts on a topic slug" clause,
+ * shared by the topic-page controller (`buildPostsByTopicFilter`) and the MTN
+ * topic-feed source (`gatherTopicTimeline`). It must match a post associated
+ * with the slug through EITHER form of the canonical topic list — the
+ * registry-linked `postClassification.topicRefs.name` OR the slug-only
+ * `postClassification.topics` — so the topic feed ranges over the SAME post set
+ * TrendingService counts (a topic that trends can never render an empty feed).
+ */
+describe('buildTopicSlugMatch — canonical topicRefs.name OR slug topics clause', () => {
+  it('matches BOTH the canonical topicRefs.name and the slug-only topics (lowercased)', () => {
+    expect(buildTopicSlugMatch('Tech')).toEqual({
+      $or: [
+        { 'postClassification.topicRefs.name': 'tech' },
+        { 'postClassification.topics': 'tech' },
+      ],
+    });
+  });
+
+  it('lowercases mixed-case and already-lowercase slugs identically', () => {
+    expect(buildTopicSlugMatch('BasketBall')).toEqual(buildTopicSlugMatch('basketball'));
+  });
+
+  it('nests cleanly under $and so a sibling cursor $or cannot clobber it', () => {
+    const match: Record<string, unknown> = {
+      $and: [buildTopicSlugMatch('tech')],
+      visibility: 'public',
+      status: 'published',
+    };
+    // A ChronoCursor timestamp cursor sets its own top-level `$or`; the topic OR
+    // survives because it lives under `$and`.
+    match.$or = [{ createdAt: { $lt: new Date() } }];
+
+    const and = match.$and as Array<Record<string, unknown>>;
+    expect(and[0].$or).toEqual([
+      { 'postClassification.topicRefs.name': 'tech' },
+      { 'postClassification.topics': 'tech' },
+    ]);
+    expect(match.$or).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -28,6 +28,7 @@ import { config } from '../config';
 import { mergeHashtags, escapeRegex } from '../utils/textProcessing';
 import { createScopedOxyClient } from '../utils/oxyHelpers';
 import { queryInt, queryString } from '../utils/queryParams';
+import { buildTopicSlugMatch } from '../utils/postTopicMatch';
 import { requestLanguageCandidates } from '../utils/viewerLanguage';
 import { normalizeMediaItems, type NormalizedMediaItem } from '../utils/mediaInput';
 import { warmLinkPreviewForText } from '../utils/linkPreviewWarm';
@@ -2248,12 +2249,8 @@ export function buildPostsByTopicFilter(
   topicName: string,
   cursor?: string,
 ): Record<string, unknown> {
-  const normalizedTopic = topicName.toLowerCase();
   const filter: Record<string, unknown> = {
-    $or: [
-      { 'postClassification.topicRefs.name': normalizedTopic },
-      { 'postClassification.topics': normalizedTopic },
-    ],
+    ...buildTopicSlugMatch(topicName),
     status: 'published',
     visibility: PostVisibility.PUBLIC,
   };

--- a/packages/backend/src/mtn/feed/engine/sources/forYouSources.ts
+++ b/packages/backend/src/mtn/feed/engine/sources/forYouSources.ts
@@ -12,6 +12,7 @@ import mongoose from 'mongoose';
 import { PostVisibility } from '@mention/shared-types';
 import { Post } from '../../../../models/Post';
 import { buildFollowedAuthorsMatch } from '../../../../utils/postAuthorship';
+import { buildTopicSlugMatch } from '../../../../utils/postTopicMatch';
 import { FEED_FIELDS } from '../../FeedAPI';
 import { ChronoCursor } from '../../CursorBuilder';
 import { logger } from '../../../../utils/logger';
@@ -132,11 +133,19 @@ async function gatherListTimeline(listId: string, ctx: FeedEngineContext, cap: n
     .lean<CandidatePost[]>();
 }
 
-/** CHRONOLOGICAL Topic-feed query (posts whose classification topics contain the slug). */
+/**
+ * CHRONOLOGICAL Topic-feed query. Matches the SAME post set TrendingService
+ * counts for the slug: a post is on the topic through EITHER the registry-linked
+ * `postClassification.topicRefs.name` OR the slug-only `postClassification.topics`
+ * (see {@link buildTopicSlugMatch}). Matching only `topics` here was the "topic
+ * trends but its page is empty" bug — a post classified with a canonical
+ * `topicRefs` entry but no matching slug in `topics` was counted as trending yet
+ * never returned by this feed. The topic `$or` is nested under `$and` so the
+ * cursor `$or` that {@link ChronoCursor.applyToQuery} may add cannot clobber it.
+ */
 async function gatherTopicTimeline(slug: string, ctx: FeedEngineContext, cap: number): Promise<CandidatePost[]> {
-  const normalized = slug.toLowerCase();
   const match: Record<string, unknown> = {
-    'postClassification.topics': normalized,
+    $and: [buildTopicSlugMatch(slug)],
     visibility: 'public',
     status: 'published',
   };

--- a/packages/backend/src/utils/postTopicMatch.ts
+++ b/packages/backend/src/utils/postTopicMatch.ts
@@ -1,0 +1,36 @@
+/**
+ * Canonical "posts associated with a topic slug" match clause.
+ *
+ * A post is associated with a topic through EITHER form of the ONE canonical
+ * topic list:
+ *   - the registry-linked `postClassification.topicRefs` (Stage-B AI enrichment)
+ *     — each element carries a lowercase slug `name`, and
+ *   - the slug-only `postClassification.topics` array (Stage-A rule baseline).
+ *
+ * `TrendingService.aggregateTopics` counts a topic from those SAME two sources
+ * (it reads `topicRefs` when present and falls back to `topics`, grouping by the
+ * slug `name`). Every topic-scoped Post query therefore matches BOTH fields via
+ * this one helper, so the topic FEED and the TRENDING aggregation always range
+ * over an identical post set — a topic that trends can never render an empty
+ * feed, and the two match rules can never drift onto different fields again
+ * (which was the original "trends but no posts" bug).
+ *
+ * Slugs are stored lowercase, so the lookup lowercases for index efficiency
+ * (backed by `{ 'postClassification.topicRefs.name': 1, createdAt: -1 }` and
+ * `{ 'postClassification.topics': 1, visibility: 1, status: 1, createdAt: -1 }`).
+ *
+ * The clause is a bare top-level `$or`. Callers that also let a cursor helper
+ * (e.g. `ChronoCursor`) add its own `$or` MUST nest this under `$and` so the two
+ * `$or`s cannot clobber each other.
+ */
+export function buildTopicSlugMatch(slug: string): {
+  $or: Array<Record<string, string>>;
+} {
+  const normalized = slug.toLowerCase();
+  return {
+    $or: [
+      { 'postClassification.topicRefs.name': normalized },
+      { 'postClassification.topics': normalized },
+    ],
+  };
+}


### PR DESCRIPTION
A topic (e.g. 'tech') showed in the trending widget but its trend page had zero posts. TrendingService counts topics from `postClassification.topicRefs` ∪ `postClassification.topics`, but the MTN `topic|<slug>` feed (`gatherTopicTimeline`) matched ONLY `postClassification.topics` (slug array). Posts classified via a canonical `topicRefs.name` whose slug array didn't contain the slug trended but were never returned by that feed.

- New canonical `buildTopicSlugMatch(slug)` (`utils/postTopicMatch.ts`): `{ $or: [ {'postClassification.topicRefs.name': lc}, {'postClassification.topics': lc} ] }`.
- `gatherTopicTimeline` uses it under `$and` (so the ChronoCursor's own `$or` isn't clobbered) + public/published + downstream safety filter.
- `buildPostsByTopicFilter` (controller path, already fixed in 580af90a) refactored onto the same helper — one source of truth so the two topic-feed paths can't drift again (that drift was the root cause).

Indexes already exist for both $or branches. Verified: build clean, 2615 tests pass, regression test proves a topicRefs-only 'tech' post is returned for slug 'tech'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)