### PR TITLE
fix(frontend): stop hiding the reply affordance from signed-out readers

### DIFF
--- a/packages/frontend/utils/__tests__/postReplies.test.ts
+++ b/packages/frontend/utils/__tests__/postReplies.test.ts
@@ -6,11 +6,16 @@ import { postAcceptsReplies, reportableReplyPermission } from '@/utils/postRepli
  * pinned composer. Both call this and nothing else, so an answer that is wrong
  * here is wrong on both.
  *
- * The channel case is the one worth pinning: a channel post still takes no
- * replies, but a channel is an Oxy ACCOUNT, so the DTO carries nothing that says
- * "channel" — the refusal reaches the client as the server's own verdict in
- * `permissions.canReply`. A predicate that read only `replyPermission` would
- * offer a reply affordance on every channel post.
+ * Two cases are worth pinning, and they pull in opposite directions.
+ *
+ * A channel post still takes no replies, and although a channel is an Oxy
+ * ACCOUNT — so the DTO carries nothing that says "channel" — the refusal DOES
+ * reach the client: `PostCreationService` persists `replyPermission: ['nobody']`
+ * on anything published as a channel account.
+ *
+ * And `permissions.canReply` must NOT be read here, however authoritative it
+ * looks. It is viewer-resolved and false for an anonymous viewer, so honouring
+ * it hides the affordance from every signed-out visitor on every post.
  */
 /**
  * `metadata` is built here rather than spread in by each case: `PostMetadataState`
@@ -51,12 +56,24 @@ describe('postAcceptsReplies', () => {
     expect(postAcceptsReplies(makePost({ replyPermission: ['nobody'] }))).toBe(false);
   });
 
-  it('refuses whenever the server resolved the viewer out, whatever the permission says', () => {
-    // The shape a CHANNEL post arrives in: nothing on the DTO names a channel,
-    // and its stated permission can be anything — the server's own verdict is
-    // the only thing that carries the refusal.
+  it('refuses a channel post, which arrives stating `nobody`', () => {
+    // The shape a CHANNEL post arrives in. Nothing on the DTO names a channel,
+    // and nothing needs to: the server wrote its refusal into the setting.
+    expect(postAcceptsReplies(makePost({ replyPermission: ['nobody'] }))).toBe(false);
+  });
+
+  /**
+   * The regression this file exists to prevent, and the fixture that catches it:
+   * `canReply: false` with a permissive setting is EXACTLY what an ordinary post
+   * looks like to a signed-out reader, because `computeReplyPermission` opens
+   * with `if (!viewerId) return false`. A predicate that consults `canReply`
+   * passes every other case here and still hides the reply affordance from every
+   * anonymous visitor — which is what shipped, and what the deploy's route-chunk
+   * check caught by failing to find the button.
+   */
+  it('still offers the affordance when the viewer is merely signed out', () => {
     expect(postAcceptsReplies(makePost({ canReply: false, replyPermission: ['anyone'] }))).toBe(
-      false,
+      true,
     );
   });
 

--- a/packages/frontend/utils/postReplies.ts
+++ b/packages/frontend/utils/postReplies.ts
@@ -4,17 +4,27 @@ import type { HydratedPostSummary, ReplyPermission } from '@mention/shared-types
  * Whether a post can be replied to at all — the ONE definition both the feed
  * row's action bar and the post detail's pinned composer read.
  *
- * The answer comes from the post's own permissions, and from nothing else. A
- * channel post still takes no replies, but a channel is an Oxy ACCOUNT now, so
- * there is no channel field on the DTO to key off: the server decides at write
- * time and says so in `permissions.canReply` and `metadata.replyPermission`.
+ * The answer comes from the post's own stated reply setting, and from nothing
+ * else. A channel post still takes no replies, but a channel is an Oxy ACCOUNT
+ * now, so there is no channel field on the DTO to key off — and none is needed:
+ * the server decides at write time and records it in `metadata.replyPermission`.
  * Re-deriving the refusal from the author's identity would be a second, weaker
  * copy of a rule the server already stated.
  *
- * `permissions.canReply` is the viewer-resolved verdict (it accounts for
- * `followers`/`mentioned` audiences the client cannot evaluate), so it wins;
- * `replyPermission` is the fallback for the surfaces whose DTO carries the
- * post's setting but no viewer resolution.
+ * It reads that setting and DELIBERATELY NOT `permissions.canReply`, even though
+ * the latter looks like the more authoritative answer. `canReply` is
+ * viewer-resolved and returns FALSE FOR AN ANONYMOUS VIEWER — the server's first
+ * line is `if (!viewerId) return false` — so honouring it here hides the reply
+ * affordance from every signed-out visitor on every post, which is what happened
+ * and what broke the deploy's route-chunk check. "Not signed in" and "not
+ * allowed" are different answers and only one of them should hide an affordance;
+ * tapping while signed out is what prompts a sign-in.
+ *
+ * A channel post is still covered, and by the mechanism that predates this:
+ * `PostCreationService` persists `replyPermission: ['nobody']` on anything
+ * published as a channel account. The SERVER's refusal does not depend on either
+ * field — `assertParentAcceptsReplies` reads the author's account kind — so this
+ * is an affordance, never the gate.
  *
  * Derived from the POST, never handed down as a prop. `PostItem`'s `React.memo`
  * comparator enumerates every prop, so a "can reply" prop missed there would
@@ -24,7 +34,6 @@ import type { HydratedPostSummary, ReplyPermission } from '@mention/shared-types
  */
 export function postAcceptsReplies(post: HydratedPostSummary | null | undefined): boolean {
   if (!post) return false;
-  if (post.permissions?.canReply === false) return false;
   return post.metadata?.replyPermission?.includes('nobody') !== true;
 }
 


### PR DESCRIPTION
## Production is split-brained right now

`Deploy Frontends` has **failed on every push since a05b76af**, so production web still serves the pre-channel-cut bundle — which calls `POST /channels`, a route the backend (which deployed fine) has deleted. The `404 Failed to create the channel` a user hit is that split, not a missing endpoint. Landing this unblocks the deploy and closes both.

## The regression

`postAcceptsReplies` began honouring `permissions.canReply === false`. That field is **viewer-resolved**, and the server's `computeReplyPermission` opens with:

```ts
if (!viewerId) return false;
```

So every **signed-out** visitor lost the reply button on **every** post. The deploy's route-chunk check looks for exactly that button (`getByLabel('Reply')`) after navigating to a post detail, and could not find it.

## Why reading the stated setting is the right answer

A channel post stays refused by the mechanism that predates this: `PostCreationService` persists `replyPermission: ['nobody']` on anything published as a channel account, so the check hides the button **with no knowledge of channels at all**. And the server's refusal never depended on either field — `assertParentAcceptsReplies` reads the author's account kind — so this is an affordance, never the gate.

"Not signed in" and "not allowed" are different answers; only one should hide an affordance.

## Why the test missed it

Every fixture had `canReply: false` paired with a **restrictive** setting — all on the same side of the distinction the check exists to make. The new fixture pairs it with a **permissive** one, which is exactly what an ordinary post looks like to an anonymous reader.

Mutation-tested: restoring the `canReply` read fails that case **and only that case** (1 of 9).

Frontend coverage gate green (1144 tests), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)