### PR TITLE
chore(deploy): one deploy script across six repos again

### DIFF
--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -22,7 +22,7 @@ export DEPLOY_TEST_EXPECT_METRICS_ARN=false
 # The SSM parameter path a case feeds to INTERNAL_METRICS_PARAMETER, and from
 # which the mocked register-task-definition derives the ARN it demands. A case
 # overrides it to cover a path shape the default does not.
-export DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
+export DEPLOY_TEST_METRICS_PARAMETER=/oxy/sampleapp/INTERNAL_METRICS_TOKEN
 export DEPLOY_TEST_TASK_EXIT_CODE=0
 export DEPLOY_TEST_EXPECT_TASK_SECRET_ARN=false
 export DEPLOY_TEST_SERVICE_DESIRED_COUNT=1
@@ -33,7 +33,7 @@ aws() {
     "failures": [],
     "services": [{
       "status": "ACTIVE",
-      "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:1",
+      "taskDefinition": "arn:aws:ecs:test:task-definition/deploy-test:1",
       "desiredCount": 1,
       "networkConfiguration": {
         "awsvpcConfiguration": {
@@ -44,14 +44,14 @@ aws() {
       "launchType": "FARGATE",
       "deployments": [
         {
-          "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:2",
+          "taskDefinition": "arn:aws:ecs:test:task-definition/deploy-test:2",
           "status": "PRIMARY",
           "rolloutState": "COMPLETED",
           "runningCount": 1,
           "desiredCount": 1
         },
         {
-          "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:1",
+          "taskDefinition": "arn:aws:ecs:test:task-definition/deploy-test:1",
           "status": "PRIMARY",
           "rolloutState": "COMPLETED",
           "runningCount": 1,
@@ -78,7 +78,7 @@ aws() {
             "$describe_count" == "2" ]]; then
         service_json="$(jq '
           .services[0].deployments |= map(
-              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/deploy-test:2"
               then
                 .rolloutState = "IN_PROGRESS"
                 | .desiredCount = 0
@@ -92,7 +92,7 @@ aws() {
         service_json="$(jq '
           .services[0].desiredCount = 0
           | .services[0].deployments |= map(
-              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/deploy-test:2"
               then .desiredCount = 0 | .runningCount = 0
               else .
               end
@@ -102,7 +102,7 @@ aws() {
               "$describe_count" == "2" ]]; then
         service_json="$(jq '
           .services[0].deployments |= map(
-              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/deploy-test:2"
               then .desiredCount = 0 | .runningCount = 0
               else .
               end
@@ -113,19 +113,19 @@ aws() {
       ;;
     "ecs describe-task-definition")
       printf '%s\n' '{
-        "family": "mention-test",
+        "family": "deploy-test",
         "networkMode": "awsvpc",
         "requiresCompatibilities": ["FARGATE"],
         "cpu": "256",
         "memory": "512",
         "containerDefinitions": [{
-          "name": "mention-test",
-          "image": "example.invalid/mention-test:old",
+          "name": "deploy-test",
+          "image": "example.invalid/deploy-test:old",
           "essential": true,
           "logConfiguration": {
             "logDriver": "awslogs",
             "options": {
-              "awslogs-group": "/ecs/mention-test",
+              "awslogs-group": "/ecs/deploy-test",
               "awslogs-stream-prefix": "ecs"
             }
           }
@@ -158,7 +158,7 @@ aws() {
           "arn:aws:ssm:test:123456789012:parameter${DEPLOY_TEST_METRICS_PARAMETER}" \
           '
           .containerDefinitions[]
-          | select(.name == "mention-test")
+          | select(.name == "deploy-test")
           | .secrets[]
           | select(
               .name == "INTERNAL_METRICS_TOKEN" and
@@ -185,11 +185,11 @@ aws() {
         # rely on this function's exit status.
         if jq -e '
           .containerDefinitions[]
-          | select(.name == "mention-test")
+          | select(.name == "deploy-test")
           | .secrets[]
           | select(
-              .name == "MENTION_MCP_JWT_SECRET" and
-              .valueFrom == "arn:aws:ssm:test:123456789012:parameter/oxy/mention-mcp/MENTION_MCP_JWT_SECRET"
+              .name == "EXTRA_TASK_SECRET" and
+              .valueFrom == "arn:aws:ssm:test:123456789012:parameter/oxy/sample-app/EXTRA_TASK_SECRET"
             )
         ' "$input_json" >/dev/null; then
           printf 'task-secret:arn\n' >>"$DEPLOY_TEST_LOG"
@@ -197,7 +197,7 @@ aws() {
           printf 'task-secret:arn:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
         fi
       fi
-      printf '%s\n' "arn:aws:ecs:test:task-definition/mention-test:2"
+      printf '%s\n' "arn:aws:ecs:test:task-definition/deploy-test:2"
       ;;
     "ecs update-service")
       local previous_argument=""
@@ -226,7 +226,7 @@ aws() {
       printf 'reconcile\n' >>"$DEPLOY_TEST_LOG"
       printf '%s\n' '{
         "failures": [],
-        "tasks": [{"taskArn": "arn:aws:ecs:test:task/mention-reconcile"}]
+        "tasks": [{"taskArn": "arn:aws:ecs:test:task/deploy-test-reconcile"}]
       }'
       ;;
     "ecs describe-tasks")
@@ -236,7 +236,7 @@ aws() {
           "lastStatus": "STOPPED",
           "stoppedReason": "Essential container exited",
           "containers": [{
-            "name": "mention-test",
+            "name": "deploy-test",
             "exitCode": %s
           }]
         }]
@@ -298,10 +298,10 @@ run_release() {
   local -a release_environment=(
     AWS_REGION=test
     AWS_ACCOUNT_ID=123456789012
-    CLUSTER=mention-test
-    APP=mention-test
-    CONTAINER_NAME=mention-test
-    IMAGE_URI="example.invalid/mention-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    CLUSTER=deploy-test
+    APP=deploy-test
+    CONTAINER_NAME=deploy-test
+    IMAGE_URI="example.invalid/deploy-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     MAX_WAIT_SECS=5
     POLL_INTERVAL=1
     RUN_MIGRATIONS="$run_migrations"
@@ -315,7 +315,7 @@ run_release() {
   fi
   if [[ "$inject_task_secret" == "true" ]]; then
     release_environment+=(
-      TASK_SECRET_OVERRIDES_JSON='{"MENTION_MCP_JWT_SECRET":"arn:aws:ssm:test:123456789012:parameter/oxy/mention-mcp/MENTION_MCP_JWT_SECRET"}'
+      TASK_SECRET_OVERRIDES_JSON='{"EXTRA_TASK_SECRET":"arn:aws:ssm:test:123456789012:parameter/oxy/sample-app/EXTRA_TASK_SECRET"}'
     )
   fi
 
@@ -336,7 +336,7 @@ run_release() {
 run_release success true false true
 printf '%s\n' \
   metrics:arn \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
   reconcile \
   >"$test_directory/success/expected.log"
@@ -346,14 +346,20 @@ diff -u \
 
 # A hyphen in the parameter path is its own case because it is its own bug: the
 # bracket expression validating this name once matched every character EXCEPT a
-# hyphen, so /oxy/mention/... deployed and /oxy/oxy-api/... did not. Mention's
-# own path has no hyphen, which is why nothing here caught it. Keep both.
-DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention-mcp/INTERNAL_METRICS_TOKEN
+# hyphen, so an app whose path had none deployed and an app whose path had one
+# did not -- and the only repo with a smoke fixture at the time was one of the
+# former, which is why nothing here caught it.
+#
+# KEEP BOTH, and keep the plain one's app segment hyphen-FREE. That asymmetry is
+# the entire test: rename them to two spellings that both contain a hyphen and
+# this pair silently stops discriminating, while the suite still passes and still
+# goes red under a mutation -- just for the wrong case.
+DEPLOY_TEST_METRICS_PARAMETER=/oxy/sample-app/INTERNAL_METRICS_TOKEN
 run_release hyphenated-metrics-parameter true false true
-DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
+DEPLOY_TEST_METRICS_PARAMETER=/oxy/sampleapp/INTERNAL_METRICS_TOKEN
 printf '%s\n' \
   metrics:arn \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
   reconcile \
   >"$test_directory/hyphenated-metrics-parameter/expected.log"
@@ -364,7 +370,7 @@ diff -u \
 run_release explicit-task-secret true false false 0 true
 printf '%s\n' \
   task-secret:arn \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
   reconcile \
   >"$test_directory/explicit-task-secret/expected.log"
@@ -374,11 +380,11 @@ diff -u \
 
 run_release reconciliation-failure false false false 1
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
   reconcile \
   tasklogs \
-  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:1:desired=1' \
   >"$test_directory/reconciliation-failure/expected.log"
 diff -u \
   "$test_directory/reconciliation-failure/expected.log" \
@@ -413,7 +419,7 @@ fi
 
 run_release transient-zero-deployment true false false 0 false 1 transient-zero-deployment
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
   reconcile \
   >"$test_directory/transient-zero-deployment/expected.log"
@@ -427,21 +433,21 @@ grep -F \
 
 run_release zero-service-during-deploy false false false 0 false 1 zero-service-during-deploy
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
-  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:1:desired=1' \
   >"$test_directory/zero-service-during-deploy/expected.log"
 diff -u \
   "$test_directory/zero-service-during-deploy/expected.log" \
   "$test_directory/zero-service-during-deploy/aws.log"
 grep -F \
-  "service mention-test reached desiredCount=0 during the deployment rollout" \
+  "service deploy-test reached desiredCount=0 during the deployment rollout" \
   "$test_directory/zero-service-during-deploy/output.log" \
   >/dev/null
 
 run_release completed-zero-deployment false false false 0 false 1 completed-zero-deployment
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
-  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:1:desired=1' \
   >"$test_directory/completed-zero-deployment/expected.log"
 diff -u \
   "$test_directory/completed-zero-deployment/expected.log" \
@@ -455,9 +461,9 @@ grep -F \
 # back, and stops the release before the reconciliation task runs.
 run_release smoke-hermetic-failure false false false 0 false 1 healthy 1
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
-  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:1:desired=1' \
   >"$test_directory/smoke-hermetic-failure/expected.log"
 diff -u \
   "$test_directory/smoke-hermetic-failure/expected.log" \
@@ -473,7 +479,7 @@ grep -F \
 # failure is paged rather than swallowed.
 run_release smoke-no-rollback-failure false false false 0 false 1 healthy 75
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
   reconcile \
   >"$test_directory/smoke-no-rollback-failure/expected.log"
@@ -481,13 +487,13 @@ diff -u \
   "$test_directory/smoke-no-rollback-failure/expected.log" \
   "$test_directory/smoke-no-rollback-failure/aws.log"
 if grep -qF \
-  'service:arn:aws:ecs:test:task-definition/mention-test:1:' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:1:' \
   "$test_directory/smoke-no-rollback-failure/aws.log"; then
   echo "A smoke failure that cannot be repaired by a rollback rolled back anyway." >&2
   exit 1
 fi
 grep -F \
-  "stays on arn:aws:ecs:test:task-definition/mention-test:2" \
+  "stays on arn:aws:ecs:test:task-definition/deploy-test:2" \
   "$test_directory/smoke-no-rollback-failure/output.log" \
   >/dev/null
 grep -F \


### PR DESCRIPTION
Mention already has the rollback-classification behaviour — it is the repo that needed it, via #550. **Only the harness moves here**, to the neutral fixture names, so the file it shares with five other repos is byte-identical again.

Both files become byte-identical across **Mention, OxyHQServices, Alia, Allo, Homiio and Syra**:

| file | blob |
|---|---|
| `.github/scripts/deploy-ecs-image.sh` | `d51fcaa1` |
| `.github/scripts/test-deploy-ecs-image.sh` | `45b2ed95` |

That is the point of the change: `git rev-parse HEAD:<path>` answers the drift question, instead of a six-way diff.

## What is being spread

Mention #550 taught the smoke-check step to distinguish a failure the new image caused from one it did not. A smoke script may exit **75** to say "this failed, and a rollback cannot fix it" — a check that crosses a boundary the deploy does not own. The release then stands, the reconciliation task still runs, and **the job still fails**, so nothing is swallowed. Every other non-zero exit rolls back exactly as before, so a smoke script that does not opt in keeps the old all-or-nothing behaviour.

It exists because a deploy rolled itself back over someone else's outage.

## Why ship it where it cannot run

**No repo except Mention passes `POST_DEPLOY_SMOKE_SCRIPT`** — measured, 0 occurrences in `.github/workflows/` for the other five. So the *entire* smoke block was already unreachable there, not just this branch. So are `RUN_MIGRATIONS`, `POST_DEPLOY_TASK_COMMAND_JSON`, `INTERNAL_METRICS_PARAMETER`, `TASK_SECRET_OVERRIDES_JSON` and the head guard.

This is an opt-in-by-env shared script, and every feature in it is inert until a workflow passes the variable that switches it on. Refusing exit-75 on the grounds that it is unreachable would equally condemn half of what the file already does. The alternative — recording Mention as a documented exception — trades a property a command can check for one a person has to read, and makes the *next* divergence unremarkable.

## The fixture rename is not a `sed`, and this is the part worth reviewing

Fixtures move to app-neutral names (`mention-test` → `deploy-test`, etc.) so no repo carries another's name. But the harness's plain-vs-hyphenated SSM pair **only tests anything while one path's app segment has no hyphen** — that asymmetry is the whole case. The obvious substitution breaks it:

| rename | mutation "revert the bracket class" fails on |
|---|---|
| naive `mention` → `deploy-test` | `Expected success to succeed` ← the plain case is no longer plain |
| **this PR** (`/oxy/sampleapp/` vs `/oxy/sample-app/`) | `Expected hyphenated-metrics-parameter to succeed` ← intact |

The naive version still passes its baseline and still goes red under mutation, just for the wrong reason — so the loss would not have shown up in CI. The comment above that pair now states the constraint.

## Verification

Baseline green in all six repos. Five mutations against the canonical pair, each failing **and naming the right thing**, then restored byte-identical (`md5sum -c`):

| mutation | result |
|---|---|
| bracket class reverted to `[A-Za-z0-9_.\-/]` | `Expected hyphenated-metrics-parameter to succeed` (and *only* that case) |
| expected metrics ARN → `/bogus/NEVER` | `-metrics:arn` / `+metrics:arn:MISMATCH` |
| expected task-secret ARN → `/bogus/NEVER` | `-task-secret:arn` / `+task-secret:arn:MISMATCH` |
| exit-75 branch disabled | `-reconcile` / `+service:…/deploy-test:1:desired=1` — it rolls back instead of reconciling |
| exit-75 stops failing the job | `Expected smoke-no-rollback-failure to fail` |

The suite now runs 11 cases, including `smoke-hermetic-failure` (exit 1 → rolls back) and `smoke-no-rollback-failure` (exit 75 → does not), and it is gated on every PR in all six repos.

Scripts only — no workflow changes, so nothing about what this repo deploys or when.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
