### PR TITLE
test(moderation): the webhook 401s name a reason, and the secret pass-through is covered

### DIFF
--- a/packages/backend/src/__tests__/services/moderation/crowdSourceWebhook.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/crowdSourceWebhook.test.ts
@@ -175,8 +175,22 @@ describe('CrowdSource webhook receiver', () => {
       tamperedBody: JSON.stringify({ ...event, data: { caseId: 'case_attacker' } }),
     });
 
+    /**
+     * The REASON, not just the status.
+     *
+     * `WEBHOOK_REJECTIONS` in `@oxyhq/crowdsource-express` holds eleven tokens and
+     * every one of them answers 401, so `toBe(401)` alone is satisfied by a
+     * `missing_event_id` just as well as by a signature that failed to verify —
+     * which means it survives deleting the signature comparison entirely. Naming
+     * the token is what makes this a test of the signature check.
+     *
+     * The values are read off `verify.ts`, never guessed: a tampered body and a
+     * forged secret both reach the HMAC comparison and come back
+     * `signature_mismatch`, while a stale delivery is refused earlier, at the
+     * window check, as `timestamp_out_of_window`.
+     */
     expect(response.status).toBe(401);
-    expect(response.body).toMatchObject({ received: false });
+    expect(response.body).toMatchObject({ received: false, rejection: 'signature_mismatch' });
     // Nothing was claimed, so the real delivery can still arrive and be processed.
     expect(events).toHaveLength(0);
     expect(outbox).toHaveLength(0);
@@ -189,6 +203,7 @@ describe('CrowdSource webhook receiver', () => {
     });
 
     expect(response.status).toBe(401);
+    expect(response.body).toMatchObject({ received: false, rejection: 'signature_mismatch' });
     expect(outbox).toHaveLength(0);
   });
 
@@ -199,6 +214,10 @@ describe('CrowdSource webhook receiver', () => {
     });
 
     expect(response.status).toBe(401);
+    expect(response.body).toMatchObject({
+      received: false,
+      rejection: 'timestamp_out_of_window',
+    });
     expect(outbox).toHaveLength(0);
   });
 
