### PR TITLE
fix(cache): evict posts stored before the signature fields existed

### DIFF
--- a/packages/frontend/db/__tests__/cacheShapeVersion.test.ts
+++ b/packages/frontend/db/__tests__/cacheShapeVersion.test.ts
@@ -1,0 +1,114 @@
+import type { HydratedPost } from '@mention/shared-types';
+import { PostVisibility } from '@mention/shared-types/post';
+import { toFeedItem } from '../feedItem';
+import { SCHEMA_VERSION } from '../migrations';
+
+/**
+ * The local cache keeps most of a post as a serialized `FeedItem` in `raw_json`,
+ * and `rowToFeedItem` spreads whatever it finds there. So the payload's shape
+ * drifts independently of every column: adding a field to `toFeedItem` changes
+ * what NEW rows carry while every row already on disk keeps answering with the
+ * old shape — forever, since nothing evicts it.
+ *
+ * That is not theoretical. `lane` and `channel` were added to the converter
+ * without a schema bump, and channel posts rendered as "Unknown user" from cache
+ * while the same post fetched fresh rendered correctly. It looks like a render
+ * bug and is not one, which is what made it expensive to find.
+ *
+ * `SCHEMA_VERSION` is the only thing that evicts a stale row, and its own
+ * docstring used to say "bump when the table definitions change" — which this
+ * class of change does not do. So the two are pinned together here: change what
+ * the converter persists and this fails until the version moves with it.
+ */
+const PERSISTED_POST_KEYS = [
+  'allMediaIds',
+  'attachments',
+  'authors',
+  'authorship',
+  'boost',
+  'channel',
+  'content',
+  'context',
+  'date',
+  'engagement',
+  'id',
+  'lane',
+  'linkPreviews',
+  'mediaIds',
+  'metadata',
+  'originalPost',
+  'parentPostId',
+  'permissions',
+  'quotedPost',
+  'replyContext',
+  'user',
+  'viewerState',
+] as const;
+
+/** The version that must ship with the key set above. */
+const VERSION_FOR_THESE_KEYS = 7;
+
+function makeFullyPopulatedPost(): HydratedPost {
+  return {
+    id: 'post-1',
+    content: { text: 'body' },
+    attachments: { media: [{ id: 'media-1', type: 'image' }] },
+    linkPreviews: [],
+    user: {
+      id: 'user-1',
+      username: 'user1',
+      name: { displayName: 'User One' },
+      avatar: 'avatar-1',
+    },
+    authors: [{
+      id: 'user-1',
+      username: 'user1',
+      name: { displayName: 'User One' },
+      role: 'owner',
+      status: 'accepted',
+    }],
+    authorship: [{ oxyUserId: 'user-1', role: 'owner', status: 'accepted' }],
+    engagement: {
+      likes: 0, downvotes: 0, boosts: 0, replies: 0, saves: 0, views: 0, impressions: 0,
+    },
+    viewerState: {
+      isOwner: false,
+      isCollaborator: false,
+      isLiked: false,
+      isDownvoted: false,
+      isBoosted: false,
+      isSaved: false,
+    },
+    permissions: {
+      canReply: true,
+      canDelete: false,
+      canPin: false,
+      canViewSources: false,
+    },
+    metadata: {
+      visibility: PostVisibility.PUBLIC,
+      createdAt: '2026-08-02T00:00:00.000Z',
+      updatedAt: '2026-08-02T00:00:00.000Z',
+    },
+    lane: { id: 'lane-1', name: 'Opinion', displayMode: 'mixed' },
+    channel: { id: 'ch-1', handle: 'nateonoxy', title: 'Nate on Oxy', signPosts: false },
+    originalPost: null,
+    quotedPost: null,
+    boost: null,
+  };
+}
+
+describe('persisted post shape is pinned to the cache schema version', () => {
+  it('carries exactly the keys the pinned version was cut for', () => {
+    const keys = Object.keys(toFeedItem(makeFullyPopulatedPost())).sort();
+
+    // A diff here means the persisted payload changed. Update BOTH this list and
+    // `SCHEMA_VERSION`, or every existing client keeps serving the old shape from
+    // disk with no error anywhere.
+    expect(keys).toEqual([...PERSISTED_POST_KEYS]);
+  });
+
+  it('ships the schema version that matches that key set', () => {
+    expect(SCHEMA_VERSION).toBe(VERSION_FOR_THESE_KEYS);
+  });
+});

