### PR TITLE
refactor: bloom 0.38 — drop per-app @theme colour duplication

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.37.1",
+        "@oxyhq/bloom": "^0.38.0",
         "@oxyhq/contracts": "^0.17.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/protocol": "^0.1.5",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.37.1",
+        "@oxyhq/bloom": "^0.38.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/services": "^22.8.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -206,7 +206,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.37.1",
+    "@oxyhq/bloom": "^0.38.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -703,7 +703,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.37.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-LLYLKH8NBPe9NkxUvfZN3MrmRoCXzlcCjz8mTL6qdsd9ona1fvZl48DIZBENIGvFgg4tgT+dX+YFflbPf7UFEQ=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.38.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-b9YIrtgkPJAVpJPQwYZ6QFMDmheR3UtmJGV/7e2CIVjCYwuhFup3/Klz1preiwb3ZW1UJVWkZf1HbdIO0ZOcGA=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.17.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-/GGLe2NsULmVBlqcTYGEag2ETbh0xfWauQXr1fb4F3UjzKQJu1bW+eeTZBegYahTYHIUujGzCk28JS2vYqoMYg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.38.0",
+        "@oxyhq/bloom": "^0.39.0",
         "@oxyhq/contracts": "^0.17.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/protocol": "^0.1.5",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.38.0",
+        "@oxyhq/bloom": "^0.39.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/services": "^22.8.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -206,7 +206,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.38.0",
+    "@oxyhq/bloom": "^0.39.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -703,7 +703,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.38.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-b9YIrtgkPJAVpJPQwYZ6QFMDmheR3UtmJGV/7e2CIVjCYwuhFup3/Klz1preiwb3ZW1UJVWkZf1HbdIO0ZOcGA=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.39.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-72wpbgbULj+KxU4v3MkZf6Za2NCjvaH0rSgIi6lqKm0AViT5xUaZAc975GA7BDvwlvoJ4yqDJ4sc60oBluR+Sg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.17.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-/GGLe2NsULmVBlqcTYGEag2ETbh0xfWauQXr1fb4F3UjzKQJu1bW+eeTZBegYahTYHIUujGzCk28JS2vYqoMYg=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.38.0",
+    "@oxyhq/bloom": "^0.39.0",
     "@oxyhq/contracts": "^0.17.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/protocol": "^0.1.5",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.38.0",
+    "@oxyhq/bloom": "^0.39.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "mongoose": "^8.17.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.37.1",
+    "@oxyhq/bloom": "^0.38.0",
     "@oxyhq/contracts": "^0.17.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/protocol": "^0.1.5",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.37.1",
+    "@oxyhq/bloom": "^0.38.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "mongoose": "^8.17.0",

