### PR TITLE
fix(deploy): stop reverting a good release over somebody else's outage

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -21,6 +21,16 @@ AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-}"
 AWS_PARTITION="${AWS_PARTITION:-aws}"
 POST_DEPLOY_SMOKE_SCRIPT="${POST_DEPLOY_SMOKE_SCRIPT:-}"
 POST_DEPLOY_TASK_COMMAND_JSON="${POST_DEPLOY_TASK_COMMAND_JSON:-}"
+# Exit code a smoke script uses to say "this failed, and rolling back cannot fix
+# it" — a check that crosses a boundary this deploy does not own (a CDN in front
+# of the origin, another service the route consults). Reverting the image for one
+# of those trades a working deployment for an outage somebody else is already
+# fixing, so the release stands and the job goes red instead.
+#
+# Every OTHER non-zero code still rolls back, so a smoke script that does not opt
+# into the protocol keeps the previous all-or-nothing behaviour.
+SMOKE_NO_ROLLBACK_EXIT=75
+smoke_reported_external_failure=false
 DEPLOY_HEAD_GUARD_SCRIPT="${DEPLOY_HEAD_GUARD_SCRIPT:-.github/scripts/require-current-main.sh}"
 
 if ! [[ "$MAX_WAIT_SECS" =~ ^[0-9]+$ ]] || (( MAX_WAIT_SECS < 1 )); then
@@ -508,7 +518,16 @@ echo "ECS rollout reached a healthy steady state at $new_task_definition"
 
 if [[ -n "$POST_DEPLOY_SMOKE_SCRIPT" ]]; then
   echo "Running post-deploy smoke checks with $POST_DEPLOY_SMOKE_SCRIPT"
-  if ! bash "$POST_DEPLOY_SMOKE_SCRIPT"; then
+  smoke_exit=0
+  bash "$POST_DEPLOY_SMOKE_SCRIPT" || smoke_exit=$?
+  if (( smoke_exit == SMOKE_NO_ROLLBACK_EXIT )); then
+    # The smoke script attributed every failure to something outside the image.
+    # The release keeps going — including the reconciliation task below, which
+    # would otherwise be skipped over a fault it has nothing to do with — and the
+    # job fails at the end so the failure is still paged rather than swallowed.
+    echo "::error::Post-deploy smoke checks failed only checks that a rollback cannot repair. $APP stays on $new_task_definition; investigate the dependency named above."
+    smoke_reported_external_failure=true
+  elif (( smoke_exit != 0 )); then
     echo "::error::Post-deploy smoke checks failed."
     if rollback_service; then
       echo "::warning::Rollback completed after smoke failure."
