### PR TITLE
fix(saved): the load-more observer stops reading a ref written during render

### DIFF
--- a/packages/frontend/components/saved/SavedPostsList.web.tsx
+++ b/packages/frontend/components/saved/SavedPostsList.web.tsx
@@ -75,8 +75,12 @@ export default function SavedPostsList({
     : 0;
   const spacerHeight = Math.max(totalSize, lastItemEnd);
 
-  const onEndReachedRef = useRef(onEndReached);
-  onEndReachedRef.current = onEndReached;
+  // The observer closes over `onEndReached` and re-subscribes when its identity
+  // changes, rather than reading it from a ref. A "latest ref" written during
+  // render is illegal input for the React Compiler (enabled for this app), which
+  // is free to memoize past the write and leave the ref on a stale callback — and
+  // a stale callback here means infinite scroll silently stops fetching. The
+  // re-subscribe is cheap and already happens per page: `posts.length` is a dep.
   useEffect(() => {
     const node = sentinelRef.current;
     if (
@@ -91,14 +95,14 @@ export default function SavedPostsList({
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
-          onEndReachedRef.current();
+          onEndReached();
         }
       },
       { root: null, rootMargin: LOAD_MORE_ROOT_MARGIN },
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, [hasNextPage, posts.length]);
+  }, [hasNextPage, onEndReached, posts.length]);
 
   useScrollRestoration('window', { enabled: true });
 


### PR DESCRIPTION
`packages/frontend/components/saved/SavedPostsList.web.tsx` kept `onEndReached` in a "latest ref" assigned in the render body:

```js
const onEndReachedRef = useRef(onEndReached);
onEndReachedRef.current = onEndReached;   // render phase, not an effect
```

That is illegal input for the React Compiler, which this app enables (`reactCompiler: true` in `app.config.js`): the compiler treats the component body as pure and may memoize past the assignment, leaving the ref on a stale callback. Under concurrent React the write also survives a discarded render. The ref feeds the `IntersectionObserver` right below it, so a stale callback means the saved list silently stops fetching and just looks like it ended.

## The fix, and why this one

The observer now closes over `onEndReached` directly and re-subscribes when its identity changes.

Moving the assignment into a `useEffect` is the other obvious option and is wrong here: the effect runs after paint, so the observer can fire once holding the previous callback. Re-subscribing costs nothing — `posts.length` is already a dep, so the observer is rebuilt once per page either way — and it makes the web fork consistent with `SavedPostsList.native`, which passes the callback straight to FlashList with no ref at all. `handleEndReached` in `app/(app)/saved.tsx` is a `useCallback` over `fetchNextPage`/`hasNextPage`/`isFetchingNextPage`, so its identity only changes on fetch transitions, and its own in-flight guard absorbs the extra initial callback a fresh observer delivers.

## Verification

Driven in a real foregrounded browser against a **production** `expo export` web build (not the dev server), because only the browser proves the observer still fires.

The screen's own query is gated on `canUsePrivateApi && viewerId`, so an unauthenticated browser can never populate the real saved list. I drove the real `SavedPostsList.web` through a throwaway harness route (**not** in this PR) that fed it real post DTOs from the public feed and paginated locally, with an `onEndReached` shaped like the real one — guarding on a closed-over in-flight flag, which is exactly how a stale callback kills infinite scroll.

Result: paged `8 -> 12 -> 16 -> 24 -> 28 -> 32`, reaching the last post, with 14 observer-driven calls (7 correctly refused by the in-flight guard), 14 re-subscriptions, and no page errors.

Mutation-tested the check: freezing the callback the way a memoized ref degrades stalls it at 4 of 32 with no progression, so the check distinguishes pass from fail rather than always passing.

Two things worth recording from building that harness, both about the app rather than this change:
- A **direct deep link into the static web export lands on the home route** — the target screen mounts and is immediately unmounted (`mounts: 1, unmounts: 1`), while the URL still reads the deep-linked path. Client-side navigation reaches it fine. The same thing makes `/@handle` render the feed on a cold direct hit.
- Scrolling the document to the bottom on a wide viewport is chased by the right rail's own window-virtualized feed loading more, so the document grows unboundedly and a bottom sentinel can never be reached by "scroll to `scrollHeight`" alone.

Gates: frontend typecheck 0 errors, jest 83 suites / 719 tests pass, eslint clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)