### PR TITLE
feat: a thread can go out under one account, plus a schedule glyph of its own

### DIFF
--- a/packages/backend/src/__tests__/controllers/channelPostSettings.test.ts
+++ b/packages/backend/src/__tests__/controllers/channelPostSettings.test.ts
@@ -9,11 +9,11 @@ import mongoose from 'mongoose';
  *    post. The 403 on the reply paths reads the AUTHOR's account kind and would
  *    hold regardless — but a change here would UN-HIDE the client's reply button
  *    and leave every reader hitting a refusal they were invited to attempt.
- *  - `POST /posts/thread` refuses a `publishAsOxyUserId` in THREAD mode: the
- *    continuations are replies, and a channel post accepts none, so the thread
- *    would be a root under the channel with its body scattered across posts the
- *    channel refuses. (Beast mode honours it per entry — that path has its own
- *    suite, `threadPublishAsAccount.test.ts`.)
+ *  - `POST /posts/thread` accepts `publishAsOxyUserId` in exactly ONE place per
+ *    mode: at the BATCH level in thread mode (one publisher for one text) and
+ *    PER ENTRY in beast mode (n independent posts). The other placement is a 400
+ *    naming the right field, so a client can never send both. Both paths have
+ *    their own suite, `threadPublishAsAccount.test.ts`.
  */
 
 const postFindOne = vi.fn();
@@ -171,23 +171,12 @@ describe('PATCH /posts/:id/settings — replyPermission on a channel post', () =
   });
 });
 
