### PR TITLE
docs(engagement): record what the outage cost, not what it could have

### DIFF
--- a/packages/backend/src/__tests__/services/engagementOutboxWrites.test.ts
+++ b/packages/backend/src/__tests__/services/engagementOutboxWrites.test.ts
@@ -31,10 +31,31 @@ const { savePostCommand, votePostCommand } = await import(
  * `createdAt`/`updatedAt` in `$setOnInsert` against schemas declaring
  * `{ timestamps: true }`, so Mongoose added the same paths and Mongo refused the
  * whole update — `Updating the path 'updatedAt' would create a conflict at
- * 'updatedAt'`. Inside `inIdempotentTransaction` that abort took the command with
- * it, so every like, downvote, save and unsave failed. It shipped in `ce333c92`
- * and the suite stayed green throughout, because a mocked `updateOne` accepts any
+ * 'updatedAt'`, `code: 40` `ConflictingUpdateOperators`. Inside
+ * `inIdempotentTransaction` that abort took the command with it, so every like,
+ * downvote, save and unsave was CAPABLE of failing. It shipped in `ce333c92` and
+ * the suite stayed green throughout, because a mocked `updateOne` accepts any
  * update document at all.
+ *
+ * ## What production actually observed, which is narrower
+ *
+ * The code was live from 2026-07-26T20:15Z (task definition `oxy-mention:20`)
+ * until the fix four days later. In that window `POST /posts/:id/like` was called
+ * 33 times — 21 on 07-28, 12 on 07-29 — and returned 500 every time. Not a
+ * sample: 33 of 33, with no other status code for that route on any day. The
+ * other three days saw zero attempts, which is the whole reason the failures
+ * cluster on two days rather than five.
+ *
+ * `POST /posts/:id/save` was called ZERO times in that window. The bookmark half
+ * was equally broken and simply never exercised, so it is recorded here as never
+ * tried rather than never broken — the distinction matters to anyone reading this
+ * later for what the outage cost.
+ *
+ * The failure is deterministic and NOT retryable: `code: 40` rejects the update
+ * document before touching a row, so a retry resends the identical document for
+ * the identical rejection. Do not confuse it with `code: 112` `WriteConflict` /
+ * `TransientTransactionError`, which is what the WRONG fix causes under
+ * concurrency (see the last test in this file) and which never shipped.
  *
  * ## Why a replica set, unlike the moderation file
  *


### PR DESCRIPTION
#520's title — `likes and saves have been failing since ce333c92` — is accurate about the code and overstates the observation. An incident write-up will be built from it, and as it stands it sends someone looking for save failures that were never observed.

**What the code did:** every like, downvote, save and unsave was *capable* of failing, from 2026-07-26T20:15Z (task definition `oxy-mention:20`) until the fix four days later.

**What production observed**, from route-level logs rather than a message substring (5,244,880 records scanned):

```
POST /posts/:id/like   2026-07-28   status=500   n=21
POST /posts/:id/like   2026-07-29   status=500   n=12
```

33 of 33 — no other status code for that route on any day. The other three days saw **zero attempts**, which is the entire reason the failures cluster on two days rather than five. Low volume was low traffic, not a conditional path.

**`POST /posts/:id/save` was called zero times.** The bookmark half was equally broken and never exercised, so it is now recorded as never *tried* rather than never broken.

## The error code, pinned

Two were in play and only one shipped:

- **`code: 40` `ConflictingUpdateOperators`** — the defect. Deterministic, rejected before a row is touched, **not retryable**: a retry resends the identical document for the identical rejection.
- **`code: 112` `WriteConflict` / `TransientTransactionError`** — what the *wrong* fix causes under concurrency. Never shipped; only ever produced by mutating the fix in the last test in this file.

A retry-absorption story was briefly offered to explain the volume of 33. It belongs to the variant nobody deployed, and 33-of-33 leaves nothing for it to explain.

The correction lands in the file's own doc comment because that is where the wrong claim lives — a confident paragraph above code is the artefact nothing executes, which is the same reason this class of bug survived a green suite.

Comment-only; no production or test behaviour changes. File still 5/5 green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)