### PR TITLE
feat(backend): drop cached Oxy identity when Oxy says it changed

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -23,6 +23,10 @@ import {
   getRedisClient,
 } from './src/utils/redis';
 import { isRedisConnectionError } from './src/utils/redisHelpers';
+import {
+  startUserInvalidationSubscriber,
+  type UserInvalidationSubscriber,
+} from './src/services/userInvalidationSubscriber';
 import { DistributedPresenceService } from './src/services/DistributedPresenceService';
 import {
   registerSocketPresence,
@@ -174,6 +178,7 @@ const io = new SocketIOServer(server, {
 setRuntimeSocketServer(io);
 
 let socketRedisClients: ReturnType<typeof createRedisPubSub> | null = null;
+let userInvalidationSubscriber: UserInvalidationSubscriber | null = null;
 
 // Setup Redis adapter for Socket.IO horizontal scaling
 // Note: @socket.io/redis-adapter v8+ supports node-redis
@@ -700,6 +705,12 @@ const bootServer = async () => {
   // cross-instance broadcasts work from the first connection
   await setupRedisAdapter();
 
+  // Drop cached Oxy identity as soon as Oxy says it changed, instead of waiting
+  // out the user-summary TTL. Runs on EVERY task: the SDK response caches it
+  // sweeps are per-process, so a leader-only subscriber would leave the rest of
+  // the fleet stale. Inert (and non-fatal) when Redis is unavailable.
+  userInvalidationSubscriber = await startUserInvalidationSubscriber();
+
   // Start BullMQ federation queue workers on EVERY task (inbox + delivery
   // throughput should scale with the fleet; BullMQ delivers each job to exactly
   // one worker). No-op when Redis is not configured — federation then falls
@@ -795,6 +806,13 @@ const gracefulShutdown = (signal: string): void => {
       });
     });
 
+    const invalidationShutdown = async (): Promise<void> => {
+      if (!userInvalidationSubscriber) return;
+      const handle = userInvalidationSubscriber;
+      userInvalidationSubscriber = null;
+      await handle.stop();
+    };
+
     const pubSubShutdown = async (): Promise<void> => {
       if (!socketRedisClients) return;
       const { publisher, subscriber } = socketRedisClients;
@@ -819,6 +837,7 @@ const gracefulShutdown = (signal: string): void => {
     await Promise.allSettled([
       httpClosed,
       socketShutdown,
+      invalidationShutdown(),
       pubSubShutdown(),
       closeRedisConnection(),
       mongoose.disconnect(),

--- a/packages/backend/src/__tests__/userInvalidationSubscriber.test.ts
+++ b/packages/backend/src/__tests__/userInvalidationSubscriber.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the Oxy user-invalidation subscriber.
+ *
+ * The three properties that make this safe to run on every task:
+ *
+ *  - A `profile` invalidation drops ALL THREE caches — the shared Redis
+ *    user-summary entry plus BOTH per-process Oxy client response caches. The
+ *    SDK caches are per-process, so missing them leaves each task serving its
+ *    own stale `GET /users/:id` for another five minutes; the Redis eviction
+ *    alone is not sufficient and a test that only asserted it would pass while
+ *    the bug survived.
+ *  - Startup is INERT on failure. No Redis, a refused connection or a failed
+ *    subscribe must return `null` and never throw into server boot — losing the
+ *    push signal costs a TTL, while throwing costs the process.
+ *  - The subscribe confirmation is logged, because it is the only evidence the
+ *    signal is live: a subscriber that silently failed to attach looks exactly
+ *    like one attached to a quiet channel.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OXY_USER_INVALIDATION_CHANNEL } from '@oxyhq/contracts';
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  subscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+  quit: vi.fn(),
+  publisherQuit: vi.fn(),
+  invalidateUserSummaries: vi.fn(),
+  serviceClearEntry: vi.fn(),
+  serviceClearPrefix: vi.fn(),
+  runtimeClearEntry: vi.fn(),
+  runtimeClearPrefix: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('../utils/redis', () => ({
+  createRedisPubSub: () => ({
+    subscriber: {
+      isOpen: true,
+      connect: mocks.connect,
+      subscribe: mocks.subscribe,
+      unsubscribe: mocks.unsubscribe,
+      quit: mocks.quit,
+    },
+    publisher: { isOpen: true, quit: mocks.publisherQuit },
+  }),
+}));
+
+vi.mock('../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    clearCacheEntry: mocks.serviceClearEntry,
+    clearCacheByPrefix: mocks.serviceClearPrefix,
+  }),
+}));
+
+vi.mock('../runtime/oxyClient', () => ({
+  getRuntimeOxyClient: () => ({
+    clearCacheEntry: mocks.runtimeClearEntry,
+    clearCacheByPrefix: mocks.runtimeClearPrefix,
+  }),
+}));
+
+vi.mock('./userSummaryCache', () => ({}));
+vi.mock('../services/userSummaryCache', () => ({
+  invalidate: mocks.invalidateUserSummaries,
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: { info: mocks.info, warn: mocks.warn, error: vi.fn(), debug: vi.fn() },
+}));
+
+import { startUserInvalidationSubscriber } from '../services/userInvalidationSubscriber';
+
+/** Run the handler the subscriber registered, as Redis would on a message. */
+function deliver(raw: string): void {
+  const handler = mocks.subscribe.mock.calls[0]?.[1] as (message: string) => void;
+  handler(raw);
+}
+
+const VALID = JSON.stringify({ userId: 'user-1', reason: 'profile', at: 1 });
+
+describe('startUserInvalidationSubscriber', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.connect.mockResolvedValue(undefined);
+    mocks.subscribe.mockResolvedValue(undefined);
+    mocks.unsubscribe.mockResolvedValue(undefined);
+    mocks.quit.mockResolvedValue(undefined);
+    mocks.publisherQuit.mockResolvedValue(undefined);
+  });
+
+  it('subscribes to the contract channel and logs the confirmation', async () => {
+    const handle = await startUserInvalidationSubscriber();
+
+    expect(handle).not.toBeNull();
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+    expect(mocks.subscribe.mock.calls[0][0]).toBe(OXY_USER_INVALIDATION_CHANNEL);
+    expect(mocks.info).toHaveBeenCalledWith(
+      '[UserInvalidation] subscriber enabled',
+      { channel: OXY_USER_INVALIDATION_CHANNEL },
+    );
+  });
+
+  it('drops the Redis summary AND both per-process SDK caches', async () => {
+    await startUserInvalidationSubscriber();
+    deliver(VALID);
+
+    expect(mocks.invalidateUserSummaries).toHaveBeenCalledWith(['user-1']);
+    // Both clients, or one task keeps answering from its own stale copy.
+    expect(mocks.serviceClearEntry).toHaveBeenCalledWith('GET:/users/user-1');
+    expect(mocks.runtimeClearEntry).toHaveBeenCalledWith('GET:/users/user-1');
+    expect(mocks.serviceClearPrefix).toHaveBeenCalled();
+    expect(mocks.runtimeClearPrefix).toHaveBeenCalled();
+  });
+
+  it('ignores a message that fails the contract schema', async () => {
+    await startUserInvalidationSubscriber();
+    // `graph` is suppressed at the publisher and rejected by the wire schema.
+    deliver(JSON.stringify({ userId: 'user-1', reason: 'graph', at: 1 }));
+    deliver('not json');
+
+    expect(mocks.invalidateUserSummaries).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalled();
+  });
+
+  it('never throws out of the message handler', async () => {
+    mocks.invalidateUserSummaries.mockImplementation(() => {
+      throw new Error('redis down');
+    });
+    await startUserInvalidationSubscriber();
+
+    expect(() => deliver(VALID)).not.toThrow();
+  });
+
+  it('returns null instead of throwing when the connection fails', async () => {
+    mocks.connect.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(startUserInvalidationSubscriber()).resolves.toBeNull();
+    expect(mocks.warn).toHaveBeenCalled();
+  });
+
+  it('returns null instead of throwing when subscribing fails', async () => {
+    mocks.subscribe.mockRejectedValue(new Error('subscribe failed'));
+
+    await expect(startUserInvalidationSubscriber()).resolves.toBeNull();
+  });
+
+  it('unsubscribes and closes both clients on stop', async () => {
+    const handle = await startUserInvalidationSubscriber();
+    await handle?.stop();
+
+    expect(mocks.unsubscribe).toHaveBeenCalledWith(OXY_USER_INVALIDATION_CHANNEL);
+    expect(mocks.quit).toHaveBeenCalled();
+    expect(mocks.publisherQuit).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/services/userInvalidationSubscriber.ts
+++ b/packages/backend/src/services/userInvalidationSubscriber.ts
@@ -1,0 +1,128 @@
+/**
+ * Subscribes to Oxy's user-invalidation broadcast and drops this task's cached
+ * copies of the user that changed.
+ *
+ * WHY THIS EXISTS — Oxy owns identity; Mention caches it. A display-name or
+ * avatar edit in Oxy was invisible here for up to the {@link userSummaryCache}
+ * TTL (10 minutes by default), to EVERY viewer rather than just the editor,
+ * because nothing told Mention the write had happened. oxy-api now publishes on
+ * {@link OXY_USER_INVALIDATION_CHANNEL} whenever a user's identity changes, and
+ * this is the consumer half.
+ *
+ * WHAT IT DROPS, and why all three:
+ *  - the Redis {@link userSummaryCache} entry — the shared, cross-task copy that
+ *    `PostHydrationService` reads for every post author;
+ *  - the GET response cache of BOTH process-level Oxy clients (service and
+ *    runtime). Those are per-PROCESS in-memory caches inside `@oxyhq/core`, so
+ *    the Redis eviction alone would leave each task serving its own stale copy
+ *    of `GET /users/:id` for another five minutes.
+ *
+ * RUNS ON EVERY TASK, deliberately not leader-gated. The Redis `DEL` is
+ * idempotent and cheap, and the SDK caches above are per-process — a leader-only
+ * subscriber would leave every other task stale, and leader-gating would add a
+ * failure mode (leader down means no invalidation anywhere) to a signal whose
+ * whole point is that losing it is merely slow, never wrong.
+ *
+ * FAILURE POSTURE — inert, never fatal. No `REDIS_URL`, a refused connection or
+ * a failed subscribe all degrade to "no push signal", which is exactly the
+ * behaviour before this existed: entries simply age out via TTL. Nothing here
+ * may throw into server startup.
+ */
+
+import { OXY_USER_INVALIDATION_CHANNEL } from '@oxyhq/contracts';
+import {
+  createOxyUserInvalidationHandler,
+  type OxyIdentityCacheEvictor,
+} from '@oxyhq/core/server';
+
+import { getRuntimeOxyClient } from '../runtime/oxyClient';
+import { createRedisPubSub } from '../utils/redis';
+import { getServiceOxyClient } from '../utils/oxyHelpers';
+import { logger } from '../utils/logger';
+import { invalidate as invalidateUserSummaries } from './userSummaryCache';
+
+/** Handle for shutting the subscriber down. */
+export interface UserInvalidationSubscriber {
+  stop: () => Promise<void>;
+}
+
+/**
+ * Fan one eviction out to both process-level Oxy clients.
+ *
+ * They are separate `OxyServices` instances (service-token vs public runtime)
+ * and therefore hold SEPARATE response caches, so an invalidation that swept
+ * only one would leave the other answering from a stale entry. Resolved lazily
+ * per event: `getRuntimeOxyClient` constructs on first use, and building it at
+ * module load would drag the Oxy runtime into every importer.
+ */
+function bothOxyClients(): OxyIdentityCacheEvictor {
+  return {
+    clearCacheEntry: (key) => {
+      getServiceOxyClient().clearCacheEntry(key);
+      getRuntimeOxyClient().clearCacheEntry(key);
+    },
+    clearCacheByPrefix: (prefix) => {
+      getServiceOxyClient().clearCacheByPrefix(prefix);
+      return getRuntimeOxyClient().clearCacheByPrefix(prefix);
+    },
+  };
+}
+
+/**
+ * Connect a dedicated subscriber and start applying invalidations.
+ *
+ * Returns `null` when no subscription could be established — the caller keeps
+ * running without the push signal rather than failing to boot.
+ */
+export async function startUserInvalidationSubscriber(): Promise<UserInvalidationSubscriber | null> {
+  // A subscribed Redis connection cannot issue ordinary commands, so this needs
+  // its own client rather than sharing the one `userSummaryCache` writes through.
+  const { publisher, subscriber } = createRedisPubSub();
+
+  try {
+    await subscriber.connect();
+
+    await subscriber.subscribe(
+      OXY_USER_INVALIDATION_CHANNEL,
+      createOxyUserInvalidationHandler({
+        oxy: bothOxyClients(),
+        onInvalidate: (event) => invalidateUserSummaries([event.userId]),
+        onError: (error, raw) => {
+          logger.warn('[UserInvalidation] dropped an invalidation message', {
+            reason: error instanceof Error ? error.message : String(error),
+            // Bounded: the payload is an id and a reason, never user content.
+            raw: raw.slice(0, 200),
+          });
+        },
+      }),
+    );
+
+    // Asserted by the deploy gate — a subscriber that silently failed to attach
+    // is indistinguishable from one that attached and received nothing, so the
+    // only evidence that the signal is live is this line appearing per task.
+    logger.info('[UserInvalidation] subscriber enabled', {
+      channel: OXY_USER_INVALIDATION_CHANNEL,
+    });
+
+    return {
+      stop: async () => {
+        await Promise.allSettled([
+          subscriber.isOpen ? subscriber.unsubscribe(OXY_USER_INVALIDATION_CHANNEL) : undefined,
+        ]);
+        await Promise.allSettled([
+          subscriber.isOpen ? subscriber.quit() : undefined,
+          publisher.isOpen ? publisher.quit() : undefined,
+        ]);
+      },
+    };
+  } catch (error: unknown) {
+    await Promise.allSettled([
+      subscriber.isOpen ? subscriber.quit() : undefined,
+      publisher.isOpen ? publisher.quit() : undefined,
+    ]);
+    logger.warn('[UserInvalidation] subscriber unavailable; identity stays TTL-bound', {
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}


### PR DESCRIPTION
## What

Oxy owns identity and Mention caches it, but nothing told Mention when it changed. A display-name or avatar edit was invisible here for up to the user-summary TTL (10 min) — to **every** viewer, not just the editor, because that Redis entry is shared. oxy-api broadcasts on `oxy:user:invalidate`; this subscribes and drops the stale copies.

**It drops three caches, and all three are needed:**
- the Redis `usersummary:` entry — the shared copy `PostHydrationService` reads for every post author;
- the GET response caches of **both** the service and runtime `OxyServices` singletons. Those live *inside the process*, so evicting only Redis would leave each task answering `GET /users/:id` from its own stale copy for another five minutes.

A test asserting only the Redis eviction would pass while that second bug survived, so the test asserts all three — mutation-tested: dropping the runtime sweep fails it.

**Runs on every task, not under the leader.** The `DEL` is idempotent and cheap, the SDK caches are per-process, and leader-gating would add a failure mode (leader down means no invalidation anywhere) to a signal whose whole point is that losing it is merely slow, never wrong. Inert and non-fatal without Redis — startup returns `null` and identity stays TTL-bound, exactly the prior behaviour.

This branch is now **only** the subscriber: `main` already carries the catalog bump (core `^17.0.2`, contracts `^0.21.0`, services `^26.0.0`), so there is no manifest or lockfile change here.

## Dependency-tree gate — passed, and the tree is now single-copy

The concern this waited on was two majors of the session SDK coexisting. Measured on this branch, resolving from `packages/frontend`:

```
@oxyhq/core              -> 17.0.2
@oxyhq/services          -> 26.0.0
core AS SEEN BY services -> 17.0.2   <- SAME FILE
total @oxyhq/core copies in node_modules: 1
```

**One copy, full stop.** `@oxyhq/services@26.0.0` (declaring core `^17.0.0`) removed the direct nesting, and `0253941b fix(deps): core 17 for the range federation actually declares` removed federation's. The transitive copies from `@alia.onl/sdk` (`@oxyhq/services: ^23.0.1`) and `@syra.fm/sdk` (`^15.0.0`) are gone from this tree as well.

Recorded because it will come up again: **had copies remained, they would have been harmless.** They are transitive, inside third-party SDKs rather than on Mention's own import path; `main` already shipped three; and core 16.0.0 and 17.0.2 are **byte-identical** across `session/`, `boot/`, `utils/storage*` and `crypto/` — verified by diffing those paths and by filtering every changed line across `16.0.0 → 17.0.2` for credential/storage identifiers, which returns four lines, all inside `exchangeOAuthCode`. So the split-brain cold-boot failure cannot occur between these versions whatever the copy count.

Also measured, and worth keeping: a nested copy Node resolves to may cost **nothing** in the browser. An A/B web export with `@alia.onl/sdk`'s nested `@oxyhq` present vs removed produced a byte-identical `async:index` at **302.02 KiB gzip** — Metro resolved to the top-level copy and never bundled the nested one. Node's `require.resolve` said otherwise; the bundle is what counts.

If `@alia.onl/sdk` / `@syra.fm/sdk` widen their ranges to admit services 26.x, **nothing in Mention needs changing** — it simply resolves.

## Why the major core bump was safe

`exchangeOAuthCode` — the only method OxyHQServices#756 changed behaviourally — is **unreachable from Mention**. Sign-in is the SDK's plain `signIn()`, a cryptographic challenge/response (`SignatureService.signChallenge` → `oxyServices.verifyChallenge`); the code exchange is reachable only via `startWebOAuthSignIn`, which Mention never calls (0 references; all 7 `signIn()` call sites are argument-less). `@oxyhq/core/server` is byte-identical between 16.1.0 and 17.0.2. All 24 core symbols the backend imports and all 7 the frontend imports were enumerated — none is in the changed set.

## Verification

| gate | result |
|---|---|
| backend `tsc` | pass |
| backend suite | **380 files / 4003 tests** |
| frontend typecheck | **0 errors** |
| frontend suite | **118 suites / 1025 tests** |
| `verify-lockfile.sh origin/main` | pass (exit 0) |
| doctor | clean (bar a pre-existing local Node version note) |

**End-to-end wiring proof against a real Redis** — seed a real `usersummary:` entry, start the actual subscriber, publish exactly as oxy-api does with ioredis, assert the key disappears:

```
PASS  seeded a real user-summary entry
PASS  subscriber attached (returned a handle)
PASS  summary-cache Redis client is ready before we publish
PASS  profile invalidation REMOVED the cached summary
PASS  a graph-reason message is rejected, entry survives
PASS  subscription still live after a malformed message
ALL CHECKS PASSED
```

**Control** (remove the summary eviction): fails exactly the two eviction assertions, so the check is not vacuous.

The live gate — change a display name in Oxy, hit a Mention feed endpoint, assert under 5s, with the control against the pre-deploy build and the per-task subscribe confirmation in CloudWatch — runs **after** this deploys, and will be reported honestly whichever way it comes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
