### PR TITLE
fix(backend): two profile-privacy leaks in settings + reply-context hydration

### DIFF
--- a/packages/backend/src/__tests__/routes/profileDesign.test.ts
+++ b/packages/backend/src/__tests__/routes/profileDesign.test.ts
@@ -20,17 +20,17 @@ vi.mock('../../models/UserSettings', () => ({
 }));
 
 // Mock privacyHelpers directly: this route test only needs the visibility
-// contract, not the helper's Oxy graph dependencies. The three exports the route
-// uses are reproduced faithfully.
+// contract, not the helper's Oxy graph dependencies. The two exports the route
+// uses are reproduced faithfully; the gate resolves to "visible" so the counts
+// below are what the assertions are actually about. The gate's own behaviour is
+// covered by `profileDesignVisibilityParity.test.ts`.
 vi.mock('../../utils/privacyHelpers', () => ({
   ProfileVisibility: {
     PUBLIC: 'public',
     PRIVATE: 'private',
     FOLLOWERS_ONLY: 'followers_only',
   },
-  requiresAccessCheck: (visibility?: string) =>
-    visibility === 'private' || visibility === 'followers_only',
-  checkFollowAccess: vi.fn().mockResolvedValue(true),
+  canViewProfileDesign: vi.fn().mockResolvedValue(true),
 }));
 
 import profileDesignRoutes from '../../routes/profileDesign';

