### PR TITLE
feat(channels): find a channel where you already look for a feed or a list

### DIFF
--- a/packages/backend/src/__tests__/routes/channelsRoutes.test.ts
+++ b/packages/backend/src/__tests__/routes/channelsRoutes.test.ts
@@ -45,8 +45,10 @@ const channelCreate = vi.fn();
 const channelCount = vi.fn();
 const channelDeleteOne = vi.fn();
 const channelUpdateOne = vi.fn();
+const channelAggregate = vi.fn();
 vi.mock('../../models/Channel', () => ({
   Channel: {
+    aggregate: (...args: unknown[]) => channelAggregate(...args),
     find: (...args: unknown[]) => channelFind(...args),
     findOne: (...args: unknown[]) => channelFindOne(...args),
     findById: (...args: unknown[]) => channelFindById(...args),
@@ -161,6 +163,7 @@ vi.mock('@oxyhq/core/server', async (importOriginal) => {
 });
 
 import channelsRouter, { publicChannelsRouter } from '../../routes/channels.routes';
+import { MAX_CHANNEL_SEARCH_OFFSET } from '../../services/channelSearch';
 
 /**
  * A chainable stand-in for the query builders these routes use.
@@ -191,6 +194,17 @@ function chain<T>(value: T) {
       Promise.resolve(value).then(onFulfilled, onRejected),
   };
   return link;
+}
+
+/**
+ * A stand-in for the search aggregation's builder. Records the pipeline so the
+ * relevance path can be told apart from the browse path by what it actually
+ * ASKED FOR, not merely by what came back.
+ */
+const aggregatePipelines: unknown[][] = [];
+function aggregateChain<T>(rows: T[]) {
+  const exec = () => Promise.resolve(rows);
+  return { option: () => ({ exec }), exec };
 }
 
 function channelDoc(overrides: Record<string, unknown> = {}) {
@@ -234,9 +248,10 @@ beforeEach(() => {
   writes.length = 0;
   sortCalls.length = 0;
   limitCalls.length = 0;
+  aggregatePipelines.length = 0;
   for (const fn of [
     channelFind, channelFindOne, channelFindById, channelCreate, channelCount,
-    channelDeleteOne, channelUpdateOne,
+    channelDeleteOne, channelUpdateOne, channelAggregate,
     memberFind, memberFindOne, memberFindOneAndUpdate, memberCreate, memberCount,
     memberExists, memberDeleteMany,
     followFind, followFindOne, followFindOneAndUpdate, followCreate, followDeleteOne,
@@ -249,6 +264,10 @@ beforeEach(() => {
   channelFind.mockReturnValue(chain([]));
   channelFindOne.mockReturnValue(chain(null));
   channelFindById.mockReturnValue(chain(null));
+  channelAggregate.mockImplementation((pipeline: unknown[]) => {
+    aggregatePipelines.push(pipeline);
+    return aggregateChain([]);
+  });
   channelCount.mockResolvedValue(0);
   channelUpdateOne.mockResolvedValue({ modifiedCount: 1 });
   channelDeleteOne.mockResolvedValue({ deletedCount: 1 });
@@ -901,6 +920,133 @@ describe('GET /channels — the directory', () => {
     expect(channelFind).toHaveBeenCalledWith(
       expect.objectContaining({ _id: { $nin: [new mongoose.Types.ObjectId(CHANNEL_ID)] } }),
     );
+  });
+});
+
+/**
+ * `?search=` — the SAME route, answering a different question.
+ *
+ * Two pagination modes on one endpoint is the arrangement that breaks on page 2
+ * while page 1 looks perfect, so the tests here are mostly about the SEAM rather
+ * than about matching: which query ran, and that neither mode can be handed the
+ * other's paging parameter and silently act on it. The ranking and the escaping
+ * are `services/channelSearch.test.ts`'s job, and their ordering is proven
+ * against a real mongod separately.
+ */
+describe('GET /channels?search= — the same route, ranked', () => {
+  /** The `$match` of the search aggregation the last request issued. */
+  function searchMatch(): Record<string, unknown> {
+    const pipeline = aggregatePipelines[aggregatePipelines.length - 1];
+    const stage = pipeline.find((entry) => typeof entry === 'object' && entry !== null && '$match' in entry);
+    return (stage as { $match: Record<string, unknown> }).$match;
+  }
+
+  it('runs the ranked aggregation, not the directory query', async () => {
+    const res = await request(buildApp()).get('/channels?search=news');
+
+    expect(res.status).toBe(200);
+    expect(channelAggregate).toHaveBeenCalledTimes(1);
+    expect(channelFind).not.toHaveBeenCalled();
+    expect(searchMatch()).toMatchObject({ visibility: 'public' });
+  });
+
+  it('CONTROL: no search term means the directory query, and no aggregation', async () => {
+    await request(buildApp()).get('/channels');
+
+    expect(channelFind).toHaveBeenCalledTimes(1);
+    expect(channelAggregate).not.toHaveBeenCalled();
+  });
+
+  it('an empty or whitespace-only term is not a search', async () => {
+    await request(buildApp()).get('/channels?search=%20%20');
+
+    expect(channelAggregate).not.toHaveBeenCalled();
+    expect(channelFind).toHaveBeenCalledTimes(1);
+  });
+
+  it('answers with items and offset paging, never a keyset cursor', async () => {
+    channelAggregate.mockReturnValue(aggregateChain([
+      channelDoc({ _id: 'a' }),
+      channelDoc({ _id: 'b' }),
+      channelDoc({ _id: 'c' }),
+    ]));
+
+    const res = await request(buildApp()).get('/channels?search=news&limit=2&offset=10');
+
+    expect(res.body.data.items.map((item: { id: string }) => item.id)).toEqual(['a', 'b']);
+    expect(res.body.data.hasMore).toBe(true);
+    expect(res.body.data.nextOffset).toBe(12);
+    expect(res.body.data).not.toHaveProperty('nextCursor');
+  });
+
+  it('omits nextOffset on the last page', async () => {
+    channelAggregate.mockReturnValue(aggregateChain([channelDoc({ _id: 'a' })]));
+
+    const res = await request(buildApp()).get('/channels?search=news&limit=2');
+
+    expect(res.body.data.hasMore).toBe(false);
+    expect(res.body.data).not.toHaveProperty('nextOffset');
+  });
+
+  /**
+   * The failure this seam exists to prevent: a follower-count cursor read as a
+   * position in the RELEVANCE order would return plausible, wrong rows on page 2.
+   * The search path returns before that cursor is parsed at all, so the caller
+   * gets the first page of results — visibly wrong rather than quietly wrong.
+   */
+  it('a browse cursor cannot move a searched page', async () => {
+    const lastId = new mongoose.Types.ObjectId().toString();
+
+    await request(buildApp()).get(`/channels?search=news&cursor=9_${lastId}`);
+
+    expect(JSON.stringify(aggregatePipelines)).not.toContain(lastId);
+    expect(JSON.stringify(searchMatch())).not.toContain('followerCount');
+    // `$skip` is the search path's only positional argument, and no cursor moved it.
+    expect(aggregatePipelines[0]).toContainEqual({ $skip: 0 });
+  });
+
+  it('ignores a search offset while browsing', async () => {
+    channelFind.mockReturnValue(chain([]));
+
+    await request(buildApp()).get('/channels?offset=200');
+
+    // The browse path pages by keyset and never skips: an offset it silently
+    // honoured would be a third pagination mode nobody documented.
+    expect(channelFind).toHaveBeenCalledWith(expect.not.objectContaining({ $or: expect.anything() }));
+    expect(channelAggregate).not.toHaveBeenCalled();
+  });
+
+  it('clamps the search offset before it reaches the database', async () => {
+    await request(buildApp()).get('/channels?search=news&offset=99999999');
+
+    expect(aggregatePipelines[0]).toContainEqual({ $skip: MAX_CHANNEL_SEARCH_OFFSET });
+  });
+
+  it('shares the directory limit — one page size for one route', async () => {
+    await request(buildApp()).get('/channels?search=news&limit=9999');
+
+    // 50 is the directory ceiling; the `+ 1` is the overfetched hasMore row.
+    expect(aggregatePipelines[0]).toContainEqual({ $limit: 51 });
+  });
+
+  it('honours excludeFollowed while searching, so the parameter keeps meaning something', async () => {
+    followFind.mockReturnValue(chain([{ channelId: CHANNEL_ID }]));
+
+    await request(buildApp()).get('/channels?search=news&excludeFollowed=true');
+
+    expect(searchMatch()).toMatchObject({
+      _id: { $nin: [new mongoose.Types.ObjectId(CHANNEL_ID)] },
+    });
+  });
+
+  it('500s rather than answering a partial page when the aggregation fails', async () => {
+    channelAggregate.mockImplementation(() => {
+      throw new Error('aggregation exploded');
+    });
+
+    const res = await request(buildApp()).get('/channels?search=news');
+
+    expect(res.status).toBe(500);
   });
 });
 

--- a/packages/backend/src/__tests__/services/channelSearch.test.ts
+++ b/packages/backend/src/__tests__/services/channelSearch.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose, { type PipelineStage } from 'mongoose';
+
+/**
+ * Finding a channel by name.
+ *
+ * The pipeline is asserted STAGE BY STAGE rather than through its results,
+ * because the properties that matter are properties of the query Mongo is asked
+ * to run: a `visibility` filter applied after the fact would produce identical
+ * results today (one visibility value exists) and leak on the day a second one
+ * does, and an unescaped term produces identical results for every query that
+ * happens to contain no metacharacter.
+ *
+ * The ordering the pipeline expresses is verified against a real mongod
+ * separately — a mock cannot evaluate `$switch` or `$regexMatch`.
+ */
+
+const aggregate = vi.fn();
+const option = vi.fn();
+const exec = vi.fn();
+
+vi.mock('../../models/Channel', () => ({
+  Channel: { aggregate: (...args: unknown[]) => aggregate(...args) },
+}));
+
+import {
+  CHANNEL_SEARCH_RANK,
+  MAX_CHANNEL_SEARCH_OFFSET,
+  searchChannels,
+} from '../../services/channelSearch';
+
+/** A lean `Channel` row, as the aggregation hands one back. */
+function channelRow(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'channel-1',
+    handle: 'weather',
+    title: 'Weather',
+    ownerOxyUserId: 'owner-1',
+    visibility: 'public',
+    signPosts: true,
+    followerCount: 12,
+    memberCount: 2,
+    postCount: 40,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+/** The pipeline the last call handed to `Channel.aggregate`. */
+function lastPipeline(): PipelineStage[] {
+  return aggregate.mock.calls[aggregate.mock.calls.length - 1][0] as PipelineStage[];
+}
+
+function stage<T = Record<string, unknown>>(operator: string): T {
+  const found = lastPipeline().find((entry) => operator in entry);
+  if (!found) throw new Error(`no ${operator} stage in the pipeline`);
+  return (found as Record<string, T>)[operator];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  aggregate.mockReturnValue({ option, exec });
+  option.mockReturnValue({ exec });
+  exec.mockResolvedValue([]);
+});
+
+describe('searchChannels', () => {
+  it('asks Mongo for public channels only, as a match clause', async () => {
+    await searchChannels('weather', { limit: 20, offset: 0 });
+
+    expect(stage('$match')).toMatchObject({ visibility: 'public' });
+  });
+
+  it('escapes the term before it reaches a regex', async () => {
+    await searchChannels('we.*ther', { limit: 20, offset: 0 });
+
+    // EVERY regex position in the whole pipeline, not just the `$match` ones: an
+    // escaped `$match` in front of an unescaped `$regexMatch` would still hand a
+    // user-supplied pattern to the ranking stage.
+    const patterns = [...JSON.stringify(lastPipeline()).matchAll(/"(?:\$regex|regex)":"(.*?)","/g)]
+      .map((occurrence) => occurrence[1]);
+    expect(patterns).toEqual(Array(5).fill('we\\\\.\\\\*ther'));
+
+    // The one place the RAW term survives is the exact-handle tier, which is a
+    // literal string equality and not a pattern — `.*` there matches the channel
+    // literally handled `we.*ther`, which cannot exist, rather than every channel.
+    const branches = stage<{ searchRank: { $switch: { branches: Array<{ case: unknown }> } } }>('$addFields')
+      .searchRank.$switch.branches;
+    expect(branches[0].case).toEqual({ $eq: ['$handleLower', 'we.*ther'] });
+  });
+
+  it('matches handle, title and description', async () => {
+    await searchChannels('weather', { limit: 20, offset: 0 });
+
+    const match = stage<{ $or: Array<Record<string, unknown>> }>('$match');
+    expect(match.$or.map((clause) => Object.keys(clause)[0])).toEqual([
+      'handleLower',
+      'title',
+      'description',
+    ]);
+  });
+
+  it('ranks an exact handle above a handle substring, a title, then a description', async () => {
+    await searchChannels('Weather', { limit: 20, offset: 0 });
+
+    const branches = stage<{ searchRank: { $switch: { branches: Array<{ case: unknown; then: number }>; default: number } } }>('$addFields')
+      .searchRank.$switch;
+
+    // LITERAL values, deliberately, not `CHANNEL_SEARCH_RANK.*`: asserting the
+    // constants against themselves passes however they are reordered, and a
+    // `$sort` reads the emitted numbers, not the names. Verified by mutation —
+    // swapping the constants leaves this the only assertion that fails.
+    expect(branches.branches.map((branch) => branch.then)).toEqual([0, 1, 2]);
+    expect(branches.default).toBe(3);
+
+    // ...and the emitted numbers are what the named tiers mean, so a caller
+    // reading `CHANNEL_SEARCH_RANK` is reading the real order.
+    expect(CHANNEL_SEARCH_RANK.exactHandle).toBeLessThan(CHANNEL_SEARCH_RANK.handle);
+    expect(CHANNEL_SEARCH_RANK.handle).toBeLessThan(CHANNEL_SEARCH_RANK.title);
+    expect(CHANNEL_SEARCH_RANK.title).toBeLessThan(CHANNEL_SEARCH_RANK.description);
+
+    // The best tier is the one whose case is the exact-handle comparison, against
+    // the canonical (lowercased) handle — the only spelling `handleLower` holds.
+    expect(branches.branches[0].case).toEqual({ $eq: ['$handleLower', 'weather'] });
+  });
+
+  it('sorts by rank, then followers, then _id — a total order, so offsets never repeat a row', async () => {
+    await searchChannels('weather', { limit: 20, offset: 0 });
+
+    expect(stage('$sort')).toEqual({ searchRank: 1, followerCount: -1, _id: -1 });
+  });
+
+  it('bounds the read: skip, overfetch by exactly one, and a time limit', async () => {
+    await searchChannels('weather', { limit: 20, offset: 40 });
+
+    expect(stage<number>('$skip')).toBe(40);
+    expect(stage<number>('$limit')).toBe(21);
+    expect(option).toHaveBeenCalledWith({ maxTimeMS: 3_000 });
+  });
+
+  it('reports hasMore from the overfetched row and does not return it', async () => {
+    exec.mockResolvedValue([
+      channelRow({ _id: 'a' }),
+      channelRow({ _id: 'b' }),
+      channelRow({ _id: 'c' }),
+    ]);
+
+    const page = await searchChannels('weather', { limit: 2, offset: 0 });
+
+    expect(page.hasMore).toBe(true);
+    expect(page.items.map((item) => item.id)).toEqual(['a', 'b']);
+  });
+
+  it('reports hasMore false when the page is not full', async () => {
+    exec.mockResolvedValue([channelRow({ _id: 'a' })]);
+
+    const page = await searchChannels('weather', { limit: 2, offset: 0 });
+
+    expect(page.hasMore).toBe(false);
+    expect(page.items).toHaveLength(1);
+  });
+
+  it('serializes through the shared channel DTO', async () => {
+    exec.mockResolvedValue([channelRow({ description: 'Forecasts', avatar: 'file-1' })]);
+
+    const page = await searchChannels('weather', { limit: 20, offset: 0 });
+
+    expect(page.items[0]).toEqual({
+      id: 'channel-1',
+      handle: 'weather',
+      title: 'Weather',
+      description: 'Forecasts',
+      avatar: 'file-1',
+      ownerOxyUserId: 'owner-1',
+      visibility: 'public',
+      signPosts: true,
+      followerCount: 12,
+      memberCount: 2,
+      postCount: 40,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    });
+    // A search result is nobody's own relationship to a channel — the viewer
+    // state comes from the channel's own page, which loads it.
+    expect(page.items[0]).not.toHaveProperty('viewerState');
+  });
+
+  it('returns nothing for a blank term without touching the database', async () => {
+    const page = await searchChannels('   ', { limit: 20, offset: 0 });
+
+    expect(page).toEqual({ items: [], hasMore: false });
+    expect(aggregate).not.toHaveBeenCalled();
+  });
+
+  it('truncates an absurdly long term rather than matching on it', async () => {
+    await searchChannels('a'.repeat(5_000), { limit: 20, offset: 0 });
+
+    const match = stage<{ $or: Array<Record<string, { $regex: string }>> }>('$match');
+    expect(match.$or[0].handleLower.$regex.length).toBe(300);
+  });
+
+  it('leaves out the excluded channels, in the same clause as the visibility gate', async () => {
+    const excluded = new mongoose.Types.ObjectId();
+    await searchChannels('weather', { limit: 20, offset: 0, excludeChannelIds: [excluded] });
+
+    expect(stage('$match')).toMatchObject({ _id: { $nin: [excluded] } });
+  });
+
+  it('CONTROL: no exclusion clause when the caller excludes nothing', async () => {
+    await searchChannels('weather', { limit: 20, offset: 0, excludeChannelIds: [] });
+
+    expect(stage('$match')).not.toHaveProperty('_id');
+  });
+
+  it('CONTROL: the offset ceiling is the caller\'s to enforce, and the route does', async () => {
+    // `searchChannels` trusts the bounds it is given — the clamp lives at the
+    // HTTP boundary, where the untrusted value arrives. This asserts the constant
+    // the route clamps to is exported and non-trivial, so the two cannot drift
+    // apart silently.
+    expect(MAX_CHANNEL_SEARCH_OFFSET).toBeGreaterThan(0);
+    await searchChannels('weather', { limit: 20, offset: MAX_CHANNEL_SEARCH_OFFSET });
+    expect(stage<number>('$skip')).toBe(MAX_CHANNEL_SEARCH_OFFSET);
+  });
+});

--- a/packages/backend/src/routes/channels.routes.ts
+++ b/packages/backend/src/routes/channels.routes.ts
@@ -55,8 +55,11 @@ import {
   canManageChannel,
   canViewChannel,
 } from '../services/channelAccess';
+import { serializeChannel, type ChannelLean } from '../services/channelDto';
+import { MAX_CHANNEL_SEARCH_OFFSET, searchChannels } from '../services/channelSearch';
 import { createNotification } from '../utils/notificationUtils';
 import { validateBody, validateObjectId } from '../middleware/validate';
+import { queryInt, queryString } from '../utils/queryParams';
 import { channelReadRateLimiter, channelWriteRateLimiter } from '../middleware/security';
 import { config } from '../config';
 import { sendErrorResponse, sendSuccessResponse } from '../utils/apiHelpers';
@@ -145,46 +148,6 @@ const followSchema = z.object({
   notify: z.boolean(),
 });
 
-/** Shape of a `Channel` document as the routes below read it back. */
-interface ChannelLean {
-  _id: unknown;
-  handle: string;
-  title: string;
-  description?: string;
-  avatar?: string;
-  banner?: string;
-  ownerOxyUserId: string;
-  visibility: string;
-  signPosts?: boolean;
-  followerCount?: number;
-  memberCount?: number;
-  postCount?: number;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-function serialize(doc: ChannelLean, viewerState?: ChannelViewerState): ChannelDTO {
-  return {
-    id: String(doc._id),
-    handle: doc.handle,
-    title: doc.title,
-    ...(doc.description ? { description: doc.description } : {}),
-    ...(doc.avatar ? { avatar: doc.avatar } : {}),
-    ...(doc.banner ? { banner: doc.banner } : {}),
-    ownerOxyUserId: doc.ownerOxyUserId,
-    // The stored value is the authority; the cast is safe because the schema enum
-    // is the same list the DTO type is built from.
-    visibility: 'public',
-    signPosts: doc.signPosts === true,
-    followerCount: doc.followerCount ?? 0,
-    memberCount: doc.memberCount ?? 0,
-    postCount: doc.postCount ?? 0,
-    createdAt: doc.createdAt.toISOString(),
-    updatedAt: doc.updatedAt.toISOString(),
-    ...(viewerState ? { viewerState } : {}),
-  };
-}
-
 /**
  * Resolve a channel by its `_id` OR its handle — the one place both spellings are
  * accepted, so a URL can carry the readable one while the feed descriptor keeps
@@ -254,15 +217,38 @@ export const publicChannelsRouter = Router();
 
 /**
  * GET /channels?cursor=<followerCount>_<id>&limit=&excludeFollowed=true
+ * GET /channels?search=<term>&offset=&limit=&excludeFollowed=true
  *
- * The directory, most-followed first. Keyset-paged on
- * `{ followerCount: -1, _id: -1 }`, which is exactly what
- * `{ visibility, followerCount, _id }` stores — the same shape
- * `GET /feeds/marketplace` uses, and for the same reason: a skip/limit directory
- * duplicates and drops rows as follower counts move underneath it.
+ * ONE route, TWO questions, and which one is being asked is decided by the
+ * presence of `search` — the same shape `GET /lists`, `GET /feeds` and
+ * `GET /starter-packs` already take, which is why the search screen can drive
+ * all four through one client facade.
+ *
+ *  - **BROWSE** (no `search`): the directory, most-followed first. Keyset-paged
+ *    on `{ followerCount: -1, _id: -1 }`, which is exactly what
+ *    `{ visibility, followerCount, _id }` stores — the same shape
+ *    `GET /feeds/marketplace` uses, and for the same reason: a skip/limit
+ *    directory duplicates and drops rows as follower counts move underneath it.
+ *  - **SEARCH** (`search` present): ranked by relevance
+ *    (`services/channelSearch.ts`), offset-paged.
+ *
+ * **The two pagination modes cannot be confused for one another**, which is the
+ * failure worth engineering out — a cursor reinterpreted on the wrong axis
+ * returns plausible, wrong rows on page 2 and nothing anywhere says so. They are
+ * kept disjoint on BOTH sides: browse reads `cursor` and answers `nextCursor`,
+ * search reads `offset` and answers `nextOffset`, and each mode ignores the
+ * other's parameter outright. A client that sends the wrong one is served page 1
+ * — a visible bug — never a silently misaligned page.
+ *
+ * Relevance paging is offset rather than keyset because the sort key is a
+ * COMPUTED rank: a keyset would have to carry that rank in the cursor and
+ * re-derive it identically on every page, which is a second definition of the
+ * ranking waiting to drift from the first.
  *
  * `excludeFollowed` needs a caller, so it is a no-op for an anonymous reader
- * rather than an error — the directory is the same list either way.
+ * rather than an error — the directory is the same list either way. It applies
+ * to BOTH modes: a documented parameter must not quietly stop meaning anything
+ * because a search term appeared next to it.
  */
 publicChannelsRouter.get('/', ...readLimiters, async (req: AuthRequest, res: Response) => {
   try {
@@ -272,7 +258,43 @@ publicChannelsRouter.get('/', ...readLimiters, async (req: AuthRequest, res: Res
       ? Math.min(rawLimit, DIRECTORY_MAX_LIMIT)
       : DIRECTORY_PAGE_SIZE;
 
+    // Shared by both modes, and the only thing that is: the caller's own
+    // exclusion set, which is about WHICH channels are eligible rather than about
+    // how the answer is ordered or paged.
+    let excludedIds: mongoose.Types.ObjectId[] = [];
+    if (viewerId && req.query.excludeFollowed === 'true') {
+      const followed = await ChannelFollow.find({ oxyUserId: viewerId })
+        .select('channelId')
+        .limit(MAX_CALLER_CHANNEL_ROWS)
+        .lean<Array<{ channelId: string }>>();
+      excludedIds = followed
+        .map((row) => row.channelId)
+        .filter((id) => mongoose.Types.ObjectId.isValid(id))
+        .map((id) => new mongoose.Types.ObjectId(id));
+    }
+
+    // SEARCH mode returns from here, before the keyset cursor is so much as
+    // parsed. That is the point: the two modes share no paging state at all, so
+    // there is no arrangement of parameters in which a follower-count cursor can
+    // be applied to a relevance-ordered page.
+    const search = queryString(req.query.search)?.trim() ?? '';
+    if (search) {
+      const offset = Math.min(
+        Math.max(queryInt(req.query.offset) ?? 0, 0),
+        MAX_CHANNEL_SEARCH_OFFSET,
+      );
+      const found = await searchChannels(search, { limit, offset, excludeChannelIds: excludedIds });
+      return sendSuccessResponse(res, 200, {
+        items: found.items,
+        hasMore: found.hasMore,
+        ...(found.hasMore ? { nextOffset: offset + found.items.length } : {}),
+      });
+    }
+
     const match: Record<string, unknown> = { visibility: 'public' };
+    if (excludedIds.length > 0) {
+      match._id = { $nin: excludedIds };
+    }
 
     // `<followerCount>_<id>`: the two-part keyset the sort needs. A malformed
     // cursor is ignored rather than rejected — it can only cost the caller a
@@ -294,20 +316,6 @@ publicChannelsRouter.get('/', ...readLimiters, async (req: AuthRequest, res: Res
       }
     }
 
-    if (viewerId && req.query.excludeFollowed === 'true') {
-      const followed = await ChannelFollow.find({ oxyUserId: viewerId })
-        .select('channelId')
-        .limit(MAX_CALLER_CHANNEL_ROWS)
-        .lean<Array<{ channelId: string }>>();
-      const followedIds = followed
-        .map((row) => row.channelId)
-        .filter((id) => mongoose.Types.ObjectId.isValid(id))
-        .map((id) => new mongoose.Types.ObjectId(id));
-      if (followedIds.length > 0) {
-        match._id = { $nin: followedIds };
-      }
-    }
-
     const overfetched = await Channel.find(match)
       .sort({ followerCount: -1, _id: -1 })
       .limit(limit + 1)
@@ -318,7 +326,7 @@ publicChannelsRouter.get('/', ...readLimiters, async (req: AuthRequest, res: Res
     const last = page[page.length - 1];
 
     return sendSuccessResponse(res, 200, {
-      items: page.map((channel) => serialize(channel)),
+      items: page.map((channel) => serializeChannel(channel)),
       hasMore,
       ...(hasMore && last
         ? { nextCursor: `${last.followerCount ?? 0}_${String(last._id)}` }
@@ -373,7 +381,7 @@ publicChannelsRouter.get('/:idOrHandle', ...readLimiters, async (req: AuthReques
       return sendErrorResponse(res, 404, 'Not Found', 'Channel not found');
     }
     const viewerState = await loadViewerState(String(channel._id), req.user?.id);
-    return sendSuccessResponse(res, 200, serialize(channel, viewerState));
+    return sendSuccessResponse(res, 200, serializeChannel(channel, viewerState));
   } catch (err) {
     logger.error('[Channels] Error loading channel:', { error: err });
     return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to load channel');
@@ -468,7 +476,7 @@ router.get('/mine', ...readLimiters, async (req: AuthRequest, res: Response) => 
       .sort({ createdAt: -1 })
       .limit(MAX_CALLER_CHANNEL_ROWS)
       .lean<ChannelLean[]>();
-    return sendSuccessResponse(res, 200, channels.map((channel) => serialize(channel)));
+    return sendSuccessResponse(res, 200, channels.map((channel) => serializeChannel(channel)));
   } catch (err) {
     logger.error('[Channels] Error listing own channels:', { userId: req.user?.id, error: err });
     return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to list channels');
@@ -493,7 +501,7 @@ router.get('/invites', ...readLimiters, async (req: AuthRequest, res: Response) 
       .sort({ createdAt: -1 })
       .limit(MAX_CALLER_CHANNEL_ROWS)
       .lean<ChannelLean[]>();
-    return sendSuccessResponse(res, 200, channels.map((channel) => serialize(channel)));
+    return sendSuccessResponse(res, 200, channels.map((channel) => serializeChannel(channel)));
   } catch (err) {
     logger.error('[Channels] Error listing channel invites:', { userId: req.user?.id, error: err });
     return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to list invites');
@@ -611,7 +619,7 @@ router.get('/following', ...readLimiters, async (req: AuthRequest, res: Response
       if (!channel) continue;
       const membership = membershipByChannel.get(follow.channelId);
       items.push(
-        serialize(channel, {
+        serializeChannel(channel, {
           isFollowing: true,
           notify: follow.notify === true,
           ...(membership ? { role: membership.role, memberStatus: membership.status } : {}),
@@ -698,7 +706,7 @@ router.post('/', ...writeLimiters, validateBody(createChannelSchema), async (req
     return sendSuccessResponse(
       res,
       201,
-      serialize(created.toObject() as ChannelLean, {
+      serializeChannel(created.toObject() as ChannelLean, {
         isFollowing: false,
         notify: false,
         role: 'owner',
@@ -765,7 +773,7 @@ router.put(
       return sendSuccessResponse(
         res,
         200,
-        serialize(channel.toObject() as ChannelLean),
+        serializeChannel(channel.toObject() as ChannelLean),
         'Channel updated',
       );
     } catch (err) {

--- a/packages/backend/src/services/channelDto.ts
+++ b/packages/backend/src/services/channelDto.ts
@@ -1,0 +1,59 @@
+/**
+ * The wire shape of a channel — ONE definition, for the same reason
+ * `services/channelAccess.ts` is the one definition of what somebody may DO with
+ * a channel.
+ *
+ * Two surfaces now answer with a channel: the channels API itself
+ * (`routes/channels.routes.ts`) and search (`services/channelSearch.ts`). A
+ * second serializer would be a second answer to "what is a channel to a client",
+ * and the two would drift on the first field either one gains — a card rendered
+ * from a search result would quietly lose whatever the directory grew.
+ */
+
+import type {
+  Channel as ChannelDTO,
+  ChannelViewerState,
+} from '@mention/shared-types';
+
+/** Shape of a `Channel` document as the read paths load it back. */
+export interface ChannelLean {
+  _id: unknown;
+  handle: string;
+  title: string;
+  description?: string;
+  avatar?: string;
+  banner?: string;
+  ownerOxyUserId: string;
+  visibility: string;
+  signPosts?: boolean;
+  followerCount?: number;
+  memberCount?: number;
+  postCount?: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export function serializeChannel(
+  doc: ChannelLean,
+  viewerState?: ChannelViewerState,
+): ChannelDTO {
+  return {
+    id: String(doc._id),
+    handle: doc.handle,
+    title: doc.title,
+    ...(doc.description ? { description: doc.description } : {}),
+    ...(doc.avatar ? { avatar: doc.avatar } : {}),
+    ...(doc.banner ? { banner: doc.banner } : {}),
+    ownerOxyUserId: doc.ownerOxyUserId,
+    // The stored value is the authority; the cast is safe because the schema enum
+    // is the same list the DTO type is built from.
+    visibility: 'public',
+    signPosts: doc.signPosts === true,
+    followerCount: doc.followerCount ?? 0,
+    memberCount: doc.memberCount ?? 0,
+    postCount: doc.postCount ?? 0,
+    createdAt: doc.createdAt.toISOString(),
+    updatedAt: doc.updatedAt.toISOString(),
+    ...(viewerState ? { viewerState } : {}),
+  };
+}

--- a/packages/backend/src/services/channelSearch.ts
+++ b/packages/backend/src/services/channelSearch.ts
@@ -1,0 +1,177 @@
+/**
+ * Finding a channel by name — the entity, not its posts.
+ *
+ * Channel POSTS already surface on every discovery surface as ordinary posts;
+ * this is how the DESTINATION itself becomes findable, which is what a reader who
+ * heard a channel's name actually wants.
+ *
+ * Pure of Express on purpose, the way `mtn/feed/interstitials/interstitialTelemetry.ts`
+ * is: the search controller cannot be unit-tested in isolation, and the ranking
+ * below is the part worth testing.
+ *
+ * THREE properties are load-bearing, and each one is a rule somebody relaxes later:
+ *
+ *  1. **`visibility` is a MATCH CLAUSE, never a post-filter.** `ChannelVisibility`
+ *     has one value today, so a filter written after the query would look correct
+ *     and stay correct until the day a second value exists — at which point the
+ *     omission leaks rather than fails. Asking Mongo means a restricted tier can
+ *     never be returned by a page this code forgot to re-audit.
+ *  2. **The term is regex-ESCAPED.** An unescaped user string in a Mongo regex is
+ *     both an injection (`.*` matches every channel) and a ReDoS. Same
+ *     `escapeRegex` precedent as `routes/lists.ts`.
+ *  3. **The sort is TOTAL** — rank, then followers, then `_id`. Offset paging over
+ *     a partial order duplicates and drops rows; `_id` is what makes the order
+ *     total, exactly as `routes/lists.ts` breaks its `updatedAt` ties.
+ */
+
+import type mongoose from 'mongoose';
+import type { PipelineStage } from 'mongoose';
+import {
+  MAX_CHANNEL_DESCRIPTION_LENGTH,
+  type Channel as ChannelDTO,
+} from '@mention/shared-types';
+import { Channel } from '../models/Channel';
+import { serializeChannel, type ChannelLean } from './channelDto';
+import { escapeRegex } from '../utils/textProcessing';
+import { config } from '../config';
+
+/**
+ * How deep a caller may page. A `$skip` is linear in the rows it discards, so an
+ * unbounded offset is a cheap way to make the server walk the whole collection;
+ * nobody scrolls past this many name matches, and the alternative — a keyset over
+ * a COMPUTED rank — would have to encode the rank in the cursor and re-derive it
+ * identically on every page.
+ */
+export const MAX_CHANNEL_SEARCH_OFFSET = 500;
+
+/**
+ * Longest term worth matching: the longest field it is matched against. Escaping
+ * already leaves a literal pattern (no alternation, no quantifiers, so nothing to
+ * backtrack), but a term longer than every field it could match is work that can
+ * only ever return nothing.
+ */
+const MAX_CHANNEL_SEARCH_TERM_LENGTH = MAX_CHANNEL_DESCRIPTION_LENGTH;
+
+/**
+ * Relevance tiers, ascending — a `$sort` reads them as an ordinary number, so
+ * "better" is SMALLER.
+ *
+ * The one ordering the product actually promises is that somebody who typed a
+ * channel's exact handle gets that channel first: a handle is unique and
+ * unambiguous, so an exact hit is an answer rather than a candidate, and losing
+ * it to a more-followed channel that merely mentions the word in its description
+ * is the failure this ranking exists to prevent. Below that, a name match beats a
+ * blurb match, and `followerCount` breaks ties.
+ */
+export const CHANNEL_SEARCH_RANK = {
+  exactHandle: 0,
+  handle: 1,
+  title: 2,
+  description: 3,
+} as const;
+
+/** A page of channel results, and whether another one exists. */
+export interface ChannelSearchPage {
+  items: ChannelDTO[];
+  hasMore: boolean;
+}
+
+export interface ChannelSearchOptions {
+  limit: number;
+  offset: number;
+  /**
+   * Channels to leave out — the directory's `excludeFollowed` set, which the
+   * search path honours too so a documented query parameter does not quietly
+   * stop meaning anything the moment a search term is added next to it.
+   */
+  excludeChannelIds?: mongoose.Types.ObjectId[];
+}
+
+/**
+ * Public channels whose handle, title or description contains `rawTerm`, best
+ * match first.
+ *
+ * A blank term returns nothing rather than the whole directory: `GET /channels`
+ * is the directory, and a search box that has not been typed in has not asked a
+ * question.
+ */
+export async function searchChannels(
+  rawTerm: string,
+  { limit, offset, excludeChannelIds }: ChannelSearchOptions,
+): Promise<ChannelSearchPage> {
+  const term = rawTerm.trim().slice(0, MAX_CHANNEL_SEARCH_TERM_LENGTH);
+  if (term.length === 0) {
+    return { items: [], hasMore: false };
+  }
+
+  const pattern = escapeRegex(term);
+  // `handleLower` is stored canonical-lowercase, so the exact tier compares
+  // against the lowercased term — only a stored handle can ever match it.
+  const exactHandle = term.toLowerCase();
+
+  const pipeline: PipelineStage[] = [
+    {
+      $match: {
+        visibility: 'public',
+        ...(excludeChannelIds && excludeChannelIds.length > 0
+          ? { _id: { $nin: excludeChannelIds } }
+          : {}),
+        // A disjunction is what "matches any of three fields" IS. No
+        // `ChronoCursor` is anywhere near this query — the rule that forbids an
+        // `$or` applies to the feed match objects `ChronoCursor.applyToQuery`
+        // ASSIGNS into, and is stated here so nobody carries it over by reflex.
+        $or: [
+          { handleLower: { $regex: pattern, $options: 'i' } },
+          { title: { $regex: pattern, $options: 'i' } },
+          { description: { $regex: pattern, $options: 'i' } },
+        ],
+      },
+    },
+    {
+      $addFields: {
+        searchRank: {
+          $switch: {
+            branches: [
+              {
+                case: { $eq: ['$handleLower', exactHandle] },
+                then: CHANNEL_SEARCH_RANK.exactHandle,
+              },
+              {
+                case: { $regexMatch: { input: '$handleLower', regex: pattern, options: 'i' } },
+                then: CHANNEL_SEARCH_RANK.handle,
+              },
+              {
+                // `$regexMatch` refuses a null input, and a legacy row is not a
+                // reason to fail the whole page.
+                case: {
+                  $regexMatch: {
+                    input: { $ifNull: ['$title', ''] },
+                    regex: pattern,
+                    options: 'i',
+                  },
+                },
+                then: CHANNEL_SEARCH_RANK.title,
+              },
+            ],
+            // Reached only by a row the `$match` already accepted, so the
+            // remaining explanation is the description.
+            default: CHANNEL_SEARCH_RANK.description,
+          },
+        },
+      },
+    },
+    { $sort: { searchRank: 1, followerCount: -1, _id: -1 } },
+    { $skip: offset },
+    // One extra row answers `hasMore` without a second count over the same match.
+    { $limit: limit + 1 },
+  ];
+
+  const matched = await Channel.aggregate<ChannelLean>(pipeline)
+    .option({ maxTimeMS: config.search.maxTimeMS })
+    .exec();
+
+  const hasMore = matched.length > limit;
+  const page = hasMore ? matched.slice(0, limit) : matched;
+
+  return { items: page.map((channel) => serializeChannel(channel)), hasMore };
+}


### PR DESCRIPTION
Channels were reachable only if you already knew one existed. `GET /channels` now takes a `search` term.

**Why there and not `/search`.** Every other searchable collection answers from its own public route — `/feeds?search=`, `/lists?search=`, `/starter-packs?search=`; only posts and users live on `/search`. That is not just consistency: `/search` is mounted on the **authenticated** router, so an anonymous caller 401s and the section renders silently empty. Channels are fully public, so built on `/search` they would have been the one result type that disappears when you log out.

**Ranking**: exact handle → handle substring → title → description, then follower count, then `_id`. An exact handle wins on one follower against a title match on nine thousand — you typed the name, you meant the channel.

**Browse and search are disjoint by structure, not by a guard.** Search returns before the keyset cursor is ever parsed. The first attempt *was* a guard, and mutating it revealed it was dead code — the search branch never read the match it protected — so a test would have approved it while measuring nothing. Search is offset-paged while browse stays keyset, because the sort key is a computed relevance rank: a keyset cursor would have to carry that rank and re-derive it per page, which is a second definition of the ranking waiting to drift.

**No new index**, checked rather than assumed: `explain` on a real mongod shows the query riding the existing directory index, and an unanchored case-insensitive substring cannot be index-served by any compound index.

## Verification

- `bun run check:types` — 0 errors (only the 4 pre-existing `import/first` warnings)
- `cd packages/backend && bun run test` — **413 files / 4502 tests**, arithmetic checked as a vacuity floor: 412→413 files, 4477+14+11 = 4502
- 18 mutations, all caught. One survived at first because the edit **never applied** — the pattern did not match and the diff went unread; the harness now asserts the file changed before running.
- A real-mongod proof (16/16) covering ranking, injection, visibility and paging. Not committed: CI has no mongod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)