### PR TITLE
feat(realtime): live post engagement counts, without leaking what authors hid

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -174,6 +174,7 @@
         "jest-expo": "~57.0.2",
         "react-test-renderer": "19.2.3",
         "sharp": "^0.35.3",
+        "socket.io": "^4.8.3",
         "typescript": "catalog:",
       },
       "optionalDependencies": {

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -32,6 +32,7 @@ import {
   registerSocketPresence,
   type AuthenticatedPresenceSocket as AuthenticatedSocket,
 } from './src/services/SocketPresenceLifecycle';
+import { registerContentRoomHandlers } from './src/services/ContentRoomLifecycle';
 import { engagementOutboxDispatcher } from './src/services/EngagementOutboxDispatcher';
 import { moderationOutboxDispatcher } from './src/services/moderation/ModerationOutboxDispatcher';
 
@@ -327,36 +328,6 @@ notificationsNamespace.on("connection", (socket: AuthenticatedSocket) => {
   });
 });
 
-function registerContentRoomHandlers(socket: AuthenticatedSocket): void {
-  socket.on("joinPost", socketRateLimiter.wrap(socket, 'joinPost', (postId: string) => {
-    if (!postId || typeof postId !== 'string') return;
-    socket.join(`post:${postId}`);
-  }));
-
-  socket.on("leavePost", socketRateLimiter.wrap(socket, 'leavePost', (postId: string) => {
-    if (!postId || typeof postId !== 'string') return;
-    socket.leave(`post:${postId}`);
-  }));
-
-  socket.on("joinFeed", socketRateLimiter.wrap(socket, 'joinFeed', (data: { feedType?: string }) => {
-    const feedType = data?.feedType;
-    if (feedType && typeof feedType === 'string') {
-      socket.join(`feed:${feedType}`);
-    }
-    const selfId = socket.user?.id;
-    if (selfId) socket.join(`feed:user:${selfId}`);
-  }));
-
-  socket.on("leaveFeed", socketRateLimiter.wrap(socket, 'leaveFeed', (data: { feedType?: string }) => {
-    const feedType = data?.feedType;
-    if (feedType && typeof feedType === 'string') {
-      socket.leave(`feed:${feedType}`);
-    }
-    const selfId = socket.user?.id;
-    if (selfId) socket.leave(`feed:user:${selfId}`);
-  }));
-}
-
 // Configure postsNamespace events
 postsNamespace.on("connection", (socket: AuthenticatedSocket) => {
   logger.info('Client connected to posts namespace');
@@ -370,7 +341,7 @@ postsNamespace.on("connection", (socket: AuthenticatedSocket) => {
   socket.on("error", (error: Error) => {
     logger.error("Posts socket error", error);
   });
-  registerContentRoomHandlers(socket);
+  registerContentRoomHandlers(socket, socketRateLimiter);
 
   socket.on("disconnect", (reason: DisconnectReason) => {
     socketRateLimiter.cleanup(socket.id);
@@ -426,7 +397,7 @@ io.on("connection", (socket: AuthenticatedSocket) => {
       socket.disconnect();
     }
   });
-  registerContentRoomHandlers(socket);
+  registerContentRoomHandlers(socket, socketRateLimiter);
 
   socket.on("disconnect", (reason: DisconnectReason, description?: unknown) => {
     socketRateLimiter.cleanup(socket.id);

--- a/packages/backend/src/__tests__/controllers/replyBoostPostIdValidation.test.ts
+++ b/packages/backend/src/__tests__/controllers/replyBoostPostIdValidation.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A client-supplied post id must be a post id before it reaches a query.
+ *
+ * ## Why this is a real check and not tidiness
+ *
+ * `postId` / `originalPostId` come out of `req.body` as parsed JSON, so they can
+ * be objects, and both handlers passed them to `Post.findById` behind nothing
+ * but a truthiness test. Measured against a real mongod on mongoose 8.24.1:
+ *
+ *   findById({ $ne: null })          -> MATCHED an arbitrary post
+ *   findByIdAndUpdate({ $ne: null }) -> MUTATED an arbitrary post
+ *   findById({ $gt: '' } | 123 | {} | 'aaaaaaaaaaaa') -> CastError
+ *
+ * So the cast is not a guard: an operator whose operand is itself castable goes
+ * straight through. Reaching the counter update was blocked only because
+ * `parentPostId` and `boostOf` are String columns and `.save()` threw first —
+ * an unrelated schema detail, and a 500 where a 400 belongs.
+ *
+ * ## What these assertions are worth
+ *
+ * Each asserts BOTH the 400 and that `Post.findById` was never called. The
+ * status alone would keep passing if the guard moved below the query, which is
+ * the arrangement that still leaks: the arbitrary post has already been read by
+ * then.
+ */
+vi.mock('../../services/postEngagementBroadcast', () => ({
+  emitPostEngagement: vi.fn(),
+  POST_ENGAGEMENT_EVENTS: {
+    LIKED: 'post:liked',
+    UNLIKED: 'post:unliked',
+    BOOSTED: 'post:boosted',
+    UNBOOSTED: 'post:unboosted',
+    SAVED: 'post:saved',
+    UNSAVED: 'post:unsaved',
+    REPLIED: 'post:replied',
+  },
+}));
+
+vi.mock('../../services/PostHydrationService', () => ({
+  postHydrationService: { hydratePosts: vi.fn(async (objs: object[]) => objs) },
+  resolveUserSummaries: vi.fn(async () => new Map()),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createScopedOxyClient: vi.fn(() => ({})),
+}));
+
+import { Post } from '../../models/Post';
+import { feedController } from '../../controllers/feed.controller';
+
+function buildResponse() {
+  const captured: { status?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return this;
+    },
+  };
+  return { res, captured };
+}
+
+/**
+ * Values a JSON body can carry that are not post ids. `{ $ne: null }` is the one
+ * that actually selected a document; the rest reached the driver and threw,
+ * which is a 500 for what is plainly a bad request.
+ */
+const HOSTILE_IDS: Array<[string, unknown]> = [
+  ['a query operator', { $ne: null }],
+  ['a comparison operator', { $gt: '' }],
+  ['an array', ['aaaaaaaaaaaaaaaaaaaaaaaa']],
+  ['a bare number', 123],
+  ['an empty object', {}],
+  ['a boolean', true],
+  ['a non-hex string', 'notanobjectid'],
+];
+
+describe('createReply / createBoost reject a post id that is not one', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(HOSTILE_IDS)('createReply refuses %s without querying', async (_label, postId) => {
+    const findById = vi.spyOn(Post, 'findById');
+    const { res, captured } = buildResponse();
+
+    await feedController.createReply(
+      { body: { postId, content: 'hello' }, user: { id: 'attacker' } } as never,
+      res as never,
+    );
+
+    expect(captured.status).toBe(400);
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it.each(HOSTILE_IDS)('createBoost refuses %s without querying', async (_label, originalPostId) => {
+    const findById = vi.spyOn(Post, 'findById');
+    const { res, captured } = buildResponse();
+
+    await feedController.createBoost(
+      { body: { originalPostId }, user: { id: 'attacker' } } as never,
+      res as never,
+    );
+
+    expect(captured.status).toBe(400);
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it('still lets a real post id through to the query', async () => {
+    // The floor under the assertions above: they would all pass just as well
+    // against a handler that refused every id it was ever given.
+    const findById = vi.spyOn(Post, 'findById').mockImplementation((() => ({
+      maxTimeMS: () => ({ lean: () => Promise.resolve(null) }),
+    })) as never);
+    const { res, captured } = buildResponse();
+
+    await feedController.createReply(
+      { body: { postId: 'aaaaaaaaaaaaaaaaaaaaaaaa', content: 'hello' }, user: { id: 'author' } } as never,
+      res as never,
+    );
+
+    expect(findById).toHaveBeenCalledWith('aaaaaaaaaaaaaaaaaaaaaaaa');
+    // 404, because the stub says no such post — the point is that it got there.
+    expect(captured.status).toBe(404);
+  });
+});

--- a/packages/backend/src/__tests__/services/contentRoomLifecycle.test.ts
+++ b/packages/backend/src/__tests__/services/contentRoomLifecycle.test.ts
@@ -1,0 +1,204 @@
+import type { Socket } from 'socket.io';
+import { postEngagementRoom } from '@mention/shared-types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const canViewerReadPostId = vi.fn<(postId: string, viewerId: string, options?: unknown) => Promise<boolean>>();
+
+vi.mock('../../services/PostHydrationService', () => ({
+  postHydrationService: {
+    canViewerReadPostId: (...args: [string, string, unknown?]) => canViewerReadPostId(...args),
+  },
+}));
+
+const createScopedOxyClient = vi.fn(() => undefined);
+vi.mock('../../utils/oxyHelpers', () => ({
+  createScopedOxyClient: (...args: unknown[]) => createScopedOxyClient(...args),
+}));
+
+const {
+  registerContentRoomHandlers,
+  MAX_POST_ROOMS_PER_SOCKET,
+} = await import('../../services/ContentRoomLifecycle');
+
+type Handler = (...args: unknown[]) => void;
+
+/**
+ * A Socket.IO socket reduced to what room membership needs: the room set, the
+ * listener table, and the connection flag the handler re-checks after its await.
+ */
+class FakeSocket {
+  readonly id = 'socket-1';
+  readonly rooms = new Set<string>();
+  readonly handlers = new Map<string, Handler>();
+  connected = true;
+  user: { id: string } | undefined = { id: 'viewer-1' };
+  handshake = { auth: { token: 'viewer-token' } };
+
+  on(event: string, handler: Handler) {
+    this.handlers.set(event, handler);
+  }
+
+  join(room: string) {
+    this.rooms.add(room);
+  }
+
+  leave(room: string) {
+    this.rooms.delete(room);
+  }
+
+  /** Deliver a client message to whatever the handler registered. */
+  send(event: string, ...args: unknown[]) {
+    const handler = this.handlers.get(event);
+    if (!handler) throw new Error(`nothing is listening for "${event}"`);
+    handler(...args);
+  }
+}
+
+/** The real limiter's shape, with the limit itself out of the way. */
+const passThroughLimiter = {
+  wrap: <A extends unknown[]>(
+    _socket: { id: string },
+    _eventName: string,
+    handler: (...args: A) => unknown,
+  ) => (...args: A): void => {
+    handler(...args);
+  },
+};
+
+function setup(): FakeSocket {
+  const socket = new FakeSocket();
+  registerContentRoomHandlers(socket as unknown as Socket & { user?: { id: string } }, passThroughLimiter);
+  return socket;
+}
+
+/** The handler joins after an await, so the assertion has to come after it too. */
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('post room membership', () => {
+  beforeEach(() => {
+    canViewerReadPostId.mockReset();
+    createScopedOxyClient.mockClear();
+  });
+
+  it('joins the room for a post this viewer may read', async () => {
+    canViewerReadPostId.mockResolvedValue(true);
+    const socket = setup();
+
+    socket.send('joinPost', '507f1f77bcf86cd799439011');
+    await settle();
+
+    expect(socket.rooms.has(postEngagementRoom('507f1f77bcf86cd799439011'))).toBe(true);
+  });
+
+  it('refuses a post this viewer may not read', async () => {
+    canViewerReadPostId.mockResolvedValue(false);
+    const socket = setup();
+
+    socket.send('joinPost', 'someone-elses-private-post');
+    await settle();
+
+    expect(socket.rooms.size).toBe(0);
+  });
+
+  it('refuses when the visibility check cannot be answered', async () => {
+    // Oxy is down, so the viewer's blocks and follows are unknown. An
+    // unanswerable ACL is not a yes.
+    canViewerReadPostId.mockRejectedValue(new Error('oxy unavailable'));
+    const socket = setup();
+
+    socket.send('joinPost', '507f1f77bcf86cd799439011');
+    await settle();
+
+    expect(socket.rooms.size).toBe(0);
+  });
+
+  it('asks nothing and joins nothing for an unauthenticated socket', async () => {
+    canViewerReadPostId.mockResolvedValue(true);
+    const socket = setup();
+    socket.user = undefined;
+
+    socket.send('joinPost', '507f1f77bcf86cd799439011');
+    await settle();
+
+    expect(canViewerReadPostId).not.toHaveBeenCalled();
+    expect(socket.rooms.size).toBe(0);
+  });
+
+  it('does not join a socket that closed while the check was running', async () => {
+    let release: (allowed: boolean) => void = () => undefined;
+    canViewerReadPostId.mockReturnValue(new Promise((resolve) => { release = resolve; }));
+    const socket = setup();
+
+    socket.send('joinPost', '507f1f77bcf86cd799439011');
+    socket.connected = false;
+    release(true);
+    await settle();
+
+    expect(socket.rooms.size).toBe(0);
+  });
+
+  it('asks once when the same post is requested twice in flight', async () => {
+    let release: (allowed: boolean) => void = () => undefined;
+    canViewerReadPostId.mockReturnValue(new Promise((resolve) => { release = resolve; }));
+    const socket = setup();
+
+    socket.send('joinPost', '507f1f77bcf86cd799439011');
+    socket.send('joinPost', '507f1f77bcf86cd799439011');
+    release(true);
+    await settle();
+
+    expect(canViewerReadPostId).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the room on unsubscribe', async () => {
+    canViewerReadPostId.mockResolvedValue(true);
+    const socket = setup();
+
+    socket.send('joinPost', '507f1f77bcf86cd799439011');
+    await settle();
+    socket.send('leavePost', '507f1f77bcf86cd799439011');
+
+    expect(socket.rooms.size).toBe(0);
+  });
+
+  it('does not land in a room the client already left', async () => {
+    let release: (allowed: boolean) => void = () => undefined;
+    canViewerReadPostId.mockReturnValue(new Promise((resolve) => { release = resolve; }));
+    const socket = setup();
+
+    // Open and close a post faster than the visibility check answers.
+    socket.send('joinPost', '507f1f77bcf86cd799439011');
+    socket.send('leavePost', '507f1f77bcf86cd799439011');
+    release(true);
+    await settle();
+
+    expect(socket.rooms.size).toBe(0);
+  });
+
+  it('holds no more than the room ceiling, evicting the oldest', async () => {
+    canViewerReadPostId.mockResolvedValue(true);
+    const socket = setup();
+
+    const ids = Array.from({ length: MAX_POST_ROOMS_PER_SOCKET + 3 }, (_, i) => `post-${i}`);
+    for (const id of ids) {
+      socket.send('joinPost', id);
+      await settle();
+    }
+
+    expect(socket.rooms.size).toBe(MAX_POST_ROOMS_PER_SOCKET);
+    expect(socket.rooms.has(postEngagementRoom('post-0'))).toBe(false);
+    expect(socket.rooms.has(postEngagementRoom(ids[ids.length - 1]))).toBe(true);
+  });
+
+  it('ignores a room key that is not a string', async () => {
+    canViewerReadPostId.mockResolvedValue(true);
+    const socket = setup();
+
+    socket.send('joinPost', { toString: () => 'evil' });
+    socket.send('joinPost', '');
+    await settle();
+
+    expect(canViewerReadPostId).not.toHaveBeenCalled();
+    expect(socket.rooms.size).toBe(0);
+  });
+});

--- a/packages/backend/src/__tests__/services/postEngagementBroadcast.test.ts
+++ b/packages/backend/src/__tests__/services/postEngagementBroadcast.test.ts
@@ -1,0 +1,165 @@
+import {
+  POST_ENGAGEMENT_EVENTS,
+  postEngagementRoom,
+  type PostEngagementCountsPayload,
+} from '@mention/shared-types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface Emission {
+  room: string;
+  event: string;
+  payload: PostEngagementCountsPayload;
+}
+
+const emissions: Emission[] = [];
+const socketServer = {
+  to: (room: string) => ({
+    emit: (event: string, payload: PostEngagementCountsPayload) => {
+      emissions.push({ room, event, payload });
+    },
+  }),
+};
+let runtimeSocketServer: typeof socketServer | undefined = socketServer;
+
+vi.mock('../../runtime/socketServer', () => ({
+  getRuntimeSocketServer: () => runtimeSocketServer,
+}));
+
+const findOne = vi.fn();
+vi.mock('../../models/UserSettings', () => ({
+  UserSettings: {
+    findOne: (...args: unknown[]) => findOne(...args),
+  },
+}));
+
+const { broadcastPostEngagement } = await import('../../services/postEngagementBroadcast');
+
+/** `UserSettings.findOne(...).select(...).lean()` reduced to its answer. */
+function settingsReturning(privacy: Record<string, boolean> | null): void {
+  findOne.mockReturnValue({
+    select: () => ({ lean: () => Promise.resolve(privacy ? { privacy } : null) }),
+  });
+}
+
+function settingsThatThrow(): void {
+  findOne.mockReturnValue({
+    select: () => ({ lean: () => Promise.reject(new Error('mongo unavailable')) }),
+  });
+}
+
+describe('post engagement broadcast', () => {
+  beforeEach(() => {
+    emissions.length = 0;
+    findOne.mockReset();
+    runtimeSocketServer = socketServer;
+    settingsReturning(null);
+  });
+
+  it("sends the write's own counters into that post's room", async () => {
+    await broadcastPostEngagement({
+      event: POST_ENGAGEMENT_EVENTS.LIKED,
+      postId: 'post-1',
+      authorOxyUserId: 'author-1',
+      counts: { likes: 42, downvotes: 1 },
+      actorId: 'actor-1',
+    });
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].room).toBe(postEngagementRoom('post-1'));
+    expect(emissions[0].event).toBe(POST_ENGAGEMENT_EVENTS.LIKED);
+    expect(emissions[0].payload).toMatchObject({
+      postId: 'post-1',
+      likesCount: 42,
+      downvotesCount: 1,
+      actorId: 'actor-1',
+    });
+  });
+
+  it('omits a counter the author hides rather than sending it', async () => {
+    settingsReturning({ hideLikeCounts: true });
+
+    await broadcastPostEngagement({
+      event: POST_ENGAGEMENT_EVENTS.LIKED,
+      postId: 'post-1',
+      authorOxyUserId: 'author-1',
+      counts: { likes: 42, downvotes: 1 },
+      actorId: 'actor-1',
+    });
+
+    // Not `likesCount: null`, not `0` — absent, so no client can render it.
+    expect(emissions).toHaveLength(0);
+  });
+
+  it('still sends the counters the author does not hide', async () => {
+    settingsReturning({ hideLikeCounts: true });
+
+    await broadcastPostEngagement({
+      event: POST_ENGAGEMENT_EVENTS.REPLIED,
+      postId: 'post-1',
+      authorOxyUserId: 'author-1',
+      counts: { likes: 42, replies: 9 },
+      actorId: 'actor-1',
+    });
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].payload.repliesCount).toBe(9);
+    expect(emissions[0].payload.likesCount).toBeUndefined();
+  });
+
+  it.each([
+    ['hideShareCounts', { boosts: 4 }, POST_ENGAGEMENT_EVENTS.BOOSTED],
+    ['hideReplyCounts', { replies: 4 }, POST_ENGAGEMENT_EVENTS.REPLIED],
+    ['hideSaveCounts', { saves: 4 }, POST_ENGAGEMENT_EVENTS.SAVED],
+  ] as const)('honours %s', async (flag, counts, event) => {
+    settingsReturning({ [flag]: true });
+
+    await broadcastPostEngagement({
+      event,
+      postId: 'post-1',
+      authorOxyUserId: 'author-1',
+      counts,
+    });
+
+    expect(emissions).toHaveLength(0);
+  });
+
+  it('never names the actor of a save', async () => {
+    await broadcastPostEngagement({
+      event: POST_ENGAGEMENT_EVENTS.SAVED,
+      postId: 'post-1',
+      authorOxyUserId: 'author-1',
+      counts: { saves: 8 },
+    });
+
+    expect(emissions[0].payload.savesCount).toBe(8);
+    expect(emissions[0].payload.actorId).toBeUndefined();
+  });
+
+  it('shows the counters when the settings read fails, as the DTO does', async () => {
+    settingsThatThrow();
+
+    await broadcastPostEngagement({
+      event: POST_ENGAGEMENT_EVENTS.LIKED,
+      postId: 'post-1',
+      authorOxyUserId: 'author-1',
+      counts: { likes: 42 },
+    });
+
+    expect(emissions[0].payload.likesCount).toBe(42);
+  });
+
+  it('is a no-op with no socket server bound', async () => {
+    runtimeSocketServer = undefined;
+
+    await expect(
+      broadcastPostEngagement({
+        event: POST_ENGAGEMENT_EVENTS.LIKED,
+        postId: 'post-1',
+        counts: { likes: 42 },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(emissions).toHaveLength(0);
+    expect(findOne).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -239,6 +239,27 @@ class FeedController {
         return res.status(400).json({ error: 'Content and post ID are required' });
       }
 
+      /**
+       * `postId` arrives as JSON, so it can be an OBJECT, and it goes straight
+       * into `Post.findById` below and into the counter update further down.
+       *
+       * Mongoose does not save us here — measured against mongod, not assumed:
+       * `{ $ne: null }` casts cleanly as a query operator on an ObjectId path
+       * and MATCHES an arbitrary post, and `findByIdAndUpdate` given the same
+       * value mutates one. (`{ $gt: '' }`, a bare number, an empty object and a
+       * 12-character string all throw `CastError` instead; the operator whose
+       * operand happens to be castable is the one that gets through.) What stops
+       * it reaching the counter today is incidental: `parentPostId` is a String
+       * column, so `reply.save()` throws first — an accident of an unrelated
+       * schema choice, one field-type change away from not holding.
+       *
+       * The string check is not redundant with `isValidObjectId`, which answers
+       * TRUE for a bare number that the cast then rejects with a 500.
+       */
+      if (typeof postId !== 'string' || !mongoose.isValidObjectId(postId)) {
+        return res.status(400).json({ error: 'Invalid post ID' });
+      }
+
       // Fetch parent post to check reply permissions
       const parentPost = await Post.findById(postId)
         .maxTimeMS(FEED_CONSTANTS.QUERY_TIMEOUT_MS)
@@ -488,6 +509,13 @@ class FeedController {
 
       if (!originalPostId) {
         return res.status(400).json({ error: 'Original post ID is required' });
+      }
+
+      // Same client-supplied id, same three queries, same reason — see the note
+      // in `createReply`. `boostOf` being a String column is what currently
+      // stops an operator object reaching the boost counter, not any check.
+      if (typeof originalPostId !== 'string' || !mongoose.isValidObjectId(originalPostId)) {
+        return res.status(400).json({ error: 'Invalid post ID' });
       }
 
       const originalPost = await Post.findById(originalPostId)

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -14,7 +14,7 @@ import {
 import mongoose, { FilterQuery } from 'mongoose';
 import { IPost } from '../models/Post';
 import { getRuntimeOxyClient } from '../runtime/oxyClient';
-import { getRuntimeSocketServer } from '../runtime/socketServer';
+import { emitPostEngagement, POST_ENGAGEMENT_EVENTS } from '../services/postEngagementBroadcast';
 import { userPreferenceService, readInteractionSurface } from '../services/UserPreferenceService';
 import { affinityEventService } from '../services/AffinityEventService';
 import { postHydrationService } from '../services/PostHydrationService';
@@ -422,10 +422,12 @@ class FeedController {
           .catch(() => undefined);
       }
 
-      // Update parent post comment count
-      await Post.findByIdAndUpdate(postId, {
+      // Update parent post comment count. Read back with `new: true` so the
+      // broadcast below carries the number the database now holds rather than a
+      // count this request computed and hoped was still current.
+      const updatedParent = await Post.findByIdAndUpdate(postId, {
         $inc: { 'stats.commentsCount': 1 }
-      }, { maxTimeMS: FEED_CONSTANTS.QUERY_TIMEOUT_MS });
+      }, { new: true, maxTimeMS: FEED_CONSTANTS.QUERY_TIMEOUT_MS });
 
       // Outbound federation: deliver the reply as a Create(Note) with `inReplyTo`
       // + a parent-author Mention to the replier's remote followers AND (when the
@@ -446,11 +448,16 @@ class FeedController {
         includeLinkMetadata: true,
       });
 
-      // Emit real-time update to post room only (not all clients)
-      getRuntimeSocketServer()?.to(`post:${postId}`).emit('post:replied', {
+      // Only the parent's new reply count goes to the room. `hydratedReply` was
+      // built for the REPLIER's viewer context and stays in the HTTP response,
+      // where exactly one person reads it; broadcasting it would hand every other
+      // room member the replier's own viewer state, and no client reads it there.
+      emitPostEngagement({
+        event: POST_ENGAGEMENT_EVENTS.REPLIED,
         postId,
-        reply: hydratedReply,
-        timestamp: new Date().toISOString()
+        authorOxyUserId: updatedParent?.oxyUserId?.toString?.(),
+        counts: { replies: updatedParent?.stats?.commentsCount },
+        actorId: currentUserId,
       });
 
       res.status(201).json({
@@ -580,15 +587,17 @@ class FeedController {
         includeLinkMetadata: true,
       });
 
-      // Emit real-time update to post room only (not all clients)
-      getRuntimeSocketServer()?.to(`post:${originalPostId}`).emit('post:boosted', {
-        originalPostId,
+      // Everyone watching the ORIGINAL gets its new boost count. The hydrated
+      // boost itself is deliberately NOT broadcast: it was hydrated for the
+      // booster's viewer context, so its `viewerState` describes the booster, and
+      // sending it to a room would tell every other member what the booster has
+      // liked and saved. Nothing on the client reads it — the count is the point.
+      emitPostEngagement({
+        event: POST_ENGAGEMENT_EVENTS.BOOSTED,
         postId: originalPostId,
-        boost: hydratedBoost,
-        boostsCount: updatedPost?.stats?.boostsCount,
-        userId: currentUserId,
+        authorOxyUserId: updatedPost?.oxyUserId?.toString?.(),
+        counts: { boosts: updatedPost?.stats?.boostsCount },
         actorId: currentUserId,
-        timestamp: new Date().toISOString()
       });
 
       res.status(201).json({
@@ -662,16 +671,13 @@ class FeedController {
         { new: true, maxTimeMS: FEED_CONSTANTS.QUERY_TIMEOUT_MS }
       );
 
-      // Emit real-time update to post room only (not all clients)
       const boostOriginalId = boost.boostOf ? String(boost.boostOf) : '';
-      getRuntimeSocketServer()?.to(`post:${boostOriginalId}`).emit('post:unboosted', {
-        originalPostId: boost.boostOf,
-        postId: boost.boostOf,
-        boostId: boost._id,
-        boostsCount: updatedPost?.stats?.boostsCount,
-        userId: currentUserId,
+      emitPostEngagement({
+        event: POST_ENGAGEMENT_EVENTS.UNBOOSTED,
+        postId: boostOriginalId,
+        authorOxyUserId: updatedPost?.oxyUserId?.toString?.(),
+        counts: { boosts: updatedPost?.stats?.boostsCount },
         actorId: currentUserId,
-        timestamp: new Date().toISOString()
       });
 
       res.json({

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -36,6 +36,7 @@ import { queryInt, queryString } from '../utils/queryParams';
 import { buildTopicSlugMatch } from '../utils/postTopicMatch';
 import { requestLanguageCandidates } from '../utils/viewerLanguage';
 import { getRuntimeSocketServer } from '../runtime/socketServer';
+import { emitPostEngagement, POST_ENGAGEMENT_EVENTS } from '../services/postEngagementBroadcast';
 import { normalizeMediaItems, type NormalizedMediaItem } from '../utils/mediaInput';
 import { warmLinkPreviewForText } from '../utils/linkPreviewWarm';
 import { authorVariants, buildPrimaryVariant, resolveVariant, validateAuthorVariants } from '../services/postVariants';
@@ -1980,6 +1981,25 @@ export const likePost = async (req: AuthRequest, res: Response) => {
         .catch((error) => logger.warn('Failed to record interaction for preferences', error));
     }
 
+    // Everyone watching this post gets the counters the transaction just wrote.
+    // The two event names cover the whole vote axis: casting an upvote RAISES the
+    // like count (from nothing, or by switching off a downvote), while a downvote
+    // can only leave it where it was or lower it. Both counters ride along either
+    // way, so a switched vote converges on one event. An unchanged vote moved
+    // nothing and is not announced.
+    if (result.changed) {
+      emitPostEngagement({
+        event: value === 1 ? POST_ENGAGEMENT_EVENTS.LIKED : POST_ENGAGEMENT_EVENTS.UNLIKED,
+        postId,
+        authorOxyUserId: result.post.oxyUserId?.toString?.(),
+        counts: {
+          likes: result.post.stats?.likesCount ?? 0,
+          downvotes: result.post.stats?.downvotesCount ?? 0,
+        },
+        actorId: userId,
+      });
+    }
+
     res.json({
       message: result.changed
         ? result.previousValue === null
@@ -2010,6 +2030,19 @@ export const unlikePost = async (req: AuthRequest, res: Response) => {
 
     const postId = req.params.id as string;
     const result = await removeVoteCommand({ userId, postId });
+
+    if (result.changed) {
+      emitPostEngagement({
+        event: POST_ENGAGEMENT_EVENTS.UNLIKED,
+        postId,
+        authorOxyUserId: result.post.oxyUserId?.toString?.(),
+        counts: {
+          likes: result.post.stats?.likesCount ?? 0,
+          downvotes: result.post.stats?.downvotesCount ?? 0,
+        },
+        actorId: userId,
+      });
+    }
 
     res.json({
       message: result.changed ? 'Vote removed successfully' : 'No vote to remove',
@@ -2048,6 +2081,19 @@ export const savePost = async (req: AuthRequest, res: Response) => {
         .catch((error) => logger.warn('Failed to record interaction for preferences', error));
     }
 
+    // No `actorId`: the save COUNT is public (it is on every post DTO), but who
+    // saved a post is not, and a room is the wrong place to say it. The trade is
+    // that this viewer's own other devices cannot tell their own save from a
+    // stranger's — they do not need to, since only the count travels here.
+    if (result.changed) {
+      emitPostEngagement({
+        event: POST_ENGAGEMENT_EVENTS.SAVED,
+        postId,
+        authorOxyUserId: result.post.oxyUserId?.toString?.(),
+        counts: { saves: result.post.stats?.savesCount ?? 0 },
+      });
+    }
+
     res.json({
       message: result.changed ? 'Post saved successfully' : 'Post already saved',
       savesCount: result.post.stats?.savesCount ?? 0,
@@ -2071,6 +2117,15 @@ export const unsavePost = async (req: AuthRequest, res: Response) => {
 
     const postId = req.params.id as string;
     const result = await unsavePostCommand({ userId, postId });
+
+    if (result.changed) {
+      emitPostEngagement({
+        event: POST_ENGAGEMENT_EVENTS.UNSAVED,
+        postId,
+        authorOxyUserId: result.post.oxyUserId?.toString?.(),
+        counts: { saves: result.post.stats?.savesCount ?? 0 },
+      });
+    }
 
     // Durable MTN side effects are delivered by the transactional outbox.
     res.json({

--- a/packages/backend/src/services/ContentRoomLifecycle.ts
+++ b/packages/backend/src/services/ContentRoomLifecycle.ts
@@ -1,0 +1,169 @@
+import type { Socket } from 'socket.io';
+import {
+  POST_ENGAGEMENT_ROOM_PREFIX,
+  postEngagementRoom,
+} from '@mention/shared-types';
+import { postHydrationService } from './PostHydrationService';
+import { createScopedOxyClient } from '../utils/oxyHelpers';
+import { logger } from '../utils/logger';
+
+export interface AuthenticatedContentSocket extends Socket {
+  user?: { id: string; [key: string]: unknown };
+}
+
+/** Rate-limited handler wrapper, as provided by `createSocketRateLimiter`. */
+interface SocketRateLimiter {
+  wrap<A extends unknown[]>(
+    socket: { id: string },
+    eventName: string,
+    handler: (...args: A) => unknown,
+  ): (...args: A) => void;
+}
+
+/**
+ * How many post rooms one socket may occupy at once.
+ *
+ * The rate limiter caps how FAST a client can join (20 per 10s); without a
+ * ceiling on the total, a client that keeps joining forever still accumulates
+ * unbounded room membership on every task in the cluster. A reader is looking at
+ * one post at a time, plus whatever a navigation stack left behind, so twenty is
+ * far above real use and still a constant.
+ *
+ * At the ceiling the OLDEST room is dropped rather than the new join refused:
+ * the room the user just opened is the one they are looking at, and a client
+ * that leaked rooms (a crash between mount and unmount) then heals instead of
+ * being locked out of live counts for the life of the connection.
+ */
+export const MAX_POST_ROOMS_PER_SOCKET = 20;
+
+function joinedPostRooms(socket: Socket): string[] {
+  return Array.from(socket.rooms).filter((room) =>
+    room.startsWith(POST_ENGAGEMENT_ROOM_PREFIX),
+  );
+}
+
+/**
+ * Subscribe this socket to one post's live engagement counters.
+ *
+ * The post id comes from the client, so membership is decided by the server's
+ * own read ACL — `canViewerReadPostId`, the same gate that decides whether the
+ * post may be rendered for this viewer at all. Anything the room later carries
+ * is therefore something this viewer could already have read over HTTP.
+ *
+ * Fails CLOSED. The gate needs the viewer's blocks and follow graph from Oxy, so
+ * an Oxy outage makes the question unanswerable — and an unanswerable ACL is not
+ * a yes. The cost of refusing is that counts stop updating live during an
+ * outage; the cost of allowing would be a subscription nobody checked.
+ */
+async function joinPostRoom(
+  socket: AuthenticatedContentSocket,
+  postId: string,
+  stillWanted: () => boolean,
+): Promise<void> {
+  const viewerId = socket.user?.id;
+  if (!viewerId) return;
+
+  const room = postEngagementRoom(postId);
+  if (socket.rooms.has(room)) return;
+
+  let allowed = false;
+  try {
+    allowed = await postHydrationService.canViewerReadPostId(postId, viewerId, {
+      // The socket carries the same bearer the HTTP client uses; the viewer's
+      // block and restriction lists are readable only under their own identity.
+      oxyClient: createScopedOxyClient({ accessToken: readHandshakeToken(socket) }),
+    });
+  } catch (error) {
+    logger.warn('Refusing post room join: visibility check failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  // The ACL is a round trip, and three things can change under it: the answer
+  // can be no, the client can have closed (joining a dead socket leaves a room
+  // entry the adapter never reaps), or the client can have navigated away and
+  // already sent `leavePost` for this very post — a leave that arrives while the
+  // check is running has nothing to remove yet, so it has to be honoured here or
+  // the viewer ends up subscribed to a post they closed.
+  if (!allowed || !socket.connected || !stillWanted()) return;
+
+  const occupied = joinedPostRooms(socket);
+  if (occupied.length >= MAX_POST_ROOMS_PER_SOCKET) {
+    for (const stale of occupied.slice(0, occupied.length - MAX_POST_ROOMS_PER_SOCKET + 1)) {
+      socket.leave(stale);
+    }
+  }
+
+  socket.join(room);
+}
+
+function readHandshakeToken(socket: Socket): string | undefined {
+  const token = socket.handshake?.auth?.token;
+  return typeof token === 'string' && token.length > 0 ? token : undefined;
+}
+
+/**
+ * Room membership for the content surfaces: one post, or one feed.
+ *
+ * Registered on both the default namespace and `/posts`, because a client may
+ * connect to either and the engagement broadcaster emits through the default
+ * namespace's server handle.
+ *
+ * Nothing here unsubscribes on disconnect, deliberately: Socket.IO's adapter
+ * removes a closing socket from every room it holds, so a manual sweep would be
+ * a second cleanup authority that can only ever disagree with the first.
+ */
+export function registerContentRoomHandlers(
+  socket: AuthenticatedContentSocket,
+  rateLimiter: SocketRateLimiter,
+): void {
+  // A join is asynchronous, so two rapid requests for the same post would both
+  // pay for the ACL. The second is dropped rather than queued — it would be
+  // asking a question already in flight.
+  const pendingJoins = new Set<string>();
+
+  socket.on('joinPost', rateLimiter.wrap(socket, 'joinPost', (postId: string) => {
+    if (!postId || typeof postId !== 'string') return;
+    if (pendingJoins.has(postId)) return;
+    pendingJoins.add(postId);
+    // Membership in `pendingJoins` doubles as "this join is still wanted":
+    // `leavePost` removes the entry, and the `finally` below only clears it once
+    // this attempt has finished.
+    void joinPostRoom(socket, postId, () => pendingJoins.has(postId))
+      .catch((error) => {
+        logger.warn('Post room join failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        pendingJoins.delete(postId);
+      });
+  }));
+
+  socket.on('leavePost', rateLimiter.wrap(socket, 'leavePost', (postId: string) => {
+    if (!postId || typeof postId !== 'string') return;
+    // Cancels an in-flight join too: without this, a client that opened and
+    // immediately closed a post would land in a room it had already left.
+    pendingJoins.delete(postId);
+    socket.leave(postEngagementRoom(postId));
+  }));
+
+  socket.on('joinFeed', rateLimiter.wrap(socket, 'joinFeed', (data: { feedType?: string }) => {
+    const feedType = data?.feedType;
+    if (feedType && typeof feedType === 'string') {
+      socket.join(`feed:${feedType}`);
+    }
+    const selfId = socket.user?.id;
+    if (selfId) socket.join(`feed:user:${selfId}`);
+  }));
+
+  socket.on('leaveFeed', rateLimiter.wrap(socket, 'leaveFeed', (data: { feedType?: string }) => {
+    const feedType = data?.feedType;
+    if (feedType && typeof feedType === 'string') {
+      socket.leave(`feed:${feedType}`);
+    }
+    const selfId = socket.user?.id;
+    if (selfId) socket.leave(`feed:user:${selfId}`);
+  }));
+}

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1,4 +1,5 @@
 import { FeedPostSlice, FeedSliceItem, HydratedPost, HydratedPostSummary, HydratedBoostContext, HydratedAuthor, PostUser, PostAttachmentBundle, PostEngagementSummary, PostLinkPreview, PostPermissions, PostReplyContext, PostViewerState, PostVisibility, PostAuthorshipEntry, MEDIA_VARIANT_THUMB } from '@mention/shared-types';
+import { isValidObjectId } from 'mongoose';
 import { Post, type PostFederationData } from '../models/Post';
 import Poll from '../models/Poll';
 import Like from '../models/Like';
@@ -21,6 +22,9 @@ import {
 import { resolveMediaItems, attachCdnVariant } from '../utils/mediaResolver';
 import { logger } from '../utils/logger';
 import { readPersistedMediaFields } from './MediaMetadataService';
+// The counter-visibility flags are shared with the realtime broadcaster, which
+// has to hide exactly what the DTO hides — see `engagementCountPrivacy.ts`.
+import { DEFAULT_PRIVACY, readEngagementCountPrivacy } from './engagementCountPrivacy';
 import type { User as OxyUser } from '@oxyhq/core';
 import { getNormalizedUserHandle, getUserLanguages } from '@oxyhq/core';
 import type { LinkPreview } from '@oxyhq/contracts';
@@ -183,13 +187,6 @@ interface ExtendedViewerContext extends ViewerContext {
   includeFullMetadata?: boolean;
   _authorPrivacyCache?: Map<string, typeof DEFAULT_PRIVACY>;
 }
-
-const DEFAULT_PRIVACY = {
-  hideLikeCounts: false,
-  hideShareCounts: false,
-  hideReplyCounts: false,
-  hideSaveCounts: false,
-};
 
 /**
  * The projection for a reply's PARENT, fetched only to answer "whom does this
@@ -1137,12 +1134,7 @@ export class PostHydrationService {
           }
 
           // Cache engagement privacy for buildAuthorPrivacyMap
-          authorPrivacyCache.set(authorId, {
-            hideLikeCounts: Boolean(s.privacy?.hideLikeCounts),
-            hideShareCounts: Boolean(s.privacy?.hideShareCounts),
-            hideReplyCounts: Boolean(s.privacy?.hideReplyCounts),
-            hideSaveCounts: Boolean(s.privacy?.hideSaveCounts),
-          });
+          authorPrivacyCache.set(authorId, readEngagementCountPrivacy(s.privacy));
         }
 
         // Set defaults for authors without settings
@@ -1175,12 +1167,7 @@ export class PostHydrationService {
     try {
       const settings = await UserSettings.findOne({ oxyUserId: viewerId }).lean();
       if (settings?.privacy) {
-        context.privacyPreferences = {
-          hideLikeCounts: Boolean(settings.privacy.hideLikeCounts),
-          hideShareCounts: Boolean(settings.privacy.hideShareCounts),
-          hideReplyCounts: Boolean(settings.privacy.hideReplyCounts),
-          hideSaveCounts: Boolean(settings.privacy.hideSaveCounts),
-        };
+        context.privacyPreferences = readEngagementCountPrivacy(settings.privacy);
       }
     } catch (error) {
       logger.warn('[PostHydration] Failed to load viewer privacy settings:', error);
@@ -1659,13 +1646,7 @@ export class PostHydrationService {
       try {
         const settings = await UserSettings.find({ oxyUserId: { $in: missingIds } }).lean();
         for (const setting of settings) {
-          const authorId = String(setting.oxyUserId);
-          cached.set(authorId, {
-            hideLikeCounts: Boolean(setting.privacy?.hideLikeCounts),
-            hideShareCounts: Boolean(setting.privacy?.hideShareCounts),
-            hideReplyCounts: Boolean(setting.privacy?.hideReplyCounts),
-            hideSaveCounts: Boolean(setting.privacy?.hideSaveCounts),
-          });
+          cached.set(String(setting.oxyUserId), readEngagementCountPrivacy(setting.privacy));
         }
         for (const id of missingIds) {
           if (!cached.has(id)) cached.set(id, { ...DEFAULT_PRIVACY });
@@ -1690,13 +1671,7 @@ export class PostHydrationService {
     try {
       const settings = await UserSettings.find({ oxyUserId: { $in: authorIds } }).lean();
       settings.forEach((setting) => {
-        const authorId = String(setting.oxyUserId);
-        privacyMap.set(authorId, {
-          hideLikeCounts: Boolean(setting.privacy?.hideLikeCounts),
-          hideShareCounts: Boolean(setting.privacy?.hideShareCounts),
-          hideReplyCounts: Boolean(setting.privacy?.hideReplyCounts),
-          hideSaveCounts: Boolean(setting.privacy?.hideSaveCounts),
-        });
+        privacyMap.set(String(setting.oxyUserId), readEngagementCountPrivacy(setting.privacy));
       });
 
       authorIds.forEach((authorId) => {
@@ -1734,6 +1709,60 @@ export class PostHydrationService {
     }
 
     return { perPostRepliers, allReplierIds };
+  }
+
+  /**
+   * May this viewer read the post with this id?
+   *
+   * The same question {@link canViewerReadPost} answers, asked by a caller that
+   * holds an id rather than a hydrated graph — today the `joinPost` socket
+   * handler, deciding whether a client may subscribe to a post's live counters.
+   *
+   * It is a real read of the real gate, not a cheaper approximation: the post is
+   * fetched with the ACL's own projection, the viewer context is built by the
+   * same builder hydration uses, and the verdict comes from the same predicate.
+   * A "is it public?" shortcut written at the call site would be a second
+   * visibility rule, and the two would drift the first time either moved.
+   *
+   * A blocked author fails here too, matching hydration — which drops a blocked
+   * author's post while COLLECTING it, before the gate below ever sees it, so
+   * asking the gate alone would let through the one case hydration never serves.
+   *
+   * Costs one indexed `_id` lookup plus the viewer context (the viewer's
+   * blocks/restrictions/graph) — the same work one post-detail request already
+   * does. Callers must therefore bound how often they can ask.
+   */
+  async canViewerReadPostId(
+    postId: string,
+    viewerId: string,
+    options?: Pick<HydrationOptions, 'oxyClient'>,
+  ): Promise<boolean> {
+    // The id reaches this seam straight from a client. `findById` CASTS, so a
+    // non-id string would throw rather than answer, and "no such post" is the
+    // honest answer to a string that could never name one.
+    if (!isValidObjectId(postId)) return false;
+
+    const post = await Post.findById(postId)
+      .select(REPLY_PARENT_PROJECTION)
+      .lean<RawPost | null>();
+    if (!post) return false;
+
+    const isFederatedPost = !!post.federation;
+    const authorId = post.oxyUserId ? String(post.oxyUserId) : undefined;
+    // A native post with no author is a data error hydration refuses to render;
+    // a federated orphan is public by definition and keeps the federated path.
+    if (!authorId) return isFederatedPost;
+
+    const viewerContext = await this.buildViewerContext([post], viewerId, options);
+    if (viewerContext.blockedIds.has(authorId)) return false;
+
+    return this.canViewerReadPost(
+      post,
+      authorId,
+      normalizeAuthorship(post.authorship as PostAuthorshipEntry[] | undefined),
+      isFederatedPost,
+      viewerContext,
+    );
   }
 
   /**

--- a/packages/backend/src/services/engagementCountPrivacy.ts
+++ b/packages/backend/src/services/engagementCountPrivacy.ts
@@ -1,0 +1,46 @@
+/**
+ * Which of a post author's engagement counters may be shown at all.
+ *
+ * The four flags live on `UserSettings.privacy` and belong to the POST'S AUTHOR,
+ * not to the viewer — an author who hides like counts hides them from everyone.
+ * `PostHydrationService` turns a hidden counter into `null` on the DTO; the
+ * realtime broadcaster omits it from the wire. Both read the flags through here
+ * so a fifth counter, or a renamed flag, cannot land in one surface only.
+ */
+export const DEFAULT_PRIVACY = {
+  hideLikeCounts: false,
+  hideShareCounts: false,
+  hideReplyCounts: false,
+  hideSaveCounts: false,
+};
+
+export type EngagementCountPrivacy = typeof DEFAULT_PRIVACY;
+
+/** The `privacy` subdocument of a `UserSettings` row, as far as counters care. */
+interface CountPrivacySource {
+  hideLikeCounts?: boolean;
+  hideShareCounts?: boolean;
+  hideReplyCounts?: boolean;
+  hideSaveCounts?: boolean;
+}
+
+/**
+ * Read the four flags off a settings row.
+ *
+ * An absent row means an author who never opened the setting, which is the
+ * default and the overwhelming majority — hence "show", matching what the DTO
+ * has always served. A read that FAILED resolves to the same value on purpose:
+ * the render path already falls back to defaults on a settings-load error, so
+ * doing anything else here would make the live number and the reloaded number
+ * disagree about the same failure.
+ */
+export function readEngagementCountPrivacy(
+  privacy: CountPrivacySource | null | undefined,
+): EngagementCountPrivacy {
+  return {
+    hideLikeCounts: Boolean(privacy?.hideLikeCounts),
+    hideShareCounts: Boolean(privacy?.hideShareCounts),
+    hideReplyCounts: Boolean(privacy?.hideReplyCounts),
+    hideSaveCounts: Boolean(privacy?.hideSaveCounts),
+  };
+}

--- a/packages/backend/src/services/postEngagementBroadcast.ts
+++ b/packages/backend/src/services/postEngagementBroadcast.ts
@@ -1,0 +1,135 @@
+import {
+  POST_ENGAGEMENT_EVENTS,
+  postEngagementRoom,
+  type PostEngagementCountsPayload,
+  type PostEngagementEvent,
+} from '@mention/shared-types';
+import { UserSettings } from '../models/UserSettings';
+import { getRuntimeSocketServer } from '../runtime/socketServer';
+import {
+  DEFAULT_PRIVACY,
+  readEngagementCountPrivacy,
+  type EngagementCountPrivacy,
+} from './engagementCountPrivacy';
+import { logger } from '../utils/logger';
+
+/**
+ * The counters a single engagement write moved, named the way the models name
+ * them. Only the ones that actually changed belong here; a counter the write did
+ * not touch is left for the client's own copy.
+ */
+export interface PostEngagementCounts {
+  likes?: number;
+  downvotes?: number;
+  boosts?: number;
+  replies?: number;
+  saves?: number;
+}
+
+export interface BroadcastPostEngagementInput {
+  event: PostEngagementEvent;
+  /** The post whose counters moved — for a boost, the ORIGINAL, not the boost row. */
+  postId: string;
+  /** Oxy id of that post's author; whose privacy settings decide what may be sent. */
+  authorOxyUserId?: string;
+  counts: PostEngagementCounts;
+  /**
+   * Whoever acted. Supply it for a PUBLIC action so the actor's own client can
+   * discard the echo of the optimistic update it already applied. Omit it for a
+   * private one (a save) — the room must not learn who saved a post.
+   */
+  actorId?: string;
+}
+
+async function loadAuthorCountPrivacy(
+  authorOxyUserId: string | undefined,
+): Promise<EngagementCountPrivacy> {
+  if (!authorOxyUserId) return { ...DEFAULT_PRIVACY };
+  try {
+    const settings = await UserSettings.findOne({ oxyUserId: authorOxyUserId })
+      .select('privacy.hideLikeCounts privacy.hideShareCounts privacy.hideReplyCounts privacy.hideSaveCounts')
+      .lean();
+    return readEngagementCountPrivacy(settings?.privacy);
+  } catch (error) {
+    // Same fallback the render path takes, for the same reason: a settings-load
+    // failure must not make the live number and the reloaded number disagree.
+    logger.warn('[PostEngagementBroadcast] Failed to load author count privacy', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { ...DEFAULT_PRIVACY };
+  }
+}
+
+function buildPayload(
+  input: BroadcastPostEngagementInput,
+  privacy: EngagementCountPrivacy,
+): PostEngagementCountsPayload | undefined {
+  const payload: PostEngagementCountsPayload = {
+    postId: input.postId,
+    timestamp: new Date().toISOString(),
+  };
+  if (input.actorId) payload.actorId = input.actorId;
+
+  // Likes and downvotes are two faces of one vote and share one author control,
+  // so a vote that switched sides reports both or neither.
+  if (!privacy.hideLikeCounts) {
+    if (typeof input.counts.likes === 'number') payload.likesCount = input.counts.likes;
+    if (typeof input.counts.downvotes === 'number') payload.downvotesCount = input.counts.downvotes;
+  }
+  if (!privacy.hideShareCounts && typeof input.counts.boosts === 'number') {
+    payload.boostsCount = input.counts.boosts;
+  }
+  if (!privacy.hideReplyCounts && typeof input.counts.replies === 'number') {
+    payload.repliesCount = input.counts.replies;
+  }
+  if (!privacy.hideSaveCounts && typeof input.counts.saves === 'number') {
+    payload.savesCount = input.counts.saves;
+  }
+
+  const carriesACount =
+    payload.likesCount !== undefined ||
+    payload.downvotesCount !== undefined ||
+    payload.boostsCount !== undefined ||
+    payload.repliesCount !== undefined ||
+    payload.savesCount !== undefined;
+
+  // Every counter this write moved is hidden, so the event has nothing a client
+  // could apply. Sending it anyway would be a notification that the hidden
+  // number changed, which is most of what hiding it was meant to prevent.
+  return carriesACount ? payload : undefined;
+}
+
+/**
+ * Push one post's new counters to everyone watching that post.
+ *
+ * Fire-and-forget by contract: callers `void` this after their own write has
+ * committed, so a socket server that is absent (tests, one-shot scripts), a
+ * settings read that fails, or a room nobody is in can never turn a successful
+ * like into a failed request.
+ */
+export async function broadcastPostEngagement(
+  input: BroadcastPostEngagementInput,
+): Promise<void> {
+  const io = getRuntimeSocketServer();
+  if (!io || !input.postId) return;
+
+  const payload = buildPayload(input, await loadAuthorCountPrivacy(input.authorOxyUserId));
+  if (!payload) return;
+
+  io.to(postEngagementRoom(input.postId)).emit(input.event, payload);
+}
+
+/**
+ * The same broadcast, detached and silenced — the shape every call site wants,
+ * since none of them may fail a write because a socket did.
+ */
+export function emitPostEngagement(input: BroadcastPostEngagementInput): void {
+  void broadcastPostEngagement(input).catch((error) => {
+    logger.warn('[PostEngagementBroadcast] Failed to broadcast engagement counts', {
+      event: input.event,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+}
+
+export { POST_ENGAGEMENT_EVENTS };

--- a/packages/frontend/app/(app)/p/[id].tsx
+++ b/packages/frontend/app/(app)/p/[id].tsx
@@ -35,6 +35,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
 import { insightsService } from '@/services/insightsService';
 import { feedService } from '@/services/feedService';
+import { socketService } from '@/services/socketService';
 import { SEO } from '@/components/SEO';
 import { createLogger } from '@oxyhq/core/logger';
 
@@ -163,6 +164,25 @@ const PostDetailScreen: React.FC = () => {
         // original), never to the boost record itself.
         if (composeReplyTargetId) router.push(`/compose?replyToPostId=${composeReplyTargetId}`);
     }, [composeReplyTargetId]);
+
+    // Watch this post's engagement counters for as long as it is on screen.
+    //
+    // This is the one surface where a stale count is conspicuous: the reader is
+    // looking at a single post, often for minutes, and someone else's like or
+    // reply lands under their eyes. Feeds deliberately do NOT subscribe — a
+    // screenful of posts would be a room each, and a number a few seconds old in
+    // a scrolling list is not the same problem.
+    //
+    // A genuine external subscription, hence an effect. The server re-checks
+    // that this viewer may read the post before admitting the socket, so the id
+    // in the URL grants nothing on its own.
+    useEffect(() => {
+        const postId = String(id ?? '');
+        if (!postId || !user) return;
+
+        socketService.joinPost(postId);
+        return () => socketService.leavePost(postId);
+    }, [id, user]);
 
     // Load the post. When the feed already cached it, the post is rendered
     // synchronously above (`cachedPost`) and this effect only revalidates it in

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -181,6 +181,7 @@
     "jest-expo": "~57.0.2",
     "react-test-renderer": "19.2.3",
     "sharp": "^0.35.3",
+    "socket.io": "^4.8.3",
     "typescript": "catalog:"
   },
   "private": true,

--- a/packages/frontend/services/__tests__/postEngagementLiveCounts.test.ts
+++ b/packages/frontend/services/__tests__/postEngagementLiveCounts.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Live post-engagement counts, executed end to end rather than asserted about.
+ *
+ * A real Socket.IO server, two real client connections over a real port, the
+ * real `socketService` wiring and the real `postsStore`. The only double is
+ * `@/db`, which stands in for SQLite — so every assertion here lands on the
+ * post the app would render, not on a spy handed to the code under test.
+ *
+ * The server side plays the part the backend plays: it keys its room with the
+ * SAME `postEngagementRoom` helper the backend uses and sends the SAME
+ * `PostEngagementCountsPayload`, so a change to either breaks this file at
+ * compile time. What it deliberately does NOT reproduce is the backend's
+ * visibility check and its privacy-aware payload construction — those are real
+ * code with their own tests in `packages/backend`; here they would be a copy,
+ * and a copy cannot fail when the original does.
+ */
+
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { Server as SocketIOServer, type Socket as ServerSocket } from 'socket.io';
+import {
+  POST_ENGAGEMENT_EVENTS,
+  postEngagementRoom,
+  type PostEngagementCountsPayload,
+} from '@mention/shared-types';
+import type { FeedItem } from '@/db';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: () => Promise.resolve(null),
+    setItem: () => Promise.resolve(),
+    removeItem: () => Promise.resolve(),
+  },
+}));
+
+// The store reaches the network and SQLite through these; none of them is on
+// the path a broadcast takes, and left real they drag the ESM-only Oxy SDK into
+// a CommonJS jest run.
+jest.mock('@/services/feedService', () => ({
+  feedService: {
+    getSavedPosts: jest.fn(),
+    getUserFeed: jest.fn(),
+    getPostById: jest.fn(),
+  },
+}));
+jest.mock('@/lib/precacheActorsFromPosts', () => ({
+  precacheActorsFromPosts: jest.fn(),
+}));
+jest.mock('@/stores/feedScrollStore', () => ({
+  useFeedScrollStore: { getState: () => ({ retainSlice: jest.fn(), getSlice: () => null }) },
+}));
+jest.mock('@/stores/liveRoomsStore', () => ({
+  useLiveRoomsStore: { getState: () => ({ fetchLiveRooms: jest.fn() }) },
+}));
+
+const mockPosts = new Map<string, FeedItem>();
+
+jest.mock('@/db', () => ({
+  upsertPost: jest.fn(),
+  upsertPosts: jest.fn(),
+  getPostById: (postId: string) => mockPosts.get(postId) ?? null,
+  updatePost: (
+    postId: string,
+    updater: (previous: FeedItem) => FeedItem | null | undefined,
+  ) => {
+    const previous = mockPosts.get(postId);
+    if (!previous) return null;
+    const next = updater(previous);
+    if (!next) return null;
+    mockPosts.set(postId, next);
+    return next;
+  },
+  deletePost: jest.fn(),
+  pruneOldPosts: jest.fn(),
+  setFeedItems: jest.fn(),
+  appendFeedItems: jest.fn(),
+  prependFeedItem: jest.fn(),
+  addFeedItemAtStart: jest.fn(),
+  removeFeedItem: jest.fn(),
+  getFeedItems: () => [],
+  getFeedMeta: () => null,
+  clearFeed: jest.fn(),
+  clearAllCachedData: jest.fn(),
+  buildFeedKey: (type: string, userId?: string) => (userId ? `user:${userId}:${type}` : type),
+  resolvePostId: (post: FeedItem) => post.id,
+}));
+
+const VIEWER_ID = 'viewer-a';
+const OTHER_ACTOR_ID = 'actor-b';
+const WATCHED_POST = 'post-watched';
+const UNWATCHED_POST = 'post-unwatched';
+
+/** A post as the store holds it, with the counters this suite moves. */
+function seedPost(id: string, engagement: Partial<FeedItem['engagement']> = {}): void {
+  mockPosts.set(id, {
+    id,
+    engagement: {
+      likes: 10,
+      downvotes: 0,
+      boosts: 3,
+      replies: 1,
+      saves: 2,
+      ...engagement,
+    },
+    viewerState: { isLiked: false, isBoosted: false, isSaved: false },
+  } as unknown as FeedItem);
+}
+
+function storedPost(id: string): FeedItem {
+  const post = mockPosts.get(id);
+  if (!post) throw new Error(`no post "${id}" in the store`);
+  return post;
+}
+
+/**
+ * The engagement queue debounces for 200ms before touching the store, so every
+ * assertion has to outlast that. Polling rather than sleeping keeps a slow CI
+ * machine from being the reason a real convergence looks like a failure.
+ */
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+describe('live post engagement counts, over a real socket', () => {
+  let httpServer: http.Server;
+  let ioServer: SocketIOServer;
+  let serverSockets: ServerSocket[] = [];
+  let joinedRooms: string[] = [];
+  let socketService: typeof import('@/services/socketService').socketService;
+
+  beforeAll(async () => {
+    httpServer = http.createServer();
+    ioServer = new SocketIOServer(httpServer, { transports: ['websocket'] });
+
+    // Stands in for `registerContentRoomHandlers`. The room KEY is the shared
+    // one; the admission decision is the backend's and is tested there.
+    ioServer.on('connection', (socket) => {
+      serverSockets.push(socket);
+      socket.on('joinPost', (postId: string) => {
+        joinedRooms.push(postId);
+        socket.join(postEngagementRoom(postId));
+      });
+      socket.on('leavePost', (postId: string) => {
+        socket.leave(postEngagementRoom(postId));
+      });
+    });
+
+    await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const { port } = httpServer.address() as AddressInfo;
+
+    // Read at module load, so the override has to land before the import.
+    process.env.EXPO_PUBLIC_API_URL_SOCKET = `http://127.0.0.1:${port}`;
+    jest.resetModules();
+    socketService = require('@/services/socketService').socketService;
+  });
+
+  afterAll(async () => {
+    socketService.dispose();
+    ioServer.close();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  beforeEach(async () => {
+    mockPosts.clear();
+    joinedRooms = [];
+    seedPost(WATCHED_POST);
+    seedPost(UNWATCHED_POST);
+
+    socketService.connect(VIEWER_ID, 'test-token');
+    await waitFor(() => socketService.getConnectionStatus().isConnected, 'the socket to connect');
+
+    socketService.joinPost(WATCHED_POST);
+    await waitFor(() => joinedRooms.includes(WATCHED_POST), 'the server to see the join');
+  });
+
+  afterEach(() => {
+    socketService.disconnect();
+    serverSockets = [];
+  });
+
+  /** Everything a real broadcast is: one payload, into one post's room. */
+  function broadcast(
+    event: string,
+    payload: Omit<PostEngagementCountsPayload, 'timestamp'>,
+  ): void {
+    ioServer
+      .to(postEngagementRoom(payload.postId))
+      .emit(event, { ...payload, timestamp: new Date().toISOString() });
+  }
+
+  it("converges on the server's number when somebody else likes the post", async () => {
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: WATCHED_POST,
+      likesCount: 42,
+      downvotesCount: 0,
+      actorId: OTHER_ACTOR_ID,
+    });
+
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.likes === 42,
+      "the watched post's like count to reach the server's 42",
+    );
+  });
+
+  it('delivers nothing for a post this client never joined', async () => {
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: UNWATCHED_POST,
+      likesCount: 999,
+      actorId: OTHER_ACTOR_ID,
+    });
+
+    // The watched post is the control: once ITS event has landed, the unwatched
+    // one has had at least as long to arrive and demonstrably did not.
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: WATCHED_POST,
+      likesCount: 11,
+      actorId: OTHER_ACTOR_ID,
+    });
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.likes === 11,
+      'the control event to land',
+    );
+
+    expect(storedPost(UNWATCHED_POST).engagement.likes).toBe(10);
+  });
+
+  it("does not double-count this viewer's own like", async () => {
+    // What the app does first: an optimistic +1 and the viewer's own flag. The
+    // server's answer names the same total, because it is a total.
+    mockPosts.set(WATCHED_POST, {
+      ...storedPost(WATCHED_POST),
+      engagement: { ...storedPost(WATCHED_POST).engagement, likes: 11 },
+      viewerState: { ...storedPost(WATCHED_POST).viewerState, isLiked: true },
+    } as FeedItem);
+
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: WATCHED_POST,
+      likesCount: 11,
+      actorId: VIEWER_ID,
+    });
+
+    // A second, unmistakably foreign event, so the wait cannot pass merely
+    // because nothing has arrived yet.
+    broadcast(POST_ENGAGEMENT_EVENTS.BOOSTED, {
+      postId: WATCHED_POST,
+      boostsCount: 4,
+      actorId: OTHER_ACTOR_ID,
+    });
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.boosts === 4,
+      'the foreign boost event to land',
+    );
+
+    // 12 would mean the event was read as "one more like" rather than as the
+    // count itself — the failure this whole wire format exists to rule out.
+    expect(storedPost(WATCHED_POST).engagement.likes).toBe(11);
+    expect(storedPost(WATCHED_POST).viewerState.isLiked).toBe(true);
+  });
+
+  it("lets a newer local change outlive the echo of this viewer's own older one", async () => {
+    // The viewer liked (optimistic 11) and immediately unliked (optimistic 10).
+    // The LIKE's echo is still in flight and truthfully reports 11 — truthfully,
+    // because at the moment the server wrote it that was the total.
+    mockPosts.set(WATCHED_POST, {
+      ...storedPost(WATCHED_POST),
+      engagement: { ...storedPost(WATCHED_POST).engagement, likes: 10 },
+    } as FeedItem);
+
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: WATCHED_POST,
+      likesCount: 11,
+      actorId: VIEWER_ID,
+    });
+
+    broadcast(POST_ENGAGEMENT_EVENTS.BOOSTED, {
+      postId: WATCHED_POST,
+      boostsCount: 4,
+      actorId: OTHER_ACTOR_ID,
+    });
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.boosts === 4,
+      'the foreign boost event to land',
+    );
+
+    // Applying the stale self-echo would flash 11 under the reader's own thumb
+    // before the unlike's echo pulled it back. Recognising it as this viewer's
+    // own is what avoids that; the unlike's echo carries the same actor and is
+    // discarded for the same reason, leaving the optimistic value standing.
+    expect(storedPost(WATCHED_POST).engagement.likes).toBe(10);
+  });
+
+  it('applies every counter in a batch, not just the last event', async () => {
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: WATCHED_POST,
+      likesCount: 50,
+      actorId: OTHER_ACTOR_ID,
+    });
+    broadcast(POST_ENGAGEMENT_EVENTS.BOOSTED, {
+      postId: WATCHED_POST,
+      boostsCount: 9,
+      actorId: OTHER_ACTOR_ID,
+    });
+    broadcast(POST_ENGAGEMENT_EVENTS.REPLIED, {
+      postId: WATCHED_POST,
+      repliesCount: 7,
+      actorId: OTHER_ACTOR_ID,
+    });
+
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.replies === 7,
+      'the batched events to land',
+    );
+    expect(storedPost(WATCHED_POST).engagement.likes).toBe(50);
+    expect(storedPost(WATCHED_POST).engagement.boosts).toBe(9);
+  });
+
+  it('takes the newest value within one batch, even when it is lower', async () => {
+    // A like then an unlike, close enough together to share one debounce window,
+    // so the merge — not the store — is what has to pick between them. Folding
+    // to the OLDEST value would settle on 50 here.
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: WATCHED_POST,
+      likesCount: 50,
+      actorId: OTHER_ACTOR_ID,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    broadcast(POST_ENGAGEMENT_EVENTS.UNLIKED, {
+      postId: WATCHED_POST,
+      likesCount: 49,
+      actorId: OTHER_ACTOR_ID,
+    });
+
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.likes === 49,
+      'the newest like count in the batch to win',
+    );
+  });
+
+  it('takes a later, lower value from a separate batch', async () => {
+    // The same two events far enough apart to be applied one after the other —
+    // the ordinary case of someone liking and then changing their mind. Nothing
+    // may refuse a count for being smaller than the one already rendered: the
+    // server's latest word is the count, and a guard that only ever let numbers
+    // climb would freeze this post at 50 for as long as it stayed on screen.
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: WATCHED_POST,
+      likesCount: 50,
+      actorId: OTHER_ACTOR_ID,
+    });
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.likes === 50,
+      'the first count to be applied on its own',
+    );
+
+    broadcast(POST_ENGAGEMENT_EVENTS.UNLIKED, {
+      postId: WATCHED_POST,
+      likesCount: 49,
+      actorId: OTHER_ACTOR_ID,
+    });
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.likes === 49,
+      'the later, lower count to replace it',
+    );
+  });
+
+  it('leaves a counter the author hides exactly where it was', async () => {
+    broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+      postId: WATCHED_POST,
+      // No `likesCount`: this author hides it, so the number never travels.
+      downvotesCount: 4,
+      actorId: OTHER_ACTOR_ID,
+    });
+
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.downvotes === 4,
+      'the visible counter to land',
+    );
+    expect(storedPost(WATCHED_POST).engagement.likes).toBe(10);
+  });
+
+  it("never lets another actor's event touch this viewer's own state", async () => {
+    broadcast(POST_ENGAGEMENT_EVENTS.SAVED, {
+      postId: WATCHED_POST,
+      savesCount: 8,
+      // Saves carry no actor, deliberately — a room must not learn who saved.
+    });
+
+    await waitFor(
+      () => storedPost(WATCHED_POST).engagement.saves === 8,
+      'the save count to land',
+    );
+    expect(storedPost(WATCHED_POST).viewerState.isSaved).toBe(false);
+  });
+
+  it('re-joins its post rooms after a reconnect', async () => {
+    joinedRooms = [];
+
+    // Drop the TRANSPORT, which is what a network blip or a load balancer
+    // recycling a connection looks like — and the case Socket.IO reconnects
+    // from. (A `socket.disconnect()` from the server would not: the client
+    // treats that as deliberate and stays down, by design.) Room membership dies
+    // with the connection either way, so the client has to say so again or the
+    // counts silently stop.
+    for (const socket of serverSockets) socket.conn.close();
+
+    await waitFor(
+      () => joinedRooms.includes(WATCHED_POST),
+      'the client to re-assert its room after reconnecting',
+    );
+  });
+});

--- a/packages/frontend/services/socketService.ts
+++ b/packages/frontend/services/socketService.ts
@@ -1,6 +1,11 @@
 import { API_URL_SOCKET } from '@/config';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import type { FeedType } from '@mention/shared-types';
+import type {
+  FeedType,
+  PostEngagementCountsPayload,
+  PostEngagementEvent,
+} from '@mention/shared-types';
+import { POST_ENGAGEMENT_EVENTS } from '@mention/shared-types';
 import { AppState, type AppStateStatus } from 'react-native';
 import { io, Socket } from 'socket.io-client';
 import { usePostsStore } from '../stores/postsStore';
@@ -23,14 +28,47 @@ const logger = createLogger('SocketService');
 // Valid feed types for validation
 const VALID_FEED_TYPES: string[] = ['posts', 'media', 'replies', 'likes', 'boosts', 'mixed', 'for_you', 'following', 'saved', 'explore', 'custom'];
 
-// TypeScript interfaces for socket events
-interface EngagementEventData {
-  postId?: string;
-  originalPostId?: string;
-  userId?: string;
-  actorId?: string;
-  likesCount?: number;
-  boostsCount?: number;
+/**
+ * The counters a post-engagement event carried, keyed the way the store keys
+ * them. A counter the author hides never arrives, which is why every field is
+ * optional and an absent one means "leave the rendered value alone" rather than
+ * zero.
+ */
+type EngagementCounts = Partial<
+  Record<'likes' | 'downvotes' | 'boosts' | 'replies' | 'saves', number>
+>;
+
+const COUNT_FIELDS: ReadonlyArray<keyof EngagementCounts> = [
+  'likes',
+  'downvotes',
+  'boosts',
+  'replies',
+  'saves',
+];
+
+/**
+ * Each engagement event and the local action it echoes. The action is only ever
+ * used to ask the echo guard "did this device just do that?" — the counters in
+ * the payload are what actually gets applied.
+ */
+const ENGAGEMENT_EVENT_ACTIONS: ReadonlyArray<[PostEngagementEvent, EchoAction]> = [
+  [POST_ENGAGEMENT_EVENTS.LIKED, 'like'],
+  [POST_ENGAGEMENT_EVENTS.UNLIKED, 'unlike'],
+  [POST_ENGAGEMENT_EVENTS.BOOSTED, 'boost'],
+  [POST_ENGAGEMENT_EVENTS.UNBOOSTED, 'unboost'],
+  [POST_ENGAGEMENT_EVENTS.SAVED, 'save'],
+  [POST_ENGAGEMENT_EVENTS.UNSAVED, 'unsave'],
+  [POST_ENGAGEMENT_EVENTS.REPLIED, 'reply'],
+];
+
+function readEngagementCounts(data: PostEngagementCountsPayload): EngagementCounts {
+  const counts: EngagementCounts = {};
+  if (typeof data.likesCount === 'number') counts.likes = data.likesCount;
+  if (typeof data.downvotesCount === 'number') counts.downvotes = data.downvotesCount;
+  if (typeof data.boostsCount === 'number') counts.boosts = data.boostsCount;
+  if (typeof data.repliesCount === 'number') counts.replies = data.repliesCount;
+  if (typeof data.savesCount === 'number') counts.saves = data.savesCount;
+  return counts;
 }
 
 interface FeedUpdateData {
@@ -45,8 +83,7 @@ interface PresenceUpdateData {
 }
 
 interface EngagementUpdate {
-  type: 'like' | 'unlike' | 'boost' | 'unboost' | 'save' | 'unsave' | 'reply';
-  data: EngagementEventData;
+  counts: EngagementCounts;
   timestamp: number;
 }
 
@@ -76,6 +113,8 @@ class SocketService {
   private readonly ENGAGEMENT_PERSIST_DEBOUNCE_MS = 50;
   // Debounce timer for coalescing live-rooms update signals (participant churn)
   private liveRoomsRefetchTimer: ReturnType<typeof setTimeout> | null = null;
+  // Post rooms the mounted screens have asked for; replayed on every connect.
+  private joinedPostIds = new Set<string>();
 
   constructor() {
     this.setupEventListeners();
@@ -122,12 +161,6 @@ class SocketService {
     return '';
   }
 
-  /**
-   * Extract actor ID from event data (handles both userId and actorId fields)
-   */
-  private getActorId(data: EngagementEventData): string | undefined {
-    return data.userId || data.actorId;
-  }
 
   /**
    * Connect to the backend socket server
@@ -185,11 +218,23 @@ class SocketService {
     }
   }
 
-  private shouldIgnoreEcho(postId: string, action: string, actorId?: string) {
-    // If server includes actor identity and it's us, ignore
+  /**
+   * Is this event the echo of something this viewer just did themselves?
+   *
+   * The action was already applied optimistically, so re-applying the server's
+   * answer would only make the number flicker if the viewer has acted again
+   * since. It cannot double-count either way — every count on the wire is the
+   * value the database holds, not a delta — so this is a smoothness guard, not a
+   * correctness one.
+   *
+   * `actorId` decides it outright when the server sent one. It does not for a
+   * SAVE, where publishing the actor to a room would say who bookmarked the
+   * post; those fall back to the short local window, and the worst case there is
+   * that the viewer's own device re-applies a number it already holds.
+   */
+  private shouldIgnoreEcho(postId: string, action: EchoAction, actorId?: string) {
     if (actorId && this.currentUserId && actorId === this.currentUserId) return true;
-    // Otherwise, ignore if we performed the same action very recently
-    return wasRecent(postId, action as EchoAction);
+    return wasRecent(postId, action);
   }
 
   /**
@@ -271,6 +316,10 @@ class SocketService {
     // Clear queues
     this.feedUpdateQueue.clear();
     this.engagementUpdateQueue.clear();
+    // A full teardown ends every subscription: `disconnect()` runs on sign-out
+    // and on a credential change, and replaying one viewer's rooms onto the
+    // next viewer's socket would be a subscription they never asked for.
+    this.joinedPostIds.clear();
 
     // Clear all listener maps
     this.presenceListeners.clear();
@@ -306,19 +355,28 @@ class SocketService {
   }
 
   /**
-   * Join a post room for real-time updates
+   * Subscribe to one post's live engagement counters.
+   *
+   * The subscription is recorded whether or not there is a socket to tell right
+   * now, and replayed on every (re)connect. Room membership is server-side state
+   * that a dropped connection destroys, so without the replay a screen that
+   * survived a reconnect — or that mounted during the 5–25s auth cold boot —
+   * would sit in a room the server has no record of, showing counts that never
+   * move again and reporting no error.
    */
   joinPost(postId: string): void {
-    if (!this.socket?.connected) return;
-    this.socket.emit('joinPost', postId);
+    if (!postId) return;
+    this.joinedPostIds.add(postId);
+    if (this.socket?.connected) this.socket.emit('joinPost', postId);
   }
 
   /**
    * Leave a post room
    */
   leavePost(postId: string): void {
-    if (!this.socket?.connected) return;
-    this.socket.emit('leavePost', postId);
+    if (!postId) return;
+    this.joinedPostIds.delete(postId);
+    if (this.socket?.connected) this.socket.emit('leavePost', postId);
   }
 
   /**
@@ -331,13 +389,9 @@ class SocketService {
     this.socket.off('disconnect');
     this.socket.off('connect_error');
     this.socket.off('feed:updated');
-    this.socket.off('post:liked');
-    this.socket.off('post:unliked');
-    this.socket.off('post:replied');
-    this.socket.off('post:boosted');
-    this.socket.off('post:unboosted');
-    this.socket.off('post:saved');
-    this.socket.off('post:unsaved');
+    for (const [event] of ENGAGEMENT_EVENT_ACTIONS) {
+      this.socket.off(event);
+    }
     this.socket.off('user:presence');
     this.socket.off('user:presenceBulk');
     this.socket.off(SOCKET_EVENT_ROOMS_LIVE_UPDATED);
@@ -361,6 +415,13 @@ class SocketService {
       if (this.currentUserId && this.socket) {
         this.socket.emit('joinFeed', { userId: this.currentUserId });
       }
+
+      // Re-assert the post rooms the mounted screens are still watching. The
+      // server re-checks visibility on each one, so this grants nothing a fresh
+      // join would not.
+      for (const postId of this.joinedPostIds) {
+        this.socket?.emit('joinPost', postId);
+      }
     });
 
     this.socket.on('disconnect', () => {
@@ -382,34 +443,12 @@ class SocketService {
       this.handleFeedUpdate(data);
     });
 
-    // Post interaction events
-    this.socket.on('post:liked', (data) => {
-      this.handlePostLiked(data);
-    });
-
-    this.socket.on('post:unliked', (data) => {
-      this.handlePostUnliked(data);
-    });
-
-    this.socket.on('post:replied', (data) => {
-      this.handlePostReplied(data);
-    });
-
-    this.socket.on('post:boosted', (data) => {
-      this.handlePostBoosted(data);
-    });
-
-    this.socket.on('post:unboosted', (data) => {
-      this.handlePostUnboosted(data);
-    });
-
-    this.socket.on('post:saved', (data) => {
-      this.handlePostSaved(data);
-    });
-
-    this.socket.on('post:unsaved', (data) => {
-      this.handlePostUnsaved(data);
-    });
+    // Post engagement events, from the `post:<id>` rooms this client joined.
+    for (const [event, action] of ENGAGEMENT_EVENT_ACTIONS) {
+      this.socket.on(event, (data: PostEngagementCountsPayload) => {
+        this.handleEngagementEvent(action, data);
+      });
+    }
 
     // Presence events
     this.socket.on('user:presence', (data) => {
@@ -572,29 +611,28 @@ class SocketService {
   }
 
   /**
-   * Handle post liked event - with batching and smart conflict resolution
+   * A post's counters moved. One entry point for all six engagement events,
+   * because what a client does with them no longer depends on which one it was:
+   * the name told the echo guard what to compare against, and the payload
+   * carries the numbers.
    */
-  private handlePostLiked(data: EngagementEventData) {
-    const { postId, likesCount } = data || {};
+  private handleEngagementEvent(action: EchoAction, data: PostEngagementCountsPayload) {
+    const postId = data?.postId;
     if (!postId) return;
-    const actualActorId = this.getActorId(data);
+    if (this.shouldIgnoreEcho(postId, action, data.actorId)) return;
 
-    // Skip echo - our own actions are handled by optimistic updates
-    if (this.shouldIgnoreEcho(postId, 'like', actualActorId)) return;
+    const counts = readEngagementCounts(data);
+    // Every counter this post's author exposes was hidden, so there is nothing
+    // to apply and nothing to queue.
+    if (COUNT_FIELDS.every((field) => counts[field] === undefined)) return;
 
-    // Queue for batching
-    this.queueEngagementUpdate(postId, 'like', {
-      postId,
-      likesCount,
-      userId: actualActorId,
-      actorId: actualActorId
-    });
+    this.queueEngagementUpdate(postId, counts);
   }
-  
+
   /**
    * Queue engagement update for batching
    */
-  private queueEngagementUpdate(postId: string, type: 'like' | 'unlike' | 'boost' | 'unboost' | 'save' | 'unsave' | 'reply', data: EngagementEventData) {
+  private queueEngagementUpdate(postId: string, counts: EngagementCounts) {
     const existingQueue = this.engagementUpdateQueue.get(postId);
     const queue = existingQueue ?? [];
     if (!existingQueue) {
@@ -607,7 +645,7 @@ class SocketService {
       this.engagementUpdateQueue.set(postId, queue.slice(-50));
     }
 
-    queue.push({ type, data, timestamp: Date.now() });
+    queue.push({ counts, timestamp: Date.now() });
 
     // Clear existing timer
     if (this.engagementUpdateTimer) {
@@ -708,186 +746,39 @@ class SocketService {
         this.engagementUpdateQueue.delete(postId);
         return;
       }
-      
-      // Get the most recent update for each type (latest wins)
-      const latestByType = new Map<string, typeof updates[0]>();
-      updates.forEach(update => {
-        const existing = latestByType.get(update.type);
-        if (!existing || update.timestamp > existing.timestamp) {
-          latestByType.set(update.type, update);
+
+      // Fold the batch PER COUNTER, newest wins. Not per event type: a like and
+      // a boost move different numbers, so keeping one winner overall would drop
+      // whichever counter the loser carried. And not by applying each event in
+      // turn, which is what the counts being authoritative makes pointless —
+      // only the last value for each counter can survive, so compute it once and
+      // touch the store once.
+      //
+      // Equal timestamps resolve to arrival order (`>=` would flip that): two
+      // events stamped in the same millisecond arrived in the order they were
+      // queued, and that is the better guess at which the server wrote last.
+      const winning: EngagementCounts = {};
+      const winningAt: Partial<Record<keyof EngagementCounts, number>> = {};
+      for (const update of updates) {
+        for (const field of COUNT_FIELDS) {
+          const value = update.counts[field];
+          if (value === undefined) continue;
+          const previousAt = winningAt[field];
+          if (previousAt !== undefined && update.timestamp < previousAt) continue;
+          winning[field] = value;
+          winningAt[field] = update.timestamp;
         }
-      });
-      
-      // Apply updates, preferring server counts when available
-      latestByType.forEach((update, type) => {
-        const { data } = update;
-        
-        switch (type) {
-          case 'like':
-            store.updatePostEverywhere(postId, (prev) => {
-              const actorId = data.actorId || data.userId;
-              const isOurAction = actorId === viewerId;
-              const currentLikes = prev.engagement?.likes ?? 0;
+      }
 
-              // Use server count if available, otherwise increment
-              const newCount = data.likesCount ?? (currentLikes + 1);
+      // `viewerState` is deliberately untouched. Whether THIS viewer liked,
+      // boosted or saved the post is theirs alone; a room event describes what
+      // somebody else did, and the one time it describes this viewer it is an
+      // echo of a state they already set optimistically.
+      store.updatePostEverywhere(postId, (prev) => ({
+        ...prev,
+        engagement: { ...prev.engagement, ...winning },
+      }));
 
-              // If it's our action, echo guard should have suppressed it
-              // But if it got through, don't override optimistic update
-              if (isOurAction) {
-                // Only update count if different (socket might have server-accurate count)
-                if (currentLikes !== newCount) {
-                  return {
-                    ...prev,
-                    // Keep our optimistic isLiked state
-                    engagement: { ...prev.engagement, likes: newCount },
-                  };
-                }
-                return prev; // No change needed
-              }
-
-              // Other user's action - only update count, NOT isLiked state
-              // Don't update if count is already correct or higher
-              if (currentLikes >= newCount) return prev;
-
-              return {
-                ...prev,
-                // Keep current isLiked state (it's about OUR state, not theirs)
-                engagement: { ...prev.engagement, likes: newCount },
-              };
-            });
-            break;
-
-          case 'unlike':
-            store.updatePostEverywhere(postId, (prev) => {
-              const actorId = data.actorId || data.userId;
-              const isOurAction = actorId === viewerId;
-              const currentLikes = prev.engagement?.likes ?? 0;
-
-              const newCount = data.likesCount ?? Math.max(0, currentLikes - 1);
-
-              // If it's our action, echo guard should have suppressed it
-              if (isOurAction) {
-                // Only update count if different
-                if (currentLikes !== newCount) {
-                  return {
-                    ...prev,
-                    // Keep our optimistic isLiked state
-                    engagement: { ...prev.engagement, likes: newCount },
-                  };
-                }
-                return prev; // No change needed
-              }
-
-              // Other user's action - only update count, NOT isLiked state
-              // Don't update if count is already correct or lower
-              if (currentLikes <= newCount) return prev;
-
-              return {
-                ...prev,
-                // Keep current isLiked state (it's about OUR state, not theirs)
-                engagement: { ...prev.engagement, likes: newCount },
-              };
-            });
-            break;
-
-          case 'boost':
-            store.updatePostEverywhere(postId, (prev) => {
-              const actorId = data.actorId || data.userId;
-              const isOurAction = actorId === viewerId;
-
-              // Use server count if available, otherwise increment
-              const currentBoosts = prev.engagement?.boosts ?? 0;
-              const newCount = data.boostsCount ?? (currentBoosts + 1);
-
-              // If it's our action, echo guard should have suppressed it
-              // But if it got through, don't override optimistic update
-              if (isOurAction) {
-                // Only update count if different (socket might have server-accurate count)
-                if (currentBoosts !== newCount) {
-                  return {
-                    ...prev,
-                    // Keep our optimistic isBoosted state
-                    engagement: { ...prev.engagement, boosts: newCount },
-                  };
-                }
-                return prev; // No change needed
-              }
-
-              // Other user's action - only update count, NOT isBoosted state
-              // Don't update if count is already correct or higher
-              if (currentBoosts >= newCount) return prev;
-
-              return {
-                ...prev,
-                // Keep current isBoosted state (it's about OUR state, not theirs)
-                engagement: { ...prev.engagement, boosts: newCount },
-              };
-            });
-            break;
-
-          case 'unboost':
-            store.updatePostEverywhere(postId, (prev) => {
-              const actorId = data.actorId || data.userId;
-              const isOurAction = actorId === viewerId;
-
-              const currentBoosts = prev.engagement?.boosts ?? 0;
-              const newCount = data.boostsCount ?? Math.max(0, currentBoosts - 1);
-
-              // If it's our action, echo guard should have suppressed it
-              if (isOurAction) {
-                // Only update count if different
-                if (currentBoosts !== newCount) {
-                  return {
-                    ...prev,
-                    // Keep our optimistic isBoosted state
-                    engagement: { ...prev.engagement, boosts: newCount },
-                  };
-                }
-                return prev; // No change needed
-              }
-
-              // Other user's action - only update count, NOT isBoosted state
-              // Don't update if count is already correct or lower
-              if (currentBoosts <= newCount) return prev;
-
-              return {
-                ...prev,
-                // Keep current isBoosted state (it's about OUR state, not theirs)
-                engagement: { ...prev.engagement, boosts: newCount },
-              };
-            });
-            break;
-            
-          case 'save':
-            // Saved state is viewer-private. Never let another actor's event
-            // change this viewer's flag; only reconcile our own missed echo.
-            if (data.userId === viewerId) {
-              store.updatePostEverywhere(postId, (prev) => ({
-                ...prev,
-                viewerState: { ...prev.viewerState, isSaved: true },
-              }));
-            }
-            break;
-
-          case 'unsave':
-            if (data.userId === viewerId) {
-              store.updatePostEverywhere(postId, (prev) => ({
-                ...prev,
-                viewerState: { ...prev.viewerState, isSaved: false },
-              }));
-            }
-            break;
-            
-          case 'reply':
-            store.updatePostEverywhere(postId, (prev) => ({
-              ...prev,
-              engagement: { ...prev.engagement, replies: (prev.engagement.replies || 0) + 1 }
-            }));
-            break;
-        }
-      });
-      
       // Clear queue for this post
       this.engagementUpdateQueue.delete(postId);
     });
@@ -899,101 +790,6 @@ class SocketService {
       this.engagementPersistTimer = null;
     }
     AsyncStorage.removeItem(engagementQueueStorageKey(viewerId)).catch(() => {});
-  }
-
-  /**
-   * Handle post unliked event - with batching
-   */
-  private handlePostUnliked(data: EngagementEventData) {
-    const { postId, likesCount } = data || {};
-    if (!postId) return;
-    const actualActorId = this.getActorId(data);
-
-    // Skip echo - our own actions are handled by optimistic updates
-    if (this.shouldIgnoreEcho(postId, 'unlike', actualActorId)) return;
-
-    this.queueEngagementUpdate(postId, 'unlike', {
-      postId,
-      likesCount,
-      userId: actualActorId,
-      actorId: actualActorId
-    });
-  }
-
-  /**
-   * Handle post replied event - with batching
-   */
-  private handlePostReplied(data: EngagementEventData) {
-    const { postId } = data || {};
-    if (!postId) return;
-    const actualActorId = this.getActorId(data);
-    if (this.shouldIgnoreEcho(postId, 'reply', actualActorId)) return;
-
-    this.queueEngagementUpdate(postId, 'reply', { postId, actorId: actualActorId });
-  }
-
-  /**
-   * Handle post boosted event - with batching
-   */
-  private handlePostBoosted(data: EngagementEventData) {
-    const { originalPostId, postId, boostsCount } = data || {};
-    const targetId = originalPostId || postId;
-    if (!targetId) return;
-    const actualActorId = this.getActorId(data);
-    if (this.shouldIgnoreEcho(targetId, 'boost', actualActorId)) return;
-
-    this.queueEngagementUpdate(targetId, 'boost', {
-      postId: targetId,
-      boostsCount,
-      userId: actualActorId
-    });
-  }
-
-  /**
-   * Handle post unboosted event - with batching
-   */
-  private handlePostUnboosted(data: EngagementEventData) {
-    const { originalPostId, postId, boostsCount } = data || {};
-    const targetId = originalPostId || postId;
-    if (!targetId) return;
-    const actualActorId = this.getActorId(data);
-    if (this.shouldIgnoreEcho(targetId, 'unboost', actualActorId)) return;
-
-    this.queueEngagementUpdate(targetId, 'unboost', {
-      postId: targetId,
-      boostsCount,
-      userId: actualActorId
-    });
-  }
-
-  /**
-   * Handle post saved event - with batching
-   */
-  private handlePostSaved(data: EngagementEventData) {
-    const { postId } = data || {};
-    if (!postId) return;
-    const actualActorId = this.getActorId(data);
-    if (this.shouldIgnoreEcho(postId, 'save', actualActorId)) return;
-
-    this.queueEngagementUpdate(postId, 'save', {
-      postId,
-      userId: actualActorId
-    });
-  }
-
-  /**
-   * Handle post unsaved event - with batching
-   */
-  private handlePostUnsaved(data: EngagementEventData) {
-    const { postId } = data || {};
-    if (!postId) return;
-    const actualActorId = this.getActorId(data);
-    if (this.shouldIgnoreEcho(postId, 'unsave', actualActorId)) return;
-
-    this.queueEngagementUpdate(postId, 'unsave', {
-      postId,
-      userId: actualActorId
-    });
   }
 
   // Presence event listeners

--- a/packages/shared-types/src/realtime.ts
+++ b/packages/shared-types/src/realtime.ts
@@ -57,3 +57,77 @@ export interface TrendsUpdatedPayload {
   /** ISO timestamp of the batch that was just published. */
   calculatedAt?: string;
 }
+
+/**
+ * The room a client joins to watch ONE post's engagement counters.
+ *
+ * Derived from a post id the server has already checked this viewer may read —
+ * see the `joinPost` handler in `packages/backend/server.ts`. The id travels
+ * from the client, so the check is what makes the room safe; the key format
+ * alone guarantees nothing.
+ */
+export const POST_ENGAGEMENT_ROOM_PREFIX = 'post:';
+
+export const postEngagementRoom = (postId: string): string =>
+  `${POST_ENGAGEMENT_ROOM_PREFIX}${postId}`;
+
+/**
+ * Server → client engagement events, emitted into {@link postEngagementRoom}.
+ *
+ * The name says which way the counter moved, so a client that renders nothing
+ * but numbers can still ignore the ones it does not care about. The numbers
+ * themselves are always authoritative — see {@link PostEngagementCountsPayload}.
+ */
+export const POST_ENGAGEMENT_EVENTS = {
+  LIKED: 'post:liked',
+  UNLIKED: 'post:unliked',
+  BOOSTED: 'post:boosted',
+  UNBOOSTED: 'post:unboosted',
+  SAVED: 'post:saved',
+  UNSAVED: 'post:unsaved',
+  REPLIED: 'post:replied',
+} as const;
+
+export type PostEngagementEvent =
+  (typeof POST_ENGAGEMENT_EVENTS)[keyof typeof POST_ENGAGEMENT_EVENTS];
+
+/**
+ * One post's counters after a write that changed them.
+ *
+ * ## Every number is the value the database holds, never a delta
+ *
+ * The emitter reads its counters back from the same `{ new: true }` update that
+ * wrote them, so a client applies the number as-is. That is what makes the
+ * events order-insensitive: two events that cross on the wire converge on
+ * whichever the client saw last, and a client that misses one entirely is
+ * corrected by the next. A delta would have to be applied exactly once, in
+ * order, which no broadcast can promise.
+ *
+ * ## An ABSENT counter is not zero — it is "do not touch"
+ *
+ * Each counter is separately hidden by its author (`UserSettings.privacy.hide*Counts`),
+ * and the hydrated DTO already sends `null` for a hidden one. Broadcasting the
+ * real number to a room would put back exactly what the author asked to remove,
+ * so a hidden counter is OMITTED here and the client leaves its rendered value
+ * alone. `undefined` and `0` therefore mean different things; do not coalesce
+ * them.
+ *
+ * ## `actorId` is present only when the action itself is public
+ *
+ * It is what lets a client discard the echo of its own action (which it already
+ * applied optimistically) without depending on a timing window. Saves are
+ * viewer-private, so save events carry the count and no actor — which is also
+ * why no client can learn WHO saved a post from this room.
+ */
+export interface PostEngagementCountsPayload {
+  postId: string;
+  likesCount?: number;
+  downvotesCount?: number;
+  boostsCount?: number;
+  repliesCount?: number;
+  savesCount?: number;
+  /** Oxy user id of whoever acted; omitted for actions that are not public. */
+  actorId?: string;
+  /** ISO timestamp of the write. */
+  timestamp: string;
+}


### PR DESCRIPTION
## The dead layer

The post room existed, was rate-limited and was joinable. Nothing ever joined it: `socketService.joinPost` had no caller anywhere in the frontend, and `post:liked` / `post:unliked` / `post:saved` / `post:unsaved` were never emitted at all. So another user's like, boost or reply on a post you were looking at never moved your view, while ~270 lines of client merge logic sat waiting for events that could not arrive.

Three claims in the original diagnosis were **wrong**, and are corrected here because they came from a sweep that read a stale checkout:

- the backend *does* register `joinPost` — `server.ts:325-353`, `registerContentRoomHandlers`, already rate-limited, on both namespaces
- `grep "socket.on("` returns **23** hits, not 2
- the boost emit lives in `src/controllers/feed.controller.ts`, not `src/mtn/controllers/`

## Two things made "just wire it up" unsafe

**Every engagement counter is subject to a per-author privacy flag** (`UserSettings.privacy.hide{Like,Share,Reply,Save}Counts`; hydration sends `null` for a hidden one). The existing `post:boosted` emit broadcast `boostsCount` **unconditionally** — harmless only because the room was empty. Populating it would have turned a dormant bug into a live leak of numbers authors had deliberately hidden. The broadcaster now omits a hidden counter from the wire, and sends nothing at all when a write moved only hidden ones.

**`post:replied` and `post:boosted` were broadcasting a fully hydrated post DTO** — hydrated for the *actor's* viewer context, so its `viewerState` says what the replier or booster has liked and saved. Sent to a room, that hands every member one member's private state. No client ever read either field. Both are dropped from the broadcast; they stay in the HTTP response, where exactly one person reads them.

## What's here

**Contract** — `shared-types/src/realtime.ts`: room name, event names, payload. Every count is the post-`{new:true}` value, never a delta; an absent counter means "do not touch", not zero; `actorId` only for public actions.

**Membership** — `ContentRoomLifecycle.ts`, extracted from `server.ts` (which is untestable — it imports the whole app). `joinPost` runs the real read ACL via a new `postHydrationService.canViewerReadPostId`, reusing hydration's own projection, viewer context and predicate rather than adding a second visibility rule, and refusing a blocked author to match hydration. The Oxy client is built from the socket's own handshake token, so blocks are read under the viewer's identity. **Fails closed** — an unanswerable ACL is not a yes.

`MAX_POST_ROOMS_PER_SOCKET = 20`, evicting oldest: the rate limiter caps join *rate*, not total membership, so a client joining forever previously accumulated unbounded rooms on every task. Disconnect cleanup is Socket.IO's adapter — no second authority added.

**Emits** — `postEngagementBroadcast.ts`, wired at like/unlike (likes + downvotes, only when `result.changed`), save/unsave, and the existing boost/unboost/reply sites, now routed through the same helper. Reply needed `{new:true}` added; it had no readable count at all.

**Frontend** — `p/[id].tsx` joins on mount, leaves on unmount. Feeds deliberately do not: a screenful would be a room each. `socketService` re-asserts rooms on reconnect — membership is server-side state a drop destroys, and without that a screen surviving a reconnect showed frozen counts forever, silently.

## The ~270 lines of merge logic were wrong, not merely unused

Delta-shaped thinking wearing an authoritative-count coat:

- **Monotonic guards** (`if (currentLikes >= newCount) return prev`) refused any authoritative count *lower* than the rendered one — a like-then-unlike froze the post at the higher number for as long as it stayed on screen.
- **`latestByType` then apply-each-in-turn** made the final value depend on `Map` insertion order, not timestamps.

Replaced with a per-**counter** fold, newest wins. Not per-event-type: a like and a boost move different numbers, so one winner overall would drop a counter. `viewerState` is never touched by a room event.

`save`/`unsave` handling was **100% dead in both branches** and unfixable as written — `shouldIgnoreEcho` suppresses any event whose `actorId` is the viewer, so the `data.userId === viewerId` branch could never run. Since save events now carry no actor at all (a room must not learn who bookmarked a post), only the public `savesCount` is applied.

**Self-echo:** discarded on `actorId === currentUserId`. But the stronger guarantee is structural — a double-count is impossible regardless, because the payload is a total, not an increment. The guard only prevents a flicker.

## Verification

```
backend    380 files / 3973 tests pass
frontend   119 suites / 1035 tests pass
typecheck  shared-types, backend, mcp, frontend — clean
```

**End-to-end round trip**, 10 tests: a real `socket.io` server on a real port, a real client through the real `socketService`, a real `postsStore`. A joins, an event lands, the store converges to the server's number. Plus: nothing for a post never joined, the fold across and within batches, a hidden counter leaving the rendered value alone, `viewerState` untouched, re-join after a real transport drop.

**8 mutations**, each restored and md5-verified: server never calls `socket.join`; ACL forced true; broadcaster ignores author privacy; echo guard disabled; counts applied as deltas; fold keeps the oldest; client `joinPost` never emits; monotonic climb-only guard.

**Two of those initially did not fire, and both were the test's fault** — the echo-guard mutation passed because the payload equalled the optimistic value, so it could not distinguish; the climb-only mutation passed because both events shared one debounce window. Both tests were rewritten and re-run. Reporting it because the first pass of that table would have been a false green.

**One real bug found by its own test:** `leavePost` deleted the pending-join entry but did not cancel the in-flight join, so opening and immediately closing a post left the viewer in a room they had left.

## Dependency

`socket.io` added to `packages/frontend` devDependencies — **one line** in `bun.lock`, because the backend already declares it and bun hoists it. The frontend was resolving it undeclared; this closes that. Adding `socket.io-client` to the backend instead was tried and backed out: it re-hoisted `debug` and produced a 111-line diff.

## Deliberately not done

- **Federated inbound engagement does not broadcast.** A Mastodon like goes through `materializeEngagementRelationship`, which has 8 call sites including a bulk backfill — emitting from inside it would fire per row. Doing it right means returning counts and letting each caller decide. **The most valuable follow-up**, since "someone on Mastodon liked it" is exactly the case this feature is for.
- **Cross-device `isSaved` sync** — cannot work through a room without publishing who bookmarked a post. Needs the actor's own `user:<id>` room and an echo-guard exemption. Different feature, different privacy question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)