### PR TITLE
fix(engagement): likes, downvotes, saves and unsaves have been failing in production since 2026-07-26

### DIFF
--- a/packages/backend/src/__tests__/services/engagementOutboxWrites.test.ts
+++ b/packages/backend/src/__tests__/services/engagementOutboxWrites.test.ts
@@ -1,0 +1,228 @@
+import { MongoMemoryReplSet } from 'mongodb-memory-server';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The repo-wide `setup.ts` replaces `mongoose.connect` with a no-op so no test
+ * can open a real connection. That is the right default and it is exactly why
+ * this class of defect was invisible: with it in force, every query buffers and
+ * nothing a real server would reject is ever sent to one.
+ *
+ * This one file opts out. The unmock is hoisted above the imports, so mongoose
+ * and everything that reaches it are loaded dynamically below.
+ */
+vi.unmock('mongoose');
+
+const mongoose = (await import('mongoose')).default;
+const { default: Bookmark } = await import('../../models/Bookmark');
+const { default: EngagementOutbox } = await import('../../models/EngagementOutbox');
+const { default: Post } = await import('../../models/Post');
+const { enqueueEngagementOutboxEvent } = await import(
+  '../../services/EngagementOutboxService'
+);
+const { savePostCommand } = await import('../../services/PostEngagementCommandService');
+
+/**
+ * The engagement writes, against a REAL server.
+ *
+ * ## Why this file exists
+ *
+ * Every other engagement test mocks `EngagementOutbox` and `Bookmark`, and a
+ * mocked `updateOne` accepts any update document at all. That made a whole class
+ * of defect invisible: an update Mongo itself rejects passes a mocked suite
+ * unanimously.
+ *
+ * It shipped one. `enqueueEngagementOutboxEvent` and `savePostCommand` both named
+ * `createdAt`/`updatedAt` in `$setOnInsert` while their schemas declare
+ * `{ timestamps: true }`, so Mongoose added `updatedAt` to `$set` itself and Mongo
+ * refused the whole write with `Updating the path 'updatedAt' would create a
+ * conflict at 'updatedAt'`. Both writes happen inside the transaction that owns
+ * the relationship and the counter, so the abort took the domain write with it —
+ * every like, downvote, save and unsave failed in production, in a tree whose
+ * suite was green.
+ *
+ * This is the shape `~/Oxy/AGENTS.md` calls a check that cannot distinguish
+ * success from failure. The fix is not a better assertion against the mock; it is
+ * one test that lets the database answer.
+ *
+ * ## Why a replica set
+ *
+ * Unlike the moderation outbox, the engagement commands open a REAL transaction
+ * themselves (`savePostCommand` → `session.withTransaction`), and it is the abort
+ * of that transaction that turned a rejected outbox row into a lost save. A
+ * standalone server cannot start one, so the production path could only be
+ * reconstructed rather than run. A single-member replica set runs it.
+ */
+
+let server: MongoMemoryReplSet;
+
+beforeAll(async () => {
+  server = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+  await mongoose.connect(server.getUri(), { dbName: 'engagement-outbox-writes' });
+}, 240_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server.stop();
+});
+
+/** Run `operation` inside a real transaction, exactly as the commands do. */
+async function inTransaction(
+  operation: (session: mongoose.ClientSession) => Promise<void>,
+): Promise<void> {
+  const session = await mongoose.startSession();
+  try {
+    await session.withTransaction(async () => {
+      await operation(session);
+    });
+  } finally {
+    await session.endSession();
+  }
+}
+
+async function createPostFixture(): Promise<string> {
+  const post = await Post.create({
+    oxyUserId: 'author-1',
+    authorship: [{ oxyUserId: 'author-1', role: 'owner', status: 'accepted' }],
+    content: { text: 'engagement fixture' },
+  });
+  return String(post._id);
+}
+
+describe('the engagement outbox write is one Mongo accepts', () => {
+  it('enqueues a first event', async () => {
+    const relationshipId = new mongoose.Types.ObjectId().toString();
+    let returnedId: string | undefined;
+
+    await inTransaction(async (session) => {
+      returnedId = await enqueueEngagementOutboxEvent(
+        {
+          kind: 'post.like',
+          relationshipId,
+          revision: 1,
+          payload: {
+            actorOxyUserId: 'viewer-a',
+            postId: 'post-1',
+            relationshipId,
+          },
+        },
+        session,
+      );
+    });
+
+    expect(returnedId).toBe(`engagement:post.like:${relationshipId}:v1`);
+    const stored = await EngagementOutbox.findById(returnedId).lean();
+    expect(stored).not.toBeNull();
+    expect(stored?.status).toBe('pending');
+    expect(stored?.createdAt).toBeInstanceOf(Date);
+    expect(stored?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('a repeated enqueue writes NOTHING — not even updatedAt', async () => {
+    /**
+     * The assertion that DISTINGUISHES the two candidate fixes, and the reason it
+     * exists as its own test.
+     *
+     * Both `timestamps: false` + explicit fields and "let Mongoose own them" clear
+     * the update-conflict, so both satisfy every other assertion in this file —
+     * including the row-count one below, because a row that was rewritten is still
+     * one row. Only `updatedAt` moves, so only `updatedAt` tells them apart.
+     *
+     * The 25 ms wait is load-bearing: without it an unchanged timestamp could be
+     * same-millisecond luck on a fast machine, and the test would pass under the
+     * wrong fix about half the time.
+     */
+    const relationshipId = new mongoose.Types.ObjectId().toString();
+    const eventId = `engagement:post.save:${relationshipId}:v1`;
+    const enqueue = async (): Promise<void> => {
+      await inTransaction(async (session) => {
+        await enqueueEngagementOutboxEvent(
+          {
+            kind: 'post.save',
+            relationshipId,
+            revision: 1,
+            payload: {
+              actorOxyUserId: 'viewer-b',
+              postId: 'post-2',
+              relationshipId,
+            },
+          },
+          session,
+        );
+      });
+    };
+
+    await enqueue();
+    const before = await EngagementOutbox.findById(eventId).lean();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    await enqueue();
+    const after = await EngagementOutbox.findById(eventId).lean();
+
+    expect(before?.updatedAt).toBeInstanceOf(Date);
+    expect(after?.updatedAt?.getTime()).toBe(before?.updatedAt?.getTime());
+    expect(after?.createdAt?.getTime()).toBe(before?.createdAt?.getTime());
+  });
+
+  it('is idempotent — a replayed enqueue writes one row, not two', async () => {
+    const relationshipId = new mongoose.Types.ObjectId().toString();
+    const eventId = `engagement:post.downvote:${relationshipId}:v3`;
+    const enqueue = async (): Promise<void> => {
+      await inTransaction(async (session) => {
+        await enqueueEngagementOutboxEvent(
+          {
+            kind: 'post.downvote',
+            relationshipId,
+            revision: 3,
+            payload: {
+              actorOxyUserId: 'viewer-c',
+              postId: 'post-3',
+              relationshipId,
+            },
+          },
+          session,
+        );
+      });
+    };
+
+    await enqueue();
+    await enqueue();
+
+    expect(await EngagementOutbox.countDocuments({ _id: eventId })).toBe(1);
+  });
+});
+
+describe('savePostCommand commits the bookmark, the counter and the event together', () => {
+  it('saves a post', async () => {
+    const postId = await createPostFixture();
+
+    const result = await savePostCommand({ userId: 'viewer-d', postId });
+
+    expect(result.changed).toBe(true);
+    expect(result.post.stats?.savesCount).toBe(1);
+    const bookmark = await Bookmark.findById(result.bookmarkId).lean();
+    expect(bookmark).not.toBeNull();
+    expect(bookmark?.createdAt).toBeInstanceOf(Date);
+    expect(bookmark?.updatedAt).toBeInstanceOf(Date);
+    expect(await EngagementOutbox.countDocuments({ _id: result.outboxEventId })).toBe(1);
+  });
+
+  it('a repeated save writes NOTHING — not even the bookmark updatedAt', async () => {
+    // Same discriminator as the outbox one above, on the write that made the
+    // whole command fail first: `Bookmark` also declares `{ timestamps: true }`,
+    // and the upsert runs before the outbox enqueue is ever reached.
+    const postId = await createPostFixture();
+    const first = await savePostCommand({ userId: 'viewer-e', postId });
+    const before = await Bookmark.findById(first.bookmarkId).lean();
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const repeated = await savePostCommand({ userId: 'viewer-e', postId });
+    const after = await Bookmark.findById(first.bookmarkId).lean();
+
+    expect(repeated.changed).toBe(false);
+    expect(before?.updatedAt).toBeInstanceOf(Date);
+    expect(after?.updatedAt?.getTime()).toBe(before?.updatedAt?.getTime());
+    expect(after?.createdAt?.getTime()).toBe(before?.createdAt?.getTime());
+    // The counter must not move either — a second save is not a second save.
+    expect(repeated.post.stats?.savesCount).toBe(1);
+    expect(await Bookmark.countDocuments({ userId: 'viewer-e', postId })).toBe(1);
+  });
+});

--- a/packages/backend/src/services/EngagementOutboxService.ts
+++ b/packages/backend/src/services/EngagementOutboxService.ts
@@ -80,11 +80,36 @@ export async function enqueueEngagementOutboxEvent(
         expiresAt: new Date(
           now.getTime() + ENGAGEMENT_OUTBOX_RETENTION_SECONDS * 1_000,
         ),
+        /**
+         * Both timestamps are written HERE, and `timestamps: false` below turns
+         * Mongoose's own timestamping off for this one operation.
+         *
+         * There are two ways to stop this update naming `updatedAt` twice and
+         * they are NOT interchangeable — the schema declares `{ timestamps: true }`,
+         * so on an upsert Mongoose adds `updatedAt` to `$set` itself. Naming it
+         * here as well puts the path under two operators of one update document
+         * and Mongo rejects the WHOLE write: `Updating the path 'updatedAt' would
+         * create a conflict at 'updatedAt'`. Every caller enqueues inside the
+         * transaction that owns the relationship and the counter, so that abort
+         * took the like/downvote/save with it.
+         *
+         * Dropping these two lines and letting Mongoose own the timestamps also
+         * clears the error, which is why it looks equivalent. It is not: it
+         * leaves Mongoose's `$set: { updatedAt }` on the update, so a repeated
+         * enqueue for a row that ALREADY EXISTS becomes a real write instead of a
+         * no-op. A repeat is ordinary here — {@link engagementOutboxEventId} is
+         * derived from the relationship transition precisely so a transaction
+         * retry or two concurrent duplicate requests land on the same id — and it
+         * runs while the dispatcher is claiming, renewing and completing leases
+         * on these same rows. A write nobody needed then contends with a live
+         * lease, trading a total, immediately visible failure for an intermittent
+         * one.
+         */
         createdAt: now,
         updatedAt: now,
       },
     },
-    { upsert: true, session },
+    { upsert: true, session, timestamps: false },
   );
   return eventId;
 }

