### PR TITLE
fix(deploy): let the SSM path validator match a hyphen

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -64,7 +64,7 @@ if ! jq -e '
     (
       .value
       | type == "string" and
-        test("^arn:aws(-[a-z]+)?:ssm:[a-z0-9-]+:[0-9]{12}:parameter/[A-Za-z0-9_.\\-/]+$")
+        test("^arn:aws(-[a-z]+)?:ssm:[a-z0-9-]+:[0-9]{12}:parameter/[A-Za-z0-9_./-]+$")
     )
   )
 ' <<<"$TASK_SECRET_OVERRIDES_JSON" >/dev/null; then
@@ -349,8 +349,13 @@ if [[ -n "$INTERNAL_METRICS_PARAMETER" ]]; then
       echo "::error::AWS_ACCOUNT_ID must be a 12-digit account id when INTERNAL_METRICS_PARAMETER is a parameter name."
       exit 1
     fi
+    # The hyphen is LAST on purpose. This is a POSIX bracket expression, where a
+    # backslash is an ordinary character rather than an escape, so the `\-/` that
+    # reads as an escaped hyphen in PCRE is really a reversed `\`-to-`/` range and
+    # the class then matches no hyphen at all. Every `/oxy/<app>/...` parameter
+    # path whose app name contains one was silently rejected.
     if [[ ! "$AWS_PARTITION" =~ ^aws(-[a-z]+)?$ ||
-          ! "$INTERNAL_METRICS_PARAMETER" =~ ^/[A-Za-z0-9_.\-/]+$ ]]; then
+          ! "$INTERNAL_METRICS_PARAMETER" =~ ^/[A-Za-z0-9_./-]+$ ]]; then
       echo "::error::AWS partition or INTERNAL_METRICS_PARAMETER name is invalid."
       exit 1
     fi

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -19,6 +19,10 @@ trap cleanup_test_directory EXIT
 
 export DEPLOY_TEST_LOG=""
 export DEPLOY_TEST_EXPECT_METRICS_ARN=false
+# The SSM parameter path a case feeds to INTERNAL_METRICS_PARAMETER, and from
+# which the mocked register-task-definition derives the ARN it demands. A case
+# overrides it to cover a path shape the default does not.
+export DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
 export DEPLOY_TEST_TASK_EXIT_CODE=0
 export DEPLOY_TEST_EXPECT_TASK_SECRET_ARN=false
 export DEPLOY_TEST_SERVICE_DESIRED_COUNT=1
