### PR TITLE
fix(search): gate authed sources on canUsePrivateApi (stop cold-boot 401)

### DIFF
--- a/packages/frontend/__tests__/searchServiceAuthGate.test.ts
+++ b/packages/frontend/__tests__/searchServiceAuthGate.test.ts
@@ -1,0 +1,143 @@
+/**
+ * `searchService.searchAll` — the "All" tab fan-out — must gate its auth-only
+ * sources on `canUsePrivateApi`.
+ *
+ * During the SSO cold-boot the viewer can be authenticated for 5–25s BEFORE the
+ * private API is ready. Firing the auth-gated search sources (posts via
+ * `/search`, lists via `/lists`, saved via `/posts/saved`) in that window 401s —
+ * console noise, not a result — and, because the search query used to key on
+ * `isAuthenticated` (unchanged), it never refetched, so those sections stayed
+ * empty even after the session landed.
+ *
+ * The fix gates those three sources on `canUsePrivateApi` (and keys the query on
+ * it, so it refetches when the private API lands). The PUBLIC sources — people
+ * via Oxy, feeds via the public client, hashtags on the public router — must run
+ * for every viewer regardless. These tests assert at the transport boundary:
+ * which underlying request each source makes, and whether it fired at all.
+ */
+
+const mockAuthGet = jest.fn();
+const mockPublicGet = jest.fn();
+const mockSearchProfiles = jest.fn();
+const mockGetProfileByUsername = jest.fn();
+const mockGetSavedPosts = jest.fn();
+
+// `/hashtags/search` and `/feeds` sit on the backend's PUBLIC router, so they
+// never 401 — `authenticatedClient` just attaches a token when one exists.
+// `/search` and `/lists` are on the authenticated router and are the 401 sources.
+jest.mock('@/utils/api', () => ({
+  authenticatedClient: { get: (...args: unknown[]) => mockAuthGet(...args) },
+  publicClient: { get: (...args: unknown[]) => mockPublicGet(...args) },
+  isUnauthorizedError: () => false,
+}));
+
+jest.mock('@/lib/oxyServices', () => ({
+  oxyServices: {
+    searchProfiles: (...args: unknown[]) => mockSearchProfiles(...args),
+    getProfileByUsername: (...args: unknown[]) => mockGetProfileByUsername(...args),
+  },
+}));
+
+jest.mock('@/services/feedService', () => ({
+  feedService: {
+    getSavedPosts: (...args: unknown[]) => mockGetSavedPosts(...args),
+  },
+}));
+
+jest.mock('@/utils/storage', () => ({
+  Storage: { get: jest.fn(), set: jest.fn(), remove: jest.fn() },
+}));
+
+jest.mock('@/lib/logger', () => ({
+  createScopedLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+}));
+
+import { searchService } from '@/services/searchService';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockAuthGet.mockImplementation((url: string) => {
+    switch (url) {
+      case '/search':
+        return Promise.resolve({ data: { posts: [{ id: 'p1', content: {} }] } });
+      case '/lists':
+        return Promise.resolve({ data: { items: [{ id: 'l1', name: 'List One' }] } });
+      case '/hashtags/search':
+        return Promise.resolve({ data: { hashtags: [{ tag: 'oxy', count: 3 }] } });
+      default:
+        return Promise.reject(new Error(`unexpected authenticated GET ${url}`));
+    }
+  });
+
+  mockPublicGet.mockImplementation((url: string) => {
+    if (url === '/feeds') return Promise.resolve({ data: { items: [{ id: 'f1', title: 'Feed One' }] } });
+    return Promise.reject(new Error(`unexpected public GET ${url}`));
+  });
+
+  mockSearchProfiles.mockResolvedValue({
+    data: [{ id: 'u1', username: 'oxy' }],
+    pagination: { offset: 0, limit: 20, hasMore: false },
+  });
+
+  mockGetSavedPosts.mockResolvedValue({ success: true, data: { posts: [{ id: 's1', content: {} }] } });
+});
+
+describe('searchService.searchAll auth gating', () => {
+  it('runs only the public sources when the private API is NOT ready', async () => {
+    const result = await searchService.searchAll('oxy', false);
+
+    // Public sources always run.
+    expect(mockSearchProfiles).toHaveBeenCalled();
+    expect(mockPublicGet).toHaveBeenCalledWith('/feeds', expect.anything());
+    expect(mockAuthGet).toHaveBeenCalledWith('/hashtags/search', expect.anything());
+
+    // Auth-gated sources must NEVER fire before the private API is ready.
+    expect(mockAuthGet).not.toHaveBeenCalledWith('/search', expect.anything());
+    expect(mockAuthGet).not.toHaveBeenCalledWith('/lists', expect.anything());
+    expect(mockGetSavedPosts).not.toHaveBeenCalled();
+
+    // Public sections populate; the gated sections stay quietly empty.
+    expect(result.users).toHaveLength(1);
+    expect(result.feeds).toHaveLength(1);
+    expect(result.hashtags).toHaveLength(1);
+    expect(result.posts).toEqual([]);
+    expect(result.lists).toEqual([]);
+    expect(result.saved).toEqual([]);
+  });
+
+  it('runs every source once the private API IS ready', async () => {
+    const result = await searchService.searchAll('oxy', true);
+
+    expect(mockAuthGet).toHaveBeenCalledWith('/search', expect.anything());
+    expect(mockAuthGet).toHaveBeenCalledWith('/lists', expect.anything());
+    expect(mockAuthGet).toHaveBeenCalledWith('/hashtags/search', expect.anything());
+    expect(mockGetSavedPosts).toHaveBeenCalled();
+    expect(mockSearchProfiles).toHaveBeenCalled();
+    expect(mockPublicGet).toHaveBeenCalledWith('/feeds', expect.anything());
+
+    expect(result.posts).toHaveLength(1);
+    expect(result.lists).toHaveLength(1);
+    expect(result.saved).toHaveLength(1);
+    expect(result.users).toHaveLength(1);
+    expect(result.feeds).toHaveLength(1);
+    expect(result.hashtags).toHaveLength(1);
+  });
+
+  it('still surfaces a total failure of the public sources when signed out', async () => {
+    // The gated sources short-circuit to a resolved empty page when signed out;
+    // that fulfilled no-op must NOT mask a genuine total failure of the sources
+    // that actually ran.
+    mockSearchProfiles.mockRejectedValue(new Error('users down'));
+    mockGetProfileByUsername.mockRejectedValue(new Error('exact-username fallback down'));
+    mockPublicGet.mockRejectedValue(new Error('feeds down'));
+    mockAuthGet.mockRejectedValue(new Error('hashtags down'));
+
+    await expect(searchService.searchAll('oxy', false)).rejects.toThrow();
+  });
+});

