### PR TITLE
fix(feed): a cache retained in the same millisecond as a write is stale

### DIFF
--- a/packages/frontend/stores/engagementInvalidation.ts
+++ b/packages/frontend/stores/engagementInvalidation.ts
@@ -65,7 +65,22 @@ export function engagementKindForFeed(
   return null;
 }
 
-/** Whether a feed cache retained at `retainedAt` predates the write it must show. */
+/**
+ * Whether a feed cache retained at `retainedAt` predates the write it must show.
+ *
+ * `<=`, not `<`: both stamps come from `Date.now()`, so a retain and a write that
+ * land in the SAME millisecond are indistinguishable in order. A slice retained no
+ * later than the write cannot be known to reflect it, so treat it as stale. The
+ * error that choice can make is one unnecessary refetch; the other direction warm-
+ * starts a list that is missing the write — an unliked post still sitting in the
+ * likes tab.
+ *
+ * The margin is not theoretical: the retain and the invalidate are ~1ms apart in a
+ * test, so whether they share a millisecond is decided by where in one the sequence
+ * happens to start. In production a human navigates between them and the gap is
+ * seconds, which is why this surfaced as an intermittent test failure rather than a
+ * bug report.
+ */
 export function isFeedCacheStale(
   type: FeedType,
   userId: string | undefined,
@@ -73,7 +88,7 @@ export function isFeedCacheStale(
   retainedAt: number,
 ): boolean {
   const kind = engagementKindForFeed(type, userId, viewerId);
-  return kind === null ? false : retainedAt < changedAt[kind];
+  return kind === null ? false : retainedAt <= changedAt[kind];
 }
 
 /**

--- a/packages/frontend/stores/engagementInvalidation.ts
+++ b/packages/frontend/stores/engagementInvalidation.ts
@@ -68,18 +68,20 @@ export function engagementKindForFeed(
 /**
  * Whether a feed cache retained at `retainedAt` predates the write it must show.
  *
- * `<=`, not `<`: both stamps come from `Date.now()`, so a retain and a write that
- * land in the SAME millisecond are indistinguishable in order. A slice retained no
- * later than the write cannot be known to reflect it, so treat it as stale. The
- * error that choice can make is one unnecessary refetch; the other direction warm-
- * starts a list that is missing the write — an unliked post still sitting in the
- * likes tab.
+ * The bound is INCLUSIVE, and that is the whole of it: both sides are
+ * `Date.now()`, whose resolution is a millisecond, so a retain and a write that
+ * happen close enough together carry the SAME number and `<` reads them as
+ * "already reflects it". A slice retained no later than the write cannot be
+ * known to reflect it, so treat it as stale. The error `<=` can make is one
+ * unnecessary refetch; the error `<` makes is rendering a list the viewer has
+ * already changed — the likes tab still showing the post they just unliked.
  *
- * The margin is not theoretical: the retain and the invalidate are ~1ms apart in a
- * test, so whether they share a millisecond is decided by where in one the sequence
- * happens to start. In production a human navigates between them and the gap is
- * seconds, which is why this surfaced as an intermittent test failure rather than a
- * bug report.
+ * Not hypothetical: the two stamps land about a millisecond apart in
+ * `hooks/__tests__/engagementListRevalidation.test.tsx`, so which side of a
+ * boundary they fall on is decided by where in a millisecond the sequence
+ * started, and CI drew the short straw. Freezing `Date.now` to a constant turns
+ * that coin-flip into a deterministic failure of three cases in that file — the
+ * reproduction, if this ever needs re-deriving.
  */
 export function isFeedCacheStale(
   type: FeedType,

--- a/packages/frontend/stores/safetyInvalidation.ts
+++ b/packages/frontend/stores/safetyInvalidation.ts
@@ -51,11 +51,14 @@ const listeners = new Set<SafetyFilterListener>();
  * safety rules — in which case it may still hold content those rules exclude, or
  * still be missing content they now allow.
  *
- * `<=`, not `<`, for the same reason as `isFeedCacheStale`: both stamps are
- * `Date.now()`, so a retain and a rule change in the same millisecond cannot be
- * ordered. Erring toward stale costs one refetch; erring the other way keeps
- * showing content the viewer just asked not to see, which is the worse half of a
- * safety rule.
+ * Inclusive for the reason `isFeedCacheStale` in `engagementInvalidation`
+ * documents at length: two `Date.now()` stamps can share a millisecond, and a
+ * slice retained no later than the change cannot be known to reflect it. Nothing
+ * has caught this half yet — a safety rule is changed from a settings screen, so
+ * the two stamps are a human apart rather than a millisecond — but the shape is
+ * identical and leaving it `<` is choosing to be surprised later. Here the
+ * wrong answer is also worse: it leaves up content the viewer just asked not to
+ * see.
  */
 export function isFeedCacheStaleForSafety(retainedAt: number): boolean {
   return retainedAt <= changedAt;

--- a/packages/frontend/stores/safetyInvalidation.ts
+++ b/packages/frontend/stores/safetyInvalidation.ts
@@ -50,9 +50,15 @@ const listeners = new Set<SafetyFilterListener>();
  * Whether a feed cache retained at `retainedAt` predates the viewer's current
  * safety rules — in which case it may still hold content those rules exclude, or
  * still be missing content they now allow.
+ *
+ * `<=`, not `<`, for the same reason as `isFeedCacheStale`: both stamps are
+ * `Date.now()`, so a retain and a rule change in the same millisecond cannot be
+ * ordered. Erring toward stale costs one refetch; erring the other way keeps
+ * showing content the viewer just asked not to see, which is the worse half of a
+ * safety rule.
  */
 export function isFeedCacheStaleForSafety(retainedAt: number): boolean {
-  return retainedAt < changedAt;
+  return retainedAt <= changedAt;
 }
 
 /**


### PR DESCRIPTION
## The bug

`isFeedCacheStale` compared `retainedAt < changedAt[kind]`, and **both stamps come from `Date.now()`**. When a retain and an engagement write land in the same millisecond the comparison is false, the slice is judged fresh, and the warm start serves membership from *before* the write — an unliked post still sitting in the likes tab on the next visit.

The margin is not theoretical. Measured with a probe around `Date.now`: the retain and the invalidate are **~1 ms apart**. Whether they share a millisecond is decided by where in one the sequence happens to start.

## How it surfaced, and why it is test-only in practice

As an intermittent `engagementListRevalidation` failure in CI — `drops an unliked post on the next visit to the likes tab` — on a PR whose diff does not touch this file. It reproduces on clean `origin/main` with no branch applied.

In production a human retains a slice, navigates, likes something, and comes back: the gap is seconds to minutes, not one millisecond. So this is a real race that only the test's timing makes reachable. Worth fixing anyway — the failure mode is a wrong render, and the cost of the fix is nothing.

## The fix

`<` → `<=`, in both authorities.

**Semantics:** a slice retained *no later than* the write cannot be known to reflect it, so treat it as stale. When the order cannot be determined, assume the cache is the older one — the error that choice can make is one unnecessary refetch, never a wrong render.

`safetyInvalidation.ts` carries the identical shape and is fixed with it. Nothing there has hit the race yet, because its `changedAt` only moves when a viewer changes a safety rule — but leaving a known race because it has not fired is choosing to be surprised later, and the wrong direction there keeps showing content a viewer just asked not to see.

## Verification

Reproduced **deterministically** by freezing `Date.now` — which is what turns a coin-flip into a certainty:

```
frozen clock, with the fix (<=)
  ✓ shows a post liked elsewhere on the next visit to the likes tab
  ✓ shows a post boosted elsewhere on the next visit to the boosts tab
  ✓ drops an unliked post on the next visit to the likes tab
  ✓ still warm-starts without a request when no engagement changed the list
  ✓ leaves another account's likes tab alone when the viewer likes something
  ✓ does not revalidate a boosts tab because a LIKE landed
  Tests: 6 passed

MUTATION — revert to '<', same frozen clock
  ✕ shows a post liked elsewhere on the next visit to the likes tab
  ✕ shows a post boosted elsewhere on the next visit to the boosts tab
  ✕ drops an unliked post on the next visit to the likes tab
  Tests: 3 failed, 3 passed
```

File restored afterwards, `md5sum -c` OK.

**The negative control matters as much as the failures:** `still warm-starts without a request when no engagement changed the list` passes under both spellings, because `changedAt` is `0` there and `retainedAt <= 0` is false. So the fix is not simply refetching more — it is the case that would catch an over-eager invalidation, and it is unaffected.

Full frontend suite: **121 suites, 1038 tests, all pass.** Coverage clears every floor.

## Follow-up, deliberately not done here

Replacing `Date.now()` with a module-level monotonic counter in both authorities would make retain-vs-write ordering exact and remove clock granularity from the question entirely. It is strictly more correct — and it changes `FeedMemoryCacheEntry`'s shape and the retain site, to remove an ambiguity `<=` already resolves safely. Worth doing on its own terms, not as a hitchhiker on a one-character fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)