### PR TITLE
fix(backend): stop two rate limiters sharing one Redis counter

### DIFF
--- a/packages/backend/src/__tests__/middleware/rateLimitPrefixUniqueness.test.ts
+++ b/packages/backend/src/__tests__/middleware/rateLimitPrefixUniqueness.test.ts
@@ -1,0 +1,133 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every `RedisStore` prefix in the backend must be unique.
+ *
+ * Two limiters that share a prefix share a Redis KEY whenever their key
+ * generators agree — and ours mostly agree, because the convention here is to
+ * key an authenticated caller as `user:<id>`. That is not a tidy-naming concern:
+ * `rateLimitStore`'s Lua sets a TTL only when it CREATES the key
+ * (`if hits == 1 or ttl == -1`), so the first limiter to arrive silently decides
+ * the window for every limiter sharing that key, and each one's counter is
+ * incremented by the others' traffic.
+ *
+ * It happened: `apiRateLimiter` and the app-wide `createOxyRateLimit` both used
+ * `rate-limit:api:` with 60s and 15min windows. Nothing detected it —
+ * `ERR_ERL_DOUBLE_COUNT` fires only for one shared client, and these were two
+ * independent `RedisStore` instances — so it survived until a CodeQL fix on an
+ * unrelated router went looking for a limiter to reuse.
+ *
+ * A per-limiter behavioural test would not have caught it: each limiter passes
+ * its own test in isolation, because the collision is a property of the SET.
+ * Hence this shape — enumerate the set, assert the invariant.
+ */
+
+const BACKEND_SRC = path.resolve(__dirname, '../..');
+
+/** The prefix `RedisStore` falls back to when a caller omits one. */
+const DEFAULT_PREFIX = 'rate-limit:';
+
+interface PrefixSite {
+  prefix: string;
+  file: string;
+  line: number;
+  /** The whole matched construction, so a failure names the offender verbatim. */
+  source: string;
+}
+
+function collectTypeScriptFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      // `__tests__` is excluded ON PURPOSE: a test may construct a store to
+      // exercise a limiter, and those never reach a real Redis. The vacuity
+      // floor below is what stops that exclusion from hiding a broken walk.
+      if (entry === '__tests__' || entry === 'node_modules' || entry === 'dist') continue;
+      collectTypeScriptFiles(full, out);
+      continue;
+    }
+    if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Find every `new RedisStore(...)` and resolve the prefix it will use.
+ *
+ * Deliberately tolerant of formatting (the constructions in-tree are split
+ * across lines in several styles) and deliberately explicit about the
+ * no-argument form, which silently takes {@link DEFAULT_PREFIX} and can collide
+ * with anything else that omits one.
+ */
+function collectPrefixSites(): PrefixSite[] {
+  const sites: PrefixSite[] = [];
+
+  for (const file of collectTypeScriptFiles(BACKEND_SRC)) {
+    const contents = readFileSync(file, 'utf8');
+    const construction = /new\s+RedisStore\s*\(([^)]*)\)/g;
+
+    let match = construction.exec(contents);
+    while (match !== null) {
+      const args = match[1];
+      const prefixMatch = /prefix\s*:\s*['"]([^'"]*)['"]/.exec(args);
+      sites.push({
+        prefix: prefixMatch ? prefixMatch[1] : DEFAULT_PREFIX,
+        file: path.relative(BACKEND_SRC, file),
+        line: contents.slice(0, match.index).split('\n').length,
+        source: match[0].replace(/\s+/g, ' ').trim(),
+      });
+      match = construction.exec(contents);
+    }
+  }
+
+  return sites;
+}
+
+/**
+ * Floor for the number of constructions the walk must find.
+ *
+ * Without it, a regex that stops matching — or a directory walk that silently
+ * returns nothing — reports "no duplicates" and passes forever. Set below the
+ * current count so ordinary additions and removals do not trip it; it only fires
+ * when the scanner itself has broken.
+ */
+const MINIMUM_EXPECTED_SITES = 10;
+
+describe('RedisStore prefix uniqueness', () => {
+  it('finds enough constructions for the scan to be meaningful', () => {
+    const sites = collectPrefixSites();
+    expect(sites.length).toBeGreaterThanOrEqual(MINIMUM_EXPECTED_SITES);
+  });
+
+  it('assigns every limiter its own prefix', () => {
+    const byPrefix = new Map<string, PrefixSite[]>();
+    for (const site of collectPrefixSites()) {
+      const existing = byPrefix.get(site.prefix);
+      if (existing) existing.push(site);
+      else byPrefix.set(site.prefix, [site]);
+    }
+
+    const collisions = [...byPrefix.entries()].filter(([, sites]) => sites.length > 1);
+
+    // Report the offenders verbatim — a bare count would leave the next reader
+    // grepping for which two limiters actually clash.
+    const detail = collisions
+      .map(([prefix, sites]) =>
+        `  ${prefix}\n${sites.map((s) => `    ${s.file}:${s.line}  ${s.source}`).join('\n')}`
+      )
+      .join('\n');
+
+    expect(collisions, `Rate-limit prefixes shared by more than one store:\n${detail}`).toEqual([]);
+  });
+
+  it('never lets a store fall back to the default prefix', () => {
+    // An omitted prefix is the collision that is easiest to introduce and hardest
+    // to see: two such stores agree without either naming a prefix at all.
+    const defaulted = collectPrefixSites().filter((site) => site.prefix === DEFAULT_PREFIX);
+    const detail = defaulted.map((s) => `  ${s.file}:${s.line}  ${s.source}`).join('\n');
+
+    expect(defaulted, `RedisStore constructed without a prefix:\n${detail}`).toEqual([]);
+  });
+});

