### PR TITLE
feat(channels): make room for a writer who is no longer the author

### DIFF
--- a/packages/backend/src/__tests__/models/channelAccountSchema.test.ts
+++ b/packages/backend/src/__tests__/models/channelAccountSchema.test.ts
@@ -1,0 +1,339 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The additive schema for channel accounts: `Post.writtenByOxyUserId` and
+ * `UserSettings.channel.signPosts`.
+ *
+ * ## Why a real database rather than a constructed document
+ *
+ * The `Post` schema is STRICT, so an undeclared field is dropped SILENTLY — no
+ * error, no warning, the write succeeds and the value is simply gone. A test that
+ * constructs a document and reads the property back can be fooled by an in-memory
+ * value that would never survive a save, so each field is written through its
+ * model and read back out of Mongo. The author-relationship matchers are likewise
+ * EXECUTED against real documents rather than inspected as objects: an assertion
+ * on the shape of a match re-states the code instead of checking its effect, and
+ * passes just as happily when the clause is present but wrong.
+ *
+ * ## The guarantee this file exists to defend
+ *
+ * `writtenByOxyUserId` must never migrate into `authorship[]`. That refactor is
+ * tempting — it looks like consolidation — and it silently breaks the anonymity of
+ * a `signPosts: false` channel AND puts channel posts back on their writer's own
+ * profile and in their followers' timelines.
+ *
+ * That guarantee is also what decides whether `EXCLUDE_CHANNEL_POSTS` can be
+ * DELETED, so the second describe block below is written as a verdict rather than
+ * a regression test: it separates what the field placement already buys from the
+ * one condition still outstanding. The third block is the mutation — the writer is
+ * moved into `authorship[]` and the resulting damage asserted — so the guarantee
+ * is shown to be load-bearing rather than merely true today.
+ */
+
+vi.unmock('mongoose');
+
+const mongoose = (await import('mongoose')).default;
+const { Post } = await import('../../models/Post');
+const { UserSettings } = await import('../../models/UserSettings');
+const {
+  buildAuthorFeedMatch,
+  buildFollowedAuthorsMatch,
+  getHeaderAuthorshipEntries,
+  EXCLUDE_CHANNEL_POSTS,
+} = await import('../../utils/postAuthorship');
+
+/** The Oxy `channel` account that authors the post once the cut-over has happened. */
+const CHANNEL_ACCOUNT = 'oxy-channel-account';
+/** The human who wrote it, and who must not be an author of it. */
+const WRITER = 'oxy-writer';
+const CHANNEL_ID = 'channel-1';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri(), { dbName: 'channel-account-schema' });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod?.stop();
+});
+
+afterEach(async () => {
+  await Promise.all([Post.deleteMany({}), UserSettings.deleteMany({})]);
+});
+
+/**
+ * The SHAPE THIS FIELD EXISTS FOR: the channel account is the author, and the
+ * human who wrote it is carried outside `authorship[]`.
+ */
+async function seedChannelAuthoredPost(): Promise<string> {
+  const post = new Post({
+    oxyUserId: CHANNEL_ACCOUNT,
+    authorship: [{ oxyUserId: CHANNEL_ACCOUNT, role: 'owner', status: 'accepted' }],
+    channelId: CHANNEL_ID,
+    writtenByOxyUserId: WRITER,
+    visibility: 'public',
+    status: 'published',
+    content: { variants: [{ source: 'author', text: 'from the channel' }] },
+  });
+  await post.save();
+  return post._id.toString();
+}
+
+/**
+ * The shape channel posts have TODAY, before the cut-over: the human is the
+ * author and `channelId` is the only thing marking it as a channel post. Nothing
+ * but `EXCLUDE_CHANNEL_POSTS` keeps one of these off its author's own surfaces —
+ * which is why the clause exists, and the condition still outstanding before it
+ * can be deleted.
+ */
+async function seedPersonAuthoredChannelPost(): Promise<void> {
+  const post = new Post({
+    oxyUserId: WRITER,
+    authorship: [{ oxyUserId: WRITER, role: 'owner', status: 'accepted' }],
+    channelId: CHANNEL_ID,
+    visibility: 'public',
+    status: 'published',
+    content: { variants: [{ source: 'author', text: 'legacy channel post' }] },
+  });
+  await post.save();
+}
+
+/** An ordinary post by the writer, on no channel — every vacuity floor's control. */
+async function seedOrdinaryPost(): Promise<string> {
+  const post = new Post({
+    oxyUserId: WRITER,
+    authorship: [{ oxyUserId: WRITER, role: 'owner', status: 'accepted' }],
+    visibility: 'public',
+    status: 'published',
+    content: { variants: [{ source: 'author', text: 'my own post' }] },
+  });
+  await post.save();
+  return post._id.toString();
+}
+
+/**
+ * A matcher with the channel exclusion REMOVED — its authorship half on its own,
+ * i.e. what the query would become the day `EXCLUDE_CHANNEL_POSTS` is deleted.
+ *
+ * Derived from the real matcher rather than re-stated, so it cannot drift from it,
+ * and the derivation is checked to have actually removed something — a no-op strip
+ * would make every assertion built on it meaningless.
+ */
+function withoutChannelExclusion(match: Record<string, unknown>): Record<string, unknown> {
+  const half = { ...match };
+  for (const key of Object.keys(EXCLUDE_CHANNEL_POSTS)) {
+    delete half[key];
+  }
+  expect(Object.keys(half).length).toBeLessThan(Object.keys(match).length);
+  return half;
+}
+
+describe('Post.writtenByOxyUserId', () => {
+  it('round-trips through the database — the strict schema does not drop it', async () => {
+    const id = await seedChannelAuthoredPost();
+
+    const stored = await Post.collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+
+    expect(stored?.writtenByOxyUserId).toBe(WRITER);
+  });
+
+  it('CONTROL: an undeclared field IS dropped, so the assertion above can fail', async () => {
+    // Without this, "the value came back" proves nothing: it would read the same
+    // way if strict mode were off and every field survived regardless.
+    const post = new Post({
+      oxyUserId: CHANNEL_ACCOUNT,
+      authorship: [{ oxyUserId: CHANNEL_ACCOUNT, role: 'owner', status: 'accepted' }],
+      writtenByOxyUserId: WRITER,
+      penNameOxyUserId: WRITER,
+      content: { variants: [{ source: 'author', text: 'x' }] },
+    });
+    await post.save();
+
+    const stored = await Post.collection.findOne({ _id: post._id });
+
+    expect(stored?.writtenByOxyUserId).toBe(WRITER);
+    expect(stored).not.toHaveProperty('penNameOxyUserId');
+  });
+
+  it('keeps the writer OUT of authorship[] — the channel is the only author', async () => {
+    await seedChannelAuthoredPost();
+
+    const stored = await Post.findOne({ channelId: CHANNEL_ID }).lean();
+
+    expect(stored?.authorship).toEqual([
+      { oxyUserId: CHANNEL_ACCOUNT, role: 'owner', status: 'accepted' },
+    ]);
+    expect(stored?.authorship?.some((entry) => entry.oxyUserId === WRITER)).toBe(false);
+  });
+
+  it('does not name the writer in the post byline', async () => {
+    const stored = await Post.findById(await seedChannelAuthoredPost()).lean();
+
+    const byline = getHeaderAuthorshipEntries(stored?.authorship ?? []);
+
+    expect(byline.map((entry) => entry.oxyUserId)).toEqual([CHANNEL_ACCOUNT]);
+  });
+});
+
+/**
+ * ## Verdict: can `EXCLUDE_CHANNEL_POSTS` be deleted?
+ *
+ * The clause is a flat `{ channelId: { $exists: false } }` term carried by BOTH
+ * author-relationship matchers — `buildAuthorFeedMatch` (the profile feed) and
+ * `buildFollowedAuthorsMatch` (the following timeline). Deleting it requires both
+ * to be safe without it, so both are measured here; testing only the profile would
+ * answer half the question while reading as if it answered all of it.
+ *
+ * **Sufficient, already true:** for a post authored BY the channel account, the
+ * authorship half alone excludes it from both surfaces. The clause is redundant
+ * for that shape. This is exactly what keeping the writer out of `authorship[]`
+ * buys, and the mutation block below shows it is the only reason it holds.
+ *
+ * **Still outstanding:** a post authored by the PERSON with `channelId` set — the
+ * shape every channel post has today — is held back by NOTHING ELSE. Deleting the
+ * clause while one such row exists puts it straight back on its author's profile
+ * and in their followers' timelines. So the precondition is not "the field
+ * exists", it is "no post retains the person-authored shape" — a DATA condition,
+ * which a clean cut with no rows worth preserving satisfies outright.
+ */
+describe('EXCLUDE_CHANNEL_POSTS — deletable for the new shape, blocked by the old one', () => {
+  it('SUFFICIENT (profile): the authorship half alone excludes a channel-authored post', async () => {
+    await seedChannelAuthoredPost();
+
+    const matched = await Post.find(withoutChannelExclusion(buildAuthorFeedMatch(WRITER))).lean();
+
+    expect(matched).toHaveLength(0);
+  });
+
+  it('SUFFICIENT (following): the authorship half alone excludes it there too', async () => {
+    await seedChannelAuthoredPost();
+
+    const matched = await Post.find(
+      withoutChannelExclusion(buildFollowedAuthorsMatch([WRITER])),
+    ).lean();
+
+    expect(matched).toHaveLength(0);
+  });
+
+  it('VACUITY FLOOR: both halved matchers DO return an ordinary post by that author', async () => {
+    // "Nothing came back" is otherwise satisfiable by a query that matches nothing
+    // at all — a typo in either match would pass both assertions above.
+    await seedChannelAuthoredPost();
+    const ordinaryId = await seedOrdinaryPost();
+
+    const onProfile = await Post.find(withoutChannelExclusion(buildAuthorFeedMatch(WRITER))).lean();
+    const onTimeline = await Post.find(
+      withoutChannelExclusion(buildFollowedAuthorsMatch([WRITER])),
+    ).lean();
+
+    expect(onProfile.map((post) => post._id.toString())).toEqual([ordinaryId]);
+    expect(onTimeline.map((post) => post._id.toString())).toEqual([ordinaryId]);
+  });
+
+  it('BLOCKER (profile): a PERSON-authored channel post is held back by the clause and nothing else', async () => {
+    // The shape every channel post has today. This is the one condition standing
+    // between the clause and its deletion — and it is a data condition, not a code
+    // one, so a clean cut with no rows to preserve satisfies it.
+    await seedPersonAuthoredChannelPost();
+
+    expect(await Post.find(buildAuthorFeedMatch(WRITER)).lean()).toHaveLength(0);
+    expect(
+      await Post.find(withoutChannelExclusion(buildAuthorFeedMatch(WRITER))).lean(),
+    ).toHaveLength(1);
+  });
+
+  it('BLOCKER (following): the same row returns to the followers timeline without the clause', async () => {
+    await seedPersonAuthoredChannelPost();
+
+    expect(await Post.find(buildFollowedAuthorsMatch([WRITER])).lean()).toHaveLength(0);
+    expect(
+      await Post.find(withoutChannelExclusion(buildFollowedAuthorsMatch([WRITER]))).lean(),
+    ).toHaveLength(1);
+  });
+
+  it('keeps a channel-authored post off the writer\'s surfaces WITH the clause in place too', async () => {
+    // The shipped behaviour today, unchanged by this step.
+    await seedChannelAuthoredPost();
+
+    expect(await Post.find(buildAuthorFeedMatch(WRITER)).lean()).toHaveLength(0);
+    expect(await Post.find(buildFollowedAuthorsMatch([WRITER])).lean()).toHaveLength(0);
+  });
+});
+
+describe('MUTATION — the writer moved into authorship[]', () => {
+  /** The "tidied" shape: writer as a co-author instead of a top-level field. */
+  async function seedWriterAsCollaborator(): Promise<void> {
+    const post = new Post({
+      oxyUserId: CHANNEL_ACCOUNT,
+      authorship: [
+        { oxyUserId: CHANNEL_ACCOUNT, role: 'owner', status: 'accepted' },
+        { oxyUserId: WRITER, role: 'collaborator', status: 'accepted' },
+      ],
+      channelId: CHANNEL_ID,
+      visibility: 'public',
+      status: 'published',
+      content: { variants: [{ source: 'author', text: 'from the channel' }] },
+    });
+    await post.save();
+  }
+
+  it('breaks anonymity: the byline now names the writer', async () => {
+    await seedWriterAsCollaborator();
+
+    const stored = await Post.findOne({ channelId: CHANNEL_ID }).lean();
+    const byline = getHeaderAuthorshipEntries(stored?.authorship ?? []);
+
+    expect(byline.map((entry) => entry.oxyUserId)).toEqual([CHANNEL_ACCOUNT, WRITER]);
+  });
+
+  it('makes EXCLUDE_CHANNEL_POSTS permanent: both surfaces would depend on it again', async () => {
+    // This is the regression the field placement prevents, and the reason it
+    // decides the clause's fate: the damage is invisible while the clause exists,
+    // so the clause could never be removed afterwards — it would be load-bearing
+    // again, for every channel post, forever.
+    await seedWriterAsCollaborator();
+
+    expect(
+      await Post.find(withoutChannelExclusion(buildAuthorFeedMatch(WRITER))).lean(),
+    ).toHaveLength(1);
+    expect(
+      await Post.find(withoutChannelExclusion(buildFollowedAuthorsMatch([WRITER]))).lean(),
+    ).toHaveLength(1);
+
+    // Still hidden today — which is precisely why nothing would notice.
+    expect(await Post.find(buildAuthorFeedMatch(WRITER)).lean()).toHaveLength(0);
+    expect(await Post.find(buildFollowedAuthorsMatch([WRITER])).lean()).toHaveLength(0);
+  });
+});
+
+describe('UserSettings.channel.signPosts', () => {
+  it('round-trips through the database', async () => {
+    await new UserSettings({ oxyUserId: CHANNEL_ACCOUNT, channel: { signPosts: true } }).save();
+
+    const stored = await UserSettings.collection.findOne({ oxyUserId: CHANNEL_ACCOUNT });
+
+    expect(stored?.channel).toEqual({ signPosts: true });
+  });
+
+  it('defaults to FALSE — a channel post is anonymous unless the owner says otherwise', async () => {
+    // Same default as `Channel.signPosts`. Backwards, it would publish every
+    // writer's identity by omission.
+    await new UserSettings({ oxyUserId: CHANNEL_ACCOUNT, channel: {} }).save();
+
+    const stored = await UserSettings.findOne({ oxyUserId: CHANNEL_ACCOUNT }).lean();
+
+    expect(stored?.channel?.signPosts).toBe(false);
+  });
+
+  it('stays ABSENT on a person\'s settings rather than defaulting a channel subdoc onto them', async () => {
+    await new UserSettings({ oxyUserId: WRITER }).save();
+
+    const stored = await UserSettings.collection.findOne({ oxyUserId: WRITER });
+
+    expect(stored).not.toHaveProperty('channel');
+  });
+});