-describe('POST /posts/thread — a THREAD cannot be published as another account', () => {
+describe('POST /posts/thread — one placement per mode, and only one', () => {
   function req(body: Record<string, unknown>): OxyAuthRequest {
     return { user: { id: USER_ID }, body } as unknown as OxyAuthRequest;
   }
 
-  it('400s a batch-level publishAsOxyUserId before writing anything, in thread mode', async () => {
-    const res = makeRes();
-    await createThread(
-      req({ mode: 'thread', publishAsOxyUserId: CHANNEL_ACCOUNT, posts: [{ content: { text: 'a' } }] }),
-      res as never,
-    );
-
-    expect(res.statusCode).toBe(400);
-    expect(postCreationCreate).not.toHaveBeenCalled();
-  });
-
-  it('400s a batch-level publishAsOxyUserId in BEAST mode too — the per-entry field is the only way to say it', async () => {
+  it('400s a batch-level publishAsOxyUserId in BEAST mode — the per-entry field is the only way to say it', async () => {
     const res = makeRes();
     await createThread(
       req({ mode: 'beast', publishAsOxyUserId: CHANNEL_ACCOUNT, posts: [{ content: { text: 'a' } }] }),
@@ -198,7 +187,7 @@ describe('POST /posts/thread — a THREAD cannot be published as another account
     expect(postCreationCreate).not.toHaveBeenCalled();
   });
 
-  it('400s a per-entry publishAsOxyUserId in thread mode, whichever entry carries it', async () => {
+  it('400s a PER-ENTRY publishAsOxyUserId in thread mode — a thread has one publisher, named once', async () => {
     const res = makeRes();
     await createThread(
       req({

--- a/packages/backend/src/__tests__/controllers/postsControllerChannelReply.test.ts
+++ b/packages/backend/src/__tests__/controllers/postsControllerChannelReply.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+import type { OxyAuthRequest } from '@oxyhq/core/server';
+
+/**
+ * `POST /posts` STILL cannot reply to a channel post — as anybody, including as
+ * the channel itself.
+ *
+ * This is the door the thread-continuation exception must never open, and it is
+ * held shut by TWO independent things. Both are asserted here, because "the other
+ * one covers it" is how both end up gone:
+ *
+ *  1. `assertParentAcceptsReplies` runs in this controller BEFORE
+ *     `PostCreationService` is reached, and it reads the PARENT's account kind
+ *     without caring who the reply's author would be — so it refuses a channel
+ *     parent whatever `publishAsOxyUserId` says.
+ *  2. The controller builds its `create` params from an explicit whitelist that
+ *     does not name `continuesOwnThread`, so a request cannot ask for the
+ *     exception at all. That is what makes the exception's own check
+ *     (`utils/threadContinuation`) unreachable from a public reply route rather
+ *     than merely hard to satisfy.
+ *
+ * Together they are why "a channel's operators may reply as the channel" is not
+ * reachable: an operator would need the parent gate to let them past AND the
+ * service parameter to be settable from a body, and neither is true.
+ */
+
+const findById = vi.hoisted(() => vi.fn());
+const create = vi.hoisted(() => vi.fn());
+const isChannelAccount = vi.hoisted(() => vi.fn());
+
+vi.mock('../../models/Post', () => ({
+  Post: {
+    findById,
+    findOne: vi.fn(),
+    find: vi.fn(() => ({ select: () => ({ lean: async () => [] }) })),
+  },
+  POST_CLASSIFICATION_PENDING: 'pending',
+}));
+
+vi.mock('../../models/Lane', () => ({
+  Lane: {
+    exists: vi.fn(async () => null),
+    findById: vi.fn(() => ({ select: () => ({ lean: async () => null }) })),
+  },
+}));
+
+vi.mock('../../services/PostCreationService', () => ({
+  postCreationService: { create },
+}));
+
+vi.mock('../../services/PostHydrationService', () => ({
+  postHydrationService: { hydratePosts: vi.fn(async () => []) },
+  resolveUserSummaries: vi.fn(async () => new Map()),
+  degradedActorSummary: vi.fn(() => ({ id: 'unknown', username: '' })),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createScopedOxyClient: vi.fn(() => ({})),
+  createUserScopedOxyServices: vi.fn(() => ({ listAccountMembers: vi.fn(async () => []) })),
+  getServiceOxyClient: vi.fn(() => ({})),
+}));
+
+vi.mock('../../runtime/socketServer', () => ({ getRuntimeSocketServer: () => undefined }));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// The REAL channel reply gate, over a mocked account-kind lookup — the point of
+// this suite is that the gate runs on this route, so stubbing it would assert
+// nothing.
+vi.mock('../../services/publishAsAccount', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isChannelAccount,
+}));
+
+import { createPost } from '../../controllers/posts.controller';
+
+const OPERATOR = 'human-1';
+const CHANNEL = 'channel-account-1';
+const CHANNEL_POST = new mongoose.Types.ObjectId().toString();
+
+interface MockRes {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => MockRes;
+  json: (body: unknown) => MockRes;
+}
+
+function makeRes(): MockRes {
+  const res: MockRes = {
+    statusCode: 200,
+    body: undefined,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.body = body; return this; },
+  };
+  return res;
+}
+
+function req(body: Record<string, unknown>): OxyAuthRequest {
+  return {
+    user: { id: OPERATOR },
+    query: {},
+    headers: {},
+    acceptsLanguages: () => [],
+    body,
+  } as unknown as OxyAuthRequest;
+}
+
+beforeEach(() => {
+  create.mockReset();
+  isChannelAccount.mockReset();
+  isChannelAccount.mockImplementation(async (id: string) => id === CHANNEL);
+  findById.mockReset();
+  // The parent lookup `assertParentAcceptsReplies` makes.
+  findById.mockImplementation(() => ({
+    select: () => ({ lean: async () => ({ _id: CHANNEL_POST, oxyUserId: CHANNEL }) }),
+    maxTimeMS: () => ({ lean: async () => ({ _id: CHANNEL_POST, oxyUserId: CHANNEL }) }),
+  }));
+});
+
+describe('POST /posts — a channel post takes no replies', () => {
+  it('403s a plain reply to a channel post', async () => {
+    const res = makeRes();
+    await createPost(req({ content: { text: 'hi' }, parentPostId: CHANNEL_POST }), res as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  /**
+   * THE ONE THIS SUITE EXISTS FOR. An operator naming the channel is the exact
+   * shape "a continuation of the account's own thread" would take if the
+   * exception were expressed as a rule about authors instead of a verified
+   * structural property. Removing `assertParentAcceptsReplies` from this
+   * controller makes this the only test that fails.
+   */
+  it('403s a reply published AS the channel — an operator is not an exception', async () => {
+    const res = makeRes();
+    await createPost(
+      req({
+        content: { text: 'part two, from outside the composer' },
+        parentPostId: CHANNEL_POST,
+        publishAsOxyUserId: CHANNEL,
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('403s it through in_reply_to_status_id too — the other spelling of the same thing', async () => {
+    const res = makeRes();
+    await createPost(
+      req({
+        content: { text: 'x' },
+        in_reply_to_status_id: CHANNEL_POST,
+        publishAsOxyUserId: CHANNEL,
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The second lock. Even past the parent gate, a request cannot ASK for the
+   * continuation exception — the controller's params are a whitelist and
+   * `continuesOwnThread` is not on it. Asserted on a NON-channel parent so the
+   * first lock is out of the way and this one is what is being measured.
+   */
+  it('never forwards continuesOwnThread from a request body', async () => {
+    isChannelAccount.mockResolvedValue(false);
+    create.mockResolvedValue({
+      _id: new mongoose.Types.ObjectId(),
+      oxyUserId: OPERATOR,
+      content: { text: 'x' },
+      toObject: () => ({ content: { text: 'x' } }),
+    });
+
+    const res = makeRes();
+    await createPost(
+      req({
+        content: { text: 'x' },
+        parentPostId: CHANNEL_POST,
+        continuesOwnThread: true,
+        threadId: CHANNEL_POST,
+      }),
+      res as never,
+    );
+
+    expect(create).toHaveBeenCalled();
+    const [params] = create.mock.calls[0] as [Record<string, unknown>];
+    expect(params.continuesOwnThread).toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/controllers/threadPublishAsAccount.test.ts
+++ b/packages/backend/src/__tests__/controllers/threadPublishAsAccount.test.ts
@@ -384,8 +384,113 @@ describe('the side effects follow the ENTRY\'s author, not the caller', () => {
   });
 });
 
-describe('thread mode refuses the field outright', () => {
-  it('400s even a ROOT-only publishAsOxyUserId, and asks Oxy nothing', async () => {
+/**
+ * THREAD mode names the account ONCE, for the whole thread.
+ *
+ * A thread is one text in several parts, so there is exactly one publisher by
+ * construction — an identity that changed mid-thread is the incoherent case, and
+ * that is the one refused. The continuations are stored as replies to their
+ * predecessor, which is the only reason this needs `PostCreationService`'s
+ * verified `continuesOwnThread` exception at all.
+ */
+describe('thread mode — one account for the whole thread', () => {
+  it('applies the batch account to EVERY entry, root and continuations alike', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        publishAsOxyUserId: CHANNEL,
+        posts: [
+          { content: { text: 'part one' } },
+          { content: { text: 'part two' } },
+          { content: { text: 'part three' } },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(requestedAccounts()).toEqual([CHANNEL, CHANNEL, CHANNEL]);
+  });
+
+  it('marks only the CONTINUATIONS as continuing their own thread, never the root', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        publishAsOxyUserId: CHANNEL,
+        posts: [
+          { content: { text: 'part one' } },
+          { content: { text: 'part two' } },
+          { content: { text: 'part three' } },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    const marks = create.mock.calls.map(
+      ([params]: [Record<string, unknown>]) => params.continuesOwnThread === true,
+    );
+    // The root is a root: it has no parent, so it needs no exception — and one
+    // granted there would be an exception with nothing to verify against.
+    expect(marks).toEqual([false, true, true]);
+  });
+
+  it('chains each continuation to its predecessor under the SAME thread root', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        publishAsOxyUserId: CHANNEL,
+        posts: [
+          { content: { text: 'part one' } },
+          { content: { text: 'part two' } },
+          { content: { text: 'part three' } },
+        ],
+      }),
+      res as never,
+    );
+
+    const calls = create.mock.calls.map(([params]: [Record<string, unknown>]) => params);
+    const rootId = String((await create.mock.results[0].value)._id);
+    const secondId = String((await create.mock.results[1].value)._id);
+    expect(calls[1]).toMatchObject({ parentPostId: rootId, threadId: rootId });
+    expect(calls[2]).toMatchObject({ parentPostId: secondId, threadId: rootId });
+  });
+
+  it('authorizes the account ONCE for the whole thread', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        publishAsOxyUserId: ORGANIZATION,
+        posts: Array.from({ length: 8 }, (_unused, i) => ({ content: { text: `part ${i}` } })),
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(create).toHaveBeenCalledTimes(8);
+    expect(listAccountMembers.mock.calls.map(([id]: [string]) => id)).toEqual([ORGANIZATION]);
+  });
+
+  it('refuses the whole thread when the account is not the caller\'s to use', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        publishAsOxyUserId: FORBIDDEN_ORG,
+        posts: [{ content: { text: 'a' } }, { content: { text: 'b' } }],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('400s a PER-ENTRY account in thread mode, and asks Oxy nothing', async () => {
     const res = makeRes();
     await createThread(
       req({
@@ -401,6 +506,24 @@ describe('thread mode refuses the field outright', () => {
     expect(res.statusCode).toBe(400);
     expect(create).not.toHaveBeenCalled();
     expect(listAccountMembers).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: a thread naming no account marks no continuation and stays the caller\'s', async () => {
+    const res = makeRes();
+    await createThread(
+      req({ mode: 'thread', posts: [{ content: { text: 'a' } }, { content: { text: 'b' } }] }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(requestedAccounts()).toEqual([null, null]);
+    // The marker rides with the CHAIN, not with the account — an ordinary
+    // self-thread carries it too and `create` simply never consults it, because
+    // no account was named.
+    const marks = create.mock.calls.map(
+      ([params]: [Record<string, unknown>]) => params.continuesOwnThread === true,
+    );
+    expect(marks).toEqual([false, true]);
   });
 });
 

--- a/packages/backend/src/__tests__/services/postCreationPublishAs.test.ts
+++ b/packages/backend/src/__tests__/services/postCreationPublishAs.test.ts
@@ -22,6 +22,12 @@ import type { AccountMember } from '@oxyhq/core';
 
 const saved: Array<Record<string, unknown>> = [];
 const constructedWith: Array<Record<string, unknown>> = [];
+/**
+ * Rows `assertContinuesOwnThread` reads back when a continuation is claimed.
+ * Empty for every other test, which is also the honest answer there: no thread
+ * exists, so no continuation can be verified against one.
+ */
+const threadRows: Array<{ _id: string; oxyUserId?: string; threadId?: string }> = [];
 
 vi.mock('../../models/Post', () => {
   class FakePost {
@@ -43,7 +49,11 @@ vi.mock('../../models/Post', () => {
   }
   return {
     Post: Object.assign(FakePost, {
-      find: vi.fn(() => ({ select: () => ({ lean: async () => [] }) })),
+      find: vi.fn((filter: { _id?: { $in?: Array<string | null | undefined> } }) => {
+        const wanted = new Set((filter?._id?.$in ?? []).map((id) => String(id)));
+        const matched = threadRows.filter((row) => wanted.has(row._id));
+        return { select: () => ({ lean: async () => matched }) };
+      }),
       findById: vi.fn(() => ({ select: () => ({ lean: async () => null }) })),
     }),
     POST_CLASSIFICATION_PENDING: 'pending',
@@ -111,6 +121,7 @@ const memberReader = {
 beforeEach(() => {
   saved.length = 0;
   constructedWith.length = 0;
+  threadRows.length = 0;
   memberReader.listAccountMembers.mockClear();
   resolveUserSummaries.mockReset();
   resolveUserSummaries.mockImplementation(async (ids: string[]) => {
@@ -279,3 +290,153 @@ describe('PostCreationService.create — publishing as another account', () => {
     expect(constructedWith).toHaveLength(0);
   });
 });
+
+/**
+ * The narrow exception, at the layer that owns it.
+ *
+ * `continuesOwnThread` is a SERVICE parameter — `POST /posts` builds its params
+ * from an explicit body whitelist and never names it, so no request can ask for
+ * it (asserted separately in `postsControllerChannelReply.test.ts`). What these
+ * pin is that the parameter grants nothing by itself: every case below sets it,
+ * and only the genuine continuation is written.
+ */
+describe('PostCreationService.create — continuing the account\'s own thread', () => {
+  const ROOT = new mongoose.Types.ObjectId().toString();
+  const CONTINUATION = new mongoose.Types.ObjectId().toString();
+  const SOMEBODY_ELSES = new mongoose.Types.ObjectId().toString();
+
+  function channelThreadExists(): void {
+    threadRows.push(
+      { _id: ROOT, oxyUserId: CHANNEL, threadId: ROOT },
+      { _id: CONTINUATION, oxyUserId: CHANNEL, threadId: ROOT },
+      { _id: SOMEBODY_ELSES, oxyUserId: 'someone-else', threadId: SOMEBODY_ELSES },
+    );
+  }
+
+  it('writes a continuation of the channel\'s own thread, authored by the channel', async () => {
+    channelThreadExists();
+
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'part two' },
+      publishAsOxyUserId: CHANNEL,
+      parentPostId: ROOT,
+      threadId: ROOT,
+      continuesOwnThread: true,
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    const [doc] = constructedWith;
+    expect(doc.oxyUserId).toBe(CHANNEL);
+    expect(doc.parentPostId).toBe(ROOT);
+    expect(doc.writtenByOxyUserId).toBe(WRITER);
+    // Still a channel post, so still unrepliable by anybody else — the exception
+    // is about who may WRITE the continuation, never about who may answer it.
+    expect(doc.replyPermission).toEqual(['nobody']);
+  });
+
+  it('writes a continuation deeper in the chain too', async () => {
+    channelThreadExists();
+
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'part three' },
+      publishAsOxyUserId: CHANNEL,
+      parentPostId: CONTINUATION,
+      threadId: ROOT,
+      continuesOwnThread: true,
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    expect(constructedWith[0].oxyUserId).toBe(CHANNEL);
+  });
+
+  /**
+   * MUTATION GUARD. The exception must be the VERIFIED continuation and nothing
+   * else. Replace `assertContinuesOwnThread` with "the author may act for the
+   * parent's account" — the wider rule that reads as the same thing — and this
+   * passes, which is a channel's replies reopened to everybody who operates it.
+   */
+  it('MUTATION GUARD: refuses a claimed continuation of SOMEBODY ELSE\'S post', async () => {
+    channelThreadExists();
+
+    await expect(
+      postCreationService.create({
+        oxyUserId: WRITER,
+        content: { text: 'not a continuation' },
+        publishAsOxyUserId: CHANNEL,
+        parentPostId: SOMEBODY_ELSES,
+        threadId: SOMEBODY_ELSES,
+        continuesOwnThread: true,
+        memberReader,
+        skipNotifications: true,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(constructedWith).toHaveLength(0);
+    expect(saved).toHaveLength(0);
+  });
+
+  it('MUTATION GUARD: refuses a continuation claimed for a thread that does not exist', async () => {
+    // Nothing seeded — the claim names ids with no rows behind them, which is
+    // what a fabricated claim looks like.
+    await expect(
+      postCreationService.create({
+        oxyUserId: WRITER,
+        content: { text: 'invented thread' },
+        publishAsOxyUserId: CHANNEL,
+        parentPostId: ROOT,
+        threadId: ROOT,
+        continuesOwnThread: true,
+        memberReader,
+        skipNotifications: true,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(constructedWith).toHaveLength(0);
+  });
+
+  it('CONTROL: the flag changes nothing for a reply that does not carry an account', async () => {
+    channelThreadExists();
+
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'an ordinary reply' },
+      parentPostId: SOMEBODY_ELSES,
+      threadId: SOMEBODY_ELSES,
+      continuesOwnThread: true,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    // No account named ⇒ no publish-as gate, no continuation check, and the reply
+    // is the writer's own exactly as before.
+    expect(constructedWith[0].oxyUserId).toBe(WRITER);
+  });
+
+  it('CONTROL: WITHOUT the flag, a reply naming an account is still refused', async () => {
+    channelThreadExists();
+
+    await expect(
+      postCreationService.create({
+        oxyUserId: WRITER,
+        content: { text: 'part two, but unmarked' },
+        publishAsOxyUserId: CHANNEL,
+        parentPostId: ROOT,
+        threadId: ROOT,
+        memberReader,
+        skipNotifications: true,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(constructedWith).toHaveLength(0);
+  });
+});
+

--- a/packages/backend/src/__tests__/utils/threadContinuation.test.ts
+++ b/packages/backend/src/__tests__/utils/threadContinuation.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import mongoose from 'mongoose';
+
+/**
+ * `assertContinuesOwnThread` — the ONE exception to "a post published as another
+ * account may not be a reply".
+ *
+ * The distinction every case here exists to draw is between **an account
+ * continuing its own text** and **an account being used to hold a conversation**.
+ * The second is what `utils/channelReplyGate` refuses at five write sites, in its
+ * own words with "no exception for the writer, and none for the channel's owner"
+ * — so an exception that cannot tell the two apart is not a narrower rule, it is
+ * that gate switched off for anybody who operates the account.
+ *
+ * Three structural conditions, all read back from the database:
+ *   1. the parent is authored by the SAME account,
+ *   2. the parent is in the thread this post declares,
+ *   3. that thread's ROOT is authored by that same account.
+ *
+ * Each has its own failing fixture below, because a check nothing can fail is a
+ * check that is not there.
+ */
+
+const find = vi.hoisted(() => vi.fn());
+
+vi.mock('../../models/Post', () => ({
+  Post: { find },
+  POST_CLASSIFICATION_PENDING: 'pending',
+}));
+
+import { assertContinuesOwnThread } from '../../utils/threadContinuation';
+import { PublishAsAccessError } from '../../services/publishAsAccount';
+
+const CHANNEL = 'channel-account-1';
+const OPERATOR = 'human-1';
+const OTHER_ACCOUNT = 'org-account-1';
+
+const ROOT = new mongoose.Types.ObjectId().toString();
+const CONTINUATION_1 = new mongoose.Types.ObjectId().toString();
+const FOREIGN_POST = new mongoose.Types.ObjectId().toString();
+const FOREIGN_ROOT = new mongoose.Types.ObjectId().toString();
+
+interface Row {
+  _id: string;
+  oxyUserId?: string;
+  threadId?: string;
+}
+
+/** Seed the collection the assertion reads. */
+function rowsAre(rows: Row[]): void {
+  find.mockImplementation((filter: { _id: { $in: Array<string | null | undefined> } }) => {
+    const wanted = new Set((filter._id.$in ?? []).map((id) => String(id)));
+    const matched = rows.filter((row) => wanted.has(row._id));
+    return { select: () => ({ lean: async () => matched }) };
+  });
+}
+
+beforeEach(() => {
+  find.mockReset();
+  rowsAre([
+    // The channel's own thread: a root and one continuation anchored on it.
+    { _id: ROOT, oxyUserId: CHANNEL, threadId: ROOT },
+    { _id: CONTINUATION_1, oxyUserId: CHANNEL, threadId: ROOT },
+    // Somebody else's post, and somebody else's thread root.
+    { _id: FOREIGN_POST, oxyUserId: OTHER_ACCOUNT, threadId: FOREIGN_ROOT },
+    { _id: FOREIGN_ROOT, oxyUserId: OTHER_ACCOUNT, threadId: FOREIGN_ROOT },
+  ]);
+});
+
+describe('assertContinuesOwnThread — what it ADMITS', () => {
+  it('admits the first continuation, whose parent IS the root', async () => {
+    await expect(
+      assertContinuesOwnThread({ parentPostId: ROOT, threadId: ROOT, authorId: CHANNEL }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('admits a later link, whose parent is anchored on the root', async () => {
+    await expect(
+      assertContinuesOwnThread({ parentPostId: CONTINUATION_1, threadId: ROOT, authorId: CHANNEL }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('assertContinuesOwnThread — what it REFUSES', () => {
+  /**
+   * CONDITION 1. The parent is somebody else's post. This is the plain "reply to
+   * another account as my account" case, which is what the gate is for.
+   */
+  it('refuses a parent authored by another account', async () => {
+    await expect(
+      assertContinuesOwnThread({
+        parentPostId: FOREIGN_POST,
+        threadId: FOREIGN_ROOT,
+        authorId: CHANNEL,
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * CONDITION 1, ISOLATED — and the case that made it worth having.
+   *
+   * The fixture is a THIRD PARTY's reply sitting inside the account's own thread.
+   * Conditions 2 and 3 both pass (the post really is in the thread, and the
+   * account really did start it), so this is the ONLY shape that tells condition 1
+   * apart from its absence — mutation-testing found the suite green without it,
+   * because every other refusal fixture failed condition 3 as well.
+   *
+   * It is reachable, not hypothetical: an ORGANIZATION's posts take replies like
+   * anybody's, so strangers' posts genuinely do end up under an organization's
+   * thread root. Answering one, as the organization, is a conversation held under
+   * the account's name — exactly what the exception must not become.
+   */
+  it('refuses a THIRD PARTY\'s post that sits inside the account\'s own thread', async () => {
+    const OWN_ROOT = new mongoose.Types.ObjectId().toString();
+    const STRANGERS_REPLY = new mongoose.Types.ObjectId().toString();
+    rowsAre([
+      { _id: OWN_ROOT, oxyUserId: OTHER_ACCOUNT, threadId: OWN_ROOT },
+      // A stranger replied into that thread — so it carries the account's own
+      // threadId while belonging to somebody else.
+      { _id: STRANGERS_REPLY, oxyUserId: 'a-stranger', threadId: OWN_ROOT },
+    ]);
+
+    await expect(
+      assertContinuesOwnThread({
+        parentPostId: STRANGERS_REPLY,
+        threadId: OWN_ROOT,
+        authorId: OTHER_ACCOUNT,
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * CONDITION 2. Parent and declared thread are both the account's own, and they
+   * still do not belong together — a client naming a real post of the account and
+   * a real thread of the account, hoping the pair is not checked.
+   */
+  it('refuses a parent that is not in the declared thread', async () => {
+    const OTHER_ROOT = new mongoose.Types.ObjectId().toString();
+    rowsAre([
+      { _id: ROOT, oxyUserId: CHANNEL, threadId: ROOT },
+      { _id: OTHER_ROOT, oxyUserId: CHANNEL, threadId: OTHER_ROOT },
+    ]);
+
+    await expect(
+      assertContinuesOwnThread({ parentPostId: ROOT, threadId: OTHER_ROOT, authorId: CHANNEL }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * CONDITION 3. The parent IS the account's own post and it IS in the declared
+   * thread — but the account did not start that thread; it was grafted onto
+   * somebody else's. Without this condition an account that once replied
+   * somewhere could keep answering in that conversation forever.
+   */
+  it('refuses a thread the account did not start, even with its own parent in it', async () => {
+    const GRAFTED = new mongoose.Types.ObjectId().toString();
+    rowsAre([
+      { _id: FOREIGN_ROOT, oxyUserId: OTHER_ACCOUNT, threadId: FOREIGN_ROOT },
+      { _id: GRAFTED, oxyUserId: CHANNEL, threadId: FOREIGN_ROOT },
+    ]);
+
+    await expect(
+      assertContinuesOwnThread({ parentPostId: GRAFTED, threadId: FOREIGN_ROOT, authorId: CHANNEL }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * THE MUTATION THE WHOLE MODULE EXISTS FOR, at its own layer. An OPERATOR of the
+   * channel is not the channel: the exception is about a post continuing itself,
+   * never about who is allowed to speak for the account. Widening condition 1 from
+   * "the parent is this account's own post" to "the author may act for the
+   * parent's account" makes this pass, and that is the channel's replies reopened
+   * to its operators.
+   */
+  it('MUTATION GUARD: refuses when the AUTHOR is the operator rather than the account', async () => {
+    await expect(
+      assertContinuesOwnThread({ parentPostId: ROOT, threadId: ROOT, authorId: OPERATOR }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  it('refuses a parent that does not exist', async () => {
+    const MISSING = new mongoose.Types.ObjectId().toString();
+    await expect(
+      assertContinuesOwnThread({ parentPostId: MISSING, threadId: ROOT, authorId: CHANNEL }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  it('refuses a thread root that does not exist', async () => {
+    const MISSING = new mongoose.Types.ObjectId().toString();
+    await expect(
+      assertContinuesOwnThread({ parentPostId: ROOT, threadId: MISSING, authorId: CHANNEL }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  it.each([
+    ['no threadId', { parentPostId: ROOT, threadId: null, authorId: CHANNEL }],
+    ['no parentPostId', { parentPostId: null, threadId: ROOT, authorId: CHANNEL }],
+    ['no author', { parentPostId: ROOT, threadId: ROOT, authorId: null }],
+    ['a malformed parent id', { parentPostId: 'not-an-objectid', threadId: ROOT, authorId: CHANNEL }],
+    ['a malformed thread id', { parentPostId: ROOT, threadId: 'not-an-objectid', authorId: CHANNEL }],
+  ])('refuses with %s, and asks the database nothing', async (_label, args) => {
+    await expect(assertContinuesOwnThread(args)).rejects.toBeInstanceOf(PublishAsAccessError);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it('answers 400, the same refusal a plain reply gets — the two are not worth distinguishing', async () => {
+    await expect(
+      assertContinuesOwnThread({ parentPostId: FOREIGN_POST, threadId: FOREIGN_ROOT, authorId: CHANNEL }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -986,63 +986,87 @@ export const createThread = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'Posts array is required and cannot be empty' });
     }
 
-    // PUBLISHING AS ANOTHER ACCOUNT IS PER ENTRY, AND `beast` MODE ONLY.
+    // WHERE THE ACCOUNT IS NAMED IS THE OPPOSITE IN THE TWO MODES, and that is the
+    // whole design rather than an inconsistency.
     //
     // A `beast` batch is n independent top-level posts that happen to be written
-    // in one action, so each entry may name its own account and they may all
-    // differ. A `thread` is one conversation: every entry after the first is a
-    // REPLY to the one before it, and `PostCreationService` refuses to publish a
-    // reply as another account at all — so "apply the root's account to the whole
-    // thread" is not implementable without punching a hole in that rule, and a
-    // per-entry account would be an identity that changes mid-conversation.
-    // Refused outright in thread mode instead, which is also what a channel needs:
-    // a channel post accepts no replies, so a thread rooted at one would be a root
-    // whose own continuations the channel refuses.
+    // in one action, so the account is PER ENTRY and they may all differ. A
+    // `thread` is one text in several parts, so it has exactly one publisher by
+    // construction: the account is named ONCE for the BATCH, and a per-entry one
+    // is refused, because an identity that changed mid-thread is the incoherent
+    // case. Each mode therefore has exactly one way to say it, and the other way
+    // is a 400 that names the right field — a client can never send both and have
+    // to discover which won.
     //
-    // The batch-level `publishAsOxyUserId` is refused in BOTH modes. It is not a
-    // field of `CreateThreadRequest` and never was; keeping one way to say this
-    // means a client cannot express a batch-wide account and a per-entry one at
-    // once and then discover which of them won.
-    if (typeof req.body.publishAsOxyUserId === 'string') {
-      return res
-        .status(400)
-        .json({ message: 'Set publishAsOxyUserId on each post, not on the thread' });
-    }
+    // The continuations are stored as replies to their predecessor, which is what
+    // joins a thread at all, and `PostCreationService` normally refuses to publish
+    // a reply as another account. The exception is `continuesOwnThread` on the
+    // create call below: VERIFIED against the parent and the thread root, not
+    // asserted — see `utils/threadContinuation`. Nothing here opens a channel's
+    // posts to replies from anyone else; every entry is authored by the account,
+    // so the reply gate refuses a third party on a continuation exactly as it does
+    // on the root.
+    const batchAccount = req.body.publishAsOxyUserId;
     const entryNamesAnotherAccount = posts.some(
       (p: { publishAsOxyUserId?: unknown }) => typeof p?.publishAsOxyUserId === 'string',
     );
     if (mode === 'thread' && entryNamesAnotherAccount) {
-      return res.status(400).json({ message: 'A thread cannot be published as another account' });
+      return res.status(400).json({
+        message: 'Set publishAsOxyUserId once for the thread, not on each post',
+      });
+    }
+    if (mode !== 'thread' && typeof batchAccount === 'string') {
+      return res
+        .status(400)
+        .json({ message: 'Set publishAsOxyUserId on each post, not on the thread' });
     }
 
     // Every DISTINCT account named across the batch is authorized ONCE, before a
     // single post is written — the same shape the collaborator and lane refusals
     // take, and for the same reason (a partial thread cannot be undone in one
-    // action). `cacheAccountMemberReads` is what makes "once" true end to end: the
-    // creation loop below hands each post the SAME reader and lets
-    // `PostCreationService` run the real gate itself, so nothing routes around the
-    // authorization, and a twelve-entry batch naming one account still makes one
-    // membership call.
+    // action). In thread mode that is literally one call for the whole request;
+    // in beast mode `cacheAccountMemberReads` is what makes it one MEMBERSHIP READ
+    // per distinct account, since the creation loop below hands every post the
+    // SAME reader and lets `PostCreationService` run the real gate itself, so
+    // nothing routes around the authorization.
     const memberReader = createUserScopedOxyServices(req);
     const batchMemberReader = memberReader ? cacheAccountMemberReads(memberReader) : undefined;
     /** Entry index → the account that entry will be AUTHORED BY. */
     const entryAuthorIds: string[] = [];
-    for (let i = 0; i < posts.length; i++) {
-      const requested = posts[i]?.publishAsOxyUserId;
-      try {
+    try {
+      if (mode === 'thread') {
         const { authorId } = await assertCanPublishAsAccount({
-          publishAsOxyUserId: typeof requested === 'string' ? requested : null,
+          publishAsOxyUserId: typeof batchAccount === 'string' ? batchAccount : null,
           callerId: userId,
           memberReader: batchMemberReader,
         });
-        entryAuthorIds.push(authorId ?? userId);
-      } catch (publishAsError) {
-        if (publishAsError instanceof PublishAsAccessError) {
-          return res.status(publishAsError.status).json({ message: publishAsError.message });
+        // One decision, applied to every entry — so no continuation can end up
+        // under an identity the root was not authorized for.
+        entryAuthorIds.push(...posts.map(() => authorId ?? userId));
+      } else {
+        for (const entry of posts) {
+          const requested = (entry as { publishAsOxyUserId?: unknown })?.publishAsOxyUserId;
+          const { authorId } = await assertCanPublishAsAccount({
+            publishAsOxyUserId: typeof requested === 'string' ? requested : null,
+            callerId: userId,
+            memberReader: batchMemberReader,
+          });
+          entryAuthorIds.push(authorId ?? userId);
         }
-        throw publishAsError;
       }
+    } catch (publishAsError) {
+      if (publishAsError instanceof PublishAsAccessError) {
+        return res.status(publishAsError.status).json({ message: publishAsError.message });
+      }
+      throw publishAsError;
     }
+    /** The account THIS request names, if any — thread-wide or per entry. */
+    const accountForEntry = (index: number): string | null => {
+      const named = mode === 'thread'
+        ? batchAccount
+        : (posts[index] as { publishAsOxyUserId?: unknown })?.publishAsOxyUserId;
+      return typeof named === 'string' ? named : null;
+    };
 
     // Lanes are validated for the WHOLE batch before a single post is written.
     // The loop below creates posts one at a time, so a lane refused on entry 3
@@ -1237,14 +1261,22 @@ export const createThread = async (req: AuthRequest, res: Response) => {
         // decides the author, so passing a pre-resolved id instead would be the
         // "checked upstream, trust me" shape that lets a later caller route around
         // it. The repeat is free: `batchMemberReader` has already answered for this
-        // account, and a thread-mode entry never reaches here carrying one.
-        publishAsOxyUserId:
-          typeof postData.publishAsOxyUserId === 'string' ? postData.publishAsOxyUserId : null,
+        // account. In thread mode the account is the batch's, applied to every
+        // entry; in beast mode it is the entry's own.
+        publishAsOxyUserId: accountForEntry(i),
         memberReader: batchMemberReader,
         // For thread mode: chain each continuation post to the immediately
         // previous post (sequential thread), with a shared threadId root.
         // For beast mode: all posts are independent.
         ...(isThreadContinuation ? { parentPostId: previousPostId, threadId: mainPostId } : {}),
+        // The narrow exception to "a reply cannot be published as another
+        // account", and the ONLY place it is ever asked for. It is safe to ask
+        // here for a structural reason and not a trusting one: `previousPostId`
+        // and `mainPostId` are ids of posts THIS request created moments ago,
+        // under the authorization above, so the parent is the same account's own
+        // post by construction — and `create` re-derives that from the database
+        // rather than believing it. See `utils/threadContinuation`.
+        ...(isThreadContinuation ? { continuesOwnThread: true } : {}),
         // Every post of a scheduled batch carries the SAME time — the author
         // picked one moment for the set, not n moments. For a beast batch each
         // is then an ordinary scheduled post published independently; for a

--- a/packages/backend/src/services/PostCreationService.ts
+++ b/packages/backend/src/services/PostCreationService.ts
@@ -38,6 +38,7 @@ import {
 import { recordRecentReplierForPost } from './PostRecentReplierService';
 import { parentHasPublished } from './scheduledChain';
 import { assertLaneAssignable } from '../utils/laneAssignment';
+import { assertContinuesOwnThread } from '../utils/threadContinuation';
 import {
   assertCanPublishAsAccount,
   PublishAsAccessError,
@@ -97,6 +98,26 @@ export interface CreatePostParams {
    * authorizable, so naming an account without one is a 403.
    */
   memberReader?: AccountMemberReader;
+  /**
+   * This post CONTINUES a thread its own author started — the single case in
+   * which a post carrying both {@link publishAsOxyUserId} and `parentPostId` is
+   * not a reply in the sense the refusal below is about. A thread is one text in
+   * several parts; a post answering itself is not a conversation.
+   *
+   * **It grants nothing on its own.** Setting it only asks for
+   * {@link assertContinuesOwnThread} to be consulted, and that reads the parent
+   * and the thread root back out of the database to confirm both are authored by
+   * the SAME account this post will be. A caller that lies is refused by exactly
+   * the same 400 it would have got for a plain reply.
+   *
+   * **Never read from a request body.** `POST /posts` builds its params from an
+   * explicit whitelist and does not name this field, so the exception is reachable
+   * only from `POST /posts/thread`, where the parent of every continuation is a
+   * post THIS SAME REQUEST just created. Adding it to a body whitelist would turn
+   * a structural property into a client claim — see `utils/threadContinuation` for
+   * why the wider "may act for the parent's account" rule is not the same thing.
+   */
+  continuesOwnThread?: boolean;
   hashtags?: string[];
   mentions?: string[];
   language?: string;
@@ -348,8 +369,17 @@ class PostCreationService {
     // where the channel argument does not apply: replying AS an organization is a
     // coherent feature, but it is a feature — nothing asks for it, and admitting
     // it here by omission would ship it unconsidered and untested.
+    //
+    // ONE EXCEPTION, and it is not "the author may act for the parent's account".
+    // A thread is one text in several parts, and the parts are joined by
+    // `parentPostId`, so every continuation is structurally a reply while being
+    // nothing like a conversation. {@link CreatePostParams.continuesOwnThread}
+    // asks for that case to be VERIFIED — parent and thread root both authored by
+    // the account this post will be — rather than asserted; see
+    // `utils/threadContinuation` for why the wider rule would reopen a channel's
+    // replies to its own operators, which is the thing that cannot happen.
     if (params.publishAsOxyUserId) {
-      if (params.parentPostId) {
+      if (params.parentPostId && !params.continuesOwnThread) {
         throw new PublishAsAccessError(400, 'A reply cannot be published as another account');
       }
       if (params.boostOf) {
@@ -371,6 +401,18 @@ class PostCreationService {
       memberReader: params.memberReader,
     });
     const publishedAsAccount = authorId !== null && authorId !== params.oxyUserId;
+
+    // The continuation claim is verified AFTER the publish-as gate, because what
+    // it has to prove is about the RESOLVED author — the account the post will
+    // actually carry — and that is not known until the gate has answered. Still
+    // before anything is written, like every other refusal here.
+    if (params.publishAsOxyUserId && params.parentPostId && params.continuesOwnThread) {
+      await assertContinuesOwnThread({
+        parentPostId: params.parentPostId,
+        threadId: params.threadId,
+        authorId,
+      });
+    }
 
     await assertLaneAssignable({
       laneId: params.laneId,

--- a/packages/backend/src/utils/threadContinuation.ts
+++ b/packages/backend/src/utils/threadContinuation.ts
@@ -1,0 +1,109 @@
+/**
+ * The ONE definition of "this post continues its own author's thread", which is
+ * the single narrow exception to "a post published as another account may not be
+ * a reply".
+ *
+ * WHY THE EXCEPTION EXISTS. A thread is one text in several parts, not a
+ * dialogue. The mechanism that makes the parts a thread is `parentPostId`, so
+ * from the storage layer's point of view every continuation is a reply — but a
+ * channel continuing its own announcement is exactly what a Telegram channel
+ * does, and refusing it means an account may publish at most one paragraph at a
+ * time. The refusal in `PostCreationService` exists to stop a CONVERSATION being
+ * held under an account's name, and a post answering itself is not one.
+ *
+ * WHY IT IS THIS NARROW, AND NOT "THE AUTHOR MAY ACT FOR THE PARENT'S ACCOUNT".
+ * That wider rule reads as the same thing and is not: it would let anybody who
+ * operates a channel post a reply, as the channel, under any of that channel's
+ * posts at any later time — which is a conversation between operators wearing the
+ * channel's name, and is precisely what `utils/channelReplyGate` refuses at five
+ * separate write sites (its docstring is explicit that there is "no exception for
+ * the writer, and none for the channel's owner"). The distinction this module
+ * draws is STRUCTURAL rather than a matter of intent:
+ *
+ *   1. the parent is authored by the SAME account this post will be,
+ *   2. the parent belongs to the SAME thread this post declares, and
+ *   3. that thread's ROOT is authored by that same account.
+ *
+ * All three are read back out of the database — nothing is taken from the
+ * caller's word. A client can name any `parentPostId` and any `threadId` it
+ * likes; what it cannot do is make a post it does not own answer to an author it
+ * is not.
+ *
+ * AND THE UNLOCK IS NOT REACHABLE FROM THE PUBLIC REPLY ROUTES ANYWAY. This check
+ * is only consulted when `CreatePostParams.continuesOwnThread` is set, which is a
+ * SERVICE-level parameter: `POST /posts` builds its params from an explicit
+ * whitelist of body fields and never reads one, so no request can ask for it. The
+ * three-part check above is what makes the parameter safe to exist; the parameter
+ * is what keeps the check off the ordinary reply paths. Neither alone is the
+ * guard.
+ */
+
+import mongoose from 'mongoose';
+import { Post } from '../models/Post';
+import { PublishAsAccessError } from '../services/publishAsAccount';
+
+/**
+ * Throw unless this post genuinely continues `authorId`'s own thread.
+ *
+ * Refuses with the same {@link PublishAsAccessError} the plain reply refusal
+ * uses, so the HTTP layer needs no new mapping and a caller cannot tell "you may
+ * not reply as that account" from "that is not your thread" — which is the right
+ * amount to say, since both answers mean the same thing to a legitimate client.
+ *
+ * `threadId` is the thread's ROOT post id (that is what `createThread` anchors a
+ * self-thread on: the root sets `threadId = its own _id`, and every continuation
+ * carries the same value). A continuation whose parent IS the root is therefore
+ * the ordinary case, and one deeper in the chain has `parent.threadId` equal to
+ * it — both are accepted, and nothing else is.
+ */
+export async function assertContinuesOwnThread(params: {
+  parentPostId: string | null | undefined;
+  threadId: string | null | undefined;
+  authorId: string | null;
+}): Promise<void> {
+  const refuse = (): never => {
+    throw new PublishAsAccessError(400, 'A reply cannot be published as another account');
+  };
+
+  const { parentPostId, threadId, authorId } = params;
+  if (!authorId || !parentPostId || !threadId) refuse();
+  if (
+    !mongoose.Types.ObjectId.isValid(String(parentPostId)) ||
+    !mongoose.Types.ObjectId.isValid(String(threadId))
+  ) {
+    refuse();
+  }
+
+  // ONE query for both rows. The root is fetched even when it IS the parent,
+  // because the third condition is about the thread's origin and reading it off
+  // the parent would make a chain inherit its own claim.
+  const rows = await Post.find({ _id: { $in: [parentPostId, threadId] } })
+    .select('oxyUserId threadId')
+    .lean<Array<{ _id: mongoose.Types.ObjectId; oxyUserId?: string; threadId?: string }>>();
+
+  const byId = new Map(rows.map((row) => [String(row._id), row]));
+  const parent = byId.get(String(parentPostId));
+  const root = byId.get(String(threadId));
+
+  // A MISSING row needs no check of its own: `authorId` is non-empty by the guard
+  // above, so an absent parent or root reads as `''` in conditions 1 and 3 and is
+  // refused there. An explicit `if (!parent || !root)` was written here first and
+  // removed after mutation-testing proved nothing could distinguish its presence
+  // from its absence — a line that cannot fail is a line that reads as a guard
+  // while guarding nothing. The two "does not exist" tests still pin the
+  // BEHAVIOUR, which is what matters.
+
+  // 1. The parent is this account's own post. NOT "an account the author may act
+  //    for" — a stranger's reply sitting inside this account's own thread would
+  //    satisfy every other condition here, and answering it is a conversation.
+  if (String(parent?.oxyUserId ?? '') !== authorId) refuse();
+  // 2. The parent is in the thread this post declares — either its root, or a
+  //    link already anchored on it.
+  if (String(parentPostId) !== String(threadId) && String(parent?.threadId ?? '') !== String(threadId)) {
+    refuse();
+  }
+  // 3. The thread was STARTED by this account. Without it, an account could
+  //    graft its own post onto somebody else's thread and call the result a
+  //    continuation.
+  if (String(root?.oxyUserId ?? '') !== authorId) refuse();
+}

--- a/packages/frontend/assets/icons/schedule-icon.tsx
+++ b/packages/frontend/assets/icons/schedule-icon.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { IconSvg } from '@/assets/icons/IconSvg';
+import { ViewStyle } from 'react-native';
+
+/**
+ * Schedule — Material Symbols `schedule`, kept at its own `0 -960 960 960`
+ * viewBox rather than re-traced onto the 24-grid the hand-built icons use.
+ * Re-drawing a glyph to fit a grid is how it stops being the one that was chosen.
+ *
+ * It also settles an ambiguity that predates it: the schedule control and the
+ * EVENT control both drew `CalendarIcon`, so two different actions in the same
+ * toolbar row were the same picture. A clock says "when this goes out"; a
+ * calendar says "an event is attached". Only the schedule control moves — the
+ * event one keeps the calendar, which is now unambiguous by being the only user.
+ *
+ * Unlike {@link ChannelIcon}, this one HAS a real filled cut (FILL1), so the
+ * active state is a different glyph rather than the same one tinted. The two
+ * paths differ by exactly the ring's inner edge — outline draws the dial as an
+ * annulus and ends with `M480-480Zm0 317.13…`, filled ends at the outer circle.
+ */
+const SCHEDULE_PATH =
+  'M523.59-497.91v-137.31q0-18.52-12.58-31.05Q498.43-678.8 480-678.8t-31.01 12.53q-12.58 12.53-12.58 31.05v153.5q0 9.2 3.36 17.55 3.36 8.36 10.08 15.04l128.17 128.17q12.2 12.2 30.39 12.2 18.2 0 30.63-12.2 12.44-12.19 12.44-30.63 0-18.43-12.44-30.87L523.59-497.91ZM480-71.87q-84.91 0-159.34-32.12-74.44-32.12-129.5-87.17-55.05-55.06-87.17-129.5Q71.87-395.09 71.87-480t32.12-159.34q32.12-74.44 87.17-129.5 55.06-55.05 129.5-87.17 74.43-32.12 159.34-32.12t159.34 32.12q74.44 32.12 129.5 87.17 55.05 55.06 87.17 129.5 32.12 74.43 32.12 159.34t-32.12 159.34q-32.12 74.44-87.17 129.5-55.06 55.05-129.5 87.17Q564.91-71.87 480-71.87ZM480-480Zm0 317.13q131.8 0 224.47-92.54 92.66-92.55 92.66-224.59 0-132.04-92.66-224.59-92.66-92.54-224.47-92.54-131.8 0-224.47 92.54-92.66 92.55-92.66 224.59 0 132.04 92.66 224.59 92.66 92.54 224.47 92.54Z';
+
+const SCHEDULE_FILLED_PATH =
+  'M523.59-497.91v-137.31q0-18.52-12.58-31.05Q498.43-678.8 480-678.8t-31.01 12.53q-12.58 12.53-12.58 31.05v153.5q0 9.2 3.36 17.55 3.36 8.36 10.08 15.04l128.17 128.17q12.2 12.2 30.39 12.2 18.2 0 30.63-12.2 12.44-12.19 12.44-30.63 0-18.43-12.44-30.87L523.59-497.91ZM480-71.87q-84.91 0-159.34-32.12-74.44-32.12-129.5-87.17-55.05-55.06-87.17-129.5Q71.87-395.09 71.87-480t32.12-159.34q32.12-74.44 87.17-129.5 55.06-55.05 129.5-87.17 74.43-32.12 159.34-32.12t159.34 32.12q74.44 32.12 129.5 87.17 55.05 55.06 87.17 129.5 32.12 74.43 32.12 159.34t-32.12 159.34q-32.12 74.44-87.17 129.5-55.06 55.05-129.5 87.17Q564.91-71.87 480-71.87Z';
+
+interface ScheduleIconProps {
+  color?: string;
+  size?: number;
+  style?: ViewStyle;
+  className?: string;
+}
+
+export const ScheduleIcon = ({
+  color = 'currentColor',
+  size = 26,
+  style,
+  className,
+}: ScheduleIconProps) => {
+  return (
+    <IconSvg
+      viewBox="0 -960 960 960"
+      width={size}
+      height={size}
+      style={{ ...style }}
+      className={className}
+    >
+      <Path d={SCHEDULE_PATH} fill={color} />
+    </IconSvg>
+  );
+};
+
+/** The FILL1 cut — drawn once a time is actually set. */
+export const ScheduleIconActive = ({
+  color = 'currentColor',
+  size = 26,
+  style,
+  className,
+}: ScheduleIconProps) => {
+  return (
+    <IconSvg
+      viewBox="0 -960 960 960"
+      width={size}
+      height={size}
+      style={{ ...style }}
+      className={className}
+    >
+      <Path d={SCHEDULE_FILLED_PATH} fill={color} />
+    </IconSvg>
+  );
+};

--- a/packages/frontend/components/ComposeToolbar.tsx
+++ b/packages/frontend/components/ComposeToolbar.tsx
@@ -13,6 +13,7 @@ import { GifIcon } from '@/assets/icons/gif-icon';
 import { SourcesIcon } from '@/assets/icons/sources-icon';
 import { ArticleIcon } from '@/assets/icons/article-icon';
 import { CalendarIcon } from '@/assets/icons/calendar-icon';
+import { ScheduleIcon, ScheduleIconActive } from '@/assets/icons/schedule-icon';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
 interface ComposeToolbarProps {
@@ -296,7 +297,15 @@ const ComposeToolbar = memo<ComposeToolbarProps>(({
                     // signals its attachment is present.
                     accessibilityLabel={t('compose.schedule.a11y', { defaultValue: 'Schedule this post' })}
                 >
-                    <CalendarIcon size={20} color={scheduleColor} />
+                    {/* The FILLED cut once a time is set, not just a tint. The
+                        colour already says "active"; the glyph saying it too is
+                        what the icon/iconActive pairs elsewhere in the app do,
+                        and it survives a colour-blind reader. */}
+                    {hasSchedule ? (
+                        <ScheduleIconActive size={20} color={scheduleColor} />
+                    ) : (
+                        <ScheduleIcon size={20} color={scheduleColor} />
+                    )}
                 </PressableScale>
             )}
 

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -20,12 +20,26 @@ export type ProfileTab = typeof TAB_NAMES[number];
  * and the differences matter, because the day one of these mechanisms changes it
  * is the reason recorded here that says whether the tab should come back:
  *
- * - **`replies`** — a channel is a publisher, not a conversant, and the model
- *   refuses replies on BOTH sides of it. Nobody may reply to a channel post
- *   (`utils/channelReplyGate.ts`, which keys on the post AUTHOR's account kind at
- *   five write sites), and the channel may not author one either:
- *   `PostCreationService` rejects `publishAsOxyUserId` together with
- *   `parentPostId`, in its own words because "a channel takes no replies at all".
+ * - **`replies`** — a channel is a publisher, not a conversant. Nobody may reply
+ *   to a channel post (`utils/channelReplyGate.ts`, which keys on the post
+ *   AUTHOR's account kind at five write sites), so the tab could only ever hold
+ *   the channel's OWN replies — and the only ones it can author are the
+ *   continuations of its own threads, which are not replies in any sense a reader
+ *   would recognise and which already render inside the root's slice on the
+ *   `posts` tab (`ThreadSlicingService` groups on `threadId` + `oxyUserId`, and
+ *   the root is a root, so `restrictToRoots` keeps it there). A tab whose entire
+ *   contents are a second copy of another tab's, under a name that describes
+ *   neither, is worse than no tab.
+ *
+ *   This used to read "the channel may not author one either", citing
+ *   `PostCreationService`'s refusal of `publishAsOxyUserId` together with
+ *   `parentPostId`. That refusal now has ONE verified exception —
+ *   `continuesOwnThread`, for a continuation of a thread the same account
+ *   started (`utils/threadContinuation.ts`) — so the old half of the reason is
+ *   false while the conclusion survives on the stronger half above. The reason a
+ *   `replies` tab would come back is unchanged and unmet: someone would have to
+ *   be able to reply to a channel, which is the thing the five write sites exist
+ *   to prevent.
  *
  * - **`likes`** — the tab does not read the channel's posts at all; it reads the
  *   `Like` collection keyed by the LIKER (`gatherAuthorLikes` →

--- a/packages/frontend/components/__tests__/ComposeToolbarSchedule.test.tsx
+++ b/packages/frontend/components/__tests__/ComposeToolbarSchedule.test.tsx
@@ -4,6 +4,7 @@ import TestRenderer, { act } from 'react-test-renderer';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import ComposeToolbar from '@/components/ComposeToolbar';
 import { CalendarIcon } from '@/assets/icons/calendar-icon';
+import { ScheduleIcon, ScheduleIconActive } from '@/assets/icons/schedule-icon';
 
 /**
  * The schedule control is an ICON, like every other attachment control in this
@@ -108,20 +109,48 @@ describe('ComposeToolbar — the schedule control', () => {
   });
 
   it('tints itself once a time is set, like every other icon in the row', () => {
-    const calendarColor = (tree: TestRenderer.ReactTestRenderer) =>
-      tree.root.findByType(CalendarIcon).props.color;
-
     const unscheduled = renderToolbar();
-    const plainColor = calendarColor(unscheduled);
+    const plainColor = unscheduled.root.findByType(ScheduleIcon).props.color;
     act(() => unscheduled.unmount());
 
     const scheduled = renderToolbar({ hasSchedule: true });
-    const activeColor = calendarColor(scheduled);
+    const activeColor = scheduled.root.findByType(ScheduleIconActive).props.color;
     act(() => scheduled.unmount());
 
     // The same "this attachment is present" signal poll, media and article give.
     expect(plainColor).toBe('#666');
     expect(activeColor).toBe('#7c3aed');
+  });
+
+  /**
+   * The stronger half, and the reason the tint above is no longer the whole
+   * story: the FILLED cut is drawn once a time is set. A colour-blind reader
+   * gets the state from the glyph, and a test that only read the colour could
+   * not tell the two icons apart at all.
+   */
+  it('swaps to the filled glyph once a time is set', () => {
+    const unscheduled = renderToolbar();
+    expect(unscheduled.root.findAllByType(ScheduleIcon)).toHaveLength(1);
+    expect(unscheduled.root.findAllByType(ScheduleIconActive)).toHaveLength(0);
+    act(() => unscheduled.unmount());
+
+    const scheduled = renderToolbar({ hasSchedule: true });
+    expect(scheduled.root.findAllByType(ScheduleIconActive)).toHaveLength(1);
+    expect(scheduled.root.findAllByType(ScheduleIcon)).toHaveLength(0);
+    act(() => scheduled.unmount());
+  });
+
+  /**
+   * The schedule control and the EVENT control used to draw the same
+   * `CalendarIcon`, so two different actions in one row were one picture. Pinned
+   * because the fix is invisible: nothing fails if a later change points either
+   * back at the other's glyph.
+   */
+  it('does not share its glyph with the event control', () => {
+    const tree = renderToolbar({ onEventPress: () => {} });
+    expect(tree.root.findAllByType(ScheduleIcon)).toHaveLength(1);
+    expect(tree.root.findAllByType(CalendarIcon)).toHaveLength(1);
+    act(() => tree.unmount());
   });
 
   it('opens the picker when tapped in EITHER state, so the time stays changeable', () => {

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -803,6 +803,28 @@ export interface CreateThreadRequest {
    * author picked a moment for the set.
    */
   scheduledFor?: string;
+  /**
+   * Publish the WHOLE thread as an Oxy account the caller operates — one identity
+   * for every entry, authorized once. Same field, same authorization and same
+   * effects as {@link CreatePostRequest.publishAsOxyUserId}.
+   *
+   * **`thread` mode only, and it is deliberately the OPPOSITE placement from
+   * beast mode's.** A thread is one text in several parts, so there is exactly one
+   * publisher by construction and an identity that changed mid-thread would be
+   * incoherent — hence batch-level here, and a per-entry
+   * {@link CreateThreadPostRequest.publishAsOxyUserId} is refused (400). A beast
+   * batch is n independent posts, so it is the other way round: per entry, and
+   * this field is refused there. Each mode has exactly one way to say it, so a
+   * client can never send both and have to discover which won.
+   *
+   * The continuations are stored as replies to their predecessor, which is how a
+   * thread is joined at all — `PostCreationService` verifies each one against the
+   * parent and the thread root before writing, and NOTHING here opens a channel's
+   * posts to replies from anybody else: every entry is authored by the account, so
+   * the reply gate refuses a third party on the continuations exactly as on the
+   * root.
+   */
+  publishAsOxyUserId?: string;
 }
 
 export interface UpdatePostRequest {


### PR DESCRIPTION
Two commits, reviewable apart.

## 1 — a thread goes out under ONE account

`thread` mode refused a per-post account, correctly: continuations are replies, and publishing a reply as another account is refused outright. But that answered the wrong question. What is wanted is **one account for the whole thread**, chosen once — a batch property, and coherent.

`CreateThreadRequest` gains `publishAsOxyUserId`. **Each mode has exactly one way to say it**: thread takes it at the batch level and 400s a per-entry one, beast takes it per entry and 400s a batch-level one. A client can never send both and discover which won. The gate runs **once** for a thread — an 8-post thread makes one `listAccountMembers` call.

### The blocker was one gate, not five

`PostCreationService.create` **never consults `channelReplyGate`**, and `createThread` calls `create` directly — so a continuation was blocked solely by `create`'s own publish-as-on-reply refusal. The four channel-reply gates are untouched, and three are unreachable here **structurally**: no session subject can be a channel, so "the author is the parent's author" is unsatisfiable for a human replying, and a remote actor is never a local channel account.

### The exemption is not "same author"

That is precisely the escape `createReply`'s gate was built to sit above. It is **three conditions read back from the DB**, never taken from the caller:

1. the parent is this account's **own** post,
2. the parent belongs to the thread this post **declares**,
3. that thread's **root** is this account's too.

It is consulted only under a service-level parameter `POST /posts` cannot name, so no request can ask for it. Neither half is the guard alone.

### Two mutations were vacuous, and that mattered

Every refusal fixture also failed condition 3, so nothing could tell condition 1 from its absence. The shape that isolates it — **a third party's reply sitting inside the account's own thread**, reachable for an organization, whose posts do take replies — is now a named test. Answering one *as* the organization is exactly the conversation these rules exist to prevent.

Independently re-mutated before merge: blanking condition 1 fails one named test.

### A rationale this made half false

The channel profile drops its `replies` tab citing both that nobody may reply **and** that the channel may not author one. The second half no longer holds. The decision survives on the first, plus `threadGrouping` pulling continuations into the root's slice — the tab would have held a second copy under a name describing neither. Comment corrected.

## 2 — the schedule glyph

The schedule control and the **event** control both drew `CalendarIcon`: two different actions, one picture. A clock says "when this goes out"; a calendar says "an event is attached". Only schedule moves.

Both cuts of Material Symbols `schedule`, kept at their own viewBox rather than re-traced. Unlike the channels icon this one **has a real FILL1**, so the active state is a different glyph rather than the same one tinted — visible to a colour-blind reader.

The existing test read `findByType(CalendarIcon).props.color`, which after this would have found the **event** control's icon and asserted the wrong thing. It now reads the schedule glyph and gains two assertions colour alone could not make: that the filled cut replaces the outline, and that the two controls do not share a glyph.

## Verification

Backend **419 files / 4543 tests** · frontend **1185** · `tsc` clean · lint 0 errors.

## Known, unchanged

A thread **does not federate for anyone** (`createThread` passes `skipFederationDelivery: true` on every entry) — pre-existing, but it means a channel *thread* behaves differently from a single channel post, which does federate. Worth a follow-up decision. And the composer still gates publish-as on `threadItems.length === 0`, so neither mode can express an account from the UI yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
