### PR TITLE
chore(deps): core 18, and the federation bump Mention was four minors behind on

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@oxyhq/crowdsource": "0.3.0",
         "@oxyhq/crowdsource-contracts": "0.3.0",
         "@oxyhq/crowdsource-express": "0.3.0",
-        "@oxyhq/federation": "^0.7.0",
+        "@oxyhq/federation": "^0.11.0",
         "@oxyhq/protocol": "^0.1.6",
         "@socket.io/redis-adapter": "^8.3.0",
         "@syra.fm/sdk": "catalog:",
@@ -241,8 +241,8 @@
   "catalog": {
     "@oxyhq/bloom": "^0.73.0",
     "@oxyhq/contracts": "^0.22.0",
-    "@oxyhq/core": "^17.1.0",
-    "@oxyhq/services": "^26.1.0",
+    "@oxyhq/core": "^18.0.0",
+    "@oxyhq/services": "^26.2.0",
     "@syra.fm/sdk": "^0.7.0",
     "@types/bun": "1.3.14",
     "@types/jsonwebtoken": "^9.0.10",
@@ -774,7 +774,7 @@
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.22.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-eVXTTjc8V8HinP8f4jKCULzFW2NzwplJadtTKvTPlr2mXaDyl0qFX6l9OasxM0E0ArIcj98vL20U0+CRsJvrDA=="],
 
-    "@oxyhq/core": ["@oxyhq/core@17.1.0", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.22.0", "@oxyhq/protocol": "^0.1.6", "@scure/bip39": "^1.6.0", "@types/elliptic": "^6.4.18", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^8.0.0", "helmet": "^8.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express", "helmet"] }, "sha512-o9HS1fuMvTSH8UtKfhceKgCC8kmy8v6sKEVeOIpOIv7oE17lA08FHRJWIedz8fVe4zq2YWGbjEuWsli9K1w9XA=="],
+    "@oxyhq/core": ["@oxyhq/core@18.0.0", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.22.0", "@oxyhq/protocol": "^0.1.6", "@scure/bip39": "^1.6.0", "@types/elliptic": "^6.4.18", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^8.0.0", "helmet": "^8.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express", "helmet"] }, "sha512-RhWFbQDFbWjWRDiREeFTn7sg5VZd8CqdCTmhneLEAAAQgmPjTf9DED6okZTNYrEiby2+S/JLz1QKpyRzZgcG7w=="],
 
     "@oxyhq/crowdsource": ["@oxyhq/crowdsource@0.3.0", "", { "dependencies": { "zod": "^4.4.3" }, "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0" } }, "sha512-YwLDyeIsXrU9qC8H51DW8KQI571HhdLXS3DjaPlJZ3n9W/Eeb/Xu+bqIHqLdFjViu/3Cvjw+dSYLPz2Zh/VAGg=="],
 
@@ -784,11 +784,11 @@
 
     "@oxyhq/crowdsource-testing": ["@oxyhq/crowdsource-testing@0.3.0", "", { "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0" } }, "sha512-Yd/cStpexe+Pl7rrSKJFkBJ8SAuid9uLBCj6VmQ30YvEB4WY2ravJUzpoTI/UTQy11gwXBuMAImzoaYxIlO4cA=="],
 
