### PR TITLE
fix(engagement): likes and saves have been failing since ce333c92

### DIFF
--- a/packages/backend/src/__tests__/services/EngagementOutboxService.test.ts
+++ b/packages/backend/src/__tests__/services/EngagementOutboxService.test.ts
@@ -139,6 +139,51 @@ describe('EngagementOutboxService', () => {
     );
   });
 
+  it('owns both timestamps and opts out of the managed ones', async () => {
+    /**
+     * Two failures, one line apart, and asserting either half alone passes the
+     * other's bug:
+     *
+     *  - Without `timestamps: false`, the schema's `timestamps: true` also puts
+     *    `updatedAt` in `$set`; one path under two operators makes the server
+     *    refuse the whole update and abort the enclosing transaction — every like,
+     *    downvote, save and unsave.
+     *  - Without the explicit fields, Mongoose's `$set: { updatedAt }` remains and a
+     *    REPEATED upsert becomes a real write rather than the no-op the
+     *    deterministic event id exists to guarantee.
+     *
+     * A proxy, and worth knowing as one: the model is mocked here and this suite has
+     * no Mongo, so it reads the update instead of executing it.
+     */
+    vi.mocked(EngagementOutbox.updateOne).mockResolvedValue(
+      { acknowledged: true } as never,
+    );
+
+    await enqueueEngagementOutboxEvent(
+      {
+        kind: 'post.save',
+        relationshipId: 'bookmark-1',
+        revision: 1,
+        payload: {
+          actorOxyUserId: 'viewer-a',
+          postId: 'post-1',
+          relationshipId: 'bookmark-1',
+        },
+      },
+      {} as never,
+    );
+
+    const [, update, options] = vi.mocked(EngagementOutbox.updateOne).mock
+      .calls[0] as unknown as [
+      unknown,
+      { $setOnInsert?: Record<string, unknown> },
+      { timestamps?: boolean } | undefined,
+    ];
+    expect(update.$setOnInsert).toHaveProperty('createdAt');
+    expect(update.$setOnInsert).toHaveProperty('updatedAt');
+    expect(options?.timestamps).toBe(false);
+  });
+
   it('atomically claims pending work or an expired lease', async () => {
     const now = new Date('2026-07-26T12:00:00.000Z');
     const event = {

--- a/packages/backend/src/__tests__/services/PostEngagementCommandService.test.ts
+++ b/packages/backend/src/__tests__/services/PostEngagementCommandService.test.ts
@@ -118,6 +118,24 @@ describe('PostEngagementCommandService', () => {
       }),
       expect.objectContaining({ upsert: true, session: expect.any(Object) }),
     );
+
+    /**
+     * The bookmark upsert must own both timestamps AND pass `timestamps: false`.
+     * `Bookmark` declares `timestamps: true`, so without the option Mongoose adds
+     * `updatedAt` to `$set`, one path lands under two operators, and the server
+     * refuses the write — aborting this transaction, so every save fails. Without
+     * the explicit fields, a duplicate save rewrites the existing bookmark and
+     * bumps `updatedAt` on a relationship that did not change.
+     */
+    const [, bookmarkUpdate, bookmarkOptions] = vi.mocked(Bookmark.updateOne).mock
+      .calls[0] as unknown as [
+      unknown,
+      { $setOnInsert?: Record<string, unknown> },
+      { timestamps?: boolean } | undefined,
+    ];
+    expect(bookmarkUpdate.$setOnInsert).toHaveProperty('createdAt');
+    expect(bookmarkUpdate.$setOnInsert).toHaveProperty('updatedAt');
+    expect(bookmarkOptions?.timestamps).toBe(false);
   });
 
   it('rejects an invalid post id before creating an orphan bookmark', async () => {

--- a/packages/backend/src/__tests__/services/engagementOutboxWrites.test.ts
+++ b/packages/backend/src/__tests__/services/engagementOutboxWrites.test.ts
@@ -1,0 +1,174 @@
+import { MongoMemoryReplSet } from 'mongodb-memory-server';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The repo-wide `setup.ts` replaces `mongoose.connect` with a no-op so no test can
+ * open a real connection. This one file opts out, so mongoose and everything that
+ * reaches it are imported dynamically below the hoisted unmock.
+ */
+vi.unmock('mongoose');
+
+const mongoose = (await import('mongoose')).default;
+const { default: Bookmark } = await import('../../models/Bookmark');
+const { default: EngagementOutbox } = await import('../../models/EngagementOutbox');
+const { default: Like } = await import('../../models/Like');
+const { default: Post } = await import('../../models/Post');
+const { enqueueEngagementOutboxEvent } = await import(
+  '../../services/EngagementOutboxService'
+);
+const { savePostCommand, votePostCommand } = await import(
+  '../../services/PostEngagementCommandService'
+);
+
+/**
+ * The engagement write path, against a REAL server.
+ *
+ * ## Why this file exists
+ *
+ * `moderationOutboxWrites.test.ts` says it for the moderation outbox; this is the
+ * same defect in the two places that were LIVE. `EngagementOutboxService` and the
+ * bookmark upsert in `PostEngagementCommandService` both named
+ * `createdAt`/`updatedAt` in `$setOnInsert` against schemas declaring
+ * `{ timestamps: true }`, so Mongoose added the same paths and Mongo refused the
+ * whole update — `Updating the path 'updatedAt' would create a conflict at
+ * 'updatedAt'`. Inside `inIdempotentTransaction` that abort took the command with
+ * it, so every like, downvote, save and unsave failed. It shipped in `ce333c92`
+ * and the suite stayed green throughout, because a mocked `updateOne` accepts any
+ * update document at all.
+ *
+ * ## Why a replica set, unlike the moderation file
+ *
+ * That file tests the enqueue in isolation and can use a standalone server. These
+ * are the real commands — `votePostCommand` and `savePostCommand` open
+ * transactions — so this pays for a single-member replica set to run the code
+ * production runs rather than a reconstruction of it. That is the point: the
+ * defect was invisible to every reconstruction.
+ *
+ * The assertions in `EngagementOutboxService.test.ts` and
+ * `PostEngagementCommandService.test.ts` that read the update document are a fast
+ * tripwire for the same regression, not the gate. Only this file can fail for the
+ * reason production failed.
+ */
+
+let server: MongoMemoryReplSet;
+
+beforeAll(async () => {
+  server = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+  await mongoose.connect(server.getUri(), { dbName: 'engagement-writes' });
+}, 180_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server.stop();
+});
+
+async function seedPost(): Promise<string> {
+  const postId = new mongoose.Types.ObjectId();
+  await Post.collection.insertOne({
+    _id: postId,
+    oxyUserId: 'oxy-author',
+    authorship: [{ oxyUserId: 'oxy-author', role: 'owner', status: 'accepted' }],
+    stats: { likesCount: 0, downvotesCount: 0, savesCount: 0 },
+    status: 'published',
+  } as never);
+  return postId.toHexString();
+}
+
+describe('the engagement writes are ones Mongo accepts', () => {
+  it('records a like, its relation and its outbox event', async () => {
+    const postId = await seedPost();
+
+    const result = await votePostCommand({ userId: 'viewer-a', postId, value: 1 });
+
+    expect(result.changed).toBe(true);
+    expect(await Like.countDocuments({ postId })).toBe(1);
+    expect(await EngagementOutbox.countDocuments({ _id: result.outboxEventId })).toBe(1);
+    const post = await Post.findById(postId).lean();
+    expect(post?.stats?.likesCount).toBe(1);
+  });
+
+  it('records a save, its bookmark and its outbox event', async () => {
+    const postId = await seedPost();
+
+    const result = await savePostCommand({ userId: 'viewer-a', postId });
+
+    expect(result.changed).toBe(true);
+    expect(await Bookmark.countDocuments({ postId })).toBe(1);
+    expect(await EngagementOutbox.countDocuments({ _id: result.outboxEventId })).toBe(1);
+  });
+
+  it('a duplicate save writes NOTHING — not even updatedAt', async () => {
+    /**
+     * The assertion that separates the two candidate fixes.
+     *
+     * Both `timestamps: false` + explicit fields and "let Mongoose own them" clear
+     * the update conflict, and both leave exactly one bookmark — a row that was
+     * rewritten is still one row, so a count cannot tell them apart. Only
+     * `updatedAt` moves.
+     *
+     * The 25 ms wait is load-bearing: without it an unchanged timestamp could be
+     * same-millisecond luck, and this would pass under the wrong fix about half the
+     * time.
+     */
+    const postId = await seedPost();
+    await savePostCommand({ userId: 'viewer-a', postId });
+    const before = await Bookmark.findOne({ userId: 'viewer-a', postId }).lean();
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const duplicate = await savePostCommand({ userId: 'viewer-a', postId });
+    const after = await Bookmark.findOne({ userId: 'viewer-a', postId }).lean();
+
+    expect(duplicate.changed).toBe(false);
+    expect(await Bookmark.countDocuments({ userId: 'viewer-a', postId })).toBe(1);
+    expect(before?.updatedAt).toBeInstanceOf(Date);
+    expect(after?.updatedAt?.getTime()).toBe(before?.updatedAt?.getTime());
+    expect(after?.createdAt?.getTime()).toBe(before?.createdAt?.getTime());
+  });
+
+  it('a replayed outbox enqueue writes NOTHING — not even updatedAt', async () => {
+    /**
+     * The event id is derived from the relationship and revision precisely so a
+     * transaction retry or two concurrent duplicate requests upsert the SAME row.
+     * If the repeat is a real write it contends with whichever dispatcher is
+     * leasing that row, which is the failure the id exists to prevent.
+     *
+     * This calls the enqueue DIRECTLY rather than voting twice, and the difference
+     * is the whole test. A second `votePostCommand` with the same value returns at
+     * the "already this value" branch and never reaches the enqueue at all — so the
+     * version of this test that voted twice passed under the wrong fix, proving
+     * only that a no-op command is a no-op. Caught by mutation, not by review.
+     */
+    const relationshipId = new mongoose.Types.ObjectId().toHexString();
+    const session = await mongoose.startSession();
+    const enqueue = async (): Promise<string> =>
+      await enqueueEngagementOutboxEvent(
+        {
+          kind: 'post.like',
+          relationshipId,
+          revision: 1,
+          payload: {
+            actorOxyUserId: 'viewer-b',
+            postId: new mongoose.Types.ObjectId().toHexString(),
+            relationshipId,
+          },
+        },
+        session,
+      );
+
+    try {
+      const eventId = await enqueue();
+      const before = await EngagementOutbox.findById(eventId).lean();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const replayed = await enqueue();
+      const after = await EngagementOutbox.findById(eventId).lean();
+
+      expect(replayed).toBe(eventId);
+      expect(await EngagementOutbox.countDocuments({ _id: eventId })).toBe(1);
+      expect(before?.updatedAt).toBeInstanceOf(Date);
+      expect(after?.updatedAt?.getTime()).toBe(before?.updatedAt?.getTime());
+      expect(after?.createdAt?.getTime()).toBe(before?.createdAt?.getTime());
+    } finally {
+      await session.endSession();
+    }
+  });
+});

--- a/packages/backend/src/services/EngagementOutboxService.ts
+++ b/packages/backend/src/services/EngagementOutboxService.ts
@@ -84,7 +84,20 @@ export async function enqueueEngagementOutboxEvent(
         updatedAt: now,
       },
     },
