### PR TITLE
feat(videos): make a reel view count, and show it on the profile grid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ Feeds live in `backend/src/mtn/` — ForYou, Following, Author, Hashtag, Explore
 
 #### Profile feed = the `author` descriptor
 
-The profile feed is NOT a separate endpoint — it is `GET /feed/mtn?descriptor=author|<oxyUserId>|<tab>`, served by the same engine as every other feed. There is no `/feed/user/:userId`. `<tab>` ∈ `AuthorFeedFilter` (`posts` | `replies` | `media` | `likes` | `boosts` — one per profile tab; unknown ⇒ `posts`). Frontend entry point: `feedService.getUserFeed`.
+The profile feed is NOT a separate endpoint — it is `GET /feed/mtn?descriptor=author|<oxyUserId>|<tab>`, served by the same engine as every other feed. There is no `/feed/user/:userId`. `<tab>` ∈ `AuthorFeedFilter` (`posts` | `replies` | `media` | `videos` | `likes` | `boosts` — one per profile tab; unknown ⇒ `posts`). Frontend entry point: `feedService.getUserFeed`.
 
 - **Cursor/sort axis:** the `authored` source sorts `{ createdAt: -1, _id: -1 }` to match the `ChronoCursor` keyset. Never sort an author query by `_id`: a federated post's import-time `_id` bears no relation to its remote `createdAt`, so an `_id` sort behind a `createdAt` cursor permanently skips backfilled posts at the page boundary (this is the "boost disappears from the profile feed" bug).
 - **Profile-visibility gate** lives in the `authored` source (`canViewAuthorFeed`) and covers EVERY tab: a private / followers-only profile returns an empty feed to a non-follower. Post-level `visibility: public` is not sufficient — profile visibility is a separate setting.