--- a/packages/backend/src/__tests__/routes/profileDesignVisibilityParity.test.ts
+++ b/packages/backend/src/__tests__/routes/profileDesignVisibilityParity.test.ts
@@ -1,0 +1,238 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `GET /profile/design/:userId` and `GET /profile/settings/:userId` serve the
+ * SAME profile-design DTO (banner, appearance, customization, pinned profile
+ * media) — the design route through `extractPublicProfileData`, the settings
+ * route through `buildSettingsResponseForViewer`. Only the design route gated it
+ * on `privacy.profileVisibility`, so a private profile's design was readable
+ * through the settings route by any authenticated account that followed nobody.
+ *
+ * Both handlers now share ONE rule (`canViewProfileDesign`), and these tests run
+ * the REAL handlers, the REAL DTO builders and the REAL gate — only the Mongo
+ * document and the Oxy follow graph are stubbed — so the two routes are asserted
+ * to agree on the same seeded document.
+ */
+
+const TARGET = 'target-user';
+const VIEWER = 'viewer-user';
+
+/** viewerId → the ids that viewer follows, as the Oxy graph would report them. */
+const followingByViewer = new Map<string, string[]>();
+
+/** The seeded UserSettings document for TARGET, or null when it has none. */
+let targetDoc: Record<string, unknown> | null = null;
+
+/** The viewer each route sees; `undefined` models an anonymous design request. */
+let currentViewer: string | undefined = VIEWER;
+
+vi.mock('../../config', () => ({
+  config: { publicApiUrl: 'https://api.mention.earth' },
+}));
+
+// One stub stands in for both Oxy seams these routes reach: media URL
+// construction (mediaResolver) and the follow graph the visibility gate reads.
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    getBaseURL: () => 'https://api.oxy.so',
+    getCloudURL: () => 'https://cloud.oxy.so',
+    getFileDownloadUrl: (fileId: string, variant?: string) =>
+      `https://cloud.oxy.so/${encodeURIComponent(fileId)}${variant ? `?variant=${variant}` : ''}`,
+    getUserFollowing: (userId: string) =>
+      Promise.resolve({ following: followingByViewer.get(userId) ?? [] }),
+  }),
+  ensureProfileMediaPublic: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../models/UserSettings', () => ({
+  default: {
+    findOne: () => ({
+      lean: () => {
+        const query = {
+          exec: () => Promise.resolve(targetDoc),
+          then: (resolve: (value: unknown) => unknown) => Promise.resolve(targetDoc).then(resolve),
+        };
+        return query;
+      },
+    }),
+  },
+}));
+
+// Post counts are unrelated to visibility; the design route only needs them to
+// resolve so the handler reaches its response.
+vi.mock('../../models/Post', () => ({
+  default: { countDocuments: vi.fn().mockResolvedValue(0) },
+  Post: { countDocuments: vi.fn().mockResolvedValue(0) },
+}));
+
+vi.mock('@oxyhq/core/server', () => ({
+  requireOxyAuth: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (!currentViewer) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    next();
+  },
+  getRequiredOxyUserId: (req: express.Request & { user?: { id: string } }) => req.user?.id ?? '',
+}));
+
+// Imported by the settings router for surfaces this test never exercises.
+vi.mock('../../utils/syraPodcast', () => ({ syraClient: {} }));
+vi.mock('../../connectors/outboundFederation', () => ({
+  federateAsResolvedActor: vi.fn(),
+}));
+vi.mock('../../models/UserBehavior', () => ({ default: {} }));
+vi.mock('../../models/Bookmark', () => ({ default: {} }));
+vi.mock('../../models/Like', () => ({ default: {} }));
+
+import profileDesignRoutes from '../../routes/profileDesign';
+import profileSettingsRoutes from '../../routes/profileSettings';
+
+const app = express();
+app.use(express.json());
+app.use((req: express.Request & { user?: { id: string }; accessToken?: string }, _res, next) => {
+  if (currentViewer) {
+    req.user = { id: currentViewer };
+    req.accessToken = 'test-token';
+  }
+  next();
+});
+app.use('/profile/design', profileDesignRoutes);
+app.use('/profile', profileSettingsRoutes);
+
+interface ProfileDesignPayload {
+  appearance?: { primaryColor?: string };
+  profileHeaderImage?: string;
+  profileCustomization?: { coverPhotoEnabled: boolean; minimalistMode: boolean };
+  profileMedia?: { type: string };
+}
+
+async function getDesign(): Promise<ProfileDesignPayload> {
+  const res = await request(app).get(`/profile/design/${TARGET}`).expect(200);
+  return res.body.data as ProfileDesignPayload;
+}
+
+async function getSettings(): Promise<ProfileDesignPayload> {
+  const res = await request(app).get(`/profile/settings/${TARGET}`).expect(200);
+  return res.body.data as ProfileDesignPayload;
+}
+
+/** Every design field a viewer without profile access must not receive. */
+function designFields(payload: ProfileDesignPayload) {
+  return {
+    appearance: payload.appearance,
+    profileHeaderImage: payload.profileHeaderImage,
+    profileCustomization: payload.profileCustomization,
+    profileMedia: payload.profileMedia,
+  };
+}
+
+function seedTarget(profileVisibility: 'public' | 'private' | 'followers_only') {
+  targetDoc = {
+    oxyUserId: TARGET,
+    appearance: { themeMode: 'dark', primaryColor: '#ff0000' },
+    profileHeaderImage: 'private-banner-file',
+    profileCustomization: {
+      coverPhotoEnabled: true,
+      minimalistMode: true,
+      profileMedia: {
+        type: 'song',
+        syraTrackId: 'track-1',
+        title: 'A private song',
+        artist: 'Someone',
+        artworkUrl: 'https://cdn.syra.fm/artwork.jpg',
+        previewUrl: 'https://cdn.syra.fm/preview.mp3',
+        startSec: 0,
+        durationSec: 180,
+      },
+    },
+    privacy: { profileVisibility, showSensitiveContent: true, hiddenWords: ['secret'] },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  followingByViewer.clear();
+  currentViewer = VIEWER;
+  targetDoc = null;
+});
+
+describe('GET /profile/settings/:userId profile-design visibility', () => {
+  it('withholds a private profile\'s design from a stranger', async () => {
+    seedTarget('private');
+    followingByViewer.set(VIEWER, []);
+
+    const settings = await getSettings();
+
+    expect(settings.profileHeaderImage).toBeUndefined();
+    expect(settings.appearance).toBeUndefined();
+    expect(settings.profileCustomization).toBeUndefined();
+    expect(settings.profileMedia).toBeUndefined();
+  });
+
+  it('withholds a followers-only profile\'s design from a non-follower', async () => {
+    seedTarget('followers_only');
+    followingByViewer.set(VIEWER, ['someone-else']);
+
+    expect(designFields(await getSettings())).toEqual({
+      appearance: undefined,
+      profileHeaderImage: undefined,
+      profileCustomization: undefined,
+      profileMedia: undefined,
+    });
+  });
+
+  // The banner assertions below are about DISCLOSURE, not URL construction: they
+  // only require the resolved URL to still address the seeded file. How a bare
+  // file id becomes a final URL (and which variant it carries) is owned by
+  // `mediaResolver` and covered by `utils/userSettings.test.ts`.
+  it('serves the design to a follower of a private profile', async () => {
+    seedTarget('private');
+    followingByViewer.set(VIEWER, [TARGET]);
+
+    const settings = await getSettings();
+
+    expect(settings.profileHeaderImage).toContain('private-banner-file');
+    expect(settings.appearance).toEqual({ primaryColor: '#ff0000' });
+    expect(settings.profileCustomization).toEqual({
+      coverPhotoEnabled: true,
+      minimalistMode: true,
+    });
+    expect(settings.profileMedia?.type).toBe('song');
+  });
+
+  it('serves the design of a public profile to a stranger', async () => {
+    seedTarget('public');
+    followingByViewer.set(VIEWER, []);
+
+    const settings = await getSettings();
+
+    expect(settings.profileHeaderImage).toContain('private-banner-file');
+    expect(settings.appearance).toEqual({ primaryColor: '#ff0000' });
+  });
+
+  it('serves the owner their own private profile design', async () => {
+    seedTarget('private');
+    currentViewer = TARGET;
+    followingByViewer.set(TARGET, []);
+
+    const settings = await getSettings();
+
+    expect(settings.profileHeaderImage).toBe('private-banner-file');
+    expect(settings.appearance).toEqual({ themeMode: 'dark', primaryColor: '#ff0000' });
+  });
+});
+
+describe('profile design and profile settings agree on visibility', () => {
+  it.each(['private', 'followers_only', 'public'] as const)(
+    'returns the same design fields from both routes for a %s profile',
+    async (profileVisibility) => {
+      seedTarget(profileVisibility);
+      followingByViewer.set(VIEWER, []);
+
+      expect(designFields(await getSettings())).toEqual(designFields(await getDesign()));
+    },
+  );
+});