@@ -529,6 +548,11 @@ if [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; then
     fi
     exit 1
   fi
+fi
+
+if [[ "$smoke_reported_external_failure" == "true" ]]; then
+  echo "::error::$APP is deployed and live at $new_task_definition, but its post-deploy smoke checks are still failing on a dependency. Nothing was rolled back; this release needs a human."
+  exit 1
 fi
 
 echo "Deployed $APP at $new_task_definition"

--- a/.github/scripts/smoke-mention.sh
+++ b/.github/scripts/smoke-mention.sh
@@ -1,12 +1,55 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -Eeuo pipefail
+
+# Post-deploy smoke checks for the Mention backend.
+#
+# Every check declares a FAILURE CLASS, because the two classes earn different
+# remedies from `.github/scripts/deploy-ecs-image.sh`:
+#
+#   hermetic  — the image just deployed is the only thing in the response path
+#               that this pipeline changed, so a failure means "put the previous
+#               image back". Both hermetic checks are served from
+#               `api.mention.earth`, which is a DNS-only record straight to the
+#               ALB: no Cloudflare, and no other service's availability decides
+#               the answer.
+#
+#   dependent — the check crosses a boundary this deploy does not own: the three
+#               apex checks go through Cloudflare (`mention.earth` is a proxied
+#               record), and the federation routes behind them consult oxy-api
+#               for fediverse-sharing consent. A failure here can indict
+#               something a rollback cannot repair, so it PAGES — the job goes
+#               red — while the image just deployed stays live.
+#
+# The class is a required argument of `request`, not a default, so a check
+# cannot land uncategorised: naming no class, or a class that is not one of the
+# two, stops the script.
+#
+# Exit protocol, consumed by `deploy-ecs-image.sh`:
+#
+#   0   every check passed (possibly with advisories)
+#   1   at least one HERMETIC check failed         → roll back
+#   75  only DEPENDENT checks failed (EX_TEMPFAIL) → page, do not roll back
+#
+# Every check runs even after an earlier one fails. Stopping at the first
+# failure would let a dependent failure hide a hermetic one behind it and
+# suppress the rollback that hermetic failure exists to trigger.
 
 API_ORIGIN="${API_ORIGIN:-https://api.mention.earth}"
 WEB_ORIGIN="${WEB_ORIGIN:-https://mention.earth}"
 smoke_dir="$(mktemp -d)"
 temporary_root="$(realpath "${TMPDIR:-/tmp}")"
 smoke_dir="$(realpath "$smoke_dir")"
+
+readonly ROLLBACK_EXIT=1
+readonly NO_ROLLBACK_EXIT=75
+
+declare -A check_class=()
+declare -A check_failed=()
+declare -A permitted_status=()
+declare -A permitted_reason=()
+hermetic_failures=0
+dependent_failures=0
 
 cleanup_smoke_dir() {
   if [[ "$smoke_dir" == "$temporary_root/"* && -d "$smoke_dir" ]]; then
@@ -17,10 +60,38 @@ cleanup_smoke_dir() {
 }
 trap cleanup_smoke_dir EXIT
 
+# An unexpected abort in this script — a missing tool, a typo, a bad path — says
+# nothing about the image that was just deployed, so it must never revert one.
+# Explicit `exit` statements do not reach this trap, so the two classified exit
+# codes above still mean exactly what they say.
+trap 'echo "::error::Smoke script aborted unexpectedly at line $LINENO; refusing to attribute that to the deployed image."; exit "$NO_ROLLBACK_EXIT"' ERR
+
+# `request <hermetic|dependent> <name> [curl args...] <url>` — records the
+# check's failure class under its name and publishes the HTTP status in
+# `http_status` for the expectations that follow. It sets a global rather than
+# echoing the status because a `$(...)` capture would run the whole function in
+# a subshell, where the class it just recorded would be discarded.
+#
+# A transport failure (DNS, TCP, TLS, timeout) publishes curl's own `000`, which
+# no expectation matches, so it fails that check under that check's class
+# instead of aborting the run under none.
+http_status=""
 request() {
-  local name="$1"
-  shift
-  curl \
+  local class="$1"
+  local name="$2"
+  shift 2
+
+  case "$class" in
+    hermetic | dependent) ;;
+    *)
+      echo "::error::Check $name declared an unknown failure class '$class' (expected hermetic or dependent)."
+      exit "$NO_ROLLBACK_EXIT"
+      ;;
+  esac
+  check_class["$name"]="$class"
+
+  local curl_exit=0
+  http_status="$(curl \
     --silent \
     --show-error \
     --max-time 20 \
@@ -31,51 +102,136 @@ request() {
     --dump-header "$smoke_dir/$name.headers" \
     --output "$smoke_dir/$name.body" \
     --write-out '%{http_code}' \
-    "$@"
+    "$@")" || curl_exit=$?
+  if (( curl_exit != 0 )); then
+    echo "::notice::$name: curl exited $curl_exit before completing the transfer."
+  fi
+}
+
+# Record the failure against the class its check declared, once per check, so a
+# check that fails two expectations is not counted twice.
+fail_check() {
+  local name="$1"
+  local message="$2"
+  local class="${check_class[$name]:-}"
+
+  if [[ -z "$class" ]]; then
+    echo "::error::Check $name reported a result without declaring a failure class."
+    exit "$NO_ROLLBACK_EXIT"
+  fi
+  if [[ -n "${check_failed[$name]:-}" ]]; then
+    return 0
+  fi
+  check_failed["$name"]=1
+
+  if [[ "$class" == "hermetic" ]]; then
+    hermetic_failures=$((hermetic_failures + 1))
+    echo "::error::$message. This check is hermetic — only the deployed image can cause it, so the deployment will be rolled back."
+  else
+    dependent_failures=$((dependent_failures + 1))
+    echo "::error::$message. This check is dependent — it crosses Cloudflare and/or oxy-api, which a rollback cannot repair, so the deployed image stays live and this needs a human."
+  fi
+}
+
+# Register a status a check may legitimately answer INSTEAD of the expected one,
+# with the reason it is legitimate. The answer is still constrained to that set
+# and still has to satisfy every other expectation; the alternative is reported
+# as a warning, never silently accepted.
+permit_alternative() {
+  permitted_status["$1"]="$2"
+  permitted_reason["$1"]="$3"
 }
 
 expect_status() {
-  local actual="$1"
-  local expected="$2"
-  local name="$3"
-  if [[ "$actual" != "$expected" ]]; then
-    echo "::error::$name returned HTTP $actual (expected $expected)."
-    exit 1
+  local name="$1"
+  local actual="$2"
+  local expected="$3"
+
+  if [[ "$actual" == "$expected" ]]; then
+    return 0
   fi
+  if [[ -n "${permitted_status[$name]:-}" && "$actual" == "${permitted_status[$name]}" ]]; then
+    echo "::warning::$name returned HTTP $actual instead of $expected. ${permitted_reason[$name]}"
+    return 0
+  fi
+  fail_check "$name" "$name returned HTTP $actual (expected $expected)"
 }
 
 expect_json_response() {
   local name="$1"
+
+  # A check that already failed its status has nothing useful to say about its
+  # content type, and on a transport failure there are no headers to read.
+  if [[ -n "${check_failed[$name]:-}" ]]; then
+    return 0
+  fi
   if ! grep -Eiq '^content-type: *application/(activity\+json|ld\+json|json)' \
     "$smoke_dir/$name.headers"; then
-    echo "::error::$name did not return a JSON/ActivityPub content type."
-    exit 1
+    fail_check "$name" "$name did not return a JSON/ActivityPub content type"
   fi
 }
 
