### PR TITLE
ci(audit): ban the @typescript/ native-binary scope from the runtime image

### DIFF
--- a/.github/scripts/audit-runtime-image.mjs
+++ b/.github/scripts/audit-runtime-image.mjs
@@ -153,6 +153,13 @@ const bannedPackagePrefixes = [
   "@expo/",
   "@jest/",
   "@testing-library/",
+  // TypeScript 7 ships the compiler as a native binary split across 20
+  // per-platform packages under this scope (`@typescript/typescript-linux-x64`
+  // and friends), pulled in as optionalDependencies of `typescript`. The exact
+  // ban on "typescript" above does not name them, and each one is ~24 MB, so
+  // without this prefix a runtime image could carry the compiler's payload
+  // while the audit reported the compiler itself absent.
+  "@typescript/",
   "@vitest/",
   "expo-",
   "jest-",

--- a/.github/scripts/test-runtime-image-audit.mjs
+++ b/.github/scripts/test-runtime-image-audit.mjs
@@ -88,6 +88,21 @@ try {
     recursive: true,
   });
 
+  // TypeScript 7 splits the compiler into per-platform native binaries under
+  // `@typescript/`, each around 24 MB. They are optionalDependencies of
+  // `typescript`, so the exact ban on that name above never sees them — this
+  // case pins the prefix that does.
+  await writeJson("node_modules/@typescript/typescript-linux-x64/package.json", {
+    name: "@typescript/typescript-linux-x64",
+  });
+  await runAudit(
+    false,
+    "Forbidden development/frontend packages are installed: @typescript/typescript-linux-x64",
+  );
+  await rm(resolve(fixtureRoot, "node_modules/@typescript"), {
+    recursive: true,
+  });
+
   await writeFile(
     resolve(fixtureRoot, "packages/backend/dist/query.spec.js"),
     "export {};\n",


### PR DESCRIPTION
`.github/scripts/audit-runtime-image.mjs` bans `typescript` by **exact package name**. That was the whole compiler up to 5.x. In TypeScript 7 the published `typescript` package is a thin launcher and the payload ships as ~20 per-platform native packages under the `@typescript/` scope (`@typescript/typescript-linux-x64` and friends, roughly 24 MB each), pulled in as optionalDependencies.

Nothing named that scope, so a runtime image could carry the compiler's payload while the audit reported the compiler absent.

Adds `@typescript/` to `bannedPackagePrefixes`, with a fixture case pinning it.

## Why this is its own PR

It came out of the TypeScript 7 migration, but it is independent of it: the gap exists in the audit script regardless of which compiler version the repo pins, and the fix is correct today. The migration itself needs three packages to land together and is still open on the backend, so this should not wait behind it.

## Verification

Mutation-tested independently of the author's own run: blanking the `"@typescript/"` entry makes the fixture suite exit 1, restoring it exits 0. (My first attempt at that control was invalid — a `sed` that silently matched nothing, so both arms "passed"; the giveaway was the control passing too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)