--- a/packages/backend/src/__tests__/services/postHydrationSliceReason.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationSliceReason.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FeedPostSlice, HydratedPost } from '@mention/shared-types';
+import type { CachedUserSummary } from '../../services/userSummaryCache';
+
+/**
+ * `hydrateSlices` re-checks post ACL per viewer and drops the items a viewer may
+ * not read. A `replyContext` slice is exactly [parent, reply] and its
+ * `reason.parentAuthor` describes the PARENT — so when the ACL drops that parent,
+ * a preserved reason would keep naming the author of a post the viewer was just
+ * denied, on a slice that no longer carries it.
+ *
+ * The reason must go with its anchor. `selfThread` and `boost` reasons are
+ * unaffected: they describe the slice as a whole, not one dropped item.
+ */
+
+const PARENT_ID = '650000000000000000000021';
+const REPLY_ID = '650000000000000000000022';
+const PARENT_AUTHOR_ID = 'oxy-parent-author';
+const REPLY_AUTHOR_ID = 'oxy-reply-author';
+const VIEWER_ID = 'oxy-viewer';
+
+const { getUsersByIds } = vi.hoisted(() => ({ getUsersByIds: vi.fn() }));
+
+vi.mock('../../runtime/oxyClient', () => ({
+  getRuntimeOxyClient: () => ({
+    getUserFollowing: vi.fn(async () => ({ following: [] })),
+    getUserFollowers: vi.fn(async () => ({ followers: [] })),
+    getUserById: vi.fn(),
+  }),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    getUsersByIds,
+    getLinkPreviews: vi.fn(async () => ({})),
+    getFileDownloadUrl: (id: string) => `https://cdn.test/${id}`,
+  }),
+}));
+
+vi.mock('../../utils/privacyHelpers', () => ({
+  getBlockedUserIds: vi.fn(async () => []),
+  getRestrictedUserIds: vi.fn(async () => []),
+  extractFollowingIds: (res: unknown) =>
+    Array.isArray((res as { following?: unknown[] })?.following)
+      ? (res as { following: string[] }).following
+      : [],
+  extractFollowersIds: (res: unknown) =>
+    Array.isArray((res as { followers?: unknown[] })?.followers)
+      ? (res as { followers: string[] }).followers
+      : [],
+}));
+
+function chainable(rows: unknown[] | null) {
+  const q: Record<string, unknown> = {};
+  for (const m of ['select', 'sort', 'limit', 'maxTimeMS']) {
+    q[m] = () => q;
+  }
+  q.lean = async () => rows;
+  return q;
+}
+
+vi.mock('../../models/Post', () => ({
+  Post: { find: () => chainable([]), findOne: () => chainable(null) },
+}));
+vi.mock('../../models/Poll', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/Like', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/Bookmark', () => ({ default: { find: () => chainable([]) } }));
+vi.mock('../../models/UserSettings', () => ({
+  UserSettings: { find: () => chainable([]), findOne: () => chainable(null) },
+}));
+vi.mock('../../models/FederatedActor', () => ({
+  FederatedActor: { find: () => ({ select: () => ({ lean: async () => [] }) }) },
+  default: { find: () => ({ select: () => ({ lean: async () => [] }) }) },
+}));
+vi.mock('../../models/StarterPack', () => ({
+  StarterPack: { aggregate: async () => [] },
+  default: { aggregate: async () => [] },
+}));
+
+const cacheStore = new Map<string, CachedUserSummary>();
+vi.mock('../../services/userSummaryCache', () => ({
+  mget: vi.fn(async (ids: string[]) => {
+    const hits = new Map<string, CachedUserSummary>();
+    for (const id of ids) {
+      const hit = cacheStore.get(id);
+      if (hit) hits.set(id, hit);
+    }
+    return hits;
+  }),
+  mset: vi.fn(async (entries: Map<string, CachedUserSummary>) => {
+    for (const [id, value] of entries) cacheStore.set(id, value);
+  }),
+}));
+
+import { PostHydrationService } from '../../services/PostHydrationService';
+
+interface PostRowOverrides {
+  status?: string;
+  visibility?: string;
+}
+
+function makePostRow(id: string, authorId: string, overrides: PostRowOverrides = {}) {
+  return {
+    _id: id,
+    oxyUserId: authorId,
+    authorship: [{ oxyUserId: authorId, role: 'owner', status: 'accepted' }],
+    type: 'post',
+    content: { text: `body of ${id}` },
+    stats: { likesCount: 0, boostsCount: 0, commentsCount: 0, downvotesCount: 0, viewsCount: 0 },
+    metadata: { createdAt: new Date('2024-01-01T00:00:00Z') },
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    visibility: overrides.visibility ?? 'public',
+    status: overrides.status ?? 'published',
+    hashtags: [],
+    mentions: [],
+  };
+}
+
+/**
+ * A reply-context slice as `ThreadSlicingService` builds it: the parent first,
+ * the reply second, and a reason naming the parent's author.
+ */
+function makeReplyContextSlice(parentOverrides: PostRowOverrides = {}): FeedPostSlice {
+  const parent = makePostRow(PARENT_ID, PARENT_AUTHOR_ID, parentOverrides);
+  const reply = makePostRow(REPLY_ID, REPLY_AUTHOR_ID);
+
+  return {
+    _sliceKey: `${PARENT_ID}+${REPLY_ID}`,
+    isIncompleteThread: true,
+    reason: {
+      type: 'replyContext',
+      parentAuthor: {
+        id: PARENT_AUTHOR_ID,
+        username: 'parenthandle',
+        name: { displayName: 'Parent Author' },
+        avatar: null,
+      },
+    },
+    items: [
+      { post: parent as unknown as HydratedPost, isThreadParent: true, isThreadChild: false, isThreadLastChild: false },
+      { post: reply as unknown as HydratedPost, isThreadParent: false, isThreadChild: true, isThreadLastChild: true },
+    ],
+  };
+}
+
+describe('PostHydrationService — reply-context reason follows its anchor', () => {
+  let service: PostHydrationService;
+
+  beforeEach(() => {
+    cacheStore.clear();
+    getUsersByIds.mockReset();
+    getUsersByIds.mockResolvedValue([
+      { id: PARENT_AUTHOR_ID, username: 'parenthandle', name: { displayName: 'Parent Author' }, badges: [], verified: false },
+      { id: REPLY_AUTHOR_ID, username: 'replyhandle', name: { displayName: 'Reply Author' }, badges: [], verified: false },
+    ]);
+    service = new PostHydrationService();
+  });
+
+  it('keeps the reason when the parent survives the ACL', async () => {
+    const [slice] = await service.hydrateSlices([makeReplyContextSlice()], { viewerId: VIEWER_ID });
+
+    expect(slice.items.map((item) => item.post.id)).toEqual([PARENT_ID, REPLY_ID]);
+    expect(slice.reason?.type).toBe('replyContext');
+  });
+
+  it.each([
+    ['an unpublished parent', { status: 'draft' }],
+    ['a private parent', { visibility: 'private' }],
+  ] as const)('clears the reason when the ACL drops %s', async (_label, parentOverrides) => {
+    const [slice] = await service.hydrateSlices([makeReplyContextSlice(parentOverrides)], {
+      viewerId: VIEWER_ID,
+    });
+
+    // The parent is gone — and so is the header that described it.
+    expect(slice.items.map((item) => item.post.id)).toEqual([REPLY_ID]);
+    expect(slice.reason).toBeUndefined();
+    expect(JSON.stringify(slice)).not.toContain('parenthandle');
+  });
+});

