### PR TITLE
test(engagement): pin the consequence, not just the mechanism

### DIFF
--- a/packages/backend/src/__tests__/services/engagementOutboxWrites.test.ts
+++ b/packages/backend/src/__tests__/services/engagementOutboxWrites.test.ts
@@ -171,4 +171,70 @@ describe('the engagement writes are ones Mongo accepts', () => {
       await session.endSession();
     }
   });
+
+  it('a replayed enqueue does not abort a transaction racing the dispatcher', async () => {
+    /**
+     * The CONSEQUENCE the no-op exists for, rather than the mechanism.
+     *
+     * The test above proves the repeat writes nothing, by watching `updatedAt`.
+     * This one proves what that buys: the dispatcher claims, renews and completes
+     * leases on these same rows inside its own transactions, so if a replayed
+     * enqueue were a real write it would collide with an uncommitted one and Mongo
+     * would abort the transaction that got there second. That failure is silent,
+     * intermittent, and only appears under concurrency — the shape that survives
+     * every single-threaded test.
+     *
+     * Both are worth keeping. `updatedAt` discriminates the two candidate fixes
+     * cheaply; this one is the reason to care which one is chosen, and it fails
+     * with a write conflict rather than a moved timestamp.
+     */
+    const relationshipId = new mongoose.Types.ObjectId().toHexString();
+    const payload = {
+      actorOxyUserId: 'viewer-c',
+      postId: new mongoose.Types.ObjectId().toHexString(),
+      relationshipId,
+    };
+    const seed = await mongoose.startSession();
+    let eventId = '';
+    try {
+      eventId = await enqueueEngagementOutboxEvent(
+        { kind: 'post.like', relationshipId, revision: 1, payload },
+        seed,
+      );
+    } finally {
+      await seed.endSession();
+    }
+
+    const dispatcher = await mongoose.startSession();
+    const replay = await mongoose.startSession();
+    try {
+      // The dispatcher holds an uncommitted write on the row, as it does whenever
+      // it is claiming or renewing that event's lease.
+      dispatcher.startTransaction();
+      await EngagementOutbox.updateOne(
+        { _id: eventId },
+        { $set: { leaseOwner: 'dispatcher-1' } },
+        { session: dispatcher },
+      );
+
+      // The replay lands on the same row, in its own transaction, while that write
+      // is still open. It must write nothing and therefore conflict with nothing.
+      replay.startTransaction();
+      await expect(
+        enqueueEngagementOutboxEvent(
+          { kind: 'post.like', relationshipId, revision: 1, payload },
+          replay,
+        ),
+      ).resolves.toBe(eventId);
+      await expect(replay.commitTransaction()).resolves.not.toThrow();
+      await dispatcher.commitTransaction();
+
+      const stored = await EngagementOutbox.findById(eventId).lean();
+      expect(stored?.leaseOwner).toBe('dispatcher-1');
+      expect(await EngagementOutbox.countDocuments({ _id: eventId })).toBe(1);
+    } finally {
+      await dispatcher.endSession();
+      await replay.endSession();
+    }
+  });
 });


### PR DESCRIPTION
Follow-up to #520, and the second regression test `shared-package` asked for.

The existing gate proves a replayed enqueue writes nothing by watching `updatedAt`. That discriminates the two candidate fixes cheaply, but it does not say *why* it matters which one is chosen. This adds the failure the no-op actually prevents.

The dispatcher claims, renews and completes leases on these same rows inside its own transactions. If a replayed enqueue were a real write it would collide with an uncommitted one. So the test holds an open dispatcher write on the row and replays the enqueue in a second transaction; with the write suppressed there is nothing to conflict with and both commit.

## Verified by mutation, not asserted

With the wrong variant — fields dropped, `timestamps: true` owning them — the replay fails:

```
MongoServerError: Write conflict during plan execution and yielding is disabled.
code: 112, codeName: 'WriteConflict', errorLabels: ['TransientTransactionError']
```

This is the one failure mode that survives every single-threaded test: silent, intermittent, only under concurrency.

## One correction for anyone tracing this from the CrowdSource discussion

The abort surfaces as **`WriteConflict`**, not `NoSuchTransaction`. Same consequence — the transaction is lost — but the code and label differ, so a log search for the wrong one finds nothing. `TransientTransactionError` also means a driver with retries configured may absorb some of them, which is part of why this would present as intermittent rather than total.

Backend suite 336 files / 3,361 passing; `tsc --noEmit` clean. No production code changes — `main` already carries the correct variant at all three sites (#517, #520).

🤖 Generated with [Claude Code](https://claude.com/claude-code)