--- a/packages/backend/src/services/PostEngagementCommandService.ts
+++ b/packages/backend/src/services/PostEngagementCommandService.ts
@@ -205,11 +205,19 @@ export async function savePostCommand(input: {
           userId: input.userId,
           postId: new mongoose.Types.ObjectId(input.postId),
           folder: null,
+          /**
+           * Same contract as the outbox enqueue: `Bookmark` declares
+           * `{ timestamps: true }`, so on an upsert Mongoose adds `updatedAt` to
+           * `$set` and Mongo refuses an update naming that path under two
+           * operators. Turning its timestamping off for this one operation and
+           * writing both fields here keeps a repeated save a genuine no-op —
+           * which is what `upsertedCount` below is reading.
+           */
           createdAt: now,
           updatedAt: now,
         },
       },
-      { upsert: true, session },
+      { upsert: true, session, timestamps: false },
     );
 
     if (write.upsertedCount !== 1) {


### PR DESCRIPTION
## Production impact

**Every like, downvote, save and unsave has been failing since `ce333c92` (2026-07-26)** — four days. Not degraded: rejected outright, with the transaction rolled back.

`EngagementOutbox` and `Bookmark` both declare `{ timestamps: true }`, so on an upsert Mongoose adds `updatedAt` to `$set` itself. `enqueueEngagementOutboxEvent` and `savePostCommand` named it in `$setOnInsert` as well, putting one path under two operators of a single update document. Mongo refuses the whole write:

```
MongoServerError: Updating the path 'updatedAt' would create a conflict at 'updatedAt'
```

Both writes run inside the transaction that owns the relationship and the counter, so the abort takes the domain write with it:

- **save / unsave** — died at the `Bookmark` upsert, before the outbox was even reached.
- **like / downvote** — the `Like` row was written first and the enqueue then aborted the transaction, rolling it back too.

`createdAt` alone would have been harmless (Mongoose skips re-adding it). Only the sites naming **both** are broken.

## Why `timestamps: false` and not the obvious alternative

Dropping the two fields and letting `timestamps: true` own them also clears the error, which is why it looks equivalent. It is not. It leaves Mongoose's `$set: { updatedAt }` on the update, so **a repeated upsert on an existing row becomes a real write instead of a no-op** (`modifiedCount: 1`, `updatedAt` bumped).

A repeat is ordinary here — `engagementOutboxEventId` is derived from the relationship transition *precisely so* a transaction retry or two concurrent duplicate requests land on the same id — and it runs while the dispatcher is claiming, renewing and completing leases on those same rows. A write nobody needed then contends with a live lease, measured elsewhere in this ecosystem as both an aborted transaction and one hanging until `operation exceeded time limit`. That trades a total, immediately visible failure for an intermittent one, which is strictly worse to ship.

So: `{ upsert: true, session, timestamps: false }` with `createdAt`/`updatedAt` written explicitly in `$setOnInsert`. Same shape as the already-merged `ModerationOutboxService` fix (#517).

## Sites swept

`git grep -n 'setOnInsert'` over `packages/backend/src`, then every `updatedAt` write site read against its owning schema.

| Site | Verdict |
| --- | --- |
| `services/EngagementOutboxService.ts` `enqueueEngagementOutboxEvent` | **FIXED** — `$setOnInsert` named both; `EngagementOutbox` is `timestamps: true` |
| `services/PostEngagementCommandService.ts` `savePostCommand` | **FIXED** — `$setOnInsert` named both; `Bookmark` is `timestamps: true` |
| `services/EngagementProjectionReconciliationService.ts` | Left — `updatedAt` is in `$set`, only `createdAt` in `$setOnInsert`. One operator, no conflict; and the write genuinely rewrites `repliers`, so a moved `updatedAt` is correct there |
| `services/PostRecentReplierService.ts` (both sites) | Left — same `$set` shape; the second is an aggregation-pipeline update, where Mongoose appends its own sequential `$set` stage |
| `migrations/0009-post-recent-repliers.ts` | Left — same `$set` shape, and it writes through the raw driver collection, so Mongoose timestamps never run |
| `services/moderation/ModerationOutboxService.ts` | Already correct on `main` (#517) — confirmed, not re-touched |

Every other `$setOnInsert` in the backend (`pokes`, `subscriptions`, `EndorsementSignalService`, `mediaCache/cacheStore`, `federatedProfileSync`, the three MTN ones, `materializeEngagementRelationship`) names no timestamp field at all.

## The test

Every repo that shipped this defect had a green suite, because **a mocked `updateOne` accepts any update document**. An assertion against the mock cannot see this class of defect, so the new harness lets the database answer: `mongodb-memory-server` (already a devDependency — no `package.json` change), the repo-wide mongoose mock opted out with a hoisted `vi.unmock('mongoose')`.

It runs a **single-member replica set** rather than the standalone server the moderation harness uses, because these commands open real transactions themselves and it is that abort which turned a rejected outbox row into a lost save — the production path is run, not reconstructed.

The load-bearing assertion is that a repeated write does **not** move `updatedAt`. It is the only one that distinguishes the two candidate fixes: both clear the error, so every other assertion — including a row count, because a row that was rewritten is still one row — passes under either.

Verified in three states:

1. **Unfixed** — all 5 fail with `MongoServerError: Updating the path 'updatedAt' would create a conflict at 'updatedAt'`, raised at `EngagementOutboxService.ts:69` and `PostEngagementCommandService.ts:200`.
2. **Fixed** — 5 passed.
3. **Wrong variant** (fields dropped, `timestamps: true` owns them) — exactly the two `updatedAt` tests go red (timestamp bumped by 154 ms and 45 ms), the other three stay green.

Full backend suite: **336 files, 3360 tests, all passing**; coverage gate green.