--- a/packages/frontend/db/__tests__/migrations.test.ts
+++ b/packages/frontend/db/__tests__/migrations.test.ts
@@ -19,6 +19,6 @@ describe('post cache schema migration', () => {
     expect(execSync).toHaveBeenCalledWith('DROP TABLE IF EXISTS "posts"');
     expect(execSync).toHaveBeenCalledWith('DROP TABLE IF EXISTS "feed_items"');
     expect(execSync).toHaveBeenCalledWith('DROP TABLE IF EXISTS "cache_metadata"');
-    expect(execSync).toHaveBeenLastCalledWith('PRAGMA user_version = 6');
+    expect(execSync).toHaveBeenLastCalledWith('PRAGMA user_version = 7');
   });
 });

--- a/packages/frontend/db/migrations.ts
+++ b/packages/frontend/db/migrations.ts
@@ -16,10 +16,25 @@ import { createLogger } from '@oxyhq/core/logger';
 const logger = createLogger('Schema');
 
 /**
- * Schema version. Bump this whenever the table definitions below change —
- * the next `getDb()` will drop the old cache and recreate it cleanly.
+ * Schema version. Bump this whenever the table definitions below change **or
+ * the shape of anything stored inside them does** — the next `getDb()` drops
+ * the old cache and recreates it cleanly.
+ *
+ * The second half of that sentence is the one that has actually bitten. Most of
+ * a post lives in `raw_json` as a serialized `FeedItem`, and that payload's
+ * shape moves independently of every column: `toFeedItem` gaining a field
+ * changes what NEW rows carry while every row already on disk keeps answering
+ * with the old shape, forever, because `rowToFeedItem` faithfully spreads what
+ * it was given. It shipped once — `lane` and `channel` were added to the
+ * converter without a bump, so a post read from cache rendered without its
+ * signature while the same post fetched fresh rendered correctly, which reads
+ * like a render bug and is not one.
+ *
+ * `db/__tests__/cacheShapeVersion.test.ts` fails when the persisted key set
+ * changes without this number moving, so the rule is enforced rather than
+ * remembered.
  */
-const SCHEMA_VERSION = 6;
+export const SCHEMA_VERSION = 7;
 
 /**
  * Create the full schema from scratch. Idempotent (IF NOT EXISTS).


### PR DESCRIPTION
The converter fix (#559) corrected what **new** rows store. It did nothing for rows already on disk — and those are what a feed reads.

`rowToFeedItem` faithfully spreads whatever was persisted, so a client that cached a post under the old build keeps rendering it without its signature: channel posts as **"Unknown user"**, lane posts with no lane. The same post opened fresh from the API renders correctly. Fresh right, cached wrong, and permanent, because nothing evicts a stale row.

`SCHEMA_VERSION` is the only thing that evicts one, and its rule said to bump it *"whenever the table definitions change"* — which this class of change does not do. Most of a post lives in `raw_json` as a serialized `FeedItem`, whose shape moves independently of every column.

## Two levels

- **The data**: the version moves, resetting each client's cache once. It repopulates from the network with the correct shape. Nobody has to clear anything by hand.
- **The rule**: `cacheShapeVersion.test.ts` pins the exact key set the converter persists against the version it shipped with. Change what is stored and it fails until the version moves with it.

Mutation-verified both ways — dropping `channel` from the converter fails the key-set test, lowering the version fails the version test — and the harness asserts the edit actually applied before trusting the result, because a mutation that does not mutate looks exactly like a gate that does not gate.

## Verification

- `bun run typecheck:frontend` — 0 errors, and **no casts**: the first draft used `as HydratedPost` to paper over an incomplete fixture, which is the exact thing the repo bans; the fixture is now complete instead.
- `bun run --cwd packages/frontend test` — **131 suites / 1126 tests**
- `db/__tests__/migrations.test.ts` pinned the old version and was updated deliberately, not to make a red go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)