--- a/packages/backend/src/__tests__/feedSources.test.ts
+++ b/packages/backend/src/__tests__/feedSources.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import mongoose from 'mongoose';
-import { PostVisibility } from '@mention/shared-types';
+import { PostType, PostVisibility } from '@mention/shared-types';
 import { notAReplyClause } from '../utils/postReply';
 
 /**
@@ -259,6 +259,22 @@ describe('authored source', () => {
     expect(mediaOr).toEqual(['type', 'content.media.0', 'content.attachments']);
   });
 
+  it('videos filter matches the two shapes videoOnly accepts — and NOT attachments', async () => {
+    findRouter = () => [];
+    await authoredSource.gather({ currentUserId: 'viewer' }, { authorId: 'a8b', filter: 'videos' }, 31);
+    const and = findCalls[0].$and as Array<Record<string, unknown>>;
+    const videoOr = and[0].$or as Array<Record<string, unknown>>;
+    // Narrower than `media` on purpose: `videoOnlyFilter.keep` has no
+    // `content.attachments` branch, so a query that fetched those posts would
+    // only be paying for candidates the filter then drops.
+    expect(videoOr.map((c) => Object.keys(c)[0])).toEqual(['type', 'content.media']);
+    expect(videoOr[0]).toEqual({ type: PostType.VIDEO });
+    expect(videoOr[1]).toEqual({ 'content.media': { $elemMatch: { type: 'video' } } });
+    // Same top-level tab shape as `media`: roots only, no boosts.
+    expect(and[1]).toEqual(notAReplyClause());
+    expect(and[2]).toEqual({ $or: [{ boostOf: null }, { boostOf: { $exists: false } }] });
+  });
+
   /**
    * Regression: "a boost disappears from the profile feed".
    *
@@ -274,6 +290,19 @@ describe('authored source', () => {
       findRouter = () => [makePost(9)];
       await authoredSource.gather({ currentUserId: 'viewer' }, { authorId: 'a9', filter: 'posts' }, 31);
       expect(sortCalls[0]).toEqual({ createdAt: -1, _id: -1 });
+    });
+
+    // The filter switch only writes `query.$and`, so the sort lives outside it
+    // and every tab inherits the same axis by construction. Pinned rather than
+    // reasoned about, because a per-tab sort is exactly the change that would
+    // reintroduce the skipped-page boundary on ONE tab and nowhere else.
+    it('sorts on the same axis for every tab, not just posts', async () => {
+      findRouter = () => [makePost(9)];
+      for (const filter of ['replies', 'media', 'videos', 'boosts'] as const) {
+        sortCalls.length = 0;
+        await authoredSource.gather({ currentUserId: 'viewer' }, { authorId: 'a9', filter }, 31);
+        expect(sortCalls[0]).toEqual({ createdAt: -1, _id: -1 });
+      }
     });
 
     it('pages with a compound createdAt keyset, not a bare _id boundary', async () => {

--- a/packages/backend/src/__tests__/presetDefinitions.test.ts
+++ b/packages/backend/src/__tests__/presetDefinitions.test.ts
@@ -54,6 +54,25 @@ describe('friends_of_friends definition', () => {
   });
 });
 
+describe('author definition', () => {
+  it('the videos tab composes the videoOnly filter', async () => {
+    const def = await resolveDefinition('author|u1|videos');
+    expect(def!.sources.map((s) => s.module)).toEqual(['authored']);
+    expect(def!.sources[0].params).toMatchObject({ authorId: 'u1', filter: 'videos' });
+    expect(def!.filters.map((f) => f.module)).toEqual(['videoOnly']);
+  });
+
+  it('the media tab still composes mediaOnly, not videoOnly', async () => {
+    const def = await resolveDefinition('author|u1|media');
+    expect(def!.filters.map((f) => f.module)).toEqual(['mediaOnly']);
+  });
+
+  it('every author variant hydrates boosts at depth 1', async () => {
+    const def = await resolveDefinition('author|u1|videos');
+    expect(def!.execution?.hydrateMaxDepth).toBe(1);
+  });
+});
+
 describe('resolveDefinition still returns null for unknown descriptors', () => {
   it('unknown → null', async () => {
     expect(await resolveDefinition('nonsense' as FeedDescriptor)).toBeNull();

--- a/packages/backend/src/mtn/feed/definitions/presets.ts
+++ b/packages/backend/src/mtn/feed/definitions/presets.ts
@@ -391,8 +391,8 @@ export const savedDefinition: FeedDefinition = {
 };
 
 /**
- * Author feed (the profile feed) — a single author's posts/replies/media/boosts
- * (chronological) or likes (ordered).
+ * Author feed (the profile feed) — a single author's
+ * posts/replies/media/videos/boosts (chronological) or likes (ordered).
  *
  * `hydrateMaxDepth: 1` on every variant is load-bearing: a boost has an
  * intentionally empty body and renders from its embedded `boostOf` original,
@@ -401,7 +401,11 @@ export const savedDefinition: FeedDefinition = {
  */
 export function authorDefinition(authorId: string, filter: AuthorFeedFilter): FeedDefinition {
   const isLikes = filter === 'likes';
-  const filters: ModuleRef[] = filter === 'media' ? [enabled('mediaOnly')] : [];
+  const filters: ModuleRef[] = filter === 'media'
+    ? [enabled('mediaOnly')]
+    : filter === 'videos'
+      ? [enabled('videoOnly')]
+      : [];
   return {
     id: `author|${authorId}${filter === 'posts' ? '' : `|${filter}`}`,
     title: 'Author',

--- a/packages/backend/src/mtn/feed/engine/sources/userSources.ts
+++ b/packages/backend/src/mtn/feed/engine/sources/userSources.ts
@@ -171,6 +171,22 @@ function buildAuthoredQuery(authorId: string, filter: AuthorFeedFilter, cursor?:
         { $or: [{ boostOf: null }, { boostOf: { $exists: false } }] },
       ];
       break;
+    case 'videos':
+      // Deliberately NARROWER than `media`: the two video shapes
+      // `videoOnlyFilter.keep` recognizes, and no `content.attachments` branch,
+      // because that predicate has none — including it would fetch posts the
+      // filter then drops, paying for a page that arrives short.
+      query.$and = [
+        {
+          $or: [
+            { type: PostType.VIDEO },
+            { 'content.media': { $elemMatch: { type: 'video' } } },
+          ],
+        },
+        notAReplyClause(),
+        { $or: [{ boostOf: null }, { boostOf: { $exists: false } }] },
+      ];
+      break;
     case 'likes':
       break;
   }

--- a/packages/frontend/app/(app)/videos.tsx
+++ b/packages/frontend/app/(app)/videos.tsx
@@ -37,6 +37,7 @@ import { BottomSheetContext } from '@/context/BottomSheetContext';
 import { VideoReplies } from '@/components/videos/VideoReplies';
 import { HIT_SLOP_LG } from '@/styles/hitSlop';
 import { useVideoPipSession } from '@/hooks/useVideoPipSession';
+import { useReelImpressions } from '@/hooks/useReelImpressions';
 import { useMediaSessionTransport, type MediaSessionTrack } from '@/hooks/useMediaSessionTransport';
 import { usePipTransportActions } from '@/hooks/usePipTransportActions';
 import { usePipAspectRatio } from '@/hooks/usePipAspectRatio';
@@ -284,6 +285,7 @@ interface VideoItemProps {
     onLike: (postId: string, isLiked: boolean) => void;
     onComment: (postId: string) => void;
     onBoost: (postId: string, isBoosted: boolean) => void;
+    onSave: (postId: string, isSaved: boolean) => void;
     onShare: (post: VideoPost) => void;
     formatCompactNumber: (count: number) => string;
     muted: boolean;
@@ -326,6 +328,10 @@ interface ActiveVideoSurfaceProps {
     isActive: boolean;
     // See VideoItemProps.screenFocused — only play when active AND focused.
     screenFocused: boolean;
+    // How much of the surface's bottom edge the floating BottomBar covers. The
+    // scrubber is the overlay's SIBLING, so it does not inherit the overlay's
+    // own bottom padding and has to lift itself clear of the bar.
+    bottomBarHeight: number;
     // Viewport height: one slide tall, so it also yields this surface's centre-Y
     // for the visibility report to the playback authority.
     windowHeight: number;
@@ -362,6 +368,7 @@ const ActiveVideoSurface = memo<ActiveVideoSurfaceProps>(({
     intrinsicSize,
     isActive,
     screenFocused,
+    bottomBarHeight,
     windowHeight,
     muted,
     onMutedChange,
@@ -927,7 +934,10 @@ const ActiveVideoSurface = memo<ActiveVideoSurfaceProps>(({
 
             {showScrubber && (
                 <View
-                    style={styles.scrubberHitArea}
+                    // Lifted clear of the floating BottomBar: pinned to the
+                    // surface's own bottom edge the whole 16px band sits UNDER
+                    // the bar, which takes every touch meant for the track.
+                    style={[styles.scrubberHitArea, { bottom: bottomBarHeight }]}
                     // Vertical only on purpose: the track's x maps to seek
                     // position, so widening it horizontally would make the
                     // touch-to-time mapping lie past both ends.
@@ -965,6 +975,7 @@ const VideoItem = memo<VideoItemProps>(({
     onLike,
     onComment,
     onBoost,
+    onSave,
     onShare,
     formatCompactNumber,
     muted,
@@ -1013,9 +1024,6 @@ const VideoItem = memo<VideoItemProps>(({
     }, [item.id, item.viewerState.isLiked, onLike]);
 
     const canRenderPlayer = isNear && !videoError && item.videoUrl.length > 0;
-    // Actions + follow always overlay the video, on every breakpoint — desktop
-    // matches mobile (there is no separate rail).
-    const showOnVideoActions = true;
     const showOnVideoFollow = Boolean(item.user?.id) && item.user?.id !== viewerId;
     const showCaptionToggle = postText.length > CAPTION_EXPAND_MIN_CHARS;
 
@@ -1034,6 +1042,7 @@ const VideoItem = memo<VideoItemProps>(({
                     intrinsicSize={item.intrinsicSize}
                     isActive={isActive}
                     screenFocused={screenFocused}
+                    bottomBarHeight={bottomBarHeight}
                     windowHeight={windowHeight}
                     muted={muted}
                     onMutedChange={onMutedChange}
@@ -1143,45 +1152,51 @@ const VideoItem = memo<VideoItemProps>(({
                     </View>
                 </View>
 
-                {showOnVideoActions && (
-                    <View style={styles.rightActions} pointerEvents="box-none">
-                        <ActionButton
-                            icon={item.viewerState.isLiked ? 'heart' : 'heart-outline'}
-                            count={item.engagement.likes ?? 0}
-                            isActive={item.viewerState.isLiked}
-                            activeColor={LIKE_ACTIVE_COLOR}
-                            onPress={() => onLike(item.id, item.viewerState.isLiked)}
-                            formatCompactNumber={formatCompactNumber}
-                        />
-                        <ActionButton
-                            icon="chatbubble-outline"
-                            count={item.engagement.replies ?? 0}
-                            onPress={() => onComment(item.id)}
-                            formatCompactNumber={formatCompactNumber}
-                        />
-                        <ActionButton
-                            icon={item.viewerState.isBoosted ? 'repeat' : 'repeat-outline'}
-                            count={item.engagement.boosts ?? 0}
-                            isActive={item.viewerState.isBoosted}
-                            activeColor={BOOST_ACTIVE_COLOR}
-                            onPress={() => onBoost(item.id, item.viewerState.isBoosted)}
-                            formatCompactNumber={formatCompactNumber}
-                        />
-                        <ActionButton
-                            icon="share-outline"
-                            count={0}
-                            onPress={() => onShare(item)}
-                            formatCompactNumber={formatCompactNumber}
-                            hideCount={true}
-                        />
-                        <View style={styles.viewCount} pointerEvents="none">
-                            <Ionicons name="eye-outline" size={26} color="white" style={styles.actionIcon} />
-                            <Text style={styles.actionCount}>
-                                {formatCompactNumber(item.engagement.views ?? 0)}
-                            </Text>
-                        </View>
-                    </View>
-                )}
+                <View style={styles.rightActions} pointerEvents="box-none">
+                    <ActionButton
+                        icon={item.viewerState.isLiked ? 'heart' : 'heart-outline'}
+                        count={item.engagement.likes ?? 0}
+                        isActive={item.viewerState.isLiked}
+                        activeColor={LIKE_ACTIVE_COLOR}
+                        onPress={() => onLike(item.id, item.viewerState.isLiked)}
+                        formatCompactNumber={formatCompactNumber}
+                        accessibilityLabel={t(item.viewerState.isLiked ? 'videos.unlike' : 'videos.like')}
+                    />
+                    <ActionButton
+                        icon="chatbubble-outline"
+                        count={item.engagement.replies ?? 0}
+                        onPress={() => onComment(item.id)}
+                        formatCompactNumber={formatCompactNumber}
+                        accessibilityLabel={t('videos.comment')}
+                    />
+                    <ActionButton
+                        icon={item.viewerState.isBoosted ? 'repeat' : 'repeat-outline'}
+                        count={item.engagement.boosts ?? 0}
+                        isActive={item.viewerState.isBoosted}
+                        activeColor={BOOST_ACTIVE_COLOR}
+                        onPress={() => onBoost(item.id, item.viewerState.isBoosted)}
+                        formatCompactNumber={formatCompactNumber}
+                        accessibilityLabel={t(item.viewerState.isBoosted ? 'videos.unboost' : 'videos.boost')}
+                    />
+                    {/* Saved state is carried by the filled icon alone — a reel's
+                        rail has no brand colour for it, and inventing one would
+                        put a fourth accent over the video. */}
+                    <ActionButton
+                        icon={item.viewerState.isSaved ? 'bookmark' : 'bookmark-outline'}
+                        count={item.engagement.saves ?? 0}
+                        onPress={() => onSave(item.id, item.viewerState.isSaved)}
+                        formatCompactNumber={formatCompactNumber}
+                        accessibilityLabel={t(item.viewerState.isSaved ? 'videos.unsave' : 'videos.save')}
+                    />
+                    <ActionButton
+                        icon="share-outline"
+                        count={0}
+                        onPress={() => onShare(item)}
+                        formatCompactNumber={formatCompactNumber}
+                        hideCount={true}
+                        accessibilityLabel={t('videos.share')}
+                    />
+                </View>
             </View>
         </View>
     );
@@ -1200,13 +1215,22 @@ interface ActionButtonProps {
     onPress: () => void;
     formatCompactNumber: (count: number) => string;
     hideCount?: boolean;
+    // Required: the icon carries the whole meaning of these buttons, and the
+    // count beside it reads as the label to a screen reader otherwise ("4.2K").
+    accessibilityLabel: string;
 }
 
-const ActionButton = memo<ActionButtonProps>(({ icon, count, isActive, activeColor, onPress, formatCompactNumber, hideCount = false }) => (
-    <Pressable style={styles.actionButton} onPress={onPress} hitSlop={HIT_SLOP_LG}>
+const ActionButton = memo<ActionButtonProps>(({ icon, count, isActive, activeColor, onPress, formatCompactNumber, hideCount = false, accessibilityLabel }) => (
+    <Pressable
+        style={styles.actionButton}
+        onPress={onPress}
+        hitSlop={HIT_SLOP_LG}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+    >
         <Ionicons
             name={icon}
-            size={28}
+            size={30}
             color={isActive && activeColor ? activeColor : 'white'}
             style={styles.actionIcon}
         />
@@ -1253,13 +1277,13 @@ export default function VideosScreen() {
     const params = useLocalSearchParams<{ postId?: string; mediaIndex?: string }>();
     const { oxyServices, user, canUsePrivateApi, isAuthResolved, isAuthenticated } = useAuth();
     const viewerId = user?.id;
-    const { likePost, unlikePost, boostPost, unboostPost, getPostById } = usePostsStore();
+    const { likePost, unlikePost, boostPost, unboostPost, savePost, unsavePost, getPostById } = usePostsStore();
     // Desktop (>=990) gate. Actions + follow now overlay the video on every
     // breakpoint (matching mobile); `isDesktop` only decides how the comment
     // button behaves — a no-op on desktop (replies are already open in the
     // RightBar) vs. opening the bottom sheet on mobile.
     const isDesktop = useIsRightBarVisible();
-    const { setRailState } = useVideosRail();
+    const { setRailState, requestComposerFocus } = useVideosRail();
     const { openBottomSheet, setBottomSheetContent } = useContext(BottomSheetContext);
 
     const [posts, setPosts] = useState<VideoPost[]>([]);
@@ -1667,11 +1691,6 @@ export default function VideosScreen() {
         onEnded: handleSessionEnded,
         loadMore: handleLoadMore,
         hasMore,
-        // The reel fetches with exactly these feed types, so its impressions are
-        // attributed to the same descriptor the feed was served under.
-        feedDescriptor: resolveFeedDescriptor(activeFeed),
-        impressionResetKey: viewerId,
-        canReportImpressions: canUsePrivateApi,
     });
 
     const sessionSource = useMemo<PlayableSource | undefined>(
@@ -1766,8 +1785,11 @@ export default function VideosScreen() {
 
     const handleComment = useCallback((postId: string) => {
         if (isDesktop) {
-            // The replies column (RightBar) is always visible on desktop —
-            // there's nothing to open/toggle here.
+            // The replies column (RightBar) is already showing this post, so
+            // there is nothing to open — but a button that paints and then does
+            // nothing observable is a dead button. Put the caret in that
+            // column's composer instead, which is what the press was asking for.
+            requestComposerFocus();
             return;
         }
         setBottomSheetContent(
@@ -1779,7 +1801,7 @@ export default function VideosScreen() {
             { scrollable: false },
         );
         openBottomSheet(true);
-    }, [isDesktop, setBottomSheetContent, openBottomSheet, handleCommentPosted]);
+    }, [isDesktop, requestComposerFocus, setBottomSheetContent, openBottomSheet, handleCommentPosted]);
 
     const handleBoost = useCallback(async (postId: string, isBoosted: boolean) => {
         try {
@@ -1808,6 +1830,40 @@ export default function VideosScreen() {
             toast(t('common.error'), { type: 'error' });
         }
     }, [boostPost, unboostPost, t]);
+
+    // Same optimistic shape as like/boost: the store's own update lands on its
+    // copy of the post, which this screen's local `posts` state never reads, so
+    // the rail's icon only flips if the screen updates itself.
+    const handleSave = useCallback(async (postId: string, isSaved: boolean) => {
+        try {
+            if (isSaved) {
+                await unsavePost({ postId });
+            } else {
+                // Attributed to the reel surface, not to the active tab's feed
+                // descriptor: a save made here means "more videos like this"
+                // whichever feed served it, and `following` is not classified as
+                // a video-first surface (see `isVideoSurface`).
+                await savePost({ postId }, 'videos');
+            }
+            setPosts(prev => prev.map(p =>
+                p.id === postId
+                    ? {
+                        ...p,
+                        viewerState: { ...p.viewerState, isSaved: !isSaved },
+                        engagement: {
+                            ...p.engagement,
+                            saves: Math.max(
+                                0,
+                                (p.engagement.saves ?? 0) + (isSaved ? -1 : 1),
+                            ),
+                        },
+                    }
+                    : p
+            ));
+        } catch {
+            toast(t('common.error'), { type: 'error' });
+        }
+    }, [savePost, unsavePost, t]);
 
     const handleShare = useCallback(async (post: VideoPost) => {
         try {
@@ -1945,6 +2001,22 @@ export default function VideosScreen() {
         [isFocused, activeVideoPost],
     );
 
+    // Report what is being watched. The screen owns this — not the surfaces and
+    // not the PiP session — because the two things a reel can be watching (the
+    // pager's slide, the OS window's cursor) have to share ONE tracker to dedupe
+    // against each other. See `useReelImpressions`.
+    useReelImpressions({
+        pipOwnerId,
+        pipPlayingId: pipPlaying?.id,
+        screenFocused: isFocused,
+        activePostId: activeVideoPost?.id,
+        // The reel fetches with exactly these feed types, so its impressions are
+        // attributed to the same descriptor the feed was served under.
+        feedDescriptor: resolveFeedDescriptor(activeFeed),
+        impressionResetKey: viewerId,
+        canReportImpressions: canUsePrivateApi,
+    });
+
     // Publish the active post + the comment-posted callback so the RightBar
     // replies panel tracks whichever video is currently active and can bump the
     // comment count after a reply posts. Engagement itself lives on the on-video
@@ -1967,6 +2039,7 @@ export default function VideosScreen() {
             onLike={handleLike}
             onComment={handleComment}
             onBoost={handleBoost}
+            onSave={handleSave}
             onShare={handleShare}
             formatCompactNumber={formatCompactNumber}
             muted={globalMuted}
@@ -1982,7 +2055,7 @@ export default function VideosScreen() {
             onSessionEnd={endPipSession}
             onRegisterTransportSeek={registerTransportSeek}
         />
-    ), [currentVisibleIndex, isFocused, theme, handleLike, handleComment, handleBoost, handleShare, globalMuted, handleMuteChange, bottomBarHeight, t, WINDOW_HEIGHT, viewerId, pipOwnerId, sessionSource, startPipSession, endPipSession, registerTransportSeek]);
+    ), [currentVisibleIndex, isFocused, theme, handleLike, handleComment, handleBoost, handleSave, handleShare, globalMuted, handleMuteChange, bottomBarHeight, t, WINDOW_HEIGHT, viewerId, pipOwnerId, sessionSource, startPipSession, endPipSession, registerTransportSeek]);
 
     const keyExtractor = useCallback((item: VideoPost) => item.id, []);
 
@@ -2063,6 +2136,7 @@ export default function VideosScreen() {
                                         onLike={handleLike}
                                         onComment={handleComment}
                                         onBoost={handleBoost}
+                                        onSave={handleSave}
                                         onShare={handleShare}
                                         formatCompactNumber={formatCompactNumber}
                                         muted={globalMuted}
@@ -2179,7 +2253,6 @@ interface VideosStyles {
     actionButton: ViewStyle;
     actionIcon: TextStyle;
     actionCount: TextStyle;
-    viewCount: ViewStyle;
     bottomInfo: ViewStyle;
     userInfo: ViewStyle;
     userHeaderRow: ViewStyle;
@@ -2299,7 +2372,7 @@ const styles = StyleSheet.create<VideosStyles>({
         position: 'absolute',
         left: 0,
         right: 0,
-        bottom: 0,
+        // `bottom` is supplied at the use site — it tracks the BottomBar's height.
         height: 16,
         justifyContent: 'flex-end',
         zIndex: 7,
@@ -2379,36 +2452,33 @@ const styles = StyleSheet.create<VideosStyles>({
     rightActions: {
         justifyContent: 'flex-end',
         alignItems: 'center',
-        gap: 24,
+        gap: 16,
         zIndex: 6,
-        paddingRight: 4,
+        paddingRight: 8,
     },
     actionButton: {
         alignItems: 'center',
         justifyContent: 'center',
-        gap: 4,
-        minWidth: 40,
+        gap: 2,
+        minWidth: 36,
     },
     actionIcon: {
         ...TEXT_SHADOW_STRONG,
     },
     actionCount: {
         color: '#FFFFFF',
-        fontSize: 12,
+        fontSize: 11,
         fontWeight: '600',
         ...TEXT_SHADOW_MEDIUM,
         marginTop: 0,
         textAlign: 'center',
     },
-    viewCount: {
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: 4,
-        minWidth: 40,
-    },
     bottomInfo: {
         flex: 1,
         justifyContent: 'flex-end',
+        // Gutter between the caption and the rail. Unaffected by the rail's
+        // compaction: a 36px button plus 8px of padding is the same 44px box the
+        // old 40 + 4 made, so the clearance is exactly what it was.
         marginRight: 70,
         maxWidth: '70%',
         zIndex: 6,

--- a/packages/frontend/components/Feed/Feed.native.tsx
+++ b/packages/frontend/components/Feed/Feed.native.tsx
@@ -273,7 +273,7 @@ const Feed = ((props: FeedProps) => {
     // Determine if we should use scoped (local) feed state
     const useScoped = !!(filters && Object.keys(filters).length) && !showOnlySaved;
 
-    const { user: currentUser, isAuthenticated, signIn } = useAuth();
+    const { user: currentUser, isAuthenticated, canUsePrivateApi, signIn } = useAuth();
     const { blockedSet } = usePrivacyControls();
 
     // Use the feed state hook for all feed operations
@@ -394,9 +394,11 @@ const Feed = ((props: FeedProps) => {
     // Feed-ranking telemetry: derive the descriptor this feed reports against and
     // own an impression tracker for the session. The session resets when the
     // descriptor changes or the feed is reloaded (reloadKey), so impressions are
-    // counted once per post per session.
+    // counted once per post per session. `canUsePrivateApi` short-circuits
+    // reporting for anonymous viewers so a public browse never POSTs (and never
+    // 401-loops) — the same gate the web feed applies.
     const feedDescriptor = resolveFeedDescriptor(type, userId, filters, showOnlySaved);
-    const impressionTracker = useFeedImpressionTracker(feedDescriptor, reloadKey);
+    const impressionTracker = useFeedImpressionTracker(feedDescriptor, reloadKey, canUsePrivateApi);
 
     // Memoize renderPostItem to prevent recreating on every render
     const renderPostItem = useCallback(({ item: row }: { item: NativeFeedRow; index: number }) => {

--- a/packages/frontend/components/Profile/MediaGrid.tsx
+++ b/packages/frontend/components/Profile/MediaGrid.tsx
@@ -10,7 +10,7 @@ import { EmptyState } from '@/components/common/EmptyState';
 import type { FeedItem } from '@/db';
 import type { HydratedPostSummary, MediaItem } from '@mention/shared-types';
 import VideoPosterCell from '@/components/common/VideoPosterCell';
-import { isVideoMediaRef } from '@/utils/mediaTypes';
+import { isVideoMediaRef, readMediaDurationSec } from '@/utils/mediaTypes';
 import { useProfileMediaFeed } from './useProfileMediaFeed';
 import { ProfileGridList, type ProfileGridEntry } from './ProfileGridList';
 
@@ -30,6 +30,15 @@ interface MediaGridEntry extends ProfileGridEntry {
     uri: string;
     isVideo: boolean;
     isCarousel: boolean;
+    /**
+     * Play count of the post this cell's media came from — set on video entries
+     * only, so the type says outright that image cells carry neither of these.
+     * Per-POST, so two videos in one post repeat it, exactly as `isCarousel`
+     * already paints on every one of a post's cells.
+     */
+    views?: number | null;
+    /** Duration of THIS item's video, in seconds. Per-item, so per-cell correct. */
+    durationSec?: number;
 }
 
 const CAROUSEL_ICON_SIZE = 12;
@@ -60,7 +69,7 @@ const MediaGrid: React.FC<MediaGridProps> = ({
     const theme = useTheme();
     const { t } = useTranslation();
     const {
-        mediaFeed,
+        primaryFeed,
         postsFeed,
         items,
         loadMore,
@@ -69,7 +78,7 @@ const MediaGrid: React.FC<MediaGridProps> = ({
     const mediaItems = useMemo<MediaGridEntry[]>(() => {
         const out: MediaGridEntry[] = [];
 
-        const pushUris = (targetId: string, sources: MediaItem[]) => {
+        const pushUris = (post: HydratedPostSummary, targetId: string, sources: MediaItem[]) => {
             const seen = new Set<string>();
 
             sources.forEach((ref, idx) => {
@@ -87,7 +96,18 @@ const MediaGrid: React.FC<MediaGridProps> = ({
                     // poster still produces a placeholder cell, so a video entry is
                     // always valid.
                     const posterUri = resolveVideoPosterUri(ref);
-                    out.push({ postId: targetId, uri: posterUri ?? '', isVideo: true, isCarousel: sources.length > 1, mediaIndex: idx });
+                    out.push({
+                        postId: targetId,
+                        uri: posterUri ?? '',
+                        isVideo: true,
+                        isCarousel: sources.length > 1,
+                        mediaIndex: idx,
+                        // `post`, not the outer feed item: for a boost/quote with no
+                        // media of its own the media belongs to the ORIGINAL, and the
+                        // count has to describe the video being shown.
+                        views: post.engagement?.views,
+                        durationSec: readMediaDurationSec(ref),
+                    });
                     return;
                 }
 
@@ -102,7 +122,7 @@ const MediaGrid: React.FC<MediaGridProps> = ({
             // (url/thumbUrl/posterUrl) — the single source for grid thumbnails.
             const media = post.content?.media;
             if (!Array.isArray(media) || media.length === 0) return;
-            pushUris(targetId, media);
+            pushUris(post, targetId, media);
         };
 
         for (const rawPost of items) {
@@ -140,7 +160,9 @@ const MediaGrid: React.FC<MediaGridProps> = ({
                         posterUri={item.uri || undefined}
                         size={itemSize}
                         placeholderColor={theme.colors.textSecondary}
-                        badge="center"
+                        views={item.views}
+                        durationSec={item.durationSec}
+                        scrim
                     />
                 ) : (
                     <Image
@@ -165,7 +187,7 @@ const MediaGrid: React.FC<MediaGridProps> = ({
     }, [router, theme.colors.textSecondary]);
 
     // Loading state first; if no items yet and feeds are still loading, show spinner
-    const isLoading = (!mediaFeed && !postsFeed) || mediaFeed?.isLoading || postsFeed?.isLoading;
+    const isLoading = (!primaryFeed && !postsFeed) || primaryFeed?.isLoading || postsFeed?.isLoading;
     const emptyContent = isLoading && mediaItems.length === 0
         ? (
             <View className="items-center justify-center p-8">

--- a/packages/frontend/components/Profile/MediaPickerSheet.tsx
+++ b/packages/frontend/components/Profile/MediaPickerSheet.tsx
@@ -17,6 +17,7 @@ import { useAppearanceStore, type ProfileMedia, type UserAppearance } from '@/st
 import { useProfileSongPreview } from '@/hooks/useProfileSongPreview';
 import { useInfiniteCatalogSearch, ResultsFooter } from '@/hooks/useInfiniteCatalogSearch';
 import { createLogger } from '@oxyhq/core/logger';
+import { formatDuration } from '@/utils/formatDuration';
 import { SongPreviewButton } from './SongPreviewButton';
 import { HIT_SLOP_MD } from '@/styles/hitSlop';
 
@@ -70,13 +71,6 @@ interface PodcastSelection {
 interface MediaPickerSheetProps {
   currentMedia: ProfileMedia | null;
   onClose: () => void;
-}
-
-function formatStartTime(totalSec: number): string {
-  const safe = Math.max(0, Math.floor(totalSec));
-  const minutes = Math.floor(safe / 60);
-  const seconds = safe % 60;
-  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
 function songSelectionFromMedia(media: ProfileMedia | null): SongSelection | null {
@@ -521,7 +515,7 @@ export const MediaPickerSheet = memo(function MediaPickerSheet({
           {maxStartSec > 0 && (
             <View className="flex-row items-center justify-between mt-3">
               <Text className="text-muted-foreground text-[13px]">
-                {t('profile.media.song.startsAt', { time: formatStartTime(startSec) })}
+                {t('profile.media.song.startsAt', { time: formatDuration(startSec) })}
               </Text>
               <View className="flex-row items-center gap-3">
                 <Pressable
@@ -536,7 +530,7 @@ export const MediaPickerSheet = memo(function MediaPickerSheet({
                   <Text className="text-foreground text-lg font-semibold leading-none">{'−'}</Text>
                 </Pressable>
                 <Text className="text-foreground text-[15px] font-semibold tabular-nums">
-                  {formatStartTime(startSec)}
+                  {formatDuration(startSec)}
                 </Text>
                 <Pressable
                   onPress={incrementStart}

--- a/packages/frontend/components/Profile/VideosGrid.tsx
+++ b/packages/frontend/components/Profile/VideosGrid.tsx
@@ -10,7 +10,7 @@ import { Video } from '@/assets/icons/video-icon';
 import { videoPosterUrl } from '@/utils/imageUrlCache';
 import type { HydratedPostSummary, MediaItem } from '@mention/shared-types';
 import VideoPosterCell from '@/components/common/VideoPosterCell';
-import { isVideoMediaRef } from '@/utils/mediaTypes';
+import { isVideoMediaRef, readMediaDurationSec } from '@/utils/mediaTypes';
 import { useProfileMediaFeed } from './useProfileMediaFeed';
 import { ProfileGridList, type ProfileGridEntry } from './ProfileGridList';
 
@@ -34,6 +34,13 @@ interface VideoGridEntry extends ProfileGridEntry {
      * 404/load error too.
      */
     posterUri?: string;
+    /**
+     * Play count of the post this cell's video came from. Per-POST, so two
+     * videos in one post repeat it.
+     */
+    views?: number | null;
+    /** Duration of THIS item's video, in seconds. Per-item, so per-cell correct. */
+    durationSec?: number;
 }
 
 const VideosGrid: React.FC<VideosGridProps> = ({
@@ -52,11 +59,11 @@ const VideosGrid: React.FC<VideosGridProps> = ({
     const theme = useTheme();
     const { t } = useTranslation();
     const {
-        mediaFeed,
+        primaryFeed,
         postsFeed,
         items,
         loadMore,
-    } = useProfileMediaFeed({ userId, isPrivate, isOwnProfile });
+    } = useProfileMediaFeed({ userId, isPrivate, isOwnProfile, filter: 'videos' });
 
     /**
      * Resolve a static video poster. Prefer the server-resolved final `posterUrl`
@@ -85,10 +92,21 @@ const VideosGrid: React.FC<VideosGridProps> = ({
             media.forEach((ref, idx) => {
                 const key = ref.id || ref.url;
                 if (!key) return;
-                if (!isVideoMediaRef(key, { mediaType: ref.type })) return; // Only include videos
+                // Still per-ITEM even though the `videos` descriptor already
+                // filtered server-side: that filter keeps POSTS, so a post mixing
+                // one photo with one video is a legitimate result whose photo this
+                // grid must drop — and the empty-primary posts fallback below is
+                // unfiltered entirely.
+                if (!isVideoMediaRef(key, { mediaType: ref.type })) return;
                 if (seen.has(key)) return;
                 seen.add(key);
-                out.push({ postId: targetId, posterUri: resolvePosterUri(ref), mediaIndex: idx });
+                out.push({
+                    postId: targetId,
+                    posterUri: resolvePosterUri(ref),
+                    mediaIndex: idx,
+                    views: post.engagement?.views,
+                    durationSec: readMediaDurationSec(ref),
+                });
             });
         };
 
@@ -101,8 +119,8 @@ const VideosGrid: React.FC<VideosGridProps> = ({
     }, [items, resolvePosterUri]);
 
     const isLoading = (
-        (!mediaFeed && !postsFeed) ||
-        mediaFeed?.isLoading ||
+        (!primaryFeed && !postsFeed) ||
+        primaryFeed?.isLoading ||
         postsFeed?.isLoading
     ) && videoItems.length === 0;
 
@@ -117,7 +135,8 @@ const VideosGrid: React.FC<VideosGridProps> = ({
                     posterUri={item.posterUri}
                     size={itemSize}
                     placeholderColor={theme.colors.textSecondary}
-                    badge="corner"
+                    views={item.views}
+                    durationSec={item.durationSec}
                 />
             </TouchableOpacity>
         );

--- a/packages/frontend/components/Profile/hooks/__tests__/useProfileScroll.test.tsx
+++ b/packages/frontend/components/Profile/hooks/__tests__/useProfileScroll.test.tsx
@@ -207,4 +207,21 @@ describe('useProfileScroll load-more targeting', () => {
 
     act(() => renderer.unmount());
   });
+
+  // Feeds, starter packs and lists are tabs with no author feed behind them. The
+  // "no more to page" answer cannot come from the slice: an unwritten feed key
+  // has no meta row, and the getter reads a missing row as `hasMore: true` so a
+  // fresh feed can make its first request. So a tab that never had a feed looks
+  // exactly like one whose first page has not loaded, and the detector pages it.
+  it.each<ProfileTab>(['feeds', 'starter_packs', 'lists'])(
+    'does not page %s, which is not backed by an author feed',
+    async (tab) => {
+      const renderer = await mount('user-1', tab);
+
+      scrollToBottom();
+      expect(mockFetchUserFeed).not.toHaveBeenCalled();
+
+      act(() => renderer.unmount());
+    },
+  );
 });

--- a/packages/frontend/components/Profile/hooks/useProfileScroll.ts
+++ b/packages/frontend/components/Profile/hooks/useProfileScroll.ts
@@ -10,6 +10,7 @@ import {
 import { usePostsStore } from '@/stores/postsStore';
 import { getFeedMeta } from '@/db/feedQueries';
 import type { FeedType } from '@mention/shared-types';
+import { isAuthorFeedFilter } from '@mention/shared-types/mtn/feedDescriptor';
 import {
   isVirtualizedProfileGridTab,
   LAYOUT,
@@ -119,6 +120,15 @@ export function useProfileScroll({ profileId, currentTab }: UseProfileScrollOpti
     if (!profileId || loadingMoreRef.current || !fetchUserFeedRef.current || !getUserSliceRef.current) {
       return;
     }
+    // Three of the nine tabs — feeds, starter packs, lists — are not backed by an
+    // author feed at all, and paging them is not merely pointless: the slice
+    // getter below reports `hasMore: true` for a feed key nothing has ever
+    // written, so scrolling one of those tabs to the bottom fires a real request
+    // that `feedService.getUserFeed` coerces back to `posts` and files under
+    // `user:<id>:feeds`. Narrow honestly against the descriptor's own filter set
+    // rather than asserting the tab into `FeedType`, so a tab added to
+    // `TAB_NAMES` without a feed behind it stops here too.
+    if (!isAuthorFeedFilter(currentTab)) return;
     // Native media/video grids own pagination through FlashList.onEndReached.
     // Running the profile's generic scroll detector too would issue a duplicate
     // request. On WEB there is no such owner — the web grid does not wire
@@ -127,14 +137,14 @@ export function useProfileScroll({ profileId, currentTab }: UseProfileScrollOpti
     // descriptor, with its own cursor.
     if (Platform.OS !== 'web' && isVirtualizedProfileGridTab(currentTab)) return;
 
-    const slice = getUserSliceRef.current(profileId, currentTab as FeedType);
+    const slice = getUserSliceRef.current(profileId, currentTab);
     if (slice && slice.hasMore && !slice.isLoading) {
       loadingMoreRef.current = true;
       const fetchUserFeed = fetchUserFeedRef.current;
       void (async () => {
         try {
           await fetchUserFeed(profileId, {
-            type: currentTab as FeedType,
+            type: currentTab,
             cursor: slice.nextCursor,
             limit: LAYOUT.FEED_LIMIT,
           });

--- a/packages/frontend/components/Profile/hooks/useProfileScroll.ts
+++ b/packages/frontend/components/Profile/hooks/useProfileScroll.ts
@@ -121,19 +121,20 @@ export function useProfileScroll({ profileId, currentTab }: UseProfileScrollOpti
     }
     // Native media/video grids own pagination through FlashList.onEndReached.
     // Running the profile's generic scroll detector too would issue a duplicate
-    // request, and `videos` is backed by the author `media` feed rather than a
-    // separate videos descriptor.
+    // request. On WEB there is no such owner — the web grid does not wire
+    // `onEndReached` at all — so this stays the only pagination those tabs get,
+    // and it must page the tab's OWN feed: `videos` is the author `videos`
+    // descriptor, with its own cursor.
     if (Platform.OS !== 'web' && isVirtualizedProfileGridTab(currentTab)) return;
 
-    const feedTab = currentTab === 'videos' ? 'media' : currentTab;
-    const slice = getUserSliceRef.current(profileId, feedTab as FeedType);
+    const slice = getUserSliceRef.current(profileId, currentTab as FeedType);
     if (slice && slice.hasMore && !slice.isLoading) {
       loadingMoreRef.current = true;
       const fetchUserFeed = fetchUserFeedRef.current;
       void (async () => {
         try {
           await fetchUserFeed(profileId, {
-            type: feedTab as FeedType,
+            type: currentTab as FeedType,
             cursor: slice.nextCursor,
             limit: LAYOUT.FEED_LIMIT,
           });

--- a/packages/frontend/components/Profile/useProfileMediaFeed.ts
+++ b/packages/frontend/components/Profile/useProfileMediaFeed.ts
@@ -10,58 +10,67 @@ interface ProfileMediaFeedArgs {
     userId?: string;
     isPrivate?: boolean;
     isOwnProfile?: boolean;
+    /**
+     * Which author descriptor backs the grid: `media` for the Media tab,
+     * `videos` for the Videos tab. Each is a real server-side filter
+     * (`author|<id>|<filter>`) with its own cursor, so the Videos tab paginates
+     * over videos rather than over a mixed pool it then discards most of.
+     */
+    filter?: 'media' | 'videos';
 }
 
 /**
  * Shared data source for the profile Media and Videos grids. Loads the user's
- * `media` feed, transparently falling back to the `posts` feed for media
- * extraction when the media feed resolves empty, and returns the flattened item
- * list both grids iterate. The two grids differ only in how they turn these
- * items into cells, so the feed plumbing lives here once.
+ * primary feed for the requested `filter`, transparently falling back to the
+ * `posts` feed for media extraction when that feed resolves empty, and returns
+ * the flattened item list both grids iterate. The two grids differ only in how
+ * they turn these items into cells, so the feed plumbing lives here once.
  */
-export function useProfileMediaFeed({ userId, isPrivate, isOwnProfile }: ProfileMediaFeedArgs) {
+export function useProfileMediaFeed({ userId, isPrivate, isOwnProfile, filter = 'media' }: ProfileMediaFeedArgs) {
     const { user } = useAuth();
     const viewerId = user?.id;
     const { fetchUserFeed } = usePostsStore();
-    const mediaFeed = useUserFeedSelector(userId || '', 'media');
+    const primaryFeed = useUserFeedSelector(userId || '', filter);
     const postsFeed = useUserFeedSelector(userId || '', 'posts');
 
     useEffect(() => {
         if (!userId || (isPrivate && !isOwnProfile)) return;
 
-        fetchUserFeed(userId, { type: 'media', limit: PROFILE_MEDIA_FEED_LIMIT });
+        fetchUserFeed(userId, { type: filter, limit: PROFILE_MEDIA_FEED_LIMIT });
         // `viewerId` is in the deps so the feed refetches when the viewer's auth
         // session resolves on cold boot — visibility of follower/owner-gated
         // media depends on who is asking, and the request would otherwise run
         // once while anonymous and never refresh.
-    }, [userId, viewerId, fetchUserFeed, isPrivate, isOwnProfile]);
+    }, [userId, viewerId, fetchUserFeed, filter, isPrivate, isOwnProfile]);
 
-    // Fallback: if the media feed finished and is empty, load the posts feed so
-    // media can still be extracted from regular posts.
+    // Fallback: if the primary feed finished and is empty, load the posts feed so
+    // media can still be extracted from regular posts. Deliberately UNFILTERED —
+    // it is the shared escape hatch for a profile whose media never made it into
+    // a filtered feed, so narrowing it to `videos` would defeat its purpose.
     useEffect(() => {
         if (!userId || (isPrivate && !isOwnProfile)) return;
 
-        const isLoaded = !!mediaFeed && !mediaFeed.isLoading;
-        const isEmpty = (mediaFeed?.items?.length || 0) === 0;
+        const isLoaded = !!primaryFeed && !primaryFeed.isLoading;
+        const isEmpty = (primaryFeed?.items?.length || 0) === 0;
         const postsLoaded = !!postsFeed;
 
         if (isLoaded && isEmpty && !postsLoaded) {
             fetchUserFeed(userId, { type: 'posts', limit: PROFILE_POSTS_FEED_LIMIT });
         }
-    }, [userId, viewerId, mediaFeed, mediaFeed?.isLoading, mediaFeed?.items?.length, postsFeed, fetchUserFeed, isPrivate, isOwnProfile]);
+    }, [userId, viewerId, primaryFeed, primaryFeed?.isLoading, primaryFeed?.items?.length, postsFeed, fetchUserFeed, isPrivate, isOwnProfile]);
 
     const items = useMemo<FeedItem[]>(
-        () => (mediaFeed?.items?.length ? mediaFeed.items : (postsFeed?.items || [])),
-        [mediaFeed?.items, postsFeed?.items],
+        () => (primaryFeed?.items?.length ? primaryFeed.items : (postsFeed?.items || [])),
+        [primaryFeed?.items, postsFeed?.items],
     );
 
     const loadMore = useCallback(() => {
         if (!userId || (isPrivate && !isOwnProfile)) return;
 
-        const usingMediaFeed =
-            (mediaFeed?.items?.length ?? 0) > 0 || !postsFeed;
-        const activeFeed = usingMediaFeed ? mediaFeed : postsFeed;
-        const type = usingMediaFeed ? 'media' : 'posts';
+        const usingPrimaryFeed =
+            (primaryFeed?.items?.length ?? 0) > 0 || !postsFeed;
+        const activeFeed = usingPrimaryFeed ? primaryFeed : postsFeed;
+        const type = usingPrimaryFeed ? filter : 'posts';
         if (
             !activeFeed ||
             activeFeed.isLoading ||
@@ -72,18 +81,19 @@ export function useProfileMediaFeed({ userId, isPrivate, isOwnProfile }: Profile
         void fetchUserFeed(userId, {
             type,
             cursor: activeFeed.nextCursor,
-            limit: type === 'media'
-                ? PROFILE_MEDIA_FEED_LIMIT
-                : PROFILE_POSTS_FEED_LIMIT,
+            limit: type === 'posts'
+                ? PROFILE_POSTS_FEED_LIMIT
+                : PROFILE_MEDIA_FEED_LIMIT,
         });
     }, [
         fetchUserFeed,
+        filter,
         isOwnProfile,
         isPrivate,
-        mediaFeed,
+        primaryFeed,
         postsFeed,
         userId,
     ]);
 
-    return { mediaFeed, postsFeed, items, loadMore };
+    return { primaryFeed, postsFeed, items, loadMore };
 }

--- a/packages/frontend/components/common/VideoPlayer.tsx
+++ b/packages/frontend/components/common/VideoPlayer.tsx
@@ -8,6 +8,7 @@ import { useVideoMuteStore } from '@/stores/videoMuteStore';
 import { useVideoPlayback } from '@/context/VideoPlaybackContext';
 import { useHlsPlayback } from '@/lib/hlsPlayback';
 import { HIT_SLOP_MD } from '@/styles/hitSlop';
+import { formatDuration } from '@/utils/formatDuration';
 
 interface VideoPlayerProps {
   src: string;
@@ -52,13 +53,6 @@ interface VideoPlayerProps {
    * expose video-track metadata there, and the HTML `<video>` auto-sizes instead.
    */
   onAspectRatio?: (ratio: number) => void;
-}
-
-function formatTime(seconds: number): string {
-  if (!isFinite(seconds) || seconds < 0) return '0:00';
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  return `${mins}:${secs.toString().padStart(2, '0')}`;
 }
 
 const CONTROLS_HIDE_DELAY = 3000;
@@ -415,7 +409,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
             <View style={styles.bottomBar}>
               {/* Time display */}
               <Text style={styles.timeText}>
-                {formatTime(currentTime)}
+                {formatDuration(currentTime)}
               </Text>
 
               {/* Progress bar */}
@@ -442,7 +436,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
               {/* Duration */}
               <Text style={styles.timeText}>
-                {formatTime(duration)}
+                {formatDuration(duration)}
               </Text>
 
               {/* Mute button */}

--- a/packages/frontend/components/common/VideoPosterCell.tsx
+++ b/packages/frontend/components/common/VideoPosterCell.tsx
@@ -1,16 +1,9 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { View } from 'react-native';
+import { Text, View, type TextStyle } from 'react-native';
 import { Image } from 'expo-image';
 import Ionicons from '@expo/vector-icons/Ionicons';
-
-/**
- * Where the play affordance sits on the cell:
- *  - `center`: a translucent full-cell scrim with a centered `play-circle`
- *    (used by the profile media grid).
- *  - `corner`: a small rounded chip in the top-right with a `play` glyph
- *    (used by the profile videos grid).
- */
-export type VideoPosterBadge = 'center' | 'corner';
+import { formatCompactNumber } from '@/utils/formatNumber';
+import { formatDuration } from '@/utils/formatDuration';
 
 interface VideoPosterCellProps {
   /**
@@ -20,40 +13,74 @@ interface VideoPosterCellProps {
   posterUri?: string;
   size: number;
   placeholderColor: string;
-  badge: VideoPosterBadge;
+  /**
+   * Play count for the post this cell's media belongs to.
+   *
+   * PER-POST, not per-media: two videos in one post carry the same number, the
+   * same way the media grid's carousel chip paints on every one of a post's
+   * cells. Absent or zero means genuinely zero — `views` carries no privacy gate
+   * on the way out of hydration, unlike likes/boosts/replies/saves — so the
+   * count is simply omitted rather than shown as `0`.
+   *
+   * The type is deliberately `number | null | undefined`: a zero-view post
+   * arrives as `null` from the API and web's in-memory store, but as `0` after
+   * the native SQLite round-trip (`views_count` is a numeric column, and
+   * `0 ?? null` is `0`). Both must render identically.
+   */
+  views?: number | null;
+  /** Duration of THIS cell's video, in seconds. Per-item, so per-cell correct. */
+  durationSec?: number;
+  /**
+   * Darken the poster behind the metadata row. The media grid mixes videos with
+   * photos and needs the contrast; an all-video grid would only be dimming
+   * itself uniformly for no signal.
+   */
+  scrim?: boolean;
 }
 
-// Corner chip (videos grid) dimensions.
-const CORNER_BADGE_SIZE = 24;
-const CORNER_BADGE_RADIUS = 12;
-const CORNER_PLAY_ICON_SIZE = 16;
+// Placeholder video icon size, per grid density (matches each grid's original).
+const SCRIM_PLACEHOLDER_ICON_SIZE = 32;
+const PLAIN_PLACEHOLDER_ICON_SIZE = 24;
 
-// Center badge (media grid) icon size.
-const CENTER_PLAY_ICON_SIZE = 24;
-
-// Placeholder video icon size, per badge variant (matches each grid's original).
-const CORNER_PLACEHOLDER_ICON_SIZE = 24;
-const CENTER_PLACEHOLDER_ICON_SIZE = 32;
+// Metadata row: the play glyph reads as a marker beside its count, so it is
+// sized to the text rather than to a tappable target.
+const META_PLAY_ICON_SIZE = 12;
 
 // Translucent overlay/scrim colors — functional alpha layers over the poster,
 // not theme/brand colors, so they live here as named constants.
-const CORNER_BADGE_BG = 'rgba(0, 0, 0, 0.6)';
-const CENTER_SCRIM_BG = 'rgba(0, 0, 0, 0.2)';
-const PLAY_GLYPH_COLOR = 'white';
-const CENTER_PLAY_GLYPH_COLOR = 'rgba(255, 255, 255, 0.9)';
+const SCRIM_BG = 'rgba(0, 0, 0, 0.2)';
+const META_TEXT_COLOR = 'white';
 
 /**
- * A single static video grid cell: a paused poster image (no live decoder) plus
- * a play affordance — playback happens only in the fullscreen reels screen on
- * tap. Shared by the profile media + videos grids; the `badge` prop selects the
- * center scrim vs. the top-right chip. Memoized so cells never remount on parent
- * re-render.
+ * Legibility over an arbitrary poster frame, without a per-cell gradient view or
+ * a pill that would eat a third of the width of a ~120px cell. Same values as
+ * the reels screen uses over moving video; redeclared rather than imported,
+ * because that module is a ROUTE and `components/common/` must not depend on
+ * one. `Ionicons` is a `Text`-based glyph font, so the glyph takes the shadow
+ * exactly like the number does.
+ */
+const META_TEXT_SHADOW: Pick<TextStyle, 'textShadowColor' | 'textShadowOffset' | 'textShadowRadius'> = {
+  textShadowColor: 'rgba(0, 0, 0, 0.8)',
+  textShadowOffset: { width: 0, height: 1 },
+  textShadowRadius: 3,
+};
+
+/**
+ * A single static video grid cell: a paused poster image (no live decoder), a
+ * play count and a duration — playback happens only in the fullscreen reels
+ * screen on tap. Shared by the profile media + videos grids; `scrim` selects
+ * whether the poster is darkened behind the metadata. Memoized so cells never
+ * remount on parent re-render.
+ *
+ * The metadata row lives here rather than beside each grid's `renderCell` so the
+ * two grids cannot drift apart pixel-wise, and so its z-order against the media
+ * grid's carousel chip is defined in one place.
  *
  * The poster (especially the federated `/media/poster` frame) can 404 / fail to
  * load → falls back to the video-icon placeholder, never a broken image.
  */
 const VideoPosterCell = React.memo<VideoPosterCellProps>(
-  ({ posterUri, size, placeholderColor, badge }) => {
+  ({ posterUri, size, placeholderColor, views, durationSec, scrim }) => {
     const containerStyle = useMemo(
       () => ({ width: size, height: size, overflow: 'hidden' as const }),
       [size]
@@ -70,8 +97,16 @@ const VideoPosterCell = React.memo<VideoPosterCellProps>(
 
     const handlePosterError = useCallback(() => setPosterFailed(true), []);
 
-    const placeholderIconSize =
-      badge === 'corner' ? CORNER_PLACEHOLDER_ICON_SIZE : CENTER_PLACEHOLDER_ICON_SIZE;
+    const placeholderIconSize = scrim ? SCRIM_PLACEHOLDER_ICON_SIZE : PLAIN_PLACEHOLDER_ICON_SIZE;
+    // Both guards are on the VALUE, not on its absence. A zero count is not
+    // information and the two platforms disagree on how they spell it (see the
+    // `views` prop); a zero duration would render `0:00`, which claims a length
+    // the clip does not have. Callers today read duration through
+    // `readMediaDurationSec`, which already rejects `<= 0` — but the component
+    // owns its own contract, and the next caller will not know that.
+    const viewsLabel = typeof views === 'number' && views > 0 ? formatCompactNumber(views) : null;
+    const durationLabel =
+      typeof durationSec === 'number' && durationSec > 0 ? formatDuration(durationSec) : null;
 
     return (
       <View className="bg-secondary" style={containerStyle}>
@@ -89,26 +124,42 @@ const VideoPosterCell = React.memo<VideoPosterCellProps>(
             <Ionicons name="videocam-outline" size={placeholderIconSize} color={placeholderColor} />
           </View>
         )}
-        {badge === 'corner' ? (
-          <View
-            className="absolute top-1 right-1 items-center justify-center"
-            style={{
-              backgroundColor: CORNER_BADGE_BG,
-              borderRadius: CORNER_BADGE_RADIUS,
-              width: CORNER_BADGE_SIZE,
-              height: CORNER_BADGE_SIZE,
-            }}
-          >
-            <Ionicons name="play" size={CORNER_PLAY_ICON_SIZE} color={PLAY_GLYPH_COLOR} />
-          </View>
-        ) : (
-          <View
-            className="absolute inset-0 items-center justify-center"
-            style={{ backgroundColor: CENTER_SCRIM_BG }}
-          >
-            <Ionicons name="play-circle" size={CENTER_PLAY_ICON_SIZE} color={CENTER_PLAY_GLYPH_COLOR} />
-          </View>
+        {scrim && (
+          <View className="absolute inset-0" style={{ backgroundColor: SCRIM_BG }} />
         )}
+        {/*
+          Both grids wrap this cell in a TouchableOpacity, so the row must not
+          swallow the tap along the bottom strip.
+        */}
+        <View
+          className="absolute bottom-0 left-0 right-0 flex-row items-center justify-between px-1 pb-1 gap-1"
+          pointerEvents="none"
+        >
+          {/*
+            The play glyph is unconditional: it is the only video marker left
+            after the centered/corner affordances were removed, and an invariant
+            one means the layout never shifts as a cell is recycled onto a post
+            with a different count.
+          */}
+          <View className="flex-row items-center gap-0.5">
+            <Ionicons
+              name="play"
+              size={META_PLAY_ICON_SIZE}
+              color={META_TEXT_COLOR}
+              style={META_TEXT_SHADOW}
+            />
+            {viewsLabel !== null && (
+              <Text className="text-white text-xs font-semibold" style={META_TEXT_SHADOW}>
+                {viewsLabel}
+              </Text>
+            )}
+          </View>
+          {durationLabel !== null && (
+            <Text className="text-white text-xs font-semibold" style={META_TEXT_SHADOW}>
+              {durationLabel}
+            </Text>
+          )}
+        </View>
       </View>
     );
   }

--- a/packages/frontend/components/common/__tests__/VideoPosterCell.test.tsx
+++ b/packages/frontend/components/common/__tests__/VideoPosterCell.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { Image } from 'expo-image';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import VideoPosterCell from '../VideoPosterCell';
+
+/**
+ * The metadata row is the only place in the app where a play count and a
+ * duration are rendered from two sources that disagree about how they spell
+ * "zero", so the states are pinned individually rather than sampled.
+ *
+ * `render` awaits an async act because `Ionicons` resolves its font in a
+ * promise and updates after mount; without the flush every assertion here would
+ * be made against a half-mounted tree.
+ */
+async function render(props: React.ComponentProps<typeof VideoPosterCell>) {
+  let renderer!: TestRenderer.ReactTestRenderer;
+  await act(async () => {
+    renderer = TestRenderer.create(<VideoPosterCell {...props} />);
+  });
+  return renderer;
+}
+
+/** Teardown is a React update like any other, so it needs the same act wrapper. */
+function unmount(...renderers: TestRenderer.ReactTestRenderer[]) {
+  act(() => {
+    renderers.forEach((renderer) => renderer.unmount());
+  });
+}
+
+function hostNodes(renderer: TestRenderer.ReactTestRenderer, type: 'Text' | 'View') {
+  // Compared as a string because `ElementType`'s own string branch enumerates
+  // DOM intrinsics, which react-native's host names are not part of. A component
+  // stringifies to its source, so it can never collide with a host name.
+  return renderer.root.findAll((node) => String(node.type) === type, { deep: true });
+}
+
+/**
+ * The strings the cell paints as LABELS. An icon glyph is also a host `Text`,
+ * and it is the only one with no `className`, so that is the discriminator —
+ * matching on the glyph character instead would depend on the icon font having
+ * loaded.
+ */
+function labels(renderer: TestRenderer.ReactTestRenderer): string[] {
+  return hostNodes(renderer, 'Text')
+    .filter((node) => typeof (node.props as { className?: unknown }).className === 'string')
+    .flatMap((node) => node.children.filter((child): child is string => typeof child === 'string'));
+}
+
+function iconNames(renderer: TestRenderer.ReactTestRenderer): string[] {
+  return renderer.root
+    .findAllByType(Ionicons)
+    .map((node) => String((node.props as { name: unknown }).name));
+}
+
+const BASE = { posterUri: 'https://cdn.example/poster.jpg', size: 120, placeholderColor: '#888' };
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+describe('VideoPosterCell metadata row', () => {
+  it('renders the compact count and the duration when both are present', async () => {
+    const renderer = await render({ ...BASE, views: 1234, durationSec: 42 });
+    expect(labels(renderer)).toEqual(['1.2K', '0:42']);
+    unmount(renderer);
+  });
+
+  it('renders the count alone when the item carries no duration', async () => {
+    const renderer = await render({ ...BASE, views: 1234 });
+    expect(labels(renderer)).toEqual(['1.2K']);
+    unmount(renderer);
+  });
+
+  it('renders the duration alone when the post has no views', async () => {
+    const renderer = await render({ ...BASE, views: 0, durationSec: 42 });
+    expect(labels(renderer)).toEqual(['0:42']);
+    unmount(renderer);
+  });
+
+  it('renders neither when the post has no views and the item no duration', async () => {
+    const renderer = await render(BASE);
+    expect(labels(renderer)).toEqual([]);
+    unmount(renderer);
+  });
+
+  /**
+   * `0:00` claims a length the clip does not have, so a zero duration is absent
+   * rather than formatted. `readMediaDurationSec` already rejects `<= 0` on
+   * every path into this component today — this pins the component's OWN guard,
+   * which is what the next caller will actually be relying on.
+   */
+  it('treats a 0 duration as absent, never rendering 0:00', async () => {
+    const zero = await render({ ...BASE, views: 12, durationSec: 0 });
+    const absent = await render({ ...BASE, views: 12 });
+
+    expect(labels(zero)).toEqual(labels(absent));
+    expect(labels(zero)).not.toContain('0:00');
+
+    unmount(zero, absent);
+  });
+
+  /**
+   * The most valuable assertion in this file. `views_count` is a numeric SQLite
+   * column and `db/schema.ts` reads it back as `row.views_count ?? null`, so a
+   * zero-view post arrives as `0` on native but as `null` on web, where
+   * `db/memoryStore.ts` hands the server object back by reference. A `!== null`
+   * predicate would print "0" under every video on iOS/Android and nothing at
+   * all on web, and no single-platform test run would show it.
+   */
+  it('treats 0, null and undefined views identically', async () => {
+    const zero = await render({ ...BASE, views: 0, durationSec: 42 });
+    const nulled = await render({ ...BASE, views: null, durationSec: 42 });
+    const absent = await render({ ...BASE, durationSec: 42 });
+
+    expect(labels(zero)).toEqual(labels(nulled));
+    expect(labels(nulled)).toEqual(labels(absent));
+    expect(iconNames(zero)).toEqual(iconNames(nulled));
+
+    unmount(zero, nulled, absent);
+  });
+
+  /**
+   * Regression guard for the two affordances this row replaced — a centered
+   * `play-circle` on the media grid and a corner `play` chip on the videos grid.
+   * A second glyph reads badly on a ~120px cell, which is why they were removed;
+   * zero glyphs would leave a video cell with no video marker at all.
+   */
+  it('paints exactly one play glyph, in both scrim modes', async () => {
+    const scrimmed = await render({ ...BASE, scrim: true, views: 12, durationSec: 5 });
+    const plain = await render({ ...BASE, views: 12, durationSec: 5 });
+
+    expect(iconNames(scrimmed)).toEqual(['play']);
+    expect(iconNames(plain)).toEqual(['play']);
+
+    unmount(scrimmed, plain);
+  });
+
+  it('adds exactly one view for the scrim and nothing else', async () => {
+    const scrimmed = await render({ ...BASE, scrim: true, views: 12, durationSec: 5 });
+    const plain = await render({ ...BASE, views: 12, durationSec: 5 });
+
+    expect(hostNodes(scrimmed, 'View')).toHaveLength(hostNodes(plain, 'View').length + 1);
+    expect(labels(scrimmed)).toEqual(labels(plain));
+
+    unmount(scrimmed, plain);
+  });
+
+  it('keeps the metadata row out of the grid cell\'s tap target', async () => {
+    const renderer = await render({ ...BASE, views: 12, durationSec: 5 });
+    const row = hostNodes(renderer, 'View').find(
+      (node) => (node.props as { pointerEvents?: string }).pointerEvents === 'none',
+    );
+    // Both grids wrap this cell in a TouchableOpacity, so an overlay that
+    // accepted touches would eat the tap along the bottom strip.
+    expect(row).toBeDefined();
+    unmount(renderer);
+  });
+});
+
+describe('VideoPosterCell poster fallback', () => {
+  it('falls back to the placeholder icon when the poster fails to load', async () => {
+    const renderer = await render(BASE);
+    expect(renderer.root.findAllByType(Image)).toHaveLength(1);
+
+    await act(async () => {
+      renderer.root.findByType(Image).props.onError();
+    });
+
+    expect(renderer.root.findAllByType(Image)).toHaveLength(0);
+    expect(iconNames(renderer)).toContain('videocam-outline');
+    unmount(renderer);
+  });
+
+  /**
+   * The failure is per-URI. It is cleared during render rather than in an
+   * effect, so a recycled cell never commits one frame of the previous poster's
+   * placeholder before recovering.
+   */
+  it('clears the failure when a new poster URI arrives', async () => {
+    const renderer = await render(BASE);
+    await act(async () => {
+      renderer.root.findByType(Image).props.onError();
+    });
+    expect(renderer.root.findAllByType(Image)).toHaveLength(0);
+
+    await act(async () => {
+      renderer.update(
+        <VideoPosterCell {...BASE} posterUri="https://cdn.example/other.jpg" />,
+      );
+    });
+
+    expect(renderer.root.findAllByType(Image)).toHaveLength(1);
+    expect(iconNames(renderer)).not.toContain('videocam-outline');
+    unmount(renderer);
+  });
+});

--- a/packages/frontend/components/videos/InlineReplyComposer.tsx
+++ b/packages/frontend/components/videos/InlineReplyComposer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { View, TextInput, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@oxyhq/bloom/theme';
@@ -12,6 +12,12 @@ interface InlineReplyComposerProps {
    * local comment count (see Global Constraints — postsStore's optimistic
    * update does not reach the Videos screen's separate local state). */
   onPosted: () => void;
+  /**
+   * A CHANGE in this value takes the caret. Deliberately not a boolean: the
+   * desktop comment button can be pressed twice in a row for the same video, and
+   * both presses have to land.
+   */
+  focusNonce?: number;
 }
 
 /**
@@ -19,12 +25,23 @@ interface InlineReplyComposerProps {
  * Deliberately narrower than the full `/compose` screen (no media, mentions,
  * or hashtags) — matches Reels' plain-text comment box.
  */
-export function InlineReplyComposer({ postId, onPosted }: InlineReplyComposerProps) {
+export function InlineReplyComposer({ postId, onPosted, focusNonce = 0 }: InlineReplyComposerProps) {
   const { t } = useTranslation();
   const theme = useTheme();
   const createReply = usePostsStore((s) => s.createReply);
   const [text, setText] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const inputRef = useRef<TextInput | null>(null);
+
+  // Only a change taken while this composer was mounted counts. Seeding the ref
+  // with the value at mount is what stops a remount — leaving /videos and coming
+  // back — from stealing the caret on a nonce raised by a press long gone.
+  const handledFocusNonceRef = useRef(focusNonce);
+  useEffect(() => {
+    if (handledFocusNonceRef.current === focusNonce) return;
+    handledFocusNonceRef.current = focusNonce;
+    inputRef.current?.focus();
+  }, [focusNonce]);
 
   const handleSubmit = useCallback(async () => {
     const trimmed = text.trim();
@@ -44,9 +61,10 @@ export function InlineReplyComposer({ postId, onPosted }: InlineReplyComposerPro
   return (
     <View style={styles.row} className="border-t border-border bg-background">
       <TextInput
+        ref={inputRef}
         value={text}
         onChangeText={setText}
-        placeholder={t('videos.addComment', { defaultValue: 'Add a comment...' })}
+        placeholder={t('videos.addComment')}
         placeholderTextColor={theme.colors.textSecondary}
         style={[styles.input, { color: theme.colors.text }]}
         multiline

--- a/packages/frontend/components/videos/VideoReplies.tsx
+++ b/packages/frontend/components/videos/VideoReplies.tsx
@@ -6,6 +6,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 // This panel owns an element-sized scroller, including on web. Use the
 // FlashList implementation explicitly instead of the document-scroll web feed.
 import Feed from '@/components/Feed/Feed.native';
+import { useVideosRail } from '@/context/VideosRailContext';
 import { InlineReplyComposer } from './InlineReplyComposer';
 
 interface VideoRepliesProps {
@@ -30,12 +31,16 @@ interface VideoRepliesProps {
 export function VideoReplies({ postId, onClose, onCommentPosted }: VideoRepliesProps) {
   const { t } = useTranslation();
   const theme = useTheme();
+  // Desktop's on-video comment button opens nothing (this column is already
+  // there) — it takes the caret instead. The mobile sheet never bumps the nonce,
+  // so its composer is unaffected.
+  const { focusComposerNonce } = useVideosRail();
 
   return (
     <View style={styles.container}>
       <View style={styles.header} className="border-b border-border">
         <Text style={[styles.title, { color: theme.colors.text }]}>
-          {t('videos.replies', { defaultValue: 'Replies' })}
+          {t('videos.replies')}
         </Text>
         {onClose && (
           <Pressable onPress={onClose} accessibilityRole="button" accessibilityLabel={t('common.close', { defaultValue: 'Close' })}>
@@ -54,7 +59,11 @@ export function VideoReplies({ postId, onClose, onCommentPosted }: VideoRepliesP
         />
       </View>
 
-      <InlineReplyComposer postId={postId} onPosted={onCommentPosted} />
+      <InlineReplyComposer
+        postId={postId}
+        onPosted={onCommentPosted}
+        focusNonce={focusComposerNonce}
+      />
     </View>
   );
 }

--- a/packages/frontend/context/VideosRailContext.tsx
+++ b/packages/frontend/context/VideosRailContext.tsx
@@ -15,17 +15,27 @@ export interface VideosRailState {
   active: boolean;
   activePost: VideosRailActivePost | null;
   onCommentPosted: (postId: string) => void;
+  /**
+   * Bumped every time the screen asks the replies column to take the caret —
+   * what the on-video comment button does on desktop, where the column is
+   * already open and there is nothing to toggle. A counter rather than a
+   * boolean: two presses in a row must both land, and a flag that is already
+   * true would swallow the second.
+   */
+  focusComposerNonce: number;
 }
 
 /**
  * The writable slice of the state. The /videos screen pushes a partial update
  * through `setRailState`; everything not provided is preserved.
  */
-type VideosRailPatch = Partial<VideosRailState>;
+type VideosRailPatch = Partial<Omit<VideosRailState, 'focusComposerNonce'>>;
 
 interface VideosRailContextValue extends VideosRailState {
   /** The /videos screen is the SOLE writer. Merges a partial into the state. */
   setRailState: (patch: VideosRailPatch) => void;
+  /** Ask the replies column's composer to take the caret. */
+  requestComposerFocus: () => void;
 }
 
 const NOOP = () => {};
@@ -34,11 +44,13 @@ const DEFAULT_STATE: VideosRailState = {
   active: false,
   activePost: null,
   onCommentPosted: NOOP,
+  focusComposerNonce: 0,
 };
 
 const VideosRailContext = createContext<VideosRailContextValue>({
   ...DEFAULT_STATE,
   setRailState: NOOP,
+  requestComposerFocus: NOOP,
 });
 
 export function VideosRailProvider({ children }: { children: React.ReactNode }) {
@@ -48,9 +60,17 @@ export function VideosRailProvider({ children }: { children: React.ReactNode }) 
     setState((prev) => ({ ...prev, ...patch }));
   }, []);
 
+  // The nonce is incremented HERE rather than patched by the screen, so the
+  // caller stays identity-stable: reading the current value to add one would put
+  // it in the screen's press handler's dependencies, and that handler is a
+  // dependency of the reel's `renderItem`.
+  const requestComposerFocus = useCallback(() => {
+    setState((prev) => ({ ...prev, focusComposerNonce: prev.focusComposerNonce + 1 }));
+  }, []);
+
   const value = useMemo<VideosRailContextValue>(
-    () => ({ ...state, setRailState }),
-    [state, setRailState],
+    () => ({ ...state, setRailState, requestComposerFocus }),
+    [state, setRailState, requestComposerFocus],
   );
 
   return (

--- a/packages/frontend/hooks/__tests__/useReelImpressions.test.tsx
+++ b/packages/frontend/hooks/__tests__/useReelImpressions.test.tsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { useReelImpressions, type UseReelImpressionsOptions } from '../useReelImpressions';
+
+/**
+ * Which video the reel reports as watched, across the handoff between its two
+ * sources: the pager's snapped slide and the OS Picture-in-Picture window's own
+ * cursor. Nothing here touches the transport — `FeedImpressionTracker` has its
+ * own tests — only the visible/hidden pairs this hook hands it.
+ */
+
+// Everything below is prefixed `mock` so the hoisted `jest.mock` factory may
+// reference it.
+type MockEvent = [event: 'visible' | 'hidden', postUri: string];
+
+interface MockSession {
+    /** The session identity this tracker instance was minted for. */
+    key: string;
+    /** What THIS instance was told, so a test can tell the instances apart. */
+    events: MockEvent[];
+    tracker: { setVisible: (postUri: string) => void; setHidden: (postUri: string) => void };
+}
+
+/** Every event, in order, whichever instance recorded it. */
+const mockImpressions: MockEvent[] = [];
+const mockSessions: MockSession[] = [];
+const mockTrackerArgs: [string, string | number | undefined, boolean | undefined][] = [];
+
+// The stable ref `useFeedImpressionTracker` hands back: ONE object for the whole
+// mount, whose `.current` is swapped when the session identity changes. Modelled
+// this way rather than as a single frozen stub because both halves matter — one
+// instance across a re-render is what makes the two watched-video sources dedupe
+// against each other, and a NEW instance on a session change is what the hook has
+// to notice.
+const mockTrackerRef: { current: MockSession['tracker'] } = {
+    current: { setVisible: () => {}, setHidden: () => {} },
+};
+
+function mockOpenSession(key: string): void {
+    const session: MockSession = {
+        key,
+        events: [],
+        tracker: {
+            setVisible: (postUri: string) => {
+                session.events.push(['visible', postUri]);
+                mockImpressions.push(['visible', postUri]);
+            },
+            setHidden: (postUri: string) => {
+                session.events.push(['hidden', postUri]);
+                mockImpressions.push(['hidden', postUri]);
+            },
+        },
+    };
+    mockSessions.push(session);
+    mockTrackerRef.current = session.tracker;
+}
+
+jest.mock('@/utils/feedTelemetry', () => ({
+    useFeedImpressionTracker: (
+        descriptor: string,
+        resetKey?: string | number,
+        canReport?: boolean,
+    ) => {
+        mockTrackerArgs.push([descriptor, resetKey, canReport]);
+        // The real hook's session identity, reproduced: a new tracker for a new
+        // descriptor or reset key, and — deliberately — the SAME one across a
+        // `canReport` flip, which must never reset a session mid-video.
+        const key = `${descriptor}::${resetKey ?? ''}`;
+        if (mockSessions.at(-1)?.key !== key) mockOpenSession(key);
+        return mockTrackerRef;
+    },
+}));
+
+function Probe(props: UseReelImpressionsOptions) {
+    useReelImpressions(props);
+    return null;
+}
+
+const BASE: UseReelImpressionsOptions = {
+    pipOwnerId: null,
+    screenFocused: true,
+    feedDescriptor: 'videos',
+    canReportImpressions: true,
+};
+
+/** Mount the hook and keep its props so a test can change one at a time. */
+function mountReel(initial: Partial<UseReelImpressionsOptions> = {}) {
+    let props: UseReelImpressionsOptions = { ...BASE, ...initial };
+    let created: TestRenderer.ReactTestRenderer | undefined;
+    act(() => {
+        created = TestRenderer.create(<Probe {...props} />);
+    });
+    const renderer = created;
+    if (!renderer) throw new Error('renderer was not created');
+
+    return {
+        update(next: Partial<UseReelImpressionsOptions>) {
+            props = { ...props, ...next };
+            act(() => {
+                renderer.update(<Probe {...props} />);
+            });
+        },
+        unmount() {
+            act(() => {
+                renderer.unmount();
+            });
+        },
+    };
+}
+
+beforeEach(() => {
+    mockImpressions.length = 0;
+    mockSessions.length = 0;
+    mockTrackerArgs.length = 0;
+});
+
+describe('reel impressions — the pager', () => {
+    it('reports the slide the pager is on', () => {
+        mountReel({ activePostId: 'a' });
+
+        expect(mockImpressions).toEqual([['visible', 'a']]);
+    });
+
+    it('closes the previous slide before opening the next one on a swipe', () => {
+        const reel = mountReel({ activePostId: 'a' });
+        reel.update({ activePostId: 'b' });
+
+        expect(mockImpressions).toEqual([
+            ['visible', 'a'],
+            ['hidden', 'a'],
+            ['visible', 'b'],
+        ]);
+    });
+
+    it('reports nothing for an empty reel, from mount to unmount', () => {
+        const reel = mountReel();
+        reel.unmount();
+
+        expect(mockImpressions).toEqual([]);
+    });
+
+    it('stops accruing on blur and resumes on re-focus', () => {
+        // A pushed route leaves the reel mounted and stops its playback, so the
+        // time spent on top of it is not dwell on the video underneath.
+        const reel = mountReel({ activePostId: 'a' });
+        reel.update({ screenFocused: false });
+        expect(mockImpressions).toEqual([
+            ['visible', 'a'],
+            ['hidden', 'a'],
+        ]);
+
+        reel.update({ screenFocused: true });
+        expect(mockImpressions).toEqual([
+            ['visible', 'a'],
+            ['hidden', 'a'],
+            ['visible', 'a'],
+        ]);
+    });
+});
+
+describe('reel impressions — the Picture-in-Picture handoff', () => {
+    it('emits nothing when the video already being watched enters PiP', () => {
+        // The failure this test exists for: a session with its OWN tracker sees
+        // the handoff as a first sighting and emits a second impression, whose
+        // dwell — the time since the window opened — is short enough to book a
+        // SKIP against a video the viewer just watched in full.
+        const reel = mountReel({ activePostId: 'a' });
+        expect(mockImpressions).toEqual([['visible', 'a']]);
+
+        reel.update({ pipOwnerId: 'a', pipPlayingId: 'a' });
+
+        expect(mockImpressions).toEqual([['visible', 'a']]);
+    });
+
+    it('emits nothing when the window closes on the video the pager lands back on', () => {
+        const reel = mountReel({ activePostId: 'a', pipOwnerId: 'a', pipPlayingId: 'c' });
+        expect(mockImpressions).toEqual([['visible', 'c']]);
+
+        // Leaving PiP re-syncs the pager to the cursor, so the same video simply
+        // changes which source is reporting it.
+        reel.update({ pipOwnerId: null, pipPlayingId: undefined, activePostId: 'c' });
+
+        expect(mockImpressions).toEqual([['visible', 'c']]);
+    });
+
+    it('ignores the pager entirely while a session is open', () => {
+        const reel = mountReel({ activePostId: 'a', pipOwnerId: 'a', pipPlayingId: 'a' });
+        reel.update({ activePostId: 'b' });
+        expect(mockImpressions).toEqual([['visible', 'a']]);
+
+        reel.update({ pipPlayingId: 'c' });
+        expect(mockImpressions).toEqual([
+            ['visible', 'a'],
+            ['hidden', 'a'],
+            ['visible', 'c'],
+        ]);
+    });
+
+    it('does not fall back to the pager when a live session has nothing to play', () => {
+        // A rebuilt list (a tab switch under a live session) can leave the cursor
+        // pointing past the end. The pager is frozen while the OS window is up,
+        // so attributing that time to its slide would be dwell on a video nobody
+        // is watching.
+        const reel = mountReel({ activePostId: 'a', pipOwnerId: 'a', pipPlayingId: 'a' });
+        reel.update({ pipPlayingId: undefined, activePostId: 'b' });
+
+        expect(mockImpressions).toEqual([
+            ['visible', 'a'],
+            ['hidden', 'a'],
+        ]);
+    });
+
+    it('keeps reporting a blurred screen while it owns the OS window', () => {
+        // PiP is exactly the case where a blurred/backgrounded reel is still the
+        // thing being watched, so the focus gate must not reach it.
+        mountReel({ pipOwnerId: 'a', pipPlayingId: 'a', screenFocused: false });
+
+        expect(mockImpressions).toEqual([['visible', 'a']]);
+    });
+});
+
+describe('reel impressions — the tracker session', () => {
+    it('builds its tracker from the descriptor, the reset key and the auth gate', () => {
+        mountReel({ activePostId: 'a', feedDescriptor: 'following', impressionResetKey: 'u1', canReportImpressions: false });
+
+        expect(mockTrackerArgs[0]).toEqual(['following', 'u1', false]);
+    });
+
+    it('re-registers the video on screen with the new tracker when the session changes', () => {
+        // The auth cold boot: the viewer lands several seconds into the first
+        // video, which is a NEW impression session for the same feed. The
+        // outgoing session is disposed during render, and it could not report
+        // anything (the private-API gate was still shut), so a new session that
+        // does not know about this video loses the impression outright — it would
+        // only open one on the next swipe.
+        const reel = mountReel({ activePostId: 'a', canReportImpressions: false });
+        expect(mockSessions).toHaveLength(1);
+        expect(mockSessions[0].events).toEqual([['visible', 'a']]);
+
+        reel.update({ impressionResetKey: 'viewer-1', canReportImpressions: true });
+
+        expect(mockSessions).toHaveLength(2);
+        expect(mockSessions[1].events).toEqual([['visible', 'a']]);
+        // …and the close went to the OUTGOING instance, never the new one. In
+        // production that instance is already disposed, where `setHidden`
+        // short-circuits, so the post is not reported twice.
+        expect(mockSessions[0].events).toEqual([
+            ['visible', 'a'],
+            ['hidden', 'a'],
+        ]);
+    });
+
+    it('does not disturb the session when only the auth gate flips', () => {
+        // `useFeedImpressionTracker` keeps its instance across an anon → authed
+        // flip precisely so a session is not reset mid-video; the hook must not
+        // manufacture a re-registration where there was no new tracker.
+        const reel = mountReel({ activePostId: 'a', impressionResetKey: 'viewer-1', canReportImpressions: false });
+        reel.update({ canReportImpressions: true });
+
+        expect(mockSessions).toHaveLength(1);
+        expect(mockImpressions).toEqual([['visible', 'a']]);
+    });
+});

--- a/packages/frontend/hooks/__tests__/useVideoPipSession.test.tsx
+++ b/packages/frontend/hooks/__tests__/useVideoPipSession.test.tsx
@@ -4,24 +4,14 @@ import TestRenderer, { act } from 'react-test-renderer';
 import { useVideoPipSession, type VideoPipSession } from '../useVideoPipSession';
 
 /**
- * The session's own decision logic: who owns it, where its cursor goes, when it
- * pages, and what it reports. These tests say NOTHING about Picture-in-Picture
- * itself — no OS window, no player, no source swap is reachable from jest — only
- * that the rules the screen drives those things with are the intended ones.
+ * The session's own decision logic: who owns it, where its cursor goes, and when
+ * it pages. These tests say NOTHING about Picture-in-Picture itself — no OS
+ * window, no player, no source swap is reachable from jest — only that the rules
+ * the screen drives those things with are the intended ones.
+ *
+ * Impressions are NOT here: the screen reports them for both of its watched-video
+ * sources through one shared tracker (see `useReelImpressions`).
  */
-
-// Prefixed `mock` so the hoisted `jest.mock` factory may reference it.
-const mockImpressions: Array<[event: 'visible' | 'hidden', postUri: string]> = [];
-const mockTracker = {
-    current: {
-        setVisible: (postUri: string) => { mockImpressions.push(['visible', postUri]); },
-        setHidden: (postUri: string) => { mockImpressions.push(['hidden', postUri]); },
-    },
-};
-
-jest.mock('@/utils/feedTelemetry', () => ({
-    useFeedImpressionTracker: () => mockTracker,
-}));
 
 interface Item {
     id: string;
@@ -34,14 +24,7 @@ const onEnded = jest.fn();
 const loadMore = jest.fn();
 
 function Probe({ items, hasMore }: { items: readonly Item[]; hasMore: boolean }) {
-    session = useVideoPipSession({
-        items,
-        onEnded,
-        loadMore,
-        hasMore,
-        feedDescriptor: 'videos',
-        canReportImpressions: true,
-    });
+    session = useVideoPipSession({ items, onEnded, loadMore, hasMore });
     return null;
 }
 
@@ -62,7 +45,6 @@ function live(): VideoPipSession<Item> {
 
 beforeEach(() => {
     session = null;
-    mockImpressions.length = 0;
     onEnded.mockClear();
     loadMore.mockClear();
 });
@@ -187,34 +169,29 @@ describe('PiP session — top-up', () => {
     });
 });
 
-describe('PiP session — impressions', () => {
-    it('reports the real post id of whatever the session is playing', () => {
+describe('PiP session — what is playing', () => {
+    it('has nothing playing until a session opens, and nothing again after it closes', () => {
         render();
-        act(() => live().start('b'));
-        expect(mockImpressions).toEqual([['visible', 'b']]);
+        expect(live().playing).toBeNull();
 
-        act(() => live().goToNext());
-        expect(mockImpressions).toEqual([
-            ['visible', 'b'],
-            ['hidden', 'b'],
-            ['visible', 'c'],
-        ]);
+        act(() => live().start('b'));
+        expect(live().playing).toEqual({ id: 'b' });
 
         act(() => live().end('b'));
-        expect(mockImpressions).toEqual([
-            ['visible', 'b'],
-            ['hidden', 'b'],
-            ['visible', 'c'],
-            ['hidden', 'c'],
-        ]);
+        expect(live().playing).toBeNull();
     });
 
-    it('reports nothing at all while no session is open', () => {
+    it('reports no item for a cursor that points outside the loaded list', () => {
+        // The screen reads `playing` to decide what to report an impression for,
+        // so a cursor left pointing past a rebuilt (shorter) list must yield null
+        // rather than the nearest item.
         const renderer = render();
+        act(() => live().start('e'));
         act(() => {
-            renderer.unmount();
+            renderer.update(<Probe items={[{ id: 'a' }, { id: 'b' }]} hasMore={false} />);
         });
 
-        expect(mockImpressions).toEqual([]);
+        expect(live().ownerId).toBe('e');
+        expect(live().playing).toBeNull();
     });
 });

--- a/packages/frontend/hooks/useReelImpressions.ts
+++ b/packages/frontend/hooks/useReelImpressions.ts
@@ -1,0 +1,92 @@
+import { useEffect } from 'react';
+import { useFeedImpressionTracker } from '@/utils/feedTelemetry';
+
+/**
+ * The reel's impression + dwell reporting.
+ *
+ * A reel has TWO ways of deciding which video is being watched — the pager's
+ * snapped slide, and, once the OS has lifted a player into its own window, the
+ * Picture-in-Picture session's cursor — but it reports through ONE tracker.
+ *
+ * One, because a `FeedImpressionTracker` dedupes against its own pending map:
+ * two instances each see the handoff into PiP as a first sighting of the same
+ * post, and emit an impression each. The `viewsCount` write is protected by the
+ * server's once-per-viewer dedupe, but the ranking signal is not — the second
+ * impression carries only the dwell accrued since the window opened, which lands
+ * under the server's skip threshold and books a NEGATIVE preference against a
+ * video the viewer just watched in full.
+ */
+export interface UseReelImpressionsOptions {
+  /** Id of the surface owning the OS window; `null` when no session is open. */
+  pipOwnerId: string | null;
+  /** What that session is playing, if its cursor points into the loaded list. */
+  pipPlayingId?: string;
+  /** Whether /videos is the focused route (a pushed screen leaves it mounted). */
+  screenFocused: boolean;
+  /** The slide the pager is on. */
+  activePostId?: string;
+  /** Feed the impressions are attributed to. */
+  feedDescriptor: string;
+  /** A change starts a fresh impression session (a reload, a new viewer). */
+  impressionResetKey?: string | number;
+  /** Whether impressions may be POSTed at all (the private-API / auth gate). */
+  canReportImpressions: boolean;
+}
+
+export function useReelImpressions({
+  pipOwnerId,
+  pipPlayingId,
+  screenFocused,
+  activePostId,
+  feedDescriptor,
+  impressionResetKey,
+  canReportImpressions,
+}: UseReelImpressionsOptions): void {
+  const impressionTracker = useFeedImpressionTracker(
+    feedDescriptor,
+    impressionResetKey,
+    canReportImpressions,
+  );
+
+  // Read DURING render, deliberately. The condition the effect below has to
+  // re-run on is "the tracker INSTANCE changed", and that is exactly what this
+  // is: `useFeedImpressionTracker` swaps its ref during ITS render whenever the
+  // session identity changes — a tab switch, or the viewer resolving on cold
+  // boot — and the call above precedes this read, so a swap render already sees
+  // the new instance. Keyed on the ref object instead, the effect never re-runs:
+  // the video on screen stays registered only with the session that was just
+  // disposed, and is re-opened on the next swipe. On cold boot the outgoing
+  // session could not report yet (`canReportImpressions` was false), so that
+  // impression is not merely late — it is lost.
+  //
+  // The cost is that the React Compiler refuses this function outright and bails
+  // it, which buys nothing back HERE: what it would cache is a ternary inside a
+  // hook that returns void. That is why the read lives in this hook and must
+  // never be moved into `VideosScreen`, where a bail would be real.
+  const tracker = impressionTracker.current;
+
+  // Discriminated on whether a session EXISTS, not on whether it currently has
+  // something to play: that is what makes the two cases total — no gap, no
+  // overlap. A `?? activePostId` fallback would look harmless and instead accrue
+  // dwell against a slide nobody is watching, because the pager is frozen for as
+  // long as the OS window is up and its cursor can point outside a list that has
+  // just been rebuilt (a tab switch under a live session).
+  //
+  // The focus gate matches the rest of the screen: a pushed route leaves the reel
+  // mounted but stops its playback, and time spent on top of a paused video is
+  // not dwell on that video. A viewer PAUSE deliberately does not gate — dwell is
+  // the time the post occupied the viewport, which is exactly what the web feed's
+  // IntersectionObserver measures for a text post that plays nothing.
+  const impressedPostId = pipOwnerId !== null
+    ? pipPlayingId
+    : (screenFocused ? activePostId : undefined);
+
+  // Visible while it is the watched video, hidden when the watch moves on or the
+  // screen goes away — the same visible/hidden contract every feed reports, so
+  // the dwell and the once-per-post dedupe come out identical.
+  useEffect(() => {
+    if (impressedPostId === undefined) return;
+    tracker.setVisible(impressedPostId);
+    return () => tracker.setHidden(impressedPostId);
+  }, [impressedPostId, tracker]);
+}

--- a/packages/frontend/hooks/useVideoPipSession.ts
+++ b/packages/frontend/hooks/useVideoPipSession.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useFeedImpressionTracker } from '@/utils/feedTelemetry';
 
 /**
  * The Picture-in-Picture **session**: what the reel becomes once the OS lifts one
@@ -13,17 +12,19 @@ import { useFeedImpressionTracker } from '@/utils/feedTelemetry';
  * player (`player.replaceAsync`), and the playback authority keeps the owner
  * playing through `ownsSession` even though the pager never moved.
  *
- * Two things stop working while the app is backgrounded, and the session owns
- * both because nothing else is running:
+ * **Pagination** stops working while the app is backgrounded, and the session
+ * owns it because nothing else is running: the list pages by scrolling — the
+ * document scroll listener on web, `onEndReached` on native — and nothing
+ * scrolls in a background tab or a backgrounded app, so the session tops itself
+ * up as its cursor approaches the end of the loaded set.
  *
- * - **Pagination.** The list pages by scrolling — the document scroll listener
- *   on web, `onEndReached` on native — and nothing scrolls in a background tab
- *   or a backgrounded app, so the session tops itself up as its cursor
- *   approaches the end of the loaded set.
- * - **Impressions.** Neither the web `IntersectionObserver` nor the list's
- *   viewability callback runs, so the session reports what it is playing itself,
- *   through the SAME tracker every feed uses — with the real post id, never a
- *   synthesised one.
+ * What the session does NOT own is impressions. The viewability callbacks are
+ * just as dead in a background tab, but the SCREEN reports for both of its
+ * watched-video sources through one shared tracker (`useReelImpressions`),
+ * reading `playing` from here. A tracker of its own would dedupe separately, so
+ * entering PiP on the video already being watched would emit a SECOND impression
+ * of it — carrying only the dwell since the window opened, which is short enough
+ * to land as a skip.
  *
  * On exit the caller re-syncs the pager to the cursor, so coming back to the app
  * lands on the video that was actually being watched.
@@ -54,12 +55,6 @@ export interface UseVideoPipSessionOptions<T extends VideoPipSessionItem> {
   loadMore: () => void;
   /** Whether another page exists at all. */
   hasMore: boolean;
-  /** Feed the session's impressions are attributed to. */
-  feedDescriptor: string;
-  /** A change starts a fresh impression session (a reload, a new viewer). */
-  impressionResetKey?: string | number;
-  /** Whether impressions may be POSTed at all (the private-API / auth gate). */
-  canReportImpressions: boolean;
 }
 
 export interface VideoPipSession<T extends VideoPipSessionItem> {
@@ -86,9 +81,6 @@ export function useVideoPipSession<T extends VideoPipSessionItem>({
   onEnded,
   loadMore,
   hasMore,
-  feedDescriptor,
-  impressionResetKey,
-  canReportImpressions,
 }: UseVideoPipSessionOptions<T>): VideoPipSession<T> {
   const [session, setSession] = useState<SessionState | null>(null);
 
@@ -133,23 +125,6 @@ export function useVideoPipSession<T extends VideoPipSessionItem>({
   }, [needsTopUp, loadMore]);
 
   const playing = session === null ? null : items.at(session.cursor) ?? null;
-
-  // Report the impression for whatever the OS window is showing. Visible while
-  // it is the session's subject, hidden when the cursor moves on or the session
-  // closes — the same visible/hidden contract the feeds report, so the dwell and
-  // the once-per-post dedupe come out identical.
-  const impressionTracker = useFeedImpressionTracker(
-    feedDescriptor,
-    impressionResetKey,
-    canReportImpressions,
-  );
-  const playingId = playing?.id;
-  useEffect(() => {
-    if (playingId === undefined) return;
-    const tracker = impressionTracker.current;
-    tracker.setVisible(playingId);
-    return () => tracker.setHidden(playingId);
-  }, [playingId, impressionTracker]);
 
   return {
     ownerId: session?.ownerId ?? null,

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -744,7 +744,17 @@
     "previous": "Previous video",
     "next": "Next video",
     "picture_in_picture": "Picture in Picture",
-    "picture_in_picture_failed": "Couldn't start Picture in Picture"
+    "picture_in_picture_failed": "Couldn't start Picture in Picture",
+    "replies": "Replies",
+    "addComment": "Add a comment...",
+    "like": "Like",
+    "unlike": "Unlike",
+    "comment": "Comment",
+    "boost": "Boost",
+    "unboost": "Undo boost",
+    "save": "Save",
+    "unsave": "Remove from saved",
+    "share": "Share"
   },
   "common": {
     "unknown": "unknown",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -638,7 +638,17 @@
     "previous": "Video anterior",
     "next": "Video siguiente",
     "picture_in_picture": "Imagen en imagen",
-    "picture_in_picture_failed": "No se pudo iniciar Imagen en imagen"
+    "picture_in_picture_failed": "No se pudo iniciar Imagen en imagen",
+    "replies": "Respuestas",
+    "addComment": "Añade un comentario...",
+    "like": "Me gusta",
+    "unlike": "Ya no me gusta",
+    "comment": "Comentar",
+    "boost": "Impulsar",
+    "unboost": "Deshacer impulso",
+    "save": "Guardar",
+    "unsave": "Quitar de guardados",
+    "share": "Compartir"
   },
   "common": {
     "unknown": "desconocido",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -632,7 +632,17 @@
     "previous": "Video precedente",
     "next": "Video successivo",
     "picture_in_picture": "Picture in picture",
-    "picture_in_picture_failed": "Impossibile avviare Picture in picture"
+    "picture_in_picture_failed": "Impossibile avviare Picture in picture",
+    "replies": "Risposte",
+    "addComment": "Aggiungi un commento...",
+    "like": "Mi piace",
+    "unlike": "Non mi piace più",
+    "comment": "Commenta",
+    "boost": "Rilancia",
+    "unboost": "Annulla rilancio",
+    "save": "Salva",
+    "unsave": "Rimuovi dai salvati",
+    "share": "Condividi"
   },
   "common": {
     "unknown": "sconosciuto",

--- a/packages/frontend/utils/__tests__/feedTelemetry.test.ts
+++ b/packages/frontend/utils/__tests__/feedTelemetry.test.ts
@@ -14,11 +14,18 @@
  *   5. Teardown flushes early, so navigating away never strands a batch.
  *   6. `resolveFeedDescriptor` maps the feed's type/userId/filters to the same
  *      descriptor the feed is fetched with.
+ *   7. `useFeedImpressionTracker` starts a NEW session — after flushing the old
+ *      one — whenever the descriptor or the reset key changes. The reel is what
+ *      makes this load-bearing: it switches feed (`videos` ↔ `following`) and
+ *      resolves its viewer without ever unmounting.
  *
  * The tracker's only outward effect is `feedService.sendFeedInteractions`, which
  * is mocked so the test never touches the network/SDK layer. `@oxyhq/core/logger` is
  * mocked for the same reason.
  */
+
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
 
 import { feedService } from '@/services/feedService';
 import {
@@ -26,6 +33,7 @@ import {
     flushFeedInteractions,
     reportFeedInteraction,
     resolveFeedDescriptor,
+    useFeedImpressionTracker,
 } from '../feedTelemetry';
 
 Object.assign(globalThis, { __DEV__: false });
@@ -270,6 +278,112 @@ describe('FeedImpressionTracker', () => {
         t.setHidden('p1');
         t.dispose();
         expect(mockSendFeedInteractions).not.toHaveBeenCalled();
+    });
+});
+
+describe('useFeedImpressionTracker', () => {
+    // The live tracker of the mounted probe — re-read after every render, since a
+    // session change replaces the instance behind the (stable) ref.
+    let mounted: { current: FeedImpressionTracker } | null = null;
+
+    function Probe({ descriptor, resetKey }: { descriptor: string; resetKey?: string }) {
+        mounted = useFeedImpressionTracker(descriptor, resetKey);
+        return null;
+    }
+
+    function tracker(): FeedImpressionTracker {
+        if (!mounted) throw new Error('no tracker probe mounted');
+        return mounted.current;
+    }
+
+    function mount(descriptor: string, resetKey?: string): TestRenderer.ReactTestRenderer {
+        let created: TestRenderer.ReactTestRenderer | undefined;
+        act(() => {
+            created = TestRenderer.create(createElement(Probe, { descriptor, resetKey }));
+        });
+        if (!created) throw new Error('renderer was not created');
+        return created;
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(0);
+        mockSendFeedInteractions.mockClear();
+        mounted = null;
+    });
+
+    afterEach(() => {
+        flushFeedInteractions();
+        jest.useRealTimers();
+    });
+
+    it('flushes the outgoing session when the descriptor changes mid-mount', () => {
+        const renderer = mount('videos');
+        const outgoing = tracker();
+        tracker().setVisible('p1');
+        jest.setSystemTime(2000);
+
+        // The reel's tab switch: same mount, different feed.
+        act(() => {
+            renderer.update(createElement(Probe, { descriptor: 'following' }));
+        });
+
+        // Sent on the spot, not on the next flush window: dispose has no later
+        // window to ride, so a tab switch must not strand the dwell it accrued.
+        expect(sentInteractions()).toEqual([
+            expect.objectContaining({ feedDescriptor: 'videos', postUri: 'p1', durationMs: 2000 }),
+        ]);
+
+        // …and the tracker behind the ref is a NEW one, so the same post counts
+        // once more against the feed that is now being watched.
+        expect(tracker()).not.toBe(outgoing);
+        tracker().setVisible('p1');
+        jest.setSystemTime(3500);
+        tracker().setHidden('p1');
+        jest.advanceTimersByTime(1000);
+
+        expect(sentInteractions()).toEqual([
+            expect.objectContaining({ feedDescriptor: 'videos', postUri: 'p1', durationMs: 2000 }),
+            expect.objectContaining({ feedDescriptor: 'following', postUri: 'p1', durationMs: 1500 }),
+        ]);
+    });
+
+    it('starts a new session on a reset key change without stranding the previous one', () => {
+        // The auth cold boot: the viewer resolves 2s into the first video, which
+        // is a new session for the same feed.
+        const renderer = mount('videos');
+        const anonymous = tracker();
+        tracker().setVisible('p1');
+        jest.setSystemTime(2000);
+
+        act(() => {
+            renderer.update(createElement(Probe, { descriptor: 'videos', resetKey: 'viewer-1' }));
+        });
+
+        expect(sentInteractions()).toEqual([
+            expect.objectContaining({ postUri: 'p1', durationMs: 2000 }),
+        ]);
+
+        expect(tracker()).not.toBe(anonymous);
+        tracker().setVisible('p2');
+        jest.setSystemTime(3200);
+        tracker().setHidden('p2');
+        jest.advanceTimersByTime(1000);
+
+        expect(sentInteractions()).toEqual([
+            expect.objectContaining({ postUri: 'p1', durationMs: 2000 }),
+            expect.objectContaining({ postUri: 'p2', durationMs: 1200 }),
+        ]);
+    });
+
+    it('keeps ONE tracker across a re-render that changes neither', () => {
+        const renderer = mount('videos', 'viewer-1');
+        const first = tracker();
+        act(() => {
+            renderer.update(createElement(Probe, { descriptor: 'videos', resetKey: 'viewer-1' }));
+        });
+
+        expect(tracker()).toBe(first);
     });
 });
 

--- a/packages/frontend/utils/__tests__/formatDuration.test.ts
+++ b/packages/frontend/utils/__tests__/formatDuration.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests run under either jest (frontend `jest-expo` preset) or vitest (workspace
+ * runner). Both provide the same describe/it/expect globals.
+ *
+ * The cases below pin the contract the module's docstring publishes, plus the
+ * two boundaries an implementation gets wrong by default: a fractional second
+ * must FLOOR (a rounding implementation would show a duration the clip has not
+ * reached), and the minute field must switch from unpadded to padded exactly at
+ * the hour, never before.
+ */
+
+import { formatDuration } from '../formatDuration';
+
+describe('formatDuration', () => {
+  it('renders sub-minute durations with a padded seconds field', () => {
+    expect(formatDuration(0)).toBe('0:00');
+    expect(formatDuration(7)).toBe('0:07');
+    expect(formatDuration(59)).toBe('0:59');
+  });
+
+  it('floors a fractional second rather than rounding up', () => {
+    expect(formatDuration(6.9)).toBe('0:06');
+    expect(formatDuration(59.999)).toBe('0:59');
+  });
+
+  it('leaves minutes unpadded below an hour', () => {
+    expect(formatDuration(83)).toBe('1:23');
+    expect(formatDuration(725)).toBe('12:05');
+    expect(formatDuration(3599)).toBe('59:59');
+  });
+
+  it('pads minutes once the hour field appears', () => {
+    expect(formatDuration(3600)).toBe('1:00:00');
+    expect(formatDuration(3723)).toBe('1:02:03');
+    expect(formatDuration(45296)).toBe('12:34:56');
+  });
+
+  it('renders 0:00 for anything that is not a finite, non-negative number', () => {
+    expect(formatDuration(-5)).toBe('0:00');
+    expect(formatDuration(NaN)).toBe('0:00');
+    expect(formatDuration(Infinity)).toBe('0:00');
+    expect(formatDuration(-Infinity)).toBe('0:00');
+    expect(formatDuration('90' as unknown as number)).toBe('0:00');
+  });
+});

--- a/packages/frontend/utils/formatDuration.ts
+++ b/packages/frontend/utils/formatDuration.ts
@@ -1,0 +1,36 @@
+/**
+ * Format a duration in seconds as a clock string.
+ *
+ * Examples:
+ * - 7 -> "0:07"
+ * - 83 -> "1:23"
+ * - 725 -> "12:05"
+ * - 3723 -> "1:02:03"
+ */
+
+/**
+ * Render `totalSec` as `m:ss`, or `h:mm:ss` once it reaches an hour.
+ *
+ * The value is FLOORED, never rounded up — the same rule `truncateToTenth` in
+ * `formatNumber.ts` applies to counts: a 6.9s clip reads "0:06", because a
+ * duration that has not reached a second must not be shown as having reached it.
+ *
+ * Minutes stay unpadded below an hour (`1:23`) and are padded above it
+ * (`1:02:03`), so the leading field is always the largest unit that is actually
+ * present. Anything that is not a finite, non-negative number renders `0:00`.
+ */
+export function formatDuration(totalSec: number): string {
+  if (typeof totalSec !== 'number' || !Number.isFinite(totalSec) || totalSec < 0) {
+    return '0:00';
+  }
+
+  const safe = Math.floor(totalSec);
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor(safe / 60) % 60;
+  const seconds = safe % 60;
+  const paddedSeconds = seconds.toString().padStart(2, '0');
+
+  return hours > 0
+    ? `${hours}:${minutes.toString().padStart(2, '0')}:${paddedSeconds}`
+    : `${minutes}:${paddedSeconds}`;
+}

--- a/packages/shared-types/__tests__/feedDescriptor.test.ts
+++ b/packages/shared-types/__tests__/feedDescriptor.test.ts
@@ -10,6 +10,9 @@ describe("feed descriptors", () => {
     expect(isValidFeedDescriptor("following")).toBe(true);
     expect(isValidFeedDescriptor("author|user-1")).toBe(true);
     expect(isValidFeedDescriptor("author|user-1|replies")).toBe(true);
+    // Every profile tab must resolve to an author descriptor, and `videos` is a
+    // tab — served by its own server-side filter, not by the `media` feed.
+    expect(isValidFeedDescriptor("author|user-1|videos")).toBe(true);
     expect(isValidFeedDescriptor("hashtag|typescript")).toBe(true);
   });
 

--- a/packages/shared-types/src/mtn/feedDescriptor.ts
+++ b/packages/shared-types/src/mtn/feedDescriptor.ts
@@ -10,13 +10,14 @@
  * profile screen, so every one of them must resolve to an author feed —
  * `author|<oxyUserId>|<filter>`.
  */
-export type AuthorFeedFilter = 'posts' | 'replies' | 'media' | 'likes' | 'boosts';
+export type AuthorFeedFilter = 'posts' | 'replies' | 'media' | 'videos' | 'likes' | 'boosts';
 
 /** {@link AuthorFeedFilter} as a runtime list, in profile-tab order. */
 export const AUTHOR_FEED_FILTERS: readonly AuthorFeedFilter[] = [
   'posts',
   'replies',
   'media',
+  'videos',
   'likes',
   'boosts',
 ];


### PR DESCRIPTION
## Why

The reels screen **never reported impressions**. `useFeedImpressionTracker` had exactly three consumers — `Feed.web.tsx`, `Feed.native.tsx`, and `useVideoPipSession` — and `/videos` uses none of them: its `onViewableItemsChanged` only drove playback. So watching a reel moved neither `stats.viewsCount` nor any ranking signal, while the rail rendered `engagement.views` the whole time.

The trigger was a product observation (drop the eye button, show plays on the profile grid), but showing that number without fixing the counter would publish a false metric at scale. Hence the order: **make the number true, then show it**.

## What changed

**Impressions.** One tracker shared by the pager and the OS window, in a new `useReelImpressions`. Two trackers with a `pipOwnerId === null` gate would duplicate at the PiP handoff — `recordDedupedView` protects the view count and `recordDwell` is protected by `countedNewView`, but `recordInteraction` is not, and a second impression carrying only post-handoff dwell lands under `dwellSkipThresholdMs`, booking `skip: -0.5` against a video the viewer just watched in full. It inverts the signal rather than inflating it.

The effect depends on the tracker **instance**, not its ref wrapper, so a session change mid-video (descriptor on a tab switch, or `viewerId` landing 5–25s into a cold boot) re-registers the video on screen instead of dropping its impression.

**Rail.** Eye removed (it was an inert `View` with `pointerEvents="none"` — never a button). Save added. Compacted to TikTok proportions (`gap` 24→16, icon 28→30, label 12→11px). Accessibility labels on every action; the two i18n keys previously called with a `defaultValue` are now real entries in en/es/it.

**Grid.** Video cells get a metadata row: play glyph always, compact count when there is one, duration when the item has one. `badge: 'center' | 'corner'` collapses to `scrim?: boolean` — the play affordance now has one canonical home.

**`author|<id>|videos`.** `videoOnlyFilter` already existed, registered and catalogued; only a preset referencing it was missing. The Videos tab stops paginating over a mixed image+video pool.

**Two defects found on the way:** the scrubber sat under the floating tab bar and was ungrabbable on mobile; the comment button was a no-op on desktop and now focuses the replies composer.

## Two traps worth knowing

**`views` is `0` on native and `null` on web.** The API always sends `null` for zero (`views: viewsCount > 0 ? viewsCount : null`); the literal `0` is manufactured by the native SQLite round-trip (`views_count: views ?? 0` written, `row.views_count ?? null` read). The guard is `typeof views === 'number' && views > 0` — a `!== null` check would print `0` under every video on device and nothing on web. Pinned by a test asserting `0`/`null`/`undefined` render identically.

**`useProfileScroll`'s `videos → media` mapping had to go.** `ProfileGridList.web.tsx` does not forward `onEndReached`, so `useProfileScroll.maybeLoadMore` is the *only* web pagination for both grids. Left in place, the web Videos tab would paginate the `media` cursor while showing `videos` items — a tab that silently stops paginating.

## Semantics, stated plainly

This reuses **impressions**, not a new play counter. So the grid number is *views*, not TikTok-style plays: a 1.2s flick-past counts (it clears the 1000ms floor), and ten rewatches count once (24h per-viewer dedupe). Reel view counts go from *never moving* to *moving*, which will look like a jump.

## ⚠️ Deploy order

**The backend must land before the frontend.** An old backend rejects `author|<id>|videos` at `isValidFeedDescriptor` with a 400, which renders as an empty "No videos yet" tab — a wrong answer, not a visible failure. Old client + new backend is zero-risk (`media` is untouched), so native users are unaffected.

Both deploy workflows fire in parallel off CI, so there is a possible few-minute window on web where the profile Videos tab reads empty. Accepted deliberately; it self-heals when ECS finishes.

## Verification

- backend: 3780 tests / 365 files pass
- frontend: 968 tests / 112 suites pass; coverage clears every floor by ≥6.8pt
- shared-types 13, mcp 32 pass
- typecheck clean across shared-types, backend, mcp, frontend, e2e
- `expo lint`: 0 errors (4 pre-existing warnings in untouched test files)
- lockfile: both layers pass, `bun.lock` and every `package.json` confirmed unchanged
- i18n: all 3 catalogs gained the same 10 keys, translated
- the two load-bearing assertions (the PiP handoff, the session change) were **mutation-tested** — reverted, confirmed failing on the exact string they guard, restored byte-identical

**Not yet done — needs a real device and a foregrounded browser tab:** the rail proportions, the grid overlay on native *and* web (that is where `0` vs `null` diverges), the scrubber hit area with real `insets.bottom`, and confirming a watched reel actually increments the counter. Jest reproduces none of these.

## Found but deliberately not fixed here

`Feed.native.tsx` calls `useFeedImpressionTracker(feedDescriptor, reloadKey)` with no `canReport` argument while `Feed.web.tsx` passes one — so an anonymous viewer on native POSTs impressions that 401. Pre-existing, unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)