### PR TITLE
chore(deps): @oxyhq/services 23.0.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@mention/shared-types": "workspace:*",
-        "@oxyhq/contracts": "^0.17.0",
+        "@oxyhq/contracts": "^0.19.0",
         "@oxyhq/core": "^13.0.0",
         "@oxyhq/federation": "^0.4.0",
         "@oxyhq/protocol": "^0.1.5",
@@ -67,7 +67,7 @@
         "@mention/shared-types": "workspace:*",
         "@oxyhq/bloom": "^0.67.0",
         "@oxyhq/core": "^13.0.0",
-        "@oxyhq/services": "^23.0.0",
+        "@oxyhq/services": "^23.0.1",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/netinfo": "^12.0.1",
         "@shopify/flash-list": "2.3.2",
@@ -179,7 +179,7 @@
       "name": "@mention/shared-types",
       "version": "1.0.0",
       "dependencies": {
-        "@oxyhq/contracts": "^0.17.0",
+        "@oxyhq/contracts": "^0.19.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -191,7 +191,7 @@
   "overrides": {
     "@oxyhq/bloom": "^0.67.0",
     "@oxyhq/core": "^13.0.0",
-    "@oxyhq/services": "^23.0.0",
+    "@oxyhq/services": "^23.0.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
@@ -733,7 +733,7 @@
 
     "@oxyhq/bloom": ["@oxyhq/bloom@0.67.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": "", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom"] }, "sha512-40pNeWVPrGCYYEfBUDnQT4D+HzI+7WosLe0A3KGjuAFwwsic+IrBeogLlCe+RDZo0pr+Y+EMBoXmKz91af61Gg=="],
 
-    "@oxyhq/contracts": ["@oxyhq/contracts@0.17.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-/GGLe2NsULmVBlqcTYGEag2ETbh0xfWauQXr1fb4F3UjzKQJu1bW+eeTZBegYahTYHIUujGzCk28JS2vYqoMYg=="],
+    "@oxyhq/contracts": ["@oxyhq/contracts@0.19.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-QrzSUKv7Q2lvBZGR/ZARlJijg7QMATAicblWkS/DiczZ4Vf018kSpXNr49BdqPjxS0/t21+1wuMjwT9TeFkDHg=="],
 
     "@oxyhq/core": ["@oxyhq/core@13.0.0", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.19.0", "@oxyhq/protocol": "^0.1.6", "bip39": "^3.1.0", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^7.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-0brt8zhiZSDW2MLEyNr5mwtbGC+kXgq2/nY3qRphObQefUp01Nfd5eB9dAWlAfSIQpxrXuL+OmFApTVK1uJU7g=="],
 
@@ -741,7 +741,7 @@
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.6", "", { "dependencies": { "@oxyhq/contracts": "^0.18.0", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-modules-core": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-/27AFpvOwxt19XWdZYJy0W4TnIQbK+IhPOfQVlod4s/kEuzIzMXo0zi9MSystegFu1RhZHKGjaxOTo+83Sx3Sw=="],
 
-    "@oxyhq/services": ["@oxyhq/services@23.0.0", "", { "dependencies": { "@oxyhq/contracts": "0.19.0", "@oxyhq/core": "^13.0.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": "^11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-gesture-handler": "~2.32.0", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": "~5.8.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "nativewind", "react-native-keyboard-controller"] }, "sha512-yfZQ7aMV2fdY7BmaSKTi3am9KWOprGh9V2P57ElTWZTQxAS+tc42rE3O0ZYeJ2iuAIvLbxfhX4sUU5tOtayybg=="],
+    "@oxyhq/services": ["@oxyhq/services@23.0.1", "", { "dependencies": { "@oxyhq/contracts": "0.19.0", "@oxyhq/core": "^13.0.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "nativewind", "react-native-keyboard-controller"] }, "sha512-imJ3FEdy1Cv46oBe6d1jCR6kA1OGNAvOocxVpctm/JW5HG4J8dJSZubNYoLuIIGSDfeciCenyp/V6FtNLyrbhA=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 
@@ -3261,15 +3261,11 @@
 
     "@oxyhq/contracts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@oxyhq/core/@oxyhq/contracts": ["@oxyhq/contracts@0.19.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-QrzSUKv7Q2lvBZGR/ZARlJijg7QMATAicblWkS/DiczZ4Vf018kSpXNr49BdqPjxS0/t21+1wuMjwT9TeFkDHg=="],
-
     "@oxyhq/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@oxyhq/protocol/@oxyhq/contracts": ["@oxyhq/contracts@0.18.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-nGdoCp63FIpy29JpAEHSYYVUWl0wH+kHMzfgJJaVa8PvtiKffK8qokEK8bqkneIWRRCUtaR143dp4ZQmQo1eqg=="],
 
     "@oxyhq/protocol/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@oxyhq/services/@oxyhq/contracts": ["@oxyhq/contracts@0.19.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-QrzSUKv7Q2lvBZGR/ZARlJijg7QMATAicblWkS/DiczZ4Vf018kSpXNr49BdqPjxS0/t21+1wuMjwT9TeFkDHg=="],
 
     "@radix-ui/react-context-menu/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
@@ -3774,8 +3770,6 @@
     "@mention/shared-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@oxyhq/services/@oxyhq/contracts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-context-menu/@radix-ui/react-menu/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.10", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@react-native/metro-config": "0.85.3",
     "@oxyhq/bloom": "^0.67.0",
     "@oxyhq/core": "^13.0.0",
-    "@oxyhq/services": "^23.0.0",
+    "@oxyhq/services": "^23.0.1",
     "brace-expansion": "2.1.2",
     "fast-uri": "3.1.4",
     "fast-xml-parser": "5.10.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mention/shared-types": "workspace:*",
-    "@oxyhq/contracts": "^0.17.0",
+    "@oxyhq/contracts": "^0.19.0",
     "@oxyhq/core": "^13.0.0",
     "@oxyhq/federation": "^0.4.0",
     "@oxyhq/protocol": "^0.1.5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -86,7 +86,7 @@
     "@mention/shared-types": "workspace:*",
     "@oxyhq/bloom": "^0.67.0",
     "@oxyhq/core": "^13.0.0",
-    "@oxyhq/services": "^23.0.0",
+    "@oxyhq/services": "^23.0.1",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^12.0.1",
     "@shopify/flash-list": "2.3.2",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -105,7 +105,7 @@
   "author": "Mention Team",
   "license": "MIT",
   "dependencies": {
-    "@oxyhq/contracts": "^0.17.0",
+    "@oxyhq/contracts": "^0.19.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Patch bump of `@oxyhq/services` `^23.0.0` -> `^23.0.1` (root override + frontend).

`@oxyhq/core` is already `^13.0.0` here from #507, which did the core 13 / services 23
majors for this app, so this PR is only the patch.

### No source changes
Mention never imported the push adapter symbols that 23.0.0 moved to the
`@oxyhq/services/notifications` subpath, which #507 also found. Re-verified here with a
multi-line-aware import scan covering named, namespace, dynamic and re-export forms.


### Verification
- `bun run build`: **passes**.
- `packages/frontend` `tsc --noEmit`: **clean**, as are backend, mcp and shared-types.
- `bun install --frozen-lockfile`: **passes**. Lockfile committed in the same commit.

### Trap for the next person doing this sweep
`useUpdateNotificationPreferences` **stayed in the root barrel** in 23.0.1. It is a
notifications-shaped symbol that did **not** move to `@oxyhq/services/notifications`.
Anything that "helpfully" relocates it to the subpath breaks the build.

Only these moved: `pushTokenPlatform`, `hasNotificationPermission`,
`requestNotificationPermission`, `getExpoPushToken`, `takeLaunchNotificationData`,
`installForegroundNotificationHandler`, `subscribeToNotificationResponses`,
`ForegroundPresentation` (plus subpath-only `ensureNotificationChannel`,
`NotificationChannelImportance`, `NotificationChannelSpec`).

Also beware the near-miss name: several Oxy apps define a **local**
`requestNotificationPermission**s**` (trailing `s`) in their own `utils/notifications.ts`.
It is a different function from the SDK's `requestNotificationPermission` and must not be
rewritten. A coarse grep matches it confidently and wrongly.