--- a/packages/backend/src/__tests__/services/threadSlicingParentPublication.test.ts
+++ b/packages/backend/src/__tests__/services/threadSlicingParentPublication.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PostVisibility } from '@mention/shared-types';
+import type { CachedUserSummary } from '../../services/userSummaryCache';
+
+/**
+ * Reply-context parents must clear the same publication bar as the feed
+ * candidates they are injected next to.
+ *
+ * `fetchParentPosts` looks parents up by raw `_id` — the reply itself came from a
+ * feed source that filtered `status: 'published'`, but its PARENT was fetched
+ * with no such filter, and `status` was left out of the projection. That second
+ * omission is what made `PostHydrationService`'s guard
+ * (`(post.status ?? 'published') !== 'published'`) inert: with the field
+ * unprojected it reads `undefined`, defaults to `'published'`, and never fires —
+ * so a draft or scheduled parent's full content would be emitted into a public
+ * feed as reply context.
+ *
+ * Unlike the sibling reply-context suite, the Post stub here HONOURS the query
+ * filter and the `.select()` projection, so both halves of the fix are asserted
+ * by behaviour: drop the query clause and the draft parent reappears in the
+ * slice; drop `status` from the projection and the parent reaches hydration
+ * without the field its guard reads.
+ */
+
+const { resolveUserSummaries, seededPosts } = vi.hoisted(() => ({
+  resolveUserSummaries: vi.fn(),
+  seededPosts: [] as Record<string, unknown>[],
+}));
+
+/** The `$in` / equality subset of Mongo these two slicer queries actually build. */
+function matches(doc: Record<string, unknown>, filter: Record<string, unknown>): boolean {
+  return Object.entries(filter).every(([key, cond]) => {
+    if (key === '$or') {
+      return Array.isArray(cond)
+        && cond.some((sub) => matches(doc, sub as Record<string, unknown>));
+    }
+    if (cond && typeof cond === 'object' && '$in' in (cond as Record<string, unknown>)) {
+      const values = (cond as { $in: unknown[] }).$in;
+      return values.some((v) => String(v) === String(doc[key]));
+    }
+    if (cond && typeof cond === 'object' && '$ne' in (cond as Record<string, unknown>)) {
+      return doc[key] !== (cond as { $ne: unknown }).$ne;
+    }
+    return doc[key] === cond;
+  });
+}
+
+/** Mongo drops every field a projection omits; so does this. */
+function project(doc: Record<string, unknown>, projection: string): Record<string, unknown> {
+  const fields = new Set(projection.split(/\s+/).filter(Boolean));
+  return Object.fromEntries(Object.entries(doc).filter(([key]) => fields.has(key)));
+}
+
+vi.mock('../../models/Post', () => ({
+  Post: {
+    find: (filter: Record<string, unknown>) => {
+      const rows = seededPosts.filter((doc) => matches(doc, filter));
+      const query: Record<string, unknown> = {
+        select: (projection: string) => {
+          query.lean = async () => rows.map((doc) => project(doc, projection));
+          return query;
+        },
+        sort: () => query,
+        limit: () => query,
+        maxTimeMS: () => query,
+        lean: async () => rows,
+      };
+      return query;
+    },
+  },
+}));
+
+vi.mock('../../services/PostHydrationService', () => ({
+  resolveUserSummaries: (...args: unknown[]) => resolveUserSummaries(...args),
+}));
+
+import { threadSlicingService } from '../../services/ThreadSlicingService';
+
+const PARENT_ID = '650000000000000000000011';
+const REPLY_ID = '650000000000000000000012';
+const PARENT_AUTHOR_ID = 'oxy-parent-author';
+const REPLY_AUTHOR_ID = 'oxy-reply-author';
+
+function seedParent(status: 'draft' | 'published' | 'scheduled') {
+  seededPosts.push({
+    _id: PARENT_ID,
+    oxyUserId: PARENT_AUTHOR_ID,
+    visibility: PostVisibility.PUBLIC,
+    status,
+    content: { text: 'the unpublished parent body' },
+  });
+}
+
+const reply = {
+  _id: REPLY_ID,
+  oxyUserId: REPLY_AUTHOR_ID,
+  parentPostId: PARENT_ID,
+  visibility: PostVisibility.PUBLIC,
+  status: 'published',
+  content: { text: 'a public reply' },
+};
+
+async function sliceReply() {
+  return threadSlicingService.sliceFeed([reply], {
+    enableThreadGrouping: false,
+    enableReplyContext: true,
+    maxSliceSize: 3,
+  });
+}
+
+/** The post ids the slicer actually put in a slice. */
+function slicedPostIds(slices: { items: { post: unknown }[] }[]): string[] {
+  return slices.flatMap((slice) =>
+    slice.items.map((item) => String((item.post as { _id: unknown })._id)),
+  );
+}
+
+beforeEach(() => {
+  resolveUserSummaries.mockReset();
+  resolveUserSummaries.mockResolvedValue(new Map<string, CachedUserSummary>());
+  seededPosts.length = 0;
+});
+
+describe('ThreadSlicingService reply-context parent publication', () => {
+  it.each(['draft', 'scheduled'] as const)(
+    'never emits a %s parent as reply context',
+    async (status) => {
+      seedParent(status);
+
+      const { slices, additionalPostIds } = await sliceReply();
+
+      expect(slicedPostIds(slices)).toEqual([REPLY_ID]);
+      expect(additionalPostIds).not.toContain(PARENT_ID);
+      expect(JSON.stringify(slices)).not.toContain('the unpublished parent body');
+    },
+  );
+
+  it('emits a published parent as reply context', async () => {
+    seedParent('published');
+
+    const { slices, additionalPostIds } = await sliceReply();
+
+    expect(slicedPostIds(slices)).toEqual([PARENT_ID, REPLY_ID]);
+    expect(additionalPostIds).toContain(PARENT_ID);
+  });
+
+  // Defence in depth behind the query filter above: hydration re-checks post ACL
+  // per viewer, and its unpublished guard can only fire on a doc that actually
+  // CARRIES `status`. An unprojected field silently defaults to 'published'.
+  it('hands the parent to hydration with its status, so the unpublished guard is not inert', async () => {
+    seedParent('published');
+
+    const { slices } = await sliceReply();
+
+    const parent = slices
+      .flatMap((slice) => slice.items)
+      .map((item) => item.post as unknown as { _id: unknown; status?: string })
+      .find((post) => String(post._id) === PARENT_ID);
+
+    expect(parent).toBeDefined();
+    expect(parent?.status).toBe('published');
+  });
+});