-    "@oxyhq/federation": ["@oxyhq/federation@0.7.0", "", { "dependencies": { "@oxyhq/core": "^17.0.2" }, "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-8g0no7bOOcqkPr23WzQ1R0ZDfNLVIuutg7Jh92b3fQ4RTtsEenSgMzs9YVH2+Ev7waYP4ZYnrr//jYEHSzy1ng=="],
+    "@oxyhq/federation": ["@oxyhq/federation@0.11.0", "", { "dependencies": { "@oxyhq/core": "^18.0.0" }, "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-xIe2Muemqid3O5K60V/e3rQk1UAO5Wi3v8yxRgRNcWJvfHyChSsdAiQLunPGsaV1nrdmaqP080TRFtqoEJg88Q=="],
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.6", "", { "dependencies": { "@oxyhq/contracts": "^0.18.0", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-modules-core": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-/27AFpvOwxt19XWdZYJy0W4TnIQbK+IhPOfQVlod4s/kEuzIzMXo0zi9MSystegFu1RhZHKGjaxOTo+83Sx3Sw=="],
 
-    "@oxyhq/services": ["@oxyhq/services@26.1.0", "", { "dependencies": { "@oxyhq/contracts": "0.22.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@oxyhq/core": "^17.0.3", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "expo-web-browser": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-css": "^3.0.6", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "expo-web-browser", "nativewind", "react-native-css", "react-native-keyboard-controller"] }, "sha512-oi6yDM085SxKhoEngyByUNjufKwHmx81YkEsXM3oFlRlFzNNCzC1x620mcxGSg/MZUKXOWC15hAr61uT7QeEtw=="],
+    "@oxyhq/services": ["@oxyhq/services@26.2.0", "", { "dependencies": { "@oxyhq/contracts": "0.22.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@oxyhq/core": "^17.0.3 || ^18.0.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "expo-web-browser": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-css": "^3.0.6", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "expo-web-browser", "nativewind", "react-native-css", "react-native-keyboard-controller"] }, "sha512-hiLYHuIMVVAARsFQUdlOti56KdJxokS9HIttmS0kgBz8yFZA3dOG/kiM/7WybVSrqIkoWqdMrRENbUd0hccpJg=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 
@@ -3374,8 +3374,6 @@
 
     "@oxyhq/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@oxyhq/federation/@oxyhq/core": ["@oxyhq/core@17.0.2", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.21.0", "@oxyhq/protocol": "^0.1.6", "@scure/bip39": "^1.6.0", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^8.0.0", "helmet": "^8.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express", "helmet"] }, "sha512-tLXSrdbWnH7AqNpgru8d05bv8YifBvH/gos4uWoNptpEb90QDoheVyPeuIU+aO7+oROgTa3KaoIQQZQ3iTWlRQ=="],
-
     "@oxyhq/protocol/@oxyhq/contracts": ["@oxyhq/contracts@0.18.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-nGdoCp63FIpy29JpAEHSYYVUWl0wH+kHMzfgJJaVa8PvtiKffK8qokEK8bqkneIWRRCUtaR143dp4ZQmQo1eqg=="],
 
     "@oxyhq/protocol/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -3903,10 +3901,6 @@
     "@livekit/react-native-webrtc/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@oxyhq/federation/@oxyhq/core/@oxyhq/contracts": ["@oxyhq/contracts@0.21.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-ATosYW2ke5XOtk7f8y8X2WJtmKJ3UYYRULmAfefEyh2bp9v3Qh5drHom/Hh1sfBsQnaWBtRAHztwZktLEPhhHw=="],
-
-    "@oxyhq/federation/@oxyhq/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-context-menu/@radix-ui/react-menu/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.10", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g=="],
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "catalog": {
       "@oxyhq/bloom": "^0.73.0",
       "@oxyhq/contracts": "^0.22.0",
-      "@oxyhq/core": "^17.1.0",
-      "@oxyhq/services": "^26.1.0",
+      "@oxyhq/core": "^18.0.0",
+      "@oxyhq/services": "^26.2.0",
       "@syra.fm/sdk": "^0.7.0",
       "@types/bun": "1.3.14",
       "@types/jsonwebtoken": "^9.0.10",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -25,7 +25,7 @@
     "@oxyhq/crowdsource": "0.3.0",
     "@oxyhq/crowdsource-contracts": "0.3.0",
     "@oxyhq/crowdsource-express": "0.3.0",
-    "@oxyhq/federation": "^0.7.0",
+    "@oxyhq/federation": "^0.11.0",
     "@oxyhq/protocol": "^0.1.6",
     "@socket.io/redis-adapter": "^8.3.0",
     "@syra.fm/sdk": "catalog:",

--- a/packages/backend/src/connectors/activitypub/delivery.service.ts
+++ b/packages/backend/src/connectors/activitypub/delivery.service.ts
@@ -11,6 +11,7 @@ import {
   FEDERATION_ENABLED,
   USER_AGENT,
   federationUrls,
+  isBlockedDomain,
   resolveOxyUser,
 } from './constants';
 import { actorService } from './actor.service';
@@ -40,6 +41,11 @@ export const deliveryService: DeliveryService = createDeliveryService<IFederated
   federationEnabled: FEDERATION_ENABLED,
   userAgent: USER_AGENT,
   apContentType: AP_CONTENT_TYPE,
+  // The SAME predicate inbound dispatch and actor resolution use, not a second
+  // one: outbound has to refuse a blocked origin symmetrically, or a domain
+  // blocked inbound keeps receiving Follow/Undo/Accept and follower fan-out
+  // through an inbox we already cached.
+  isBlockedDomain,
   // `sign` is wrapped rather than passed by reference so `signViaOxy` is read at
   // CALL time (matching the former `deliverActivity`), not at module init — the
   // private-key signer is a runtime credential, never touched just to load.


### PR DESCRIPTION
## The core major is the cheap half

`@oxyhq/core@18.0.0` removes `UserCreatableAccountKind` — a signed-in person may now create their own channel account, so the type had become an alias of `ChildAccountKind`. **Mention never referenced it**, so on its own the major costs nothing here.

## The federation range is the part that mattered

Mention pinned `@oxyhq/federation: ^0.7.0`, and **a caret on a `0.x` version pins the MINOR** — so Mention was resolving **0.7.0**, four minors behind, and 0.7.0 declares `@oxyhq/core: ^17.0.2`.

Publishing `federation@0.11.0` against core 18 was therefore **necessary but not sufficient**. Without moving this range, the top level goes to 18 while `@oxyhq/federation/@oxyhq/core` stays at 17 — the bump looks done and a dependency loads the previous major, with a green install and a green `--frozen-lockfile`.

Measured, not reasoned:

| | `@oxyhq/federation/@oxyhq/core` |
|---|---|
| `^0.7.0` | `17.0.2` ← nested |
| `^0.11.0` | absent |

Two nested copies remain, from `@alia.onl/sdk` and `@syra.fm/sdk`, which pin their own `@oxyhq/services@26.0.0` and each bring its own core. Third-party pins; they clear when those SDKs republish, not from here.

## One code change, and it is a real gap being closed

Crossing 0.7 → 0.11 makes `DeliveryServiceConfig.isBlockedDomain` **required**. Mention already has that predicate — `constants.ts` exports the one inbound dispatch and actor resolution use — so it is **passed, not reimplemented**. Outbound must refuse a blocked origin symmetrically, or a domain blocked inbound keeps receiving Follow/Undo/Accept and follower fan-out through an inbox we already cached.

## Verification

Against the published packages: backend **413 files / 4400 tests**, `tsc --noEmit` clean on backend and frontend, lockfile gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)