### PR TITLE
fix(drafts): restored threads lost their reply/sensitivity settings — plus removing every `any`

### DIFF
--- a/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
+++ b/packages/backend/src/connectors/activitypub/ActivityPubConnector.ts
@@ -200,7 +200,7 @@ class ActivityPubConnector implements NetworkConnector<PostContent> {
   /** Process an inbound, already-verified ActivityPub activity. */
   async receive(payload: unknown, ctx: ReceiveContext): Promise<void> {
     await inboxProcessingService.processInboxActivity(
-      payload as Record<string, any>,
+      payload as Record<string, unknown>,
       ctx.verifiedActorUri,
     );
   }
@@ -432,7 +432,7 @@ class ActivityPubConnector implements NetworkConnector<PostContent> {
   // ============================================================
 
   processInboxActivity(
-    activity: Record<string, any>,
+    activity: Record<string, unknown>,
     verifiedActorUri: string,
   ): Promise<void> {
     return inboxProcessingService.processInboxActivity(activity, verifiedActorUri);

--- a/packages/backend/src/connectors/activitypub/apSchemas.ts
+++ b/packages/backend/src/connectors/activitypub/apSchemas.ts
@@ -80,9 +80,9 @@ export const apPublished = z
 export const apType = z.union([z.string(), z.array(z.string())]);
 
 /** The primary `type` string from an `apType` value (first entry of an array). */
-export function primaryApType(type: string | string[] | undefined): string | undefined {
+export function primaryApType(type: unknown): string | undefined {
   if (typeof type === 'string') return type;
-  if (Array.isArray(type)) return type[0];
+  if (Array.isArray(type)) return typeof type[0] === 'string' ? type[0] : undefined;
   return undefined;
 }
 

--- a/packages/backend/src/connectors/activitypub/constants.ts
+++ b/packages/backend/src/connectors/activitypub/constants.ts
@@ -1,4 +1,4 @@
-import { registrableApex } from '@oxyhq/core';
+import { registrableApex, type User } from '@oxyhq/core';
 import { createDomainPolicy, createUrlBuilders } from '@oxyhq/federation';
 import { config } from '../../config';
 import { logger } from '../../utils/logger';
@@ -112,7 +112,7 @@ export const USER_AGENT = `Mention/${FEDERATION_DOMAIN} (ActivityPub)`;
  * Resolve an Oxy user by username (tries getUserByUsername, falls back to searchUsers).
  * Returns the user object or null.
  */
-export async function resolveOxyUser(username: string): Promise<any> {
+export async function resolveOxyUser(username: string): Promise<User | null> {
   // Service-authed Oxy client — the process-wide request-auth client is
   // unauthenticated and reserved for validating incoming request tokens
   // (`oxy.auth()`), so resolving a profile on it returns nothing.

--- a/packages/backend/src/connectors/activitypub/helpers.ts
+++ b/packages/backend/src/connectors/activitypub/helpers.ts
@@ -46,13 +46,13 @@ function activityPubJsonContentType(raw: string | null): boolean {
     || (family.startsWith('application/') && family.endsWith('+json'));
 }
 
-export function asRecord(value: unknown): Record<string, any> | null {
+export function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
-    ? value as Record<string, any>
+    ? value as Record<string, unknown>
     : null;
 }
 
-export function activityPubItems(value: Record<string, any>): unknown[] {
+export function activityPubItems(value: Record<string, unknown>): unknown[] {
   if (Array.isArray(value.orderedItems)) return value.orderedItems;
   if (Array.isArray(value.items)) return value.items;
   return [];
@@ -328,7 +328,7 @@ function isPubliclyAddressed(to?: unknown, cc?: unknown): boolean {
 }
 
 export interface FetchedAnnouncedNote {
-  note: Record<string, any>;
+  note: Record<string, unknown>;
   finalUrl: string;
 }
 
@@ -379,9 +379,9 @@ export async function fetchVerifiedAnnouncedNote(objectUri: string): Promise<Fet
       return null;
     }
 
-    let note: Record<string, any>;
+    let note: Record<string, unknown>;
     try {
-      note = await res.json() as Record<string, any>;
+      note = await res.json() as Record<string, unknown>;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.info('[FedSync] failed to parse boosted object', {
@@ -419,7 +419,7 @@ export async function fetchVerifiedAnnouncedNote(objectUri: string): Promise<Fet
  * Fetch and parse a remote ActivityPub object via `signedFetch`. Returns null
  * on any HTTP/parse failure.
  */
-export async function fetchActivityPubObject(url: string): Promise<Record<string, any> | null> {
+export async function fetchActivityPubObject(url: string): Promise<Record<string, unknown> | null> {
   try {
     const res = await signedFetch(url, AP_CONTENT_TYPE);
     if (!res.ok) {
@@ -576,7 +576,7 @@ export function extractApQuoteUri(object: Record<string, unknown>): string | und
  * attachment shapes (Mastodon string `url`, Pleroma `Link` object, PeerTube/Lemmy
  * array of `Link` objects) and picks the most broadly-playable video variant.
  */
-export function extractApMedia(note: Record<string, any>): {
+export function extractApMedia(note: Record<string, unknown>): {
   media: MediaItem[];
   attachments: Array<{ type: 'media'; id: string; mediaType: ApMediaType }>;
 } {
@@ -591,7 +591,7 @@ export function extractApMedia(note: Record<string, any>): {
  * `HashtagFeed`, and the trending aggregations. Entries that are empty after
  * stripping the leading `#` are skipped.
  */
-export function extractApHashtags(note: Record<string, any>): string[] {
+export function extractApHashtags(note: Record<string, unknown>): string[] {
   const hashtags: string[] = [];
   if (!Array.isArray(note.tag)) return hashtags;
 
@@ -609,12 +609,13 @@ export function extractApHashtags(note: Record<string, any>): string[] {
 /**
  * Map ActivityPub to/cc addressing to Mention visibility.
  */
-export function mapApVisibility(to?: string[], cc?: string[]): PostVisibility {
-  const allAddressees = [...(to || []), ...(cc || [])];
-  if (allAddressees.includes('https://www.w3.org/ns/activitystreams#Public')) {
-    return PostVisibility.PUBLIC;
-  }
-  return PostVisibility.FOLLOWERS_ONLY;
+/**
+ * `to`/`cc` come straight off remote JSON-LD, so they are `unknown` until the
+ * addressee check narrows them — the same narrowing {@link isPubliclyAddressed}
+ * already performs.
+ */
+export function mapApVisibility(to?: unknown, cc?: unknown): PostVisibility {
+  return isPubliclyAddressed(to, cc) ? PostVisibility.PUBLIC : PostVisibility.FOLLOWERS_ONLY;
 }
 
 /**

--- a/packages/backend/src/connectors/activitypub/inbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/inbox.service.ts
@@ -20,6 +20,7 @@ import { outboxSyncService } from './outbox.service';
 import { deliveryService } from './delivery.service';
 import { getServiceOxyClient } from '../../utils/oxyHelpers';
 import {
+  asRecord,
   extractAnnouncedObjectUri,
   extractApQuoteUri,
   extractInReplyToUri,
@@ -75,7 +76,7 @@ export class InboxProcessingService {
    * engine dispatcher. Kept as an instance method so the BullMQ worker + the
    * connector facade keep calling `inboxProcessingService.processInboxActivity`.
    */
-  processInboxActivity(activity: Record<string, any>, verifiedActorUri: string): Promise<void> {
+  processInboxActivity(activity: Record<string, unknown>, verifiedActorUri: string): Promise<void> {
     return inboundDispatcher.processInboxActivity(activity, verifiedActorUri);
   }
 
@@ -86,7 +87,7 @@ export class InboxProcessingService {
    * the primary type and routes to the matching content handler, so the handlers'
    * side effects stay byte-for-byte identical to the prior single-dispatch path.
    */
-  async onContentActivity(activity: Record<string, any>, verifiedActorUri: string): Promise<void> {
+  async onContentActivity(activity: Record<string, unknown>, verifiedActorUri: string): Promise<void> {
     const type = primaryApType(activity.type);
     switch (type) {
       case 'Create':
@@ -119,12 +120,14 @@ export class InboxProcessingService {
    * `Post`. Both are ungated (an Undo is teardown, not new engagement) — see the
    * handler doc comments.
    */
-  private async handleUndoContent(object: any, actorUri: string): Promise<void> {
-    const objectType = typeof object === 'string' ? null : object?.type;
+  private async handleUndoContent(object: unknown, actorUri: string): Promise<void> {
+    const undone = asRecord(object);
+    if (!undone) return;
+    const objectType = undone.type;
     if (objectType === 'Like') {
-      await this.handleUndoLike(object, actorUri);
+      await this.handleUndoLike(undone, actorUri);
     } else if (objectType === 'Announce') {
-      await this.handleUndoAnnounce(object, actorUri);
+      await this.handleUndoAnnounce(undone, actorUri);
     }
   }
 
@@ -267,8 +270,10 @@ export class InboxProcessingService {
    * permanently orphaned. Mirrors the pre-existing `handleUndo(Follow)`
    * branch above, which is likewise ungated.
    */
-  private async handleUndoLike(likeObject: Record<string, any>, actorUri: string): Promise<void> {
-    const likedObjectId = typeof likeObject.object === 'string' ? likeObject.object : likeObject.object?.id;
+  private async handleUndoLike(likeObject: Record<string, unknown>, actorUri: string): Promise<void> {
+    const likedObjectId = typeof likeObject.object === 'string'
+      ? likeObject.object
+      : asRecord(likeObject.object)?.id;
     if (!likedObjectId || typeof likedObjectId !== 'string') return;
 
     const postId = await resolvePostIdFromObjectUri(likedObjectId);
@@ -299,7 +304,7 @@ export class InboxProcessingService {
    * permanently orphan the boost Post and its counter contribution. Mirrors
    * the pre-existing, likewise-ungated `handleUndo(Follow)` branch.
    */
-  private async handleUndoAnnounce(announceObject: Record<string, any>, actorUri: string): Promise<void> {
+  private async handleUndoAnnounce(announceObject: Record<string, unknown>, actorUri: string): Promise<void> {
     const announceId = typeof announceObject.id === 'string' ? announceObject.id : undefined;
     const announcedUri = extractAnnouncedObjectUri(announceObject.object);
 
@@ -380,7 +385,7 @@ export class InboxProcessingService {
    * a local poll), leaving {@link handleCreate} to process it as a normal
    * reply/post. Fail-soft is inherited from the shared helpers; nothing throws.
    */
-  private async handlePollVote(object: Record<string, any>, actorUri: string): Promise<boolean> {
+  private async handlePollVote(object: Record<string, unknown>, actorUri: string): Promise<boolean> {
     // Shape gate — cheap checks first, no DB until the shape is a plausible vote.
     const name = typeof object.name === 'string' ? object.name.trim() : '';
     if (!name) return false;
@@ -424,9 +429,9 @@ export class InboxProcessingService {
     return true;
   }
 
-  private async handleCreate(activity: Record<string, any>, actorUri: string): Promise<void> {
-    const object = activity.object;
-    if (!object || typeof object !== 'object') return;
+  private async handleCreate(activity: Record<string, unknown>, actorUri: string): Promise<void> {
+    const object = asRecord(activity.object);
+    if (!object) return;
     if (object.type !== 'Note' && object.type !== 'Article') return;
 
     // Validate the embedded content object before reading its fields by raw
@@ -443,6 +448,11 @@ export class InboxProcessingService {
       );
       return;
     }
+    // The validated view of the same object. Only the fields the schema passes
+    // through untouched are read from here (`id`, `content`, `url`); everything
+    // else stays on the raw record, whose `published` the schema would have
+    // coerced from its ISO string to a `Date`.
+    const note = parsedNote.data;
 
     // A remote poll VOTE arrives as a Create(Note) — chosen option in `name`,
     // `inReplyTo` = our poll's Question id, no content — and must be recorded
@@ -460,14 +470,14 @@ export class InboxProcessingService {
     if (!hasFollower) return;
 
     // Sanitize and check content length
-    const rawContent = object.content || '';
+    const rawContent = note.content || '';
     if (rawContent.length > FEDERATION_MAX_CONTENT_LENGTH) {
       logger.debug('[Federation] rejected oversized content');
       return;
     }
 
     // Dedup by activityId
-    const existingPost = await Post.exists({ 'federation.activityId': object.id });
+    const existingPost = await Post.exists({ 'federation.activityId': note.id });
     if (existingPost) return;
 
     // The Oxy link is MANDATORY: a federated post must carry a real Oxy author,
@@ -478,7 +488,7 @@ export class InboxProcessingService {
     // (Oxy reachable) the actor resolves and the post inserts with a real author.
     // We NEVER insert an orphan post with a null author.
     const actor = await actorService.getOrFetchActor(actorUri);
-    const authorOxyUserId = requireActorOxyUserId(actor, actorUri, `Create ${object.id}`);
+    const authorOxyUserId = requireActorOxyUserId(actor, actorUri, `Create ${note.id}`);
 
     // Resolve the Note's @mentions BEFORE building the body: each `Mention` tag's
     // actor URI is resolved (and synced/created) to a federated or local Oxy user
@@ -496,7 +506,7 @@ export class InboxProcessingService {
     // storable (no text, no surviving media, no content-warning) is dropped
     // instead of persisted as a blank post.
     const built = await buildFederatedNoteContent(noteObject, authorOxyUserId, {
-      activityId: object.id,
+      activityId: note.id,
       actorUri,
     });
     if (built.skip) {
@@ -548,10 +558,10 @@ export class InboxProcessingService {
     const createdPost = await getPostCreator().create({
       oxyUserId: authorOxyUserId,
       federation: {
-        activityId: object.id,
+        activityId: note.id,
         actorUri,
         inReplyTo: inReplyToUri,
-        url: object.url || object.id,
+        url: typeof note.url === 'string' ? note.url : note.id,
         sensitive,
         spoilerText: summary,
       },
@@ -623,9 +633,11 @@ export class InboxProcessingService {
     logger.debug('[Federation] stored federated post');
   }
 
-  private async handleDelete(activity: Record<string, any>, actorUri: string): Promise<void> {
-    const objectId = typeof activity.object === 'string' ? activity.object : activity.object?.id;
-    if (!objectId) return;
+  private async handleDelete(activity: Record<string, unknown>, actorUri: string): Promise<void> {
+    const objectId = typeof activity.object === 'string'
+      ? activity.object
+      : asRecord(activity.object)?.id;
+    if (!objectId || typeof objectId !== 'string') return;
 
     // The object id is public and remote-controlled. Authorize directly against
     // the actor URI stamped when the post was ingested, using the actor whose
@@ -654,8 +666,10 @@ export class InboxProcessingService {
    * idempotent). Skips entirely when the post or the federated user can't be
    * resolved, so the count only ever reflects real, listable likers.
    */
-  private async handleLike(activity: Record<string, any>, actorUri: string): Promise<void> {
-    const objectId = typeof activity.object === 'string' ? activity.object : activity.object?.id;
+  private async handleLike(activity: Record<string, unknown>, actorUri: string): Promise<void> {
+    const objectId = typeof activity.object === 'string'
+      ? activity.object
+      : asRecord(activity.object)?.id;
     if (!objectId || typeof objectId !== 'string') return;
 
     const postId = await resolvePostIdFromObjectUri(objectId);
@@ -698,7 +712,7 @@ export class InboxProcessingService {
    * creating a boost Post for a non-followed booster populates the boost list and
    * count without flooding anyone's feed.
    */
-  private async handleAnnounce(activity: Record<string, any>, actorUri: string): Promise<void> {
+  private async handleAnnounce(activity: Record<string, unknown>, actorUri: string): Promise<void> {
     const announcedUri = extractAnnouncedObjectUri(activity.object);
     if (!announcedUri) return;
 
@@ -745,9 +759,9 @@ export class InboxProcessingService {
     }
   }
 
-  private async handleUpdate(activity: Record<string, any>, actorUri: string): Promise<void> {
-    const object = activity.object;
-    if (!object || typeof object !== 'object') return;
+  private async handleUpdate(activity: Record<string, unknown>, actorUri: string): Promise<void> {
+    const object = asRecord(activity.object);
+    if (!object) return;
 
     if (object.type === 'Note' || object.type === 'Article') {
       // Validate the edited content object before reading its fields by raw

--- a/packages/backend/src/connectors/activitypub/outbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/outbox.service.ts
@@ -112,8 +112,8 @@ const MAX_ANCESTOR_DEPTH = 30;
  * of another actor's object.
  */
 type OutboxCandidate =
-  | { kind: 'note'; note: Record<string, any>; activity: Record<string, any>; activityId: string }
-  | { kind: 'announce'; activity: Record<string, any>; activityId: string; announcedUri: string };
+  | { kind: 'note'; note: Record<string, unknown>; activity: Record<string, unknown>; activityId: string }
+  | { kind: 'announce'; activity: Record<string, unknown>; activityId: string; announcedUri: string };
 
 /**
  * Typed reason describing why an outbox sync produced no posts (or only a
@@ -410,7 +410,7 @@ export class OutboxSyncService {
       }
       // Keep reading raw fields below so every existing field access (including
       // `.loose()` passthrough extensions) behaves identically to before.
-      const collection = rawCollection as Record<string, any>;
+      const collection = rawCollection as Record<string, unknown>;
       logger.debug('[FedSync] parsed outbox collection', {
         type: collection.type,
         totalItems: collection.totalItems,
@@ -435,7 +435,7 @@ export class OutboxSyncService {
       const visitedPageUrls = new Set<string>();
 
       const processPage = async (
-        pageData: Record<string, any>,
+        pageData: Record<string, unknown>,
         pageUrl: string,
         startItemOffset: number,
       ): Promise<void> => {
@@ -509,7 +509,7 @@ export class OutboxSyncService {
             return;
           }
           // Keep reading raw fields so every existing access is unchanged.
-          const pageData = rawPage as Record<string, any>;
+          const pageData = rawPage as Record<string, unknown>;
           await processPage(pageData, pageUrl, startItemOffset);
         } catch (pageErr) {
           logger.debug('[FedSync] outbox pagination error', {
@@ -741,7 +741,7 @@ export class OutboxSyncService {
       for (const { note, activity, activityId } of noteCandidates) {
         if (existingIds.has(activityId)) continue;
 
-        const rawContent = note.content || '';
+        const rawContent = typeof note.content === 'string' ? note.content : '';
         if (rawContent.length > FEDERATION_MAX_CONTENT_LENGTH) continue;
 
         // Normalize the AP `inReplyTo` (string IRI or embedded Link object) to a
@@ -1180,7 +1180,7 @@ export class OutboxSyncService {
       // Raw `===` on `type` preserves the prior behavior exactly (array-typed
       // `type` values were already not matched here).
       if (activity.type === 'Announce') {
-        const activityId = activity.id;
+        const activityId = typeof activity.id === 'string' ? activity.id : '';
         const announcedUri = extractAnnouncedObjectUri(activity.object);
         if (!activityId || !announcedUri) continue;
         if (!actorUrisMatch(extractActorUri(activity.actor), expectedActorUri)) continue;
@@ -1208,7 +1208,8 @@ export class OutboxSyncService {
       // `activityIdBelongsToActor` guards below still ensure only the actor's own
       // notes become candidates.
 
-      const activityId = note.id || activity.id;
+      const noteId = typeof note.id === 'string' ? note.id : '';
+      const activityId = noteId || (typeof activity.id === 'string' ? activity.id : '');
       if (!activityId) continue;
 
       const attributedTo = extractActorUri(note.attributedTo);
@@ -1222,7 +1223,7 @@ export class OutboxSyncService {
     return maxIndexExclusive;
   }
 
-  private async resolveOutboxActivity(item: unknown, sourcePageUrl: string): Promise<Record<string, any> | null> {
+  private async resolveOutboxActivity(item: unknown, sourcePageUrl: string): Promise<Record<string, unknown> | null> {
     const inlineActivity = asRecord(item);
     if (inlineActivity) return inlineActivity;
 
@@ -1230,7 +1231,7 @@ export class OutboxSyncService {
     return fetchActivityPubObject(item);
   }
 
-  private async extractOutboxNote(activity: Record<string, any>, sourcePageUrl: string): Promise<Record<string, any> | null> {
+  private async extractOutboxNote(activity: Record<string, unknown>, sourcePageUrl: string): Promise<Record<string, unknown> | null> {
     if (activity.type === 'Note' || activity.type === 'Article') return activity;
     if (activity.type !== 'Create') return null;
 
@@ -1260,7 +1261,7 @@ export class OutboxSyncService {
    * @returns true when a new boost Post was created.
    */
   async importAnnounce(
-    announceActivity: Record<string, any>,
+    announceActivity: Record<string, unknown>,
     announcedUri: string,
     boosterOxyUserId: string | null,
   ): Promise<boolean> {

--- a/packages/backend/src/middleware/validate.ts
+++ b/packages/backend/src/middleware/validate.ts
@@ -63,28 +63,80 @@ export function validateObjectId(paramName: string = 'id') {
   };
 }
 
+/** A `MediaItem` as a client submits it: the id and kind, plus optional metadata. */
+const mediaItemSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(['image', 'video', 'gif']),
+  alt: z.string().optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  durationSec: z.number().optional(),
+  sizeBytes: z.number().optional(),
+  mime: z.string().optional(),
+});
+
+/** A `GeoJSONPoint` — `[longitude, latitude]`, optionally with a readable address. */
+const locationSchema = z.object({
+  type: z.literal('Point'),
+  coordinates: z.tuple([z.number(), z.number()]),
+  address: z.string().optional(),
+});
+
+/** A `PostSourceLink` cited within the post body. */
+const sourceLinkSchema = z.object({
+  url: z.string().min(1),
+  title: z.string().optional(),
+});
+
+/** A `PostArticleContent` — long-form body attached to the post. */
+const articleSchema = z.object({
+  articleId: z.string().optional(),
+  title: z.string().optional(),
+  body: z.string().optional(),
+  excerpt: z.string().optional(),
+});
+
+/** A `PostEventContent` — name and ISO date are the only required parts. */
+const eventSchema = z.object({
+  eventId: z.string().optional(),
+  name: z.string().min(1),
+  date: z.string().min(1),
+  location: z.string().optional(),
+  description: z.string().optional(),
+});
+
+/** A `PostAttachmentDescriptor` — the render order of the post's attachments. */
+const attachmentSchema = z.object({
+  type: z.enum(['media', 'poll', 'article', 'location', 'sources', 'event', 'room', 'podcast']),
+  id: z.string().optional(),
+  mediaType: z.enum(['image', 'video', 'gif']).optional(),
+});
+
+/** The `PostContentInput` a client submits, for a top-level post or a reply. */
+const postContentSchema = z.object({
+  text: z.string().max(5000).default(''),
+  media: z.array(mediaItemSchema).max(10).optional(),
+  poll: z.object({
+    question: z.string().min(1).max(280),
+    options: z.array(z.string().min(1).max(100)).min(2).max(4),
+    endTime: z.string().optional(),
+    isMultipleChoice: z.boolean().optional(),
+    isAnonymous: z.boolean().optional(),
+  }).optional(),
+  location: locationSchema.optional(),
+  sources: z.array(sourceLinkSchema).max(5).optional(),
+  article: articleSchema.optional(),
+  event: eventSchema.optional(),
+  attachments: z.array(attachmentSchema).optional(),
+});
+
 /**
  * Common validation schemas for reuse across routes.
  */
 export const schemas = {
   /** Post creation request body */
   createPost: z.object({
-    content: z.object({
-      text: z.string().max(5000).default(''),
-      media: z.array(z.any()).max(10).optional(),
-      poll: z.object({
-        question: z.string().min(1).max(280),
-        options: z.array(z.string().min(1).max(100)).min(2).max(4),
-        endTime: z.string().optional(),
-        isMultipleChoice: z.boolean().optional(),
-        isAnonymous: z.boolean().optional(),
-      }).optional(),
-      location: z.any().optional(),
-      sources: z.array(z.any()).max(5).optional(),
-      article: z.any().optional(),
-      event: z.any().optional(),
-      attachments: z.array(z.any()).optional(),
-    }).optional().default({ text: '' }),
+    content: postContentSchema.optional().default({ text: '' }),
     hashtags: z.array(z.string()).optional(),
     mentions: z.array(z.string()).optional(),
     visibility: z.enum(['public', 'private', 'followers_only']).optional().default('public'),
@@ -106,7 +158,7 @@ export const schemas = {
   /** Reply creation request body */
   createReply: z.object({
     postId: z.string().min(1),
-    content: z.any(),
+    content: postContentSchema.optional().default({ text: '' }),
     mentions: z.array(z.string()).optional(),
     hashtags: z.array(z.string()).optional(),
   }),

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -98,7 +98,10 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
     const oxyUserId = getAuthenticatedUserId(req);
     const { appearance, profileHeaderImage, privacy, profileCustomization, profileMedia, interests, feedSettings, notificationPreferences, externalEmbeds, fediversePreferredLanguage } = req.body || {};
 
-    const update: Record<string, any> = {};
+    // Dot-notation leaf paths mapped to the value Mongo should store. The values
+    // are deliberately heterogeneous (scalars, arrays, sub-documents) and are only
+    // ever handed to `$set`, never read back here.
+    const update: Record<string, unknown> = {};
     const unset: Record<string, ''> = {};
     // The Oxy file id newly set as the profile banner (if any). Captured here so
     // we can promote it to public AFTER the settings persist — profile banners
@@ -381,7 +384,7 @@ router.put('/settings', async (req: AuthRequest, res: Response) => {
       }
     }
 
-    const operation: Record<string, Record<string, any>> = {};
+    const operation: { $set?: Record<string, unknown>; $unset?: Record<string, ''> } = {};
     if (Object.keys(update).length > 0) {
       operation.$set = update;
     }

--- a/packages/backend/src/utils/apiHelpers.ts
+++ b/packages/backend/src/utils/apiHelpers.ts
@@ -11,7 +11,7 @@ export interface ApiErrorResponse {
 /**
  * Standard API success response format
  */
-export interface ApiSuccessResponse<T = any> {
+export interface ApiSuccessResponse<T = unknown> {
   success?: boolean;
   message?: string;
   data?: T;

--- a/packages/backend/src/utils/apiResponse.ts
+++ b/packages/backend/src/utils/apiResponse.ts
@@ -4,7 +4,7 @@ import { Response } from 'express';
  * Standard API response format.
  * Ensures consistent response shape across all endpoints.
  */
-export interface ApiSuccessResponse<T = any> {
+export interface ApiSuccessResponse<T = unknown> {
   success: true;
   data: T;
   pagination?: PaginationMeta;
@@ -31,7 +31,7 @@ export interface ApiErrorResponse {
   };
 }
 
-export type ApiResponse<T = any> = ApiSuccessResponse<T> | ApiErrorResponse;
+export type ApiResponse<T = unknown> = ApiSuccessResponse<T> | ApiErrorResponse;
 
 /**
  * Send a success response with consistent format.

--- a/packages/frontend/app/(app)/[username]/connections.tsx
+++ b/packages/frontend/app/(app)/[username]/connections.tsx
@@ -159,27 +159,16 @@ function ConnectionsContent({
     isFederated: profileData?.isFederated,
   }) || cleanUsername;
 
-  // Determine active tab from pathname
-  const getActiveTab = useCallback((): TabType => {
-    if (pathname?.endsWith('/following')) return 'following';
-    if (pathname?.endsWith('/who-may-know')) return 'who-may-know';
-    if (pathname?.endsWith('/in-common')) return 'in-common';
-    return 'followers';
-  }, [pathname]);
-
-  const [activeTab, setActiveTab] = useState<TabType>(() => {
-    if (pathname?.endsWith('/following')) return 'following';
-    if (pathname?.endsWith('/who-may-know')) return 'who-may-know';
-    if (pathname?.endsWith('/in-common')) return 'in-common';
-    return 'followers';
-  });
-
-  useEffect(() => {
-    const newTab = getActiveTab();
-    if (newTab !== activeTab) {
-      setActiveTab(newTab);
-    }
-  }, [pathname, activeTab, getActiveTab]);
+  // The route IS the active tab — `handleTabPress` navigates, so there is
+  // nothing else that could select one. Derived rather than held in state, which
+  // is what made the old copy need an effect to chase the pathname.
+  const activeTab: TabType = pathname?.endsWith('/following')
+    ? 'following'
+    : pathname?.endsWith('/who-may-know')
+      ? 'who-may-know'
+      : pathname?.endsWith('/in-common')
+        ? 'in-common'
+        : 'followers';
 
   // Load followers
   const loadFollowers = useCallback(async () => {

--- a/packages/frontend/assets/images/images.d.ts
+++ b/packages/frontend/assets/images/images.d.ts
@@ -1,4 +1,8 @@
 declare module "@/assets/images/*" {
-  const value: any;
+  // Metro turns a bundled image into an asset reference, which is exactly what
+  // `ImageRequireSource` describes — a number on native, an object on web.
+  import type { ImageRequireSource } from "react-native";
+
+  const value: ImageRequireSource;
   export default value;
 }

--- a/packages/frontend/components/Compose/ComposeThreadItem.tsx
+++ b/packages/frontend/components/Compose/ComposeThreadItem.tsx
@@ -5,6 +5,9 @@ import {
   TouchableOpacity,
   ScrollView,
   Image,
+  type ImageStyle,
+  type TextStyle,
+  type ViewStyle,
 } from 'react-native';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types/post';
@@ -27,6 +30,49 @@ import type { MentionTextValue } from '@/utils/mentions';
 import { HIT_SLOP_SM } from '@/styles/hitSlop';
 
 import { HPAD, BOTTOM_LEFT_PAD, TIMELINE_LINE_OFFSET } from './composeLayout';
+
+/**
+ * The exact slice of the composer's stylesheet this row renders with. The
+ * composer owns the sheet, so spelling the contract out here is what makes a
+ * missing or renamed entry a compile error on the parent instead of a silently
+ * unstyled row.
+ */
+export interface ComposeThreadItemStyles {
+  threadItemWithTimeline: ViewStyle;
+  itemConnectorLineAbove: ViewStyle;
+  itemConnectorLine: ViewStyle;
+  timelineForeground: ViewStyle;
+  postContainer: ViewStyle;
+  unfocusedItem: ViewStyle;
+  headerRow: ViewStyle;
+  headerMeta: ViewStyle;
+  headerChildren: ViewStyle;
+  threadTextInput: TextStyle;
+  toolbarWrapper: ViewStyle;
+  removeThreadBtn: ViewStyle;
+  mediaPreviewContainer: ViewStyle;
+  mediaPreviewScroll: ViewStyle;
+  mediaPreviewItem: ViewStyle;
+  mediaPreviewImage: ImageStyle;
+  mediaReorderControls: ViewStyle;
+  mediaReorderButton: ViewStyle;
+  mediaReorderButtonDisabled: ViewStyle;
+  mediaRemoveButton: ViewStyle;
+  pollAttachmentWrapper: ViewStyle;
+  pollAttachmentCard: ViewStyle;
+  pollAttachmentHeader: ViewStyle;
+  pollAttachmentBadge: ViewStyle;
+  pollAttachmentBadgeText: TextStyle;
+  pollAttachmentMeta: TextStyle;
+  pollAttachmentQuestion: TextStyle;
+  pollAttachmentOptions: ViewStyle;
+  pollAttachmentOption: ViewStyle;
+  pollAttachmentOptionText: TextStyle;
+  pollAttachmentMore: TextStyle;
+  pollAttachmentRemoveButton: ViewStyle;
+  articleAttachmentWrapper: ViewStyle;
+  articleAttachmentPreview: ViewStyle;
+}
 
 interface ComposeThreadItemProps {
   item: ThreadItem;
@@ -65,7 +111,7 @@ interface ComposeThreadItemProps {
   getFileDownloadUrl: (id: string) => string;
   textInputRef: (threadId: string, el: MentionTextInputHandle | null) => void;
   // Styles from parent
-  styles: Record<string, any>;
+  styles: ComposeThreadItemStyles;
 }
 
 const ComposeThreadItem = memo<ComposeThreadItemProps>(({

--- a/packages/frontend/components/Compose/ScheduleSheet.tsx
+++ b/packages/frontend/components/Compose/ScheduleSheet.tsx
@@ -10,7 +10,7 @@ export type ScheduleOption = {
   date: Date;
 };
 
-interface ScheduleSheetProps {
+export interface ScheduleSheetProps {
   scheduledAt: Date | null;
   options: ScheduleOption[];
   onSelect: (date: Date) => void;

--- a/packages/frontend/components/Post/Attachments/ExternalEmbedPoster.tsx
+++ b/packages/frontend/components/Post/Attachments/ExternalEmbedPoster.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, View } from 'react-native';
 import { Image } from 'expo-image';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -26,10 +26,14 @@ export function ExternalEmbedPoster({ thumb, active, loading, onPressPlay }: Ext
   // A remote link-preview thumbnail can 404 or fail to load even through the
   // proxy — fall back to the plain dim scrim + play button rather than showing a
   // broken image. Reset the error state when the thumb URL changes.
+  // Reset during render rather than in an effect, so a new thumb never renders
+  // one committed frame of the previous one's failure.
   const [thumbErrored, setThumbErrored] = useState(false);
-  useEffect(() => {
+  const [erroredThumb, setErroredThumb] = useState(thumb);
+  if (erroredThumb !== thumb) {
+    setErroredThumb(thumb);
     setThumbErrored(false);
-  }, [thumb]);
+  }
 
   if (active && !loading) return null;
 

--- a/packages/frontend/components/Profile/ProfileGridList.types.ts
+++ b/packages/frontend/components/Profile/ProfileGridList.types.ts
@@ -1,5 +1,6 @@
 import type React from 'react';
 import type { FlatList, View } from 'react-native';
+import type { ScrollableRef } from '@/context/LayoutScrollContext';
 
 /** Minimal shape every profile-grid entry shares, used for keying + layout. */
 export interface ProfileGridEntry {
@@ -21,6 +22,6 @@ export interface ProfileGridListProps<T extends ProfileGridEntry> {
     emptyComponent?: React.ReactElement | null;
     contentContainerStyle?: React.ComponentProps<typeof View>['style'];
     onScroll?: React.ComponentProps<typeof FlatList<T>>['onScroll'];
-    scrollRef?: (node: unknown | null) => void;
+    scrollRef?: (node: ScrollableRef | null) => void;
     onEndReached?: () => void;
 }

--- a/packages/frontend/components/Profile/hooks/useProfileScroll.ts
+++ b/packages/frontend/components/Profile/hooks/useProfileScroll.ts
@@ -1,6 +1,12 @@
 import { useRef, useCallback, useEffect, useMemo } from 'react';
 import { Platform } from 'react-native';
-import { useLayoutScroll, extractOffsetY, type ScrollEvent } from '@/context/LayoutScrollContext';
+import {
+  useLayoutScroll,
+  extractOffsetY,
+  type ScrollableRef,
+  type ScrollableRefTarget,
+  type ScrollEvent,
+} from '@/context/LayoutScrollContext';
 import { usePostsStore } from '@/stores/postsStore';
 import { getFeedMeta } from '@/db/feedQueries';
 import type { FeedType } from '@mention/shared-types';
@@ -35,8 +41,9 @@ export function useProfileScroll({ profileId, currentTab }: UseProfileScrollOpti
     setScrollY,
   } = useLayoutScroll();
 
-  // Refs - using any for ScrollView ref due to Animated wrapper complexity
-  const scrollRef = useRef<any>(null);
+  // The active scroller: the profile ScrollView on non-feed tabs, the grid's
+  // FlashList on virtualized ones.
+  const scrollRef = useRef<ScrollableRef | null>(null);
   const loadingMoreRef = useRef(false);
   const unregisterRef = useRef<(() => void) | null>(null);
   const lastScrollCheckRef = useRef(0);
@@ -80,17 +87,18 @@ export function useProfileScroll({ profileId, currentTab }: UseProfileScrollOpti
   const lastProfileRef = useRef<string | undefined>(undefined);
 
   // Assign scroll ref with registration
-  const assignScrollRef = useCallback((node: any) => {
-    scrollRef.current = node;
+  const assignScrollRef = useCallback((node: ScrollableRefTarget | null) => {
+    const scroller = node && 'getNode' in node ? node.getNode() : node;
+    scrollRef.current = scroller;
     clearRegistration();
-    if (node && registerScrollable) {
+    if (scroller && registerScrollable) {
       // Only reset scroll position when navigating to a different profile,
       // not when switching tabs within the same profile
       if (lastProfileRef.current !== profileId) {
         setScrollY(0);
         lastProfileRef.current = profileId;
       }
-      unregisterRef.current = registerScrollable(node);
+      unregisterRef.current = registerScrollable(scroller);
     }
   }, [clearRegistration, registerScrollable, setScrollY, profileId]);
 

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -247,11 +247,3 @@ export interface UseSubscriptionReturn {
   loading: boolean;
   toggle: () => Promise<void>;
 }
-
-export interface UseProfileScrollReturn {
-  scrollY: any; // Animated.Value type from useLayoutScroll
-  scrollRef: React.RefObject<any>;
-  onScroll: any; // Animated scroll handler
-  assignScrollRef: (node: any) => void;
-  scrollToContent: (offset: number) => void;
-}

--- a/packages/frontend/components/ZoomableAvatar.tsx
+++ b/packages/frontend/components/ZoomableAvatar.tsx
@@ -68,6 +68,15 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
   const { oxyServices } = useAuth();
   const imageResolver = useImageResolver();
   const [errored, setErrored] = useState(false);
+  // A new source has not failed yet. Reset during render rather than in an
+  // effect, so `thumbUri` below never gets one committed frame of the previous
+  // source's failure — which showed the default avatar over a perfectly good
+  // new image.
+  const [erroredSource, setErroredSource] = useState(source);
+  if (erroredSource !== source) {
+    setErroredSource(source);
+    setErrored(false);
+  }
   const wrapperRef = useRef<View>(null);
   const galleryRef = useRef<ZoomableImageGalleryHandle>(null);
 
@@ -94,10 +103,6 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
     if (typeof source === 'string' && source.startsWith('http')) return source;
     return resolvedFull ?? thumbUri;
   }, [source, resolvedFull, thumbUri]);
-
-  React.useEffect(() => {
-    setErrored(false);
-  }, [source]);
 
   const imageSource = useMemo(() => {
     if (thumbUri) return { uri: thumbUri };

--- a/packages/frontend/components/common/VideoPosterCell.tsx
+++ b/packages/frontend/components/common/VideoPosterCell.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { View } from 'react-native';
 import { Image } from 'expo-image';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -59,10 +59,14 @@ const VideoPosterCell = React.memo<VideoPosterCellProps>(
       [size]
     );
     const [posterFailed, setPosterFailed] = useState(false);
-
-    useEffect(() => {
+    // A new poster has not failed yet. Reset during render rather than in an
+    // effect, so a new URI never renders one committed frame of the previous
+    // one's placeholder.
+    const [failedUri, setFailedUri] = useState(posterUri);
+    if (failedUri !== posterUri) {
+      setFailedUri(posterUri);
       setPosterFailed(false);
-    }, [posterUri]);
+    }
 
     const handlePosterError = useCallback(() => setPosterFailed(true), []);
 

--- a/packages/frontend/context/LayoutScrollContext.tsx
+++ b/packages/frontend/context/LayoutScrollContext.tsx
@@ -4,20 +4,39 @@ import { useSharedValue, type SharedValue } from 'react-native-reanimated';
 
 const IS_WEB = Platform.OS === 'web';
 
-export type ScrollEvent = {
-    nativeEvent?: {
-        contentOffset?: { x?: number; y?: number } | number;
-        target?: { scrollTop?: number };
-        [key: string]: any;
-    };
-    target?: { scrollTop?: number };
-    [key: string]: any;
+/**
+ * The scroll metrics every scroller reports, whichever platform produced them.
+ * Native delivers them under `nativeEvent`; react-native-web sometimes reports
+ * the offset as `scrollTop` on the target DOM node instead, and `target` is a
+ * numeric node handle rather than a node on native — hence the unions.
+ */
+type ScrollMetrics = {
+    contentOffset?: { x?: number; y?: number } | number;
+    contentSize?: { height?: number; width?: number };
+    layoutMeasurement?: { height?: number; width?: number };
+    target?: { scrollTop?: number } | number;
 };
 
-type ScrollableRef = {
+/**
+ * A scroll event as this app consumes it. The metrics are readable at the top
+ * level too, so a caller may hand over a bare `nativeEvent` payload.
+ */
+export type ScrollEvent = ScrollMetrics & {
+    nativeEvent?: ScrollMetrics;
+};
+
+/** Anything this app can drive to an offset — a FlashList, a ScrollView, a FlatList. */
+export type ScrollableRef = {
     scrollToOffset?: (params: { offset: number; animated?: boolean }) => void;
     scrollTo?: (params: { x?: number; y?: number; animated?: boolean }) => void;
 };
+
+/**
+ * What a ref callback is actually handed. `Animated.ScrollView` still types its
+ * ref as possibly the legacy `getNode()` wrapper, so a callback that registers a
+ * scroller has to unwrap before it gets a {@link ScrollableRef}.
+ */
+export type ScrollableRefTarget = ScrollableRef | { getNode(): ScrollableRef };
 
 type LayoutScrollContextValue = {
     scrollY: Animated.Value;
@@ -42,7 +61,7 @@ type LayoutScrollContextValue = {
      * Factory that returns an Animated.event handler bound to the shared scrollY.
      * Consumers can provide an optional listener to run side effects alongside the shared update.
      */
-    createAnimatedScrollHandler: (listener?: (event: ScrollEvent) => void) => (...args: any[]) => void;
+    createAnimatedScrollHandler: (listener?: (event: ScrollEvent) => void) => (event: ScrollEvent) => void;
     /**
      * Direct setter for components that need to programmatically adjust the global scroll position.
      */
@@ -80,7 +99,9 @@ export function extractOffsetY(event: ScrollEvent): number {
 
     // React Native Web sometimes keeps scrollTop on the target node instead.
     const target = nativeEvent.target ?? event?.target;
-    if (target && typeof target.scrollTop === 'number') return target.scrollTop;
+    if (typeof target === 'object' && target !== null && typeof target.scrollTop === 'number') {
+        return target.scrollTop;
+    }
 
     return 0;
 }
@@ -137,11 +158,11 @@ export function LayoutScrollProvider({
             let lastCallTime = 0;
             const THROTTLE_MS = 16; // ~60fps
             
-            return Animated.event(
+            return Animated.event<ScrollMetrics>(
                 [{ nativeEvent: { contentOffset: { y: scrollY } } }],
                 {
                     useNativeDriver: false, // Required for scroll position
-                    listener: (event: any) => {
+                    listener: (event) => {
                         const now = Date.now();
                         // Always update scrollY state (required for animations)
                         handleScroll(event);

--- a/packages/frontend/db/database.native.ts
+++ b/packages/frontend/db/database.native.ts
@@ -19,9 +19,9 @@ const DB_NAME = 'mention.db';
 /** Minimal database surface used by the cache layer. */
 export interface SQLiteDb {
   execSync(sql: string): void;
-  runSync(sql: string, ...params: any[]): { changes: number; lastInsertRowId: number };
-  getFirstSync<T>(sql: string, ...params: any[]): T | null;
-  getAllSync<T>(sql: string, ...params: any[]): T[];
+  runSync(sql: string, ...params: SQLite.SQLiteBindValue[]): { changes: number; lastInsertRowId: number };
+  getFirstSync<T>(sql: string, ...params: SQLite.SQLiteBindValue[]): T | null;
+  getAllSync<T>(sql: string, ...params: SQLite.SQLiteBindValue[]): T[];
   closeSync(): void;
 }
 

--- a/packages/frontend/db/database.web.ts
+++ b/packages/frontend/db/database.web.ts
@@ -5,14 +5,20 @@
  * in network-only mode so expo-sqlite/WASM and SharedArrayBuffer requirements
  * are excluded from its initial bundle.
  */
+// Type-only, so expo-sqlite stays out of the web bundle while both platform
+// contracts still describe the SAME bind-parameter surface — `database.ts`
+// re-exports this file for tsc, so a native call site is only ever checked
+// against what is written here.
+import type { SQLiteBindValue } from 'expo-sqlite';
+
 export interface SQLiteDb {
   execSync(sql: string): void;
   runSync(
     sql: string,
-    ...params: unknown[]
+    ...params: SQLiteBindValue[]
   ): { changes: number; lastInsertRowId: number };
-  getFirstSync<T>(sql: string, ...params: unknown[]): T | null;
-  getAllSync<T>(sql: string, ...params: unknown[]): T[];
+  getFirstSync<T>(sql: string, ...params: SQLiteBindValue[]): T | null;
+  getAllSync<T>(sql: string, ...params: SQLiteBindValue[]): T[];
   closeSync(): void;
 }
 

--- a/packages/frontend/db/feedQueries.ts
+++ b/packages/frontend/db/feedQueries.ts
@@ -23,6 +23,7 @@ import {
   memGetFeedKeysForPost,
   memClearFeed,
 } from './memoryStore';
+import type { FeedFilters } from '@/utils/feedUtils';
 import { createLogger } from '@oxyhq/core/logger';
 
 const logger = createLogger('FeedQueries');
@@ -41,7 +42,7 @@ export interface FeedMetaData {
   nextCursor?: string;
   totalCount: number;
   lastUpdated: number;
-  filters?: Record<string, any>;
+  filters?: FeedFilters;
 }
 
 // ── Write operations ─────────────────────────────────────────────

--- a/packages/frontend/db/postQueries.ts
+++ b/packages/frontend/db/postQueries.ts
@@ -300,7 +300,7 @@ export function updatePost(
       // undo, but a rollback that fails for any other reason is worth seeing.
       logger.debug('Rollback after a failed post update did not apply', { error: rollbackError });
     }
-    logger.error(`Failed to update post ${id} in place`, { error });
+    logger.error(`Failed to update post ${id} in place`, error);
     return null;
   }
 }

--- a/packages/frontend/db/postQueries.ts
+++ b/packages/frontend/db/postQueries.ts
@@ -292,8 +292,15 @@ export function updatePost(
     );
     db.execSync('COMMIT');
     return updated;
-  } catch {
-    try { db.execSync('ROLLBACK'); } catch {}
+  } catch (error) {
+    try {
+      db.execSync('ROLLBACK');
+    } catch (rollbackError) {
+      // The transaction was already closed (or never opened) — nothing left to
+      // undo, but a rollback that fails for any other reason is worth seeing.
+      logger.debug('Rollback after a failed post update did not apply', { error: rollbackError });
+    }
+    logger.error(`Failed to update post ${id} in place`, { error });
     return null;
   }
 }

--- a/packages/frontend/hooks/__tests__/useThreadManagerDraftRestore.test.tsx
+++ b/packages/frontend/hooks/__tests__/useThreadManagerDraftRestore.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { useThreadManager, type ThreadItem } from '../useThreadManager';
+
+/**
+ * A thread item restored from a draft must arrive COMPLETE.
+ *
+ * A draft persists only what the composer can rebuild from — it carries no
+ * sources, article, event, room, attachment order, or per-item interaction
+ * settings. `loadThreadsFromDraft` used to declare `ThreadItem[]` while being
+ * handed that narrower persisted shape and pass it straight to `setThreadItems`,
+ * so a restored item reached the composer with `replyPermission`, `isSensitive`,
+ * `quotesDisabled` and `reviewReplies` simply ABSENT.
+ *
+ * That silently discarded the author's own choices: a thread drafted with
+ * replies restricted, or flagged sensitive, came back unrestricted and unflagged
+ * and would have posted that way. These assertions pin the consent-bearing
+ * fields specifically, because that is the part whose loss is invisible.
+ */
+
+type ThreadManager = ReturnType<typeof useThreadManager>;
+let latest: ThreadManager | null = null;
+
+function Probe() {
+  latest = useThreadManager();
+  return null;
+}
+
+/** Exactly what a stored draft carries for one thread item — nothing more. */
+const persistedThreadItem = {
+  id: 'thread-1',
+  text: 'restored body',
+  mediaIds: [{ id: 'file-1', type: 'image' as const }],
+  pollOptions: ['a', 'b'],
+  pollTitle: 'poll?',
+  showPollCreator: true,
+  location: { latitude: 1, longitude: 2, address: 'somewhere' },
+  mentions: [],
+};
+
+describe('useThreadManager draft restore', () => {
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    latest = null;
+    act(() => {
+      TestRenderer.create(<Probe />);
+    });
+  });
+
+  it('gives a draft-restored item the same interaction defaults as a fresh one', () => {
+    act(() => {
+      latest!.addThread();
+    });
+    const fresh = latest!.threadItems[0];
+
+    act(() => {
+      latest!.loadThreadsFromDraft([persistedThreadItem]);
+    });
+    const restored = latest!.threadItems[0];
+
+    // The consent-bearing fields a draft never persisted. Absent before the fix.
+    expect(restored.replyPermission).toEqual(fresh.replyPermission);
+    expect(restored.isSensitive).toBe(fresh.isSensitive);
+    expect(restored.quotesDisabled).toBe(fresh.quotesDisabled);
+    expect(restored.reviewReplies).toBe(fresh.reviewReplies);
+  });
+
+  it('leaves no field of a restored item undefined', () => {
+    act(() => {
+      latest!.loadThreadsFromDraft([persistedThreadItem]);
+    });
+    const restored = latest!.threadItems[0];
+
+    // A vacuity floor: catches a future field added to `ThreadItem` that the
+    // restore path forgets, which is exactly how this bug arose.
+    const keys: (keyof ThreadItem)[] = [
+      'id', 'text', 'mediaIds', 'pollOptions', 'pollTitle', 'showPollCreator',
+      'location', 'mentions', 'sources', 'article', 'event', 'room',
+      'attachmentOrder', 'replyPermission', 'reviewReplies', 'quotesDisabled',
+      'isSensitive',
+    ];
+    for (const key of keys) {
+      expect(restored[key]).toBeDefined();
+    }
+  });
+
+  it('preserves what the draft DID persist', () => {
+    act(() => {
+      latest!.loadThreadsFromDraft([persistedThreadItem]);
+    });
+    const restored = latest!.threadItems[0];
+
+    expect(restored.id).toBe('thread-1');
+    expect(restored.text).toBe('restored body');
+    expect(restored.mediaIds).toEqual([{ id: 'file-1', type: 'image' }]);
+    expect(restored.pollOptions).toEqual(['a', 'b']);
+    expect(restored.pollTitle).toBe('poll?');
+    expect(restored.showPollCreator).toBe(true);
+    expect(restored.location).toEqual({ latitude: 1, longitude: 2, address: 'somewhere' });
+  });
+});

--- a/packages/frontend/hooks/useAttachmentOrder.ts
+++ b/packages/frontend/hooks/useAttachmentOrder.ts
@@ -13,25 +13,24 @@ import {
   ROOM_ATTACHMENT_KEY,
   PODCAST_ATTACHMENT_KEY,
 } from '@/utils/composeUtils';
+import type { ArticleData } from './useArticleManager';
+import type { EventData } from './useEventManager';
+import type { LocationData } from './useLocationManager';
 import type { PodcastAttachmentData } from './usePodcastManager';
-
-interface Source {
-  id: string;
-  url?: string;
-  title?: string;
-}
+import type { RoomAttachmentData } from './useRoomManager';
+import type { Source } from './useSourcesManager';
 
 interface UseAttachmentOrderProps {
   showPollCreator: boolean;
   hasArticleContent: boolean;
-  article: any;
+  article: ArticleData | null;
   hasEventContent: boolean;
-  event: any;
+  event: EventData | null;
   hasRoomContent: boolean;
-  room: any;
+  room: RoomAttachmentData | null;
   hasPodcastContent: boolean;
   podcast: PodcastAttachmentData | null;
-  location: any;
+  location: LocationData | null;
   sources: Source[];
   mediaIds: ComposerMediaItem[];
   /** URLs of the links detected in the post text — one carousel card each. */

--- a/packages/frontend/hooks/useComposeValidation.ts
+++ b/packages/frontend/hooks/useComposeValidation.ts
@@ -2,18 +2,14 @@ import { useMemo } from 'react';
 import { ComposerMediaItem } from '@/utils/composeUtils';
 import type { ThreadItem } from '@/hooks/useThreadManager';
 import { shouldIncludeThreadItem } from '@/utils/postBuilder';
-
-interface Source {
-  id: string;
-  url?: string;
-  title?: string;
-}
+import type { LocationData } from '@/hooks/useLocationManager';
+import type { Source } from '@/hooks/useSourcesManager';
 
 interface UseComposeValidationProps {
   postContent: string;
   mediaIds: ComposerMediaItem[];
   pollOptions: string[];
-  location: any;
+  location: LocationData | null;
   hasArticleContent: boolean;
   threadItems: ThreadItem[];
   sources: Source[];
@@ -36,7 +32,7 @@ export const useComposeValidation = ({
       postContent.trim().length > 0 ||
       mediaIds.length > 0 ||
       (pollOptions.length > 0 && pollOptions.some(opt => opt.trim().length > 0)) ||
-      location ||
+      location !== null ||
       hasArticleContent ||
       threadItems.some(shouldIncludeThreadItem)
     );

--- a/packages/frontend/hooks/useDraftManager.ts
+++ b/packages/frontend/hooks/useDraftManager.ts
@@ -14,7 +14,12 @@ import {
   PODCAST_ATTACHMENT_KEY,
   createMediaAttachmentKey,
 } from '@/utils/composeUtils';
+import type { ArticleData } from './useArticleManager';
+import type { Draft, DraftInput } from './useDrafts';
+import type { LocationData } from './useLocationManager';
 import type { PodcastAttachmentData } from './usePodcastManager';
+import type { Source } from './useSourcesManager';
+import type { DraftThreadItem, ThreadItem } from './useThreadManager';
 import {
   hasVariantWork,
   draftVariantTextsForItem,
@@ -24,8 +29,84 @@ import {
   type ComposeVariantsState,
 } from '@/utils/composeVariants';
 
+/**
+ * A draft AS IT COMES OUT OF STORAGE.
+ *
+ * Drafts are persisted raw and unversioned, so a stored blob may predate any
+ * field's current shape — the media list, for one, used to hold bare file id
+ * strings. {@link Draft} describes what the composer WRITES; this describes what
+ * the reader may actually find, which is why every value below is narrowed
+ * rather than trusted.
+ */
+type StoredDraft = { [K in keyof Draft]?: unknown };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isString = (value: unknown): value is string => typeof value === 'string';
+
+const readArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+const readString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const readNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+/** Stored media entries, tolerating the legacy bare-file-id form. */
+const readMediaItems = (value: unknown): ComposerMediaItem[] =>
+  readArray(value)
+    .map((entry) => {
+      if (isString(entry)) {
+        return { id: entry, type: toComposerMediaType(undefined, undefined) };
+      }
+      const item = isRecord(entry) ? entry : {};
+      return {
+        id: readString(item.id) ?? '',
+        type: toComposerMediaType(
+          readString(item.type),
+          readString(item.mime) ?? readString(item.contentType),
+        ),
+      };
+    })
+    .filter((item) => item.id.length > 0);
+
+/** Stored mentions, mapped onto the composer's {@link MentionData} shape. */
+const readMentions = (value: unknown): MentionData[] =>
+  readArray(value)
+    .filter(isRecord)
+    .map((mention) => ({
+      userId: readString(mention.userId) ?? '',
+      username: readString(mention.handle) ?? '',
+      displayName: readString(mention.name) ?? '',
+    }));
+
+/**
+ * The composer state a draft is built from — the live values, not the persisted
+ * shape. Shared by the three functions that read it so the contract is stated
+ * once instead of re-spelled per function.
+ */
+interface ComposeDraftRefs {
+  postContent: string;
+  mediaIds: ComposerMediaItem[];
+  pollOptions: string[];
+  pollTitle: string;
+  showPollCreator: boolean;
+  location: LocationData | null;
+  sources: Source[];
+  article: ArticleData | null;
+  podcast: PodcastAttachmentData | null;
+  threadItems: ThreadItem[];
+  mentions: MentionData[];
+  postingMode: 'thread' | 'beast';
+  attachmentOrder: string[];
+  scheduledAt: Date | null;
+  currentDraftId: string | null;
+  variants: ComposeVariantsState;
+}
+
 interface DraftManagerProps {
-  saveDraft: (draft: any) => Promise<string>;
+  saveDraft: (draft: DraftInput) => Promise<string>;
   deleteDraft: (draftId: string) => Promise<void>;
   onDraftLoad: (draft: {
     postContent: string;
@@ -33,9 +114,9 @@ interface DraftManagerProps {
     pollOptions: string[];
     pollTitle: string;
     showPollCreator: boolean;
-    location: any;
-    sources: any[];
-    article: any;
+    location: LocationData | null;
+    sources: Source[];
+    article: ArticleData | null;
     articleDraftTitle: string;
     articleDraftBody: string;
     podcast: PodcastAttachmentData | null;
@@ -43,7 +124,7 @@ interface DraftManagerProps {
     attachmentOrder: string[];
     mentions: MentionData[];
     postingMode: 'thread' | 'beast';
-    threadItems: any[];
+    threadItems: DraftThreadItem[];
     /**
      * The draft's persisted variant buffer, exactly as it came out of storage.
      * Unknown by design — an old draft has none, and the composer's tolerant
@@ -61,24 +142,7 @@ export const useDraftManager = ({
   const [currentDraftId, setCurrentDraftId] = useState<string | null>(null);
   const autoSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const buildDraftData = useCallback((refs: {
-    postContent: string;
-    mediaIds: ComposerMediaItem[];
-    pollOptions: string[];
-    pollTitle: string;
-    showPollCreator: boolean;
-    location: any;
-    sources: any[];
-    article: any;
-    podcast: PodcastAttachmentData | null;
-    threadItems: any[];
-    mentions: MentionData[];
-    postingMode: 'thread' | 'beast';
-    attachmentOrder: string[];
-    scheduledAt: Date | null;
-    currentDraftId: string | null;
-    variants: ComposeVariantsState;
-  }) => {
+  const buildDraftData = useCallback((refs: ComposeDraftRefs): DraftInput => {
     const shouldShowPollCreator = refs.showPollCreator ||
       (refs.pollOptions.length > 0 && refs.pollOptions.some(opt => opt.trim().length > 0));
     const languages = serializeVariants(refs.variants);
@@ -121,12 +185,12 @@ export const useDraftManager = ({
       threadItems: refs.threadItems.map(item => ({
         id: item.id,
         text: item.text,
-        mediaIds: item.mediaIds.map((m: ComposerMediaItem) => ({ id: m.id, type: m.type })),
+        mediaIds: item.mediaIds.map(m => ({ id: m.id, type: m.type })),
         pollOptions: item.pollOptions || [],
         pollTitle: item.pollTitle || '',
-        showPollCreator: item.showPollCreator || 
-          (item.pollOptions && item.pollOptions.length > 0 && 
-           item.pollOptions.some((opt: string) => opt.trim().length > 0)),
+        showPollCreator: item.showPollCreator ||
+          (item.pollOptions && item.pollOptions.length > 0 &&
+           item.pollOptions.some(opt => opt.trim().length > 0)),
         location: item.location ? {
           latitude: item.location.latitude,
           longitude: item.location.longitude,
@@ -152,33 +216,23 @@ export const useDraftManager = ({
     };
   }, []);
 
-  const hasContent = useCallback((refs: {
-    postContent: string;
-    mediaIds: ComposerMediaItem[];
-    pollOptions: string[];
-    location: any;
-    article: any;
-    podcast: PodcastAttachmentData | null;
-    sources: any[];
-    threadItems: any[];
-    variants: ComposeVariantsState;
-  }) => {
+  const hasContent = useCallback((refs: ComposeDraftRefs) => {
     return hasVariantWork(refs.variants) ||
       refs.postContent.trim().length > 0 ||
       refs.mediaIds.length > 0 ||
       (refs.pollOptions.length > 0 && refs.pollOptions.some(opt => opt.trim().length > 0)) ||
-      refs.location ||
+      refs.location !== null ||
       (refs.article && ((refs.article.title && refs.article.title.trim().length > 0) ||
                         (refs.article.body && refs.article.body.trim().length > 0))) ||
       Boolean(refs.podcast?.syraPodcastId) ||
       refs.sources.some(source => (source.title && source.title.trim().length > 0) || 
                                    (source.url && source.url.trim().length > 0)) ||
       refs.threadItems.some(item => item.text.trim().length > 0 || item.mediaIds.length > 0 ||
-        (item.pollOptions.length > 0 && item.pollOptions.some((opt: string) => opt.trim().length > 0)) || 
-        item.location);
+        (item.pollOptions.length > 0 && item.pollOptions.some(opt => opt.trim().length > 0)) ||
+        item.location !== null);
   }, []);
 
-  const autoSave = useCallback(async (refs: any) => {
+  const autoSave = useCallback(async (refs: ComposeDraftRefs) => {
     if (!hasContent(refs)) {
       if (refs.currentDraftId) {
         await deleteDraft(refs.currentDraftId);
@@ -196,55 +250,60 @@ export const useDraftManager = ({
     }
   }, [hasContent, buildDraftData, saveDraft, deleteDraft]);
 
-  const loadDraft = useCallback((draft: any) => {
-    const mediaIdsData = (draft.mediaIds || []).map((m: any) => ({
-      id: m.id || m,
-      type: toComposerMediaType(m.type, m.mime || m.contentType),
-    })).filter((m: any) => m.id);
+  const loadDraft = useCallback((draft: StoredDraft) => {
+    const mediaIdsData = readMediaItems(draft.mediaIds);
 
-    const pollOpts = draft.pollOptions || [];
-    const shouldShowPoll = draft.showPollCreator || pollOpts.length > 0;
+    const pollOpts = readArray(draft.pollOptions).filter(isString);
+    const shouldShowPoll = draft.showPollCreator === true || pollOpts.length > 0;
 
-    let locationData = null;
-    if (draft.location) {
+    let locationData: LocationData | null = null;
+    const storedLocation = isRecord(draft.location) ? draft.location : null;
+    if (storedLocation) {
       locationData = {
-        latitude: draft.location.latitude,
-        longitude: draft.location.longitude,
-        address: draft.location.address || null,
+        latitude: readNumber(storedLocation.latitude) ?? 0,
+        longitude: readNumber(storedLocation.longitude) ?? 0,
+        address: readString(storedLocation.address),
       };
     }
 
-    const sourcesData = (draft.sources || []).map((source: any) => ({
-      id: source.id || '',
-      title: source.title || '',
-      url: source.url || '',
-    }));
+    const sourcesData: Source[] = readArray(draft.sources)
+      .filter(isRecord)
+      .map((source) => ({
+        id: readString(source.id) ?? '',
+        title: readString(source.title) ?? '',
+        url: readString(source.url) ?? '',
+      }));
 
-    let articleData = null;
+    let articleData: ArticleData | null = null;
     let articleDraftTitle = '';
     let articleDraftBody = '';
-    if (draft.article && (draft.article.title || draft.article.body)) {
-      articleData = {
-        title: draft.article.title || '',
-        body: draft.article.body || '',
-      };
-      articleDraftTitle = draft.article.title || '';
-      articleDraftBody = draft.article.body || '';
+    const storedArticle = isRecord(draft.article) ? draft.article : null;
+    if (storedArticle) {
+      const title = readString(storedArticle.title) ?? '';
+      const body = readString(storedArticle.body) ?? '';
+      if (title || body) {
+        articleData = { title, body };
+        articleDraftTitle = title;
+        articleDraftBody = body;
+      }
     }
 
     let podcastData: PodcastAttachmentData | null = null;
-    if (draft.podcast && typeof draft.podcast.syraPodcastId === 'string' && draft.podcast.syraPodcastId.length > 0) {
+    const storedPodcast = isRecord(draft.podcast) ? draft.podcast : null;
+    const syraPodcastId = storedPodcast ? readString(storedPodcast.syraPodcastId) : undefined;
+    if (storedPodcast && syraPodcastId) {
       podcastData = {
-        syraPodcastId: draft.podcast.syraPodcastId,
-        title: draft.podcast.title || '',
-        author: draft.podcast.author,
-        artworkUrl: draft.podcast.artworkUrl,
+        syraPodcastId,
+        title: readString(storedPodcast.title) ?? '',
+        author: readString(storedPodcast.author),
+        artworkUrl: readString(storedPodcast.artworkUrl),
       };
     }
 
     let scheduledAtData: Date | null = null;
-    if (draft.scheduledAt) {
-      const parsed = new Date(draft.scheduledAt);
+    const storedScheduledAt = readString(draft.scheduledAt);
+    if (storedScheduledAt) {
+      const parsed = new Date(storedScheduledAt);
       if (!Number.isNaN(parsed.getTime())) {
         scheduledAtData = parsed;
       }
@@ -264,16 +323,15 @@ export const useDraftManager = ({
     if (locationData) {
       availableAttachmentKeys.push(LOCATION_ATTACHMENT_KEY);
     }
-    if (sourcesData.some((source: any) => source.url.trim().length > 0)) {
+    if (sourcesData.some((source) => source.url.trim().length > 0)) {
       availableAttachmentKeys.push(SOURCES_ATTACHMENT_KEY);
     }
-    mediaIdsData.forEach((media: ComposerMediaItem) => {
+    mediaIdsData.forEach((media) => {
       availableAttachmentKeys.push(createMediaAttachmentKey(media.id));
     });
 
-    const draftAttachmentOrder = Array.isArray(draft.attachmentOrder) ? draft.attachmentOrder : [];
     const sanitizedAttachmentOrder: string[] = [];
-    draftAttachmentOrder.forEach((key: string) => {
+    readArray(draft.attachmentOrder).filter(isString).forEach((key) => {
       if (availableAttachmentKeys.includes(key)) {
         sanitizedAttachmentOrder.push(key);
       }
@@ -284,44 +342,47 @@ export const useDraftManager = ({
       }
     });
 
-    const postContent = typeof draft.postContent === 'string' ? draft.postContent : '';
-    const mentionCandidates = (draft.mentions || []).map((m: any) => ({
-      userId: m.userId,
-      username: m.handle,
-      displayName: m.name,
-    }));
+    const postContent = readString(draft.postContent) ?? '';
     const mentionsData = reconcileMentionData(
       [
         postContent,
         ...draftVariantTextsForItem(draft.languages, MAIN_ITEM_ID),
       ],
-      mentionCandidates,
+      readMentions(draft.mentions),
     );
 
-    const threadItemsData = (draft.threadItems || []).map((item: any) => ({
-      ...item,
-      mediaIds: (item.mediaIds || []).map((m: any) => ({
-        id: m.id || m,
-        type: toComposerMediaType(m.type, m.mime || m.contentType),
-      })).filter((m: any) => m.id),
-      mentions: reconcileMentionData(
-        [
-          typeof item.text === 'string' ? item.text : '',
-          ...draftVariantTextsForItem(draft.languages, String(item.id ?? '')),
-        ],
-        (item.mentions || []).map((m: any) => ({
-          userId: m.userId,
-          username: m.handle,
-          displayName: m.name,
-        })),
-      ),
-    }));
+    const threadItemsData: DraftThreadItem[] = readArray(draft.threadItems)
+      .filter(isRecord)
+      .map((item) => {
+        const id = readString(item.id) ?? '';
+        const text = readString(item.text) ?? '';
+        const storedLocation = isRecord(item.location) ? item.location : null;
+        return {
+          id,
+          text,
+          mediaIds: readMediaItems(item.mediaIds),
+          pollOptions: readArray(item.pollOptions).filter(isString),
+          pollTitle: readString(item.pollTitle) ?? '',
+          showPollCreator: item.showPollCreator === true,
+          location: storedLocation
+            ? {
+              latitude: readNumber(storedLocation.latitude) ?? 0,
+              longitude: readNumber(storedLocation.longitude) ?? 0,
+              address: readString(storedLocation.address),
+            }
+            : null,
+          mentions: reconcileMentionData(
+            [text, ...draftVariantTextsForItem(draft.languages, id)],
+            readMentions(item.mentions),
+          ),
+        };
+      });
 
     onDraftLoad({
       postContent,
       mediaIds: mediaIdsData,
       pollOptions: pollOpts,
-      pollTitle: draft.pollTitle || '',
+      pollTitle: readString(draft.pollTitle) ?? '',
       showPollCreator: shouldShowPoll,
       location: locationData,
       sources: sourcesData,
@@ -332,12 +393,12 @@ export const useDraftManager = ({
       scheduledAt: scheduledAtData,
       attachmentOrder: sanitizedAttachmentOrder,
       mentions: mentionsData,
-      postingMode: draft.postingMode || 'thread',
+      postingMode: draft.postingMode === 'beast' ? 'beast' : 'thread',
       threadItems: threadItemsData,
       languages: draft.languages,
     });
 
-    setCurrentDraftId(draft.id);
+    setCurrentDraftId(readString(draft.id) ?? null);
   }, [onDraftLoad]);
 
   return {

--- a/packages/frontend/hooks/useDrafts.ts
+++ b/packages/frontend/hooks/useDrafts.ts
@@ -47,6 +47,12 @@ export interface Draft {
   updatedAt: number;
 }
 
+/**
+ * A draft as a CALLER submits it. The id is optional (absent means "create") and
+ * the timestamps are owned by {@link useDrafts}, never by the composer.
+ */
+export type DraftInput = Omit<Draft, 'id' | 'createdAt' | 'updatedAt'> & { id?: string };
+
 const LEGACY_DRAFTS_STORAGE_KEY = '@mention_drafts';
 const DRAFTS_STORAGE_KEY = '@mention_drafts:v2';
 
@@ -127,7 +133,7 @@ export const useDrafts = () => {
   }, [viewerId]);
 
   // Create or update a draft
-  const saveDraft = useCallback(async (draft: Omit<Draft, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }) => {
+  const saveDraft = useCallback(async (draft: DraftInput) => {
     try {
       const now = Date.now();
       const draftId = draft.id || `draft_${now}_${Math.random().toString(36).substr(2, 9)}`;

--- a/packages/frontend/hooks/useFeedState.ts
+++ b/packages/frontend/hooks/useFeedState.ts
@@ -574,7 +574,7 @@ export function useFeedState({
                     const pid = filters?.postId || filters?.parentPostId;
                     if (pid) {
                         items = items.filter(
-                            (it: any) => String(it.postId || it.parentPostId) === String(pid)
+                            (it) => String(it.parentPostId) === String(pid)
                         );
                     }
 
@@ -722,7 +722,7 @@ export function useFeedState({
                 const pid = filters?.postId || filters?.parentPostId;
                 if (pid) {
                     items = items.filter(
-                        (it: any) => String(it.postId || it.parentPostId) === String(pid)
+                        (it) => String(it.parentPostId) === String(pid)
                     );
                 }
 
@@ -849,7 +849,7 @@ export function useFeedState({
                 const pid = filters?.postId || filters?.parentPostId;
                 if (pid) {
                     items = items.filter(
-                        (it: any) => String(it.postId || it.parentPostId) === String(pid)
+                        (it) => String(it.parentPostId) === String(pid)
                     );
                 }
 

--- a/packages/frontend/hooks/useRefSync.ts
+++ b/packages/frontend/hooks/useRefSync.ts
@@ -13,18 +13,3 @@ export const useRefSync = <T>(value: T) => {
 
   return ref;
 };
-
-/**
- * Sync multiple values to refs at once
- * Returns an object with all the refs
- */
-export const useMultiRefSync = <T extends Record<string, any>>(values: T): { [K in keyof T]: React.MutableRefObject<T[K]> } => {
-  const refs = {} as { [K in keyof T]: React.MutableRefObject<T[K]> };
-
-  for (const key in values) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    refs[key] = useRefSync(values[key]);
-  }
-
-  return refs;
-};

--- a/packages/frontend/hooks/useScheduleManager.ts
+++ b/packages/frontend/hooks/useScheduleManager.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, createElement, Suspense } from 'react';
 import type { TFunction } from 'i18next';
 import { toast as toastFn } from '@oxyhq/bloom/toast';
-import type { ScheduleOption } from '@/components/Compose/ScheduleSheet';
+import type { ScheduleOption, ScheduleSheetProps } from '@/components/Compose/ScheduleSheet';
 import type { BottomSheetContextProps } from '@/context/BottomSheetContext';
 import { addMinutes } from '@/utils/dateUtils';
 
@@ -78,7 +78,7 @@ export const useScheduleManager = ({
     ];
   }, [t]);
 
-  const openScheduleSheet = useCallback((ScheduleSheetComponent: React.ComponentType<any>) => {
+  const openScheduleSheet = useCallback((ScheduleSheetComponent: React.ComponentType<ScheduleSheetProps>) => {
     if (!scheduleEnabled) {
       toast(t('compose.schedule.singlePostOnly', { defaultValue: 'Scheduling is only available for single posts' }), { type: 'info' });
       return;

--- a/packages/frontend/hooks/useThreadManager.ts
+++ b/packages/frontend/hooks/useThreadManager.ts
@@ -10,7 +10,20 @@ import { Source } from "@/hooks/useSourcesManager";
 import { ArticleData } from "@/hooks/useArticleManager";
 import { EventData } from "@/hooks/useEventManager";
 import { RoomAttachmentData } from "@/hooks/useRoomManager";
+import type { Draft } from "@/hooks/useDrafts";
 import type { ReplyPermission } from "@/components/Compose/ReplySettingsSheet";
+
+/**
+ * A thread item as it comes back OUT of a stored draft: the persisted subset,
+ * with mentions and media already reconciled into their composer shapes by the
+ * draft reader. Narrower than {@link ThreadItem} — a draft never persisted the
+ * attachments or the per-item interaction settings.
+ */
+export interface DraftThreadItem
+  extends Omit<Draft['threadItems'][number], 'mediaIds' | 'mentions'> {
+  mediaIds: ComposerMediaItem[];
+  mentions: MentionData[];
+}
 
 export interface ThreadItem {
   id: string;
@@ -509,8 +522,34 @@ export const useThreadManager = () => {
     setThreadItems([]);
   }, []);
 
-  const loadThreadsFromDraft = useCallback((threads: ThreadItem[]) => {
-    setThreadItems(threads);
+  /**
+   * Restore thread items from a stored draft. A draft persists only the parts of
+   * a thread item the composer can rebuild from — it carries no sources,
+   * article, event, room, or per-item interaction settings — so each restored
+   * item is completed with the SAME defaults `addThread` uses. Without that, a
+   * restored thread item reaches the composer missing `replyPermission` and the
+   * sensitive/quote flags entirely.
+   */
+  const loadThreadsFromDraft = useCallback((threads: DraftThreadItem[]) => {
+    setThreadItems(threads.map((thread) => ({
+      id: thread.id,
+      text: thread.text,
+      mediaIds: thread.mediaIds,
+      pollOptions: thread.pollOptions,
+      pollTitle: thread.pollTitle ?? "",
+      showPollCreator: thread.showPollCreator,
+      location: thread.location,
+      mentions: thread.mentions,
+      sources: [],
+      article: null,
+      event: null,
+      room: null,
+      attachmentOrder: [],
+      replyPermission: ["anyone"],
+      reviewReplies: false,
+      quotesDisabled: false,
+      isSensitive: false,
+    })));
   }, []);
 
   return {

--- a/packages/frontend/services/feedService.ts
+++ b/packages/frontend/services/feedService.ts
@@ -150,9 +150,8 @@ function requestIdentityDedupeMarker(): string {
 }
 
 // Extended FeedRequest with frontend-specific filter properties
-interface ExtendedFeedRequest extends Omit<FeedRequest, 'filters'> {
+export interface ExtendedFeedRequest extends Omit<FeedRequest, 'filters'> {
   filters?: FeedFilters;
-  sort?: string;
 }
 
 interface PublicReadRequestConfig {
@@ -274,10 +273,10 @@ function getDedupeKey(request: ExtendedFeedRequest): string {
   const filterKey = filters
     ? Object.keys(filters)
         .sort()
-        .map((k) => `${k}=${(filters as Record<string, unknown>)[k] ?? ''}`)
+        .map((k) => `${k}=${filters[k] ?? ''}`)
         .join('&')
     : '';
-  return `${requestIdentityDedupeMarker()}|${request.type || 'mixed'}|${request.cursor || 'initial'}|${request.userId || ''}|${request.sort || ''}|${filterKey}`;
+  return `${requestIdentityDedupeMarker()}|${request.type || 'mixed'}|${request.cursor || 'initial'}|${request.userId || ''}|${filterKey}`;
 }
 
 class FeedService {

--- a/packages/frontend/stores/postsStore.ts
+++ b/packages/frontend/stores/postsStore.ts
@@ -16,7 +16,7 @@ import type {
   FeedPostSlice,
 } from '@mention/shared-types';
 import { createLogger } from '@oxyhq/core/logger';
-import { feedService } from '../services/feedService';
+import { feedService, type ExtendedFeedRequest } from '../services/feedService';
 import { markLocalAction } from '../services/echoGuard';
 import { publishNewLocalPost, publishRemovedLocalPost } from '@/stores/feedScrollStore';
 
@@ -155,7 +155,7 @@ interface PostsStoreState {
   lastRefresh: number;
 
   // Feed operations
-  fetchFeed: (request: FeedRequest) => Promise<void>;
+  fetchFeed: (request: ExtendedFeedRequest) => Promise<void>;
   fetchUserFeed: (userId: string, request: FeedRequest) => Promise<{ pending: boolean }>;
   fetchSavedPosts: (request: { page?: number; limit?: number }) => Promise<void>;
   refreshFeed: (type: FeedType, filters?: FeedFilters) => Promise<void>;
@@ -358,7 +358,7 @@ export const usePostsStore = create<PostsStoreState>()(
     getPostFromDb: (postId: string) => dbGetPostById(postId),
 
     // ── fetchFeed ────────────────────────────────────────────
-    fetchFeed: async (request: FeedRequest) => {
+    fetchFeed: async (request: ExtendedFeedRequest) => {
       const operationEpoch = captureViewerStateEpoch();
       const { type = 'mixed' } = request;
       const feedKey = buildFeedKey(type);

--- a/packages/frontend/types/validation.ts
+++ b/packages/frontend/types/validation.ts
@@ -1,6 +1,37 @@
 import { z } from "zod";
 import { logger } from '@oxyhq/core/logger';
 
+/**
+ * Reject legacy fields that the profile-identity contract retired, so a shim
+ * cannot re-enter through notifications. Shared by the three embedded shapes
+ * that each guard their own list.
+ *
+ * `.passthrough()` is what makes this necessary: unknown keys are preserved
+ * rather than stripped, so without an explicit refusal a resurrected `handle`
+ * or `isLiked` would ride along and be read downstream.
+ */
+const refuseLegacyFields = (
+  kind: string,
+  fields: readonly string[],
+): ((value: object, context: z.RefinementCtx) => void) =>
+  (value, context) => {
+    for (const field of fields) {
+      if (field in value) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Legacy ${kind} field "${field}" is not allowed`,
+          path: [field],
+        });
+      }
+    }
+  };
+
+/** Identity shims replaced by `username` / `avatar` / `verified`. */
+const LEGACY_IDENTITY_FIELDS = ['handle', 'avatarUrl', 'isVerified'] as const;
+
+/** Viewer-state shims that moved onto `viewerState`. */
+const LEGACY_VIEWER_FIELDS = ['isLiked', 'isDownvoted', 'isBoosted', 'isSaved'] as const;
+
 // Actor/profile coming from actorId_populated
 export const ZActor = z.object({
   _id: z.string().optional(),
@@ -8,9 +39,9 @@ export const ZActor = z.object({
   username: z.string().optional(),
   // Canonical resolved display name (profile-identity contract). The backend
   // serializer always emits `name.displayName`; clients render it directly.
-  name: z.object({ displayName: z.string().optional() }).partial().optional(),
+  name: z.object({ displayName: z.string().optional() }).optional(),
   avatar: z.string().optional(),
-}).partial();
+});
 
 // Embedded post user — the canonical Oxy `User` shape emitted by
 // `PostHydrationService` (Oxy owns identity). Render `name.displayName` directly,
@@ -31,17 +62,7 @@ const embeddedUserShape = {
 export const ZEmbeddedUser = z
   .object(embeddedUserShape)
   .passthrough()
-  .superRefine((user, context) => {
-    for (const field of ['handle', 'avatarUrl', 'isVerified'] as const) {
-      if (field in user) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Legacy identity field "${field}" is not allowed`,
-          path: [field],
-        });
-      }
-    }
-  });
+  .superRefine(refuseLegacyFields('identity', LEGACY_IDENTITY_FIELDS));
 
 const ZEmbeddedAuthor = z
   .object({
@@ -50,17 +71,7 @@ const ZEmbeddedAuthor = z
     status: z.enum(['pending', 'accepted', 'declined', 'stopped']),
   })
   .passthrough()
-  .superRefine((author, context) => {
-    for (const field of ['handle', 'avatarUrl', 'isVerified'] as const) {
-      if (field in author) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Legacy identity field "${field}" is not allowed`,
-          path: [field],
-        });
-      }
-    }
-  });
+  .superRefine(refuseLegacyFields('identity', LEGACY_IDENTITY_FIELDS));
 
 // Embedded posts are hydrated by PostHydrationService. Keep the validator
 // aligned with that canonical contract so old identity/viewer shims cannot
@@ -114,17 +125,7 @@ export const ZEmbeddedPost = z
     parentPostId: z.string().optional(),
   })
   .passthrough()
-  .superRefine((post, context) => {
-    for (const field of ['isLiked', 'isDownvoted', 'isBoosted', 'isSaved'] as const) {
-      if (field in post) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Legacy viewer field "${field}" is not allowed`,
-          path: [field],
-        });
-      }
-    }
-  });
+  .superRefine(refuseLegacyFields('viewer', LEGACY_VIEWER_FIELDS));
 
 // Raw notification as received from API
 export const ZRawNotification = z

--- a/packages/frontend/types/validation.ts
+++ b/packages/frontend/types/validation.ts
@@ -130,14 +130,17 @@ export const ZEmbeddedPost = z
 export const ZRawNotification = z
   .object({
     _id: z.string(),
-    recipientId: z.any(),
-    actorId: z.any(),
+    // `recipientId` and `actorId` hold Oxy user ids (the backend model types both
+    // as `String`, never a Mongoose ref — hence the separate `actorId_populated`).
+    // `entityId` is an ObjectId that serializes to its hex string over JSON.
+    recipientId: z.string(),
+    actorId: z.string(),
     type: z.string(),
-    entityId: z.any(),
+    entityId: z.string(),
     entityType: z.string(),
     read: z.boolean().default(false),
     createdAt: z.string(),
-    updatedAt: z.any().optional(),
+    updatedAt: z.string().optional(),
     preview: z.string().optional(),
     post: ZEmbeddedPost.optional(),
     actorId_populated: ZActor.optional(),

--- a/packages/frontend/utils/feedUtils.ts
+++ b/packages/frontend/utils/feedUtils.ts
@@ -12,7 +12,9 @@ import type {
     HydratedPost,
 } from '@mention/shared-types';
 
-// Extended FeedFilters with additional properties used by the app
+// Extended FeedFilters with additional properties used by the app.
+// The index signature is what `serializeFeedFilters` and `shallowFiltersEqual`
+// walk, so it states the real contract: filters are a flat bag of scalars.
 export interface FeedFilters extends SharedFeedFilters {
     searchQuery?: string;
     postId?: string;
@@ -20,7 +22,9 @@ export interface FeedFilters extends SharedFeedFilters {
     customFeedId?: string;
     hashtag?: string;
     topic?: string;
-    [key: string]: any;
+    /** Reply ordering, as the replies feed sends it to the API. */
+    sort?: string;
+    [key: string]: string | boolean | undefined;
 }
 
 /**

--- a/packages/frontend/utils/groupNotifications.ts
+++ b/packages/frontend/utils/groupNotifications.ts
@@ -174,18 +174,9 @@ function extractActor(n: TRawNotification): GroupedActor {
     };
   }
 
-  const actor = objectValue(n.actorId);
-  if (actor) {
-    const username = stringValue(actor.username);
-    const actorName = objectValue(actor.name);
-    return {
-      id: objectId(actor) || 'unknown',
-      name: stringValue(actorName?.displayName) || stringValue(actor.displayName) || username || actorId,
-      username,
-      avatar: stringValue(actor.avatar),
-    };
-  }
-
+  // `actorId` is a bare Oxy user id — the backend models it as a `String` and
+  // never populates it (that is what `actorId_populated` above is for). The
+  // handle is the never-blank floor, never a name recompute.
   return { id: actorId, name: actorId };
 }
 

--- a/packages/frontend/utils/userPlaceholderColor.ts
+++ b/packages/frontend/utils/userPlaceholderColor.ts
@@ -1,13 +1,13 @@
-import { APP_COLOR_PRESETS, type AppColorName } from '@oxyhq/bloom/theme';
+import { APP_COLOR_PRESETS } from '@oxyhq/bloom/theme';
 
 /**
  * Returns the hex color for a user's profile color, to be used as
  * the Avatar placeholder background when no avatar image is available.
  */
-export function getUserPlaceholderColor(user?: Record<string, any> | null): string | undefined {
-    const colorName = user?.color as AppColorName | undefined;
-    if (colorName && APP_COLOR_PRESETS[colorName]) {
-        return APP_COLOR_PRESETS[colorName].hex;
-    }
-    return undefined;
+export function getUserPlaceholderColor(user?: { color?: string | null } | null): string | undefined {
+    const color = user?.color;
+    if (!color) return undefined;
+    // Matching the stored string against the preset names is what narrows it to a
+    // real preset, so an unknown or stale color simply yields no placeholder.
+    return Object.entries(APP_COLOR_PRESETS).find(([name]) => name === color)?.[1].hex;
 }


### PR DESCRIPTION
## The bug this uncovered

Restoring a thread from a draft **silently discarded the author's own interaction settings**. `loadThreadsFromDraft` declared it took `ThreadItem[]`, but a draft persists a narrower shape — no sources, article, event, room, attachment order, or per-item interaction settings — and the function passed whatever it was handed straight to `setThreadItems`. A restored item reached the composer with `replyPermission`, `isSensitive`, `quotesDisabled` and `reviewReplies` **absent**.

A user who drafted a thread with replies restricted, or flagged sensitive, got those settings dropped on restore and would have posted without them. That is a consent and privacy regression, not a cosmetic one, and nothing surfaced it: the declared parameter type asserted the fields were present, so neither tsc nor a reader had reason to doubt it.

Fixed in `83eb995f`, pinned by a test in `cbeaa17c` that compares a restored item against a freshly added one (so the two paths cannot drift) and walks every `ThreadItem` key requiring it be defined. The test was verified to **fail against the pre-fix implementation** — two of its three cases go red — rather than merely passing.

## The cleanup that found it

| violation | reported | actually real | after |
|---|---|---|---|
| `: any` / `Record<string,any>` / `z.any()` / `any[]` | fe 48, be 14 | **fe 55, be 43** | **0 / 0** |
| `any` in `.d.ts` | not counted | **1** | **0** |
| silent `catch {}` | 1 | 1 | **0** |
| `as any` | fe 10, be 1 | **0** — all 11 hits were comments/prose | 0 |
| `var` | be 2 | **0** — the English word in JSDoc | 0 |
| `@ts-ignore` / `@ts-expect-error` | 0 | 0 | 0 |
| `useEffect` | 198 | 195 | **191** |

The original counts came from a grep that matched comments and prose. The scanner used here strips comments and string literals first, and was mutation-tested (inject `function __mutationProbe(x: any): any` → caught; remove → back to 0) so a zero means something.

## Other behaviour changes that fell out of the typing

- **`assignScrollRef`** now unwraps a legacy `getNode()` Animated ref; previously such a ref was registered as-is and every `scrollToOffset` on it silently no-opped.
- **Inbound ActivityPub `federation.url`**: a Note whose `url` is a Link object was stored as an object into a field declared `string`. Now falls back to the note id.
- **`canPostContent` / `hasContent`** returned the location *object* rather than a boolean, so `isPostButtonEnabled` was not a boolean either.
- **`useFeedState`'s scoped filter** no longer reads `it.postId` — not declared on `HydratedPost`, never emitted by `PostHydrationService`.
- **Notification validation** now requires string ids. `z.any()` in a validator was accepting anything into the one function whose job is to reject things.
- **`types/validation.ts`**: the legacy-field guard was copy-pasted three times and is now one helper — mutation-tested three ways (drop `avatarUrl` → the avatar test fails; drop `isLiked` → the viewer test fails; empty the loop → all four fail). `actorId` was traced across REST *and* socket before narrowing: the socket path emits `notification.toObject()` (ObjectIds and Dates) into the same schema, and `hasBinary({_id: ObjectId})` was measured `false` against the installed bson 6.10.4 and socket.io-parser, confirming hex-string encoding. The dead `actorId`-as-object branch in `groupNotifications.ts`, which read a flat `displayName` the identity contract forbids, is removed.

Also removed three dead things the `any` was hiding: `UseProfileScrollReturn` (unimported), `useMultiRefSync` (uncalled, and it called `useRefSync` in a loop behind an `eslint-disable react-hooks/rules-of-hooks`), and `ExtendedFeedRequest.sort` (never set — `sort` lives inside `filters`, which is where the code reads it).

## Effects: 4 converted, the rest left

`connections.tsx` held its active tab in state and ran an effect to chase the pathname into it; nothing else ever selected a tab, so it is now derived. The other three reset an image-error flag on a URI change — in an effect, that renders the new image once with the old failure still committed. Moved to render-time adjustment.

Subscriptions, imperative Reanimated/bottom-sheet calls and genuine synchronisation were left alone. Two categories are deliberately **not** touched and are with the team lead: four props→state drafts (depends on what should happen to unsaved edits when the server value changes underneath) and two React Query migrations.

## Verification

Frontend tsc **0 errors**, backend tsc **0 errors**, frontend **90 suites / 786 tests**, backend **336 files / 3362 tests**, frontend lint **0 errors** (2 pre-existing `import/first` warnings in an untouched test file). `bun install` leaves `bun.lock` byte-unchanged; no `package.json` change.
