### PR TITLE
chore(deps): bump @oxyhq/bloom to ^0.37.0 (engine palette)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.37.0",
+        "@oxyhq/bloom": "^0.37.1",
         "@oxyhq/contracts": "^0.17.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/protocol": "^0.1.5",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.37.0",
+        "@oxyhq/bloom": "^0.37.1",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/services": "^22.8.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -206,7 +206,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.37.0",
+    "@oxyhq/bloom": "^0.37.1",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -703,7 +703,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.37.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-13/F8af1/XeGhbHy+C1AT1BxArhjWNdU9t8BaP7GsHevlKbwvcpS84A5ZaVfhgfHYoZR9M0Xd/EfxbW8RQG2yA=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.37.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-LLYLKH8NBPe9NkxUvfZN3MrmRoCXzlcCjz8mTL6qdsd9ona1fvZl48DIZBENIGvFgg4tgT+dX+YFflbPf7UFEQ=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.17.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-/GGLe2NsULmVBlqcTYGEag2ETbh0xfWauQXr1fb4F3UjzKQJu1bW+eeTZBegYahTYHIUujGzCk28JS2vYqoMYg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.36.0",
+        "@oxyhq/bloom": "^0.37.0",
         "@oxyhq/contracts": "^0.17.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/protocol": "^0.1.5",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.36.0",
+        "@oxyhq/bloom": "^0.37.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/services": "^22.8.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -206,7 +206,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.36.0",
+    "@oxyhq/bloom": "^0.37.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -703,7 +703,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.36.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-bzO331NIgrw+Jn6yXGGBebGbPf8qo2zcUv5MuYqutttGwBSvGlc+gGylowWPVEjvZ+93AQo1dc2uSYKEBl1LtQ=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.37.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-13/F8af1/XeGhbHy+C1AT1BxArhjWNdU9t8BaP7GsHevlKbwvcpS84A5ZaVfhgfHYoZR9M0Xd/EfxbW8RQG2yA=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.17.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-/GGLe2NsULmVBlqcTYGEag2ETbh0xfWauQXr1fb4F3UjzKQJu1bW+eeTZBegYahTYHIUujGzCk28JS2vYqoMYg=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.37.0",
+    "@oxyhq/bloom": "^0.37.1",
     "@oxyhq/contracts": "^0.17.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/protocol": "^0.1.5",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.37.0",
+    "@oxyhq/bloom": "^0.37.1",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "mongoose": "^8.17.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.36.0",
+    "@oxyhq/bloom": "^0.37.0",
     "@oxyhq/contracts": "^0.17.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/protocol": "^0.1.5",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.36.0",
+    "@oxyhq/bloom": "^0.37.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "mongoose": "^8.17.0",

--- a/packages/frontend/components/AppSplashScreen.tsx
+++ b/packages/frontend/components/AppSplashScreen.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect, useCallback, useMemo, useRef, useState } from 'react';
 import { View, Animated, StyleSheet, Platform } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import {
-    APP_COLOR_PRESETS,
-    type AppColorName,
-    type PersistedThemeState,
-} from '@oxyhq/bloom/theme';
+import { APP_COLOR_NAMES, type AppColorName, type PersistedThemeState } from '@oxyhq/bloom/theme';
+import { getPresetVars } from '@oxyhq/bloom/preset-vars';
 import { LogoIcon } from '@/assets/logo';
 import { Loading } from '@oxyhq/bloom/loading';
 import { BLOOM_THEME_PERSIST_KEY, BLOOM_THEME_STORAGE } from '@/lib/themePersistence';
@@ -23,9 +20,9 @@ const SPINNER_SIZE = 28;
 // i.e. BEFORE the theme context is available — so it must NOT depend on `useTheme()`
 // (which throws outside the provider). Instead it reads the SAME persisted theme key
 // that the provider writes (`BLOOM_THEME_PERSIST_KEY`) and derives a DARK gradient
-// from the active preset's hue. The logo + spinner are white, so the gradient must
-// stay dark enough for white to pop — we never use the preset's near-white light
-// `--background` here.
+// from the active preset's DARK-mode `--background` (a very dark, preset-tinted
+// surface from the colour engine). The logo + spinner are white, so we use the
+// dark-mode background — never the preset's near-white light `--background`.
 
 // Safe literal fallback when no preset can be resolved at all (missing key,
 // unparseable JSON, unknown preset, storage unavailable). Both stops are dark.
@@ -39,33 +36,22 @@ const DEFAULT_PRESET: AppColorName = 'blue';
 const DARK_STOP = '#1A1A1A';
 
 /**
- * Extract the integer hue from a raw HSL triple like `'205 87% 53%'`
- * (optionally `'205 87% 53% / 0.5'`). Returns `null` if the value can't be parsed.
- */
-function parseHue(hslTriple: string | undefined): number | null {
-    if (!hslTriple) return null;
-    const first = hslTriple.trim().split(/\s+/)[0];
-    const hue = Number.parseFloat(first);
-    return Number.isFinite(hue) ? hue : null;
-}
-
-/**
- * Build a DARK two-stop gradient from a preset. Stop 1 is a very dark shade of the
- * preset's hue (`hsl(<hue> 60% 8%)`), stop 2 is near-black, so the white logo/spinner
- * always stay clearly visible regardless of preset. Falls back to the safe literal
- * when the preset's primary hue can't be parsed.
+ * Build a DARK two-stop gradient from a preset. Stop 1 is the engine's dark-mode
+ * `--background` for the preset (a very dark, preset-tinted surface), stop 2 is
+ * near-black, so the white logo/spinner always stay clearly visible regardless of
+ * preset. Falls back to the safe literal when the preset can't be resolved.
  */
 function buildDarkGradient(presetName: AppColorName): readonly [string, string] {
-    const hue = parseHue(APP_COLOR_PRESETS[presetName]?.dark?.['--primary']);
-    if (hue === null) return FALLBACK_GRADIENT;
-    return [`hsl(${hue} 60% 8%)`, DARK_STOP];
+    const darkBackground = getPresetVars(presetName, 'dark')['--background'];
+    if (!darkBackground) return FALLBACK_GRADIENT;
+    return [darkBackground, DARK_STOP];
 }
 
 /** Validate an unknown value as a known preset name. */
 function isAppColorName(value: unknown): value is AppColorName {
     return (
         typeof value === 'string'
-        && Object.prototype.hasOwnProperty.call(APP_COLOR_PRESETS, value)
+        && APP_COLOR_NAMES.some((name) => name === value)
     );
 }
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.37.0",
+    "@oxyhq/bloom": "^0.37.1",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "^2.2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.36.0",
+    "@oxyhq/bloom": "^0.37.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "^2.2.0",


### PR DESCRIPTION
Adopts Bloom's new dependency-free tonal colour engine (`@oxyhq/bloom@0.37.0`).

- **card** is now the lightest surface (was mirroring `--surface`).
- **secondary** is a real contrast colour (was a mirror of `primary`).
- Token-name contract unchanged → recompiles untouched; only the visible palette shifts.
- `^0.36.0 → ^0.37.0` (0.x caret locks the minor). Lockfile regenerated + `--frozen-lockfile` verified.

Root install runs `tsc` clean with the new palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->