@@ -140,16 +144,31 @@ aws() {
           fi
           previous_argument="$argument"
         done
-        jq -e '
+        # The verdict is written to the log rather than left to `set -e`. A
+        # command that fails in the MIDDLE of this function does not abort the
+        # run -- measured, and it holds whether the function is exported or
+        # local -- because the caller consumes it as `v="$(aws ...)"` and only
+        # the function's LAST command reaches that assignment's exit status. An
+        # assertion whose only effect is its own exit status therefore cannot
+        # fail, which is what this one did: pointing it at an ARN no case uses
+        # left the suite green. Logging a distinct token instead puts the
+        # mismatch in the expected.log diff, where it names itself.
+        if jq -e \
+          --arg expected \
+          "arn:aws:ssm:test:123456789012:parameter${DEPLOY_TEST_METRICS_PARAMETER}" \
+          '
           .containerDefinitions[]
           | select(.name == "mention-test")
           | .secrets[]
           | select(
               .name == "INTERNAL_METRICS_TOKEN" and
-              .valueFrom == "arn:aws:ssm:test:123456789012:parameter/oxy/mention/INTERNAL_METRICS_TOKEN"
+              .valueFrom == $expected
             )
-        ' "$input_json" >/dev/null
-        printf 'metrics:arn\n' >>"$DEPLOY_TEST_LOG"
+        ' "$input_json" >/dev/null; then
+          printf 'metrics:arn\n' >>"$DEPLOY_TEST_LOG"
+        else
+          printf 'metrics:arn:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
+        fi
       fi
       if [[ "$DEPLOY_TEST_EXPECT_TASK_SECRET_ARN" == "true" ]]; then
         local previous_argument=""
@@ -162,7 +181,9 @@ aws() {
           fi
           previous_argument="$argument"
         done
-        jq -e '
+        # Same reason as the metrics assertion above: log the verdict, do not
+        # rely on this function's exit status.
+        if jq -e '
           .containerDefinitions[]
           | select(.name == "mention-test")
           | .secrets[]
@@ -170,8 +191,11 @@ aws() {
               .name == "MENTION_MCP_JWT_SECRET" and
               .valueFrom == "arn:aws:ssm:test:123456789012:parameter/oxy/mention-mcp/MENTION_MCP_JWT_SECRET"
             )
-        ' "$input_json" >/dev/null
-        printf 'task-secret:arn\n' >>"$DEPLOY_TEST_LOG"
+        ' "$input_json" >/dev/null; then
+          printf 'task-secret:arn\n' >>"$DEPLOY_TEST_LOG"
+        else
+          printf 'task-secret:arn:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
+        fi
       fi
       printf '%s\n' "arn:aws:ecs:test:task-definition/mention-test:2"
       ;;
@@ -282,7 +306,7 @@ run_release() {
   )
   if [[ "$inject_internal_metrics" == "true" ]]; then
     release_environment+=(
-      INTERNAL_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
+      INTERNAL_METRICS_PARAMETER="$DEPLOY_TEST_METRICS_PARAMETER"
     )
   fi
   if [[ "$inject_task_secret" == "true" ]]; then
@@ -315,6 +339,23 @@ printf '%s\n' \
 diff -u \
   "$test_directory/success/expected.log" \
   "$test_directory/success/aws.log"
+
+# A hyphen in the parameter path is its own case because it is its own bug: the
+# bracket expression validating this name once matched every character EXCEPT a
+# hyphen, so /oxy/mention/... deployed and /oxy/oxy-api/... did not. Mention's
+# own path has no hyphen, which is why nothing here caught it. Keep both.
+DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention-mcp/INTERNAL_METRICS_TOKEN
+run_release hyphenated-metrics-parameter true false true
+DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
+printf '%s\n' \
+  metrics:arn \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  reconcile \
+  >"$test_directory/hyphenated-metrics-parameter/expected.log"
+diff -u \
+  "$test_directory/hyphenated-metrics-parameter/expected.log" \
+  "$test_directory/hyphenated-metrics-parameter/aws.log"
 
 run_release explicit-task-secret true false false 0 true
 printf '%s\n' \


### PR DESCRIPTION
## The bug

`deploy-ecs-image.sh` validates `INTERNAL_METRICS_PARAMETER` with the bracket expression `[A-Za-z0-9_.\-/]`. That is a POSIX bracket expression, not PCRE — **a backslash inside one is an ordinary character**, so `\-/` is a reversed `\`(0x5C)-to-`/`(0x2F) range rather than an escaped hyphen, and the class matches no hyphen at all.

Measured, same bash 5.2, one variable:

```
--- broken class [A-Za-z0-9_.\-/] ---
/oxy/oxy-api/INTERNAL_METRICS_TOKEN   NO MATCH
/oxy/mention/INTERNAL_METRICS_TOKEN   MATCH
--- fixed class [A-Za-z0-9_./-] ---
/oxy/oxy-api/INTERNAL_METRICS_TOKEN   MATCH
/oxy/mention/INTERNAL_METRICS_TOKEN   MATCH
```

Mention has never hit it because its own path is `/oxy/mention/…`. It surfaced porting this script to oxy-api, whose every path is `/oxy/oxy-api/…` (OxyHQServices#760).

## The fix

Hyphen moved to the end of the class, where it is unambiguously a literal to both the shell and a reader. The alternative — escaping it "properly" — is the thing that cannot be done here: there is no escape inside a POSIX bracket expression, which is the whole bug.

The **jq** copy of the same class was *not* broken; Oniguruma does honour `\-`, and Mention's own `/oxy/mention-mcp/…` task-secret ARN has been passing through it. It is normalised to the same idiom anyway, because one file carrying a working spelling next to an identical-looking broken one is how this recurs. A truth table over both forms agrees on every input, including a literal backslash:

```
…parameter/oxy/mention-mcp/X   current=true   hyphen-last=true   AGREE
…parameter/oxy/mention/X       current=true   hyphen-last=true   AGREE
…parameter/oxy/a\b/X           current=false  hyphen-last=false  AGREE
…parameter/oxy/a b/X           current=false  hyphen-last=false  AGREE
…parameter/oxy/oxy-api/TOKEN   current=true   hyphen-last=true   AGREE
arn:aws-cn:…/oxy/oxy-api/X     current=true   hyphen-last=true   AGREE
not-an-arn                     current=false  hyphen-last=false  AGREE
```

## The test that should have caught it, and could not

`hyphenated-metrics-parameter` is a new case covering a hyphenated path alongside the existing plain one (both kept — Mention's real path has no hyphen, so dropping that case would trade one blind spot for another). The expected ARN is now derived from the path the case feeds in, rather than hardcoded in the mock.

While mutation-testing that, the existing assertion turned out to be **unfalsifiable, on `main`, today**:

```
$ # pristine origin/main, expected metrics ARN pointed at a path no case uses
$ bash .github/scripts/test-deploy-ecs-image.sh
Deployment script transaction tests passed.        # exit 0
```

The mocked `aws` ran `jq -e` and ignored its status, relying on `set -e`. But a command failing in the **middle** of a shell function consumed as `v="$(aws …)"` does not abort the run — only the function's last command reaches that assignment's exit status. Reproduced minimally, and it holds whether the function is exported or local, `case`-wrapped or not; a control with the failure as the last command does abort. `jq` was returning 4 the whole time and nothing read it.

Both ARN assertions now log a distinct token, so a mismatch lands in the `expected.log` diff by name.

## Verification

Every claim above is a measurement. Mutation-tested — break it, confirm the suite fails *and names the right thing*, restore, confirm byte-identical (`md5sum -c`):

| mutation | before | after |
|---|---|---|
| expected metrics ARN → `/bogus/NEVER` | **passed** (false green) | fails: `-metrics:arn` / `+metrics:arn:MISMATCH` |
| expected task-secret ARN → `/bogus/NEVER` | **passed** (false green) | fails: `-task-secret:arn` / `+task-secret:arn:MISMATCH` |
| bash bracket class reverted to `[A-Za-z0-9_.\-/]` | n/a (no case covered it) | fails: `Expected hyphenated-metrics-parameter to succeed` + `::error::AWS partition or INTERNAL_METRICS_PARAMETER name is invalid` |

The gate is real: `ci.yml`'s `quality` job runs `bash .github/scripts/test-deploy-ecs-image.sh` on every PR to `main`, so the new case runs here.

Not verified by running a deploy — nothing in this PR changes what Mention deploys, since Mention's own parameter path has no hyphen. It changes what the script would accept for the four repos this is being ported to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)