-status="$(request readiness "$API_ORIGIN/health/ready")"
-expect_status "$status" 200 "readiness"
+# --- hermetic: api.mention.earth, DNS-only to the ALB ------------------------
 
-status="$(request anonymous-feed "$API_ORIGIN/feed/mtn?descriptor=for_you&limit=1")"
-expect_status "$status" 200 "anonymous feed"
+# Readiness is the deployed process describing itself. The rollout already
+# reached a healthy steady state to get here, so a 503 now is the new image
+# degrading after the fact.
+request hermetic readiness "$API_ORIGIN/health/ready"
+expect_status readiness "$http_status" 200
 
-status="$(request webfinger "$WEB_ORIGIN/.well-known/webfinger?resource=acct:__smoke_missing__@mention.earth")"
-expect_status "$status" 404 "webfinger"
+# The anonymous feed is the widest read path in the app. It is hermetic despite
+# touching Oxy: author hydration soft-fails to a degraded summary rather than
+# throwing, so an oxy-api outage costs display names here, not a 5xx.
+request hermetic anonymous-feed "$API_ORIGIN/feed/mtn?descriptor=for_you&limit=1"
+expect_status anonymous-feed "$http_status" 200
+
+# --- dependent: mention.earth, a Cloudflare-proxied record -------------------
+
+request dependent webfinger "$WEB_ORIGIN/.well-known/webfinger?resource=acct:__smoke_missing__@mention.earth"
+expect_status webfinger "$http_status" 404
 expect_json_response webfinger
 
-status="$(request actor \
+request dependent actor \
   --header 'Accept: application/activity+json' \
-  "$WEB_ORIGIN/ap/users/__smoke_missing__")"
-expect_status "$status" 404 "ActivityPub actor"
+  "$WEB_ORIGIN/ap/users/__smoke_missing__"
+expect_status actor "$http_status" 404
 expect_json_response actor
 
