### PR TITLE
fix(safety): make a changed safety rule reach the feed you are looking at

### DIFF
--- a/packages/frontend/app/(app)/settings/privacy.tsx
+++ b/packages/frontend/app/(app)/settings/privacy.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/hooks/usePrivacySettings';
 import { queryClient } from '@/lib/queryClient';
 import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import { invalidateSafetyFilters } from '@/stores/safetyInvalidation';
 import { OxyAuthPrompt, useAuth } from '@oxyhq/services/ui/client';
 
 const FILTER_TOGGLES: {
@@ -128,6 +129,11 @@ export default function PrivacySettingsScreen() {
         try {
             await authenticatedClient.put('/profile/settings', { privacy: updated });
             await updatePrivacySettingsCache(updated, cacheLease);
+            // Sensitive content is excluded by the SERVER's feed/search queries,
+            // so a cache filled under the previous answer is now showing (or
+            // withholding) exactly what the viewer just decided about. One
+            // authority tells both read caches: `stores/safetyInvalidation`.
+            invalidateSafetyFilters();
         } catch (error) {
             logger.error('Error updating privacy setting', error, { field });
             setPrivacySettings(previous);

--- a/packages/frontend/app/(app)/settings/privacy/__tests__/safetyFilterWiring.test.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/__tests__/safetyFilterWiring.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { TextInput, TouchableOpacity } from 'react-native';
+import TestRenderer, { act } from 'react-test-renderer';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BottomSheetContext, type BottomSheetContextProps } from '@/context/BottomSheetContext';
+import { muteWordsService, type SerializedMuteWord } from '@/services/muteWordsService';
+import HiddenWordsScreen from '../hidden-words';
+
+/**
+ * The muted-words screen must REPORT every change it lands, and only the ones it
+ * lands.
+ *
+ * This is the join between the two halves of the fix, and the one place a
+ * regression would be completely silent: `useFeedState` keeps honouring the
+ * signal perfectly, the screen simply stops sending it, and every feed goes back
+ * to needing a reload. The read side is driven directly in
+ * `hooks/__tests__/safetyFilterRevalidation.test.tsx`, so nothing there can catch
+ * this — hence the real screen, its real mutations, and a spy on the one
+ * authority they are supposed to call.
+ *
+ * Mocks stop at the module boundary: the HTTP service, the invalidation
+ * authority, and the SDK/Bloom packages that ship untranspiled TS. The screen's
+ * mutations and their success/error branches are real.
+ */
+
+const mockInvalidate = jest.fn();
+
+jest.mock('@/stores/safetyInvalidation', () => ({
+  invalidateSafetyFilters: (...args: unknown[]) => mockInvalidate(...args),
+}));
+
+jest.mock('@/services/muteWordsService', () => ({
+  muteWordsService: {
+    list: jest.fn(),
+    create: jest.fn(),
+    remove: jest.fn(),
+  },
+  isHashtagMuteWord: (word: { targets: string[] }) =>
+    word.targets.length === 1 && word.targets[0] === 'tag',
+  muteWordDisplayValue: (word: { value: string }) => word.value,
+}));
+
+// `t` returns the key so every accessibility label queried below is exact and
+// independent of the translation catalogue.
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({
+    isDark: false,
+    colors: {
+      primary: '#0000ff',
+      error: '#ff0000',
+      text: '#000000',
+      textSecondary: '#666666',
+      border: '#cccccc',
+      background: '#ffffff',
+      card: '#ffffff',
+    },
+  }),
+}));
+
+jest.mock('@oxyhq/bloom/loading', () => {
+  const { View: RNView } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { Loading: () => <RNView /> };
+});
+
+jest.mock('@oxyhq/bloom/toast', () => ({ toast: jest.fn() }));
+
+// Ships untranspiled TS, and is reached only through `BottomSheetContext`'s
+// provider — which this file replaces with its own.
+jest.mock('@oxyhq/bloom/bottom-sheet', () => ({ BottomSheet: () => null }));
+
+jest.mock('@oxyhq/bloom/settings-list', () => {
+  const { View: RNView } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    SettingsListGroup: ({ children }: { children?: React.ReactNode }) => <RNView>{children}</RNView>,
+    SettingsListItem: ({ rightElement }: { rightElement?: React.ReactNode }) => (
+      <RNView>{rightElement}</RNView>
+    ),
+  };
+});
+
+jest.mock('@oxyhq/services/ui/client', () => ({
+  useAuth: () => ({ isAuthenticated: true, user: { id: 'viewer-1' }, canUsePrivateApi: true }),
+  OxyAuthPrompt: () => null,
+}));
+
+jest.mock('@/components/ThemedView', () => {
+  const { View: RNView } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { ThemedView: ({ children }: { children?: React.ReactNode }) => <RNView>{children}</RNView> };
+});
+
+jest.mock('@/components/Header', () => ({ Header: () => null }));
+jest.mock('@/components/ui/Button', () => ({ IconButton: () => null }));
+jest.mock('@/assets/icons/back-arrow-icon', () => ({ BackArrowIcon: () => null }));
+jest.mock('@/lib/icons', () => ({ Icon: () => null }));
+jest.mock('@/components/common/EmptyState', () => ({ EmptyState: () => null }));
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }));
+
+jest.mock('@oxyhq/core/logger', () => ({
+  ...jest.requireActual('@oxyhq/core/logger'),
+  createLogger: () => ({ debug: jest.fn(), error: jest.fn(), warn: jest.fn(), info: jest.fn() }),
+}));
+
+const listMock = muteWordsService.list as jest.Mock;
+const createMock = muteWordsService.create as jest.Mock;
+const removeMock = muteWordsService.remove as jest.Mock;
+
+const STORED_WORD: SerializedMuteWord = {
+  id: 'word-1',
+  value: 'dogs',
+  targets: ['content', 'tag'],
+  actorTarget: 'all',
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+/** The node the screen hands the bottom sheet, so the confirm can be invoked. */
+let sheetContent: React.ReactElement | null = null;
+
+const bottomSheet: BottomSheetContextProps = {
+  openBottomSheet: jest.fn(),
+  setBottomSheetContent: (content) => {
+    sheetContent = content as React.ReactElement;
+  },
+  bottomSheetRef: { current: null },
+};
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+/** This test's client, torn down in `afterEach` so its timers cannot outlive the run. */
+let queryClient: QueryClient | null = null;
+
+async function openScreen(): Promise<TestRenderer.ReactTestRenderer> {
+  // `gcTime: 0` on BOTH matters: a settled query or mutation is otherwise held
+  // for the default five minutes, and that timer outlives the run and keeps
+  // jest's worker open (same reason as `useFeedSettingsInstantSave.test.tsx`).
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+  queryClient = client;
+  let renderer!: TestRenderer.ReactTestRenderer;
+  await act(async () => {
+    renderer = TestRenderer.create(
+      <QueryClientProvider client={client}>
+        <BottomSheetContext.Provider value={bottomSheet}>
+          <HiddenWordsScreen />
+        </BottomSheetContext.Provider>
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return renderer;
+}
+
+function pressByLabel(renderer: TestRenderer.ReactTestRenderer, label: string): void {
+  const target = renderer.root
+    .findAllByType(TouchableOpacity)
+    .find((node) => node.props.accessibilityLabel === label);
+  if (!target) throw new Error(`No pressable labelled "${label}"`);
+  act(() => {
+    target.props.onPress();
+  });
+}
+
+describe('the muted-words screen reports every change it lands', () => {
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sheetContent = null;
+    listMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    queryClient?.unmount();
+    queryClient = null;
+  });
+
+  it('reports a muted word once the server has stored it', async () => {
+    createMock.mockResolvedValue(STORED_WORD);
+
+    const screen = await openScreen();
+    act(() => {
+      screen.root.findByType(TextInput).props.onChangeText('dogs');
+    });
+    pressByLabel(screen, 'settings.privacy.addMutedWord');
+    await flush();
+
+    expect(createMock).toHaveBeenCalledWith('dogs');
+    expect(mockInvalidate).toHaveBeenCalledTimes(1);
+
+    act(() => screen.unmount());
+  });
+
+  it('reports an unmuted word once the server has removed it', async () => {
+    listMock.mockResolvedValue([STORED_WORD]);
+    removeMock.mockResolvedValue(undefined);
+
+    const screen = await openScreen();
+    pressByLabel(screen, 'settings.privacy.removeMutedWord');
+    // Removal is behind a confirmation sheet; take the same path the viewer does.
+    const confirm = sheetContent?.props as { onConfirm?: () => void } | undefined;
+    if (!confirm?.onConfirm) throw new Error('Remove did not open a confirmation sheet');
+    await act(async () => {
+      confirm.onConfirm?.();
+    });
+    await flush();
+
+    expect(removeMock).toHaveBeenCalledWith(STORED_WORD.id);
+    expect(mockInvalidate).toHaveBeenCalledTimes(1);
+
+    act(() => screen.unmount());
+  });
+
+  it('reports nothing when the server refuses the change', async () => {
+    createMock.mockRejectedValue(new Error('network'));
+
+    const screen = await openScreen();
+    act(() => {
+      screen.root.findByType(TextInput).props.onChangeText('dogs');
+    });
+    pressByLabel(screen, 'settings.privacy.addMutedWord');
+    await flush();
+
+    // A refused change leaves every surface exactly as the caches already have
+    // it — telling them otherwise would throw away a feed for nothing.
+    expect(mockInvalidate).not.toHaveBeenCalled();
+
+    act(() => screen.unmount());
+  });
+});

--- a/packages/frontend/app/(app)/settings/privacy/hidden-words.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/hidden-words.tsx
@@ -25,6 +25,7 @@ import {
     type SerializedMuteWord,
 } from '@/services/muteWordsService';
 import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import { invalidateSafetyFilters } from '@/stores/safetyInvalidation';
 
 const hiddenWordsLogger = createLogger('HiddenWords');
 
@@ -57,17 +58,6 @@ export default function HiddenWordsScreen() {
         enabled: canUsePrivateApi,
     });
 
-    // Muting/unmuting changes which posts are filtered out of the MTN feed.
-    // The home feed is store-based (postsStore + feedService), not React-Query
-    // cached, so it re-filters on its next fetchInitial(true)/pull-to-refresh.
-    // We still invalidate the ['feed'] key to cover any React-Query feed
-    // consumers and prime a refetch on next navigation.
-    const invalidateFeed = () => {
-        queryClient.invalidateQueries({
-            queryKey: viewerQueryKeys.feedsRoot(user?.id),
-        });
-    };
-
     const addMutation = useMutation<SerializedMuteWord, unknown, string>({
         mutationFn: (rawInput: string) => muteWordsService.create(rawInput),
         onSuccess: () => {
@@ -75,7 +65,10 @@ export default function HiddenWordsScreen() {
             queryClient.invalidateQueries({
                 queryKey: viewerQueryKeys.muteWords(user?.id),
             });
-            invalidateFeed();
+            // Muting decides what the SERVER sends, so every surface holding
+            // content fetched under the old rules is now wrong. One authority
+            // tells both read caches: `stores/safetyInvalidation`.
+            invalidateSafetyFilters();
             toast(t('settings.privacy.wordMuted', { defaultValue: 'Word muted' }), { type: 'success' });
         },
         onError: (error) => {
@@ -92,7 +85,9 @@ export default function HiddenWordsScreen() {
             queryClient.invalidateQueries({
                 queryKey: viewerQueryKeys.muteWords(user?.id),
             });
-            invalidateFeed();
+            // Unmuting can only be honoured by asking again: the posts it lets
+            // back in were never sent to this device.
+            invalidateSafetyFilters();
             toast(t('settings.privacy.wordUnmuted', { defaultValue: 'Word unmuted' }), { type: 'success' });
         },
         onError: (error) => {

--- a/packages/frontend/components/providers/AccountSwitchReset.tsx
+++ b/packages/frontend/components/providers/AccountSwitchReset.tsx
@@ -20,6 +20,7 @@ import { useLiveRoomsStore } from '@/stores/liveRoomsStore';
 import { useTrendsStore } from '@/stores/trendsStore';
 import { clearAllFeedMemoryCaches } from '@/stores/feedScrollStore';
 import { resetEngagementInvalidation } from '@/stores/engagementInvalidation';
+import { resetSafetyInvalidation } from '@/stores/safetyInvalidation';
 import { setFeedViewerRequestScope } from '@/services/feedService';
 import { searchService } from '@/services/searchService';
 import { socketService } from '@/services/socketService';
@@ -118,8 +119,11 @@ export function AccountSwitchReset({
     useTrendsStore.getState().resetViewerState();
     clearAllFeedMemoryCaches();
     // The previous viewer's engagements say nothing about the next viewer's
-    // lists, and every cache they could have marked stale is gone anyway.
+    // lists, and every cache they could have marked stale is gone anyway. The
+    // same holds for the safety rules they changed — muted words and the
+    // sensitive-content toggle are per-account.
     resetEngagementInvalidation();
+    resetSafetyInvalidation();
 
     resetAppearance();
     resetTheme();

--- a/packages/frontend/components/providers/__tests__/AccountSwitchReset.test.tsx
+++ b/packages/frontend/components/providers/__tests__/AccountSwitchReset.test.tsx
@@ -13,6 +13,7 @@ import { useLiveRoomsStore } from '@/stores/liveRoomsStore';
 import { useTrendsStore } from '@/stores/trendsStore';
 import { clearAllFeedMemoryCaches } from '@/stores/feedScrollStore';
 import { resetEngagementInvalidation } from '@/stores/engagementInvalidation';
+import { resetSafetyInvalidation } from '@/stores/safetyInvalidation';
 import { setFeedViewerRequestScope } from '@/services/feedService';
 import { searchService } from '@/services/searchService';
 import { socketService } from '@/services/socketService';
@@ -113,6 +114,10 @@ jest.mock('@/stores/engagementInvalidation', () => ({
   resetEngagementInvalidation: jest.fn(),
 }));
 
+jest.mock('@/stores/safetyInvalidation', () => ({
+  resetSafetyInvalidation: jest.fn(),
+}));
+
 jest.mock('@/services/feedService', () => ({
   setFeedViewerRequestScope: jest.fn(),
 }));
@@ -147,6 +152,7 @@ const mockGetTrendsState = useTrendsStore.getState as jest.Mock;
 const mockSetReaderLanguages = jest.fn();
 const mockClearFeedMemory = clearAllFeedMemoryCaches as jest.Mock;
 const mockResetEngagementInvalidation = resetEngagementInvalidation as jest.Mock;
+const mockResetSafetyInvalidation = resetSafetyInvalidation as jest.Mock;
 const mockSetFeedViewerRequestScope =
   setFeedViewerRequestScope as jest.Mock;
 const mockClearSearchHistory = searchService.clearSearchHistory as jest.Mock;
@@ -257,6 +263,7 @@ describe('AccountSwitchReset identity boundary', () => {
     expect(mockResetPrivacySettingsCache).toHaveBeenCalledWith('viewer-a');
     expect(mockClearFeedMemory).toHaveBeenCalledTimes(1);
     expect(mockResetEngagementInvalidation).toHaveBeenCalledTimes(1);
+    expect(mockResetSafetyInvalidation).toHaveBeenCalledTimes(1);
     expect(mockResetAppearance).toHaveBeenCalledTimes(1);
     expect(mockResetTheme).toHaveBeenCalledTimes(1);
     expect(mockClearSearchHistory).toHaveBeenCalledWith('viewer-a');

--- a/packages/frontend/hooks/__tests__/safetyFilterRevalidation.test.tsx
+++ b/packages/frontend/hooks/__tests__/safetyFilterRevalidation.test.tsx
@@ -1,0 +1,350 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import type { HydratedPost, SlicedFeedResponse } from '@mention/shared-types';
+import { feedService } from '@/services/feedService';
+import { usePostsStore } from '@/stores/postsStore';
+import { clearAllFeedMemoryCaches } from '@/stores/feedScrollStore';
+import { resetEngagementInvalidation } from '@/stores/engagementInvalidation';
+import {
+    invalidateSafetyFilters,
+    resetSafetyInvalidation,
+} from '@/stores/safetyInvalidation';
+import { useFeedState, type UseFeedStateReturn } from '../useFeedState';
+
+/**
+ * Muting a word must hide the posts already on screen that match it, and
+ * unmuting must bring them back — without the viewer reloading the app. Same for
+ * the sensitive-content toggle. A viewer who asks not to see something and keeps
+ * seeing it is a safety failure, not a staleness annoyance.
+ *
+ * Both rules are applied ENTIRELY on the server, so this file models the server
+ * honestly: `serverPosts` is everything that exists, and the fake transport
+ * returns only what the CURRENT rules allow. That is what makes the un-mute
+ * direction a real assertion — a post the rules excluded was never sent to this
+ * device, so nothing but a refetch can put it back, and a client-side filter
+ * would pass the hide test while silently failing this one.
+ *
+ * The write side of the signal is the two settings screens, which call
+ * `invalidateSafetyFilters` after the server accepts the change; the read side is
+ * `useFeedState`, in two halves — a live subscription for feeds still mounted
+ * under the settings screen, and a warm-start staleness check for feeds that were
+ * unmounted when the rule changed. Both halves are exercised here.
+ */
+
+(globalThis as { __DEV__?: boolean }).__DEV__ = false;
+
+jest.mock('@/stores/postsStore', () => {
+    const state = {
+        fetchFeed: jest.fn(() => Promise.resolve()),
+        fetchUserFeed: jest.fn(() => Promise.resolve({ pending: false })),
+        refreshFeed: jest.fn(() => Promise.resolve()),
+        loadMoreFeed: jest.fn(() => Promise.resolve()),
+        cachePosts: jest.fn(),
+        clearFeed: jest.fn(),
+        clearUserFeed: jest.fn(),
+        clearError: jest.fn(),
+        feedUI: {},
+    };
+    const usePostsStore = (selector: (value: typeof state) => unknown) => selector(state);
+    usePostsStore.getState = () => state;
+    return {
+        usePostsStore,
+        useFeedSelector: () => undefined,
+        useUserFeedSelector: () => undefined,
+    };
+});
+
+jest.mock('@/services/feedService', () => ({
+    feedService: { getFeed: jest.fn(), getUserFeed: jest.fn() },
+}));
+
+// Web has no SQLite and runs the memory path; native has it and reads through
+// the store instead. Both branches carry the fix, so both are switched on here.
+let mockDbAvailable = false;
+
+jest.mock('@/db', () => ({
+    buildFeedKey: jest.fn(() => FEED_KEY),
+    hasFeedData: jest.fn(() => mockDbAvailable),
+    isDbAvailable: jest.fn(() => mockDbAvailable),
+}));
+
+jest.mock('@oxyhq/core/logger', () => ({
+    ...jest.requireActual('@oxyhq/core/logger'),
+    createLogger: () => ({ debug: jest.fn(), error: jest.fn(), warn: jest.fn() }),
+}));
+
+jest.mock('@/lib/precacheActorsFromPosts', () => ({
+    precacheActorsFromPosts: jest.fn(),
+}));
+
+const VIEWER_ID = 'viewer-a';
+const FEED_KEY = 'feed-key';
+
+/** One post as the server holds it, before any viewer rule is applied. */
+interface ServerPost {
+    id: string;
+    text: string;
+    sensitive?: boolean;
+}
+
+/** Everything that exists, and the viewer's rules as the server currently has them. */
+let serverPosts: ServerPost[] = [];
+let mutedWords: string[] = [];
+let showSensitiveContent = false;
+
+/**
+ * The server's half of both rules: a muted post is dropped from the response and
+ * a sensitive one never enters the query, so neither ever reaches the client.
+ */
+function visiblePosts(): ServerPost[] {
+    return serverPosts.filter((post) => {
+        if (post.sensitive && !showSensitiveContent) return false;
+        return !mutedWords.some((word) => post.text.toLowerCase().includes(word));
+    });
+}
+
+function page(posts: ServerPost[]): SlicedFeedResponse {
+    return {
+        items: posts.map(
+            (post) => ({ id: post.id, user: { id: `author-${post.id}` } }) as unknown as HydratedPost,
+        ),
+        slices: [],
+        interstitials: [],
+        hasMore: false,
+        totalCount: posts.length,
+    };
+}
+
+let latest: UseFeedStateReturn | undefined;
+
+/**
+ * Every feed opened by this file and not yet closed. A mounted feed holds a live
+ * subscription, so one leaked by a failing assertion would answer the NEXT test's
+ * signal and report a second, unrelated failure there — which is exactly what a
+ * mutation test must not do if its output is to name the code it broke.
+ */
+const openFeeds = new Set<TestRenderer.ReactTestRenderer>();
+
+function HomeFeed() {
+    latest = useFeedState({
+        type: 'for_you',
+        useScoped: false,
+        isAuthenticated: true,
+        currentUserId: VIEWER_ID,
+    });
+    return null;
+}
+
+const getFeedMock = feedService.getFeed as jest.Mock;
+
+async function flush(): Promise<void> {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+}
+
+/** Open the feed, as a navigation would: a fresh mount. */
+async function openFeed(): Promise<TestRenderer.ReactTestRenderer> {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+        renderer = TestRenderer.create(<HomeFeed />);
+    });
+    await flush();
+    openFeeds.add(renderer);
+    return renderer;
+}
+
+/** Navigate away from the feed: it unmounts and unsubscribes. */
+function closeFeed(renderer: TestRenderer.ReactTestRenderer): void {
+    act(() => renderer.unmount());
+    openFeeds.delete(renderer);
+}
+
+/**
+ * Change a safety rule the way the settings screens do: the server accepts the
+ * write first, then the one authority tells the caches. Never unmounts anything.
+ */
+async function changeSafetyRule(change: () => void): Promise<void> {
+    await act(async () => {
+        change();
+        invalidateSafetyFilters();
+    });
+    await flush();
+}
+
+function renderedIds(): string[] {
+    return (latest?.items ?? []).map((item) => item.id);
+}
+
+describe('safety rules converge on the feeds the viewer is looking at', () => {
+    beforeAll(() => {
+        (
+            globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = true;
+    });
+
+    beforeEach(() => {
+        latest = undefined;
+        jest.clearAllMocks();
+        clearAllFeedMemoryCaches();
+        resetEngagementInvalidation();
+        resetSafetyInvalidation();
+        serverPosts = [];
+        mutedWords = [];
+        showSensitiveContent = false;
+        mockDbAvailable = false;
+        usePostsStore.getState().feedUI = {};
+        getFeedMock.mockImplementation(() => Promise.resolve(page(visiblePosts())));
+    });
+
+    afterEach(() => {
+        for (const renderer of openFeeds) {
+            act(() => renderer.unmount());
+        }
+        openFeeds.clear();
+    });
+
+    it('hides a matching post from the feed on screen when a word is muted, then brings it back when it is unmuted', async () => {
+        serverPosts = [
+            { id: 'post-cats', text: 'a thread about cats' },
+            { id: 'post-dogs', text: 'a thread about dogs' },
+        ];
+
+        const feed = await openFeed();
+        expect(renderedIds()).toEqual(['post-cats', 'post-dogs']);
+
+        // The viewer mutes "dogs" from the settings screen pushed over this feed.
+        // The feed is never unmounted for the rest of this test.
+        await changeSafetyRule(() => {
+            mutedWords = ['dogs'];
+        });
+        expect(renderedIds()).toEqual(['post-cats']);
+
+        // Unmuting has to bring it back. This is the direction no client-side
+        // filter could serve: the post was withheld, so it is not held anywhere
+        // on this device to un-hide.
+        await changeSafetyRule(() => {
+            mutedWords = [];
+        });
+        expect(renderedIds()).toEqual(['post-cats', 'post-dogs']);
+
+        closeFeed(feed);
+    });
+
+    it('reveals and re-hides sensitive posts as the viewer toggles show-sensitive-content', async () => {
+        serverPosts = [
+            { id: 'post-safe', text: 'a sunset' },
+            { id: 'post-sensitive', text: 'not for everyone', sensitive: true },
+        ];
+
+        const feed = await openFeed();
+        expect(renderedIds()).toEqual(['post-safe']);
+
+        await changeSafetyRule(() => {
+            showSensitiveContent = true;
+        });
+        expect(renderedIds()).toEqual(['post-safe', 'post-sensitive']);
+
+        await changeSafetyRule(() => {
+            showSensitiveContent = false;
+        });
+        expect(renderedIds()).toEqual(['post-safe']);
+
+        closeFeed(feed);
+    });
+
+    it('applies a rule changed while the feed was unmounted on its next mount', async () => {
+        serverPosts = [
+            { id: 'post-cats', text: 'a thread about cats' },
+            { id: 'post-dogs', text: 'a thread about dogs' },
+        ];
+
+        const firstVisit = await openFeed();
+        expect(renderedIds()).toEqual(['post-cats', 'post-dogs']);
+        closeFeed(firstVisit);
+
+        // Nothing is subscribed now, so only the retained slice's age can carry
+        // the change to the next mount.
+        mutedWords = ['dogs'];
+        invalidateSafetyFilters();
+
+        const secondVisit = await openFeed();
+        expect(renderedIds()).toEqual(['post-cats']);
+        closeFeed(secondVisit);
+    });
+
+    it('still warm-starts without a request when no safety rule changed', async () => {
+        serverPosts = [{ id: 'post-cats', text: 'a thread about cats' }];
+
+        const firstVisit = await openFeed();
+        expect(getFeedMock).toHaveBeenCalledTimes(1);
+        closeFeed(firstVisit);
+
+        // Reopening a feed under unchanged rules must stay free. This is the
+        // property a blanket "always refetch on mount" would destroy, and the
+        // reason the warm start exists at all.
+        const secondVisit = await openFeed();
+        expect(getFeedMock).toHaveBeenCalledTimes(1);
+        expect(renderedIds()).toEqual(['post-cats']);
+        closeFeed(secondVisit);
+    });
+
+    it('leaves an unmounted feed alone until it is opened again', async () => {
+        serverPosts = [{ id: 'post-cats', text: 'a thread about cats' }];
+
+        const firstVisit = await openFeed();
+        expect(getFeedMock).toHaveBeenCalledTimes(1);
+        closeFeed(firstVisit);
+
+        // An unsubscribed feed must not be woken by the signal — the whole point
+        // of the staleness half is that it costs nothing until the feed is needed.
+        act(() => {
+            invalidateSafetyFilters();
+        });
+        expect(getFeedMock).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * Native reads its feed out of SQLite rather than local state, so the same
+     * question is asked in a different place: `fetchInitial` skips the fetch
+     * entirely when the store says this feed was already loaded. That skip has to
+     * notice a safety rule changed since, or the rows SQLite is holding — which
+     * survive an app restart — keep being served.
+     */
+    describe('on the SQLite path', () => {
+        /** Put the store in the state a previously-loaded native feed leaves behind. */
+        function seedLoadedSqliteFeed(): void {
+            mockDbAvailable = true;
+            usePostsStore.getState().feedUI = {
+                [FEED_KEY]: { isLoading: false, error: null, lastUpdated: Date.now() },
+            };
+        }
+
+        it('refetches on the next mount when a rule changed since the cache was written', async () => {
+            seedLoadedSqliteFeed();
+            const fetchFeed = usePostsStore.getState().fetchFeed as jest.Mock;
+
+            const firstVisit = await openFeed();
+            expect(fetchFeed).not.toHaveBeenCalled();
+            closeFeed(firstVisit);
+
+            invalidateSafetyFilters();
+
+            const secondVisit = await openFeed();
+            expect(fetchFeed).toHaveBeenCalledTimes(1);
+            closeFeed(secondVisit);
+        });
+
+        it('still serves the SQLite cache without a request when no rule changed', async () => {
+            seedLoadedSqliteFeed();
+            const fetchFeed = usePostsStore.getState().fetchFeed as jest.Mock;
+
+            const firstVisit = await openFeed();
+            closeFeed(firstVisit);
+
+            const secondVisit = await openFeed();
+            expect(fetchFeed).not.toHaveBeenCalled();
+            closeFeed(secondVisit);
+        });
+    });
+});

--- a/packages/frontend/hooks/useFeedState.ts
+++ b/packages/frontend/hooks/useFeedState.ts
@@ -28,6 +28,10 @@ import {
     type FeedMemoryCacheEntry,
 } from '@/stores/feedScrollStore';
 import { isFeedCacheStale } from '@/stores/engagementInvalidation';
+import {
+    isFeedCacheStaleForSafety,
+    subscribeToSafetyFilterChanges,
+} from '@/stores/safetyInvalidation';
 
 // Re-export so callers that already imported from here keep working.
 export { resolveUseMemoryFeed } from '@/utils/feedMemoryMode';
@@ -510,6 +514,7 @@ export function useFeedState({
                     && ui?.lastUpdated
                     && ui.lastUpdated > 0
                     && !isFeedCacheStale(feedTypeToCheck, userId, currentUserId, ui.lastUpdated)
+                    && !isFeedCacheStaleForSafety(ui.lastUpdated)
                 ) {
                     logger.debug('Skipping — feed has SQLite cache');
                     isFetchingRef.current = false;
@@ -550,15 +555,24 @@ export function useFeedState({
             // or ordering. The seed still renders (no flash), but the fetch below
             // has to run or the list keeps showing its pre-write membership until
             // a reload. See `stores/engagementInvalidation`.
+            //
+            // THIRD EXCEPTION — a slice that predates a safety rule the viewer has
+            // since changed. Muted words and the sensitive-content toggle decide
+            // what the server is willing to send at all, so a slice retained under
+            // the old rules holds content the viewer asked not to see (or is
+            // missing content they just asked for). See `stores/safetyInvalidation`.
             const seeded = seededCacheRef.current;
             if (useMemoryFeed && !forceRefresh && seeded && type !== 'replies') {
                 seededCacheRef.current = undefined;
-                if (!isFeedCacheStale(feedTypeToCheck, userId, currentUserId, seeded.retainedAt)) {
+                if (
+                    !isFeedCacheStale(feedTypeToCheck, userId, currentUserId, seeded.retainedAt)
+                    && !isFeedCacheStaleForSafety(seeded.retainedAt)
+                ) {
                     logger.debug('Skipping — memory feed warm-started from cache');
                     isFetchingRef.current = false;
                     return;
                 }
-                logger.debug('Warm cache predates an engagement write — revalidating');
+                logger.debug('Warm cache predates an engagement or safety change — revalidating');
             }
 
             try {
@@ -692,6 +706,22 @@ export function useFeedState({
 
     // Keep the ref pointing at the latest fetchInitial for the pending-poll scheduler.
     fetchInitialRef.current = fetchInitial;
+
+    // A muted word or the sensitive-content toggle changes what the server is
+    // willing to send, so a feed already on screen cannot re-derive its own
+    // contents — it has to ask again. The warm-start check in `fetchInitial`
+    // covers feeds that are unmounted when the rule changes; this covers the
+    // common case, where the settings screen was pushed OVER a feed that stays
+    // mounted underneath and would otherwise never run that check.
+    //
+    // Subscribed once for the hook's lifetime: the listener reads the current
+    // `fetchInitial` off the ref, so it never needs re-subscribing.
+    useEffect(
+        () => subscribeToSafetyFilterChanges(() => {
+            void fetchInitialRef.current?.(true);
+        }),
+        [],
+    );
 
     const refresh = useCallback(async () => {
         // Gate onEndReached synchronously before React commits localLoading.

--- a/packages/frontend/stores/__tests__/safetyInvalidation.test.ts
+++ b/packages/frontend/stores/__tests__/safetyInvalidation.test.ts
@@ -1,0 +1,79 @@
+import { queryClient } from '@/lib/queryClient';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import {
+  invalidateSafetyFilters,
+  isFeedCacheStaleForSafety,
+  resetSafetyInvalidation,
+  subscribeToSafetyFilterChanges,
+} from '../safetyInvalidation';
+
+/**
+ * The authority has to reach BOTH read caches, and the React Query half is the
+ * one that cannot be seen from a feed test: search results and the notifications
+ * list are filtered by the server with the same two rules, and they live under
+ * query keys, not in the feed store.
+ *
+ * The family tokens are the whole risk here — `isFamily` matches one position of
+ * a key, so a token that reads plausibly but does not match ('notificationsRoot',
+ * 'feeds') silently invalidates nothing. Hence a real `QueryClient` with real
+ * keys, and an unrelated family asserted to be left alone so a predicate that
+ * matched everything could not pass either.
+ */
+
+const VIEWER_ID = 'viewer-a';
+
+function wasInvalidated(key: readonly unknown[]): boolean {
+  return queryClient.getQueryState(key)?.isInvalidated === true;
+}
+
+describe('the safety-filter authority', () => {
+  beforeEach(() => {
+    resetSafetyInvalidation();
+    queryClient.clear();
+  });
+
+  afterAll(() => {
+    queryClient.clear();
+  });
+
+  it('invalidates exactly the query families the server filters by these rules', () => {
+    const search = viewerQueryKeys.search(VIEWER_ID, 'posts', 'dogs', true);
+    const notifications = viewerQueryKeys.notifications(VIEWER_ID);
+    const unrelated = viewerQueryKeys.scheduledPosts(VIEWER_ID);
+
+    for (const key of [search, notifications, unrelated]) {
+      queryClient.setQueryData(key, []);
+    }
+
+    invalidateSafetyFilters();
+
+    expect(wasInvalidated(search)).toBe(true);
+    expect(wasInvalidated(notifications)).toBe(true);
+    // A muted word cannot change what the viewer has scheduled to post.
+    expect(wasInvalidated(unrelated)).toBe(false);
+  });
+
+  it('marks a feed cache retained before the change as stale, and one retained after as current', () => {
+    const beforeChange = Date.now() - 1;
+    expect(isFeedCacheStaleForSafety(beforeChange)).toBe(false);
+
+    invalidateSafetyFilters();
+
+    expect(isFeedCacheStaleForSafety(beforeChange)).toBe(true);
+    expect(isFeedCacheStaleForSafety(Date.now() + 1)).toBe(false);
+  });
+
+  it('stops notifying a subscriber that has unsubscribed', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToSafetyFilterChanges(listener);
+
+    invalidateSafetyFilters();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // An unmounted feed must not be woken, or a screen the viewer left would
+    // issue a request nothing is waiting for.
+    unsubscribe();
+    invalidateSafetyFilters();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/stores/safetyInvalidation.ts
+++ b/packages/frontend/stores/safetyInvalidation.ts
@@ -1,0 +1,101 @@
+import { queryClient } from '@/lib/queryClient';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+
+/**
+ * The single authority for "the viewer changed a safety rule, so what they are
+ * allowed to be shown has changed".
+ *
+ * Two rules sit behind this: the muted words and hashtags
+ * (`app/(app)/settings/privacy/hidden-words.tsx`) and the show-sensitive-content
+ * toggle (`app/(app)/settings/privacy.tsx`). Both are applied ENTIRELY on the
+ * server — a muted post is dropped from the response, a sensitive one never
+ * enters the query — so a cache filled before the change keeps showing exactly
+ * what the viewer just asked not to see, and no client-held state can correct it.
+ *
+ * Why this is a refetch signal and not a client-side filter, the way the blocked
+ * author list is. Two of the four transitions need content the client was NEVER
+ * SENT: unmuting a word and turning sensitive content on both have to ask the
+ * server for what it previously withheld, so a filter cannot serve them at all.
+ * And the flags the client does hold are not the whole rule — hydration emits
+ * `metadata.isSensitive` alone, while the server's verdict is that OR the
+ * classifier's OR the federating instance's OR an NSFW hashtag — so a local
+ * predicate would hide some sensitive posts and leave others up, which is worse
+ * than a filter that does not exist.
+ *
+ * Mention holds gated content in TWO read caches, and neither can see the other
+ * (the same seam `engagementInvalidation` documents):
+ *
+ *   * React Query owns search results and the notifications list. The server
+ *     gates both with these exact two rules.
+ *   * The feed store owns every `<Feed>` surface, and warm-starts a remount from
+ *     a retained slice rather than refetching.
+ *
+ * A feed also differs from the engagement lists in one way that decides the
+ * design: the viewer changes a safety rule from a settings screen pushed OVER
+ * the feed, so the feed is usually still MOUNTED and would never reach its
+ * warm-start check. Hence both halves — {@link subscribeToSafetyFilterChanges}
+ * converges the feeds already on screen, {@link isFeedCacheStaleForSafety}
+ * converges the rest on their next mount.
+ */
+
+/** When the viewer last changed a safety rule, in `Date.now()` terms. */
+let changedAt = 0;
+
+/** Notified when a safety rule changes, so a mounted feed can refetch. */
+type SafetyFilterListener = () => void;
+
+const listeners = new Set<SafetyFilterListener>();
+
+/**
+ * Whether a feed cache retained at `retainedAt` predates the viewer's current
+ * safety rules — in which case it may still hold content those rules exclude, or
+ * still be missing content they now allow.
+ */
+export function isFeedCacheStaleForSafety(retainedAt: number): boolean {
+  return retainedAt < changedAt;
+}
+
+/**
+ * Subscribe a mounted feed to safety-rule changes so it refetches without
+ * waiting for a remount. Returns an unsubscribe function.
+ */
+export function subscribeToSafetyFilterChanges(
+  listener: SafetyFilterListener,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Record that the viewer changed a muted word or the sensitive-content toggle,
+ * and tell both caches. Call this only after the server has accepted the write:
+ * a change that failed leaves every surface exactly as the caches already have
+ * it.
+ */
+export function invalidateSafetyFilters(): void {
+  changedAt = Date.now();
+
+  // The two React Query families the server filters with these rules. Search
+  // excludes sensitive at the query level and drops muted results after
+  // hydration; notifications withhold a gated preview and remove a muted row.
+  void queryClient.invalidateQueries({
+    predicate: (query) =>
+      viewerQueryKeys.isFamily(query.queryKey, 'search')
+      || viewerQueryKeys.isFamily(query.queryKey, 'notifications'),
+  });
+
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/**
+ * Drop the recorded change. For tests, and for a viewer switch that clears both
+ * caches. Subscriptions belong to mounted feeds and are left alone — a viewer
+ * switch unmounts them itself.
+ */
+export function resetSafetyInvalidation(): void {
+  changedAt = 0;
+}


### PR DESCRIPTION
## The bug

Muting a word did not hide posts already on screen, and unmuting did not bring them back, until a reload. Same for the sensitive-content toggle.

A viewer asks not to see something and keeps seeing it. That is what makes this a safety bug rather than a staleness one.

## Why not filter client-side

Blocks already work that way (`blockedSet` filters rows in `feedRows.tsx`), so it was the obvious shape. It was rejected on two counts, both checked in the tree:

1. **Two of the four transitions need content the client was never sent.** Unmuting a word and turning sensitive content ON both have to ask the server for what it previously withheld. A local filter cannot serve them at all, so it could only sit on top of a refetch, not replace one — and would still leave half the bug.

2. **A local sensitivity predicate would be strictly weaker than the server's, which is worse than none.** The server's verdict (`mtn/feed/feedSafety.ts`, `isSensitivePost`) is the OR of `postClassification.sensitive`, `metadata.isSensitive`, `federation.sensitive`, and an NSFW-hashtag blocklist. The DTO carries **only the second** — `PostHydrationService.ts:2071` emits `isSensitive: Boolean(post.metadata?.isSensitive)`, and `HydratedPostSummary` has no `postClassification` or `federation` at all. So it would hide some sensitive posts and leave others up, diverging exactly on classifier-flagged content, which is precisely where nobody would notice.

The mute matcher *is* portable (pure, one import) and `metadata.hashtags` *is* on MTN DTOs, so the hide direction alone was buildable. Not built: a second copy of a predicate whose own file header warns against exactly that, serving one of four directions, when the refetch serves all four.

## What changed

`stores/safetyInvalidation.ts`, shaped like the existing `engagementInvalidation.ts` — the "one authority, both caches" seam `AGENTS.md` § Stale-after-write documents — plus one half that precedent does not need:

- **`subscribeToSafetyFilterChanges`.** The settings screens push OVER the feed, so the feed is usually still **mounted** and would never reach a warm-start check. `useFeedState` subscribes once and refetches. A remount-only fix — all the engagement precedent requires — would have silently missed the main case.
- **`isFeedCacheStaleForSafety`** in *both* cache-skip branches of `fetchInitial` (memory `retainedAt`, SQLite `ui.lastUpdated`), so feeds that were unmounted converge too, native included.
- React Query: the `search` and `notifications` families are invalidated. Both are filtered by these same two rules server-side (`routes/search.ts`, `routes/notifications.ts`) and neither cache can see the other.

Write sites: `hidden-words.tsx` (add + remove) and `privacy.tsx` (after the PUT). Reset in `AccountSwitchReset` beside the engagement reset.

## Correction to the original diagnosis

`invalidateFeed()` in `hidden-words.tsx` was not "best-effort" — it was **provably dead**. `viewerQueryKeys.feed` has zero call sites outside the key-factory's own test, so nothing has ever lived under `feedsRoot`. Removed rather than left behind a comment that misdescribes the mechanism.

Likewise `clearAllFeedMemoryCaches` / `clearAllCachedData` would have worked for hiding but not for un-muting on a mounted feed: dropping a cache does not make a mounted `useFeedState` re-run `fetchInitial`. A signal was needed either way.

## Known trade-off

A changed rule rebuilds the feed from page 1, so deep scroll position is lost. It happens only when the viewer deliberately changes a safety rule, and a safety change converging visibly is the right side of that trade. Stated rather than hidden.

## Verification

```
Test Suites: 121 passed    Tests: 1038 passed
Frontend type-check passed with 0 errors
Statements 24.68%  Branches 19.96%   (floors 14.86 / 12.32)
```

**9 mutations, each caught by exactly the tests that guard it and no others:** subscription disabled, memory staleness dropped, SQLite staleness dropped, mute/unmute/refusal reporting each broken in turn, account-switch reset removed, and two query-family mistakes (wrong root token, predicate → `() => true`). All sources restored byte-identical, md5-verified.

Two run notes: the "worker process failed to exit gracefully" warning is **pre-existing** — measured by excluding both new test files and seeing it persist (117 suites, 1005 tests); its trace points at `SuggestedFeedsInterstitial` + the `@oxyhq/core` logger sink. And the new wiring test initially *did* leak a handle, from react-query's 5-minute gc timer on a settled mutation; fixed with `gcTime: 0`, the same fix `useFeedSettingsInstantSave.test.tsx` already documents.

## Needs a human, jest cannot reach it

- **Foregrounded browser tab:** mute a word with the home feed deep-scrolled; confirm the post is gone and the rebuild-from-page-1 is acceptable. Then unmute and confirm it returns. Also that several mounted feeds (home tabs + the `/videos` right rail) converge without a visible stall.
- **Device:** the SQLite path, specifically that a mute survives an app restart. It should self-heal — `feedUI` is in-memory only, so a relaunch has no `lastUpdated` and takes the cold-start branch — but that is a read of the code, not a measurement.

## Deliberately not done

`privacy.tsx`'s call site has no wiring test; covering it means dragging `usePrivacySettings` → AsyncStorage → the api client into jest, and its user-visible behaviour is already covered by the sensitive-toggle test. The uncovered risk is exactly "someone deletes that one line".

🤖 Generated with [Claude Code](https://claude.com/claude-code)