--- a/packages/frontend/app/(app)/search/index.tsx
+++ b/packages/frontend/app/(app)/search/index.tsx
@@ -144,10 +144,11 @@ async function fetchSearchPage(
     tab: SearchTab,
     query: string,
     pageParam: SearchPageParam,
+    canUsePrivateApi: boolean,
 ): Promise<SearchResultsPage> {
     switch (tab) {
         case "all": {
-            const all = await searchService.searchAll(query);
+            const all = await searchService.searchAll(query, canUsePrivateApi);
             return {
                 results: {
                     posts: all.posts ?? [],
@@ -161,6 +162,10 @@ async function fetchSearchPage(
             };
         }
         case "posts": {
+            // Auth-gated: `/search` 401s until the private API is ready. Don't fire
+            // early — the query is keyed on `canUsePrivateApi`, so it refetches (and
+            // this page fills in) the moment the session lands.
+            if (!canUsePrivateApi) return { results: EMPTY_RESULTS, nextPageParam: undefined };
             const cursor = typeof pageParam === "string" ? pageParam : undefined;
             const { posts, hasMore, nextCursor } = await searchService.searchPostsPage(query, cursor);
             return { results: { ...EMPTY_RESULTS, posts }, nextPageParam: hasMore ? nextCursor : undefined };
@@ -171,6 +176,8 @@ async function fetchSearchPage(
             return { results: { ...EMPTY_RESULTS, users }, nextPageParam: hasMore ? nextOffset : undefined };
         }
         case "saved": {
+            // Auth-gated (`/posts/saved`) — see the posts tab above.
+            if (!canUsePrivateApi) return { results: EMPTY_RESULTS, nextPageParam: undefined };
             const page = typeof pageParam === "number" ? pageParam : 1;
             const { posts, hasMore, nextPage } = await searchService.searchSavedPage(query, page);
             return { results: { ...EMPTY_RESULTS, saved: posts }, nextPageParam: hasMore ? nextPage : undefined };
@@ -186,6 +193,8 @@ async function fetchSearchPage(
             return { results: { ...EMPTY_RESULTS, hashtags }, nextPageParam: hasMore ? nextOffset : undefined };
         }
         case "lists": {
+            // Auth-gated (`/lists`) — see the posts tab above.
+            if (!canUsePrivateApi) return { results: EMPTY_RESULTS, nextPageParam: undefined };
             const offset = typeof pageParam === "number" ? pageParam : 0;
             const { lists, hasMore, nextOffset } = await searchService.searchListsPage(query, offset);
             return { results: { ...EMPTY_RESULTS, lists }, nextPageParam: hasMore ? nextOffset : undefined };
@@ -305,9 +314,13 @@ export default function SearchIndex() {
     const params = useLocalSearchParams();
     const urlQuery = (params.q as string) || "";
 
-    // Keyed into the search query so a cold-boot search re-runs once the session
-    // lands: several sources are auth-gated and 401 (→ empty) while anonymous.
-    const { isAuthenticated } = useAuth();
+    // The auth-gated search sources (posts, lists, saved) 401 until the PRIVATE
+    // API is ready — which lags `isAuthenticated` by 5–25s during the SSO
+    // cold-boot. `canUsePrivateApi` both GATES those fetchers (so they never fire
+    // early → no 401 noise) and is KEYED into the search query below, so the query
+    // refetches and those sections fill in the moment the session lands. A genuine
+    // signed-out viewer keeps them quietly empty and still gets people + feeds.
+    const { canUsePrivateApi } = useAuth();
 
     const [query, setQuery] = useState(urlQuery);
     // `query` drives the input box; `debouncedQuery` drives the actual request
@@ -410,8 +423,8 @@ export default function SearchIndex() {
         isError: searchFailed,
         refetch: refetchSearch,
     } = useInfiniteQuery({
-        queryKey: ["search", activeTab, trimmedDebounced, isAuthenticated],
-        queryFn: ({ pageParam }) => fetchSearchPage(activeTab, trimmedDebounced, pageParam),
+        queryKey: ["search", activeTab, trimmedDebounced, canUsePrivateApi],
+        queryFn: ({ pageParam }) => fetchSearchPage(activeTab, trimmedDebounced, pageParam, canUsePrivateApi),
         initialPageParam: null as SearchPageParam,
         // Each tab reports its own "next page" token; `undefined` stops paging, so
         // the "all" overview settles after one page while every single-category tab

--- a/packages/frontend/services/searchService.ts
+++ b/packages/frontend/services/searchService.ts
@@ -377,28 +377,45 @@ class SearchService {
   }
 
   // Search all - shows users above posts in "all" tab.
+  //
+  // The PUBLIC sources (users via Oxy, feeds via the public client, hashtags on
+  // the public router) run for every viewer. The AUTH-GATED sources (posts,
+  // lists, saved — all behind the authenticated API) only fire once the private
+  // API is ready: during the SSO cold-boot the viewer can be authenticated while
+  // the private API is still pending, and firing then would 401 (console noise,
+  // not a result). Those sections stay empty until the search query refetches on
+  // `canUsePrivateApi` flipping true (it is part of the search query key), then
+  // fill in. A signed-out viewer keeps them empty for good — a quiet "nothing
+  // here", never a 401 storm.
+  //
   // One flaky source must not blank the whole screen, so sources settle
   // independently: a partial failure degrades to that section being empty, and
-  // only a TOTAL failure (every source rejected) surfaces as an error.
-  async searchAll(query: string): Promise<SearchResults> {
-    const [posts, users, feeds, lists, hashtags, saved] = await Promise.allSettled([
-      this.searchPosts(query),
+  // only a TOTAL failure of the sources that actually RAN surfaces as an error.
+  async searchAll(query: string, canUsePrivateApi: boolean): Promise<SearchResults> {
+    const [users, feeds, hashtags, posts, lists, saved] = await Promise.allSettled([
       this.searchUsers(query),
       this.searchFeeds(query),
-      this.searchLists(query),
       this.searchHashtags(query),
-      this.searchSaved(query)
+      canUsePrivateApi ? this.searchPosts(query) : Promise.resolve<SearchPostResult[]>([]),
+      canUsePrivateApi ? this.searchLists(query) : Promise.resolve<SearchListResult[]>([]),
+      canUsePrivateApi ? this.searchSaved(query) : Promise.resolve<SearchPostResult[]>([]),
     ]);
 
-    const settled = [posts, users, feeds, lists, hashtags, saved];
-    const rejections = settled.filter(
+    // The gated sources short-circuit to a resolved empty page when the private
+    // API isn't ready, so exclude them from the total-failure count — otherwise a
+    // signed-out viewer with healthy public sources could never surface a real
+    // error, and a fulfilled no-op would mask one.
+    const activeSources = canUsePrivateApi
+      ? [users, feeds, hashtags, posts, lists, saved]
+      : [users, feeds, hashtags];
+    const rejections = activeSources.filter(
       (result): result is PromiseRejectedResult => result.status === 'rejected',
     );
     for (const rejection of rejections) {
       logger.warn("A search source failed", { error: rejection.reason });
     }
     const firstRejection = rejections[0];
-    if (firstRejection && rejections.length === settled.length) {
+    if (firstRejection && rejections.length === activeSources.length) {
       throw firstRejection.reason;
     }
 


### PR DESCRIPTION
Searching fired GET /search?type=posts, /lists, /posts/saved with 401 during the 5-25s SSO restore window (the authed sources are on the backend's authenticatedApiRouter). The query was keyed on isAuthenticated (true early, private API not ready) so it never refetched once the token landed → authed tabs stayed empty + a 401 console storm.

- Search screen: uses canUsePrivateApi, keys the useInfiniteQuery on it, and short-circuits posts/saved/lists to an empty page (no request) until it's true — so the query refetches when the private API lands and the authed tabs populate.
- searchService: searchAll runs public sources (users/feeds/hashtags) always, skips authed sources until canUsePrivateApi; the total-failure check counts only sources that actually ran. emptyIfSignedOut + retry:false untouched.

Matches the documented usePrivacyControls infinite-401 pattern. Signed-out viewers get people+feeds+hashtags with quiet-empty authed sections. Verified: tsc clean, 3/3 new test, build:frontend ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)