-status="$(request inbox \
+# The inbox POST is the one check no GET can stand in for. The apex ActivityPub
+# ENDPOINT paths have to be served directly — never 301/302'd, never swallowed
+# by the SPA proxy — because a redirect there kills ALL inbound federation while
+# every GET keeps working, so the profile still renders and looks healthy. What
+# this check is really asserting is that the AP router itself answered: a 404
+# and a 401 both prove that, while a redirect, an HTML body from the SPA
+# fallback, or a 5xx do not.
+#
+# 401 is therefore a permitted answer rather than a failure. The route 404s for
+# a consent state of 'disabled' or 'unknown-user'; when the oxy-api lookup
+# behind that read fails it returns 'unavailable', which deliberately does NOT
+# 404 — a 4xx makes Mastodon drop deliveries permanently — so the request falls
+# through to signature verification and this unsigned body earns its 401. On
+# 2026-08-02 oxy-api was scaled to zero tasks for ~12 minutes, the inbox
+# answered 401, and this check reverted a perfectly good deploy.
+permit_alternative inbox 401 \
+  "401 means the fediverse-sharing consent read returned 'unavailable' — the oxy-api lookup behind it failed — which the inbox route is specified to pass through rather than 404. The AP router still answered, so the endpoint is mounted and reachable; check oxy-api's health."
+request dependent inbox \
   --request POST \
   --header 'Accept: application/activity+json' \
   --header 'Content-Type: application/activity+json' \
   --data '{}' \
-  "$WEB_ORIGIN/ap/users/__smoke_missing__/inbox")"
-expect_status "$status" 404 "ActivityPub inbox"
+  "$WEB_ORIGIN/ap/users/__smoke_missing__/inbox"
+expect_status inbox "$http_status" 404
 expect_json_response inbox
