### PR TITLE
fix(frontend): carousel + widget-menu cards use bg-card

### DIFF
--- a/packages/frontend/components/Feed/interstitials/SimilarAccountsInterstitial.tsx
+++ b/packages/frontend/components/Feed/interstitials/SimilarAccountsInterstitial.tsx
@@ -247,5 +247,5 @@ function SimilarAccountItem({
 
   if (!isCarousel) return row;
 
-  return <View className="bg-surface flex-1 justify-center overflow-hidden rounded-xl">{row}</View>;
+  return <View className="bg-card flex-1 justify-center overflow-hidden rounded-xl">{row}</View>;
 }

--- a/packages/frontend/components/Feed/interstitials/SuggestedUsersInterstitial.tsx
+++ b/packages/frontend/components/Feed/interstitials/SuggestedUsersInterstitial.tsx
@@ -184,5 +184,5 @@ function SuggestedUserItem({
 
   if (!isCarousel) return row;
 
-  return <View className="bg-surface flex-1 justify-center overflow-hidden rounded-xl">{row}</View>;
+  return <View className="bg-card flex-1 justify-center overflow-hidden rounded-xl">{row}</View>;
 }

--- a/packages/frontend/hooks/useWidgetItemMenu.tsx
+++ b/packages/frontend/hooks/useWidgetItemMenu.tsx
@@ -33,7 +33,7 @@ function ActionRow({
 }: MenuRow & { isFirst: boolean; isLast: boolean }) {
   return (
     <TouchableOpacity
-      className="bg-surface flex-row items-center justify-between py-3 px-3.5"
+      className="bg-card flex-row items-center justify-between py-3 px-3.5"
       style={{
         borderTopLeftRadius: isFirst ? 16 : 0,
         borderTopRightRadius: isFirst ? 16 : 0,


### PR DESCRIPTION
Surface-token audit tail: the similar/suggested-accounts carousel item wrappers and the widget item-menu grouped rows are elevated cards → moved from `bg-surface` to `bg-card` (surfaceContainerLowest, the lightest surface) so they lift above the page instead of reading as muddy slabs under the new palette. Frontend type-check: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->