--- a/packages/frontend/app/(app)/compose.tsx
+++ b/packages/frontend/app/(app)/compose.tsx
@@ -2113,7 +2113,7 @@ const ComposeScreenBody = () => {
                                 total={total}
                                 onMove={moveAttachment}
                                 onRemove={removeArticle}
-                                wrapperStyle={[styles.articleAttachmentWrapper, { borderColor: theme.colors.border, backgroundColor: theme.colors.backgroundSecondary }]}
+                                wrapperStyle={[styles.articleAttachmentWrapper, { borderColor: theme.colors.border, backgroundColor: theme.colors.card }]}
                               >
                                 <PostArticlePreview
                                   title={article.title}
@@ -2135,7 +2135,7 @@ const ComposeScreenBody = () => {
                                 total={total}
                                 onMove={moveAttachment}
                                 onRemove={removeEvent}
-                                wrapperStyle={[styles.articleAttachmentWrapper, { borderColor: theme.colors.border, backgroundColor: theme.colors.backgroundSecondary }]}
+                                wrapperStyle={[styles.articleAttachmentWrapper, { borderColor: theme.colors.border, backgroundColor: theme.colors.card }]}
                               >
                                 <PostAttachmentEvent
                                   name={event.name}
@@ -2158,7 +2158,7 @@ const ComposeScreenBody = () => {
                                 total={total}
                                 onMove={moveAttachment}
                                 onRemove={removeRoom}
-                                wrapperStyle={[styles.articleAttachmentWrapper, { borderColor: theme.colors.border, backgroundColor: theme.colors.backgroundSecondary }]}
+                                wrapperStyle={[styles.articleAttachmentWrapper, { borderColor: theme.colors.border, backgroundColor: theme.colors.card }]}
                               >
                                 <RoomCard
                                   room={{
@@ -2186,7 +2186,7 @@ const ComposeScreenBody = () => {
                                 total={total}
                                 onMove={moveAttachment}
                                 onRemove={removePodcast}
-                                wrapperStyle={[styles.articleAttachmentWrapper, { borderColor: theme.colors.border, backgroundColor: theme.colors.backgroundSecondary }]}
+                                wrapperStyle={[styles.articleAttachmentWrapper, { borderColor: theme.colors.border, backgroundColor: theme.colors.card }]}
                               >
                                 <PodcastCard
                                   variant="card"

--- a/packages/frontend/components/Compose/PollAttachmentCard.tsx
+++ b/packages/frontend/components/Compose/PollAttachmentCard.tsx
@@ -73,7 +73,7 @@ export const PollAttachmentCard: React.FC<PollAttachmentCardProps> = ({
                     styles.card,
                     {
                         borderColor: theme.colors.border,
-                        backgroundColor: theme.colors.backgroundSecondary,
+                        backgroundColor: theme.colors.card,
                     },
                 ]}
                 activeOpacity={0.85}

--- a/packages/frontend/components/FeedCard.tsx
+++ b/packages/frontend/components/FeedCard.tsx
@@ -40,7 +40,7 @@ interface FeedCardProps {
 
 /** Card surface (default) vs. flush full-width feed row (result lists). */
 const OUTER_CLASS: Record<FeedCardVariant, string> = {
-    card: 'w-full p-4 gap-2 rounded-xl bg-surface',
+    card: 'w-full p-4 gap-2 rounded-xl bg-card',
     row: 'w-full px-3 py-3 gap-1 border-b border-border',
 };
 

--- a/packages/frontend/global.css
+++ b/packages/frontend/global.css
@@ -20,42 +20,17 @@
 @source "../../node_modules/@oxyhq/services/lib/**/*.{js,jsx}";
 @source "../../node_modules/@oxyhq/bloom/lib/**/*.{js,jsx}";
 
+/* Colour utilities (`bg-card`, `bg-primary`, `text-muted-foreground`, …) come
+   from Bloom's imported theme.css — the single source of truth — so they are
+   NOT re-declared here. Per-app duplication is exactly what let `--color-card`
+   drift to `var(--surface)` (card === surface no longer holds: card is the
+   lightest surface). */
 @theme {
   --font-sans: Inter, sans-serif;
 
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
-
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: hsl(0 0% 100%);
-
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-
-  --color-card: var(--surface);
-  --color-card-foreground: var(--surface-foreground);
-
-  --color-surface: var(--surface);
-  --color-surface-foreground: var(--surface-foreground);
 }
 
 @layer base {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.38.0",
+    "@oxyhq/bloom": "^0.39.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "^2.2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.37.1",
+    "@oxyhq/bloom": "^0.38.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "^2.2.0",


### PR DESCRIPTION
Bumps `@oxyhq/bloom` to `^0.38.0`, which now ships the shadcn-canonical `--color-*` aliases from its own `design-tokens/theme.css` (single source of truth). The frontend drops its per-app `@theme { --color-*: var(--*) }` block — that duplication is what let `--color-card` drift to `var(--surface)`. Also fixes the stale `--color-card: var(--surface)` the app carried: card is now the lightest surface, distinct from surface.

Frontend type-check: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->