--- a/packages/backend/src/__tests__/utils/userSettings.test.ts
+++ b/packages/backend/src/__tests__/utils/userSettings.test.ts
@@ -52,7 +52,9 @@ describe('buildSettingsResponseForViewer', () => {
       },
     };
 
-    expect(buildSettingsResponseForViewer(doc, 'user-1', 'user-1')).toBe(doc);
+    expect(
+      buildSettingsResponseForViewer(doc, 'user-1', 'user-1', { canViewProfileDesign: true }),
+    ).toBe(doc);
   });
 
   it('redacts private preferences from cross-user settings responses', () => {
@@ -74,6 +76,7 @@ describe('buildSettingsResponseForViewer', () => {
       },
       'target-user',
       'viewer-user',
+      { canViewProfileDesign: true },
     );
 
     expect(result).toBeTruthy();
@@ -89,5 +92,46 @@ describe('buildSettingsResponseForViewer', () => {
     if (result) {
       expect('privacy' in result).toBe(false);
     }
+  });
+
+  // The design fields are gated on the target's profile visibility. The caller
+  // resolves that rule (`canViewProfileDesign` in utils/privacyHelpers); this
+  // asserts the DTO honours a denial rather than falling back to the full
+  // payload — the fail-open shape a defaulted option would have produced.
+  it('suppresses every design field when the viewer has no profile access', () => {
+    const result = buildSettingsResponseForViewer(
+      {
+        oxyUserId: 'target-user',
+        appearance: { themeMode: 'system', primaryColor: '#00f' },
+        profileHeaderImage: 'banner-file',
+        profileCustomization: {
+          coverPhotoEnabled: true,
+          minimalistMode: false,
+          profileMedia: {
+            type: 'podcast',
+            syraPodcastId: 'show-1',
+            title: 'A private show',
+            artworkUrl: 'https://cdn.syra.fm/artwork.jpg',
+            showUrl: 'https://syra.fm/show-1',
+          },
+        },
+        privacy: {
+          profileVisibility: 'private',
+          showSensitiveContent: true,
+          hiddenWords: ['private'],
+        },
+      },
+      'target-user',
+      'viewer-user',
+      { canViewProfileDesign: false },
+    );
+
+    expect(result).toEqual({
+      oxyUserId: 'target-user',
+      appearance: undefined,
+      profileHeaderImage: undefined,
+      profileCustomization: undefined,
+      profileMedia: undefined,
+    });
   });
 });

