### PR TITLE
fix(scripts): make the repair sweep's resume cursor survive its own runtime

### DIFF
--- a/packages/backend/src/__tests__/migrations/adminScriptCursorIndex.test.ts
+++ b/packages/backend/src/__tests__/migrations/adminScriptCursorIndex.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+import { migrationAdminScriptCursorIndex } from '../../migrations/0016-admin-script-cursor-index';
+
+/**
+ * Offline coverage for migration 0016 (admin-sweep resume-cursor identity).
+ *
+ * `autoIndex`/`autoCreate` are OFF in production, so this migration is the only
+ * thing that creates the UNIQUE `{script, scope}` index. The Mongo `Db` /
+ * collection are faked (createIndex captured) so the real call runs without a
+ * database.
+ *
+ * The uniqueness flag is what is actually being pinned. A plain compound index
+ * would satisfy every query the cursor makes and look completely healthy, while
+ * letting two tasks against one scope each insert their own row — after which a
+ * resume reads whichever it happens to find and silently re-walks or skips a
+ * stretch of the corpus.
+ */
+function makeDb() {
+  const createIndex = vi.fn().mockResolvedValue('script_1_scope_1');
+  const collection = { collectionName: 'adminscriptcursors', createIndex };
+  const db = { collection: vi.fn().mockReturnValue(collection) } as unknown as mongoose.mongo.Db;
+  return { db, createIndex };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('migration 0016 — admin script cursor index', () => {
+  it('targets the collection resolved from the model, not a hardcoded name', async () => {
+    const { db } = makeDb();
+
+    await migrationAdminScriptCursorIndex.run(db);
+
+    expect(db.collection).toHaveBeenCalledWith('adminscriptcursors');
+  });
+
+  it('creates the UNIQUE { script, scope } identity', async () => {
+    const { db, createIndex } = makeDb();
+
+    await migrationAdminScriptCursorIndex.run(db);
+
+    expect(createIndex).toHaveBeenCalledWith({ script: 1, scope: 1 }, { unique: true });
+    expect(createIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('is re-runnable — `createIndex` with an identical spec is the no-op', async () => {
+    const { db, createIndex } = makeDb();
+
+    await migrationAdminScriptCursorIndex.run(db);
+    await migrationAdminScriptCursorIndex.run(db);
+
+    expect(createIndex).toHaveBeenNthCalledWith(2, { script: 1, scope: 1 }, { unique: true });
+  });
+});

--- a/packages/backend/src/__tests__/migrations/registration.test.ts
+++ b/packages/backend/src/__tests__/migrations/registration.test.ts
@@ -1,0 +1,64 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { MIGRATION_IDS } from '../../migrations/runner';
+import type { Migration } from '../../migrations/runner';
+
+/**
+ * Every migration on disk is registered with the runner, in order.
+ *
+ * Forgetting the registration is silent by construction: nothing imports the
+ * file, nothing runs it, and no test anywhere fails. In production —
+ * `autoIndex`/`autoCreate` are OFF — the index it was supposed to create simply
+ * never exists, while every query keeps working, more slowly or without the
+ * constraint it was meant to enforce. That is exactly the shape of bug that gets
+ * found months later by the incident it causes.
+ */
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../migrations');
+
+/** `NNNN-slug.ts`; `constants.ts`, `runner.ts` and `task.ts` are not migrations. */
+const MIGRATION_FILE = /^(\d{4}-[a-z0-9-]+)\.ts$/;
+
+/**
+ * Migrations present when this guard was written. A traversal that silently
+ * stopped matching would otherwise "pass" against an empty set, which is the
+ * failure mode a filesystem-scanning test is most prone to.
+ */
+const VACUITY_FLOOR = 16;
+
+const migrationFiles = readdirSync(MIGRATIONS_DIR)
+  .map((entry) => MIGRATION_FILE.exec(entry))
+  .filter((match): match is RegExpExecArray => match !== null)
+  .map((match) => ({ file: match[0], id: match[1] }))
+  .sort((a, b) => a.id.localeCompare(b.id));
+
+describe('migration registration', () => {
+  it('finds the migration files at all', () => {
+    expect(migrationFiles.length).toBeGreaterThanOrEqual(VACUITY_FLOOR);
+  });
+
+  it('registers every migration on disk, in numeric order', () => {
+    // Set equality BOTH ways plus order, in one assertion: an unregistered file,
+    // a registered id with no file, and a list out of sequence all fail here.
+    expect(MIGRATION_IDS).toEqual(migrationFiles.map((migration) => migration.id));
+  });
+
+  it('gives each migration the id its filename promises', async () => {
+    // The runner records applied work under the id, so an id that disagrees with
+    // its filename would re-run (or skip) under a name nobody can trace back.
+    for (const { file, id } of migrationFiles) {
+      // The extension stays in the STATIC part of the specifier — Vite cannot
+      // resolve a fully dynamic one and warns rather than failing.
+      const module: Record<string, unknown> = await import(`../../migrations/${id}.ts`);
+      const exported = Object.values(module).find(
+        (value): value is Migration =>
+          typeof value === 'object'
+          && value !== null
+          && typeof (value as Migration).id === 'string'
+          && typeof (value as Migration).run === 'function',
+      );
+      expect(exported, `${file} exports no Migration`).toBeDefined();
+      expect(exported?.id, `${file} declares a mismatched id`).toBe(id);
+    }
+  });
+});

--- a/packages/backend/src/__tests__/scripts/adminScriptCursor.test.ts
+++ b/packages/backend/src/__tests__/scripts/adminScriptCursor.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The resume-cursor store shared by every long-running administrative sweep.
+ *
+ * These scripts only ever run as one-shot Fargate tasks, so a cursor on the
+ * container filesystem dies with the task, and CloudWatch cannot hold one either
+ * — the backend logger rewrites every 24-hex ObjectId to `[REDACTED]` and
+ * redacts any key ending in `id` (covered by
+ * `__tests__/utils/loggerSanitization.test.ts`). MongoDB is the only durable
+ * place a sweep already has, so what is pinned here is the read/write/clear
+ * contract every sweep depends on to be resumable at all.
+ */
+const mocks = vi.hoisted(() => ({
+  findOne: vi.fn(),
+  updateOne: vi.fn(),
+  deleteOne: vi.fn(),
+}));
+
+vi.mock('../../models/AdminScriptCursor', () => ({
+  AdminScriptCursor: {
+    findOne: mocks.findOne,
+    updateOne: mocks.updateOne,
+    deleteOne: mocks.deleteOne,
+  },
+}));
+
+import {
+  clearAdminScriptCursor,
+  readAdminScriptCursor,
+  recordAdminScriptCursor,
+} from '../../scripts/lib/adminScriptCursor';
+import { logger } from '../../utils/logger';
+
+const SCRIPT = 'repairFederatedMentions';
+const SCOPE = 'after:|before:|actor:';
+const CURSOR = '65fdc8c8c8c8c8c8c8c8c8c8';
+
+/** `findOne(...).lean()` resolving to `row`. */
+function leanResult(row: unknown): { lean: () => Promise<unknown> } {
+  return { lean: async () => row };
+}
+
+beforeEach(() => {
+  mocks.findOne.mockReset();
+  mocks.updateOne.mockReset().mockResolvedValue({ acknowledged: true });
+  mocks.deleteOne.mockReset().mockResolvedValue({ deletedCount: 1 });
+  vi.mocked(logger.warn).mockClear();
+});
+
+describe('readAdminScriptCursor', () => {
+  it('returns null for a scope that has never run', async () => {
+    mocks.findOne.mockReturnValue(leanResult(null));
+
+    await expect(readAdminScriptCursor(SCRIPT, SCOPE)).resolves.toBeNull();
+    expect(mocks.findOne).toHaveBeenCalledWith(
+      { script: SCRIPT, scope: SCOPE },
+      { cursor: 1, scanned: 1, completedAt: 1 },
+    );
+  });
+
+  it('reports where the scope got to, and whether it finished', async () => {
+    const completedAt = new Date('2026-08-01T15:46:38Z');
+    mocks.findOne.mockReturnValue(leanResult({ cursor: CURSOR, scanned: 30_000, completedAt }));
+
+    await expect(readAdminScriptCursor(SCRIPT, SCOPE)).resolves.toEqual({
+      cursor: CURSOR,
+      scanned: 30_000,
+      completedAt,
+    });
+  });
+
+  it('normalizes a legacy row with no completion stamp to "not finished"', async () => {
+    mocks.findOne.mockReturnValue(leanResult({ cursor: CURSOR, scanned: 1 }));
+
+    await expect(readAdminScriptCursor(SCRIPT, SCOPE)).resolves.toMatchObject({
+      completedAt: null,
+    });
+  });
+
+  it('propagates a read failure instead of degrading to "never ran"', async () => {
+    // Swallowing this would silently restart the sweep from the beginning —
+    // the exact failure the cursor exists to prevent.
+    mocks.findOne.mockReturnValue({ lean: async () => { throw new Error('no primary'); } });
+
+    await expect(readAdminScriptCursor(SCRIPT, SCOPE)).rejects.toThrow('no primary');
+  });
+});
+
+describe('recordAdminScriptCursor', () => {
+  it('upserts the scope\'s progress and reports that the write landed', async () => {
+    await expect(
+      recordAdminScriptCursor(SCRIPT, SCOPE, { cursor: CURSOR, scanned: 500 }),
+    ).resolves.toBe(true);
+
+    expect(mocks.updateOne).toHaveBeenCalledWith(
+      { script: SCRIPT, scope: SCOPE },
+      { $set: { cursor: CURSOR, scanned: 500, completedAt: null } },
+      { upsert: true },
+    );
+  });
+
+  it('stamps a completion time only when the range was exhausted', async () => {
+    await recordAdminScriptCursor(SCRIPT, SCOPE, {
+      cursor: CURSOR,
+      scanned: 500,
+      completed: true,
+    });
+
+    const [, update] = mocks.updateOne.mock.calls[0] as [
+      unknown,
+      { $set: { completedAt: Date | null } },
+    ];
+    expect(update.$set.completedAt).toBeInstanceOf(Date);
+  });
+
+  it('clears an earlier completion stamp when the scope has more work', async () => {
+    // A scope that gained new candidates after finishing must not keep reading
+    // as finished, or the next operator sees "nothing to do" and believes it.
+    await recordAdminScriptCursor(SCRIPT, SCOPE, { cursor: CURSOR, scanned: 900 });
+
+    const [, update] = mocks.updateOne.mock.calls[0] as [
+      unknown,
+      { $set: { completedAt: Date | null } },
+    ];
+    expect(update.$set.completedAt).toBeNull();
+  });
+
+  it('reports a failed write instead of throwing, and never logs the cursor', async () => {
+    mocks.updateOne.mockRejectedValue(new Error('connection reset by peer'));
+
+    // A transient blip must not kill a sweep that is otherwise doing its work
+    // correctly; the caller counts the miss and fails the run at the end.
+    await expect(
+      recordAdminScriptCursor(SCRIPT, SCOPE, { cursor: CURSOR, scanned: 500 }),
+    ).resolves.toBe(false);
+
+    const [message, context] = vi.mocked(logger.warn).mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(message).toContain('could not persist the resume cursor');
+    expect(JSON.stringify(context)).not.toContain(CURSOR);
+  });
+});
+
+describe('clearAdminScriptCursor', () => {
+  it('forgets the scope\'s progress', async () => {
+    await clearAdminScriptCursor(SCRIPT, SCOPE);
+
+    expect(mocks.deleteOne).toHaveBeenCalledWith({ script: SCRIPT, scope: SCOPE });
+  });
+
+  it('propagates a failed clear rather than resuming anyway', async () => {
+    // This only ever runs because an operator asked for a fresh start. Resuming
+    // after failing to honour that would be a silent lie about what ran.
+    mocks.deleteOne.mockRejectedValue(new Error('not authorized'));
+
+    await expect(clearAdminScriptCursor(SCRIPT, SCOPE)).rejects.toThrow('not authorized');
+  });
+});

--- a/packages/backend/src/__tests__/scripts/repairFederatedMentions.test.ts
+++ b/packages/backend/src/__tests__/scripts/repairFederatedMentions.test.ts
@@ -29,6 +29,15 @@ interface StoredVariant {
   tag?: string;
 }
 
+/** A stored `adminscriptcursors` row — where one shard scope got to. */
+interface StoredCursor {
+  script: string;
+  scope: string;
+  cursor: string;
+  scanned: number;
+  completedAt: Date | null;
+}
+
 /** A stored post row as `.lean()` hands it to the script. */
 interface StoredPost {
   _id: mongoose.Types.ObjectId;
@@ -50,7 +59,15 @@ interface BulkOp {
 }
 
 const mocks = vi.hoisted(() => {
-  const store: { posts: StoredPost[]; ops: BulkOp[] } = { posts: [], ops: [] };
+  const store: {
+    posts: StoredPost[];
+    ops: BulkOp[];
+    cursors: StoredCursor[];
+    /** Every cursor value written, in order — the per-page persistence itself. */
+    cursorWrites: { scope: string; cursor: string; scanned: number; completed: boolean }[];
+    /** Set to make the next cursor write fail, like a database blip would. */
+    cursorWriteError: Error | null;
+  } = { posts: [], ops: [], cursors: [], cursorWrites: [], cursorWriteError: null };
 
   /**
    * Read every value a dotted filter key reaches, fanning out through arrays the
@@ -82,6 +99,8 @@ const mocks = vi.hoisted(() => {
           return values.some((value) => Array.isArray(value) && value.length === operand);
         case '$gt':
           return values.some((value) => String(value) > String(operand));
+        case '$lte':
+          return values.some((value) => String(value) <= String(operand));
         case '$regex':
           return values.some((value) => typeof value === 'string' && (operand as RegExp).test(value));
         default:
@@ -146,10 +165,50 @@ const mocks = vi.hoisted(() => {
         return { modifiedCount: ops.length };
       }),
     },
+    /**
+     * A minimal `adminscriptcursors` collection, so the REAL cursor helper runs
+     * against it rather than being stubbed out. Mocking the helper instead would
+     * leave the wiring — which scope a run reads, when it writes, whether a dry
+     * run writes at all — untested, and that wiring is the entire fix.
+     */
+    cursorModel: {
+      findOne: vi.fn((filter: { script: string; scope: string }) => ({
+        lean: async () =>
+          store.cursors.find(
+            (row) => row.script === filter.script && row.scope === filter.scope,
+          ) ?? null,
+      })),
+      updateOne: vi.fn(async (
+        filter: { script: string; scope: string },
+        update: { $set: Omit<StoredCursor, 'script' | 'scope'> },
+      ) => {
+        if (store.cursorWriteError) throw store.cursorWriteError;
+        store.cursorWrites.push({
+          scope: filter.scope,
+          cursor: update.$set.cursor,
+          scanned: update.$set.scanned,
+          completed: update.$set.completedAt !== null,
+        });
+        const existing = store.cursors.find(
+          (row) => row.script === filter.script && row.scope === filter.scope,
+        );
+        if (existing) Object.assign(existing, update.$set);
+        else store.cursors.push({ ...filter, ...update.$set });
+        return { acknowledged: true };
+      }),
+      deleteOne: vi.fn(async (filter: { script: string; scope: string }) => {
+        store.cursors = store.cursors.filter(
+          (row) => !(row.script === filter.script && row.scope === filter.scope),
+        );
+        return { deletedCount: 1 };
+      }),
+    },
   };
 });
 
 vi.mock('../../models/Post', () => ({ Post: mocks.postModel }));
+
+vi.mock('../../models/AdminScriptCursor', () => ({ AdminScriptCursor: mocks.cursorModel }));
 
 vi.mock('../../connectors/activitypub/helpers', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../connectors/activitypub/helpers')>()),
@@ -179,8 +238,10 @@ vi.mock('../../connectors/shared/federatedMedia', () => ({
 import {
   assertRepairRunComplete,
   buildCandidateFilter,
+  buildCursorScope,
   repairFederatedMentions,
   resolveSourceUrl,
+  SCRIPT_NAME,
   type RepairFederatedMentionsSummary,
 } from '../../scripts/repairFederatedMentions';
 import { logger } from '../../utils/logger';
@@ -257,9 +318,15 @@ function apResponse(body: unknown): Response {
 beforeEach(() => {
   store.posts = [];
   store.ops = [];
+  store.cursors = [];
+  store.cursorWrites = [];
+  store.cursorWriteError = null;
   postModel.countDocuments.mockClear();
   postModel.find.mockClear();
   postModel.bulkWrite.mockClear();
+  mocks.cursorModel.findOne.mockClear();
+  mocks.cursorModel.updateOne.mockClear();
+  mocks.cursorModel.deleteOne.mockClear();
   mocks.signedFetch.mockReset();
   mocks.getOrFetchActor.mockReset();
   mocks.findExistingActor.mockReset();
@@ -643,6 +710,214 @@ describe('repairFederatedMentions', () => {
 });
 
 /**
+ * The resume cursor, which is the difference between a killed sweep being
+ * continued and being restarted.
+ *
+ * Restarting is not merely slower: the candidate filter only stops matching a
+ * post once it is REPAIRED, so every `unresolved`, `gone` and `fetchFailed` post
+ * keeps matching forever at the LOWEST ids. Measured in production on
+ * 2026-08-01, a restart re-walked a 9,466-post stuck head for 51 repairs (0.5%)
+ * — nine thousand requests to other people's servers that could not succeed.
+ * Every assertion below is ultimately about that: `signedFetch` call counts are
+ * requests to somebody else's server.
+ *
+ * The cursor is exercised through a mocked `AdminScriptCursor` COLLECTION rather
+ * than a mocked helper, so the wiring under test — which scope a run reads, when
+ * it writes, and whether a dry run writes at all — actually runs.
+ */
+describe('resume cursor', () => {
+  /** An id with hex LETTERS in it, so case canonicalisation is observable. */
+  const LETTERED_ID = '65fdc8c8c8c8c8c8c8c8c8c8';
+
+  /** A stored cursor for `scope`, as a killed run would have left it. */
+  function storedCursor(scope: string, cursor: string, scanned: number): StoredCursor {
+    return { script: SCRIPT_NAME, scope, cursor, scanned, completedAt: null };
+  }
+
+  it('records the cursor after EVERY page, not once at the end', async () => {
+    store.posts = [damagedPost('1'), damagedPost('2'), damagedPost('3')];
+
+    const summary = await repairFederatedMentions({ batchSize: 1, noteTimeoutMs: 1_000 });
+
+    // A run that dies never reaches its final summary, so a cursor written only
+    // at the end could not survive the one case it exists for.
+    expect(store.cursorWrites).toEqual([
+      { scope: summary.cursorScope, cursor: oid('1').toString(), scanned: 1, completed: false },
+      { scope: summary.cursorScope, cursor: oid('2').toString(), scanned: 2, completed: false },
+      { scope: summary.cursorScope, cursor: oid('3').toString(), scanned: 3, completed: false },
+      // The empty page that ends the sweep: the range is exhausted, so the scope
+      // is stamped finished rather than merely paused.
+      { scope: summary.cursorScope, cursor: oid('3').toString(), scanned: 3, completed: true },
+    ]);
+    expect(store.cursors).toEqual([{
+      script: SCRIPT_NAME,
+      scope: summary.cursorScope,
+      cursor: oid('3').toString(),
+      scanned: 3,
+      completedAt: expect.any(Date),
+    }]);
+  });
+
+  it('leaves the scope unfinished when the run stopped on its limit', async () => {
+    store.posts = [damagedPost('1'), damagedPost('2'), damagedPost('3')];
+
+    await repairFederatedMentions({ limit: 2, batchSize: 1, noteTimeoutMs: 1_000 });
+
+    // Stopping on a budget is not finishing, and a scope wrongly stamped
+    // complete would read as "nothing left to do" forever.
+    expect(store.cursorWrites.map((write) => write.completed)).toEqual([false, false]);
+    expect(store.cursors[0]).toMatchObject({ cursor: oid('2').toString(), completedAt: null });
+  });
+
+  it('resumes past everything the previous run visited instead of restarting', async () => {
+    store.posts = [damagedPost('1'), damagedPost('2'), damagedPost('3')];
+    store.cursors = [storedCursor(buildCursorScope({}), oid('2').toString(), 2)];
+
+    const summary = await repairFederatedMentions({ noteTimeoutMs: 1_000 });
+
+    expect(summary.resumed).toBe(true);
+    expect(summary.resumedFromScanned).toBe(2);
+    expect(summary.scanned).toBe(1);
+    // Counted within the resumed range, so the run reports the work it has LEFT.
+    expect(summary.candidates).toBe(1);
+    expect(store.ops.map((op) => op.updateOne.filter._id.toString())).toEqual([
+      oid('3').toString(),
+    ]);
+    // The whole point: the stuck head is not re-fetched from its origin.
+    expect(mocks.signedFetch).toHaveBeenCalledTimes(1);
+    expect(store.posts[0].mentions).toEqual([]);
+  });
+
+  it('reads the cursor under a DRY RUN but never advances it', async () => {
+    store.posts = [damagedPost('1'), damagedPost('2'), damagedPost('3')];
+    store.cursors = [storedCursor(buildCursorScope({}), oid('1').toString(), 1)];
+
+    const summary = await repairFederatedMentions({ dryRun: true, noteTimeoutMs: 1_000 });
+
+    // Reading is what makes a preview show what the next LIVE run would do.
+    expect(summary.resumed).toBe(true);
+    expect(summary.scanned).toBe(2);
+    // Writing would make that live run skip exactly the posts just previewed.
+    expect(store.cursorWrites).toEqual([]);
+    expect(store.cursors[0]).toMatchObject({ cursor: oid('1').toString(), scanned: 1 });
+  });
+
+  it('keeps each shard scope separate, so parallel shards never resume each other', async () => {
+    store.posts = [damagedPost('1'), damagedPost('2'), damagedPost('3'), damagedPost('4')];
+    // Shard A — ids up to 2 — has already finished its territory.
+    store.cursors = [{
+      ...storedCursor(buildCursorScope({ beforeId: oid('2') }), oid('2').toString(), 2),
+      completedAt: new Date(),
+    }];
+
+    // Shard B — ids 3 and 4 — must be untouched by any of that.
+    const summary = await repairFederatedMentions({
+      afterId: oid('2').toString(),
+      beforeId: oid('4').toString(),
+      noteTimeoutMs: 1_000,
+    });
+
+    expect(summary.resumed).toBe(false);
+    expect(summary.scanned).toBe(2);
+    expect(store.ops.map((op) => op.updateOne.filter._id.toString())).toEqual([
+      oid('3').toString(),
+      oid('4').toString(),
+    ]);
+    expect(store.cursors).toHaveLength(2);
+    expect(store.cursorWrites.every((write) => write.scope === summary.cursorScope)).toBe(true);
+  });
+
+  it('separates shards that differ only in their upper bound', async () => {
+    store.posts = [damagedPost('1'), damagedPost('2'), damagedPost('3'), damagedPost('4')];
+    // A narrow shard covering ids up to 2 has run to the end of its range.
+    store.cursors = [storedCursor(
+      buildCursorScope({ beforeId: oid('2') }),
+      oid('2').toString(),
+      2,
+    )];
+
+    // A WIDER shard from the same lower bound is a different territory. Sharing
+    // a scope with the narrow one would make it skip ids 1 and 2 outright —
+    // invisible in every counter, because it would report a clean resumed run.
+    const summary = await repairFederatedMentions({
+      beforeId: oid('4').toString(),
+      noteTimeoutMs: 1_000,
+    });
+
+    expect(summary.resumed).toBe(false);
+    expect(summary.scanned).toBe(4);
+  });
+
+  it('treats a differently-spelled bound as the SAME shard, not a second one', async () => {
+    store.posts = [damagedPost('1')];
+
+    const canonical = await repairFederatedMentions({
+      afterId: LETTERED_ID,
+      dryRun: true,
+      noteTimeoutMs: 1_000,
+    });
+    const spelledDifferently = await repairFederatedMentions({
+      afterId: `  ${LETTERED_ID.toUpperCase()}  `,
+      dryRun: true,
+      noteTimeoutMs: 1_000,
+    });
+
+    // Two spellings of one shard resolving to two scopes would leave each
+    // re-walking the other's ground while both looked resumed.
+    expect(spelledDifferently.cursorScope).toBe(canonical.cursorScope);
+    // Vacuity floor: the scope really carries the canonicalised bound, rather
+    // than both spellings collapsing to some constant.
+    expect(canonical.cursorScope).toContain(LETTERED_ID);
+  });
+
+  it('refuses to run when the stored cursor lies outside the declared range', async () => {
+    store.posts = [damagedPost('1'), damagedPost('2'), damagedPost('3')];
+    const scope = buildCursorScope({ afterId: oid('1'), beforeId: oid('2') });
+    store.cursors = [storedCursor(scope, oid('3').toString(), 3)];
+
+    // Resuming from it would either skip a stretch of the corpus or re-walk a
+    // neighbouring shard, and both are invisible in the counters.
+    await expect(repairFederatedMentions({
+      afterId: oid('1').toString(),
+      beforeId: oid('2').toString(),
+      noteTimeoutMs: 1_000,
+    })).rejects.toThrow(/outside this run's declared _id range/);
+    expect(mocks.signedFetch).not.toHaveBeenCalled();
+  });
+
+  it('starts the shard again, once, when the cursor is explicitly reset', async () => {
+    store.posts = [damagedPost('1'), damagedPost('2'), damagedPost('3')];
+    store.cursors = [storedCursor(buildCursorScope({}), oid('2').toString(), 2)];
+
+    const summary = await repairFederatedMentions({ resetCursor: true, noteTimeoutMs: 1_000 });
+
+    expect(summary.resumed).toBe(false);
+    expect(summary.resumedFromScanned).toBe(0);
+    expect(summary.scanned).toBe(3);
+    expect(mocks.cursorModel.deleteOne).toHaveBeenCalledWith({
+      script: SCRIPT_NAME,
+      scope: summary.cursorScope,
+    });
+  });
+
+  it('counts a cursor write that did not land, and fails the run for it', async () => {
+    store.posts = [damagedPost('1')];
+    store.cursorWriteError = new Error('connection reset by peer');
+
+    const summary = await repairFederatedMentions({ noteTimeoutMs: 1_000 });
+
+    // The sweep itself is unharmed — a database blip must not kill a six-hour
+    // run that is repairing posts correctly.
+    expect(summary.repaired).toBe(1);
+    expect(summary.written).toBe(1);
+    // But it is never swallowed: the damage lands on the NEXT run, which would
+    // silently restart at the beginning.
+    expect(summary.cursorWriteFailures).toBe(2);
+    expect(() => assertRepairRunComplete(summary)).toThrow('cursorNotPersisted=2');
+  });
+});
+
+/**
  * Which counters reach the completion guard, and in which bucket. The guard's own
  * threshold arithmetic is covered by `adminRunTolerance.test.ts`; this pins the
  * WIRING, which is the part specific to this sweep and the part a future edit
@@ -670,6 +945,11 @@ describe('assertRepairRunComplete', () => {
       skippedNoSource: 0,
       skippedEmptyBody: 0,
       written: 0,
+      lastScannedId: null,
+      cursorScope: buildCursorScope({}),
+      resumed: false,
+      resumedFromScanned: 0,
+      cursorWriteFailures: 0,
       samples: [],
       failures: [],
       ...overrides,
@@ -721,6 +1001,15 @@ describe('assertRepairRunComplete', () => {
   it('fails on a single candidate with no source URL — the filter guarantees one', () => {
     expect(() => assertRepairRunComplete(summaryOf({ skippedNoSource: 1 }))).toThrow(
       'skippedNoSource=1',
+    );
+  });
+
+  it('fails on a single cursor write that did not persist', () => {
+    // Costs this run nothing — which is exactly why it must fail here. The
+    // damage lands on the NEXT run, which restarts at the beginning and
+    // re-fetches the whole stuck head from other people's servers.
+    expect(() => assertRepairRunComplete(summaryOf({ cursorWriteFailures: 1 }))).toThrow(
+      'cursorNotPersisted=1',
     );
   });
 

--- a/packages/backend/src/migrations/0016-admin-script-cursor-index.ts
+++ b/packages/backend/src/migrations/0016-admin-script-cursor-index.ts
@@ -1,0 +1,41 @@
+/**
+ * Migration 0016: the UNIQUE identity of an administrative sweep's resume cursor.
+ *
+ * `AdminScriptCursor` stores where a long-running sweep got to, so a one-shot
+ * Fargate task that is killed mid-run can be resumed instead of restarting at
+ * the beginning and re-fetching everything it already visited. Its whole
+ * usefulness rests on `(script, scope)` addressing exactly ONE row.
+ *
+ *  - `adminscriptcursors` UNIQUE `{ script: 1, scope: 1 }` — the cursor's
+ *    identity. The sweep records progress with an upsert on that pair; WITHOUT
+ *    the constraint, two tasks started against the same scope can each insert
+ *    their own row, and the next run's `findOne` then resumes from whichever it
+ *    happens to read. That is the invisible failure: a run that reports itself
+ *    cleanly resumed while silently re-walking, or skipping, a stretch of the
+ *    corpus. The schema declares the index, but `autoIndex`/`autoCreate` are OFF
+ *    in production (see `utils/database.ts`), so this migration is the only
+ *    thing that creates it.
+ *
+ * Idempotent: `createIndex` with an identical spec is a no-op, and it creates
+ * the `adminscriptcursors` collection on first run. Data-free — the collection
+ * is new, so the unique constraint has nothing to conflict with.
+ */
+
+import mongoose from 'mongoose';
+import { logger } from '../utils/logger';
+import { MIGRATION_ADMIN_SCRIPT_CURSOR_INDEX } from './constants';
+import { AdminScriptCursor } from '../models/AdminScriptCursor';
+import type { Migration } from './runner';
+
+export const migrationAdminScriptCursorIndex: Migration = {
+  id: MIGRATION_ADMIN_SCRIPT_CURSOR_INDEX,
+
+  async run(db: mongoose.mongo.Db): Promise<void> {
+    const cursors = db.collection(AdminScriptCursor.collection.collectionName);
+    await cursors.createIndex({ script: 1, scope: 1 }, { unique: true });
+    logger.info(
+      `[migration] ensured index on ${cursors.collectionName} ` +
+        `{ script: 1, scope: 1 } (unique)`,
+    );
+  },
+};

--- a/packages/backend/src/migrations/constants.ts
+++ b/packages/backend/src/migrations/constants.ts
@@ -126,3 +126,11 @@ export const MIGRATION_POST_TREND_TERMS_INDEX = '0014-post-trend-terms-index';
  * migration is the schema authority. See {@link ./0015-trend-summary-indexes}.
  */
 export const MIGRATION_TREND_SUMMARY_INDEXES = '0015-trend-summary-indexes';
+
+/**
+ * Create the UNIQUE `{script, scope}` identity of an administrative sweep's
+ * resume cursor, so one shard scope can only ever have one recorded position.
+ * Production disables Mongoose auto-indexing, so this migration is the schema
+ * authority. See {@link ./0016-admin-script-cursor-index}.
+ */
+export const MIGRATION_ADMIN_SCRIPT_CURSOR_INDEX = '0016-admin-script-cursor-index';

--- a/packages/backend/src/migrations/runner.ts
+++ b/packages/backend/src/migrations/runner.ts
@@ -26,6 +26,7 @@ import { migrationMtnEventIdempotencyIndex } from './0012-mtn-event-idempotency-
 import { migrationTrendingNameTypeUniqueIndex } from './0013-trending-name-type-unique-index';
 import { migrationPostTrendTermsIndex } from './0014-post-trend-terms-index';
 import { migrationTrendSummaryIndexes } from './0015-trend-summary-indexes';
+import { migrationAdminScriptCursorIndex } from './0016-admin-script-cursor-index';
 import { MIGRATIONS_COLLECTION } from './constants';
 
 export interface Migration {
@@ -77,7 +78,20 @@ const MIGRATIONS: readonly Migration[] = [
   migrationTrendingNameTypeUniqueIndex,
   migrationPostTrendTermsIndex,
   migrationTrendSummaryIndexes,
+  migrationAdminScriptCursorIndex,
 ];
+
+/**
+ * The ordered ids this runner will apply.
+ *
+ * Exported so that a migration which was WRITTEN but never registered here is a
+ * test failure rather than a discovery months later. That mistake is silent by
+ * construction: nothing imports the file, nothing runs it, and in production —
+ * where `autoIndex`/`autoCreate` are off — the index it was meant to create
+ * simply does not exist while every query still works, more slowly or without
+ * the constraint it was supposed to enforce.
+ */
+export const MIGRATION_IDS: readonly string[] = MIGRATIONS.map((migration) => migration.id);
 
 export async function getPendingMigrationIds(): Promise<string[]> {
   const db = mongoose.connection.db;

--- a/packages/backend/src/models/AdminScriptCursor.ts
+++ b/packages/backend/src/models/AdminScriptCursor.ts
@@ -1,0 +1,56 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+/**
+ * Where a long-running administrative sweep got to, so a run that dies can be
+ * resumed instead of restarted.
+ *
+ * WHY THE DATABASE AND NOT A FILE OR A LOG LINE
+ *   These sweeps are only ever run as one-shot Fargate tasks, so the container
+ *   filesystem dies with the task — a cursor written to a path is gone exactly
+ *   when it is needed. CloudWatch cannot hold it either: `sanitizeLogString`
+ *   rewrites every 24-hex ObjectId to `[REDACTED]` and `isSensitiveKey` redacts
+ *   any key ending in `id`, both covered by `__tests__/utils/loggerSanitization.test.ts`,
+ *   so a logged cursor reads `[REDACTED]` whatever it is called. The database is
+ *   the one durable place a sweep already holds a connection to, and keeping the
+ *   id there keeps it out of the log where it does not belong.
+ *
+ * SCOPE
+ *   A sweep may be split into parallel shards, each owning a half-open `_id`
+ *   range. `scope` is the shard's declared territory, so shards record their
+ *   progress independently and re-running one shard's command resumes THAT
+ *   shard. The `(script, scope)` pair is unique.
+ */
+export interface IAdminScriptCursor extends Document {
+  /** The script's own name — the same token its mutation guard confirms. */
+  script: string;
+  /** The shard's declared territory, canonical and deterministic per shard. */
+  scope: string;
+  /** The `_id` of the last document the scope scanned, as a hex string. */
+  cursor: string;
+  /** Documents this scope has scanned in total, accumulated across resumes. */
+  scanned: number;
+  /**
+   * Set when the scope's range was walked to exhaustion, so a finished sweep is
+   * distinguishable from one that stopped on a limit or died mid-page.
+   */
+  completedAt?: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const AdminScriptCursorSchema = new Schema<IAdminScriptCursor>({
+  script: { type: String, required: true },
+  scope: { type: String, required: true },
+  cursor: { type: String, required: true },
+  scanned: { type: Number, required: true, default: 0 },
+  completedAt: { type: Date, default: null },
+}, {
+  timestamps: true,
+});
+
+AdminScriptCursorSchema.index({ script: 1, scope: 1 }, { unique: true });
+
+export const AdminScriptCursor = mongoose.model<IAdminScriptCursor>(
+  'AdminScriptCursor',
+  AdminScriptCursorSchema,
+);

--- a/packages/backend/src/scripts/lib/adminScriptCursor.ts
+++ b/packages/backend/src/scripts/lib/adminScriptCursor.ts
@@ -1,0 +1,96 @@
+import { AdminScriptCursor } from '../../models/AdminScriptCursor';
+import { logger } from '../../utils/logger';
+
+/** A scope's recorded progress, as the sweep left it. */
+export interface AdminScriptCursorState {
+  /** The `_id` of the last document the scope scanned, as a hex string. */
+  cursor: string;
+  /** Documents this scope has scanned in total, accumulated across resumes. */
+  scanned: number;
+  /** When the scope's range was walked to exhaustion, or `null` if it was not. */
+  completedAt: Date | null;
+}
+
+/** What a sweep knows about its own progress at the end of a page. */
+export interface AdminScriptCursorUpdate {
+  cursor: string;
+  scanned: number;
+  /** The range was walked to exhaustion — stamp the scope as finished. */
+  completed?: boolean;
+}
+
+/** The stored fields a read needs; the rest of the document is bookkeeping. */
+type AdminScriptCursorRow = Pick<AdminScriptCursorState, 'cursor' | 'scanned'> & {
+  completedAt?: Date | null;
+};
+
+/**
+ * Read where a scope got to, or `null` if it has never run.
+ *
+ * Deliberately NOT wrapped in a try/catch: a sweep that cannot read its own
+ * cursor must not silently start over from the beginning, which is the exact
+ * failure this mechanism exists to prevent.
+ */
+export async function readAdminScriptCursor(
+  script: string,
+  scope: string,
+): Promise<AdminScriptCursorState | null> {
+  const stored = await AdminScriptCursor.findOne(
+    { script, scope },
+    { cursor: 1, scanned: 1, completedAt: 1 },
+  ).lean<AdminScriptCursorRow | null>();
+  if (!stored) return null;
+  return {
+    cursor: stored.cursor,
+    scanned: stored.scanned,
+    completedAt: stored.completedAt ?? null,
+  };
+}
+
+/**
+ * Record where a scope has got to. Called after EVERY page, because the case
+ * that most needs a resume point is a run that DIES mid-sweep and never reaches
+ * its final summary.
+ *
+ * Returns whether the write landed instead of throwing: a transient database
+ * blip must not kill a sweep that is otherwise repairing documents correctly.
+ * It is NOT swallowed, though — the caller counts every miss and hands the total
+ * to `assertAdminRunComplete` as a strict issue, so a run whose cursor never
+ * persisted exits non-zero rather than quietly becoming unresumable again.
+ */
+export async function recordAdminScriptCursor(
+  script: string,
+  scope: string,
+  update: AdminScriptCursorUpdate,
+): Promise<boolean> {
+  try {
+    await AdminScriptCursor.updateOne(
+      { script, scope },
+      {
+        $set: {
+          cursor: update.cursor,
+          scanned: update.scanned,
+          completedAt: update.completed ? new Date() : null,
+        },
+      },
+      { upsert: true },
+    );
+    return true;
+  } catch (error) {
+    // The cursor itself cannot go in this record — the logger redacts a 24-hex
+    // ObjectId under every key. The scope is on the returned summary.
+    logger.warn('[adminScript] could not persist the resume cursor', { script, error });
+    return false;
+  }
+}
+
+/**
+ * Forget a scope's progress so the next run starts at its declared bound.
+ *
+ * Throws on failure, unlike a write: this only ever runs because an operator
+ * explicitly asked for a fresh start, and honouring that instruction is the
+ * whole point. Resuming anyway after a failed clear would be a silent lie.
+ */
+export async function clearAdminScriptCursor(script: string, scope: string): Promise<void> {
+  await AdminScriptCursor.deleteOne({ script, scope });
+}

--- a/packages/backend/src/scripts/repairFederatedMentions.ts
+++ b/packages/backend/src/scripts/repairFederatedMentions.ts
@@ -109,15 +109,14 @@
  *   REPAIR_BATCH_SIZE=500     posts per `_id` page
  *   REPAIR_CONCURRENCY=8      posts re-fetched in parallel (clamped to 32)
  *   REPAIR_LIMIT=<n>          cap total posts scanned (canary budget)
- *   REPAIR_AFTER_ID=<oid>     resume/shard lower bound, EXCLUSIVE. Set it to the
- *                             previous run's `lastScannedId` to chain chunks;
- *                             without it EVERY run restarts at the lowest `_id`
- *                             and re-fetches the whole stuck head (see below).
- *                             A malformed value ABORTS — never a silent rescan.
+ *   REPAIR_AFTER_ID=<oid>     shard lower bound, EXCLUSIVE — where this shard's
+ *                             territory STARTS. Resuming does not use it: that is
+ *                             automatic (see RESUMING below). A malformed value
+ *                             ABORTS — never a silent rescan.
  *   REPAIR_BEFORE_ID=<oid>    shard upper bound, INCLUSIVE. Only needed for
- *                             PARALLEL shards; sequential chaining does not use it.
- *   REPAIR_CURSOR_FILE=<path> persist the resume cursor here after every page, so
- *                             a run that dies mid-sweep is resumable
+ *                             PARALLEL shards; a single sequential sweep has none.
+ *   REPAIR_RESET_CURSOR=true  forget this shard's recorded progress and start
+ *                             again at the declared bound (see RESUMING below)
  *   REPAIR_ACTOR_URI=<uri>    restrict to one `federation.actorUri`
  *   REPAIR_NOTE_TIMEOUT_MS    per-note fetch budget (default 20000; note the
  *                             transport's own `ACTIVITYPUB_FETCH_DEADLINE_MS` of
@@ -131,22 +130,42 @@
  *   CONFIRM_ADMIN_MUTATION=repairFederatedMentions \
  *     bun packages/backend/dist/src/scripts/repairFederatedMentions.js
  *
- * CHAINING BOUNDED CHUNKS (the reason `REPAIR_AFTER_ID` exists)
+ * RESUMING (why the cursor lives in MongoDB)
  *   The candidate filter only stops matching a post once it is REPAIRED. An
  *   `unresolved`, `gone` or `fetchFailed` post writes nothing and keeps matching
- *   forever — and those sit at the LOWEST ids. So without a resume cursor, chunk
- *   N+1 re-fetches the entire stuck head of chunk N: thousands of requests to
- *   other people's servers that cannot produce a repair. Measured: chunk 1
- *   scanned 20,000 and left 9,466 stuck (47%), so chunk 2's yield would have
- *   halved while still spending its full fetch budget.
+ *   forever — and those sit at the LOWEST ids. So a run that restarts at the
+ *   beginning re-fetches the entire stuck head of the previous one: thousands of
+ *   requests to other people's servers that cannot produce a repair. Measured in
+ *   production on 2026-08-01: a `REPAIR_LIMIT=20000` chunk left 9,466 stuck, and
+ *   the unbounded run that followed re-walked all of it — 9,500 posts scanned for
+ *   51 repairs (0.5%), against 70% for that run overall.
  *
- *     CURSOR=/var/run/repair.cursor
- *     REPAIR_CURSOR_FILE=$CURSOR REPAIR_LIMIT=20000 \
- *       CONFIRM_ADMIN_MUTATION=repairFederatedMentions \
+ *   So the cursor has to survive the run, and this script is only ever executed
+ *   as a ONE-SHOT FARGATE TASK: the container filesystem dies with the task, so
+ *   a cursor written to a path is gone exactly when it is needed. It cannot go
+ *   to CloudWatch either — the backend logger rewrites every 24-hex ObjectId to
+ *   `[REDACTED]` and redacts any key ending in `id` (see
+ *   `__tests__/utils/loggerSanitization.test.ts`), so a logged cursor is
+ *   unreadable whatever it is called, and evading that would mean defeating a
+ *   privacy control on purpose. It is therefore persisted to MongoDB, the one
+ *   durable place this script already holds a connection to, after EVERY page —
+ *   see {@link AdminScriptCursor}.
+ *
+ *   Resuming is consequently AUTOMATIC and needs no operator bookkeeping: run
+ *   the same command again and it continues past everything the previous run
+ *   visited, stuck posts included.
+ *
+ *     REPAIR_LIMIT=20000 CONFIRM_ADMIN_MUTATION=repairFederatedMentions \
  *       bun .../repairFederatedMentions.js
- *     REPAIR_AFTER_ID=$(cat $CURSOR) REPAIR_CURSOR_FILE=$CURSOR REPAIR_LIMIT=20000 \
- *       CONFIRM_ADMIN_MUTATION=repairFederatedMentions \
+ *     # the SAME command again — it resumes, it does not restart:
+ *     REPAIR_LIMIT=20000 CONFIRM_ADMIN_MUTATION=repairFederatedMentions \
  *       bun .../repairFederatedMentions.js
+ *
+ *   Progress is recorded per SHARD SCOPE — the range and actor a run declares —
+ *   so parallel shards never read or overwrite each other's cursor, and a
+ *   deliberate re-sweep of a scope is `REPAIR_RESET_CURSOR=true`. A DRY RUN reads
+ *   the cursor (so a preview shows what the next live run would do) but never
+ *   writes one, so previewing 50 posts can never make a live run skip them.
  *
  * PARALLEL SHARDS
  *   Compute the boundary ids ONCE, then give each task a half-open range. The
@@ -166,7 +185,6 @@
  *   await g.disconnect();})()"
  */
 
-import { renameSync, writeFileSync } from 'node:fs';
 import mongoose from 'mongoose';
 import { PostType, type MediaItem, type PostContentVariant } from '@mention/shared-types';
 import { Post } from '../models/Post';
@@ -182,6 +200,14 @@ import {
   assertAdminRunComplete,
   closeAdminScriptResources,
 } from './lib/adminScriptLifecycle';
+import {
+  clearAdminScriptCursor,
+  readAdminScriptCursor,
+  recordAdminScriptCursor,
+} from './lib/adminScriptCursor';
+
+/** This sweep's own name — the mutation-guard token and the cursor's key. */
+export const SCRIPT_NAME = 'repairFederatedMentions';
 
 /** Posts scanned per `_id` page when the caller supplies no batch size. */
 const DEFAULT_PAGE_SIZE = 500;
@@ -301,15 +327,13 @@ export interface RepairFailure {
 
 export interface RepairFederatedMentionsOptions {
   /**
-   * Resume/shard lower bound, EXCLUSIVE: only posts with `_id > afterId`.
+   * Shard lower bound, EXCLUSIVE: only posts with `_id > afterId`. Where this
+   * shard's TERRITORY starts, together with {@link beforeId} — not where the run
+   * picks up, which the stored cursor decides on its own.
    *
-   * Without it every invocation restarts at the lowest `_id`. That matters
-   * because the candidate filter only stops matching a post once it is REPAIRED
-   * — an `unresolved`, `gone` or `fetchFailed` post writes nothing and keeps
-   * matching forever, at the lowest ids. So a second bounded chunk re-fetches the
-   * whole stuck head of the previous one: thousands of requests to other people's
-   * servers that cannot produce a repair. Measured on the real corpus: chunk 1
-   * scanned 20,000 and left 9,466 stuck (47%).
+   * It is also half of the cursor's scope key, so two shards can record their
+   * progress independently and re-running one shard's exact command resumes THAT
+   * shard.
    */
   afterId?: string;
   /**
@@ -320,20 +344,19 @@ export interface RepairFederatedMentionsOptions {
    * than its limit keeps walking forward into the next shard's range and
    * re-fetches it. Bounding the range makes a shard's territory a property of the
    * range itself, so N tasks can never overlap however the candidate set shifts
-   * under them. Sequential chaining does not need it.
+   * under them. A single sequential sweep has no upper bound at all.
    */
   beforeId?: string;
   /**
-   * Where to persist the resume cursor, rewritten after EVERY page.
+   * Forget this shard's recorded progress and start again at `afterId`.
    *
-   * A cursor reported only in the final summary cannot survive the case that
-   * needs it most — a run that DIES mid-sweep never prints a summary at all. And
-   * the cursor cannot go in the log: the backend logger redacts a 24-hex
-   * ObjectId under every key (verified), so a logged cursor reads `[REDACTED]`.
-   * A file is durable, survives the process, and keeps the id out of CloudWatch.
+   * Resuming is otherwise automatic, which is what makes a died-mid-sweep run
+   * recoverable in a one-shot task. A deliberate re-sweep of ground already
+   * covered therefore has to be asked for, and it is worth asking twice: every
+   * post re-walked is another request to somebody else's server.
    */
-  cursorFile?: string;
-  /** Resolve + report, write nothing. */
+  resetCursor?: boolean;
+  /** Resolve + report, write nothing — including no cursor. */
   dryRun?: boolean;
   /** Posts per `_id` page. */
   batchSize?: number;
@@ -370,12 +393,29 @@ export interface RepairFederatedMentionsSummary {
   /**
    * The `_id` of the LAST post this run scanned, or `null` if it scanned none.
    *
-   * The resume cursor: pass it as the next run's `afterId` and the next chunk
-   * starts past everything this one already visited, stuck posts included.
-   * RETURNED (and written to `cursorFile` when set) rather than logged — the
-   * backend logger redacts a 24-hex ObjectId under every key.
+   * The resume cursor. Persisted to MongoDB under {@link cursorScope} after every
+   * page and RETURNED here — never logged, because the backend logger redacts a
+   * 24-hex ObjectId under every key.
    */
   lastScannedId: string | null;
+  /**
+   * The shard territory this run recorded its progress under, derived from the
+   * DECLARED bounds so it is stable across resumes of the same shard.
+   */
+  cursorScope: string;
+  /** Whether the lower bound came from a stored cursor rather than `afterId`. */
+  resumed: boolean;
+  /**
+   * Posts this scope had already scanned before this invocation. Added to
+   * {@link scanned} it gives the shard's running total.
+   */
+  resumedFromScanned: number;
+  /**
+   * Cursor writes that did not land. STRICT: any at all fails the run, because a
+   * sweep whose cursor stopped persisting is a sweep that cannot be resumed —
+   * the failure this whole mechanism exists to prevent.
+   */
+  cursorWriteFailures: number;
   samples: RepairSample[];
   failures: RepairFailure[];
 }
@@ -484,27 +524,24 @@ export function buildCandidateFilter(actorUri?: string): Record<string, unknown>
 }
 
 /**
- * Write the resume cursor to `path`, atomically, if the caller asked for one.
+ * The key a run records its progress under: the territory it DECLARED, never the
+ * position it has reached.
  *
- * Written via a temp file plus `rename` so a run killed mid-write leaves the
- * PREVIOUS cursor intact rather than a truncated id — resuming from a torn value
- * would either skip a stretch of the corpus or throw on the next parse.
- *
- * Best-effort by design: an unwritable path must not abort a sweep that is
- * otherwise repairing posts correctly. It is logged as a warning, and the cursor
- * is still on the returned summary.
+ * Built from the CANONICAL parsed bounds rather than the raw strings, so
+ * `REPAIR_AFTER_ID=" 65FD… "` and `65fd…` are one shard rather than two that
+ * silently re-walk each other's ground. Every component is always present, so no
+ * two different shards can spell the same scope.
  */
-function persistCursor(path: string | undefined, cursor: string): void {
-  if (!path) return;
-  try {
-    const temporary = `${path}.tmp`;
-    writeFileSync(temporary, `${cursor}\n`, 'utf8');
-    renameSync(temporary, path);
-  } catch (err) {
-    logger.warn('[repairFederatedMentions] could not persist the resume cursor', {
-      error: err,
-    });
-  }
+export function buildCursorScope(scope: {
+  afterId?: mongoose.Types.ObjectId;
+  beforeId?: mongoose.Types.ObjectId;
+  actorUri?: string;
+}): string {
+  return [
+    `after:${scope.afterId?.toString() ?? ''}`,
+    `before:${scope.beforeId?.toString() ?? ''}`,
+    `actor:${scope.actorUri?.trim() ?? ''}`,
+  ].join('|');
 }
 
 /** A 24-character hex ObjectId — the only shape a range bound may take. */
@@ -533,6 +570,24 @@ function parseIdBound(name: string, value: string | undefined): mongoose.Types.O
     );
   }
   return new mongoose.Types.ObjectId(trimmed);
+}
+
+/**
+ * Whether an id sits in the half-open range `(after, before]` a run declared.
+ *
+ * Compared as canonical lowercase hex, which orders identically to the 12 bytes
+ * Mongo compares — `toString()` always yields that form, so the two can never
+ * disagree about which side of a bound an id falls on.
+ */
+function isWithinRange(
+  id: mongoose.Types.ObjectId,
+  after: mongoose.Types.ObjectId | undefined,
+  before: mongoose.Types.ObjectId | undefined,
+): boolean {
+  const value = id.toString();
+  if (after && value <= after.toString()) return false;
+  if (before && value > before.toString()) return false;
+  return true;
 }
 
 /** Order-independent equality of two string arrays (treated as sets/bags). */
@@ -706,26 +761,53 @@ export async function repairFederatedMentions(
   const afterId = parseIdBound('afterId', options.afterId);
   const beforeId = parseIdBound('beforeId', options.beforeId);
 
-  // `afterId` is EXCLUSIVE and `beforeId` INCLUSIVE, so chaining is exactly
-  // `afterId = <previous run's lastScannedId>` — no gap, no overlap — and
-  // parallel shards partition as (b[k-1], b[k]].
+  // Keyed on the DECLARED territory, so the same shard command always addresses
+  // the same recorded progress however far into its range it has got.
+  const cursorScope = buildCursorScope({ afterId, beforeId, actorUri: options.actorUri });
+  if (options.resetCursor) await clearAdminScriptCursor(SCRIPT_NAME, cursorScope);
+  const resumeFrom = options.resetCursor
+    ? null
+    : await readAdminScriptCursor(SCRIPT_NAME, cursorScope);
+
+  // A stored cursor is only ever written from a post this scope actually
+  // scanned, so it must lie inside the declared range. If it does not, the state
+  // and the bounds disagree and resuming would either skip a stretch of the
+  // corpus or re-walk somebody else's shard — both invisible. Abort instead.
+  const resumeId = resumeFrom ? parseIdBound('storedCursor', resumeFrom.cursor) : undefined;
+  if (resumeId && !isWithinRange(resumeId, afterId, beforeId)) {
+    throw new Error(
+      "the stored resume cursor lies outside this run's declared _id range. "
+        + 'Refusing to run: resuming from it would skip or duplicate a stretch of the corpus. '
+        + 'Re-run with resetCursor to start this shard again.',
+    );
+  }
+
+  // `afterId` is EXCLUSIVE and `beforeId` INCLUSIVE, so a resume is exactly
+  // `$gt = <last scanned id>` — no gap, no overlap — and parallel shards
+  // partition as (b[k-1], b[k]].
+  const lowerBound = resumeId ?? afterId;
   const idRange: Record<string, mongoose.Types.ObjectId> = {};
-  if (afterId) idRange.$gt = afterId;
+  if (lowerBound) idRange.$gt = lowerBound;
   if (beforeId) idRange.$lte = beforeId;
   const hasIdRange = Object.keys(idRange).length > 0;
 
   const baseFilter = buildCandidateFilter(options.actorUri);
   if (hasIdRange) baseFilter._id = { ...idRange };
 
-  // Counted WITHIN the range, so a shard reports its own territory rather than
-  // the whole corpus.
+  // Counted WITHIN the range, so a shard reports the work it has LEFT rather
+  // than the whole corpus or ground it has already covered.
   const candidates = await Post.countDocuments(baseFilter);
   logger.info('[repairFederatedMentions] candidate posts selected', {
     count: candidates,
     dryRun,
     concurrency,
     narrowedScope: Boolean(options.actorUri),
-    resumed: Boolean(afterId),
+    // The cursor itself cannot be logged (24-hex ObjectIds are redacted under
+    // every key), so what rides here is where the bound CAME FROM and how far
+    // this scope had already got. Both are on the returned summary too.
+    resumed: Boolean(resumeId),
+    resumedFromScanned: resumeFrom?.scanned ?? 0,
+    scopeCompletedEarlier: Boolean(resumeFrom?.completedAt),
     rangeBounded: Boolean(beforeId),
   });
 
@@ -749,6 +831,10 @@ export async function repairFederatedMentions(
       malformedJson: 0,
     },
     lastScannedId: null,
+    cursorScope,
+    resumed: Boolean(resumeId),
+    resumedFromScanned: resumeFrom?.scanned ?? 0,
+    cursorWriteFailures: 0,
     samples: [],
     failures: [],
   };
@@ -775,6 +861,24 @@ export async function repairFederatedMentions(
     pendingOps = [];
   };
 
+  /**
+   * Record where this scope has got to, so a task that is killed mid-sweep can
+   * be resumed rather than restarted.
+   *
+   * A DRY RUN never writes one. A preview that advanced the real cursor would
+   * make the next live run skip exactly the posts it previewed — the invisible
+   * kind of wrong, and the reason this is a guard rather than an optimization.
+   */
+  const persistCursor = async (cursor: string, completed: boolean): Promise<void> => {
+    if (dryRun) return;
+    const persisted = await recordAdminScriptCursor(SCRIPT_NAME, cursorScope, {
+      cursor,
+      scanned: summary.resumedFromScanned + summary.scanned,
+      completed,
+    });
+    if (!persisted) summary.cursorWriteFailures += 1;
+  };
+
   // Forward-only cursor. The repair only ever removes a post from the matching
   // set (it fills in `mentions`, which the filter selects on), so no page is
   // revisited and none is skipped.
@@ -795,7 +899,13 @@ export async function repairFederatedMentions(
       .limit(pageLimit)
       .lean<CandidatePostRow[]>();
 
-    if (page.length === 0) break;
+    // An empty page means this scope's range is exhausted — the one exit that
+    // means FINISHED, as opposed to stopping on a limit or dying mid-page. Stamp
+    // it so a later run can tell the difference.
+    if (page.length === 0) {
+      if (lastId) await persistCursor(lastId.toString(), true);
+      break;
+    }
 
     // The page is already sliced to at most the remaining budget, so repairing
     // the WHOLE page in a bounded pool can never overshoot the limit.
@@ -875,7 +985,7 @@ export async function repairFederatedMentions(
     // resume cursor is a run that DIES mid-sweep, and a dying run never reaches
     // its final summary.
     summary.lastScannedId = lastId.toString();
-    persistCursor(options.cursorFile, summary.lastScannedId);
+    await persistCursor(summary.lastScannedId, false);
 
     // Counters ride in the structured CONTEXT, never interpolated into the
     // message — the backend logging policy (and its test,
@@ -939,6 +1049,12 @@ const REMOTE_UNAVAILABLE_TOLERANCE = 0.1;
  * actor — the lookup-only resolver working as designed) are TERMINAL, EXPECTED
  * outcomes, not failures. They are reported in the summary and deliberately never
  * handed to the guard at all.
+ *
+ * A cursor that did not persist is likewise never tolerated. It costs the run
+ * nothing at the time — every post it scanned was still repaired — which is
+ * exactly why it has to fail here: the damage lands on the NEXT run, which
+ * silently restarts at the beginning and re-fetches the whole stuck head from
+ * other people's servers.
  */
 export function assertRepairRunComplete(summary: RepairFederatedMentionsSummary): void {
   const byReason = summary.fetchFailedByReason;
@@ -946,12 +1062,13 @@ export function assertRepairRunComplete(summary: RepairFederatedMentionsSummary)
   const malformedPayload = byReason.nonObjectPayload + byReason.malformedJson;
 
   assertAdminRunComplete(
-    'repairFederatedMentions',
+    SCRIPT_NAME,
     {
       remoteUnavailable,
       malformedPayload,
       skippedNoSource: summary.skippedNoSource,
       skippedEmptyBody: summary.skippedEmptyBody,
+      cursorNotPersisted: summary.cursorWriteFailures,
       // Vacuity guard: every `fetchFailed` must land in exactly one reason
       // bucket. If a future path ever increments the total without classifying
       // it, the difference surfaces here and fails the run STRICTLY, rather than
@@ -987,7 +1104,7 @@ async function main(): Promise<void> {
   const dryRun = process.env.DRY_RUN === 'true';
 
   try {
-    assertAdminMutationAllowed({ scriptName: 'repairFederatedMentions', dryRun });
+    assertAdminMutationAllowed({ scriptName: SCRIPT_NAME, dryRun });
     await mongoose.connect(mongoUri, { dbName });
     logger.info('[repairFederatedMentions] connected to MongoDB', { dryRun });
 
@@ -995,7 +1112,7 @@ async function main(): Promise<void> {
       dryRun,
       afterId: process.env.REPAIR_AFTER_ID,
       beforeId: process.env.REPAIR_BEFORE_ID,
-      cursorFile: process.env.REPAIR_CURSOR_FILE?.trim() || undefined,
+      resetCursor: process.env.REPAIR_RESET_CURSOR === 'true',
       batchSize: parsePositiveInt(process.env.REPAIR_BATCH_SIZE, DEFAULT_PAGE_SIZE),
       concurrency: parsePositiveInt(process.env.REPAIR_CONCURRENCY, DEFAULT_CONCURRENCY),
       limit: process.env.REPAIR_LIMIT ? parsePositiveInt(process.env.REPAIR_LIMIT, 0) : undefined,
@@ -1029,11 +1146,13 @@ async function main(): Promise<void> {
       sampled: summary.samples.length,
       // The cursor ITSELF cannot go here: the backend logger redacts a 24-hex
       // ObjectId under every key (verified empirically), so it would read
-      // `[REDACTED]`. What CAN be reported is whether more work remains and
-      // whether a resume cursor was persisted — read the id from `cursorFile`
-      // or from the returned summary.
+      // `[REDACTED]`. What CAN be reported is whether more work remains and how
+      // far this shard has now got in total — the id lives in MongoDB, which is
+      // where the next run reads it from without an operator in the loop.
       hasMore: summary.scanned < summary.candidates,
-      cursorPersisted: Boolean(process.env.REPAIR_CURSOR_FILE?.trim() && summary.lastScannedId),
+      resumed: summary.resumed,
+      shardScannedTotal: summary.resumedFromScanned + summary.scanned,
+      cursorWriteFailures: summary.cursorWriteFailures,
       durationMs: Date.now() - startedAt,
     });
 


### PR DESCRIPTION
## Summary
- `REPAIR_CURSOR_FILE` promised a mid-sweep-death resume, but a one-shot Fargate task's container filesystem dies with the task — the cursor was gone exactly when it was needed, and CloudWatch's redacted progress line carries no id to recover it from (`sanitizeLogString` rewrites every 24-hex ObjectId to `[REDACTED]`, `isSensitiveKey` redacts any key ending in `id`).
- Replaces it with `AdminScriptCursor` (new model, collection `adminscriptcursors`, unique on `script`+`scope`), written after every page so a run that dies never reaches its final summary but still leaves progress behind. Resuming is automatic on the next run; `REPAIR_RESET_CURSOR=true` forces a deliberate re-sweep. Progress keys on the shard's declared territory (from the canonical parsed bounds) so parallel shards can't collide, a dry run never writes a cursor, a stored cursor outside the declared range aborts rather than silently skipping/duplicating, and a cursor write that doesn't land fails the completion guard strictly.
- Migration `0016-admin-script-cursor-index` creates the required unique index (`autoIndex`/`autoCreate` are off in prod, so a schema-declared index alone never reaches it); `runner.ts` now exports `MIGRATION_IDS` and asserts every on-disk migration is registered, in numeric order, under the id its filename promises.

## Production evidence
On 2026-08-01, a `REPAIR_LIMIT=20000` chunk left 9,466 stuck candidates. The unbounded follow-up run had no cursor to resume from, so it restarted at the lowest `_id` and re-walked all of them: 9,500 posts scanned for 51 repairs (0.5%), against 70% for that run overall — roughly 9,000 requests to other people's servers that could not succeed.

## Test plan
- [x] `bun run lint:backend` (tsc --noEmit) — 0 errors
- [x] `bun run test:backend` — 362 files / 3745 tests passed (baseline on origin/main: 359 files / 3718 tests)
- [x] `bun run test:frontend` — 105 suites / 893 tests passed (matches origin/main baseline; no frontend files touched)
- [x] `bun run typecheck:frontend` — 0 errors
- [x] `bun run lint:frontend` — 0 errors, 2 pre-existing warnings (import/first) in `subscriptionsScreen.test.tsx`, present on origin/main too
- [x] `bun install` — `bun.lock` byte-unchanged, no dependency change
- [x] `validate:workflows`, `validate:i18n`, `validate:logger`, `audit:security`, `validate:lockfile` — all pass
- 27 new tests, mutation-tested (14/14 mutations killed by the completion guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)