--- a/packages/backend/src/models/Post.ts
+++ b/packages/backend/src/models/Post.ts
@@ -72,6 +72,35 @@ export interface IPost extends Document {
    * conjunctive term rather than a disjunction `ChronoCursor` would clobber.
    */
   channelId?: string;
+  /**
+   * The PERSON who wrote this post, when the post's author is a channel account
+   * rather than a human.
+   *
+   * A channel is becoming a real Oxy account, so `oxyUserId` and `authorship[]`
+   * will hold the CHANNEL. That leaves the writer with nowhere else on the row —
+   * and Mention still needs them: a channel whose `signPosts` is on renders a
+   * "by <writer>" line beneath the channel's byline.
+   *
+   * **It is its own top-level field and must NEVER be folded into `authorship[]`.**
+   * That looks like tidying and breaks two things, both load-bearing:
+   *
+   *  - `getHeaderAuthorshipEntries` (`utils/postAuthorship`) would render the
+   *    writer as a CO-AUTHOR, so the DTO would name the person a channel with
+   *    `signPosts: false` exists to keep anonymous.
+   *  - `buildAuthorFeedMatch` matches on `authorship`, so the post would reappear
+   *    on the writer's OWN profile — exactly what `EXCLUDE_CHANNEL_POSTS` is there
+   *    to prevent. Kept out of `authorship[]`, that clause can eventually be
+   *    deleted; put in, it has to stay forever.
+   *
+   * Both properties are pinned (and mutation-tested) in
+   * `__tests__/models/channelAccountSchema.test.ts`.
+   *
+   * No `index:` — nothing reads the field yet, and the read it is being added for
+   * takes a post the caller already holds and resolves its writer by id. Adding a
+   * schema index would create nothing in production anyway (`autoIndex` is OFF),
+   * so an index here would be a migration for a query that does not exist.
+   */
+  writtenByOxyUserId?: string;
   parentPostId?: string; // for replies
   threadId?: string; // for thread posts
   replyPermission?: ReplyPermission[]; // Who can reply and quote this post
@@ -583,6 +612,10 @@ const PostSchema = new Schema<IPost>({
   // EXCLUSION (`{ channelId: { $exists: false } }`) is a residual filter after the
   // seek on `post_author_chrono_v1`, so it needs no index either.
   channelId: { type: String },
+  // The person behind a channel post — see the field's doc comment on `IPost` for
+  // why it is here and NOT an `authorship[]` entry. No `index:`: nothing queries
+  // by writer.
+  writtenByOxyUserId: { type: String },
   parentPostId: { type: String, index: true },
   threadId: { type: String, index: true },
   replyPermission: {

--- a/packages/backend/src/models/UserSettings.ts
+++ b/packages/backend/src/models/UserSettings.ts
@@ -104,6 +104,29 @@ export interface InterestsSettings {
   tags?: string[]; // Array of interest tags
 }
 
+/**
+ * Settings that apply only when the account these settings belong to IS a channel.
+ *
+ * A channel is becoming a real Oxy account, and `UserSettings` is keyed on
+ * `oxyUserId` — which a channel account has — so this is the one place a
+ * per-channel preference can live. It cannot live in Oxy: Oxy owns identity and
+ * has no concept of signing a post, and Mention-owned settings do not belong
+ * there. The subdocument is ABSENT on a person's settings, which is what makes
+ * "is this account a channel" a question nothing here has to answer.
+ */
+export interface ChannelAccountSettings {
+  /**
+   * Whether a post published by this channel also NAMES the person who wrote it
+   * (rendered as a "by <writer>" line beneath the channel's byline; the writer
+   * itself is stored on `Post.writtenByOxyUserId`).
+   *
+   * `false` is the default, matching `Channel.signPosts` — a channel post is
+   * anonymous behind the channel unless its owner says otherwise. Getting the
+   * default backwards would publish every writer's identity by omission.
+   */
+  signPosts: boolean;
+}
+
 export interface NotificationPreferences {
   pushEnabled: boolean;
   emailEnabled: boolean;
@@ -139,6 +162,11 @@ export interface UserSettingsData {
   privacy?: PrivacySettings;
   profileCustomization?: ProfileCustomization;
   interests?: InterestsSettings;
+  /**
+   * Channel-only settings — present only when this account IS a channel. See
+   * {@link ChannelAccountSettings}.
+   */
+  channel?: ChannelAccountSettings;
   feedSettings?: FeedSettings;
   /**
    * Mention-local per-user FEED TUNING (Phase 4B) — the viewer's overrides on
@@ -238,6 +266,13 @@ const InterestsSchema = new Schema<InterestsSettings>({
   tags: [{ type: String }],
 }, { _id: false });
 
+// Channel-only settings. The subdocument itself has NO default, so it stays absent
+// on a person's settings — only `signPosts` inside it defaults, and it defaults to
+// `false` exactly as `Channel.signPosts` does.
+const ChannelAccountSchema = new Schema<ChannelAccountSettings>({
+  signPosts: { type: Boolean, default: false },
+}, { _id: false });
+
 // Per-user For You discovery-gate tuning. Each module carries an optional
 // `enabled` toggle + a single numeric threshold. Bounds are NOT duplicated here —
 // `validateForYouTuning` (shared spec) is the authoritative validator run in the
@@ -314,6 +349,7 @@ const UserSettingsSchema = new Schema<IUserSettings>({
   privacy: { type: PrivacySchema, default: () => ({ profileVisibility: 'public' }) },
   profileCustomization: { type: ProfileCustomizationSchema },
   interests: { type: InterestsSchema },
+  channel: { type: ChannelAccountSchema },
   feedSettings: { type: FeedSettingsSchema },
   feedTuning: { type: FeedTuningSchema },
   notificationPreferences: { type: NotificationPreferencesSchema },


### PR DESCRIPTION
Two additive fields. Nothing reads them yet.

They exist because a channel is about to become a real Oxy account — so a channel post will be authored **by that account**, and the person who wrote it disappears from the row.

## `Post.writtenByOxyUserId`

Keeps the writer. It is deliberately **its own field and not an `authorship[]` entry**, and that is the whole point. Measured both ways here: a writer inside `authorship[]` renders as a co-author (destroying the anonymity an unsigned channel promises them) **and** puts the post back on their own profile *and* in their followers' timeline. Kept out, the authorship match alone already excludes it from both — which is what makes `EXCLUDE_CHANNEL_POSTS` redundant and deletable later rather than permanent.

The guarantee is **defended, not merely true**: the mutation lives in the file as a block asserting the damage, plus a second mutation in the opposite direction proving that block measures the writer's presence rather than passing for some other reason.

Two things the measurement showed that the plan did not:

- **The clause is carried by TWO matchers** — the profile feed and the followers timeline. Checking only the profile would have answered half the question while looking like all of it, and the miss would have surfaced as channel posts appearing in the *writer's* followers' feeds.
- **Its deletion is gated on a DATA condition**, not on this field: that no row still has a person as author with a channel id beside it. The clean cut satisfies that.

## `UserSettings.channel.signPosts`

A home for "does this channel name its writers", now that the `Channel` model is going away. `UserSettings` is Mention-owned and keyed on an `oxyUserId`, which a channel account has; Oxy has no concept of the setting.

## Verification

- `bun run check:types` — 0 errors (only the 4 pre-existing `import/first` warnings)
- `cd packages/backend && bun run test` — **414 files / 4517 tests**, +15 of them mine, and **no pre-existing test changed** — which is the evidence that an additive step is actually additive
- Four mutations, all caught. Tests run against a real mongod rather than constructed documents, because a strict schema drops an undeclared field *silently* and an in-memory read cannot tell the two apart
- Neither field is writable from a request; both write paths take explicit field lists, checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)