### PR TITLE
feat(lanes): parallel tracks, not a branch

### DIFF
--- a/packages/frontend/app/(app)/lanes.tsx
+++ b/packages/frontend/app/(app)/lanes.tsx
@@ -19,6 +19,7 @@ import { ThemedView } from '@/components/ThemedView';
 import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
+import { LaneIcon } from '@/assets/icons/lane-icon';
 import { useSafeBack } from '@/hooks/useSafeBack';
 import { Icon, type IconName } from '@/lib/icons';
 import { EmptyState } from '@/components/common/EmptyState';
@@ -299,7 +300,7 @@ export default function LanesScreen() {
 
                     <SettingsListGroup title={t('lanes.addLane', { defaultValue: 'New lane' })}>
                         <View className="px-4 py-3 flex-row items-center gap-3">
-                            <Icon name="git-branch-outline" size={20} color={colors.textSecondary} />
+                            <LaneIcon size={20} color={colors.textSecondary} />
                             <TextInput
                                 className="flex-1 text-[15px] text-foreground"
                                 placeholder={t('lanes.namePlaceholder', { defaultValue: 'Lane name' })}

--- a/packages/frontend/assets/icons/lane-icon.tsx
+++ b/packages/frontend/assets/icons/lane-icon.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { IconSvg } from '@/assets/icons/IconSvg';
+import { ViewStyle } from 'react-native';
+
+/**
+ * Lanes — Material Symbols `schema`, kept at its own `0 -960 960 960` viewBox
+ * rather than re-traced onto the 24-grid the hand-built icons use. Re-drawing a
+ * glyph to fit a grid is how it stops being the one that was chosen.
+ *
+ * It replaces a `git-branch`, which said the wrong thing: a branch is a fork —
+ * one history splitting into divergent ones. A lane does not divert a post; it
+ * is a track a post is filed on, and the post's distribution, visibility,
+ * replies and federation are all untouched by it. The parallel rows of `schema`
+ * say "tracks side by side", which is what a lane is.
+ *
+ * There is one path and `Active` renders it too: this is the FILL0 cut, where
+ * the outline IS the filled path, so a heavier variant would have to be invented
+ * rather than swapped in. The toolbar already tints an active control, which is
+ * how every other icon in that row signals its attachment is present.
+ */
+const LANE_PATH =
+  'M152.51-103.72v-92.29q0-29.18 20.66-49.92 20.67-20.74 49.99-20.74h29.35v-93.86h-29.35q-29.32 0-49.99-20.74-20.66-20.74-20.66-49.96v-97.54q0-29.22 20.66-49.96 20.67-20.74 49.99-20.74h29.35v-93.86h-29.35q-29.32 0-49.99-20.74-20.66-20.74-20.66-49.92v-92.29q0-31.56 22.13-53.74 22.13-22.18 53.62-22.18h125.6q31.33 0 53.54 22.18 22.22 22.18 22.22 53.74v92.29q0 29.18-20.74 49.92-20.74 20.74-49.92 20.74h-29.34v93.86h31.74q28.32 0 48.29 19.97 19.97 19.96 19.97 48.29v13.33h140.76v-13.33q0-28.3 19.97-48.28t48.29-19.98h133.1q31.56 0 53.74 22.21 22.17 22.22 22.17 53.54v87.44q0 31.32-22.17 53.54-22.18 22.21-53.74 22.21h-133.1q-28.32 0-48.29-19.97-19.97-19.96-19.97-48.29v-13.33H429.62v13.33q0 28.3-19.97 48.28t-48.29 19.98h-31.74v93.86h29.34q29.18 0 49.92 20.74 20.74 20.74 20.74 49.92v92.29q0 31.56-22.22 53.74-22.21 22.18-53.54 22.18h-125.6q-31.49 0-53.62-22.18t-22.13-53.74Zm75.75 0h125.6v-87.19h-125.6v87.19Zm0-332.56h125.6v-87.44h-125.6v87.44Zm417.88 0h125.6v-87.44h-125.6v87.44ZM228.26-769.25h125.6v-87.03h-125.6v87.03Zm62.92-43.55Zm0 332.8Zm417.88 0ZM291.18-147.2Z';
+
+interface LaneIconProps {
+  color?: string;
+  size?: number;
+  style?: ViewStyle;
+  className?: string;
+}
+
+export const LaneIcon = ({
+  color = 'currentColor',
+  size = 26,
+  style,
+  className,
+}: LaneIconProps) => {
+  return (
+    <IconSvg
+      viewBox="0 -960 960 960"
+      width={size}
+      height={size}
+      style={{ ...style }}
+      className={className}
+    >
+      <Path d={LANE_PATH} fill={color} />
+    </IconSvg>
+  );
+};

--- a/packages/frontend/assets/icons/translate-icon.tsx
+++ b/packages/frontend/assets/icons/translate-icon.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Path } from 'react-native-svg';
+import { IconSvg } from '@/assets/icons/IconSvg';
+import { ViewStyle } from 'react-native';
+
+/**
+ * Translation — Material Symbols `language_chinese_quick`, kept at its own
+ * `0 -960 960 960` viewBox rather than re-traced onto the 24-grid the hand-built
+ * icons use. Re-drawing a glyph to fit a grid is how it stops being the one that
+ * was chosen.
+ *
+ * It replaces Ionicons `language`/`language-outline`, whose globe said "a
+ * language exists" where this says "these two scripts are the same thing" —
+ * which is what a translation is, and what the control does.
+ *
+ * ONE cut, so the two states are carried by the tint alone, exactly as the lane
+ * control does. The glyph pair it replaced did distinguish them by shape, so
+ * this is a real if small loss of signal: with a FILL1 cut the active state
+ * could be the filled glyph, the way the schedule control now works. Worth
+ * doing if the filled variant turns up.
+ */
+const TRANSLATE_PATH =
+  'M86-280q-5-8-3-18t11-16q14-10 27-20.5t27-21.5v-115h-45q-9 0-15.5-6.5T81-493q0-9 6.5-15.5T103-515h71q8 0 14 6t6 14v136q20 25 50 38t62 13q50 0 99-1t99-3q10-1 14.5 5.5T520-290q-3 10-10.5 17.5T488-265q-46 0-91-.5t-91-.5q-38 0-74-13t-62-41q-12 12-25 24t-27 23q-8 7-17.5 4.5T86-280Zm384-62q-26-16-47.5-36T381-421v83q0 9-6.5 15.5T359-316q-9 0-16-7t-7-16v-83q-18 24-41 43.5T247-342q-8 5-17.5 4t-16.5-9q-7-8-5-14.5t10-11.5q28-15 52-35t44-45h-64q-8 0-14-6t-6-14v-89q0-8 6-14t14-6h87v-30H230q-8 0-14-6.5t-6-14.5q0-8 6.5-14t14.5-6h106v-26q0-9 6.5-15.5T359-701q9 0 15.5 6.5T381-679v26h116q8 0 14 6t6 14q0 8-6 14.5t-14 6.5H381v30h93q8 0 14 6t6 14v88q0 8-6 14t-14 6h-71q21 24 45.5 44t52.5 34q9 5 10 11.5t-6 14.5q-8 8-17.5 10.5T470-342ZM275-492h61v-51h-61v51Zm105 0h70v-51h-70v51ZM158-599q-12-15-26-27.5T102-650q-8-5-8.5-13t6.5-14q8-6 18-6t17 5q15 12 28.5 24.5T191-627q7 7 7 16.5t-8 15.5q-8 6-17 5t-15-9Zm544 265q28 0 54.5-13t48.5-37v-106q-23 3-42.5 7t-36.5 9q-45 14-67.5 35T636-390q0 26 18 41t48 15Zm-23 68q-57 0-90-32.5T556-387q0-52 33-85t106-53q23-6 50.5-11t59.5-9q-2-47-22-68.5T721-635q-21 0-41 6t-47 20q-12 7-25 4t-20-15q-7-12-3-25.5t16-20.5q31-17 66.5-27.5T740-704q71 0 108 44t37 128v224q0 14-9.5 23.5T852-275h-5q-13 0-22-8.5T814-304l-2-16q-28 25-61.5 39.5T679-266Z';
+
+export const TranslateIcon = ({
+  color = 'currentColor',
+  size = 26,
+  style,
+  className,
+}: {
+  color?: string;
+  size?: number;
+  style?: ViewStyle;
+  className?: string;
+}) => {
+  return (
+    <IconSvg
+      viewBox="0 -960 960 960"
+      width={size}
+      height={size}
+      style={{ ...style }}
+      className={className}
+    >
+      <Path d={TRANSLATE_PATH} fill={color} />
+    </IconSvg>
+  );
+};

