### PR TITLE
fix(lists): a profile's Lists tab showed the VIEWER's lists, not the owner's

### DIFF
--- a/packages/backend/src/__tests__/routes/searchListsPagination.test.ts
+++ b/packages/backend/src/__tests__/routes/searchListsPagination.test.ts
@@ -105,6 +105,60 @@ describe('GET /lists — search filter (the bug) + visibility gate', () => {
   });
 });
 
+describe("GET /lists — ?userId, ONE account's lists", () => {
+  beforeEach(() => {
+    seed([
+      { _id: 'v-pub', ownerOxyUserId: VIEWER, isPublic: true, title: 'Viewer public', updatedAt: 6 },
+      { _id: 'v-priv', ownerOxyUserId: VIEWER, isPublic: false, title: 'Viewer private', updatedAt: 5 },
+      { _id: 'o-pub', ownerOxyUserId: OTHER, isPublic: true, title: 'Other public', updatedAt: 4 },
+      { _id: 'o-priv', ownerOxyUserId: OTHER, isPublic: false, title: 'Other private', updatedAt: 3 },
+    ]);
+  });
+
+  /**
+   * The bug this parameter exists for. The profile's Lists tab sent `?userId=`
+   * for a long time while the route read only `mine`/`publicOnly`, so it fell
+   * through to the viewer-shaped visibility gate and answered a DIFFERENT
+   * question: the viewer's own lists plus every public one — on somebody else's
+   * profile. It read as a rendering quirk and was a leak between profiles.
+   *
+   * Nothing typed caught it: the tab builds its params in a VARIABLE, and
+   * TypeScript's excess-property check applies only to object literals passed
+   * directly.
+   */
+  it("returns only that owner's lists, not the viewer's", async () => {
+    const res = await request(app).get('/lists').query({ userId: OTHER }).expect(200);
+    const titles = (res.body.items as Array<{ title: string }>).map((l) => l.title);
+
+    expect(titles).toEqual(['Other public']);
+    expect(titles).not.toContain('Viewer public');
+    expect(titles).not.toContain('Viewer private');
+  });
+
+  /**
+   * The load-bearing half. `?userId=` must not become a way to read somebody's
+   * PRIVATE lists — a filter that widens what a viewer can see is worse than the
+   * bug it replaced.
+   */
+  it("never exposes another owner's private lists", async () => {
+    const res = await request(app).get('/lists').query({ userId: OTHER }).expect(200);
+    const titles = (res.body.items as Array<{ title: string }>).map((l) => l.title);
+    expect(titles).not.toContain('Other private');
+  });
+
+  it('returns the viewer their own private lists when they ask for themselves', async () => {
+    const res = await request(app).get('/lists').query({ userId: VIEWER }).expect(200);
+    const titles = (res.body.items as Array<{ title: string }>).map((l) => l.title);
+    expect(titles).toEqual(['Viewer public', 'Viewer private']);
+  });
+
+  it('still narrows within the owner when a search term is given', async () => {
+    const res = await request(app).get('/lists').query({ userId: OTHER, search: 'public' }).expect(200);
+    const titles = (res.body.items as Array<{ title: string }>).map((l) => l.title);
+    expect(titles).toEqual(['Other public']);
+  });
+});
+
 describe('GET /lists — offset pagination', () => {
   // Five public lists, all matching "team", newest-first by updatedAt.
   const lists: Doc[] = Array.from({ length: 5 }, (_, i) => ({

--- a/packages/backend/src/routes/lists.ts
+++ b/packages/backend/src/routes/lists.ts
@@ -100,13 +100,33 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Authentication required' });
     const { mine, publicOnly } = req.query;
+    const ownerId = queryString(req.query.userId)?.trim();
     const q: Record<string, unknown> = {};
     if (mine === 'true') q.ownerOxyUserId = userId;
     if (publicOnly === 'true') q.isPublic = true;
+    // `userId` — ONE account's lists, which is what a profile's Lists tab asks.
+    // Named `userId` because that is what `GET /feeds` and `GET /starter-packs`
+    // already call the same parameter, and the three serve sibling tabs on one
+    // screen; a fourth spelling here is how a client ends up sending the wrong
+    // one, which is precisely what happened.
+    //
+    // Without it that tab fell through to the visibility gate below and answered a
+    // different question entirely: the VIEWER's own lists plus every public list,
+    // on somebody else's profile. It read as a rendering quirk and was a data
+    // leak — you saw your own lists sitting under a stranger's name.
+    //
+    // A non-owner gets that owner's PUBLIC lists only. The two clauses are set
+    // together rather than letting the gate below add its own, because that gate
+    // is written around the viewer and would re-admit every public list from
+    // everyone.
+    if (ownerId) {
+      q.ownerOxyUserId = ownerId;
+      if (ownerId !== userId) q.isPublic = true;
+    }
     // Visibility gate: without an explicit filter the viewer sees their OWN lists
     // plus every public list. The search term (below) narrows within that gate —
     // it never widens it, so a non-owner still can't reach a private list.
-    if (!mine && !publicOnly) q.$or = [{ ownerOxyUserId: userId }, { isPublic: true }];
+    if (!mine && !publicOnly && !ownerId) q.$or = [{ ownerOxyUserId: userId }, { isPublic: true }];
 
     // Filter by `search` (name/description, case-insensitive). Previously ignored —
     // the search tab received every accessible list unfiltered. Regex-ESCAPED so a

--- a/packages/frontend/services/listsService.ts
+++ b/packages/frontend/services/listsService.ts
@@ -45,7 +45,17 @@ type ListWriteBody = {
 };
 
 class ListsService {
-  async list(params?: { mine?: boolean; publicOnly?: boolean }) {
+  /**
+   * `userId` asks for ONE account's lists — the same spelling `feedsService` and
+   * `starterPacksService` use for the sibling profile tabs.
+   *
+   * It is named in the type because the profile tab passed it for a long time
+   * while neither this type nor the route knew it: the call site builds its
+   * params in a VARIABLE, and TypeScript's excess-property check only applies to
+   * object literals passed directly, so nothing objected and the tab silently
+   * answered a different question.
+   */
+  async list(params?: { mine?: boolean; publicOnly?: boolean; userId?: string }) {
     const res = await authenticatedClient.get('/lists', { params });
     return res.data as MentionListCollection;
   }


### PR DESCRIPTION
`GET /lists` read only `mine` and `publicOnly`. The profile tab has been sending `?userId=<profile>` for a long time, the route ignored it, and the request fell through to the visibility gate — which is written around the **viewer**: their own lists plus every public one.

**So on somebody else's profile you saw your own lists sitting under their name**, private ones included. It reads as a rendering quirk and is a leak between profiles.

## Why nothing caught it

`listsService.list` declared `{ mine?, publicOnly? }`, and the tab builds its params in a **variable**, not an object literal — TypeScript's excess-property check applies only to literals passed directly, so `userId` was silently accepted and silently dropped. The parameter is now in that type, which is what makes the next wrong spelling a compile error instead of a quiet behaviour change.

## Why it is spelled `userId`

`GET /feeds` (`customFeeds.routes.ts:114`) and `GET /starter-packs` (`starterPacks.ts:247`) — the two sibling tabs on the same screen — already call it that and already honour it. **Only lists was missing the read.** A fourth spelling here is how a client sends the wrong one, which is precisely what happened.

## The privacy half

A non-owner gets that owner's **public** lists only. Both clauses are set together rather than letting the viewer-shaped gate contribute, because that gate would re-admit every public list from everyone — turning a narrowing filter into a widening one.

## Verification

Backend **417 files / 4513 tests**, frontend **1169**, `tsc` clean on both.

Mutation-tested, both halves:

| mutation | result |
|---|---|
| drop the privacy clause | 2 tests fail, incl. `never exposes another owner's private lists` |
| ignore `userId` again (the original bug) | 3 tests fail |

Found while auditing the channel profile's tab set; it affects **people**, not channels — a channel no longer has that tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
