### PR TITLE
ci(deploy): sync DATABASE_URL to SSM and inject it into the task definition

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Sync GitHub secrets to SSM
         env:
           ALIA_API_KEY: ${{ secrets.ALIA_API_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           INTERNAL_METRICS_TOKEN: ${{ secrets.INTERNAL_METRICS_TOKEN }}
@@ -122,7 +123,7 @@ jobs:
           REDIS_URI: ${{ secrets.REDIS_URI }}
           REDIS_URL: ${{ secrets.REDIS_URL }}
           SSM_SECRET_ALLOWLIST: >-
-            ALIA_API_KEY FIREBASE_SERVICE_ACCOUNT_BASE64 FIREBASE_PROJECT_ID
+            ALIA_API_KEY DATABASE_URL FIREBASE_SERVICE_ACCOUNT_BASE64 FIREBASE_PROJECT_ID
             INTERNAL_METRICS_TOKEN KLIPY_APP_KEY MENTION_OXY_CLIENT_ID
             MENTION_DID MENTION_PRIVATE_KEY MENTION_PUBLIC_KEY MONGODB_URI
             OXY_SERVICE_API_KEY OXY_SERVICE_API_SECRET OXY_SERVICE_TOKEN
@@ -185,8 +186,19 @@ jobs:
           IMAGE_URI: ${{ env.ECR_REGISTRY }}/oxy/${{ env.APP }}@${{ steps.build.outputs.digest }}
           RUN_MIGRATIONS: 'true'
           INTERNAL_METRICS_PARAMETER: /oxy/mention/INTERNAL_METRICS_TOKEN
+          # The task definition this deploy registers is derived from the LIVE one,
+          # not from Terraform — `terraform-uswest2` is many revisions behind and
+          # its `image` is `:latest`, so applying it would replace the
+          # digest-pinned image this pipeline runs. Anything that must reach
+          # production therefore goes HERE as well as in the Terraform record.
+          #
+          # DATABASE_URL: the Mongo->Postgres port requires it at boot. Added
+          # ahead of the port so the wiring is proven against an image that
+          # ignores the variable; a missing parameter would otherwise surface as
+          # `ResourceInitializationError: unable to pull secrets` during a cutover.
           TASK_SECRET_OVERRIDES_JSON: >-
-            {"MENTION_MCP_JWT_SECRET":"arn:aws:ssm:us-west-2:237343248947:parameter/oxy/mention/MENTION_MCP_JWT_SECRET"}
+            {"MENTION_MCP_JWT_SECRET":"arn:aws:ssm:us-west-2:237343248947:parameter/oxy/mention/MENTION_MCP_JWT_SECRET",
+             "DATABASE_URL":"arn:aws:ssm:us-west-2:237343248947:parameter/oxy/mention/DATABASE_URL"}
           POST_DEPLOY_TASK_COMMAND_JSON: >-
             ["bun","packages/backend/dist/scripts/reconcile-engagement-projections.js"]
           POST_DEPLOY_SMOKE_SCRIPT: .github/scripts/smoke-mention.sh


### PR DESCRIPTION
Prepares the Mongo→Postgres cutover wiring **ahead of** the port, so a mistake surfaces against an image that ignores the variable rather than during a cutover.

Two mechanisms, each of which fails silently on its own:

- **Secret sync.** `deploy-aws.yml` enumerates secrets explicitly — no `toJSON(secrets)` fallback — so a name missing from either the env block or `SSM_SECRET_ALLOWLIST` is never written to SSM.
- **Task definition.** The registered task definition is derived from the LIVE one, not from Terraform: `terraform-uswest2` is **91 revisions behind** and its `image` is `:latest`, so applying it would replace the digest-pinned image production runs. Anything that must reach production goes in `TASK_SECRET_OVERRIDES_JSON` as well as in the Terraform record.

Ordering matters in one direction: a task definition naming a parameter that does not exist crash-loops with `ResourceInitializationError: unable to pull secrets`. The parameter exists first.

`/oxy/mention/DATABASE_URL` points at the `mention` database on the shared `oxy-postgres` instance (PostgreSQL 17.9), owned by the `mention` role, PostGIS 3.5.6 installed — verified by connecting as that role from a Fargate task and round-tripping a `geography(Point,4326)`.

Supersedes #556, which accidentally carried another session's commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)