-    { upsert: true, session },
+    /**
+     * `timestamps: false` is what makes naming the two fields above correct.
+     *
+     * Without it the schema's `timestamps: true` puts `updatedAt` in `$set` too,
+     * one path under two operators, and the server rejects the whole update —
+     * aborting the enclosing transaction, i.e. every like, downvote, save and
+     * unsave. Dropping the fields instead clears the error but leaves Mongoose's
+     * `$set: { updatedAt }`, making a repeated upsert a real write where the
+     * deterministic id exists precisely so a retry is a no-op.
+     *
+     * See `ModerationOutboxService.enqueueModerationOutboxEvent` for the full
+     * account and the measurements.
+     */
+    { upsert: true, session, timestamps: false },
   );
   return eventId;
 }

--- a/packages/backend/src/services/PostEngagementCommandService.ts
+++ b/packages/backend/src/services/PostEngagementCommandService.ts
@@ -209,7 +209,18 @@ export async function savePostCommand(input: {
           updatedAt: now,
         },
       },
-      { upsert: true, session },
+      /**
+       * `timestamps: false` is what makes naming the two fields above correct —
+       * `Bookmark` declares `timestamps: true`, so otherwise Mongoose adds
+       * `updatedAt` to `$set`, the path appears under two operators and the server
+       * rejects the write, aborting this transaction and failing every save.
+       *
+       * Dropping the fields instead would clear the error and make a duplicate save
+       * rewrite the existing bookmark, bumping `updatedAt` on a relationship that
+       * did not change. `upsertedCount` is what decides `changed` either way; this
+       * keeps the no-op an actual no-op.
+       */
+      { upsert: true, session, timestamps: false },
     );
 
     if (write.upsertedCount !== 1) {


### PR DESCRIPTION
The same defect #517 fixed in the moderation outbox, in the two places that were **live**.

`EngagementOutboxService` and the bookmark upsert in `PostEngagementCommandService` name `createdAt`/`updatedAt` in `$setOnInsert` against schemas declaring `{ timestamps: true }`. Mongoose adds `updatedAt` to `$set`, the path lands under two operators, and the server refuses the whole update:

```
MongoServerError: Updating the path 'updatedAt' would create a conflict at 'updatedAt'
```

Both sit inside `inIdempotentTransaction`, so the abort takes the command with it. **Every like, downvote, save and unsave fails** — no `Like` row, no `Bookmark`, no counter movement, no outbox event.

Reproduced end-to-end against a real single-node replica set by calling `votePostCommand` itself, not a reconstruction:

```
likePost: MongoServerError: Updating the path 'updatedAt' would create a conflict at 'updatedAt'
likesCount after: 0
likes rows: 0
```

It landed in `ce333c92` on 2026-07-26, so this is four days old on `main`, which auto-deploys. The moderation instance found first was the harmless one — that path is dark behind `CROWDSOURCE_ENABLED=false`. I have not observed production logs; the code path is unconditional on any state-changing engagement call.

## The fix is the option, not deleting the fields

`timestamps: false` on the operation, keeping both fields explicit. Both variants clear the error, which is why deleting them looks right — but that leaves Mongoose's `$set: { updatedAt }` and turns a **repeated** upsert into a real write. That matters exactly here: the outbox event id is derived from the relationship and revision so a transaction retry or two concurrent duplicate requests upsert the *same* row, and a needless write contends with whichever dispatcher holds that row's lease.

Measured both ways against a real server — dropped: `modified=1`, `updatedAt` bumped; as written: `modified=0`, row untouched.

## The gate

`engagementOutboxWrites.test.ts` follows #517's pattern — unmock mongoose, run the real commands against a real server. Unlike the moderation file it pays for a single-member replica set, because these commands open transactions and the whole lesson is that a reconstruction could not see this.

Both mutations proven:

| mutation | result |
|---|---|
| remove `timestamps: false` | all 4 tests fail with the production `MongoServerError` |
| delete the explicit fields | both idempotency tests fail on a moved `updatedAt` |

One of those tests was worthless when written, and mutation testing is what said so: it replayed a like by voting twice, which returns at the "already this value" branch and never reaches the enqueue, so it passed under the wrong fix. It now calls the enqueue directly.

The two assertions added to the existing mocked suites are a fast tripwire for the same regression, not the gate — they read the update document rather than executing it, and are labelled as proxies where they sit.

Backend suite 3,360 passing / 336 files; `bun run lint` (tsc across all five packages) green; `bun install` left `bun.lock` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)