@@ -211,6 +230,49 @@ describe('CrowdSource webhook receiver', () => {
     // §10.8 allows two valid secrets so a rotation drops nothing.
     expect(response.status).toBe(200);
     expect(outbox).toHaveLength(1);
+  });
+
+  it('hands the SDK the secrets Mention resolved, instead of leaving it to read the environment', async () => {
+    const app = await buildApp();
+
+    /**
+     * What every other test in this file CANNOT see.
+     *
+     * `configuredSecrets` in `@oxyhq/crowdsource-express` is
+     * `options.secret ?? process.env[WEBHOOK_SECRET_ENV_VAR]`, and every test here
+     * sets that variable through `vi.stubEnv`. So deleting the `secret` /
+     * `previousSecret` pass-through in `crowdSourceWebhook.routes.ts` leaves all of
+     * them green — the SDK's own env fallback quietly covers for it. They confirm
+     * signatures are verified; none of them confirms MENTION is why.
+     *
+     * The discriminator is an ordering asymmetry, checked rather than assumed:
+     * `config/index.ts` builds `environment` from ONE
+     * `parseRuntimeEnvironment(process.env)` at module load, so the router captured
+     * both secrets when `buildApp` imported it, whereas the SDK re-reads
+     * `process.env` on every request. Clearing the variables here therefore leaves
+     * standing only a value Mention captured and passed explicitly. With the
+     * pass-through gone the SDK sees no secret at all and refuses with
+     * `no_secret_configured`.
+     *
+     * Not tidiness: `config` is where the secret is length-validated
+     * (`optionalString(16)`), so a deployment leaning on the SDK's raw env read
+     * would silently accept a secret this app rejects at boot.
+     */
+    vi.stubEnv('CROWDSOURCE_WEBHOOK_SECRET', undefined);
+    vi.stubEnv('CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS', undefined);
+
+    const active = await deliver(app, caseDecidedEventFixture({ id: 'evt_passthrough_1' }));
+    expect(active.status).toBe(200);
+    expect(outbox).toHaveLength(1);
+
+    // Asserted separately because the two are passed separately: a rotation that
+    // only forwards the active secret drops every delivery still signed with the
+    // old one, and that is exactly the loss §10.8's overlap exists to prevent.
+    const previous = await deliver(app, caseDecidedEventFixture({ id: 'evt_passthrough_2' }), {
+      secret: PREVIOUS_SECRET,
+    });
+    expect(previous.status).toBe(200);
+    expect(outbox).toHaveLength(2);
   });
 
   it('acknowledges an event type it does not handle without queueing work', async () => {


### PR DESCRIPTION
Test-only. No production code changes.

Mention's `crowdSourceWebhook.test.ts` already carried the full refusal bracket — tamper → 401, wrong secret → 401, stale timestamp → 401, previous secret accepted, unmounted-without-a-secret → 404, each with a side-effect assertion that `events` and `outbox` stayed empty. That is deliberately left as it was. Two narrower things it could not see are closed here.

## 1. The 401s asserted no reason

`WEBHOOK_REJECTIONS` in `@oxyhq/crowdsource-express` holds eleven tokens and **every one of them answers 401**, so `expect(response.status).toBe(401)` plus `{ received: false }` was satisfied by a `missing_event_id` exactly as well as by a signature that failed to verify. It survived deleting the signature comparison.

The three refusal tests now assert the specific token, and the values are **read off `verify.ts`, not guessed**:

- tampered body → `signature_mismatch`
- forged secret → `signature_mismatch`
- stale delivery → `timestamp_out_of_window` (refused earlier, at the window check, before any HMAC is computed)

The token already travels in the response body (`{ received: false, rejection }`), so no spy was needed.

## 2. The pass-through was untested — the subtle one

`crowdSourceWebhook.routes.ts:72-75` passes `secret` and `previousSecret` explicitly, and Mention is correct today. But the SDK's `configuredSecrets` is `options.secret ?? process.env[WEBHOOK_SECRET_ENV_VAR]`, evaluated **per request**, and every test in this file sets those variables through `vi.stubEnv`. So **deleting Mention's pass-through entirely left every existing test green** — the SDK's env fallback quietly covered for it. They confirmed signatures are verified; none of them confirmed Mention is why.

*A test can confirm a property holds without confirming that your code is why.* From outside, those two are indistinguishable, and the second is the half a consumer owns.

The new test uses an ordering asymmetry, **checked in Mention's config rather than assumed**: `config/index.ts` builds `environment` from one `parseRuntimeEnvironment(process.env)` at module load, so the router captured both secrets when `buildApp()` imported it, while the SDK re-reads the environment on every request. Clearing the variables after the app is built therefore leaves standing only a value Mention captured and passed explicitly — with the pass-through gone, the SDK sees no secret at all and refuses `no_secret_configured`. Active and rotation secrets are asserted separately because they are passed separately.

This is not tidiness. `config` is where the secret is length-validated (`optionalString(16)`), so a deployment leaning on the SDK's raw env read would silently accept a secret this app rejects at boot.

## Mutation proof

**A — delete Mention's pass-through.** Three variants, each `tsc --noEmit` clean (the `const secret` at the top stays, the not-mounted guard reads it):

| variant | result |
| --- | --- |
| both dropped | `Tests 1 failed \| 9 passed (10)` — `expected 401 to be 200` at the active-secret assertion |
| `secret` only | `Tests 1 failed \| 9 passed (10)` — same assertion, line 265 |
| `previousSecret` only | `Tests 1 failed \| 9 passed (10)` — `expected 401 to be 200` at line 274, the rotation assertion |

Both halves hold: the new test goes red, and all nine pre-existing tests stay green under every variant. The third variant is what earns the separate rotation assertion — a receiver that forwards only the active secret drops every delivery still signed with the old one, which is the loss §10.8's overlap exists to prevent.

**B — a plausible-but-wrong token.** `signature_mismatch` → `invalid_signature` (the exact wrong guess made elsewhere today) and `timestamp_out_of_window` → `timestamp_expired`. `Tests 3 failed | 7 passed (10)`, each naming the real token against the wrong one:

```
-   "rejection": "invalid_signature",
+   "rejection": "signature_mismatch",
```
```
-   "rejection": "timestamp_expired",
+   "rejection": "timestamp_out_of_window",
```

So the assertions are specific rather than incidentally true.

Restores were in place (`cat pristine > target`, never `mv`), inside a trap whose first line is `trap - EXIT INT TERM`, verified afterwards with `git diff --stat`.

## Suite

`cd packages/backend && bun run test`: **336 files, 3361 tests, all passing** (3360 before). Coverage gate green — statements 63.64%, branches 56.87%, functions 68.73%, lines 64.92%. `tsc --noEmit` clean.