--- a/packages/backend/src/middleware/rateLimiter.ts
+++ b/packages/backend/src/middleware/rateLimiter.ts
@@ -4,11 +4,28 @@ import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { hashedIpKey } from '../utils/ipKey';
 
 /**
- * General API rate limiter (for non-feed endpoints)
- * More lenient limits for general API usage
+ * General API rate limiter for non-feed endpoints: a per-MINUTE burst bound,
+ * mounted per router (`notifications.ts`), layered on top of the app-wide
+ * sustained budget that `createOxyRateLimit` enforces from `runtimeApp.ts`.
+ *
+ * The prefix is `rate-limit:api-burst:`, NOT `rate-limit:api:`, and the
+ * distinction is load-bearing rather than cosmetic. This limiter keys
+ * authenticated callers as `user:<id>`, and so does the app-wide one — core's
+ * `resolveTrustedAuthenticatedKey` builds the identical string. Sharing a prefix
+ * therefore meant sharing a Redis KEY, and `rateLimitStore`'s Lua only sets a
+ * TTL when it creates the key, so whichever limiter arrived first decided the
+ * window for both. The app-wide limiter is mounted before route composition and
+ * always arrives first, so this one silently inherited a 15-minute TTL and
+ * counted every unrelated API request the caller made — a 200/minute bound
+ * behaving as roughly 200 per quarter hour, shared with all other traffic.
+ *
+ * It never threw `ERR_ERL_DOUBLE_COUNT`: the two are independent `RedisStore`
+ * instances rather than one shared client, so express-rate-limit's own
+ * double-count detection could not see across them. Uniqueness is enforced by
+ * `__tests__/middleware/rateLimitPrefixUniqueness.test.ts` instead.
  */
 export const apiRateLimiter = rateLimit({
-  store: new RedisStore({ prefix: 'rate-limit:api:', windowMs: 60 * 1000 }),
+  store: new RedisStore({ prefix: 'rate-limit:api-burst:', windowMs: 60 * 1000 }),
   windowMs: 60 * 1000, // 1 minute
   max: 200, // 200 requests per minute
   standardHeaders: true,

--- a/packages/backend/src/runtimeApp.ts
+++ b/packages/backend/src/runtimeApp.ts
@@ -21,6 +21,11 @@ export function createRuntimeApp() {
   const oxy = new OxyServices({ baseURL: config.oxyApiUrl });
   setRuntimeOxyClient(oxy);
 
+  // `rate-limit:api:` belongs to THIS limiter — the app-wide one, whose scope is
+  // the entire API surface. Route-level limiters must not reuse it: they key
+  // authenticated callers as `user:<id>` exactly as this one does, so a shared
+  // prefix is a shared counter, and the Lua in `rateLimitStore` hands the whole
+  // key one TTL — whichever limiter creates it. See `middleware/rateLimiter.ts`.
   const redisStore = new RedisStore({
     prefix: 'rate-limit:api:',
     windowMs: 15 * 60 * 1000,


### PR DESCRIPTION
## The bug

`apiRateLimiter` and the app-wide limiter in `runtimeApp.ts` both wrote the prefix `rate-limit:api:`, and for an authenticated caller their keys were **byte-identical** — core's `resolveTrustedAuthenticatedKey` builds the same `user:<id>` string the middleware's own `keyGenerator` does.

Anonymous callers collided too, on IPv4: `ipKeyGenerator` returns the address unchanged and so does core, so both HMAC the same input. Only the IPv6 normalisation differs (core joins all eight hextets; express-rate-limit compresses with `::`). That matters because `/federation/*` runs under `optionalAuth`, and behind a NAT or CDN many people share one address.

## What it did, measured rather than reasoned about

The store's Lua sets a TTL only when it creates the key. The app-wide limiter is mounted before route composition and is not in core's exempt list, so it always arrives first — this is deterministic, not order-dependent. Against a real local Redis running that exact Lua:

```
A: live ordering — app-wide (900s) first, then apiRateLimiter (60s)
  app-wide  -> 1 900
  api(60s)  -> 2 900        ← inherits the 15-minute TTL, already at 2
  TTL on the shared key: 900

B: counterfactual — apiRateLimiter creates the key first
  api(60s)  -> 1 60
  app-wide  -> 2 60
```

So a **200/minute** bound behaved as roughly **200 per quarter hour**, its counter fed by every unrelated API request the caller made — and a request to a router carrying both cost **2**, halving it again to ~100 per 15 minutes for a user doing nothing else.

## Who was affected — two routers, not one

- `routes/notifications.ts:40`
- `connectors/connectors.routes.ts:41` — the `/federation` API: `resolve`, `follow`, `unfollow`, `following`, `followers`, `actor/posts`, `sharing-changed`

The federation half is the consequential one. Federation degrading quietly is this repo's most painful failure shape, and this was throttling user-facing federation actions at a fraction of their intended budget.

## The fix

**The app-wide limiter keeps `rate-limit:api:`. `apiRateLimiter` moves to `rate-limit:api-burst:`.**

Two independent arguments land on the same answer. The app-wide limiter's scope genuinely *is* the whole API surface, so the prefix describes it exactly; `apiRateLimiter` is a per-router, per-minute burst bound layered on a 15-minute sustained budget, and its old prefix overclaimed. And on deploy, whichever prefix moves abandons its live keys — moving the app-wide one would hand every caller a fresh global abuse budget for 15 minutes, while moving the narrow one resets at most a 60-second burst counter.

All 15 `RedisStore` prefixes verified unique afterwards.

## This LOOSENS throttling, deliberately

Stated plainly because it changes what users experience:

- **Before:** a shared counter that hit 200 across *all* API traffic in a *15-minute* window, then 429'd notifications and federation actions.
- **After:** 200 notification-or-federation requests per actual minute, isolated from other traffic.

No user becomes more throttled. Abuse protection is unchanged — the ceiling that actually bounds abuse is the app-wide 5000/15min (600 anonymous), which this does not touch. On deploy the old keys keep serving the app-wide limiter unchanged and the burst counters start empty, so there is a one-time ≤60s window where those two routers are unbounded by the burst limiter.

## The test asserts a set-level invariant

`__tests__/middleware/rateLimitPrefixUniqueness.test.ts` enumerates every `RedisStore` construction and asserts prefix uniqueness — **because a per-limiter behavioural test cannot catch this**: each limiter passes in isolation, and the collision is a property of the SET. Three cases: uniqueness, a vacuity floor, and a guard on the no-prefix default (`RedisStore` falls back to `'rate-limit:'`, so two stores that both omit a prefix agree without either naming one). Failures print file, line and the whole construction.

Mutations, all three caught:

| mutation | result |
|---|---|
| restore `rate-limit:api:` on `apiRateLimiter` | names both sites with their constructions |
| break the scanner regex | `expected 0 to be greater than or equal to 10` — **and the uniqueness case passed under this mutation**, which is exactly the silent pass the floor exists to stop |
| drop the prefix entirely | names the default-fallback construction |

## Verification

```
backend      378 files / 3946 tests pass
frontend     118 suites / 1025 tests pass
shared-types 13 pass    mcp 32 pass
```

`bun run build` exit 0; `check:types` all packages `Done`, frontend 0 errors; `expo lint` 0 errors (4 pre-existing warnings in untouched files); `validate:lockfile` 1993 resolutions; `audit:security` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)