### PR TITLE
fix: bloom 0.43.0 secondary surfaces + accent-token cleanups

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mention",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/contracts": "^0.17.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/protocol": "^0.1.5",
@@ -81,7 +81,7 @@
         "@livekit/react-native": "^2.11.1",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^144.1.1",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/core": "^12.9.0",
         "@oxyhq/services": "^22.8.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -206,7 +206,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -703,7 +703,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.41.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-jyufBluqZxF/6sDTrljs6gJ6PWD8G6uCCoLo3WglJjV++lJVmzyD2tuQsQ0pndYDG7Vr8cm5p4LJeN59iCPf2Q=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.43.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-GOZUizlYWy+50Cy+zbn2KBcqT5HWSVDd8mGPdgIIeekcmLMCh0iu4TgckukS50RkguQEmoJ4WQz0qiBWptCbAg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.17.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-/GGLe2NsULmVBlqcTYGEag2ETbh0xfWauQXr1fb4F3UjzKQJu1bW+eeTZBegYahTYHIUujGzCk28JS2vYqoMYg=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/contracts": "^0.17.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/protocol": "^0.1.5",
@@ -54,7 +54,7 @@
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
     "@react-native/metro-config": "0.85.3",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "mongoose": "^8.17.0",

--- a/packages/frontend/components/Profile/ProfileContent.tsx
+++ b/packages/frontend/components/Profile/ProfileContent.tsx
@@ -63,7 +63,7 @@ export const ProfileContent = memo(function ProfileContent({
   const followsYouTag =
     !isOwnProfile && isAuthenticated && profileData.followsYou ? (
       <View className="bg-secondary px-2 py-0.5 rounded-full">
-        <Text className="text-muted-foreground text-xs font-medium" numberOfLines={1}>
+        <Text className="text-secondary-foreground text-xs font-medium" numberOfLines={1}>
           {t('profile.followsYou', { defaultValue: 'Follows you' })}
         </Text>
       </View>

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -221,11 +221,11 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
                             ]}
                         >
                             {showExpanded ? (
-                                <Text style={{ color: theme.colors.card, fontSize: 17, fontWeight: '800', textAlign: 'center' }}>
+                                <Text style={{ color: theme.colors.primaryForeground, fontSize: 17, fontWeight: '800', textAlign: 'center' }}>
                                     {t("sidebar.compose")}
                                 </Text>
                             ) : (
-                                <ComposeIcon size={26} color={theme.colors.card} />
+                                <ComposeIcon size={26} color={theme.colors.primaryForeground} />
                             )}
                         </Pressable>
                     </View>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
     "@livekit/react-native": "^2.11.1",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^144.1.1",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/core": "^12.9.0",
     "@oxyhq/services": "^22.8.0",
     "@react-native-async-storage/async-storage": "^2.2.0",


### PR DESCRIPTION
Bumps @oxyhq/bloom ^0.43.0 (`--secondary`/`--tertiary` = soft M3 container surfaces) so the ~109 `bg-secondary` fills read as soft tinted surfaces again. Plus: compose button uses `primaryForeground` (not `card`); Follows-you chip uses `secondary-foreground`. Frontend type-check: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)