+
+# --- verdict -----------------------------------------------------------------
+
+if (( hermetic_failures > 0 )); then
+  echo "::error::Mention post-deploy smoke checks failed $hermetic_failures hermetic check(s); rolling the deployment back."
+  exit "$ROLLBACK_EXIT"
+fi
+if (( dependent_failures > 0 )); then
+  echo "::error::Mention post-deploy smoke checks failed $dependent_failures dependent check(s) and no hermetic ones. The deployed image is live and will NOT be rolled back — investigate Cloudflare and oxy-api."
+  exit "$NO_ROLLBACK_EXIT"
+fi
 
 echo "Mention post-deploy smoke checks passed."

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -243,6 +243,7 @@ run_release() {
   local inject_task_secret="${6:-false}"
   local service_desired_count="${7:-1}"
   local rollout_scenario="${8:-healthy}"
+  local smoke_exit_code="${9:-0}"
   local case_directory="$test_directory/$case_name"
   local output_file="$case_directory/output.log"
   local smoke_script="$case_directory/smoke.sh"
@@ -260,11 +261,14 @@ run_release() {
   export DEPLOY_TEST_SERVICE_DESIRED_COUNT
   export DEPLOY_TEST_ROLLOUT_SCENARIO
 
-  # The generated smoke fixture expands this variable when it runs.
+  # The generated smoke fixture expands DEPLOY_TEST_LOG when it runs; its exit
+  # code is the entire interface deploy-ecs-image.sh reads, so each case picks
+  # one. 75 is the "failed, but a rollback cannot repair it" code.
   # shellcheck disable=SC2016
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'printf "smoke\n" >>"$DEPLOY_TEST_LOG"' \
+    "exit $smoke_exit_code" \
     >"$smoke_script"
 
   local -a release_environment=(
@@ -404,6 +408,50 @@ diff -u \
 grep -F \
   "completed at desiredCount=0; refusing to accept a zero-task steady state" \
   "$test_directory/completed-zero-deployment/output.log" \
+  >/dev/null
+
+# A smoke failure the smoke script attributes to the new image rolls the service
+# back, and stops the release before the reconciliation task runs.
+run_release smoke-hermetic-failure false false false 0 false 1 healthy 1
+printf '%s\n' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
+  >"$test_directory/smoke-hermetic-failure/expected.log"
+diff -u \
+  "$test_directory/smoke-hermetic-failure/expected.log" \
+  "$test_directory/smoke-hermetic-failure/aws.log"
+grep -F \
+  "Post-deploy smoke checks failed." \
+  "$test_directory/smoke-hermetic-failure/output.log" \
+  >/dev/null
+
+# A smoke failure the smoke script attributes to something outside the new image
+# (exit 75) must NOT roll back: the service stays on the new task definition, the
+# release finishes its reconciliation task, and the job still fails so the
+# failure is paged rather than swallowed.
+run_release smoke-no-rollback-failure false false false 0 false 1 healthy 75
+printf '%s\n' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  reconcile \
+  >"$test_directory/smoke-no-rollback-failure/expected.log"
+diff -u \
+  "$test_directory/smoke-no-rollback-failure/expected.log" \
+  "$test_directory/smoke-no-rollback-failure/aws.log"
+if grep -qF \
+  'service:arn:aws:ecs:test:task-definition/mention-test:1:' \
+  "$test_directory/smoke-no-rollback-failure/aws.log"; then
+  echo "A smoke failure that cannot be repaired by a rollback rolled back anyway." >&2
+  exit 1
+fi
+grep -F \
+  "stays on arn:aws:ecs:test:task-definition/mention-test:2" \
+  "$test_directory/smoke-no-rollback-failure/output.log" \
+  >/dev/null
+grep -F \
+  "Nothing was rolled back; this release needs a human." \
+  "$test_directory/smoke-no-rollback-failure/output.log" \
   >/dev/null
 
 echo "Deployment script transaction tests passed."

--- a/.github/scripts/test-smoke-mention.sh
+++ b/.github/scripts/test-smoke-mention.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Drives .github/scripts/smoke-mention.sh against a stubbed `curl` so the
+# classification it encodes is testable without a deployment.
+#
+# What is stubbed: `curl` only. Every scenario names, per check, the HTTP status
+# the origin answers, the content type it answers with, and whether curl reaches
+# the origin at all. The script under test is otherwise unmodified — it computes
+# its own verdict and its own exit code, which is the thing being asserted,
+# because that exit code is the entire interface `deploy-ecs-image.sh` uses to
+# decide whether to roll a deployment back.
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+smoke_script="$repository_root/.github/scripts/smoke-mention.sh"
+test_directory="$(mktemp -d)"
+temporary_root="$(realpath "${TMPDIR:-/tmp}")"
+test_directory="$(realpath "$test_directory")"
+
+cleanup_test_directory() {
+  if [[ "$test_directory" == "$temporary_root/"* && -d "$test_directory" ]]; then
+    rm -rf -- "$test_directory"
+  else
+    echo "Refusing to remove unexpected test directory: $test_directory" >&2
+  fi
+}
+trap cleanup_test_directory EXIT
+
+# Every check this script knows about, in the order smoke-mention.sh runs them.
+# The order is asserted on every scenario, which is what proves a failing check
+# does not stop the ones after it.
+readonly EXPECTED_CHECK_ORDER='readiness
+anonymous-feed
+webfinger
+actor
+inbox'
+
+# Stubbed curl. Derives which check is calling from the `--dump-header` path
+# smoke-mention.sh passes, then answers from the scenario's environment.
+curl() {
+  local dump_header="" output="" previous="" argument name key status content_type curl_exit
+  for argument in "$@"; do
+    case "$previous" in
+      --dump-header) dump_header="$argument" ;;
+      --output) output="$argument" ;;
+    esac
+    previous="$argument"
+  done
+
+  if [[ -z "$dump_header" ]]; then
+    echo "Stubbed curl received no --dump-header; cannot identify the check." >&2
+    return 2
+  fi
+  name="$(basename "$dump_header" .headers)"
+  key="${name//-/_}"
+
+  printf '%s\n' "$name" >>"$SMOKE_TEST_CALL_LOG"
+
+  local status_variable="SMOKE_TEST_STATUS_${key}"
+  local content_type_variable="SMOKE_TEST_CT_${key}"
+  local curl_exit_variable="SMOKE_TEST_CURL_EXIT_${key}"
+  status="${!status_variable:-}"
+  content_type="${!content_type_variable:-application/json; charset=utf-8}"
+  curl_exit="${!curl_exit_variable:-0}"
+
+  if [[ -z "$status" ]]; then
+    echo "Stubbed curl has no configured status for check $name." >&2
+    return 2
+  fi
+
+  if (( curl_exit != 0 )); then
+    # curl writes an empty header dump and reports 000 when it never completes
+    # a transfer — reproduce both, since the script reads both.
+    : >"$dump_header"
+    [[ -n "$output" ]] && : >"$output"
+    printf '000\n'
+    return "$curl_exit"
+  fi
+
+  printf 'HTTP/2 %s\r\ncontent-type: %s\r\n\r\n' "$status" "$content_type" >"$dump_header"
+  [[ -n "$output" ]] && printf '{}' >"$output"
+  printf '%s\n' "$status"
+}
+export -f curl
+
+# run_scenario <name> <expected exit code> [VAR=value ...]
+run_scenario() {
+  local scenario="$1"
+  local expected_exit="$2"
+  shift 2
+
+  local scenario_directory="$test_directory/$scenario"
+  mkdir -p "$scenario_directory"
+
+  local -a scenario_environment=(
+    "SMOKE_TEST_CALL_LOG=$scenario_directory/calls.log"
+    SMOKE_TEST_STATUS_readiness=200
+    SMOKE_TEST_STATUS_anonymous_feed=200
+    SMOKE_TEST_STATUS_webfinger=404
+    SMOKE_TEST_STATUS_actor=404
+    SMOKE_TEST_STATUS_inbox=404
+    "$@"
+  )
+
+  : >"$scenario_directory/calls.log"
+  local actual_exit=0
+  env "${scenario_environment[@]}" bash "$smoke_script" \
+    >"$scenario_directory/output.log" 2>&1 || actual_exit=$?
+
+  if [[ "$actual_exit" != "$expected_exit" ]]; then
+    echo "Scenario $scenario exited $actual_exit (expected $expected_exit)." >&2
+    sed -n '1,80p' "$scenario_directory/output.log" >&2
+    return 1
+  fi
+
+  # Vacuity floor: a scenario that silently skipped checks would otherwise pass
+  # by never exercising the assertion it was written for.
+  if [[ "$(<"$scenario_directory/calls.log")" != "$EXPECTED_CHECK_ORDER" ]]; then
+    echo "Scenario $scenario did not run every check in order:" >&2
+    cat "$scenario_directory/calls.log" >&2
+    return 1
+  fi
+}
+
+expect_output() {
+  local scenario="$1"
+  local needle="$2"
+  if ! grep -qF "$needle" "$test_directory/$scenario/output.log"; then
+    echo "Scenario $scenario output is missing: $needle" >&2
+    sed -n '1,80p' "$test_directory/$scenario/output.log" >&2
+    exit 1
+  fi
+}
+
+refute_output() {
+  local scenario="$1"
+  local needle="$2"
+  if grep -qF "$needle" "$test_directory/$scenario/output.log"; then
+    echo "Scenario $scenario output should not contain: $needle" >&2
+    sed -n '1,80p' "$test_directory/$scenario/output.log" >&2
+    exit 1
+  fi
+}
+
+# A healthy production answers exactly this, and the script must stay silent.
+run_scenario healthy 0
+expect_output healthy "Mention post-deploy smoke checks passed."
+refute_output healthy "::error::"
+refute_output healthy "::warning::"
+
+# The 2026-08-02 regression: oxy-api was unreachable, the consent read returned
+# 'unavailable', the inbox fell through to signature verification and answered
+# 401 — a documented, permitted answer. It must not fail the run at all.
+run_scenario inbox-401-during-oxy-outage 0 SMOKE_TEST_STATUS_inbox=401
+expect_output inbox-401-during-oxy-outage "::warning::inbox returned HTTP 401 instead of 404"
+expect_output inbox-401-during-oxy-outage "Mention post-deploy smoke checks passed."
+refute_output inbox-401-during-oxy-outage "::error::"
+
+# The permitted 401 is a permitted STATUS, not a blanket pass: an HTML body at
+# that status means something other than the AP router answered.
+run_scenario inbox-401-but-html 75 \
+  SMOKE_TEST_STATUS_inbox=401 \
+  "SMOKE_TEST_CT_inbox=text/html; charset=utf-8"
+expect_output inbox-401-but-html "inbox did not return a JSON/ActivityPub content type"
+
+# Anything outside the permitted set is still a failure — loud, but not a
+# rollback, because the apex path it crosses is not this image's to fix.
+run_scenario inbox-500 75 SMOKE_TEST_STATUS_inbox=500
+expect_output inbox-500 "inbox returned HTTP 500 (expected 404)"
+expect_output inbox-500 "This check is dependent"
+expect_output inbox-500 "will NOT be rolled back"
+
+# The regression the inbox check exists to catch: an apex AP endpoint path
+# answering with a redirect instead of being served directly.
+run_scenario actor-redirected 75 SMOKE_TEST_STATUS_actor=302
+expect_output actor-redirected "actor returned HTTP 302 (expected 404)"
+
+# The SPA fallback shape — right status, wrong server answering.
+run_scenario webfinger-html 75 "SMOKE_TEST_CT_webfinger=text/html; charset=utf-8"
+expect_output webfinger-html "webfinger did not return a JSON/ActivityPub content type"
+
+# Hermetic failures still roll back. This is the case a change like this one is
+# most likely to break, so it is asserted from both directions below.
+run_scenario readiness-503 1 SMOKE_TEST_STATUS_readiness=503
+expect_output readiness-503 "readiness returned HTTP 503 (expected 200)"
+expect_output readiness-503 "This check is hermetic"
+expect_output readiness-503 "rolling the deployment back"
+
+run_scenario feed-500 1 SMOKE_TEST_STATUS_anonymous_feed=500
+expect_output feed-500 "anonymous-feed returned HTTP 500 (expected 200)"
+expect_output feed-500 "rolling the deployment back"
+
+# A transport failure to the hermetic origin is a rollback, not an advisory:
+# curl reports 000, which no expectation matches, and the check's own class
+# decides the remedy.
+run_scenario feed-unreachable 1 \
+  SMOKE_TEST_CURL_EXIT_anonymous_feed=7 \
+  SMOKE_TEST_STATUS_anonymous_feed=200
+expect_output feed-unreachable "curl exited 7"
+expect_output feed-unreachable "anonymous-feed returned HTTP 000 (expected 200)"
+expect_output feed-unreachable "rolling the deployment back"
+
+# A dependent failure must never mask a hermetic one. Both fail here; the run
+# has to end in a rollback, and the dependent failure has to be reported too.
+run_scenario hermetic-outranks-dependent 1 \
+  SMOKE_TEST_STATUS_readiness=503 \
+  SMOKE_TEST_STATUS_webfinger=500
+expect_output hermetic-outranks-dependent "readiness returned HTTP 503 (expected 200)"
+expect_output hermetic-outranks-dependent "webfinger returned HTTP 500 (expected 404)"
+expect_output hermetic-outranks-dependent "rolling the deployment back"
+refute_output hermetic-outranks-dependent "will NOT be rolled back"
+
+echo "Mention smoke check classification tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           bash -n .github/scripts/*.sh
           bash .github/scripts/test-deploy-ecs-image.sh
+          bash .github/scripts/test-smoke-mention.sh
           bun .github/scripts/test-runtime-image-audit.mjs
 
   # Ported from bluesky-social/social-app 513a188a2 ("Add a GitHub Action


### PR DESCRIPTION
## What happened

A deploy rolled itself back on 2026-08-02 because the post-deploy smoke check asserted **404** on the ActivityPub inbox and got **401**. Nothing was wrong with the release.

Someone ran `update-service --desired-count 0` on **oxy-api**. `api.oxy.so` served zero tasks for ~12 minutes and the ALB emitted **1,606 503s**. Mention logged `[FediverseSharing] Oxy lookup failed, treating as unavailable` at 03:48:09Z, inside the failing deploy job.

That fail-open is deliberate: a 4xx makes Mastodon drop deliveries permanently, so `fediverseSharing.ts` maps any non-404 failure to `'unavailable'`, which falls through to `handleInbox` → `401 Invalid signature`. **The check was asserting a status the code it probes explicitly permits.**

## The fix is not "accept 401 there"

That was the presenting symptom. The real problem is that `deploy-ecs-image.sh` rolled back on **any** smoke failure, including checks that cannot fail because of the new image.

Each check now declares its class, verified by reading the handlers rather than trusting the docs:

| check | origin | class | why |
|---|---|---|---|
| `/health/ready` | api → ALB | **hermetic** | runtime phase + migrations + mongo — all properties of the process just deployed |
| `/feed/mtn?descriptor=for_you` | api → ALB | **hermetic** | touches Oxy but cannot be broken by it: `resolveOxyUserSummaryMisses` catches the bulk failure *and* each per-id fallback, so an outage costs display names, not a 5xx |
| webfinger | apex → **Cloudflare** | dependent | `resolveOxyUser` swallows both lookups and returns `null`, so it 404s through an Oxy outage — CF is the only third party that can change the answer |
| AP actor | apex → **Cloudflare** | dependent | same |
| AP inbox POST | apex → CF **+ oxy-api** | dependent, 401 permitted | the one route that reads consent by username without an already-resolved user |

`getent hosts` confirms the split: `mention.earth` resolves to Cloudflare; `api.mention.earth` and `mcp.mention.earth` go straight to the ALB.

**Class is a required argument.** A check with none, or a bad one, stops the script — it is not a default anyone has to remember. `permit_alternative inbox 401 "<reason>"` sits directly above the check it applies to, so the exception is at the call site rather than buried in a status branch.

**Exit protocol:** `0` pass · `1` a hermetic check failed → roll back · `75` (`EX_TEMPFAIL`) only dependent checks failed → **no rollback, job still red**. Every other non-zero still rolls back, so `smoke-mcp.sh` (both its checks are hermetic) is unchanged.

Checks no longer stop at the first failure — exiting early would let a dependent failure hide a hermetic one behind it and suppress the rollback that hermetic failure exists to trigger. There is a test for exactly that.

## Loud, not advisory

A dependent failure fails the job red with an `::error::` naming the check and its class, ending:

> `$APP is deployed and live at <task-def>, but its post-deploy smoke checks are still failing on a dependency. Nothing was rolled back; this release needs a human.`

Only the *permitted* 401 is quiet — a `::warning::` and a green job — because it is a specified answer, not a failure. Those are two different things and they are implemented as two; collapsing them would have made every dependent check advisory-only.

## The inbox check is kept, and now asserts the right thing

It has no incident behind it (one commit, a batch hardening pass), but it earns its place: it is the only check that can catch an apex AP **endpoint** being 301/302'd or swallowed by `apexFrontendProxy` — the failure `AGENTS.md` flags as CRITICAL, which kills all inbound federation while every GET keeps working and the profile still renders. A GET-only suite is blind to it.

So it now asserts **that the AP router answered at all**. 404 and 401 both prove that; a redirect, an HTML body from the SPA fallback, or a 5xx do not. The content-type assertion still runs on the 401 path, so the permitted status is not a blanket pass.

## Verification

No harness existed for the smoke scripts, so there is one now: **`test-smoke-mention.sh`**, stubbing only `curl`, with 10 scenarios asserting the script's own verdict and exit code — healthy; the 2026-08-02 case (inbox 401 → **0**); inbox 401 with `text/html` → 75; inbox 500 → 75; actor 302 → 75; webfinger HTML → 75; readiness 503 → **1**; feed 500 → **1**; feed unreachable → **1**; readiness 503 + webfinger 500 → **1**. Vacuity floor: every scenario asserts all five checks ran, in order.

`test-deploy-ecs-image.sh` gains the two cases that matter: exit 1 → `update-service` back to `:1`, reconciliation skipped; exit 75 → no second `update-service`, reconciliation *does* run, job fails naming the task definition it stayed on.

**Seven mutations, each caught and each naming its scenario** — including the one that answers "is rollback still reachable": making every smoke failure skip rollback → `Expected smoke-hermetic-failure to fail`. Also: dropping the permitted 401; reclassifying readiness as dependent; exiting at first failure; a vacuous content-type assertion; 75 rolling back anyway; 75 not failing the job.

Both suites wired into CI. The rewritten script was also run **against live production with real curl** — five passes, exit 0 — which covers the plumbing the stub deliberately does not: the `http_status` global, the class map surviving out of a subshell, and the ERR trap.

An `ERR` trap converts an *unexpected* abort in the script itself (missing tool, typo) to 75: a broken smoke script must not revert a good deploy. Verified by probe that `exit 1` does not reach an ERR trap, so the classified codes still mean what they say.

## Judgement call worth flagging

The three apex checks are now all dependent, so a genuine "apex AP routing broke" regression **pages instead of auto-reverting**. That follows from Cloudflare sitting in the path — a revert would not fix a CF-side problem anyway — but it is a real narrowing, and the remedy for that class of bug is now a human reading a red deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)