### PR TITLE
feat: publish as any account you may act for, and per-post in a beast batch

### DIFF
--- a/packages/backend/src/__tests__/controllers/channelPostSettings.test.ts
+++ b/packages/backend/src/__tests__/controllers/channelPostSettings.test.ts
@@ -9,10 +9,11 @@ import mongoose from 'mongoose';
  *    post. The 403 on the reply paths reads the AUTHOR's account kind and would
  *    hold regardless — but a change here would UN-HIDE the client's reply button
  *    and leave every reader hitting a refusal they were invited to attempt.
- *  - `POST /posts/thread` refuses a `publishAsOxyUserId` outright: in thread mode
- *    the continuations are replies, and a channel post accepts none, so the thread
+ *  - `POST /posts/thread` refuses a `publishAsOxyUserId` in THREAD mode: the
+ *    continuations are replies, and a channel post accepts none, so the thread
  *    would be a root under the channel with its body scattered across posts the
- *    channel refuses.
+ *    channel refuses. (Beast mode honours it per entry — that path has its own
+ *    suite, `threadPublishAsAccount.test.ts`.)
  */
 
 const postFindOne = vi.fn();
@@ -54,8 +55,12 @@ vi.mock('../../utils/logger', () => ({
 const isChannelAccount = vi.fn();
 vi.mock('../../services/publishAsAccount', () => ({
   isChannelAccount: (...args: unknown[]) => isChannelAccount(...args),
+  cacheAccountMemberReads: (reader: unknown) => reader,
   assertCanPublishAsAccount: vi.fn(
-    async (params: { callerId: string | null }) => params.callerId,
+    async (params: { callerId: string | null }) => ({
+      authorId: params.callerId,
+      authorKind: null,
+    }),
   ),
   PublishAsAccessError: class PublishAsAccessError extends Error {
     readonly status: number;
@@ -166,12 +171,12 @@ describe('PATCH /posts/:id/settings — replyPermission on a channel post', () =
   });
 });
 
-describe('POST /posts/thread — a thread cannot be published as another account', () => {
+describe('POST /posts/thread — a THREAD cannot be published as another account', () => {
   function req(body: Record<string, unknown>): OxyAuthRequest {
     return { user: { id: USER_ID }, body } as unknown as OxyAuthRequest;
   }
 
-  it('400s a top-level publishAsOxyUserId before writing anything', async () => {
+  it('400s a batch-level publishAsOxyUserId before writing anything, in thread mode', async () => {
     const res = makeRes();
     await createThread(
       req({ mode: 'thread', publishAsOxyUserId: CHANNEL_ACCOUNT, posts: [{ content: { text: 'a' } }] }),
@@ -182,11 +187,22 @@ describe('POST /posts/thread — a thread cannot be published as another account
     expect(postCreationCreate).not.toHaveBeenCalled();
   });
 
-  it('400s a per-entry publishAsOxyUserId too', async () => {
+  it('400s a batch-level publishAsOxyUserId in BEAST mode too — the per-entry field is the only way to say it', async () => {
+    const res = makeRes();
+    await createThread(
+      req({ mode: 'beast', publishAsOxyUserId: CHANNEL_ACCOUNT, posts: [{ content: { text: 'a' } }] }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(postCreationCreate).not.toHaveBeenCalled();
+  });
+
+  it('400s a per-entry publishAsOxyUserId in thread mode, whichever entry carries it', async () => {
     const res = makeRes();
     await createThread(
       req({
-        mode: 'beast',
+        mode: 'thread',
         posts: [
           { content: { text: 'a' } },
           { content: { text: 'b' }, publishAsOxyUserId: CHANNEL_ACCOUNT },

--- a/packages/backend/src/__tests__/controllers/createThreadChain.test.ts
+++ b/packages/backend/src/__tests__/controllers/createThreadChain.test.ts
@@ -31,6 +31,10 @@ vi.mock('../../services/PostHydrationService', () => ({
 
 vi.mock('../../utils/oxyHelpers', () => ({
   createScopedOxyClient: vi.fn(() => ({})),
+  // `undefined` = no membership reader, which is exactly what a caller who names
+  // no account gets. These batches name none, so the publish-as gate answers
+  // "the caller" without asking Oxy anything.
+  createUserScopedOxyServices: vi.fn(() => undefined),
 }));
 
 import { Post } from '../../models/Post';

--- a/packages/backend/src/__tests__/controllers/createThreadScheduled.test.ts
+++ b/packages/backend/src/__tests__/controllers/createThreadScheduled.test.ts
@@ -34,6 +34,10 @@ vi.mock('../../services/PostHydrationService', () => ({
 
 vi.mock('../../utils/oxyHelpers', () => ({
   createScopedOxyClient: vi.fn(() => ({})),
+  // `undefined` = no membership reader, which is exactly what a caller who names
+  // no account gets. These batches name none, so the publish-as gate answers
+  // "the caller" without asking Oxy anything.
+  createUserScopedOxyServices: vi.fn(() => undefined),
 }));
 
 vi.mock('../../utils/notificationUtils', async (importOriginal) => ({

--- a/packages/backend/src/__tests__/controllers/threadPublishAsAccount.test.ts
+++ b/packages/backend/src/__tests__/controllers/threadPublishAsAccount.test.ts
@@ -1,0 +1,449 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AccountMember } from '@oxyhq/core';
+import type { OxyAuthRequest } from '@oxyhq/core/server';
+
+/**
+ * `POST /posts/thread` — publishing individual entries of a BEAST batch as
+ * accounts the caller operates.
+ *
+ * Three things this path has to get right, and each has failed in a plausible
+ * design:
+ *
+ *  1. **Per ENTRY, and beast mode only.** A beast batch is n independent posts,
+ *     so entry 1 may come from a channel and entry 2 from an organization. A
+ *     THREAD is a chain of replies, and a reply can never be published as another
+ *     account, so the whole request is refused there instead of silently applying
+ *     the root's identity to posts that cannot carry it.
+ *  2. **Refused BEFORE anything is written.** Half a batch cannot be undone in one
+ *     action, so an entry naming an account the caller may not use must not leave
+ *     the earlier entries published.
+ *  3. **One membership call per distinct account, not one per post.** The real
+ *     gate runs here (only `PostCreationService.create` is stubbed), so the count
+ *     of `listAccountMembers` calls is a real measurement rather than a proxy.
+ */
+
+const listAccountMembers = vi.hoisted(() => vi.fn());
+const resolveUserSummaries = vi.hoisted(() => vi.fn());
+const createMentionNotifications = vi.hoisted(() => vi.fn(async () => undefined));
+const emit = vi.hoisted(() => vi.fn());
+
+vi.mock('../../runtime/socketServer', () => ({
+  getRuntimeSocketServer: () => ({ emit }),
+}));
+
+vi.mock('../../services/PostHydrationService', () => ({
+  postHydrationService: { hydratePosts: vi.fn(async (objs: object[]) => objs) },
+  resolveUserSummaries,
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createScopedOxyClient: vi.fn(() => ({})),
+  // The caller's own bearer-scoped Oxy client, which is what the gate reads
+  // membership with. One shared spy so the call COUNT across the whole request is
+  // observable — that is the assertion behind "resolve each account once".
+  createUserScopedOxyServices: vi.fn(() => ({ listAccountMembers })),
+}));
+
+vi.mock('../../utils/notificationUtils', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createMentionNotifications,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const laneExists = vi.hoisted(() => vi.fn());
+vi.mock('../../models/Lane', () => ({
+  Lane: {
+    exists: laneExists,
+    findById: vi.fn(() => ({ select: () => ({ lean: async () => null }) })),
+  },
+}));
+
+const create = vi.hoisted(() => vi.fn());
+vi.mock('../../services/PostCreationService', () => ({
+  postCreationService: { create },
+}));
+
+import mongoose from 'mongoose';
+import { createThread } from '../../controllers/posts.controller';
+
+const CALLER = 'caller-1';
+const CHANNEL = 'channel-account-1';
+const ORGANIZATION = 'org-account-1';
+const FORBIDDEN_ORG = 'org-account-2';
+const CALLER_LANE = new mongoose.Types.ObjectId().toString();
+
+const EDITOR_PERMISSIONS = ['account:read', 'account:act_as', 'members:read'];
+const VIEWER_PERMISSIONS = ['account:read', 'members:read'];
+
+function member(overrides: Partial<AccountMember> = {}): AccountMember {
+  return {
+    _id: 'member-row',
+    accountId: 'account',
+    memberUserId: CALLER,
+    role: 'editor',
+    permissions: EDITOR_PERMISSIONS,
+    inherit: true,
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+interface MockRes {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => MockRes;
+  json: (body: unknown) => MockRes;
+}
+
+function makeRes(): MockRes {
+  const res: MockRes = {
+    statusCode: 200,
+    body: undefined,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.body = body; return this; },
+  };
+  return res;
+}
+
+function req(body: Record<string, unknown>): OxyAuthRequest {
+  return {
+    user: { id: CALLER },
+    query: {},
+    headers: {},
+    // Express content negotiation, which hydration reads for the response's
+    // language preference. Absent, the controller throws and every assertion
+    // below reads 500 for a reason that has nothing to do with publishing as.
+    acceptsLanguages: () => [],
+    body,
+  } as unknown as OxyAuthRequest;
+}
+
+/** The `publishAsOxyUserId` each `create` call was given, in order. */
+function requestedAccounts(): Array<string | null> {
+  return create.mock.calls.map(([params]: [Record<string, unknown>]) =>
+    (params.publishAsOxyUserId as string | null) ?? null,
+  );
+}
+
+beforeEach(() => {
+  create.mockReset();
+  // Stands in for the real service, which resolves the author itself through the
+  // gate. Mirroring that here (the named account when there is one) is what makes
+  // the DOWNSTREAM assertions — the notification actor, the socket author —
+  // measure the controller rather than the stub.
+  create.mockImplementation(async (params: Record<string, unknown>) => {
+    const oxyUserId = (params.publishAsOxyUserId as string | null) ?? (params.oxyUserId as string);
+    const _id = new mongoose.Types.ObjectId();
+    return {
+      _id,
+      oxyUserId,
+      mentions: (params.mentions as string[]) ?? [],
+      content: params.content,
+      threadId: null,
+      save: vi.fn(async () => undefined),
+      toObject: () => ({ _id, oxyUserId, content: params.content }),
+    };
+  });
+
+  listAccountMembers.mockReset();
+  listAccountMembers.mockImplementation(async (accountId: string) => {
+    if (accountId === CHANNEL) return [member({ role: 'viewer', permissions: VIEWER_PERMISSIONS })];
+    if (accountId === ORGANIZATION) return [member({ role: 'editor', permissions: EDITOR_PERMISSIONS })];
+    // An organization the caller is a member of but may not ACT AS.
+    if (accountId === FORBIDDEN_ORG) return [member({ role: 'viewer', permissions: VIEWER_PERMISSIONS })];
+    return [];
+  });
+
+  resolveUserSummaries.mockReset();
+  resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+    const kinds: Record<string, string> = {
+      [CHANNEL]: 'channel',
+      [ORGANIZATION]: 'organization',
+      [FORBIDDEN_ORG]: 'organization',
+    };
+    const map = new Map<string, { user: { id: string; kind?: string; name: object } }>();
+    for (const id of ids) {
+      if (kinds[id]) map.set(id, { user: { id, kind: kinds[id], name: {} } });
+    }
+    return map;
+  });
+
+  // A lane owned by the CALLER and by nobody else — which is the discriminator
+  // for the pre-flight's author (see the lane suite below).
+  laneExists.mockReset();
+  laneExists.mockImplementation(async (filter: { ownerId?: string }) =>
+    filter?.ownerId === CALLER ? { _id: CALLER_LANE } : null,
+  );
+
+  createMentionNotifications.mockClear();
+  emit.mockClear();
+});
+
+describe('beast mode — each entry may come from a different account', () => {
+  it('creates every entry, each carrying its own publishAsOxyUserId', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [
+          { content: { text: 'from the channel' }, publishAsOxyUserId: CHANNEL },
+          { content: { text: 'from the org' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'from me' } },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(requestedAccounts()).toEqual([CHANNEL, ORGANIZATION, null]);
+  });
+
+  it('hands the SAME memberReader to every create, so the gate cannot be routed around', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [
+          { content: { text: 'a' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'b' }, publishAsOxyUserId: ORGANIZATION },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    const readers = create.mock.calls.map(([params]: [Record<string, unknown>]) => params.memberReader);
+    expect(readers[0]).toBeDefined();
+    expect(readers[1]).toBe(readers[0]);
+  });
+
+  /**
+   * The performance property, measured rather than assumed: twelve entries naming
+   * ONE account cost ONE membership read. Without `cacheAccountMemberReads` the
+   * pre-flight alone would make twelve.
+   */
+  it('reads each distinct account\'s members ONCE per request, not once per post', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: Array.from({ length: 12 }, (_unused, i) => ({
+          content: { text: `entry ${i}` },
+          publishAsOxyUserId: ORGANIZATION,
+        })),
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(create).toHaveBeenCalledTimes(12);
+    expect(listAccountMembers.mock.calls.map(([id]: [string]) => id)).toEqual([ORGANIZATION]);
+  });
+
+  it('still reads once PER distinct account when a batch names several', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [
+          { content: { text: 'a' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'b' }, publishAsOxyUserId: CHANNEL },
+          { content: { text: 'c' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'd' } },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(listAccountMembers.mock.calls.map(([id]: [string]) => id).sort()).toEqual(
+      [CHANNEL, ORGANIZATION].sort(),
+    );
+  });
+
+  it('a channel entry needs no account:act_as — bare membership is the whole right', async () => {
+    const res = makeRes();
+    await createThread(
+      req({ mode: 'beast', posts: [{ content: { text: 'a' }, publishAsOxyUserId: CHANNEL }] }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(requestedAccounts()).toEqual([CHANNEL]);
+  });
+});
+
+describe('beast mode — a refused entry takes the WHOLE batch with it', () => {
+  it('403s an organization the caller may not act as, before writing anything', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [
+          { content: { text: 'would have been published' } },
+          { content: { text: 'b' }, publishAsOxyUserId: FORBIDDEN_ORG },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(403);
+    // The half-batch this pre-flight exists to prevent: entry 0 is perfectly
+    // valid, and must still not be written.
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('400s a personal account named by any entry, before writing anything', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [
+          { content: { text: 'a' } },
+          { content: { text: 'b' }, publishAsOxyUserId: 'some-humans-account' },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('503s when the membership read fails, so the client can retry the whole batch', async () => {
+    listAccountMembers.mockRejectedValue(new Error('oxy 500'));
+
+    const res = makeRes();
+    await createThread(
+      req({ mode: 'beast', posts: [{ content: { text: 'a' }, publishAsOxyUserId: ORGANIZATION }] }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(503);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe('the side effects follow the ENTRY\'s author, not the caller', () => {
+  it('attributes a mention notification to the account the entry was published as', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [{ content: { text: 'hi @someone' }, mentions: ['mentioned-1'], publishAsOxyUserId: CHANNEL }],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(createMentionNotifications).toHaveBeenCalledTimes(1);
+    // Third argument is the ACTOR. Naming the caller here would put a channel's
+    // writer into the notification of a post the channel signed — the anonymity
+    // `writtenByOxyUserId` exists to keep.
+    expect(createMentionNotifications.mock.calls[0][2]).toBe(CHANNEL);
+  });
+
+  it('emits the following-feed update under the first entry\'s author', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [
+          { content: { text: 'a' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'b' } },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    const following = emit.mock.calls.find(
+      ([, payload]: [string, { type?: string }]) => payload?.type === 'following',
+    );
+    expect(following?.[1]).toMatchObject({ authorId: ORGANIZATION });
+  });
+
+  it('CONTROL: an ordinary batch still attributes both to the caller', async () => {
+    const res = makeRes();
+    await createThread(
+      req({ mode: 'beast', posts: [{ content: { text: 'hi' }, mentions: ['mentioned-1'] }] }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(createMentionNotifications.mock.calls[0][2]).toBe(CALLER);
+    const following = emit.mock.calls.find(
+      ([, payload]: [string, { type?: string }]) => payload?.type === 'following',
+    );
+    expect(following?.[1]).toMatchObject({ authorId: CALLER });
+  });
+});
+
+describe('thread mode refuses the field outright', () => {
+  it('400s even a ROOT-only publishAsOxyUserId, and asks Oxy nothing', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'root' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'continuation' } },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+    expect(listAccountMembers).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The lane pre-flight has to measure each entry against the account that entry
+ * will be AUTHORED BY, because `PostCreationService` certainly will. Measured
+ * against the CALLER instead, a caller-owned lane on an account-published entry
+ * sails through the pre-flight and is then refused mid-loop by the service — with
+ * the earlier entries already written. That is precisely the half-batch the
+ * pre-flight exists to prevent, so it is the one shape worth pinning.
+ */
+describe('the lane pre-flight follows the ENTRY\'s author', () => {
+  it('404s a lane the CALLER owns on an entry published as an organization, before writing anything', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [
+          { content: { text: 'would have been published' } },
+          { content: { text: 'b' }, laneId: CALLER_LANE, publishAsOxyUserId: ORGANIZATION },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(404);
+    expect(create).not.toHaveBeenCalled();
+    // The lane was looked up under the ORGANIZATION, never the caller.
+    expect(laneExists).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: CALLER_LANE, ownerId: ORGANIZATION }),
+    );
+  });
+
+  it('CONTROL: the same lane on an entry the caller publishes as themselves is accepted', async () => {
+    const res = makeRes();
+    await createThread(
+      req({ mode: 'beast', posts: [{ content: { text: 'b' }, laneId: CALLER_LANE }] }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(laneExists).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: CALLER_LANE, ownerId: CALLER }),
+    );
+  });
+});

--- a/packages/backend/src/__tests__/routes/profileSettingsOperatedAccount.test.ts
+++ b/packages/backend/src/__tests__/routes/profileSettingsOperatedAccount.test.ts
@@ -21,6 +21,7 @@ const store = new Map<string, Record<string, unknown>>();
 const CALLER = 'user-1';
 const CHANNEL = 'channel-account-1';
 const OTHER_CHANNEL = 'channel-account-2';
+const ORGANIZATION = 'organization-account-1';
 
 function getDoc(oxyUserId: string): Record<string, unknown> {
   let doc = store.get(oxyUserId);
@@ -78,7 +79,9 @@ vi.mock('../../models/UserSettings', () => ({
  * The authorization gate is mocked, not reimplemented: it is unit-tested in
  * `publishAsAccount`'s own suite, and what THIS route has to get right is that it
  * consults that gate at all, honours its status codes, and refuses a target the
- * gate would wave through for a different reason (the caller's own account).
+ * gate ALLOWS but whose kind makes `channel.signPosts` meaningless — the caller's
+ * own account, and (since the gate was widened) an organization the caller may
+ * act for.
  */
 // `vi.mock` is hoisted above every top-level statement, so the error class and
 // the membership map have to be created inside `vi.hoisted` or the factory runs
@@ -92,7 +95,7 @@ const gate = vi.hoisted(() => {
       this.status = status;
     }
   }
-  return { PublishAsAccessError, membershipOf: new Map<string, boolean>() };
+  return { PublishAsAccessError, operableKindOf: new Map<string, string>() };
 });
 
 vi.mock('../../services/publishAsAccount', () => ({
@@ -100,11 +103,16 @@ vi.mock('../../services/publishAsAccount', () => ({
   assertCanPublishAsAccount: vi.fn(
     async (params: { publishAsOxyUserId?: string | null; callerId?: string | null }) => {
       const target = params.publishAsOxyUserId?.trim();
-      if (!target || target === params.callerId) return params.callerId ?? null;
-      if (!gate.membershipOf.get(target)) {
+      if (!target || target === params.callerId) {
+        // The real gate resolves nothing when the target IS the caller, so it
+        // answers with no kind. That `null` is what the route reads to refuse.
+        return { authorId: params.callerId ?? null, authorKind: null };
+      }
+      const kind = gate.operableKindOf.get(target);
+      if (!kind) {
         throw new gate.PublishAsAccessError(403, 'You are not a member of that account');
       }
-      return target;
+      return { authorId: target, authorKind: kind };
     },
   ),
 }));
@@ -134,8 +142,9 @@ app.use('/profile', profileSettingsRoutes);
 describe('PUT /profile/settings/:userId — an operated account', () => {
   beforeEach(() => {
     store.clear();
-    gate.membershipOf.clear();
-    gate.membershipOf.set(CHANNEL, true);
+    gate.operableKindOf.clear();
+    gate.operableKindOf.set(CHANNEL, 'channel');
+    gate.operableKindOf.set(ORGANIZATION, 'organization');
     vi.clearAllMocks();
   });
 
@@ -179,6 +188,22 @@ describe('PUT /profile/settings/:userId — an operated account', () => {
       .expect(400);
 
     expect(store.has(CALLER)).toBe(false);
+  });
+
+  /**
+   * The hole the widened gate would otherwise open. `assertCanPublishAsAccount`
+   * now ALLOWS an organization the caller may act for, so "the gate said yes" is
+   * no longer the same statement as "this is a channel" — and `channel.signPosts`
+   * is read by `PostHydrationService` for a `kind: 'channel'` author only, so
+   * writing it anywhere else stores a control nothing will ever read.
+   */
+  it('refuses an ORGANIZATION the caller may act for — the gate allows it, the field means nothing there', async () => {
+    await request(app)
+      .put(`/profile/settings/${ORGANIZATION}`)
+      .send({ channel: { signPosts: true } })
+      .expect(400);
+
+    expect(store.has(ORGANIZATION)).toBe(false);
   });
 
   /**

--- a/packages/backend/src/__tests__/services/postCreationPublishAs.test.ts
+++ b/packages/backend/src/__tests__/services/postCreationPublishAs.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+import type { AccountMember } from '@oxyhq/core';
+
+/**
+ * What `PostCreationService.create` DOES with the account it was told to publish
+ * as — as distinct from whether it was allowed to, which is
+ * `publishAsAccount.test.ts`.
+ *
+ * The rule that is easy to get wrong, and was: **`replyPermission: ['nobody']` is
+ * keyed on the author being a CHANNEL, not on the post having been published as
+ * somebody else.** "No replies, ever" is a property of channels — a newspaper, not
+ * a group chat. An organization is an ordinary account: `utils/channelReplyGate`
+ * reads the author's kind and lets replies through for one, so forcing `['nobody']`
+ * on its posts would leave the persisted field and the server's own rule
+ * disagreeing, and would silently close every organization's comments with no
+ * setting anywhere to reopen them.
+ *
+ * `postData` is an explicit WHITELIST, so each of these fields is written or not
+ * written by one line and a mistake there is silent.
+ */
+
+const saved: Array<Record<string, unknown>> = [];
+const constructedWith: Array<Record<string, unknown>> = [];
+
+vi.mock('../../models/Post', () => {
+  class FakePost {
+    [key: string]: unknown;
+
+    constructor(data: Record<string, unknown>) {
+      constructedWith.push(data);
+      Object.assign(this, data);
+      this._id = new mongoose.Types.ObjectId();
+    }
+
+    async save(): Promise<void> {
+      saved.push(this as unknown as Record<string, unknown>);
+    }
+
+    toObject(): Record<string, unknown> {
+      return { ...(this as unknown as Record<string, unknown>) };
+    }
+  }
+  return {
+    Post: Object.assign(FakePost, {
+      find: vi.fn(() => ({ select: () => ({ lean: async () => [] }) })),
+      findById: vi.fn(() => ({ select: () => ({ lean: async () => null }) })),
+    }),
+    POST_CLASSIFICATION_PENDING: 'pending',
+  };
+});
+
+vi.mock('../../models/Lane', () => ({
+  Lane: { exists: vi.fn(async () => null) },
+}));
+
+vi.mock('../../services/PostRecentReplierService', () => ({
+  recordRecentReplierForPost: vi.fn(async () => undefined),
+}));
+vi.mock('../../services/postEnrichment', () => ({ enrichIngestedPosts: vi.fn() }));
+vi.mock('../../services/mtn/MentionRecordEmitter', () => ({
+  emitPostCreated: vi.fn(async () => undefined),
+  emitRepostCreated: vi.fn(async () => undefined),
+}));
+
+const resolveUserSummaries = vi.hoisted(() => vi.fn());
+vi.mock('../../services/PostHydrationService', () => ({
+  postHydrationService: { hydratePosts: vi.fn(async () => []) },
+  resolveUserSummaries,
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({ getServiceOxyClient: vi.fn(() => ({})) }));
+vi.mock('../../runtime/socketServer', () => ({ getRuntimeSocketServer: () => undefined }));
+vi.mock('../../services/MediaMetadataService', () => ({
+  mediaMetadataService: { enrichFromOxy: vi.fn(async (media: unknown[]) => media) },
+  readPersistedMediaFields: vi.fn(() => ({})),
+}));
+
+import { postCreationService } from '../../services/PostCreationService';
+import { PublishAsAccessError } from '../../services/publishAsAccount';
+
+const WRITER = 'writer-1';
+const CHANNEL = 'channel-account-1';
+const ORGANIZATION = 'org-account-1';
+
+const ACT_AS_PERMISSIONS = ['account:read', 'account:act_as', 'members:read'];
+const NO_ACT_AS_PERMISSIONS = ['account:read', 'members:read'];
+
+function memberRow(permissions: string[]): AccountMember {
+  return {
+    _id: 'member-row',
+    accountId: 'account',
+    memberUserId: WRITER,
+    role: 'editor',
+    permissions,
+    inherit: true,
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const memberReader = {
+  listAccountMembers: vi.fn(async (accountId: string) =>
+    // A channel member with NO act_as, so the channel cases also prove the
+    // permission is not being demanded where it cannot exist.
+    accountId === CHANNEL ? [memberRow(NO_ACT_AS_PERMISSIONS)] : [memberRow(ACT_AS_PERMISSIONS)],
+  ),
+};
+
+beforeEach(() => {
+  saved.length = 0;
+  constructedWith.length = 0;
+  memberReader.listAccountMembers.mockClear();
+  resolveUserSummaries.mockReset();
+  resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+    const kinds: Record<string, string> = { [CHANNEL]: 'channel', [ORGANIZATION]: 'organization' };
+    const map = new Map<string, { user: { id: string; kind?: string; name: object } }>();
+    for (const id of ids) {
+      if (kinds[id]) map.set(id, { user: { id, kind: kinds[id], name: {} } });
+    }
+    return map;
+  });
+});
+
+describe('PostCreationService.create — publishing as another account', () => {
+  it('authors the post as the CHANNEL and records the writer outside authorship', async () => {
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'from the channel' },
+      publishAsOxyUserId: CHANNEL,
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    const [doc] = constructedWith;
+    expect(doc.oxyUserId).toBe(CHANNEL);
+    expect(doc.writtenByOxyUserId).toBe(WRITER);
+    expect(doc.authorship).toEqual([expect.objectContaining({ oxyUserId: CHANNEL, role: 'owner' })]);
+  });
+
+  it('authors the post as the ORGANIZATION the same way', async () => {
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'from the org' },
+      publishAsOxyUserId: ORGANIZATION,
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    const [doc] = constructedWith;
+    expect(doc.oxyUserId).toBe(ORGANIZATION);
+    expect(doc.writtenByOxyUserId).toBe(WRITER);
+    expect(doc.authorship).toEqual([
+      expect.objectContaining({ oxyUserId: ORGANIZATION, role: 'owner' }),
+    ]);
+  });
+
+  it('forces replyPermission ["nobody"] on a CHANNEL post, over whatever was asked for', async () => {
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'from the channel' },
+      publishAsOxyUserId: CHANNEL,
+      replyPermission: ['anyone'],
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    expect(constructedWith[0].replyPermission).toEqual(['nobody']);
+  });
+
+  /**
+   * The regression this suite exists for. Keyed on "published as somebody" rather
+   * than on the author's kind, this comes back `['nobody']` — an organization that
+   * can never be replied to, with no setting anywhere that reopens it, while
+   * `channelReplyGate` happily admits the replies the client has stopped offering.
+   */
+  it('does NOT force ["nobody"] on an ORGANIZATION post — it is an ordinary post', async () => {
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'from the org' },
+      publishAsOxyUserId: ORGANIZATION,
+      replyPermission: ['anyone'],
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    expect(constructedWith[0].replyPermission).toEqual(['anyone']);
+  });
+
+  it('honours a NARROWER replyPermission on an organization post too', async () => {
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'from the org' },
+      publishAsOxyUserId: ORGANIZATION,
+      replyPermission: ['followers'],
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    expect(constructedWith[0].replyPermission).toEqual(['followers']);
+  });
+
+  it('defaults an organization post to ["anyone"], like any other post', async () => {
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'from the org' },
+      publishAsOxyUserId: ORGANIZATION,
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    expect(constructedWith[0].replyPermission).toEqual(['anyone']);
+  });
+
+  it('CONTROL: an ordinary post is unaffected and records no writer', async () => {
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'just me' },
+      replyPermission: ['anyone'],
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    const [doc] = constructedWith;
+    expect(doc.oxyUserId).toBe(WRITER);
+    expect(doc.replyPermission).toEqual(['anyone']);
+    expect('writtenByOxyUserId' in doc).toBe(false);
+  });
+
+  it('refuses an account the caller may not act as, BEFORE writing anything', async () => {
+    memberReader.listAccountMembers.mockResolvedValueOnce([memberRow(NO_ACT_AS_PERMISSIONS)]);
+
+    await expect(
+      postCreationService.create({
+        oxyUserId: WRITER,
+        content: { text: 'not mine to sign' },
+        publishAsOxyUserId: ORGANIZATION,
+        memberReader,
+        skipNotifications: true,
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+
+    expect(constructedWith).toHaveLength(0);
+    expect(saved).toHaveLength(0);
+  });
+
+  it('still refuses a reply, a boost and a federated ingest', async () => {
+    for (const extra of [
+      { parentPostId: 'parent-1' },
+      { boostOf: 'original-1' },
+      { federation: { activityId: 'https://remote/1' } },
+    ]) {
+      await expect(
+        postCreationService.create({
+          oxyUserId: WRITER,
+          content: { text: 'x' },
+          publishAsOxyUserId: ORGANIZATION,
+          memberReader,
+          skipNotifications: true,
+          ...extra,
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+    }
+
+    expect(constructedWith).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/__tests__/services/publishAsAccount.test.ts
+++ b/packages/backend/src/__tests__/services/publishAsAccount.test.ts
@@ -1,0 +1,438 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AccountMember } from '@oxyhq/core';
+
+/**
+ * `assertCanPublishAsAccount` — "may this person publish as that account".
+ *
+ * The whole point of this suite is the DISTINCTION the gate draws between two
+ * families of account, because collapsing them is the mistake that reads as
+ * correct:
+ *
+ *  - A **channel** cannot be acted as at all, so accepted membership is the whole
+ *    authority. A `viewer` of a channel may publish as it.
+ *  - An **organization / project / bot** CAN be acted as, and the right that
+ *    governs that is `account:act_as`. A `viewer` of an organization may NOT
+ *    publish as it, even though they are just as much a member.
+ *
+ * Every fixture below therefore carries an EXPLICIT `permissions` array, and the
+ * channel cases deliberately use a permission set WITHOUT `account:act_as` while
+ * the organization cases include both shapes. A suite whose members all held
+ * `account:act_as` could not tell the real check from `Boolean(membership)`; a
+ * suite whose channels all held it could not tell the real check from "everything
+ * needs act_as". The two mutation guards named below are the ones that fail if
+ * either half is loosened.
+ *
+ * `resolveUserSummaries` is mocked because it is the Redis/Oxy identity path, not
+ * because the kind is incidental — the kind is the first thing the gate decides
+ * on.
+ */
+
+const resolveUserSummaries = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/PostHydrationService', () => ({
+  resolveUserSummaries,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  assertCanPublishAsAccount,
+  cacheAccountMemberReads,
+  isChannelAccount,
+  PublishAsAccessError,
+  resolveAccountKind,
+  type AccountMemberReader,
+} from '../../services/publishAsAccount';
+
+const CALLER = 'caller-1';
+const CHANNEL = 'channel-1';
+const ORGANIZATION = 'org-1';
+const PROJECT = 'project-1';
+const BOT = 'bot-1';
+const PERSONAL = 'personal-1';
+
+/** The permission sets Oxy derives from its roles, as they arrive on the wire. */
+const OWNER_PERMISSIONS = ['account:read', 'account:update', 'account:act_as', 'members:read'];
+const EDITOR_PERMISSIONS = ['account:read', 'account:act_as', 'members:read'];
+/** `viewer` — a real, active member who deliberately may NOT act as the account. */
+const VIEWER_PERMISSIONS = ['account:read', 'members:read', 'children:read', 'apps:read'];
+/** `developer` — another active member without `account:act_as`. */
+const DEVELOPER_PERMISSIONS = ['account:read', 'children:read', 'credentials:create'];
+
+function member(overrides: Partial<AccountMember> = {}): AccountMember {
+  return {
+    _id: 'member-row-1',
+    accountId: 'account-1',
+    memberUserId: CALLER,
+    role: 'viewer',
+    permissions: VIEWER_PERMISSIONS,
+    inherit: true,
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** A reader that answers with a fixed list, and counts how often it was asked. */
+function readerReturning(members: AccountMember[]): AccountMemberReader & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    async listAccountMembers(accountId: string) {
+      calls.push(accountId);
+      return members;
+    },
+  };
+}
+
+function kindsAre(byId: Record<string, string>): void {
+  resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+    const map = new Map<string, { user: { id: string; kind?: string; name: object } }>();
+    for (const id of ids) {
+      const kind = byId[id];
+      if (kind) map.set(id, { user: { id, kind, name: {} } });
+    }
+    return map;
+  });
+}
+
+beforeEach(() => {
+  resolveUserSummaries.mockReset();
+  kindsAre({
+    [CHANNEL]: 'channel',
+    [ORGANIZATION]: 'organization',
+    [PROJECT]: 'project',
+    [BOT]: 'bot',
+    [PERSONAL]: 'personal',
+  });
+});
+
+describe('assertCanPublishAsAccount — the free path', () => {
+  it('answers with the caller and no kind when no account was named', async () => {
+    const reader = readerReturning([]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: null, callerId: CALLER, memberReader: reader }),
+    ).resolves.toEqual({ authorId: CALLER, authorKind: null });
+
+    // Not one question asked of Oxy — this is the overwhelming majority of posts.
+    expect(reader.calls).toEqual([]);
+    expect(resolveUserSummaries).not.toHaveBeenCalled();
+  });
+
+  it('treats naming your OWN account as naming none', async () => {
+    const reader = readerReturning([]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: CALLER, callerId: CALLER, memberReader: reader }),
+    ).resolves.toEqual({ authorId: CALLER, authorKind: null });
+
+    expect(reader.calls).toEqual([]);
+  });
+
+  it('trims before comparing, so whitespace does not buy a membership lookup', async () => {
+    const reader = readerReturning([]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: `  ${CALLER} `, callerId: CALLER, memberReader: reader }),
+    ).resolves.toEqual({ authorId: CALLER, authorKind: null });
+
+    expect(reader.calls).toEqual([]);
+  });
+});
+
+describe('assertCanPublishAsAccount — a channel', () => {
+  it('admits an ACTIVE member with no account:act_as at all', async () => {
+    const reader = readerReturning([member({ role: 'viewer', permissions: VIEWER_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+    ).resolves.toEqual({ authorId: CHANNEL, authorKind: 'channel' });
+
+    expect(reader.calls).toEqual([CHANNEL]);
+  });
+
+  /**
+   * MUTATION GUARD (the other direction). Requiring `account:act_as` for EVERY
+   * kind — the obvious "simplification" of the two-family rule — locks every
+   * channel viewer out of the only mechanism a channel post can be written by,
+   * and the test above is the one that fails. This one states why the two halves
+   * cannot be merged: a channel can never be acted as, so `account:act_as` over
+   * one is a right nobody holds.
+   */
+  it('MUTATION GUARD: no channel membership carries account:act_as, so requiring it would refuse them all', async () => {
+    const reader = readerReturning([
+      member({ memberUserId: 'someone-else', role: 'owner', permissions: OWNER_PERMISSIONS }),
+      member({ role: 'editor', permissions: VIEWER_PERMISSIONS }),
+    ]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+    ).resolves.toEqual({ authorId: CHANNEL, authorKind: 'channel' });
+  });
+
+  it('refuses a non-member (403)', async () => {
+    const reader = readerReturning([member({ memberUserId: 'somebody-else', permissions: OWNER_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it.each([['invited'], ['removed']] as const)('refuses a %s membership (403)', async (status) => {
+    const reader = readerReturning([member({ status, permissions: OWNER_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe('assertCanPublishAsAccount — an act-as-eligible account', () => {
+  const eligible: Array<[string, string]> = [
+    ['organization', ORGANIZATION],
+    ['project', PROJECT],
+    ['bot', BOT],
+  ];
+
+  it.each(eligible)('admits a %s member holding account:act_as', async (kind, accountId) => {
+    const reader = readerReturning([member({ role: 'editor', permissions: EDITOR_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: accountId, callerId: CALLER, memberReader: reader }),
+    ).resolves.toEqual({ authorId: accountId, authorKind: kind });
+  });
+
+  /**
+   * MUTATION GUARD. This is the test that must fail if the act-as check is
+   * loosened to bare membership: the fixture is an ACTIVE, genuine `viewer` — so
+   * `members.some(m => m.memberUserId === callerId && m.status === 'active')` says
+   * yes, and only reading `permissions` says no. It is the same person Oxy's own
+   * `POST /accounts/:id/switch` refuses, so admitting them here would hand out
+   * through this door exactly what that one is closed against.
+   */
+  it.each(eligible)(
+    'MUTATION GUARD: refuses an ACTIVE %s member without account:act_as (403)',
+    async (_kind, accountId) => {
+      const reader = readerReturning([member({ role: 'viewer', permissions: VIEWER_PERMISSIONS })]);
+
+      await expect(
+        assertCanPublishAsAccount({ publishAsOxyUserId: accountId, callerId: CALLER, memberReader: reader }),
+      ).rejects.toMatchObject({ status: 403 });
+    },
+  );
+
+  it('MUTATION GUARD: refuses a developer too — it is the permission, not one role name', async () => {
+    const reader = readerReturning([member({ role: 'developer', permissions: DEVELOPER_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: ORGANIZATION, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  /**
+   * The permission is read off the row Oxy resolved, never inferred from the role
+   * name — so a row whose role SAYS `owner` while its permissions say otherwise is
+   * refused. Without this a role→permission map would creep back in, and the copy
+   * is what goes stale when Oxy changes a grant.
+   */
+  it('reads permissions, not the role name: role owner with no act_as permission is refused', async () => {
+    const reader = readerReturning([member({ role: 'owner', permissions: VIEWER_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: ORGANIZATION, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('refuses a membership whose permissions array is missing entirely', async () => {
+    // A row from an older Oxy, or a truncated response. The type says the field is
+    // there; the wire is not bound by the type, and an absent permission list must
+    // not read as "no restrictions".
+    const withoutPermissions = member({ role: 'owner' });
+    Reflect.deleteProperty(withoutPermissions, 'permissions');
+    const reader = readerReturning([withoutPermissions]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: ORGANIZATION, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('matches the ACTIVE row when the caller also has an inactive one', async () => {
+    const reader = readerReturning([
+      member({ status: 'removed', role: 'owner', permissions: OWNER_PERMISSIONS }),
+      member({ _id: 'member-row-2', status: 'active', role: 'editor', permissions: EDITOR_PERMISSIONS }),
+    ]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: ORGANIZATION, callerId: CALLER, memberReader: reader }),
+    ).resolves.toEqual({ authorId: ORGANIZATION, authorKind: 'organization' });
+  });
+
+  it('does NOT borrow another member\'s act_as', async () => {
+    const reader = readerReturning([
+      member({ memberUserId: 'somebody-else', role: 'owner', permissions: OWNER_PERMISSIONS }),
+      member({ role: 'viewer', permissions: VIEWER_PERMISSIONS }),
+    ]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: ORGANIZATION, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe('assertCanPublishAsAccount — the refusals that never reach Oxy', () => {
+  it('refuses a personal account (400), before any membership call', async () => {
+    const reader = readerReturning([member({ role: 'owner', permissions: OWNER_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: PERSONAL, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(reader.calls).toEqual([]);
+  });
+
+  it('refuses an account whose kind will not resolve (400) — failing closed', async () => {
+    const reader = readerReturning([member({ role: 'owner', permissions: OWNER_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: 'unknown-account', callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(reader.calls).toEqual([]);
+  });
+
+  it('refuses when the identity lookup itself throws (400) — failing closed', async () => {
+    resolveUserSummaries.mockRejectedValue(new Error('oxy down'));
+    const reader = readerReturning([member({ role: 'owner', permissions: OWNER_PERMISSIONS })]);
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: ORGANIZATION, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('refuses an unauthenticated caller (403)', async () => {
+    await expect(
+      assertCanPublishAsAccount({
+        publishAsOxyUserId: CHANNEL,
+        callerId: null,
+        memberReader: readerReturning([]),
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('refuses when there is no reader to ask with (403) — an MCP caller', async () => {
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: CHANNEL, callerId: CALLER, memberReader: undefined }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('answers 503 when the membership read fails — the caller can retry', async () => {
+    const reader: AccountMemberReader = {
+      listAccountMembers: async () => {
+        throw new Error('oxy 500');
+      },
+    };
+
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: ORGANIZATION, callerId: CALLER, memberReader: reader }),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+
+  it('the refusals are PublishAsAccessError, so the HTTP layer can map them', async () => {
+    await expect(
+      assertCanPublishAsAccount({ publishAsOxyUserId: PERSONAL, callerId: CALLER, memberReader: readerReturning([]) }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+});
+
+describe('resolveAccountKind / isChannelAccount', () => {
+  it('answers the kind Oxy holds', async () => {
+    await expect(resolveAccountKind(ORGANIZATION)).resolves.toBe('organization');
+    await expect(resolveAccountKind(CHANNEL)).resolves.toBe('channel');
+  });
+
+  it('answers null for an id with no resolvable account, and for no id at all', async () => {
+    await expect(resolveAccountKind('nobody')).resolves.toBeNull();
+    await expect(resolveAccountKind(undefined)).resolves.toBeNull();
+  });
+
+  it('fails soft to null when the identity path throws', async () => {
+    resolveUserSummaries.mockRejectedValue(new Error('redis down'));
+    await expect(resolveAccountKind(CHANNEL)).resolves.toBeNull();
+  });
+
+  /**
+   * The reply gate's contract, unchanged by the widening: an ORGANIZATION is not a
+   * channel, so its posts take replies like anybody else's. If this ever answered
+   * `true` for a non-channel the whole fediverse-facing reply rule would move with
+   * it.
+   */
+  it('is a channel test, not an "is a managed account" test', async () => {
+    await expect(isChannelAccount(CHANNEL)).resolves.toBe(true);
+    await expect(isChannelAccount(ORGANIZATION)).resolves.toBe(false);
+    await expect(isChannelAccount(PROJECT)).resolves.toBe(false);
+    await expect(isChannelAccount(BOT)).resolves.toBe(false);
+    await expect(isChannelAccount(PERSONAL)).resolves.toBe(false);
+    await expect(isChannelAccount(undefined)).resolves.toBe(false);
+  });
+});
+
+describe('cacheAccountMemberReads', () => {
+  it('asks once per account however many times it is asked', async () => {
+    const reader = readerReturning([member({ permissions: EDITOR_PERMISSIONS })]);
+    const cached = cacheAccountMemberReads(reader);
+
+    await Promise.all([
+      cached.listAccountMembers(ORGANIZATION),
+      cached.listAccountMembers(ORGANIZATION),
+      cached.listAccountMembers(ORGANIZATION),
+    ]);
+    await cached.listAccountMembers(ORGANIZATION);
+
+    expect(reader.calls).toEqual([ORGANIZATION]);
+  });
+
+  it('keeps distinct accounts distinct', async () => {
+    const reader = readerReturning([member({ permissions: EDITOR_PERMISSIONS })]);
+    const cached = cacheAccountMemberReads(reader);
+
+    await cached.listAccountMembers(ORGANIZATION);
+    await cached.listAccountMembers(CHANNEL);
+    await cached.listAccountMembers(ORGANIZATION);
+
+    expect(reader.calls).toEqual([ORGANIZATION, CHANNEL]);
+  });
+
+  it('shares a FAILURE too, so a batch refuses consistently', async () => {
+    let calls = 0;
+    const cached = cacheAccountMemberReads({
+      listAccountMembers: async () => {
+        calls += 1;
+        throw new Error('oxy 500');
+      },
+    });
+
+    await expect(cached.listAccountMembers(ORGANIZATION)).rejects.toThrow('oxy 500');
+    await expect(cached.listAccountMembers(ORGANIZATION)).rejects.toThrow('oxy 500');
+    expect(calls).toBe(1);
+  });
+
+  it('drives the gate: authorizing one account twice costs one membership read', async () => {
+    const reader = readerReturning([member({ permissions: EDITOR_PERMISSIONS })]);
+    const cached = cacheAccountMemberReads(reader);
+
+    await assertCanPublishAsAccount({
+      publishAsOxyUserId: ORGANIZATION,
+      callerId: CALLER,
+      memberReader: cached,
+    });
+    await assertCanPublishAsAccount({
+      publishAsOxyUserId: ORGANIZATION,
+      callerId: CALLER,
+      memberReader: cached,
+    });
+
+    expect(reader.calls).toEqual([ORGANIZATION]);
+  });
+});

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -48,7 +48,11 @@ import {
   ChannelReplyError,
   postIsAuthoredByChannel,
 } from '../utils/channelReplyGate';
-import { PublishAsAccessError } from '../services/publishAsAccount';
+import {
+  assertCanPublishAsAccount,
+  cacheAccountMemberReads,
+  PublishAsAccessError,
+} from '../services/publishAsAccount';
 import { Lane } from '../models/Lane';
 import { sendSuccessResponse } from '../utils/apiHelpers';
 import type { LaneDisplayMode } from '@mention/shared-types';
@@ -752,10 +756,11 @@ export const createPost = async (req: AuthRequest, res: Response) => {
       // refusals, never a silent drop.
       laneId: typeof laneId === 'string' ? laneId : null,
       // Validated inside `create` (see `assertCanPublishAsAccount`): an account
-      // the caller is not an active member of is a 403 and one that is not a
-      // channel a 400 — both refusals, never a silent drop, and both raised
-      // before anything is written. `create` is also where the post picks up the
-      // channel as its AUTHOR, the writer as `writtenByOxyUserId`, and
+      // the caller is not an active member of is a 403, an act-as-eligible one
+      // they hold no `account:act_as` over is a 403, and a personal account is a
+      // 400 — all refusals, never a silent drop, and all raised before anything is
+      // written. `create` is also where the post picks up that account as its
+      // AUTHOR, the writer as `writtenByOxyUserId`, and (for a channel)
       // `replyPermission: ['nobody']`, so no caller can route around any of it.
       publishAsOxyUserId: typeof publishAsOxyUserId === 'string' ? publishAsOxyUserId : null,
       memberReader: createUserScopedOxyServices(req),
@@ -981,20 +986,62 @@ export const createThread = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'Posts array is required and cannot be empty' });
     }
 
-    // A THREAD CANNOT BE PUBLISHED AS ANOTHER ACCOUNT. In `thread` mode the
-    // continuations are replies, and a channel post accepts no replies — so the
-    // thread would be a root under the channel with its body scattered across
-    // posts the channel refuses. In `beast` mode the entries are independent posts
-    // and could each carry one, but a batch endpoint is the wrong place to
-    // introduce a second membership check, and nothing asks for it. Refused for
-    // the whole request, before anything is written; the same shape the
-    // collaborator refusal above takes, and for the same reason (a partial thread
-    // cannot be undone in one action).
-    const threadNamesAnotherAccount =
-      typeof req.body.publishAsOxyUserId === 'string' ||
-      posts.some((p: { publishAsOxyUserId?: unknown }) => typeof p?.publishAsOxyUserId === 'string');
-    if (threadNamesAnotherAccount) {
+    // PUBLISHING AS ANOTHER ACCOUNT IS PER ENTRY, AND `beast` MODE ONLY.
+    //
+    // A `beast` batch is n independent top-level posts that happen to be written
+    // in one action, so each entry may name its own account and they may all
+    // differ. A `thread` is one conversation: every entry after the first is a
+    // REPLY to the one before it, and `PostCreationService` refuses to publish a
+    // reply as another account at all — so "apply the root's account to the whole
+    // thread" is not implementable without punching a hole in that rule, and a
+    // per-entry account would be an identity that changes mid-conversation.
+    // Refused outright in thread mode instead, which is also what a channel needs:
+    // a channel post accepts no replies, so a thread rooted at one would be a root
+    // whose own continuations the channel refuses.
+    //
+    // The batch-level `publishAsOxyUserId` is refused in BOTH modes. It is not a
+    // field of `CreateThreadRequest` and never was; keeping one way to say this
+    // means a client cannot express a batch-wide account and a per-entry one at
+    // once and then discover which of them won.
+    if (typeof req.body.publishAsOxyUserId === 'string') {
+      return res
+        .status(400)
+        .json({ message: 'Set publishAsOxyUserId on each post, not on the thread' });
+    }
+    const entryNamesAnotherAccount = posts.some(
+      (p: { publishAsOxyUserId?: unknown }) => typeof p?.publishAsOxyUserId === 'string',
+    );
+    if (mode === 'thread' && entryNamesAnotherAccount) {
       return res.status(400).json({ message: 'A thread cannot be published as another account' });
+    }
+
+    // Every DISTINCT account named across the batch is authorized ONCE, before a
+    // single post is written — the same shape the collaborator and lane refusals
+    // take, and for the same reason (a partial thread cannot be undone in one
+    // action). `cacheAccountMemberReads` is what makes "once" true end to end: the
+    // creation loop below hands each post the SAME reader and lets
+    // `PostCreationService` run the real gate itself, so nothing routes around the
+    // authorization, and a twelve-entry batch naming one account still makes one
+    // membership call.
+    const memberReader = createUserScopedOxyServices(req);
+    const batchMemberReader = memberReader ? cacheAccountMemberReads(memberReader) : undefined;
+    /** Entry index → the account that entry will be AUTHORED BY. */
+    const entryAuthorIds: string[] = [];
+    for (let i = 0; i < posts.length; i++) {
+      const requested = posts[i]?.publishAsOxyUserId;
+      try {
+        const { authorId } = await assertCanPublishAsAccount({
+          publishAsOxyUserId: typeof requested === 'string' ? requested : null,
+          callerId: userId,
+          memberReader: batchMemberReader,
+        });
+        entryAuthorIds.push(authorId ?? userId);
+      } catch (publishAsError) {
+        if (publishAsError instanceof PublishAsAccessError) {
+          return res.status(publishAsError.status).json({ message: publishAsError.message });
+        }
+        throw publishAsError;
+      }
     }
 
     // Lanes are validated for the WHOLE batch before a single post is written.
@@ -1020,7 +1067,13 @@ export const createThread = async (req: AuthRequest, res: Response) => {
         return res.status(400).json({ message: 'A reply cannot be assigned to a lane' });
       }
       try {
-        await assertLaneAssignable({ laneId: requestedLaneId, authorId: userId });
+        // Against the entry's OWN author, which is the account it is published as
+        // when it names one — a lane belongs to a publisher, and `create` will
+        // measure it against exactly that. Checking the caller here instead would
+        // let a caller-owned lane on an account-published entry pass the
+        // pre-flight and then be refused mid-batch, which is the half-thread this
+        // whole loop exists to prevent.
+        await assertLaneAssignable({ laneId: requestedLaneId, authorId: entryAuthorIds[i] });
       } catch (laneError) {
         if (laneError instanceof LaneAssignmentError) {
           return res.status(laneError.status).json({ message: laneError.message });
@@ -1179,6 +1232,15 @@ export const createThread = async (req: AuthRequest, res: Response) => {
         // Already validated for the whole batch above; a continuation never
         // reaches here carrying one.
         laneId: typeof postData.laneId === 'string' ? postData.laneId : null,
+        // Pre-flighted for the whole batch above, and re-run HERE by `create`
+        // itself — deliberately, not wastefully. The gate is the one place that
+        // decides the author, so passing a pre-resolved id instead would be the
+        // "checked upstream, trust me" shape that lets a later caller route around
+        // it. The repeat is free: `batchMemberReader` has already answered for this
+        // account, and a thread-mode entry never reaches here carrying one.
+        publishAsOxyUserId:
+          typeof postData.publishAsOxyUserId === 'string' ? postData.publishAsOxyUserId : null,
+        memberReader: batchMemberReader,
         // For thread mode: chain each continuation post to the immediately
         // previous post (sequential thread), with a shared threadId root.
         // For beast mode: all posts are independent.
@@ -1231,7 +1293,13 @@ export const createThread = async (req: AuthRequest, res: Response) => {
           await createMentionNotifications(
             persistedMentions,
             post._id.toString(),
-            userId,
+            // The ACTOR is the post's author, read off the row `create` just
+            // wrote — the account when the entry was published as one, the caller
+            // otherwise. `PostCreationService` attributes its own mention
+            // notifications the same way; naming the caller here would put a
+            // channel's writer in the notification of a post the channel signed,
+            // which is the anonymity `writtenByOxyUserId` exists to keep.
+            String(post.oxyUserId ?? userId),
             'post'
           );
         }
@@ -1286,7 +1354,11 @@ export const createThread = async (req: AuthRequest, res: Response) => {
         io.emit('feed:updated', {
           type: 'following',
           post: mainPost,
-          authorId: userId,
+          // The FIRST entry's author, which is who a following feed would have to
+          // follow to see it — the account when that entry was published as one.
+          // Naming the caller would push an account's post into the feeds of the
+          // caller's followers, who may not follow the account at all.
+          authorId: entryAuthorIds[0] ?? userId,
           timestamp: new Date().toISOString()
         });
       }

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -5,6 +5,7 @@ import Post from '../models/Post';
 import Bookmark from '../models/Bookmark';
 import Like from '../models/Like';
 // Block and Restrict routes removed - frontend should use Oxy services directly
+import type { AccountKind } from '@oxyhq/contracts';
 import { requireOxyAuth as requireAuth, type OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { buildSettingsResponseForViewer, ensureUserSettings } from '../utils/userSettings';
 import { createUserScopedOxyServices, ensureProfileMediaPublic } from '../utils/oxyHelpers';
@@ -128,23 +129,29 @@ router.put(
         return sendErrorResponse(res, 400, 'Bad Request', 'channel.signPosts must be a boolean');
       }
 
+      let authorKind: AccountKind | null;
       try {
-        await assertCanPublishAsAccount({
+        ({ authorKind } = await assertCanPublishAsAccount({
           publishAsOxyUserId: targetUserId,
           callerId,
           memberReader: createUserScopedOxyServices(req),
-        });
+        }));
       } catch (error) {
         if (error instanceof PublishAsAccessError) {
           return sendErrorResponse(res, error.status, 'Forbidden', error.message);
         }
         throw error;
       }
-      // `assertCanPublishAsAccount` returns the caller unchanged when the target IS
-      // the caller, which would let a person write `channel.signPosts` onto their own
-      // personal settings — a field with no meaning there. The target must be a
-      // channel, so say so rather than relying on the gate's publish-shaped answer.
-      if (targetUserId === callerId) {
+      // The gate admits every account the caller may act for — a channel, and also
+      // an organization / project / bot. `channel.signPosts` means something on
+      // exactly one of those: it decides whether a CHANNEL discloses the human who
+      // wrote a post, and `PostHydrationService` reads it only for a `kind:
+      // 'channel'` author. So the kind the gate resolved is checked here, which
+      // also covers the target being the CALLER'S OWN account (the gate answers
+      // that one without resolving anything, so `authorKind` is `null`) — writing
+      // the field onto a personal settings row would be storing a control that
+      // nothing reads.
+      if (authorKind !== 'channel') {
         return sendErrorResponse(res, 400, 'Bad Request', 'That account cannot be published as');
       }
 

--- a/packages/backend/src/services/PostCreationService.ts
+++ b/packages/backend/src/services/PostCreationService.ts
@@ -68,8 +68,8 @@ export interface CreatePostParams {
    */
   laneId?: string | null;
   /**
-   * Publish this post AS another Oxy account the caller operates — today, a
-   * `channel` account.
+   * Publish this post AS another Oxy account the caller operates: a `channel`,
+   * or an organization / project / bot they may act as.
    *
    * The post is AUTHORED BY that account: it carries the account's `oxyUserId`
    * and its `authorship`, so it lands on that account's profile and in the
@@ -79,8 +79,10 @@ export interface CreatePostParams {
    * back on their own profile.
    *
    * Validated by {@link assertCanPublishAsAccount} before the document is built:
-   * an account the caller is not an accepted member of is a 403. Publishing as a
-   * channel also forces `replyPermission: ['nobody']` — see there.
+   * an account the caller is not an accepted member of is a 403, and so is an
+   * act-as-eligible account they hold no `account:act_as` over. Publishing as a
+   * CHANNEL additionally forces `replyPermission: ['nobody']`; publishing as an
+   * organization does not — see there.
    */
   publishAsOxyUserId?: string | null;
   /**
@@ -340,7 +342,12 @@ class PostCreationService {
     // federated post's author is resolved from the remote actor, so a second
     // author on the same row could only contradict it. Each is a REFUSAL rather
     // than a silent drop — an author told nothing would go on believing they had
-    // published as the channel.
+    // published as the account.
+    //
+    // The reply refusal is deliberately kept for the act-as-eligible kinds too,
+    // where the channel argument does not apply: replying AS an organization is a
+    // coherent feature, but it is a feature — nothing asks for it, and admitting
+    // it here by omission would ship it unconsidered and untested.
     if (params.publishAsOxyUserId) {
       if (params.parentPostId) {
         throw new PublishAsAccessError(400, 'A reply cannot be published as another account');
@@ -358,7 +365,7 @@ class PostCreationService {
     // record's subject — reads this, never `params.oxyUserId`, so the authorship
     // and the authorization can never disagree. The authenticated human survives
     // only as `writtenByOxyUserId`, outside `authorship`.
-    const authorId = await assertCanPublishAsAccount({
+    const { authorId, authorKind } = await assertCanPublishAsAccount({
       publishAsOxyUserId: params.publishAsOxyUserId,
       callerId: params.oxyUserId,
       memberReader: params.memberReader,
@@ -416,13 +423,20 @@ class PostCreationService {
       boostOf: params.boostOf ?? null,
       parentPostId: params.parentPostId ?? null,
       threadId: params.threadId ?? null,
-      // A channel post is persisted with `['nobody']` whatever the caller asked
+      // A CHANNEL post is persisted with `['nobody']` whatever the caller asked
       // for — DEFENCE IN DEPTH, and it buys the client's existing reply-button
       // suppression with no new UI. It is NOT what the server's refusal rests on:
       // `utils/channelReplyGate` reads the AUTHOR's account kind, because this
       // field is mutable and a later settings write must not be able to reopen
       // the post.
-      replyPermission: publishedAsAccount ? ['nobody'] : params.replyPermission ?? ['anyone'],
+      //
+      // Keyed on the author's KIND, not on "was this published as somebody else":
+      // "no replies, ever" is a property of channels, not of publishing as an
+      // account. An organization/project/bot post is an ORDINARY post — the reply
+      // gate lets replies through for a non-channel author, so forcing `['nobody']`
+      // here would leave the persisted field and the server's own rule disagreeing,
+      // and would silently close every organization's comments.
+      replyPermission: authorKind === 'channel' ? ['nobody'] : params.replyPermission ?? ['anyone'],
       reviewReplies: params.reviewReplies ?? false,
       quotesDisabled: params.quotesDisabled ?? false,
       status: params.status ?? 'published',

--- a/packages/backend/src/services/publishAsAccount.ts
+++ b/packages/backend/src/services/publishAsAccount.ts
@@ -8,6 +8,27 @@
  * keep in sync with the account graph, and it would go stale exactly when it
  * matters (a member removed in Oxy would still be publishing here).
  *
+ * TWO FAMILIES OF ACCOUNT, TWO DIFFERENT AUTHORITIES — this is the part that is
+ * easy to get wrong by collapsing it into one membership test.
+ *
+ *  - A **channel** can never be acted as (`isActAsEligibleKind` refuses it: it is
+ *    a content identity, not a seat). There is no session anybody could switch
+ *    into, so there is no stronger right than membership to ask for — acting for
+ *    a channel simply IS being one of its members.
+ *  - An **act-as-eligible** account (organization / project / bot) CAN be switched
+ *    into, and the right that governs that switch is `account:act_as`. Signing a
+ *    post as the organization is the same claim of identity as being it for a
+ *    session, so it is gated on the same permission. Bare membership is NOT
+ *    enough: an account's `viewer`, `billing` and `developer` members are members
+ *    who deliberately may not act as it, and letting one of them publish under
+ *    its name would hand out through this door exactly what
+ *    `POST /accounts/:id/switch` refuses at the other one.
+ *
+ * `AccountMember.permissions` is derived from the role by Oxy at write time, so
+ * the permission is READ rather than inferred from a role name — a role list here
+ * would be a second copy of Oxy's role→permission map, free to drift the moment a
+ * role is added or its grants change.
+ *
  * WHY THE CALLER'S OWN OXY CLIENT, AND NOT THE SERVICE CREDENTIAL.
  * `GET /accounts/:id/members` is gated on the AUTHENTICATED USER's effective
  * `members:read` over that account (`requireAccountPermission` in oxy-api); it
@@ -24,9 +45,24 @@
  * a refusal, not a default.
  */
 
+import type { AccountKind } from '@oxyhq/contracts';
+import { isActAsEligibleKind } from '@oxyhq/contracts';
 import type { AccountMember } from '@oxyhq/core';
 import { resolveUserSummaries } from './PostHydrationService';
 import { logger } from '../utils/logger';
+
+/**
+ * The Oxy account permission that authorises assuming an account's identity —
+ * what `POST /accounts/:id/switch` gates on, and therefore what publishing under
+ * that account's name gates on too.
+ *
+ * A literal because it is a WIRE value: Oxy derives each member's `permissions`
+ * from their role server-side and ships the resulting strings, and neither
+ * `@oxyhq/contracts` nor `@oxyhq/core` exports the permission vocabulary today.
+ * Its eventual home is `@oxyhq/contracts` beside `ACCOUNT_KINDS`; until then this
+ * is one named constant rather than a string scattered through the checks.
+ */
+const ACCOUNT_ACT_AS_PERMISSION = 'account:act_as';
 
 /** A refusal carrying the status the HTTP layer should answer with. */
 export class PublishAsAccessError extends Error {
@@ -49,36 +85,100 @@ export interface AccountMemberReader {
 }
 
 /**
- * Whether this Oxy account is a channel.
+ * Collapse repeated reads of the SAME account's member list onto one call, for a
+ * caller that authorizes several targets in one request (`POST /posts/thread` in
+ * beast mode, where every entry may name its own account). Twelve entries naming
+ * one organization make one membership call, not twelve.
+ *
+ * The PROMISE is memoized, not its value, so two concurrent asks for one account
+ * share a single in-flight request — and a failure is shared too, which is what
+ * makes the batch refuse consistently instead of depending on which entry hit the
+ * outage.
+ *
+ * **Per REQUEST, never module scope.** This holds an authorization answer for one
+ * specific caller's bearer; hoisting it would serve one person's membership to
+ * the next — the same reason `createUserScopedOxyServices` builds a fresh Oxy
+ * client per request.
+ */
+export function cacheAccountMemberReads(reader: AccountMemberReader): AccountMemberReader {
+  const byAccount = new Map<string, Promise<AccountMember[]>>();
+  return {
+    listAccountMembers(accountId: string): Promise<AccountMember[]> {
+      const pending = byAccount.get(accountId);
+      if (pending) return pending;
+      const started = reader.listAccountMembers(accountId);
+      byAccount.set(accountId, started);
+      return started;
+    },
+  };
+}
+
+/**
+ * The Oxy account `kind` behind an id, or `null` when it cannot be resolved.
  *
  * Resolved through {@link resolveUserSummaries} — the SAME Redis-cached identity
  * path post hydration already fills for every author it renders — so the hot
  * paths that ask (the reply gate, on every reply) cost a batched Redis read
  * rather than an Oxy round trip.
  *
- * Fail-soft to `false`: the callers each decide what to do with "not a channel",
- * and each documents why that direction is the safe one for them.
+ * Fail-soft to `null`: the callers each decide what an unknown kind means, and
+ * each documents why that direction is the safe one for them.
+ */
+export async function resolveAccountKind(
+  oxyUserId: string | null | undefined,
+): Promise<AccountKind | null> {
+  if (!oxyUserId) return null;
+  try {
+    const summaries = await resolveUserSummaries([oxyUserId]);
+    return summaries.get(oxyUserId)?.user.kind ?? null;
+  } catch (error) {
+    logger.warn('[publishAsAccount] Failed to resolve account kind', error);
+    return null;
+  }
+}
+
+/**
+ * Whether this Oxy account is a channel — the question `utils/channelReplyGate`
+ * asks about a post's author, on every reply.
+ *
+ * Fail-soft to `false`, deliberately: see that module on why an unresolvable
+ * author must read as not-a-channel rather than refusing every reply on the site
+ * for the duration of an identity outage.
  */
 export async function isChannelAccount(
   oxyUserId: string | null | undefined,
 ): Promise<boolean> {
-  if (!oxyUserId) return false;
-  try {
-    const summaries = await resolveUserSummaries([oxyUserId]);
-    return summaries.get(oxyUserId)?.user.kind === 'channel';
-  } catch (error) {
-    logger.warn('[publishAsAccount] Failed to resolve account kind', error);
-    return false;
-  }
+  return (await resolveAccountKind(oxyUserId)) === 'channel';
+}
+
+/** What {@link assertCanPublishAsAccount} answers with. */
+export interface PublishAsAuthor {
+  /**
+   * The account the post is AUTHORED BY — the named account when one was asked
+   * for and allowed, otherwise the caller. Callers use this rather than
+   * re-deriving it, so the authorization and the authorship cannot disagree.
+   */
+  authorId: string | null;
+  /**
+   * That author's Oxy account kind, resolved ONLY when another account was named
+   * and allowed; `null` on the ordinary path, where nothing was looked up.
+   *
+   * It rides along because the ONE resolution that authorized the publish is also
+   * the answer every downstream rule keyed on the author's kind needs — today
+   * whether the post is persisted `replyPermission: ['nobody']` (a channel takes
+   * no replies; an organization is an ordinary account and takes them normally).
+   * Returning it is what keeps that rule from re-deriving the kind through a
+   * second lookup that could answer differently.
+   */
+  authorKind: AccountKind | null;
 }
 
 /**
  * Refuse unless `callerId` may publish as `publishAsOxyUserId`.
  *
- * Returns the account the post will be AUTHORED BY: `publishAsOxyUserId` when one
- * was asked for and allowed, otherwise the caller. Callers use the return value
- * rather than re-deriving it, so the authorization and the authorship cannot
- * disagree.
+ * Returns {@link PublishAsAuthor}: the account the post will be AUTHORED BY, and
+ * that account's kind. Callers use the return value rather than re-deriving it,
+ * so the authorization, the authorship and the author-kind rules cannot disagree.
  *
  * Free when nothing was asked for — no query, which is the overwhelming majority
  * of posts. Naming your OWN account is treated as naming none: it is the same
@@ -86,30 +186,41 @@ export async function isChannelAccount(
  * asking Oxy a question with no bearing on the answer.
  *
  * The refusals:
- *  - **400** — the target is not a `channel` account. Publishing as an
- *    organization/project/bot is the SESSION SWITCH (`account:act_as`), which
- *    mints a real session for it; a second mechanism for the same thing is how
- *    the two drift. A channel is the case that cannot use it — `isActAsEligibleKind`
- *    refuses a channel, because it is a content identity rather than a seat.
- *  - **403** — no client to ask with (an unauthenticated or MCP caller), or the
- *    caller is not an ACTIVE member of that account.
+ *  - **400** — the target is an account nothing can be published as: a `personal`
+ *    account (a human login — authoring as one is impersonation, and its owner is
+ *    the only person who can post as it, by signing in), or an id whose kind could
+ *    not be resolved at all. An unknown kind refuses because the two directions
+ *    are not comparable — see the module docstring on failing closed. Any kind Oxy
+ *    adds later is refused until it is deliberately admitted here, rather than
+ *    inherited by accident.
+ *  - **403** — no client to ask with (an unauthenticated or MCP caller), the
+ *    caller is not an ACTIVE member of that account, or — for an act-as-eligible
+ *    account — they are a member without `account:act_as`.
  *  - **503** — Oxy could not answer. See the module docstring on failing closed.
  */
 export async function assertCanPublishAsAccount(params: {
   publishAsOxyUserId: string | null | undefined;
   callerId: string | null | undefined;
   memberReader: AccountMemberReader | undefined;
-}): Promise<string | null> {
+}): Promise<PublishAsAuthor> {
   const target = params.publishAsOxyUserId?.trim();
   const callerId = params.callerId ?? null;
-  if (!target || target === callerId) return callerId;
+  if (!target || target === callerId) return { authorId: callerId, authorKind: null };
 
   if (!callerId) {
     throw new PublishAsAccessError(403, 'You cannot publish as another account');
   }
-  if (!(await isChannelAccount(target))) {
+
+  // WHICH authority this account answers to, decided before anything is asked of
+  // Oxy's member list. `isActAsEligibleKind` rather than a `kind !== 'personal'`
+  // test on purpose: it is the predicate Oxy itself gates the session switch on,
+  // so the two can never disagree about what may be assumed.
+  const authorKind = await resolveAccountKind(target);
+  const requiresActAs = isActAsEligibleKind(authorKind);
+  if (authorKind !== 'channel' && !requiresActAs) {
     throw new PublishAsAccessError(400, 'That account cannot be published as');
   }
+
   if (!params.memberReader) {
     throw new PublishAsAccessError(403, 'You cannot publish as another account');
   }
@@ -126,12 +237,23 @@ export async function assertCanPublishAsAccount(params: {
     throw new PublishAsAccessError(503, 'Could not verify your access to that account');
   }
 
-  const isMember = members.some(
+  const membership = members.find(
     (member) => member.memberUserId === callerId && member.status === 'active',
   );
-  if (!isMember) {
+  if (!membership) {
     throw new PublishAsAccessError(403, 'You are not a member of that account');
   }
 
-  return target;
+  // The permission is READ off the membership Oxy resolved, never inferred from
+  // `membership.role` — a role list here would be a second copy of Oxy's
+  // role→permission map, and the copy is what goes stale. An absent or malformed
+  // `permissions` array is therefore a refusal, not an assumption.
+  if (
+    requiresActAs &&
+    !(Array.isArray(membership.permissions) && membership.permissions.includes(ACCOUNT_ACT_AS_PERMISSION))
+  ) {
+    throw new PublishAsAccessError(403, 'You cannot publish as that account');
+  }
+
+  return { authorId: target, authorKind };
 }

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -723,24 +723,35 @@ export interface CreatePostRequest {
    */
   laneId?: string;
   /**
-   * Publish this post AS another Oxy account — today, a `channel` account the
-   * caller operates. The post is AUTHORED BY that account: it carries the
-   * channel's `oxyUserId` and its `authorship`, so it lands on the channel's
-   * profile and in the timelines of the channel's followers, and it renders with
-   * the channel's avatar and name because `user` IS the channel.
+   * Publish this post AS another Oxy account the caller operates. The post is
+   * AUTHORED BY that account: it carries the account's `oxyUserId` and its
+   * `authorship`, so it lands on that account's profile and in the timelines of
+   * its followers, and it renders with its avatar and name because `user` IS that
+   * account.
    *
    * The authenticated human is recorded OUTSIDE `authorship`, in
    * `writtenByOxyUserId`, and is disclosed only when the channel sets
    * `signPosts`. Putting them in `authorship` would both break that anonymity and
    * put the post back on their own profile.
    *
-   * A channel can never be acted as (`isActAsEligibleKind` refuses it — it is a
-   * content identity, not a seat), so this field, not a session switch, is how a
-   * post comes to be authored by one. The server refuses it (403) unless the
-   * caller is an accepted member of that account.
+   * TWO FAMILIES OF ACCOUNT ARE ACCEPTED, on two different authorities:
    *
-   * To put a channel post on your own profile you boost it; there is no field for
-   * that, because a boost is already the right row with the right owner.
+   *  - A **channel**, where accepted membership is the whole right. A channel can
+   *    never be acted as (`isActAsEligibleKind` refuses it — it is a content
+   *    identity, not a seat), so this field, not a session switch, is the ONLY way
+   *    a post comes to be authored by one. A channel post is additionally
+   *    persisted `replyPermission: ['nobody']` — a channel takes no replies.
+   *  - An **organization / project / bot**, where the right is `account:act_as` —
+   *    the same permission that would let the caller switch INTO the account. The
+   *    point of the field here is signing a post as the account WITHOUT switching;
+   *    a member who may not be the account may not sign as it either. Such a post
+   *    is an ordinary post in every other respect, replies included.
+   *
+   * A `personal` account is refused (400): authoring as a human login is
+   * impersonation, and its owner posts as it by signing in.
+   *
+   * To put an account's post on your own profile you boost it; there is no field
+   * for that, because a boost is already the right row with the right owner.
    */
   publishAsOxyUserId?: string;
 }
@@ -762,6 +773,23 @@ export interface CreateThreadPostRequest {
    * chip belongs anyway.
    */
   laneId?: string;
+  /**
+   * Publish THIS entry as another Oxy account the caller operates — the same
+   * field, the same authorization and the same effects as
+   * {@link CreatePostRequest.publishAsOxyUserId}, decided per entry so one batch
+   * can post from several accounts.
+   *
+   * **`beast` mode only.** In `beast` mode the entries are independent top-level
+   * posts, so each may name its own account and they may all differ. In `thread`
+   * mode they are one conversation whose continuations are REPLIES to the entry
+   * before them, and a reply can never be published as another account — so the
+   * server refuses the field outright there (400) rather than letting the author
+   * believe an identity was applied that a mid-thread post could not carry.
+   *
+   * Refused for the WHOLE request before any entry is written, like every other
+   * batch-level refusal here: half a batch cannot be undone in one action.
+   */
+  publishAsOxyUserId?: string;
 }
 
 export interface CreateThreadRequest {


### PR DESCRIPTION
`publishAsOxyUserId` admitted only `kind: 'channel'`. It now admits any account the caller may act for — but **the authority is not the same for the two families**, and conflating them would have been the bug.

| kind | right to publish as it |
|---|---|
| `channel` | active membership — it can never be acted as, so membership is the whole right |
| `organization` / `project` / `bot` | active membership **plus `account:act_as`** — publishing under its name is the same authority as becoming it |

Without that split, a member with fewer rights could sign as the organization while being unable to be it.

The permission is read off `AccountMember.permissions`, **never inferred from `membership.role`** — a role list here would be a second copy of Oxy's role→permission map, and the copy is what goes stale. An absent or malformed array is a refusal. Eligibility uses `isActAsEligibleKind`, not `kind !== 'personal'`, so a kind Oxy adds later is refused rather than inherited.

## `replyPermission` was wrong, and this exposed it

The forced `['nobody']` was keyed on "published as an account", but the reply gate refuses only a `channel` author. An organization's post would have been persisted **uncommentable while the server itself admitted replies** — a permanently closed comment section with no setting that reopens it. Now keyed on the kind the gate resolved, which is why the gate returns the kind instead of a second lookup deciding it again.

## Per-post accounts in a beast batch

`CreateThreadPostRequest` gains the field. **`thread` mode refuses it (400)** rather than applying the root's: continuations are replies, publishing a reply as another account is refused outright, so "apply the root's" needs a hole in that rule — and a channel would refuse its own thread's continuations anyway. The batch-level field is refused in both modes, naming the per-entry one: two ways to say it lets a client send both and discover which won.

**One membership read per distinct account per request**, memoized on the in-flight promise and built per request (module scope would serve one caller's membership to the next). The controller pre-flights every entry through the real gate before writing anything, then hands the same cached reader to each create — nothing receives a "checked upstream, trust me" flag.

## Three fixes the per-post path forced

- The **lane pre-flight** measures the ENTRY's author, not the caller. Otherwise a caller-owned lane on an account-published entry passes pre-flight and is refused mid-loop — the half-written batch pre-flight exists to prevent.
- The **mention-notification actor** and the **socket `following` author** are the post's author. Naming the caller would put a channel's writer into a notification for a post the channel signed.

`PUT /profile/settings/:userId` used this gate as its authorization, so widening it would have let an organization write `channel.signPosts` onto a row nothing reads. It now checks the resolved kind.

## Verification

**417 files / 4501 tests** (baseline 414 / 4444), `tsc` clean across backend / shared-types / mcp / e2e / frontend.

Mutation matrix, every load-bearing clause: loosening `account:act_as` to bare membership fails **7 tests**, three named for it; requiring it for *every* kind fails 2; dropping the per-entry account, the memoization, the pre-flight, the lane-author fix, the notification actor and the socket author each fail their own named tests. The lane mutation was initially **vacuous** — tests were added and the whole matrix re-run.

## Known gaps, deliberate

- An organization's post is **anonymous by default with no way to sign it**: writer disclosure is gated on `kind: 'channel'` + `signPosts`. Fails toward privacy, but it is a gap.
- **Inherited memberships are invisible**: `GET /accounts/:id/members` returns direct rows only, so a role cascading from an ancestor is refused. Pre-existing and fails closed; fixing it means moving `AccountMemberReader` onto `getAccount()` → `callerMembership`.
- The frontend still hides the affordance for any batch, so nothing user-visible changes until the composer lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
