### PR TITLE
refactor(moderation): the report metadata keys drop the app's name

### DIFF
--- a/packages/backend/src/__tests__/services/moderation/subjectProviders.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/subjectProviders.test.ts
@@ -279,8 +279,8 @@ describe('report input — what the SDK is handed', () => {
     // §6.2: details are the reporter's claim, never evidence for it — so they are not
     // repeated across codes as if written about each separately.
     expect(built?.reportInput.metadata).toMatchObject({
-      mentionTaxonomyVersion: expect.any(String),
-      mentionCategories: 'harassment,spam',
+      taxonomyVersion: expect.any(String),
+      categories: 'harassment,spam',
     });
     expect(built?.reportInput.submittedAt).toEqual(report.createdAt);
   });

--- a/packages/backend/src/services/moderation/EvidenceSnapshotService.ts
+++ b/packages/backend/src/services/moderation/EvidenceSnapshotService.ts
@@ -137,9 +137,19 @@ export async function buildModerationReportInput(
        */
       submittedAt: report.createdAt,
       metadata: {
-        /** So a case can be read back against the mapping that produced it. */
-        mentionTaxonomyVersion: REPORT_TAXONOMY_VERSION,
-        mentionCategories: [...report.categories].sort().join(','),
+        /**
+         * So a case can be read back against the mapping that produced it.
+         *
+         * The keys are deliberately un-branded. Every application sends these two,
+         * `buildModerationReportInput` is being lifted into `@oxyhq/crowdsource-app`
+         * for all of them, and one consumer's prefix in a shared builder is a prefix
+         * the other six inherit for no reason. Renaming them is free only until the
+         * first delivery: ingress fingerprints the whole envelope, so afterwards a
+         * retry of an already-sent report is a different payload and a permanent
+         * 409 (§10.5) rather than a new case.
+         */
+        taxonomyVersion: REPORT_TAXONOMY_VERSION,
+        categories: [...report.categories].sort().join(','),
         /**
          * Declared, because it cannot yet be attached — see `postSubject.ts`. A
          * jury that can see material exists which it was not given can answer


### PR DESCRIPTION
`mentionTaxonomyVersion` → `taxonomyVersion`, `mentionCategories` → `categories`. They are the only two app-branded keys in the report payload.

This was meant to ride in #515 and missed the merge by about two minutes.

**The window is still open, and it is not the PR's — it is the first delivery.** No report has left the application: `CROWDSOURCE_ENABLED` defaults to `false`, and nothing in `.github/workflows/` or `oxy-infra/terraform-uswest2` sets it, so the dispatcher no-ops. Landing the rename here costs exactly what landing it in #515 would have.

**Why the deadline is real and invisible if missed.** CrowdSource's ingress fingerprints the whole `{ externalReportId, envelope }` to detect a §10.5 payload conflict. Once a report has gone out under the old keys, renaming them makes a *retry of that same report* a different payload — not a new case, a permanent 409 on every attempt. Nothing fails at the moment of the rename; it surfaces days later as moderation work stuck in the outbox with no error anyone reads.

**Why neutral names.** They come from `@oxyhq/crowdsource-app`, which is taking the reusable half of this integration — `buildModerationReportInput` included. Seven applications send these two keys; one consumer's prefix baked into a shared builder is a prefix the other six inherit for no reason.

## Verification

- Rename, not an addition: no `mention`-prefixed spelling survives anywhere in the tree.
- The assertion is load-bearing: putting the old keys back fails `subjectProviders.test.ts`, naming both spellings in the diff.
- No collision — metadata is an open scalar bag (`MetadataBagSchema`) with no reserved names.
- Backend suite 3,351 passing / 334 files; `bun run lint` (tsc across all five packages) and `bun install` (lockfile unchanged) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)