--- a/packages/frontend/components/ComposeToolbar.tsx
+++ b/packages/frontend/components/ComposeToolbar.tsx
@@ -15,6 +15,7 @@ import { ArticleIcon } from '@/assets/icons/article-icon';
 import { CalendarIcon } from '@/assets/icons/calendar-icon';
 import { ScheduleIcon, ScheduleIconActive } from '@/assets/icons/schedule-icon';
 import { LaneIcon } from '@/assets/icons/lane-icon';
+import { TranslateIcon } from '@/assets/icons/translate-icon';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
 interface ComposeToolbarProps {
@@ -268,13 +269,13 @@ const ComposeToolbar = memo<ComposeToolbarProps>(({
                     accessibilityLabel={t('compose.languages.add', { defaultValue: 'Add a language' })}
                 >
                     {/* The SAME icon the post component marks a translation
-                        with, in the same two states: `PostActions` renders
-                        `isTranslated ? 'language' : 'language-outline'` tinted
-                        primary or secondary. Here "carries another language" is
-                        the authoring side of that same fact, so the control that
-                        writes one and the badge that reads one look alike. */}
-                    <Ionicons
-                        name={hasLanguages ? 'language' : 'language-outline'}
+                        with — `PostActions` draws it too, tinted primary or
+                        secondary. Here "carries another language" is the
+                        authoring side of that same fact, so the control that
+                        writes one and the badge that reads one look alike.
+                        The state is the tint alone now; the pair it replaced
+                        distinguished the two by shape as well. */}
+                    <TranslateIcon
                         size={20}
                         color={disabled || !languageEnabled
                             ? theme.colors.textTertiary

--- a/packages/frontend/components/ComposeToolbar.tsx
+++ b/packages/frontend/components/ComposeToolbar.tsx
@@ -14,6 +14,7 @@ import { SourcesIcon } from '@/assets/icons/sources-icon';
 import { ArticleIcon } from '@/assets/icons/article-icon';
 import { CalendarIcon } from '@/assets/icons/calendar-icon';
 import { ScheduleIcon, ScheduleIconActive } from '@/assets/icons/schedule-icon';
+import { LaneIcon } from '@/assets/icons/lane-icon';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
 interface ComposeToolbarProps {
@@ -346,11 +347,13 @@ const ComposeToolbar = memo<ComposeToolbarProps>(({
                     accessibilityRole="button"
                     accessibilityLabel={t('lanes.compose.choose', { defaultValue: 'Choose a lane' })}
                 >
-                    {/* A signpost, in the two states this row uses everywhere
-                        else: filled once the post is on a lane, outline while it
-                        is not. */}
-                    <Ionicons
-                        name={hasLane ? 'git-branch' : 'git-branch-outline'}
+                    {/* Parallel tracks, not a branch. A branch is a fork — one
+                        history splitting into divergent ones — and a lane forks
+                        nothing: the post's distribution, visibility, replies and
+                        federation are untouched by it. It is a track the post is
+                        filed on. The tint carries the on/off state, the way every
+                        other icon in this row signals its attachment. */}
+                    <LaneIcon
                         size={20}
                         color={disabled
                             ? theme.colors.textTertiary

--- a/packages/frontend/components/Post/PostActions.tsx
+++ b/packages/frontend/components/Post/PostActions.tsx
@@ -1,7 +1,6 @@
 import React, { useRef } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { SpinnerIcon } from '@oxyhq/bloom/loading';
-import Ionicons from '@expo/vector-icons/Ionicons';
 import { CommentIcon } from '@/assets/icons/comment-icon';
 import { TranslateIcon } from '@/assets/icons/translate-icon';
 import { BoostIcon, BoostIconActive } from '@/assets/icons/boost-icon';

--- a/packages/frontend/components/Post/PostActions.tsx
+++ b/packages/frontend/components/Post/PostActions.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { SpinnerIcon } from '@oxyhq/bloom/loading';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { CommentIcon } from '@/assets/icons/comment-icon';
+import { TranslateIcon } from '@/assets/icons/translate-icon';
 import { BoostIcon, BoostIconActive } from '@/assets/icons/boost-icon';
 import { ShareIcon } from '@/assets/icons/share-icon';
 import { Bookmark, BookmarkActive } from '@/assets/icons/bookmark-icon';
@@ -218,8 +219,7 @@ const PostActions: React.FC<Props> = ({
           {isTranslating ? (
             <SpinnerIcon size={16} className="text-muted-foreground" />
           ) : (
-            <Ionicons
-              name={isTranslated ? 'language' : 'language-outline'}
+            <TranslateIcon
               size={ICON_SIZE}
               color={isTranslated ? theme.colors.primary : theme.colors.textSecondary}
             />

--- a/packages/frontend/components/__tests__/ComposeToolbarSchedule.test.tsx
+++ b/packages/frontend/components/__tests__/ComposeToolbarSchedule.test.tsx
@@ -5,6 +5,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import ComposeToolbar from '@/components/ComposeToolbar';
 import { CalendarIcon } from '@/assets/icons/calendar-icon';
 import { ScheduleIcon, ScheduleIconActive } from '@/assets/icons/schedule-icon';
+import { TranslateIcon } from '@/assets/icons/translate-icon';
 
 /**
  * The schedule control is an ICON, like every other attachment control in this
@@ -311,19 +312,20 @@ describe('ComposeToolbar — the language control', () => {
     );
   }
 
-  it('uses the post component\'s translation icon, in its two states', () => {
+  /**
+   * `PostActions` draws the SAME `TranslateIcon`, so the control that writes a
+   * language and the badge that reads one look alike. The glyph pair this
+   * replaced carried the state in its shape as well; with one cut the tint is
+   * the only signal, so the tint is what this pins.
+   */
+  it("uses the post component's translation icon, tinted by state", () => {
     const plain = renderLanguageToolbar();
-    expect(plain.root.findAllByType(Ionicons).map((n) => n.props.name))
-      .toContain('language-outline');
+    expect(plain.root.findAllByType(TranslateIcon)).toHaveLength(1);
+    expect(plain.root.findByType(TranslateIcon).props.color).toBe('#666');
     act(() => plain.unmount());
 
-    // `PostActions` renders `isTranslated ? 'language' : 'language-outline'`.
-    // Matching both states is the point — a different glyph, or the same glyph
-    // in both states, still compiles and still looks fine in isolation.
     const multilingual = renderLanguageToolbar({ hasLanguages: true });
-    const names = multilingual.root.findAllByType(Ionicons).map((n) => n.props.name);
-    expect(names).toContain('language');
-    expect(names).not.toContain('language-outline');
+    expect(multilingual.root.findByType(TranslateIcon).props.color).toBe('#7c3aed');
     act(() => multilingual.unmount());
   });
 
@@ -369,9 +371,7 @@ describe('ComposeToolbar — the language control', () => {
 
   it('tints itself once the post actually carries another language', () => {
     const languageColor = (tree: TestRenderer.ReactTestRenderer) =>
-      tree.root
-        .findAllByType(Ionicons)
-        .find((node) => /^language(-outline)?$/.test(node.props.name))?.props.color;
+      tree.root.findByType(TranslateIcon).props.color;
 
     const plain = renderLanguageToolbar();
     const plainColor = languageColor(plain);

--- a/packages/frontend/hooks/usePostActions.tsx
+++ b/packages/frontend/hooks/usePostActions.tsx
@@ -18,6 +18,7 @@ import { getNormalizedUserHandle } from '@oxyhq/core';
 import type { HydratedPost } from '@mention/shared-types';
 import type { FeedItem } from '@/db';
 import { AnalyticsIcon } from '@/assets/icons/analytics-icon';
+import { LaneIcon } from '@/assets/icons/lane-icon';
 import { Bookmark, BookmarkActive } from '@/assets/icons/bookmark-icon';
 import { TrashIcon } from '@/assets/icons/trash-icon';
 import { SourcesIcon } from '@/assets/icons/sources-icon';
@@ -221,7 +222,7 @@ export function usePostActions({
         const isReplyOrBoost = Boolean(viewPost?.parentPostId) || Boolean(viewPost?.boost);
         if (isOwner && !isReplyOrBoost) {
             saveActionGroup.push({
-                icon: <Ionicons name="git-branch-outline" size={20} color={theme.colors.textSecondary} />,
+                icon: <LaneIcon size={20} color={theme.colors.textSecondary} />,
                 label: t('lanes.postActions.moveToLane', { defaultValue: 'Move to lane…' }),
                 onPress: () => {
                     bottomSheet.setBottomSheetContent(


### PR DESCRIPTION
A lane drew `git-branch`, which says the wrong thing. **A branch is a fork** — one history splitting into divergent ones — and a lane forks nothing: a post that carries one is an ordinary post, its distribution, visibility, replies and federation untouched. It is a *track the post is filed on*, and the parallel rows of Material Symbols `schema` say exactly that.

Applied to the three surfaces that mean "lane": the composer's control, the post's **Move to lane…** action, and the New-lane row on the lanes screen.

## Two uses of the old glyph are deliberately left

- **`ReplyPreferencesSheet`'s "Threaded" option** — that one is a reply *tree*, where a branch is apt. And the two stop sharing a picture, which is the same ambiguity the schedule/event pair just lost.
- **`MODE_ICON` on the lanes screen**, whose `tab` entry denotes the display **mode** (`mixed` / `tab` / `hidden`), not lanes. Its own comment says it is that screen's vocabulary and nowhere else's. Swapping it would have made the mode indicator and the feature icon the same picture — the problem being fixed, not a second instance of the fix.

I nearly changed it before reading what it was for.

## The glyph

Kept at its own `0 -960 960 960` viewBox rather than re-traced onto the 24-grid the hand-built icons use. No `Active` export: this is the FILL0 cut, where the outline **is** the filled path, so a heavier variant would have to be invented rather than swapped in — unlike the schedule icon, which has a real FILL1. The toolbar already tints an active control, the way every other icon in that row signals its attachment is present.

## Verification

`tsc` 0 errors · `test:coverage` **1185 tests** · `lint:frontend` 0 errors (4 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