--- a/packages/backend/src/routes/profileDesign.ts
+++ b/packages/backend/src/routes/profileDesign.ts
@@ -1,9 +1,9 @@
 import { Router, Response } from 'express';
 import UserSettings, { type ProfileMedia } from '../models/UserSettings';
 import Post from '../models/Post';
-import { extractPublicProfileData } from '../utils/userSettings';
+import { extractPublicProfileData, redactedProfileDesign } from '../utils/userSettings';
 import { sendErrorResponse, sendSuccessResponse, validateRequired } from '../utils/apiHelpers';
-import { checkFollowAccess, requiresAccessCheck, ProfileVisibility } from '../utils/privacyHelpers';
+import { canViewProfileDesign, ProfileVisibility } from '../utils/privacyHelpers';
 import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { PostType, PostVisibility } from '@mention/shared-types';
 import { logger } from '../utils/logger';
@@ -52,32 +52,15 @@ router.get('/:userId', async (req: AuthRequest, res: Response) => {
 
     const doc = await UserSettings.findOne({ oxyUserId: userId }).lean();
     const profileVisibility = doc?.privacy?.profileVisibility || ProfileVisibility.PUBLIC;
-    const isOwnProfile = currentUserId === userId;
-    
-    // Build minimal response helper
-    const buildMinimalResponse = (): PublicProfileDesignResponse => ({
-      oxyUserId: userId,
-      appearance: undefined,
-      profileHeaderImage: undefined,
-      profileCustomization: undefined,
-      privacy: {
-        profileVisibility: profileVisibility,
-      },
-    });
-    
-    // Check privacy settings
-    if (!isOwnProfile && requiresAccessCheck(profileVisibility)) {
-      if (!currentUserId) {
-        // Not authenticated - return minimal public data but include privacy info so frontend knows it's private
-        return sendSuccessResponse(res, 200, buildMinimalResponse());
-      }
-      
-      // Check if current user is following the profile owner
-      const hasAccess = await checkFollowAccess(currentUserId, userId);
-      if (!hasAccess) {
-        // No access - return minimal public data but include privacy info
-        return sendSuccessResponse(res, 200, buildMinimalResponse());
-      }
+
+    // The shared profile-design rule (`GET /profile/settings/:userId` applies the
+    // same one). A viewer without access still learns the profile IS restricted,
+    // so the frontend can render the locked state instead of an empty profile.
+    if (!(await canViewProfileDesign(userId, currentUserId, profileVisibility))) {
+      return sendSuccessResponse(res, 200, {
+        ...redactedProfileDesign(userId),
+        privacy: { profileVisibility },
+      } satisfies PublicProfileDesignResponse);
     }
 
     // User has access - return full profile design data with privacy info

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -8,6 +8,7 @@ import Like from '../models/Like';
 import { requireOxyAuth as requireAuth, type OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { buildSettingsResponseForViewer, ensureUserSettings } from '../utils/userSettings';
 import { ensureProfileMediaPublic } from '../utils/oxyHelpers';
+import { canViewProfileDesign } from '../utils/privacyHelpers';
 import { sendErrorResponse, sendSuccessResponse, validateRequired } from '../utils/apiHelpers';
 import { getRequiredOxyUserId as getAuthenticatedUserId } from '@oxyhq/core/server';
 import { type TrackSummary, type PodcastSummary } from '@syra.fm/sdk';
@@ -64,7 +65,24 @@ router.get('/settings/:userId', async (req: AuthRequest, res: Response) => {
     const doc = userId === viewerUserId
       ? await ensureUserSettings(userId)
       : await UserSettings.findOne({ oxyUserId: userId }).lean().exec();
-    return sendSuccessResponse(res, 200, buildSettingsResponseForViewer(doc, userId, viewerUserId));
+
+    // This route serves the SAME profile-design DTO as `GET /profile/design/:userId`,
+    // so it applies the SAME visibility rule. Without it a private profile's
+    // banner, appearance, customization and pinned profile media were readable
+    // here by any authenticated account, while the design route withheld them.
+    const canViewDesign = await canViewProfileDesign(
+      userId,
+      viewerUserId,
+      doc?.privacy?.profileVisibility,
+    );
+
+    return sendSuccessResponse(
+      res,
+      200,
+      buildSettingsResponseForViewer(doc, userId, viewerUserId, {
+        canViewProfileDesign: canViewDesign,
+      }),
+    );
   } catch (err) {
     logger.error('[ProfileSettings] Error fetching user settings:', { userId: req.user?.id, targetUserId: req.params.userId, error: err });
     return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to fetch settings');

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1005,9 +1005,20 @@ export class PostHydrationService {
           ? slice._sliceKey
           : recalculated.map((i) => i.post.id).join('+');
 
+        // A `replyContext` reason describes the parent that anchors the slice
+        // ("Replying to @…"), and such a slice is exactly [parent, reply]. When
+        // the per-viewer ACL above drops the parent, the reason is left
+        // describing an item the response no longer carries — so it goes with its
+        // anchor instead of naming the author of a post this viewer was denied.
+        const reason = slice.reason?.type === 'replyContext'
+          && hydratedItems.length !== slice.items.length
+          ? undefined
+          : slice.reason;
+
         result.push({
           ...slice,
           _sliceKey: sliceKey,
+          reason,
           items: recalculated,
         });
       }

--- a/packages/backend/src/services/ThreadSlicingService.ts
+++ b/packages/backend/src/services/ThreadSlicingService.ts
@@ -44,6 +44,19 @@ const DEFAULT_OPTIONS: ThreadSlicingOptions = {
   maxSliceSize: MtnConfig.feed.maxSliceSize,
 };
 
+/**
+ * The projection for the posts the slicer pulls in itself — self-thread children
+ * and reply-context parents. Both queries share it because they feed the same
+ * consumer.
+ *
+ * `status` is part of it deliberately. These lean docs go straight to
+ * `PostHydrationService`, whose unpublished guard reads `post.status ?? 'published'`:
+ * leave the field unprojected and that guard reads `undefined`, defaults to
+ * `'published'`, and never fires — an inert ACL rather than an enforced one.
+ */
+const SLICE_POST_PROJECTION =
+  '_id oxyUserId authorship federation createdAt parentPostId threadId content status stats metadata hashtags mentions language visibility type boostOf quoteOf';
+
 class ThreadSlicingService {
   /**
    * Takes a flat array of feed posts (already ranked/sorted) and groups them
@@ -216,7 +229,7 @@ class ThreadSlicingService {
         status: 'published',
         $or: orConditions,
       })
-        .select('_id oxyUserId authorship federation createdAt parentPostId threadId content stats metadata hashtags mentions language visibility type boostOf quoteOf')
+        .select(SLICE_POST_PROJECTION)
         .sort({ createdAt: 1 })
         .limit(threadRoots.size * (maxSliceSize - 1))
         .maxTimeMS(3000)
@@ -267,8 +280,15 @@ class ThreadSlicingService {
     try {
       const parents = await Post.find({
         _id: { $in: uniqueParentIds },
+        // A reply-context parent is injected into whatever feed the reply landed
+        // in, so it must clear the same publication bar as every feed candidate:
+        // a draft or scheduled parent must never be rendered as reply context.
+        // `visibility` is deliberately NOT filtered here — hydration re-checks
+        // post ACL per viewer, and a followers-only parent that a follower IS
+        // entitled to see must still reach them.
+        status: 'published',
       })
-        .select('_id oxyUserId authorship federation createdAt parentPostId threadId content stats metadata hashtags mentions language visibility type boostOf quoteOf')
+        .select(SLICE_POST_PROJECTION)
         .maxTimeMS(3000)
         .lean();
 

--- a/packages/backend/src/utils/privacyHelpers.ts
+++ b/packages/backend/src/utils/privacyHelpers.ts
@@ -323,3 +323,34 @@ export function requiresAccessCheck(profileVisibility: string | undefined): bool
   return profileVisibility === ProfileVisibility.PRIVATE ||
          profileVisibility === ProfileVisibility.FOLLOWERS_ONLY;
 }
+
+/**
+ * Whether a viewer may read a profile's DESIGN surface — banner, appearance,
+ * customization, pinned profile media.
+ *
+ * This is the ONE access rule behind every profile-design response. Both
+ * `GET /profile/design/:userId` and `GET /profile/settings/:userId` serve that
+ * same DTO, so both must call this: when only the design route gated it, a
+ * private profile's banner and appearance stayed readable through the settings
+ * route by any authenticated account.
+ *
+ * The owner always has access; a public profile is open to everyone, anonymous
+ * viewers included; a private or followers-only profile requires an
+ * authenticated viewer who follows the owner.
+ *
+ * @param targetUserId - The profile being read
+ * @param viewerUserId - The viewer, or undefined when unauthenticated
+ * @param profileVisibility - The target's `privacy.profileVisibility`
+ * @param client - Optional per-request OxyServices instance
+ */
+export async function canViewProfileDesign(
+  targetUserId: string,
+  viewerUserId: string | undefined,
+  profileVisibility: string | undefined,
+  client?: OxyClient,
+): Promise<boolean> {
+  if (viewerUserId && viewerUserId === targetUserId) return true;
+  if (!requiresAccessCheck(profileVisibility)) return true;
+  if (!viewerUserId) return false;
+  return checkFollowAccess(viewerUserId, targetUserId, client);
+}

--- a/packages/backend/src/utils/userSettings.ts
+++ b/packages/backend/src/utils/userSettings.ts
@@ -78,20 +78,47 @@ export function extractPublicProfileData(doc: Partial<UserSettingsData> | null |
 }
 
 /**
+ * The profile-design DTO with every design field suppressed — what a viewer
+ * without profile access receives. Sharing this list means a design field added
+ * to {@link extractPublicProfileData} cannot be redacted on one profile surface
+ * and forgotten on the other.
+ */
+export function redactedProfileDesign(userId: string) {
+  return {
+    oxyUserId: userId,
+    appearance: undefined,
+    profileHeaderImage: undefined,
+    profileCustomization: undefined,
+    profileMedia: undefined,
+  };
+}
+
+/**
  * Returns the appropriate settings payload for a viewer.
  *
  * Full settings documents include private preferences (for example NSFW opt-in
  * and hidden words) and must only be returned to the settings owner. Other
  * authenticated viewers receive the same public-safe profile data used by
  * profile surfaces.
+ *
+ * `canViewProfileDesign` is REQUIRED, not optional: the design fields are gated
+ * on the target's `privacy.profileVisibility`, and a permissive default is
+ * exactly how the next call site would silently reopen the bypass this closed.
+ * Resolve it with `canViewProfileDesign` from `utils/privacyHelpers` — the same
+ * rule `GET /profile/design/:userId` applies.
  */
 export function buildSettingsResponseForViewer(
   doc: Partial<UserSettingsData> | null | undefined,
   targetUserId: string,
   viewerUserId: string,
+  options: { canViewProfileDesign: boolean },
 ) {
   if (targetUserId === viewerUserId) {
     return doc;
+  }
+
+  if (!options.canViewProfileDesign) {
+    return redactedProfileDesign(targetUserId);
   }
 
   return extractPublicProfileData(doc, targetUserId);


### PR DESCRIPTION
## Summary

Two independent backend privacy fixes, both centered on ACL gating that existed on one code path but not its sibling.

**1. `fix(privacy): the settings route gates profile design like the design route does`** — real, exploitable leak.
`GET /profile/settings/:userId` and `GET /profile/design/:userId` serve the same profile-design DTO (banner, appearance, customization, pinned profile media), but only the design route checked `privacy.profileVisibility`. Any authenticated account with no relationship to the owner could read a private profile's design through the settings route — a resolved `cloud.oxy.so` banner URL, `appearance.primaryColor`, `profileCustomization`, and `profileMedia` — all fields the design route correctly redacted. Fix: both handlers now resolve one shared rule (`canViewProfileDesign` in `utils/privacyHelpers`) and one shared redaction payload (`redactedProfileDesign`), and `buildSettingsResponseForViewer`'s new option is required (not defaulted) so a future call site can't silently reopen this. `GET /profile/design/:userId` behavior is unchanged.

Explicitly **not** fixed here (called out as a separate, real remaining exposure): a private profile's banner *bytes* stay world-readable at `cloud.oxy.so`, because `PUT /profile/settings` promotes every new banner asset to public and an anonymous image load carries no viewer identity. The real fix is routing private-profile banners through Mention's authenticated media proxy — out of scope for this PR.

**2. `fix(feed): reply-context parents must be published, and their reason follows them`** — inert guard, not an exploited leak.
`ThreadSlicingService.fetchParentPosts` looked up reply-context parents by raw `_id` with no publication filter, and left `status` unprojected. Hydration's unpublished guard defaults to `'published'` when `status` is `undefined`, so it never fired for these parents — a draft or scheduled parent's full content could be emitted into a public feed as reply context. Honestly assessed severity: this guard is currently inert, not an active leak. No third-party victim can be named — you need the parent's ObjectId, drafts/scheduled posts aren't publicly listed, and no API path flips a published post back to draft. The one reachable path today is self-inflicted: `createReply` fetches the parent with a bare `Post.findById` and no status gate, so an author could publicly reply to their own scheduled post and leak it ahead of its publish time. It starts leaking for real the day unpublish/soft-delete lands. Fix: `status: 'published'` added to the parent query and projection (now a shared constant with `fetchThreadChildren`, since the two were byte-identical). `visibility` is deliberately left unfiltered — over-filtering would drop reply context for a followers-only parent a follower is entitled to see. Also fixed: `hydrateSlices` was preserving `slice.reason` verbatim through a dropped/ACL'd parent; the reason is now cleared with its anchor.

## Test plan

All checks re-run clean in an isolated worktree on top of current `origin/main`:
- [x] `cd packages/backend && bun run test` — 310 files / 3028 tests passed
- [x] `bunx tsc --noEmit -p packages/backend/tsconfig.json` — clean
- [x] repo root `bun run build` (shared-types + backend + mcp) — exit 0
- [x] repo root `bun run lint` — 0 errors (2 pre-existing warnings in an unrelated frontend test file)
- [x] `bun install --frozen-lockfile` — passes, lockfile byte-unchanged

Backend-only change set (11 files): `routes/profileDesign.ts`, `routes/profileSettings.ts`, `services/PostHydrationService.ts`, `services/ThreadSlicingService.ts`, `utils/privacyHelpers.ts`, `utils/userSettings.ts`, plus new/updated test coverage (`profileDesignVisibilityParity.test.ts`, `postHydrationSliceReason.test.ts`, `threadSlicingParentPublication.test.ts`, `userSettings.test.ts`, `profileDesign.test.ts`).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>