### PR TITLE
chore(deps): @oxyhq/bloom 0.73.0 — overlay stacking by open order

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -237,7 +237,7 @@
     "react-native-svg": "15.15.4",
   },
   "catalog": {
-    "@oxyhq/bloom": "^0.72.2",
+    "@oxyhq/bloom": "^0.73.0",
     "@oxyhq/contracts": "^0.20.0",
     "@oxyhq/core": "^16.0.0",
     "@oxyhq/services": "^25.0.1",
@@ -768,7 +768,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.72.2", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-iGtT3+qbewDTUEL4jskPyA/pBXVR47dXST++T6We58IsNiwR6pGzn5a8Z+4BDJTX5WnvIx+azB0AYxk1j9qoaw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.73.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-kOWcMfNZWPPYtwru8MrFes5nte31ChH+72PpKdMYB2QGVFQAdgqxNfAILITrIaBAfgU3Ib/acy0gPAItp9pVkA=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.20.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-zcpvzqsNg+1ELAJ7yl2XxboLWAMnBxB9SdzdJ13MQBes4DZI8HTEUtM8aErPdP/3qfi2qqlw04SJ+VbpSyaplA=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@oxyhq/bloom": "^0.72.2",
+      "@oxyhq/bloom": "^0.73.0",
       "@oxyhq/contracts": "^0.20.0",
       "@oxyhq/core": "^16.0.0",
       "@oxyhq/services": "^25.0.1",


### PR DESCRIPTION
Fixes the reported bug: opening a delete-confirm dialog while a bottom sheet was up rendered the dialog fully and interactively **underneath** the sheet, where it could neither be pressed nor dismissed.

## Why it happened

Bloom decided overlay stacking with hand-picked z-index rungs fixed per **component kind** — dialogs at `50/60`, sheets pinning the portal root at `999999`. So which surface won was decided by what it *was*, not by which one the user opened last, and this particular pairing was inverted permanently, whatever the order. It failed silently: correct markup, correct styles, nothing in the console.

`@oxyhq/bloom@0.73.0` ([OxyHQ/Bloom#25](https://github.com/OxyHQ/Bloom/pull/25)) replaces the rungs with a single open-order authority — a surface opened later paints above one opened earlier.

## No code change needed here

`ConfirmPromptProvider` already renders a plain `<Dialog>` at the app root, which is exactly the shape that was broken. Bloom's fix is enough.

## Breaking-change check

0.73.0 is breaking — Bloom dropped the `Dialog` `layer` prop and the overlay z-index rungs/helpers (`createOverlayZIndex`, `createDropdownZIndex`, `Z_INDEX_LAYER_STEP`, and the `overlayBackdrop`/`overlaySurface`/`dropdownSurface`/`tooltip`/`toast`/`fullscreen`/`fullscreenControl` keys). Nothing in this repo referenced any of it — verified by scan.

## Verification

- `bun run typecheck:frontend` — passes, 0 errors
- `bun run validate:lockfile` — 1993 resolutions, 5 workspace records, 6 frozen installs across 2 Dockerfiles
- lockfile committed in the same commit; installed `@oxyhq/bloom` resolves to `0.73.0` and its lockfile integrity matches the published tarball
- upstream: 4/4 stacking cases pass in a real browser (2/4 before), 128 suites / 1368 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)