### PR TITLE
fix(notifications): stop dropping notification groups + gesture-handler 2.32.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -129,7 +129,7 @@
         "react-native": "0.85.3",
         "react-native-compressor": "^2.0.2",
         "react-native-css": "^3.0.7",
-        "react-native-gesture-handler": "~2.31.2",
+        "react-native-gesture-handler": "~2.32.0",
         "react-native-keyboard-controller": "1.21.6",
         "react-native-nitro-modules": "^0.36.1",
         "react-native-popup-menu": "^0.19.0",
@@ -2633,7 +2633,7 @@
 
     "react-native-fit-image": ["react-native-fit-image@1.5.5", "", { "dependencies": { "prop-types": "^15.5.10" } }, "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg=="],
 
-    "react-native-gesture-handler": ["react-native-gesture-handler@2.31.2", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "@types/react-test-renderer": "^19.1.0", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-rw5q74i2AfS7YGYdbxQDhOU7xqgY6WRM1132/CCm3erqjblhECZDZFHIm0tteHoC9ih24wogVBVVzcTBQtZ+5A=="],
+    "react-native-gesture-handler": ["react-native-gesture-handler@2.32.0", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "@types/react-test-renderer": "^19.1.0", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-uYIMOKlKENORq2SABE+jIjbPU+h5I/sQKcq2v16zRq848nwEp1fWRVwML4QWqijc8UcXJC25o54S8GQd4Mf2OA=="],
 
     "react-native-ios-context-menu": ["react-native-ios-context-menu@3.1.0", "", { "dependencies": { "@dominicstop/ts-event-emitter": "^1.1.0" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-ios-utilities": "*" } }, "sha512-qdPSXMKUp5lDgmZeUPdv5sgBFhkFrIqma+zsnqJQYOvekb6Qs17yJy1Rqhrj0bJrwuduHzZX0aYbaA8whxqpDw=="],
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -139,7 +139,7 @@
     "react-native": "0.85.3",
     "react-native-compressor": "^2.0.2",
     "react-native-css": "^3.0.7",
-    "react-native-gesture-handler": "~2.31.2",
+    "react-native-gesture-handler": "~2.32.0",
     "react-native-keyboard-controller": "1.21.6",
     "react-native-nitro-modules": "^0.36.1",
     "react-native-popup-menu": "^0.19.0",

--- a/packages/frontend/utils/__tests__/groupNotifications.test.ts
+++ b/packages/frontend/utils/__tests__/groupNotifications.test.ts
@@ -1,0 +1,142 @@
+import type { TRawNotification } from '@/types/validation';
+import { GROUPABLE_TYPES, groupNotifications } from '../groupNotifications';
+
+const HOUR_MS = 60 * 60 * 1000;
+const WINDOW_MS = 24 * HOUR_MS;
+
+/** Fixed clock so "recent" and "old" are unambiguous distances, not wall time. */
+const NOW = Date.parse('2026-07-29T12:00:00.000Z');
+
+function at(msAgo: number): string {
+  return new Date(NOW - msAgo).toISOString();
+}
+
+/**
+ * Only the fields `groupNotifications` reads. `actorId` / `entityId` are `z.any()`
+ * on the wire and a bare id string is one of the shapes the backend sends, so the
+ * fixture uses it directly rather than a full populated actor.
+ */
+function notification(fields: {
+  id: string;
+  type: string;
+  entityId: string;
+  actorId: string;
+  createdAt: string;
+  read?: boolean;
+}): TRawNotification {
+  return {
+    _id: fields.id,
+    recipientId: 'viewer',
+    actorId: fields.actorId,
+    type: fields.type,
+    entityId: fields.entityId,
+    entityType: fields.type === 'follow' ? 'profile' : 'post',
+    read: fields.read ?? true,
+    createdAt: fields.createdAt,
+  };
+}
+
+/** The notification ids each emitted row collapsed, in emission order. */
+function idsPerRow(rows: { notificationIds: string[] }[]): string[][] {
+  return rows.map((row) => row.notificationIds);
+}
+
+describe('groupNotifications', () => {
+  // One case per groupable type, driven off the module's own set so a newly
+  // groupable type cannot slip through uncovered.
+  it.each([...GROUPABLE_TYPES])(
+    'emits both windows when %s notifications on one entity span more than the group window',
+    (type) => {
+      const rows = groupNotifications([
+        // Newest-first, the order the screen feeds in.
+        notification({ id: 'recent-a', type, entityId: 'entity-1', actorId: 'actor-a', createdAt: at(0) }),
+        notification({ id: 'recent-b', type, entityId: 'entity-1', actorId: 'actor-b', createdAt: at(HOUR_MS) }),
+        notification({ id: 'old-a', type, entityId: 'entity-1', actorId: 'actor-c', createdAt: at(3 * WINDOW_MS) }),
+        notification({ id: 'old-b', type, entityId: 'entity-1', actorId: 'actor-d', createdAt: at(3 * WINDOW_MS + HOUR_MS) }),
+      ]);
+
+      // The recent window is the one a naive keyed accumulator overwrites, and it
+      // is the one the user cares about most.
+      expect(idsPerRow(rows)).toEqual([
+        ['recent-a', 'recent-b'],
+        ['old-a', 'old-b'],
+      ]);
+    },
+  );
+
+  it('keeps every window of every entity when several entities each span more than the window', () => {
+    const rows = groupNotifications([
+      notification({ id: 'p1-recent', type: 'like', entityId: 'post-1', actorId: 'actor-a', createdAt: at(0) }),
+      notification({ id: 'p2-recent', type: 'like', entityId: 'post-2', actorId: 'actor-b', createdAt: at(HOUR_MS) }),
+      notification({ id: 'p1-old', type: 'like', entityId: 'post-1', actorId: 'actor-c', createdAt: at(2 * WINDOW_MS) }),
+      notification({ id: 'p2-old', type: 'like', entityId: 'post-2', actorId: 'actor-d', createdAt: at(2 * WINDOW_MS + HOUR_MS) }),
+    ]);
+
+    expect(idsPerRow(rows)).toEqual([['p1-recent'], ['p2-recent'], ['p1-old'], ['p2-old']]);
+  });
+
+  it('gives each window of one entity a distinct list key', () => {
+    // The notifications screen de-dupes rows by `key`, so two windows sharing a
+    // key lose one row on render even when grouping emitted both.
+    const rows = groupNotifications([
+      notification({ id: 'recent', type: 'like', entityId: 'post-1', actorId: 'actor-a', createdAt: at(0) }),
+      notification({ id: 'old', type: 'like', entityId: 'post-1', actorId: 'actor-b', createdAt: at(2 * WINDOW_MS) }),
+    ]);
+
+    const keys = rows.map((row) => row.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toHaveLength(2);
+  });
+
+  it('orders the emitted rows most recent first by each row lead notification', () => {
+    const rows = groupNotifications([
+      notification({ id: 'like-recent', type: 'like', entityId: 'post-1', actorId: 'actor-a', createdAt: at(0) }),
+      notification({ id: 'reply', type: 'reply', entityId: 'post-9', actorId: 'actor-e', createdAt: at(WINDOW_MS) }),
+      notification({ id: 'boost', type: 'boost', entityId: 'post-2', actorId: 'actor-f', createdAt: at(2 * WINDOW_MS) }),
+      notification({ id: 'like-old', type: 'like', entityId: 'post-1', actorId: 'actor-b', createdAt: at(4 * WINDOW_MS) }),
+    ]);
+
+    expect(rows.map((row) => row.createdAt)).toEqual([at(0), at(WINDOW_MS), at(2 * WINDOW_MS), at(4 * WINDOW_MS)]);
+    expect(idsPerRow(rows)).toEqual([['like-recent'], ['reply'], ['boost'], ['like-old']]);
+  });
+
+  it('keeps each window actors and unread flag to itself', () => {
+    const rows = groupNotifications([
+      notification({ id: 'recent-a', type: 'like', entityId: 'post-1', actorId: 'actor-a', createdAt: at(0), read: true }),
+      notification({ id: 'old-a', type: 'like', entityId: 'post-1', actorId: 'actor-b', createdAt: at(2 * WINDOW_MS), read: false }),
+      notification({ id: 'old-b', type: 'like', entityId: 'post-1', actorId: 'actor-c', createdAt: at(2 * WINDOW_MS + HOUR_MS), read: true }),
+    ]);
+
+    expect(rows.map((row) => ({ ids: row.notificationIds, actors: row.actors.map((a) => a.id), hasUnread: row.hasUnread, isGroup: row.isGroup }))).toEqual([
+      { ids: ['recent-a'], actors: ['actor-a'], hasUnread: false, isGroup: false },
+      { ids: ['old-a', 'old-b'], actors: ['actor-b', 'actor-c'], hasUnread: true, isGroup: true },
+    ]);
+  });
+
+  it('collapses notifications on one entity inside the window into a single row', () => {
+    const rows = groupNotifications([
+      notification({ id: 'a', type: 'like', entityId: 'post-1', actorId: 'actor-a', createdAt: at(0) }),
+      notification({ id: 'b', type: 'like', entityId: 'post-1', actorId: 'actor-b', createdAt: at(HOUR_MS) }),
+      notification({ id: 'c', type: 'like', entityId: 'post-1', actorId: 'actor-c', createdAt: at(2 * HOUR_MS) }),
+    ]);
+
+    expect(idsPerRow(rows)).toEqual([['a', 'b', 'c']]);
+    expect(rows[0].totalActors).toBe(3);
+    expect(rows[0].createdAt).toBe(at(0));
+  });
+
+  it('leaves non-groupable types as individual rows even on one entity', () => {
+    const rows = groupNotifications([
+      notification({ id: 'reply-a', type: 'reply', entityId: 'post-1', actorId: 'actor-a', createdAt: at(0) }),
+      notification({ id: 'reply-b', type: 'reply', entityId: 'post-1', actorId: 'actor-b', createdAt: at(HOUR_MS) }),
+      notification({ id: 'mention', type: 'mention', entityId: 'post-1', actorId: 'actor-c', createdAt: at(2 * HOUR_MS) }),
+    ]);
+
+    expect(idsPerRow(rows)).toEqual([['reply-a'], ['reply-b'], ['mention']]);
+    expect(rows.every((row) => row.isGroup)).toBe(false);
+  });
+
+  it('returns nothing for an empty list', () => {
+    expect(groupNotifications([])).toEqual([]);
+  });
+});

--- a/packages/frontend/utils/groupNotifications.ts
+++ b/packages/frontend/utils/groupNotifications.ts
@@ -4,7 +4,7 @@ import { TRawNotification } from '../types/validation';
  * Types that should be grouped when they share the same target entity.
  * Mentions and replies are kept individual since they carry unique content.
  */
-const GROUPABLE_TYPES = new Set(['like', 'boost', 'follow', 'quote']);
+export const GROUPABLE_TYPES = new Set(['like', 'boost', 'follow', 'quote']);
 
 /**
  * Time window (in ms) within which notifications of the same type+entity
@@ -87,13 +87,19 @@ export function groupNotifications(
 ): GroupedNotification[] {
   if (!notifications || notifications.length === 0) return [];
 
-  const groups = new Map<string, GroupedNotification>();
-  const singles: GroupedNotification[] = [];
+  // Every item — single or group — lands in `rows` as soon as it is created, so
+  // nothing can be lost afterwards. `openGroups` is only an index of the group
+  // each key is CURRENTLY merging into (plus how many groups that key has opened,
+  // which keeps the list keys unique). A key whose next notification falls
+  // outside the window opens a second group and re-points the index at it; the
+  // group it was pointing at stays in `rows` with every actor already merged.
+  const rows: GroupedNotification[] = [];
+  const openGroups = new Map<string, { group: GroupedNotification; ordinal: number }>();
 
   for (const n of notifications) {
     // Non-groupable types stay as individual items
     if (!GROUPABLE_TYPES.has(n.type)) {
-      singles.push(toSingle(n));
+      rows.push(toSingle(n));
       continue;
     }
 
@@ -101,31 +107,32 @@ export function groupNotifications(
     const entityId = objectId(n.entityId) || String(n.entityId || '');
     const groupKey = `${n.type}:${entityId}`;
 
-    const existing = groups.get(groupKey);
+    const open = openGroups.get(groupKey);
 
-    if (existing) {
+    if (open) {
       // Check time window — compare against the lead (most recent) notification
-      const existingTime = new Date(existing.createdAt).getTime();
+      const openTime = new Date(open.group.createdAt).getTime();
       const currentTime = new Date(n.createdAt).getTime();
-      const timeDiff = Math.abs(existingTime - currentTime);
+      const timeDiff = Math.abs(openTime - currentTime);
 
       if (timeDiff <= windowMs) {
-        // Merge into existing group
-        mergeIntoGroup(existing, n);
+        // Merge into the group this key is open on
+        mergeIntoGroup(open.group, n);
         continue;
       }
     }
 
-    // Start a new group
-    const group = toGroup(n, groupKey, entityId);
-    groups.set(groupKey, group);
+    // First of its key, or outside the open group's window: start a new group
+    const ordinal = open ? open.ordinal + 1 : 0;
+    const group = toGroup(n, groupKey, entityId, ordinal);
+    rows.push(group);
+    openGroups.set(groupKey, { group, ordinal });
   }
 
-  // Combine groups and singles, sort by createdAt descending
-  const all: GroupedNotification[] = [...groups.values(), ...singles];
-  all.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  // Sort by createdAt descending — each row's createdAt is its lead notification's
+  rows.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
-  return all;
+  return rows;
 }
 
 // ---------------------------------------------------------------------------
@@ -200,10 +207,16 @@ function toSingle(n: TRawNotification): GroupedNotification {
   };
 }
 
-function toGroup(n: TRawNotification, groupKey: string, entityId: string): GroupedNotification {
+/**
+ * `ordinal` counts how many groups this key has already opened. A type+entity
+ * whose notifications span more than one window emits more than one group, and
+ * the notifications screen de-dupes rows by `key` — so the ordinal is what keeps
+ * the later windows from being dropped on render.
+ */
+function toGroup(n: TRawNotification, groupKey: string, entityId: string, ordinal: number): GroupedNotification {
   const actor = extractActor(n);
   return {
-    key: `group:${groupKey}`,
+    key: `group:${groupKey}#${ordinal}`,
     type: n.type,
     entityId,
     entityType: n.entityType,


### PR DESCRIPTION
Two independent commits.

## 1. `groupNotifications` silently dropped groups

`packages/frontend/utils/groupNotifications.ts` accumulated into a `Map` keyed on `type:entityId`. When a notification for a key already in the map fell OUTSIDE the 24 h window, the loop fell through to `groups.set(groupKey, ...)` — replacing the group already built for that key along with every actor merged into it.

Input arrives newest-first, so the entry destroyed was the **recent** group and the survivor was the older one: a user with likes on the same post spanning more than a day lost their newest likes from the list entirely. Every groupable type was affected (`like`, `boost`, `follow`, `quote`).

Groups now land in an array the moment they are created; the map only indexes the group each key is currently merging into. Each group also carries an ordinal in its list key, because the notifications screen de-dupes rows by `key` — two windows of one entity sharing a key would lose one row on render even once grouping emitted both.

New test file `packages/frontend/utils/__tests__/groupNotifications.test.ts` (11 tests). 8 of them failed before the fix. The per-type case is driven off the module's own `GROUPABLE_TYPES` set (now exported) so a newly groupable type cannot slip through uncovered.

Mutation-tested both halves:
- reinstating the drop → the four per-type tests and three others fail, naming the lost ids (`- "recent-a"`, `- "recent-b"`)
- reinstating the ordinal-free key → only *gives each window of one entity a distinct list key* fails

## 2. `react-native-gesture-handler` `~2.31.2` → `~2.32.0`

2.32.0 rewrote `findGestureHandlerByRecognizer:` (`apple/RNGestureHandler.mm`), verified in the installed tarball. Mention reaches `UIContextMenuInteraction` through `@alia.onl/sdk` (zeego → react-native-ios-context-menu), and `@alia.onl/sdk@5.0.0` declares `react-native-gesture-handler: ^2.32.0` as a peer — which `~2.31.2` did not satisfy.

Lockfile in the same commit; the diff is only the manifest range plus the one resolution entry (identical dependency set). Expo SDK 56 bundles `~2.31.1`, so `expo install --check` now lists this alongside the ~13 packages the project already holds ahead of Expo's expected versions.

## Verification

- frontend typecheck: 0 errors
- frontend jest: 83 suites / 719 tests pass
- frontend lint: 0 errors (2 pre-existing warnings in an untouched file)
- clean `bun install` leaves `bun.lock` byte-unchanged
- post and profile menus driven with Playwright against a web dev server on real prod data: both open, render their rows, and close on Escape

**Not verified: iOS.** No macOS/simulator is reachable from this box, and that is where the gesture-handler fix applies — the web check above is a regression check only (web gesture-handler is the JS shim, and the app's own menus are Bloom Dialogs, not `UIContextMenuInteraction`). The iOS context menu needs a real device/simulator pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)