### PR TITLE
fix(media): give a video's two still surfaces the sizes they each need

### DIFF
--- a/packages/backend/src/__tests__/utils/mediaResolver.test.ts
+++ b/packages/backend/src/__tests__/utils/mediaResolver.test.ts
@@ -209,7 +209,11 @@ describe('resolveMediaItems', () => {
     // The playable source stays un-varianted; the poster keeps its own endpoint.
     expect(items[1].url).toBe(`${PUBLIC_BASE}/media/proxy?url=${encoded}`);
     expect(items[1].posterUrl).toBe(`${PUBLIC_BASE}/media/poster?url=${encoded}`);
-    expect(items[1].fullUrl).toBe(`${PUBLIC_BASE}/media/proxy?url=${encoded}&variant=w2048`);
+    // A federated video's `thumbUrl` is its POSTER, never the proxied video
+    // asking for an image variant: `/media/proxy` honours a variant only for
+    // image content types, so that URL would hand an <Image> raw video bytes.
+    expect(items[1].thumbUrl).toBe(`${PUBLIC_BASE}/media/poster?url=${encoded}`);
+    expect(items[1].thumbUrl).not.toContain('/media/proxy');
   });
 
   it('leaves the Oxy-file branch on its own variants, untouched by the federated fix', () => {
@@ -227,7 +231,7 @@ describe('resolveMediaItems', () => {
     expect(items[0].posterUrl).toBe(`${OXY_BASE}/assets/native-img/stream?variant=w320`);
     expect(items[0].fullUrl).toBe(`${OXY_BASE}/assets/native-img/stream?variant=w2048`);
 
-    expect(items[1].thumbUrl).toBe(`${OXY_BASE}/assets/native-vid/stream?variant=thumb`);
+    expect(items[1].thumbUrl).toBe(`${OXY_BASE}/assets/native-vid/stream?variant=w320`);
     expect(items[1].fullUrl).toBeUndefined();
 
     for (const item of items) {
@@ -237,14 +241,41 @@ describe('resolveMediaItems', () => {
     }
   });
 
-  it('uses the native thumb variant for Oxy video posters', () => {
+  it('gives a native video TWO still sizes: a grid-cell thumb and a player poster', () => {
+    // The two surfaces differ by an order of magnitude — a ~130px grid cell
+    // versus a full-width player — so one size cannot serve both. `thumb`(256)
+    // used to serve both and was wrong at each end: 144x256 is soft fullscreen,
+    // while the only other working option (the raw 1920px `poster`) is ~6x
+    // oversized for a cell.
     const items = resolveMediaItems([{ id: 'video-file', type: 'video' }]);
 
     expect(items).toHaveLength(1);
     expect(items[0].url).toBe(`${OXY_BASE}/assets/video-file/stream`);
-    expect(items[0].thumbUrl).toBe(`${OXY_BASE}/assets/video-file/stream?variant=thumb`);
-    expect(items[0].posterUrl).toBe(`${OXY_BASE}/assets/video-file/stream?variant=thumb`);
+    expect(items[0].thumbUrl).toBe(`${OXY_BASE}/assets/video-file/stream?variant=w320`);
+    expect(items[0].posterUrl).toBe(`${OXY_BASE}/assets/video-file/stream?variant=w1280`);
+    expect(items[0].thumbUrl).not.toBe(items[0].posterUrl);
     expect(items[0].fullUrl).toBeUndefined();
+  });
+
+  it('never asks for a variant name the asset service does not generate', () => {
+    // Every name emitted for a video must exist server-side. `thumb` for a video
+    // was a hard 404 on the CDN until oxy-api learned to render image sizes from
+    // the poster frame, and a name outside the taxonomy (`full`, `large`,
+    // `original`) 404s for every mime.
+    const generated = new Set([
+      'w96', 'w128', 'thumb', 'w320', 'w640', 'w1280', 'w2048', 'poster', 'hls_master',
+    ]);
+    const items = resolveMediaItems([
+      { id: 'video-file', type: 'video' },
+      { id: 'img-file', type: 'image' },
+    ]);
+
+    for (const item of items) {
+      for (const url of [item.url, item.thumbUrl, item.posterUrl, item.fullUrl, item.hlsUrl]) {
+        const variant = url ? new URL(url).searchParams.get('variant') : null;
+        if (variant) expect(generated).toContain(variant);
+      }
+    }
   });
 
   it('resolves the hls_master variant as hlsUrl for a native Oxy video', () => {
@@ -305,7 +336,7 @@ describe('resolveMediaItems — persisted geometry passthrough', () => {
     ]);
 
     expect(item).toMatchObject({ ...geometry, durationSec: 12.5 });
-    expect(item.posterUrl).toBe(`${OXY_BASE}/assets/video-file/stream?variant=thumb`);
+    expect(item.posterUrl).toBe(`${OXY_BASE}/assets/video-file/stream?variant=w1280`);
   });
 
   it('forwards geometry for a GIF', () => {

--- a/packages/backend/src/utils/mediaResolver.ts
+++ b/packages/backend/src/utils/mediaResolver.ts
@@ -3,6 +3,7 @@ import {
   MEDIA_VARIANT_THUMB,
   MEDIA_VARIANT_FULL,
   MEDIA_VARIANT_AVATAR,
+  MEDIA_VARIANT_VIDEO_THUMB,
   MEDIA_VARIANT_VIDEO_POSTER,
   MEDIA_VARIANT_BANNER,
 } from '@mention/shared-types';
@@ -75,9 +76,11 @@ export interface ResolvedMedia {
  *  - avatars (small, circular crop)             → {@link MEDIA_VARIANT_AVATAR}.
  *    The dedicated 96px square `w96` crop — most avatars across the app
  *    render ≤40px, comfortably covered even at 3x DPR.
- *  - video posters (feed media rectangle)       → {@link MEDIA_VARIANT_VIDEO_POSTER}.
- *    Kept on the 256px `thumb` crop: a poster fills the media card, so it
- *    must not be shrunk to a small square.
+ *  - video grid cell / notification still       → {@link MEDIA_VARIANT_VIDEO_THUMB}.
+ *    A small still, sized exactly like an image in the same grid (`w320`).
+ *  - video poster behind a player               → {@link MEDIA_VARIANT_VIDEO_POSTER}.
+ *    The in-feed video card and the fullscreen Reels viewer are both
+ *    full-width (~1180 device px on a 3x phone), so both take `w1280`.
  *  - profile banners (full-bleed 170px strip)   → {@link MEDIA_VARIANT_BANNER}.
  *    Bounded by width, not by the lightbox: `w1280` covers a 3x-DPR phone.
  */
@@ -387,8 +390,30 @@ export function resolveMediaItems(items: MediaItem[] | undefined | null): MediaI
       const altField = item.alt ? { alt: item.alt } : {};
       const geometry = persistedGeometry(item);
 
+      if (item.type === 'video' && isAbsoluteHttpUrl(item.id)) {
+        // FEDERATED video. `resolved.thumbUrl` is the proxied VIDEO asking for an
+        // image variant — bytes no <Image> can render, because `/media/proxy`
+        // honours a variant only for image content types. A still is what every
+        // consumer of `thumbUrl` wants here, so both still fields point at the
+        // extracted poster frame. `/media/poster` takes no variant (it caps the
+        // frame at 720px itself), so the grid and the player share one size.
+        return {
+          id: item.id,
+          type: item.type,
+          ...altField,
+          ...geometry,
+          url: resolved.url || undefined,
+          thumbUrl: resolved.posterUrl,
+          posterUrl: resolved.posterUrl,
+        };
+      }
+
       if (item.type === 'video' && !isAbsoluteHttpUrl(item.id)) {
         try {
+          // Two sizes, because the surfaces differ by an order of magnitude: a
+          // ~130px grid cell versus a full-width player. See the MEDIA_VARIANT_*
+          // block in `@mention/shared-types` for the sizing rationale.
+          const thumbUrl = getServiceOxyClient().getFileDownloadUrl(item.id, MEDIA_VARIANT_VIDEO_THUMB);
           const posterUrl = getServiceOxyClient().getFileDownloadUrl(item.id, MEDIA_VARIANT_VIDEO_POSTER);
           // Adaptive-bitrate HLS master playlist. NOT guaranteed to exist yet
           // (background transcode is fire-and-forget on upload) — the frontend
@@ -401,7 +426,7 @@ export function resolveMediaItems(items: MediaItem[] | undefined | null): MediaI
             ...altField,
             ...geometry,
             url: resolved.url || undefined,
-            thumbUrl: posterUrl,
+            thumbUrl,
             posterUrl,
             hlsUrl,
           };

--- a/packages/frontend/app/(app)/[username]/about.tsx
+++ b/packages/frontend/app/(app)/[username]/about.tsx
@@ -4,7 +4,7 @@ import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import { useLocalSearchParams } from 'expo-router';
 import { useSafeBack } from '@/hooks/useSafeBack';
 import React, { useMemo } from 'react';
@@ -192,7 +192,7 @@ function AccountInfoContent({ profileData, profileLoading }: AccountInfoContentP
             @handle) and inline verified / federated / agent badges via the shared
             UserName, so it reads as the same identity surface as the profile. */}
         <View className="px-4 pt-4 pb-5 items-center">
-          <Avatar source={avatarUri} size={80} variant={MEDIA_VARIANT_VIDEO_POSTER} />
+          <Avatar source={avatarUri} size={80} variant={MEDIA_VARIANT_AVATAR_LG} />
           <UserName
             name={profileData.design.displayName ?? profileData.name?.displayName}
             handle={profileData.username}

--- a/packages/frontend/app/(app)/insights/weekly_recap.tsx
+++ b/packages/frontend/app/(app)/insights/weekly_recap.tsx
@@ -18,7 +18,7 @@ import { insightsService, type AccountInsights } from '@/services/insightsServic
 import { useTranslation } from 'react-i18next';
 import { useAuth, OxyAuthPrompt } from '@oxyhq/services/ui/client';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import StatCard from '@/components/insights/StatCard';
 import { formatCompactNumber } from '@/utils/formatNumber';
 import { ArticleIcon } from '@/assets/icons/article-icon';
@@ -323,7 +323,7 @@ const WeeklyRecapScreen: React.FC = () => {
                     <Avatar
                         source={avatarUri}
                         size={72}
-                        variant={MEDIA_VARIANT_VIDEO_POSTER}
+                        variant={MEDIA_VARIANT_AVATAR_LG}
                     />
                     <Text className="text-2xl font-bold mt-4 mb-2 text-foreground" style={{ letterSpacing: -0.3 }}>
                         {t('insights.weeklyRecap.pageTitle')}

--- a/packages/frontend/app/(app)/lists/[id].tsx
+++ b/packages/frontend/app/(app)/lists/[id].tsx
@@ -22,7 +22,7 @@ import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import { ProfileCard, ProfileCardSkeletonList } from '@/components/ProfileCard';
 
 import Feed from '@/components/Feed/Feed';
@@ -155,7 +155,7 @@ export default function ListDetailScreen() {
         <Avatar
           source={list?.avatar || undefined}
           size={58}
-          variant={MEDIA_VARIANT_VIDEO_POSTER}
+          variant={MEDIA_VARIANT_AVATAR_LG}
           style={{ borderRadius: 12 }}
         />
         <View className="flex-1 justify-center">

--- a/packages/frontend/app/(app)/oauth/mcp/authorize.tsx
+++ b/packages/frontend/app/(app)/oauth/mcp/authorize.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useAuth, OxyAuthPrompt } from '@oxyhq/services/ui/client';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import { ThemedView } from '@/components/ThemedView';
 import { Header } from '@/components/Header';
 import { IconButton, Button } from '@/components/ui/Button';
@@ -168,7 +168,7 @@ function ConsentBody({ params }: { params: Required<Pick<McpAuthorizeParams, 'cl
       <View className="items-center gap-4">
         <View className="flex-row items-center gap-3">
           {currentUserProfile ? (
-            <Avatar source={currentUserProfile.avatar} size={56} variant={MEDIA_VARIANT_VIDEO_POSTER} />
+            <Avatar source={currentUserProfile.avatar} size={56} variant={MEDIA_VARIANT_AVATAR_LG} />
           ) : (
             <View
               className="w-14 h-14 rounded-full items-center justify-center bg-primary/10"

--- a/packages/frontend/app/(app)/oauth/mcp/link.tsx
+++ b/packages/frontend/app/(app)/oauth/mcp/link.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useAuth, OxyAuthPrompt } from '@oxyhq/services/ui/client';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import { ThemedView } from '@/components/ThemedView';
 import { Header } from '@/components/Header';
 import { IconButton, Button } from '@/components/ui/Button';
@@ -145,7 +145,7 @@ function LinkBody({ token }: { token: string }) {
     >
       <View className="items-center gap-3">
         {currentUserProfile ? (
-          <Avatar source={currentUserProfile.avatar} size={72} variant={MEDIA_VARIANT_VIDEO_POSTER} />
+          <Avatar source={currentUserProfile.avatar} size={72} variant={MEDIA_VARIANT_AVATAR_LG} />
         ) : (
           <View
             className="w-[72px] h-[72px] rounded-full items-center justify-center bg-primary/10"

--- a/packages/frontend/app/(app)/settings/index.tsx
+++ b/packages/frontend/app/(app)/settings/index.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "expo-router";
 import { useSafeBack } from '@/hooks/useSafeBack';
 import { useProfileData } from "@/hooks/useProfileData";
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import { SettingsListGroup, SettingsListItem } from '@oxyhq/bloom/settings-list';
 import { Loading } from '@oxyhq/bloom/loading';
 import { RowIcon } from '@/components/settings/RowIcon';
@@ -125,7 +125,7 @@ export default function SettingsScreen() {
                         <Avatar
                             source={currentUserProfile.avatar}
                             size={80}
-                            variant={MEDIA_VARIANT_VIDEO_POSTER}
+                            variant={MEDIA_VARIANT_AVATAR_LG}
                         />
                         <Text className="text-2xl font-bold text-foreground mt-2" numberOfLines={1}>
                             {currentUserProfile.design.displayName}

--- a/packages/frontend/app/(app)/starter-packs/[id].tsx
+++ b/packages/frontend/app/(app)/starter-packs/[id].tsx
@@ -14,7 +14,7 @@ import { useAuth, FollowButton } from '@oxyhq/services/ui/client';
 import { useHaptics } from '@oxyhq/bloom/hooks';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { AvatarGroup, type AvatarGroupItem } from '@oxyhq/bloom/avatar-group';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import { ProfileCard } from '@/components/ProfileCard';
 
 import { SEO } from '@/components/SEO';
@@ -128,7 +128,7 @@ export default function StarterPackDetailScreen() {
       {/* Hero section with grouped member avatars */}
       <View className="items-center px-6 pt-6 pb-4 gap-4">
         {avatarItems.length > 0 ? (
-          <AvatarGroup items={avatarItems} size={56} max={8} total={members.length} variant={MEDIA_VARIANT_VIDEO_POSTER} />
+          <AvatarGroup items={avatarItems} size={56} max={8} total={members.length} variant={MEDIA_VARIANT_AVATAR_LG} />
         ) : (
           <View className="w-16 h-16 rounded-2xl items-center justify-center bg-primary/20">
             <StarterPackIcon size={32} color={theme.colors.primary} />

--- a/packages/frontend/components/Profile/MediaGrid.tsx
+++ b/packages/frontend/components/Profile/MediaGrid.tsx
@@ -49,10 +49,15 @@ const WINDOW_SIZE = 7;
 // fallback `url`).
 const resolveImageUri = (ref: MediaItem): string | undefined => ref.thumbUrl || ref.url || undefined;
 
-// Static video poster from the server-resolved media object (`posterUrl`,
-// fallback `thumbUrl`). Undefined → icon placeholder; a 404/error from the URL
-// is handled by the cell's own image-error fallback.
-const resolveVideoPosterUri = (ref: MediaItem): string | undefined => ref.posterUrl || ref.thumbUrl || undefined;
+// Static video still from the server-resolved media object (`thumbUrl`, fallback
+// `posterUrl`). `thumbUrl` comes FIRST because a grid cell is ~130px and
+// `posterUrl` is sized for a full-width player — an order of magnitude more
+// bytes than this surface can show. Both fields are a still image for a video of
+// EITHER origin (the resolver points a federated video's `thumbUrl` at its
+// extracted poster, not at the proxied video), so this order is safe.
+// Undefined → icon placeholder; a 404/error from the URL is handled by the
+// cell's own image-error fallback.
+const resolveVideoPosterUri = (ref: MediaItem): string | undefined => ref.thumbUrl || ref.posterUrl || undefined;
 
 const MediaGrid: React.FC<MediaGridProps> = ({
     userId,

--- a/packages/frontend/components/Profile/ProfileHeader.tsx
+++ b/packages/frontend/components/Profile/ProfileHeader.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
 import { ZoomableAvatar } from '@/components/ZoomableAvatar';
 import { LiveAvatar } from '@/components/ui/LiveAvatar';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import { useLiveUsers } from '@/hooks/useLiveUsers';
 import { useLayoutScroll } from '@/context/LayoutScrollContext';
 import { AnalyticsIcon } from '@/assets/icons/analytics-icon';
@@ -92,7 +92,7 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
             className="border-[3px] border-background bg-secondary rounded-full"
             style={liveAvatarCollapseStyle}
           >
-            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={90} variant={MEDIA_VARIANT_VIDEO_POSTER} />
+            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={90} variant={MEDIA_VARIANT_AVATAR_LG} />
           </Animated.View>
         ) : (
           <ZoomableAvatar
@@ -208,7 +208,7 @@ export const ProfileHeaderMinimalist = memo(function ProfileHeaderMinimalist({
       <View className="relative">
         {isProfileLive ? (
           <View className="border-[3px] border-background bg-secondary rounded-full">
-            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={70} variant={MEDIA_VARIANT_VIDEO_POSTER} />
+            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={70} variant={MEDIA_VARIANT_AVATAR_LG} />
           </View>
         ) : (
           <ZoomableAvatar

--- a/packages/frontend/components/Profile/VideosGrid.tsx
+++ b/packages/frontend/components/Profile/VideosGrid.tsx
@@ -66,15 +66,17 @@ const VideosGrid: React.FC<VideosGridProps> = ({
     } = useProfileMediaFeed({ userId, isPrivate, isOwnProfile, filter: 'videos' });
 
     /**
-     * Resolve a static video poster. Prefer the server-resolved final `posterUrl`
-     * (fallback `thumbUrl`) from the media object; fall back to the legacy client
-     * resolver keyed on the id/url (Oxy `thumb` / backend `/media/poster`).
+     * Resolve a static video still. Prefer the server-resolved `thumbUrl` — this
+     * is a grid cell, and `posterUrl` is sized for a full-width player — falling
+     * back to `posterUrl` and then to the legacy client resolver keyed on the
+     * id/url (backend `/media/poster`). Both server fields are a still image for
+     * a video of either origin, so preferring the smaller one is safe.
      * Undefined → icon placeholder. A 404/error from the URL is handled by the
      * cell's own image-error fallback.
      */
     const resolvePosterUri = useCallback(
         (ref: MediaItem): string | undefined => {
-            const serverUrl = ref.posterUrl || ref.thumbUrl;
+            const serverUrl = ref.thumbUrl || ref.posterUrl;
             if (serverUrl) return serverUrl;
             return videoPosterUrl(ref.id || ref.url || '', oxyServices);
         },

--- a/packages/frontend/components/ProfileHoverCard/index.web.tsx
+++ b/packages/frontend/components/ProfileHoverCard/index.web.tsx
@@ -14,7 +14,7 @@ import { usePostActivity } from '@/hooks/usePostActivity';
 import { formatCompactNumber } from '@/utils/formatNumber';
 import { Portal } from '@oxyhq/bloom/portal';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 import UserName from '@/components/UserName';
 import { RemoteActorBadge } from '@/components/Fediverse/FediverseBadge';
 import { useFederatedFollowSync } from '@/components/Profile/hooks/useFederatedFollowSync';
@@ -389,7 +389,7 @@ function CardContent({
           <Avatar
             source={profile.design.avatar || profile.avatar}
             size={64}
-            variant={MEDIA_VARIANT_VIDEO_POSTER}
+            variant={MEDIA_VARIANT_AVATAR_LG}
             verified={profile.verified}
           />
         </View>

--- a/packages/frontend/components/ZoomableAvatar.tsx
+++ b/packages/frontend/components/ZoomableAvatar.tsx
@@ -25,7 +25,7 @@ import { useAuth } from '@oxyhq/services/ui/client';
 
 import DefaultAvatar from '@/assets/images/default-avatar.jpg';
 import { useImageUrl } from '@/hooks/useImageUrl';
-import { MEDIA_VARIANT_FULL, MEDIA_VARIANT_VIDEO_POSTER } from '@mention/shared-types/post';
+import { MEDIA_VARIANT_FULL, MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
 
 interface ZoomableAvatarProps {
   source?: ImageSourcePropType | string | undefined | null;
@@ -88,9 +88,9 @@ export const ZoomableAvatar: React.FC<ZoomableAvatarProps> = ({
   // image fills most of the screen, so it takes the 2048px rendition. BOTH pass
   // an explicit variant: the app resolver defaults a missing one to the 96px
   // avatar crop, which is what made the zoom look pixelated.
-  const resolvedThumb = imageResolver?.(fileId ?? '', MEDIA_VARIANT_VIDEO_POSTER);
+  const resolvedThumb = imageResolver?.(fileId ?? '', MEDIA_VARIANT_AVATAR_LG);
   const resolvedFull = imageResolver?.(fileId ?? '', MEDIA_VARIANT_FULL);
-  const asyncThumb = useImageUrl(errored ? undefined : fileId, MEDIA_VARIANT_VIDEO_POSTER, oxyServices);
+  const asyncThumb = useImageUrl(errored ? undefined : fileId, MEDIA_VARIANT_AVATAR_LG, oxyServices);
 
   const thumbUri = useMemo(() => {
     if (!source || errored) return undefined;

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -45,9 +45,27 @@ export enum PostVisibility {
  * dedicated 96px square `w96` crop — most avatars across the app render
  * ≤40px (post headers ~36px, notifications, facepiles), so `w96` covers
  * those comfortably even at 3x DPR while staying lighter than the 128px
- * crop it replaced. Video posters are a DIFFERENT context: they fill the (up
- * to ~320px wide) media card as a rectangle, so they keep the 256px `thumb`
- * crop via VIDEO_POSTER rather than being shrunk to a small square.
+ * crop it replaced. A handful of surfaces render a MUCH bigger avatar —
+ * the profile header (90px / 70px), the about page (80px), the OAuth consent
+ * screens (72px / 56px), starter-pack and list avatar groups (56px) — where
+ * `w96` would be visibly soft at 3x DPR; AVATAR_LG covers those with the 256px
+ * `thumb` crop. Those call sites previously reached for VIDEO_POSTER purely
+ * because it happened to equal `'thumb'`, which made every one of them read as
+ * if it were rendering a video.
+ *
+ * VIDEO posters are two contexts, not one, and a single size cannot serve both:
+ *  - VIDEO_THUMB (`w320`) is a small STILL — the profile media grid cell and
+ *    the notification thumbnail. It matches THUMB exactly, so a video cell and
+ *    an image cell in the same grid now cost the same.
+ *  - VIDEO_POSTER (`w1280`) is the frame shown BEHIND a player, and both of its
+ *    surfaces are full-width: the in-feed video card and the fullscreen Reels
+ *    viewer. On a 3x-DPR phone that is ~1180 device px, so the two differ by
+ *    padding, not by an order of magnitude. `w1280` covers both; `w2048` would
+ *    add rows neither can show.
+ * The previous single `'thumb'` (256px) was wrong at BOTH ends — it yielded
+ * 144x256 for a 720x1280 source, too soft fullscreen, while the only other
+ * working option (the raw `poster`, up to 1920px / ~240 KB) was ~6x oversized
+ * for a grid cell.
  *
  * The profile banner is its own context: a full-bleed 170px-tall strip, so its
  * width — not the lightbox's — is what bounds it. The widest real surface is a
@@ -60,7 +78,9 @@ export enum PostVisibility {
 export const MEDIA_VARIANT_THUMB = 'w320';
 export const MEDIA_VARIANT_FULL = 'w2048';
 export const MEDIA_VARIANT_AVATAR = 'w96';
-export const MEDIA_VARIANT_VIDEO_POSTER = 'thumb';
+export const MEDIA_VARIANT_AVATAR_LG = 'thumb';
+export const MEDIA_VARIANT_VIDEO_THUMB = 'w320';
+export const MEDIA_VARIANT_VIDEO_POSTER = 'w1280';
 export const MEDIA_VARIANT_BANNER = 'w1280';
 
 export interface MediaItem {


### PR DESCRIPTION
Follow-up to OxyHQServices#758, which made an image size name resolve for a video. **It depends on that deploy**: `w320`/`w1280` on a video 404'd until oxy-api learned to render image sizes from the poster frame.

## The problem

`MEDIA_VARIANT_VIDEO_POSTER` was `'thumb'` (256px, fit-inside), and `mediaResolver` handed that **one** URL to both `thumbUrl` (a ~130px profile grid cell) and `posterUrl` (the fullscreen Reels player).

For a 720x1280 source that is **144x256** — visibly soft behind a fullscreen player. The only other working option, the raw `poster`, is up to 1920px and ~240 KB — roughly **6x oversized** for a grid cell. One constant cannot serve surfaces an order of magnitude apart.

## Sizes chosen, and why

| constant | value | surfaces | measured on a real file |
|---|---|---|---|
| `MEDIA_VARIANT_VIDEO_THUMB` | `w320` | profile media grid cell, notification still | 320x569, **35,418 B** |
| `MEDIA_VARIANT_VIDEO_POSTER` | `w1280` | in-feed video card, fullscreen Reels | 1080x1920, **129,912 B** |

- `w320` matches `MEDIA_VARIANT_THUMB` exactly, so a video cell and an image cell in the same grid now cost the same.
- `w1280` covers **both** player surfaces because both are full-width: the in-feed video card and fullscreen Reels differ by padding, not by an order of magnitude (~1180 device px on a 3x phone). `w2048` would add rows neither can show. Note this yields the same pixels as the raw JPEG poster (242,919 B) at **46% fewer bytes**, because the variant pipeline emits webp.

The in-repo comment justifying `'thumb'` claimed a poster "must not be shrunk to a small square" — backwards, since `thumb` is the second-smallest variant in the taxonomy. Rewritten; a wrong comment outlives a wrong line.

## Two things that had to be fixed for the split to be correct rather than merely different

**1. `MEDIA_VARIANT_VIDEO_POSTER` had TEN call sites that render an avatar and no video at all.** The profile header (90px/70px), the about page (80px), both OAuth consent screens (72px/56px), starter-pack and list avatar groups (56px), weekly recap, settings, the hover card, and `ZoomableAvatar`. Every one reached for it purely because it happened to equal `'thumb'`, the right size for a 56–90px avatar — which made each site read as if it were rendering video. They now use `MEDIA_VARIANT_AVATAR_LG` (same value, honest name), so retargeting `VIDEO_POSTER` to `w1280` could not silently blow those ten up.

**2. A federated video's `thumbUrl` was the proxied VIDEO carrying an image variant.** `/media/proxy` honours a variant only for image content types (`withImageVariant`), so that URL hands an `<Image>` raw video bytes. The profile grids dodged it by preferring `posterUrl`; `NotificationItem` did not, and rendered a broken still for any federated video post — a pre-existing bug this surfaces and fixes. Both still fields now point at the extracted poster frame, so `thumbUrl` means "a small still" for a video of **either** origin. That is precisely what lets the grids prefer the cheaper field instead of pulling a player-sized poster into a 130px cell.

A federated video also stops emitting `fullUrl` (the lightbox image URL, meaningless for video), matching the native branch, which never emitted one. No consumer reads it for video — `PostAttachmentsRow` routes video through the `playable` context and `posterUrl`.

## Verification

Backend suite **376 files / 3924 tests passing**; frontend **117 suites / 1005 tests passing**. `bun run build` and `bun run check:types` clean; lint reports 4 pre-existing warnings in files this PR does not touch.

**Mutation test** — reverting `MEDIA_VARIANT_VIDEO_POSTER` to `'thumb'` (the old bug) and rebuilding shared-types:

```
× gives a native video TWO still sizes: a grid-cell thumb and a player poster
× forwards geometry and durationSec for a video
Tests  2 failed | 24 passed (26)
```

So the new assertions discriminate rather than passing vacuously. A new test also pins that every variant name the resolver can emit exists server-side, for either mime — the class of bug that started all this.

**Against production**, after the OxyHQServices#758 deploy:

```
6a390d4b9d8fecf98a320181  w320  -> 200 image/webp 35,418 B   WebP 320x569
6a390d4b9d8fecf98a320181  w1280 -> 200 image/webp 129,912 B  WebP 1080x1920
6a3480c63cb625d346576a55  w320  -> 200 image/webp 36,756 B   WebP 320x569
6a3480c63cb625d346576a55  w1280 -> 200 image/webp 208,368 B  WebP 1080x1920

control — AVATAR_LG ('thumb') on an IMAGE, the 10 repointed sites:
6a689588abe6d1a081112436  thumb -> 200 image/webp 18,906 B   WebP 256x171
```

Note `bun run check` also fails `doctor` on this machine with `Node 22.17.0 is required … but 22.23.1 is available`. Confirmed pre-existing: the unmodified checkout produces the identical failure. It is a local Node version mismatch, not this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)