### PR TITLE
chore(deps): take @oxyhq/services 25.0.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
         "@mention/shared-types": "workspace:*",
         "@oxyhq/bloom": "^0.72.2",
         "@oxyhq/core": "^16.0.0",
-        "@oxyhq/services": "^25.0.0",
+        "@oxyhq/services": "^25.0.1",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/netinfo": "^12.0.1",
         "@shopify/flash-list": "2.3.2",
@@ -210,7 +210,7 @@
   "overrides": {
     "@oxyhq/bloom": "^0.72.2",
     "@oxyhq/core": "^16.0.0",
-    "@oxyhq/services": "^25.0.0",
+    "@oxyhq/services": "^25.0.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native/babel-preset": "0.85.3",
     "@react-native/metro-babel-transformer": "0.85.3",
@@ -770,7 +770,7 @@
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.6", "", { "dependencies": { "@oxyhq/contracts": "^0.18.0", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-modules-core": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-/27AFpvOwxt19XWdZYJy0W4TnIQbK+IhPOfQVlod4s/kEuzIzMXo0zi9MSystegFu1RhZHKGjaxOTo+83Sx3Sw=="],
 
-    "@oxyhq/services": ["@oxyhq/services@25.0.0", "", { "dependencies": { "@oxyhq/contracts": "0.20.0", "@oxyhq/core": "^16.0.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "nativewind", "react-native-keyboard-controller"] }, "sha512-yis/mYtOqUyxaqCXDZDnUThhmbsHqEIlo83lZ8Pdzj6UPA+njyKJvzYWcnJJq0y6GaQzv8bH+QSupgeBpsvQbA=="],
+    "@oxyhq/services": ["@oxyhq/services@25.0.1", "", { "dependencies": { "@oxyhq/contracts": "0.20.0", "@oxyhq/core": "^16.0.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "nativewind", "react-native-keyboard-controller"] }, "sha512-+6PidKIs5j2LiAT9of4YmXS2375rxvPXdfxrxPHU4qmVRad+1g/+Ub+7G4j+aiPuPIGJGoIa1qPph2DaGjpFkg=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@react-native/metro-config": "0.85.3",
     "@oxyhq/bloom": "^0.72.2",
     "@oxyhq/core": "^16.0.0",
-    "@oxyhq/services": "^25.0.0",
+    "@oxyhq/services": "^25.0.1",
     "brace-expansion": "2.1.2",
     "fast-uri": "3.1.4",
     "fast-xml-parser": "5.10.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -90,7 +90,7 @@
     "@mention/shared-types": "workspace:*",
     "@oxyhq/bloom": "^0.72.2",
     "@oxyhq/core": "^16.0.0",
-    "@oxyhq/services": "^25.0.0",
+    "@oxyhq/services": "^25.0.1",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^12.0.1",
     "@shopify/flash-list": "2.3.2",


### PR DESCRIPTION
Two-line patch bump of `@oxyhq/services`, in both places that pin it, plus the lockfile.

Replaces #531, which I closed: that branch's root manifest and lockfile had picked up TypeScript **7.0.2** from a migration experiment I ran in the same worktree. That is what broke CI there — `scripts/validate-logger-error-args.mjs` died on `ts.ScriptTarget` being undefined under the TS 7 API, taking `validate:logger`, the backend tests and the bundle budget with it. This branch is cut fresh from `origin/main` and touches nothing else; `typescript` stays `~5.9.3` in both the manifest and the lockfile.

The rest of the requested set was already current, verified against the registry rather than assumed:

| package | installed | latest |
|---|---|---|
| `@oxyhq/core` | 16.0.0 | 16.0.0 |
| `@oxyhq/bloom` | 0.72.2 | 0.72.2 |
| `bun` | 1.3.14 | 1.3.14 — `packageManager`, both CI workflows and the local toolchain agree |

## Verification

Ran locally the three gates that failed on #531: `validate:logger` passes (all 9 validator cases), `bun run build` succeeds, and the frontend type-check reports 0 errors.

TypeScript 7 and Expo 57 are real migrations and are being done on their own branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)