### PR TITLE
feat: a channel-free thread may speak with several accounts

### DIFF
--- a/packages/backend/src/__tests__/controllers/channelPostSettings.test.ts
+++ b/packages/backend/src/__tests__/controllers/channelPostSettings.test.ts
@@ -9,11 +9,11 @@ import mongoose from 'mongoose';
  *    post. The 403 on the reply paths reads the AUTHOR's account kind and would
  *    hold regardless — but a change here would UN-HIDE the client's reply button
  *    and leave every reader hitting a refusal they were invited to attempt.
- *  - `POST /posts/thread` accepts `publishAsOxyUserId` in exactly ONE place per
- *    mode: at the BATCH level in thread mode (one publisher for one text) and
- *    PER ENTRY in beast mode (n independent posts). The other placement is a 400
- *    naming the right field, so a client can never send both. Both paths have
- *    their own suite, `threadPublishAsAccount.test.ts`.
+ *  - `POST /posts/thread` takes `publishAsOxyUserId` per ENTRY in both modes, and
+ *    additionally at the BATCH level in thread mode, where it is the default for
+ *    entries naming none. A batch-level field in beast mode is a 400 — there is
+ *    no thread there to speak for. Which COMBINATIONS are allowed (a channel's
+ *    thread must speak with one voice) is `threadPublishAsAccount.test.ts`.
  */
 
 const postFindOne = vi.fn();
@@ -187,7 +187,12 @@ describe('POST /posts/thread — one placement per mode, and only one', () => {
     expect(postCreationCreate).not.toHaveBeenCalled();
   });
 
-  it('400s a PER-ENTRY publishAsOxyUserId in thread mode — a thread has one publisher, named once', async () => {
+  it('ACCEPTS a per-entry publishAsOxyUserId in thread mode — entries may name their own account', async () => {
+    // The gate is stubbed in this suite (it answers "the caller" for everything),
+    // so what this pins is that the route no longer refuses the SHAPE. Which
+    // combinations of accounts are allowed — and the channel single-voice rule
+    // that refuses most of them — is `threadPublishAsAccount.test.ts`, where the
+    // real gate runs.
     const res = makeRes();
     await createThread(
       req({
@@ -200,8 +205,8 @@ describe('POST /posts/thread — one placement per mode, and only one', () => {
       res as never,
     );
 
-    expect(res.statusCode).toBe(400);
-    expect(postCreationCreate).not.toHaveBeenCalled();
+    expect(res.statusCode).not.toBe(400);
+    expect(postCreationCreate).toHaveBeenCalled();
   });
 
   it('CONTROL: an ordinary thread is still created', async () => {

--- a/packages/backend/src/__tests__/controllers/threadPublishAsAccount.test.ts
+++ b/packages/backend/src/__tests__/controllers/threadPublishAsAccount.test.ts
@@ -73,6 +73,7 @@ const CALLER = 'caller-1';
 const CHANNEL = 'channel-account-1';
 const ORGANIZATION = 'org-account-1';
 const FORBIDDEN_ORG = 'org-account-2';
+const SECOND_ORG = 'org-account-3';
 const CALLER_LANE = new mongoose.Types.ObjectId().toString();
 
 const EDITOR_PERMISSIONS = ['account:read', 'account:act_as', 'members:read'];
@@ -154,6 +155,7 @@ beforeEach(() => {
   listAccountMembers.mockImplementation(async (accountId: string) => {
     if (accountId === CHANNEL) return [member({ role: 'viewer', permissions: VIEWER_PERMISSIONS })];
     if (accountId === ORGANIZATION) return [member({ role: 'editor', permissions: EDITOR_PERMISSIONS })];
+    if (accountId === SECOND_ORG) return [member({ role: 'editor', permissions: EDITOR_PERMISSIONS })];
     // An organization the caller is a member of but may not ACT AS.
     if (accountId === FORBIDDEN_ORG) return [member({ role: 'viewer', permissions: VIEWER_PERMISSIONS })];
     return [];
@@ -165,6 +167,7 @@ beforeEach(() => {
       [CHANNEL]: 'channel',
       [ORGANIZATION]: 'organization',
       [FORBIDDEN_ORG]: 'organization',
+      [SECOND_ORG]: 'organization',
     };
     const map = new Map<string, { user: { id: string; kind?: string; name: object } }>();
     for (const id of ids) {
@@ -490,22 +493,22 @@ describe('thread mode — one account for the whole thread', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
-  it('400s a PER-ENTRY account in thread mode, and asks Oxy nothing', async () => {
+  it('lets an entry override the batch account — the batch one is the DEFAULT', async () => {
     const res = makeRes();
     await createThread(
       req({
         mode: 'thread',
+        publishAsOxyUserId: ORGANIZATION,
         posts: [
-          { content: { text: 'root' }, publishAsOxyUserId: ORGANIZATION },
-          { content: { text: 'continuation' } },
+          { content: { text: 'part one' } },
+          { content: { text: 'part two' }, publishAsOxyUserId: SECOND_ORG },
         ],
       }),
       res as never,
     );
 
-    expect(res.statusCode).toBe(400);
-    expect(create).not.toHaveBeenCalled();
-    expect(listAccountMembers).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(201);
+    expect(requestedAccounts()).toEqual([ORGANIZATION, SECOND_ORG]);
   });
 
   it('CONTROL: a thread naming no account marks no continuation and stays the caller\'s', async () => {
@@ -570,3 +573,255 @@ describe('the lane pre-flight follows the ENTRY\'s author', () => {
     );
   });
 });
+
+/**
+ * A THREAD FROM SEVERAL ACCOUNTS — and the boundary that stops a channel being
+ * one of them.
+ *
+ * An entry whose account differs from its predecessor's is mechanically that
+ * account REPLYING to the other's post, so a multi-account thread is a
+ * conversation between accounts. Between organizations the caller operates that
+ * is the feature; with a channel at either end it is the door
+ * `utils/channelReplyGate` holds shut at five write sites, with no exception for
+ * the channel's own operators.
+ *
+ * The controller decides WHICH of the two verified exceptions each link is
+ * created under; the exceptions themselves are unit-tested in
+ * `utils/threadContinuation.test.ts` against a real database shape.
+ */
+describe('thread mode — several accounts, and the channel boundary', () => {
+  /** Which exception each `create` call asked for, in order. */
+  function linkKinds(): Array<'own' | 'answers' | 'none'> {
+    return create.mock.calls.map(([params]: [Record<string, unknown>]) => {
+      if (params.continuesOwnThread === true) return 'own';
+      if (params.answersOperatedAccount === true) return 'answers';
+      return 'none';
+    });
+  }
+
+  it('accepts a thread alternating between two organizations the caller operates', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'A speaks' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'B answers' }, publishAsOxyUserId: SECOND_ORG },
+          { content: { text: 'A again' }, publishAsOxyUserId: ORGANIZATION },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(requestedAccounts()).toEqual([ORGANIZATION, SECOND_ORG, ORGANIZATION]);
+  });
+
+  it('creates every link of a multi-account thread under the ANSWERS exception', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'A' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'B' }, publishAsOxyUserId: SECOND_ORG },
+          { content: { text: 'B again' }, publishAsOxyUserId: SECOND_ORG },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    // Entry 3's account MATCHES its parent's and differs from the ROOT's, so the
+    // own-thread exception would refuse it (its third condition is about the
+    // root). The choice is made per THREAD, not per adjacent pair, which is what
+    // makes an [A, B, B] thread expressible at all.
+    expect(linkKinds()).toEqual(['none', 'answers', 'answers']);
+  });
+
+  it('keeps the OWN-THREAD exception for a single-voice thread', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        publishAsOxyUserId: CHANNEL,
+        posts: [{ content: { text: 'a' } }, { content: { text: 'b' } }],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(linkKinds()).toEqual(['none', 'own']);
+  });
+
+  /**
+   * MUTATION GUARD — the hole the whole boundary exists to close. Dropping the
+   * channel test from the single-voice rule makes this a 201, and what it creates
+   * is an organization's post REPLYING to a channel's, which is the one thing a
+   * channel's operators may never do.
+   */
+  it('MUTATION GUARD: 400s a thread whose ROOT is a channel and whose later entry is not', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'the channel announces' }, publishAsOxyUserId: CHANNEL },
+          { content: { text: 'the org chimes in' }, publishAsOxyUserId: ORGANIZATION },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  /**
+   * MUTATION GUARD — the same rule read from the other end. Looking only at the
+   * PARENT is not enough: a channel answering an organization is a channel in a
+   * conversation just as much as the reverse, and this is the fixture that tells
+   * a both-ends check from a parent-only one.
+   */
+  it('MUTATION GUARD: 400s a thread whose root is an ORGANIZATION and whose later entry is a channel', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'the org speaks' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'the channel answers' }, publishAsOxyUserId: CHANNEL },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('400s a channel sitting in the MIDDLE of an otherwise channel-free thread', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'A' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'the channel' }, publishAsOxyUserId: CHANNEL },
+          { content: { text: 'B' }, publishAsOxyUserId: SECOND_ORG },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('names the channel in the refusal, so the author knows which account is the obstacle', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'a' }, publishAsOxyUserId: CHANNEL },
+          { content: { text: 'b' }, publishAsOxyUserId: ORGANIZATION },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(String((res.body as { message: string }).message)).toContain(CHANNEL);
+  });
+
+  it('mixing a channel with the CALLER\'s own posts is refused too', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'the channel' }, publishAsOxyUserId: CHANNEL },
+          { content: { text: 'and me' } },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: a channel alone for the whole thread is still fine', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'part one' }, publishAsOxyUserId: CHANNEL },
+          { content: { text: 'part two' }, publishAsOxyUserId: CHANNEL },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(requestedAccounts()).toEqual([CHANNEL, CHANNEL]);
+  });
+
+  it('CONTROL: a BEAST batch may still mix a channel with anything — no entry replies to another', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'beast',
+        posts: [
+          { content: { text: 'a' }, publishAsOxyUserId: CHANNEL },
+          { content: { text: 'b' }, publishAsOxyUserId: ORGANIZATION },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(requestedAccounts()).toEqual([CHANNEL, ORGANIZATION]);
+  });
+
+  it('authorizes each DISTINCT account once, however many entries carry it', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'a' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'b' }, publishAsOxyUserId: SECOND_ORG },
+          { content: { text: 'c' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'd' }, publishAsOxyUserId: SECOND_ORG },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(listAccountMembers.mock.calls.map(([id]: [string]) => id).sort()).toEqual(
+      [ORGANIZATION, SECOND_ORG].sort(),
+    );
+  });
+
+  it('refuses the whole thread when ONE entry names an account the caller may not use', async () => {
+    const res = makeRes();
+    await createThread(
+      req({
+        mode: 'thread',
+        posts: [
+          { content: { text: 'a' }, publishAsOxyUserId: ORGANIZATION },
+          { content: { text: 'b' }, publishAsOxyUserId: FORBIDDEN_ORG },
+        ],
+      }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+

--- a/packages/backend/src/__tests__/services/postCreationPublishAs.test.ts
+++ b/packages/backend/src/__tests__/services/postCreationPublishAs.test.ts
@@ -92,6 +92,7 @@ import { PublishAsAccessError } from '../../services/publishAsAccount';
 const WRITER = 'writer-1';
 const CHANNEL = 'channel-account-1';
 const ORGANIZATION = 'org-account-1';
+const SECOND_ORG = 'org-account-2';
 
 const ACT_AS_PERMISSIONS = ['account:read', 'account:act_as', 'members:read'];
 const NO_ACT_AS_PERMISSIONS = ['account:read', 'members:read'];
@@ -125,7 +126,11 @@ beforeEach(() => {
   memberReader.listAccountMembers.mockClear();
   resolveUserSummaries.mockReset();
   resolveUserSummaries.mockImplementation(async (ids: string[]) => {
-    const kinds: Record<string, string> = { [CHANNEL]: 'channel', [ORGANIZATION]: 'organization' };
+    const kinds: Record<string, string> = {
+      [CHANNEL]: 'channel',
+      [ORGANIZATION]: 'organization',
+      [SECOND_ORG]: 'organization',
+    };
     const map = new Map<string, { user: { id: string; kind?: string; name: object } }>();
     for (const id of ids) {
       if (kinds[id]) map.set(id, { user: { id, kind: kinds[id], name: {} } });
@@ -429,6 +434,129 @@ describe('PostCreationService.create — continuing the account\'s own thread', 
         oxyUserId: WRITER,
         content: { text: 'part two, but unmarked' },
         publishAsOxyUserId: CHANNEL,
+        parentPostId: ROOT,
+        threadId: ROOT,
+        memberReader,
+        skipNotifications: true,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(constructedWith).toHaveLength(0);
+  });
+});
+
+/**
+ * The SECOND exception at the service layer — `answersOperatedAccount`.
+ *
+ * Same discipline as `continuesOwnThread` above: the parameter grants nothing.
+ * Every case here sets it, and only the ones that survive
+ * {@link assertAnswersOperatedAccount}'s verification are written. Without these
+ * the whole wiring is untested — mutation-testing found the branch could be
+ * deleted outright with the suite still green.
+ */
+describe('PostCreationService.create — one operated account answering another', () => {
+  const ROOT = new mongoose.Types.ObjectId().toString();
+  const CHANNEL_ROOT = new mongoose.Types.ObjectId().toString();
+
+  it('writes an organization\'s answer to another organization\'s post', async () => {
+    threadRows.push({ _id: ROOT, oxyUserId: ORGANIZATION, threadId: ROOT });
+
+    await postCreationService.create({
+      oxyUserId: WRITER,
+      content: { text: 'B answers A' },
+      publishAsOxyUserId: SECOND_ORG,
+      parentPostId: ROOT,
+      threadId: ROOT,
+      answersOperatedAccount: true,
+      memberReader,
+      skipNotifications: true,
+      skipSocketEmit: true,
+      skipFederationDelivery: true,
+    });
+
+    const [doc] = constructedWith;
+    expect(doc.oxyUserId).toBe(SECOND_ORG);
+    expect(doc.parentPostId).toBe(ROOT);
+    // An organization's post is ordinary in every other respect — replies
+    // included. Only a channel forces `['nobody']`.
+    expect(doc.replyPermission).toEqual(['anyone']);
+  });
+
+  /**
+   * MUTATION GUARD. The parent belongs to a CHANNEL, and the publisher is an
+   * organization the caller may act for — so every condition except the channel
+   * one is satisfied. Accepting `answersOperatedAccount` without running the
+   * verification writes this post, and what it writes is a reply to a channel.
+   */
+  it('MUTATION GUARD: refuses an organization answering a CHANNEL\'s post', async () => {
+    threadRows.push({ _id: CHANNEL_ROOT, oxyUserId: CHANNEL, threadId: CHANNEL_ROOT });
+
+    await expect(
+      postCreationService.create({
+        oxyUserId: WRITER,
+        content: { text: 'answering the channel' },
+        publishAsOxyUserId: SECOND_ORG,
+        parentPostId: CHANNEL_ROOT,
+        threadId: CHANNEL_ROOT,
+        answersOperatedAccount: true,
+        memberReader,
+        skipNotifications: true,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(constructedWith).toHaveLength(0);
+    expect(saved).toHaveLength(0);
+  });
+
+  /**
+   * MUTATION GUARD, the other end. Here the parent is a fine organization and the
+   * CHANNEL is doing the answering — refused by the publishing-account half of the
+   * boundary, which a parent-only check would miss.
+   */
+  it('MUTATION GUARD: refuses a CHANNEL answering an organization\'s post', async () => {
+    threadRows.push({ _id: ROOT, oxyUserId: ORGANIZATION, threadId: ROOT });
+
+    await expect(
+      postCreationService.create({
+        oxyUserId: WRITER,
+        content: { text: 'the channel answers' },
+        publishAsOxyUserId: CHANNEL,
+        parentPostId: ROOT,
+        threadId: ROOT,
+        answersOperatedAccount: true,
+        memberReader,
+        skipNotifications: true,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(constructedWith).toHaveLength(0);
+  });
+
+  it('refuses a claimed answer to a thread that does not exist', async () => {
+    await expect(
+      postCreationService.create({
+        oxyUserId: WRITER,
+        content: { text: 'invented' },
+        publishAsOxyUserId: SECOND_ORG,
+        parentPostId: ROOT,
+        threadId: ROOT,
+        answersOperatedAccount: true,
+        memberReader,
+        skipNotifications: true,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(constructedWith).toHaveLength(0);
+  });
+
+  it('CONTROL: WITHOUT either flag, the same reply is refused', async () => {
+    threadRows.push({ _id: ROOT, oxyUserId: ORGANIZATION, threadId: ROOT });
+
+    await expect(
+      postCreationService.create({
+        oxyUserId: WRITER,
+        content: { text: 'unmarked' },
+        publishAsOxyUserId: SECOND_ORG,
         parentPostId: ROOT,
         threadId: ROOT,
         memberReader,

--- a/packages/backend/src/__tests__/utils/threadContinuation.test.ts
+++ b/packages/backend/src/__tests__/utils/threadContinuation.test.ts
@@ -22,14 +22,28 @@ import mongoose from 'mongoose';
  */
 
 const find = vi.hoisted(() => vi.fn());
+const resolveUserSummaries = vi.hoisted(() => vi.fn(async () => new Map()));
 
 vi.mock('../../models/Post', () => ({
   Post: { find },
   POST_CLASSIFICATION_PENDING: 'pending',
 }));
 
-import { assertContinuesOwnThread } from '../../utils/threadContinuation';
+// The identity path behind account KINDS. The real `publishAsAccount` is used
+// throughout — the second case's condition 4 delegates to its authorization gate,
+// and stubbing that would leave the delegation untested.
+vi.mock('../../services/PostHydrationService', () => ({ resolveUserSummaries }));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  assertAnswersOperatedAccount,
+  assertContinuesOwnThread,
+} from '../../utils/threadContinuation';
 import { PublishAsAccessError } from '../../services/publishAsAccount';
+import type { AccountMember } from '@oxyhq/core';
 
 const CHANNEL = 'channel-account-1';
 const OPERATOR = 'human-1';
@@ -207,5 +221,267 @@ describe('assertContinuesOwnThread — what it REFUSES', () => {
     await expect(
       assertContinuesOwnThread({ parentPostId: FOREIGN_POST, threadId: FOREIGN_ROOT, authorId: CHANNEL }),
     ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+/**
+ * `assertAnswersOperatedAccount` — the SECOND case: two accounts the caller
+ * operates, talking to each other inside one composed thread.
+ *
+ * Four conditions, and every refusal fixture below is built so it fails on
+ * EXACTLY the one it names — the others are satisfied. That discipline is not
+ * decoration: an earlier version of the first case's suite was green with a
+ * condition deleted, because every refusal fixture happened to fail a second
+ * condition too, and a check nothing can isolate is a check that is not there.
+ *
+ *   1. the parent is in the declared thread,
+ *   2. the PARENT's account is not a channel,
+ *   3. the PUBLISHING account is not a channel,
+ *   4. the caller may act for the parent's account too.
+ */
+describe('assertAnswersOperatedAccount — two operated accounts talking', () => {
+  const ORG_A = 'org-a';
+  const ORG_B = 'org-b';
+  const A_ROOT = new mongoose.Types.ObjectId().toString();
+  const A_SECOND = new mongoose.Types.ObjectId().toString();
+  const CHANNEL_ROOT = new mongoose.Types.ObjectId().toString();
+  const ELSEWHERE = new mongoose.Types.ObjectId().toString();
+
+  const ACT_AS = ['account:read', 'account:act_as', 'members:read'];
+  const NO_ACT_AS = ['account:read', 'members:read'];
+
+  function member(memberUserId: string, permissions: string[]): AccountMember {
+    return {
+      _id: 'row', accountId: 'acct', memberUserId, role: 'editor', permissions,
+      inherit: true, status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+  }
+
+  /** Every account the caller may act for, unless a test says otherwise. */
+  function readerFor(actable: Record<string, string[]>) {
+    return {
+      listAccountMembers: async (accountId: string) =>
+        actable[accountId] ? [member(OPERATOR, actable[accountId])] : [],
+    };
+  }
+
+  const ALL_OPERATED = { [ORG_A]: ACT_AS, [ORG_B]: ACT_AS, [CHANNEL]: NO_ACT_AS };
+
+  function kindsAre(byId: Record<string, string>): void {
+    resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+      const map = new Map<string, { user: { id: string; kind?: string; name: object } }>();
+      for (const id of ids) {
+        if (byId[id]) map.set(id, { user: { id, kind: byId[id], name: {} } });
+      }
+      return map;
+    });
+  }
+
+  beforeEach(() => {
+    kindsAre({ [ORG_A]: 'organization', [ORG_B]: 'organization', [CHANNEL]: 'channel', [OPERATOR]: 'personal' });
+    rowsAre([
+      { _id: A_ROOT, oxyUserId: ORG_A, threadId: A_ROOT },
+      { _id: A_SECOND, oxyUserId: ORG_A, threadId: A_ROOT },
+      { _id: CHANNEL_ROOT, oxyUserId: CHANNEL, threadId: CHANNEL_ROOT },
+      { _id: ELSEWHERE, oxyUserId: ORG_A, threadId: ELSEWHERE },
+    ]);
+  });
+
+  const base = {
+    parentPostId: A_ROOT,
+    threadId: A_ROOT,
+    authorId: ORG_B,
+    authorKind: 'organization' as const,
+    callerId: OPERATOR,
+  };
+
+  it('admits organization B answering organization A in A\'s thread', async () => {
+    await expect(
+      assertAnswersOperatedAccount({ ...base, memberReader: readerFor(ALL_OPERATED) }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('admits an entry whose account MATCHES its parent but not the thread root', async () => {
+    // [A, B, B] — the shape the own-thread exception cannot express, because its
+    // third condition is about the root. Both ends are still B and A, both
+    // operated, neither a channel.
+    rowsAre([
+      { _id: A_ROOT, oxyUserId: ORG_A, threadId: A_ROOT },
+      { _id: A_SECOND, oxyUserId: ORG_B, threadId: A_ROOT },
+    ]);
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        parentPostId: A_SECOND,
+        memberReader: readerFor(ALL_OPERATED),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('admits an organization answering the CALLER\'s own post', async () => {
+    rowsAre([{ _id: A_ROOT, oxyUserId: OPERATOR, threadId: A_ROOT }]);
+    await expect(
+      assertAnswersOperatedAccount({ ...base, memberReader: readerFor(ALL_OPERATED) }),
+    ).resolves.toBeUndefined();
+  });
+
+  /** CONDITION 1, isolated: both accounts operated, neither a channel. */
+  it('refuses a parent that is not in the declared thread', async () => {
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        parentPostId: ELSEWHERE,
+        memberReader: readerFor(ALL_OPERATED),
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * CONDITION 2, isolated — MUTATION GUARD. The publishing account is a perfectly
+   * ordinary organization the caller may act for, and the parent is genuinely in
+   * the declared thread; the ONLY thing wrong is that the parent belongs to a
+   * channel. This is literally "an organization replying to a channel's post",
+   * which is the hole the whole boundary exists to close.
+   */
+  it('MUTATION GUARD: refuses answering a CHANNEL\'s post', async () => {
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        parentPostId: CHANNEL_ROOT,
+        threadId: CHANNEL_ROOT,
+        memberReader: readerFor(ALL_OPERATED),
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * CONDITION 3, isolated — MUTATION GUARD. The mirror image, and the reason
+   * checking the parent alone is not enough: here the PARENT is a fine
+   * organization and the publisher is the channel. A channel answering an
+   * organization is a channel in a conversation just the same.
+   */
+  it('MUTATION GUARD: refuses a CHANNEL doing the answering', async () => {
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        authorId: CHANNEL,
+        authorKind: 'channel',
+        memberReader: readerFor(ALL_OPERATED),
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * CONDITION 2 again, via the ROOT rather than the parent — a channel at the head
+   * of the thread with an organization's post as the immediate parent. Without the
+   * root in the check, every entry after the first would escape the boundary by
+   * chaining onto a non-channel predecessor.
+   */
+  it('refuses when the thread ROOT is a channel, whoever the immediate parent is', async () => {
+    rowsAre([
+      { _id: CHANNEL_ROOT, oxyUserId: CHANNEL, threadId: CHANNEL_ROOT },
+      { _id: A_SECOND, oxyUserId: ORG_A, threadId: CHANNEL_ROOT },
+    ]);
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        parentPostId: A_SECOND,
+        threadId: CHANNEL_ROOT,
+        memberReader: readerFor(ALL_OPERATED),
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * CONDITION 4, isolated: neither end is a channel and the parent really is in
+   * the thread — the caller simply may not speak for the account being answered.
+   * Without this, "an account you operate may reply to ANYBODY" is what ships.
+   */
+  it('refuses answering an account the caller may NOT act for', async () => {
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        memberReader: readerFor({ [ORG_B]: ACT_AS }),
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  it('refuses when the caller is a MEMBER of the answered account without account:act_as', async () => {
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        memberReader: readerFor({ [ORG_A]: NO_ACT_AS, [ORG_B]: ACT_AS }),
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * Failing CLOSED on an unknown kind — the opposite direction from
+   * `channelReplyGate`'s fail-soft, and deliberately: reading "unknown" as "not a
+   * channel" here would admit the one thing this function refuses.
+   */
+  it('refuses when the parent account\'s kind will not resolve', async () => {
+    kindsAre({ [ORG_B]: 'organization' });
+    await expect(
+      assertAnswersOperatedAccount({ ...base, memberReader: readerFor(ALL_OPERATED) }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  /**
+   * The unknown-kind refusal, ISOLATED to the thread ROOT.
+   *
+   * An unresolvable PARENT is refused by condition 4 anyway (the authorization
+   * gate refuses an account whose kind it cannot read), so a parent-side fixture
+   * cannot tell the explicit unknown-kind check from its absence — mutation-
+   * testing found exactly that. The ROOT never goes through condition 4, so this
+   * is the only shape that pins it: parent fine, caller authorized for it, and
+   * only the root's kind missing.
+   */
+  it('refuses when the thread ROOT\'s kind will not resolve, though the parent\'s does', async () => {
+    const UNKNOWN_ROOT = new mongoose.Types.ObjectId().toString();
+    kindsAre({ [ORG_A]: 'organization', [ORG_B]: 'organization' });
+    rowsAre([
+      { _id: UNKNOWN_ROOT, oxyUserId: 'an-account-oxy-cannot-resolve', threadId: UNKNOWN_ROOT },
+      { _id: A_SECOND, oxyUserId: ORG_A, threadId: UNKNOWN_ROOT },
+    ]);
+
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        parentPostId: A_SECOND,
+        threadId: UNKNOWN_ROOT,
+        memberReader: readerFor(ALL_OPERATED),
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  it('refuses a parent that does not exist', async () => {
+    rowsAre([{ _id: A_ROOT, oxyUserId: ORG_A, threadId: A_ROOT }]);
+    await expect(
+      assertAnswersOperatedAccount({
+        ...base,
+        parentPostId: new mongoose.Types.ObjectId().toString(),
+        memberReader: readerFor(ALL_OPERATED),
+      }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+  });
+
+  it.each([
+    ['no parentPostId', { parentPostId: null }],
+    ['no threadId', { threadId: null }],
+    ['no author', { authorId: null }],
+    ['a malformed parent id', { parentPostId: 'not-an-objectid' }],
+  ])('refuses with %s, and asks the database nothing', async (_label, override) => {
+    await expect(
+      assertAnswersOperatedAccount({ ...base, ...override, memberReader: readerFor(ALL_OPERATED) }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it('refuses with no member reader at all — an MCP caller cannot compose one', async () => {
+    await expect(
+      assertAnswersOperatedAccount({ ...base, memberReader: undefined }),
+    ).rejects.toBeInstanceOf(PublishAsAccessError);
   });
 });

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -48,6 +48,7 @@ import {
   ChannelReplyError,
   postIsAuthoredByChannel,
 } from '../utils/channelReplyGate';
+import type { AccountKind } from '@oxyhq/contracts';
 import {
   assertCanPublishAsAccount,
   cacheAccountMemberReads,
@@ -986,35 +987,33 @@ export const createThread = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'Posts array is required and cannot be empty' });
     }
 
-    // WHERE THE ACCOUNT IS NAMED IS THE OPPOSITE IN THE TWO MODES, and that is the
-    // whole design rather than an inconsistency.
+    // WHO PUBLISHES WHAT, in both modes.
     //
-    // A `beast` batch is n independent top-level posts that happen to be written
-    // in one action, so the account is PER ENTRY and they may all differ. A
-    // `thread` is one text in several parts, so it has exactly one publisher by
-    // construction: the account is named ONCE for the BATCH, and a per-entry one
-    // is refused, because an identity that changed mid-thread is the incoherent
-    // case. Each mode therefore has exactly one way to say it, and the other way
-    // is a 400 that names the right field — a client can never send both and have
-    // to discover which won.
+    // A `beast` batch is n independent top-level posts, so the account is PER
+    // ENTRY and the batch-level field is refused — there is no batch to speak of.
     //
-    // The continuations are stored as replies to their predecessor, which is what
-    // joins a thread at all, and `PostCreationService` normally refuses to publish
-    // a reply as another account. The exception is `continuesOwnThread` on the
-    // create call below: VERIFIED against the parent and the thread root, not
-    // asserted — see `utils/threadContinuation`. Nothing here opens a channel's
-    // posts to replies from anyone else; every entry is authored by the account,
-    // so the reply gate refuses a third party on a continuation exactly as it does
-    // on the root.
+    // A `thread` takes BOTH, with per-entry winning: the batch-level field is the
+    // thread's account, and an entry may name its own. Those two shapes are
+    // different threads, not two spellings of one, which is why both exist:
+    //
+    //   - ONE account for the whole thread — one text in several parts. This is
+    //     the only shape available to a CHANNEL, and it is what `channelReplyGate`
+    //     leaves room for.
+    //   - DIFFERENT accounts per entry — two organizations the caller operates,
+    //     talking to each other. Mechanically each such entry REPLIES to the one
+    //     before it, so this is a conversation between accounts, and a channel may
+    //     never be in one: "no replies, ever" has no exception for a channel's own
+    //     operators. Hence the single-voice rule enforced below.
+    //
+    // The links are stored as replies to their predecessor, which is what joins a
+    // thread at all, and `PostCreationService` normally refuses to publish a reply
+    // as another account. The two exceptions are `continuesOwnThread` and
+    // `answersOperatedAccount` on the create call below, both VERIFIED against the
+    // database rather than asserted — see `utils/threadContinuation`. Nothing here
+    // opens any account's posts to replies from a third party: every entry is
+    // authored by one of the caller's own accounts, so the reply gate refuses
+    // everybody else on a continuation exactly as it does on the root.
     const batchAccount = req.body.publishAsOxyUserId;
-    const entryNamesAnotherAccount = posts.some(
-      (p: { publishAsOxyUserId?: unknown }) => typeof p?.publishAsOxyUserId === 'string',
-    );
-    if (mode === 'thread' && entryNamesAnotherAccount) {
-      return res.status(400).json({
-        message: 'Set publishAsOxyUserId once for the thread, not on each post',
-      });
-    }
     if (mode !== 'thread' && typeof batchAccount === 'string') {
       return res
         .status(400)
@@ -1031,28 +1030,43 @@ export const createThread = async (req: AuthRequest, res: Response) => {
     // nothing routes around the authorization.
     const memberReader = createUserScopedOxyServices(req);
     const batchMemberReader = memberReader ? cacheAccountMemberReads(memberReader) : undefined;
+    /**
+     * The account THIS request names for an entry, if any. In thread mode the
+     * entry's own field wins and the batch-level one is the default for entries
+     * that name none; in beast mode there is no batch-level field to fall back to.
+     */
+    const accountForEntry = (index: number): string | null => {
+      const named = (posts[index] as { publishAsOxyUserId?: unknown })?.publishAsOxyUserId;
+      if (typeof named === 'string') return named;
+      return mode === 'thread' && typeof batchAccount === 'string' ? batchAccount : null;
+    };
+
     /** Entry index → the account that entry will be AUTHORED BY. */
     const entryAuthorIds: string[] = [];
+    /** That account's Oxy kind, `null` when the entry is the caller's own post. */
+    const entryAuthorKinds: Array<AccountKind | null> = [];
     try {
-      if (mode === 'thread') {
-        const { authorId } = await assertCanPublishAsAccount({
-          publishAsOxyUserId: typeof batchAccount === 'string' ? batchAccount : null,
-          callerId: userId,
-          memberReader: batchMemberReader,
-        });
-        // One decision, applied to every entry — so no continuation can end up
-        // under an identity the root was not authorized for.
-        entryAuthorIds.push(...posts.map(() => authorId ?? userId));
-      } else {
-        for (const entry of posts) {
-          const requested = (entry as { publishAsOxyUserId?: unknown })?.publishAsOxyUserId;
-          const { authorId } = await assertCanPublishAsAccount({
-            publishAsOxyUserId: typeof requested === 'string' ? requested : null,
+      // Authorized once per DISTINCT account, memoized across the batch: a thread
+      // naming one account asks Oxy once however many entries it has, and one
+      // naming two asks twice. `cacheAccountMemberReads` is what makes that true
+      // end to end, since the creation loop below hands every post the SAME reader
+      // and lets `PostCreationService` run the real gate itself — nothing routes
+      // around the authorization.
+      const decided = new Map<string, { authorId: string | null; authorKind: AccountKind | null }>();
+      for (let i = 0; i < posts.length; i++) {
+        const requested = accountForEntry(i);
+        const key = requested ?? '';
+        let decision = decided.get(key);
+        if (!decision) {
+          decision = await assertCanPublishAsAccount({
+            publishAsOxyUserId: requested,
             callerId: userId,
             memberReader: batchMemberReader,
           });
-          entryAuthorIds.push(authorId ?? userId);
+          decided.set(key, decision);
         }
+        entryAuthorIds.push(decision.authorId ?? userId);
+        entryAuthorKinds.push(decision.authorKind);
       }
     } catch (publishAsError) {
       if (publishAsError instanceof PublishAsAccessError) {
@@ -1060,13 +1074,42 @@ export const createThread = async (req: AuthRequest, res: Response) => {
       }
       throw publishAsError;
     }
-    /** The account THIS request names, if any — thread-wide or per entry. */
-    const accountForEntry = (index: number): string | null => {
-      const named = mode === 'thread'
-        ? batchAccount
-        : (posts[index] as { publishAsOxyUserId?: unknown })?.publishAsOxyUserId;
-      return typeof named === 'string' ? named : null;
-    };
+
+    // A CHANNEL'S THREAD SPEAKS WITH ONE VOICE.
+    //
+    // A thread carrying more than one account is a conversation between them —
+    // every entry whose account differs from its predecessor's is that account
+    // REPLYING to the other's post. A channel may not be in one, at either end,
+    // and that is not a preference: `utils/channelReplyGate` refuses replies to a
+    // channel's post at five write sites with no exception for the channel's own
+    // operators, so admitting it here would reopen exactly that door from inside
+    // the composer.
+    //
+    // Checked over the WHOLE thread rather than pairwise, because a channel at the
+    // head makes every later entry an answer to a channel whichever post is the
+    // immediate parent — and because a channel in the middle is the same problem
+    // read from the other side. The message names the channel, since "you cannot
+    // do that" without saying which of several accounts is the obstacle is a
+    // refusal nobody can act on.
+    const distinctThreadAccounts = new Set(entryAuthorIds);
+    if (mode === 'thread' && distinctThreadAccounts.size > 1) {
+      const channelIndex = entryAuthorKinds.findIndex((kind) => kind === 'channel');
+      if (channelIndex >= 0) {
+        return res.status(400).json({
+          message:
+            'A channel publishes alone: a thread including ' +
+            `${entryAuthorIds[channelIndex]} must use that one account for every post, ` +
+            'because a post from another account would be a reply to the channel.',
+        });
+      }
+    }
+    /**
+     * Whether this thread is one account's own text (every entry the same) rather
+     * than several accounts talking. It decides which of the two verified
+     * exceptions each link below is created under, and the two are NOT
+     * interchangeable — a channel may only ever use the first.
+     */
+    const threadSpeaksWithOneVoice = distinctThreadAccounts.size === 1;
 
     // Lanes are validated for the WHOLE batch before a single post is written.
     // The loop below creates posts one at a time, so a lane refused on entry 3
@@ -1269,14 +1312,23 @@ export const createThread = async (req: AuthRequest, res: Response) => {
         // previous post (sequential thread), with a shared threadId root.
         // For beast mode: all posts are independent.
         ...(isThreadContinuation ? { parentPostId: previousPostId, threadId: mainPostId } : {}),
-        // The narrow exception to "a reply cannot be published as another
-        // account", and the ONLY place it is ever asked for. It is safe to ask
-        // here for a structural reason and not a trusting one: `previousPostId`
-        // and `mainPostId` are ids of posts THIS request created moments ago,
-        // under the authorization above, so the parent is the same account's own
-        // post by construction — and `create` re-derives that from the database
-        // rather than believing it. See `utils/threadContinuation`.
-        ...(isThreadContinuation ? { continuesOwnThread: true } : {}),
+        // The two verified exceptions to "a reply cannot be published as another
+        // account", and the ONLY place either is ever asked for. Which one this
+        // link gets is decided by the THREAD, not by the adjacent pair: a
+        // single-voice thread is one account's own text end to end, and anything
+        // else is accounts talking. Asking for the wrong one is safe — both are
+        // re-derived from the database inside `create`, so a mismatch is a
+        // refusal, never a bypass.
+        //
+        // Safe to ask for here for a structural reason rather than a trusting
+        // one: `previousPostId` and `mainPostId` are ids of posts THIS request
+        // created moments ago under the authorization above. See
+        // `utils/threadContinuation`.
+        ...(isThreadContinuation
+          ? threadSpeaksWithOneVoice
+            ? { continuesOwnThread: true }
+            : { answersOperatedAccount: true }
+          : {}),
         // Every post of a scheduled batch carries the SAME time — the author
         // picked one moment for the set, not n moments. For a beast batch each
         // is then an ordinary scheduled post published independently; for a

--- a/packages/backend/src/services/PostCreationService.ts
+++ b/packages/backend/src/services/PostCreationService.ts
@@ -38,7 +38,10 @@ import {
 import { recordRecentReplierForPost } from './PostRecentReplierService';
 import { parentHasPublished } from './scheduledChain';
 import { assertLaneAssignable } from '../utils/laneAssignment';
-import { assertContinuesOwnThread } from '../utils/threadContinuation';
+import {
+  assertAnswersOperatedAccount,
+  assertContinuesOwnThread,
+} from '../utils/threadContinuation';
 import {
   assertCanPublishAsAccount,
   PublishAsAccessError,
@@ -118,6 +121,22 @@ export interface CreatePostParams {
    * why the wider "may act for the parent's account" rule is not the same thing.
    */
   continuesOwnThread?: boolean;
+  /**
+   * This post ANSWERS another account, in a thread the same request is composing
+   * whose entries carry different accounts — the second, separate exception.
+   *
+   * Distinct from {@link continuesOwnThread} rather than a looser setting of it,
+   * because the two authorize opposite shapes: that one says "one account, its
+   * own text"; this one says "two accounts the caller operates, talking". A
+   * CHANNEL may use only the first — a channel in a conversation is the thing
+   * `utils/channelReplyGate` refuses at five write sites, with no exception for
+   * its own operators — so {@link assertAnswersOperatedAccount} refuses a channel
+   * at BOTH ends of the link, reading both kinds from the account graph.
+   *
+   * Grants nothing on its own, and never read from a request body, for the same
+   * reasons as {@link continuesOwnThread}.
+   */
+  answersOperatedAccount?: boolean;
   hashtags?: string[];
   mentions?: string[];
   language?: string;
@@ -370,16 +389,22 @@ class PostCreationService {
     // coherent feature, but it is a feature — nothing asks for it, and admitting
     // it here by omission would ship it unconsidered and untested.
     //
-    // ONE EXCEPTION, and it is not "the author may act for the parent's account".
-    // A thread is one text in several parts, and the parts are joined by
-    // `parentPostId`, so every continuation is structurally a reply while being
-    // nothing like a conversation. {@link CreatePostParams.continuesOwnThread}
-    // asks for that case to be VERIFIED — parent and thread root both authored by
-    // the account this post will be — rather than asserted; see
-    // `utils/threadContinuation` for why the wider rule would reopen a channel's
-    // replies to its own operators, which is the thing that cannot happen.
+    // TWO EXCEPTIONS, and neither is "the author may act for the parent's
+    // account". A thread is joined by `parentPostId`, so every entry after the
+    // first is structurally a reply; whether it is a CONVERSATION depends on
+    // whose accounts are at the two ends, which is what the two checks decide:
+    //
+    //   - `continuesOwnThread` — one account, its own text. Verified: parent and
+    //     thread root both authored by the account this post will be.
+    //   - `answersOperatedAccount` — two accounts the caller operates, talking.
+    //     Verified: neither end is a CHANNEL, and the caller may act for the
+    //     parent's account too.
+    //
+    // Both are VERIFIED below rather than asserted, and a channel may only ever
+    // use the first — see `utils/threadContinuation` for why the wider rule would
+    // reopen a channel's replies to its own operators, which cannot happen.
     if (params.publishAsOxyUserId) {
-      if (params.parentPostId && !params.continuesOwnThread) {
+      if (params.parentPostId && !params.continuesOwnThread && !params.answersOperatedAccount) {
         throw new PublishAsAccessError(400, 'A reply cannot be published as another account');
       }
       if (params.boostOf) {
@@ -406,12 +431,26 @@ class PostCreationService {
     // it has to prove is about the RESOLVED author — the account the post will
     // actually carry — and that is not known until the gate has answered. Still
     // before anything is written, like every other refusal here.
-    if (params.publishAsOxyUserId && params.parentPostId && params.continuesOwnThread) {
-      await assertContinuesOwnThread({
-        parentPostId: params.parentPostId,
-        threadId: params.threadId,
-        authorId,
-      });
+    if (params.publishAsOxyUserId && params.parentPostId) {
+      if (params.continuesOwnThread) {
+        await assertContinuesOwnThread({
+          parentPostId: params.parentPostId,
+          threadId: params.threadId,
+          authorId,
+        });
+      } else if (params.answersOperatedAccount) {
+        // `authorKind` is handed over rather than re-resolved: it is the kind the
+        // gate just decided this post's identity on, so the channel test and the
+        // authorization cannot end up disagreeing about what this account is.
+        await assertAnswersOperatedAccount({
+          parentPostId: params.parentPostId,
+          threadId: params.threadId,
+          authorId,
+          authorKind,
+          callerId: params.oxyUserId,
+          memberReader: params.memberReader,
+        });
+      }
     }
 
     await assertLaneAssignable({

--- a/packages/backend/src/services/publishAsAccount.ts
+++ b/packages/backend/src/services/publishAsAccount.ts
@@ -128,13 +128,40 @@ export async function resolveAccountKind(
   oxyUserId: string | null | undefined,
 ): Promise<AccountKind | null> {
   if (!oxyUserId) return null;
+  return (await resolveAccountKinds([oxyUserId])).get(oxyUserId) ?? null;
+}
+
+/**
+ * The kinds behind SEVERAL ids, in one batched identity read.
+ *
+ * The single-id form above is the common case (the reply gate asks about one
+ * author); this exists because deciding whether a thread link is a channel's
+ * asks about two or three accounts at once, and three sequential single reads
+ * would be three round trips to answer one question.
+ *
+ * Ids that do not resolve are ABSENT from the map rather than present with a
+ * `null` — so a caller reading a kind off it gets `undefined` and has to decide
+ * what an unknown account means, instead of one that silently reads as "not a
+ * channel". Fail-soft on error, for the same reason the single form is: see
+ * `utils/channelReplyGate` on why an identity outage must not refuse every reply
+ * on the site.
+ */
+export async function resolveAccountKinds(
+  oxyUserIds: ReadonlyArray<string | null | undefined>,
+): Promise<Map<string, AccountKind>> {
+  const kinds = new Map<string, AccountKind>();
+  const ids = [...new Set(oxyUserIds.filter((id): id is string => Boolean(id)))];
+  if (ids.length === 0) return kinds;
   try {
-    const summaries = await resolveUserSummaries([oxyUserId]);
-    return summaries.get(oxyUserId)?.user.kind ?? null;
+    const summaries = await resolveUserSummaries(ids);
+    for (const id of ids) {
+      const kind = summaries.get(id)?.user.kind;
+      if (kind) kinds.set(id, kind);
+    }
   } catch (error) {
-    logger.warn('[publishAsAccount] Failed to resolve account kind', error);
-    return null;
+    logger.warn('[publishAsAccount] Failed to resolve account kinds', error);
   }
+  return kinds;
 }
 
 /**

--- a/packages/backend/src/utils/threadContinuation.ts
+++ b/packages/backend/src/utils/threadContinuation.ts
@@ -1,7 +1,31 @@
 /**
- * The ONE definition of "this post continues its own author's thread", which is
- * the single narrow exception to "a post published as another account may not be
- * a reply".
+ * The TWO ways a link in a batch-composed thread may be authorized, and nothing
+ * else, against the standing refusal that "a post published as another account
+ * may not be a reply".
+ *
+ *   - {@link assertContinuesOwnThread} — **the account continues its OWN text.**
+ *     One account for the whole thread, root included. This is the only route
+ *     available when a CHANNEL is involved, and it is unchanged.
+ *   - {@link assertAnswersOperatedAccount} — **two accounts the caller operates
+ *     talk to each other.** A thread whose entries carry different accounts, and
+ *     it is refused outright the moment a channel is one of them.
+ *
+ * THE SECOND IS A SECOND CASE, NOT A WIDENING OF THE FIRST, and keeping them
+ * apart is the whole safety property. An entry whose account differs from its
+ * parent's is mechanically account B REPLYING to account A's post — a
+ * conversation between accounts. That is coherent between two organizations the
+ * same person operates, and it is exactly what a channel may never be part of:
+ * "no replies, ever" has no exception for a channel's own operators
+ * (`utils/channelReplyGate`, five write sites). So the channel test below is not
+ * a detail of the second case, it IS the second case's boundary, and it is
+ * checked on BOTH ends — the parent's account and the publishing one. A channel
+ * answering an organization is just as much a channel in a conversation as an
+ * organization answering a channel.
+ *
+ * ------------------------------------------------------------------------
+ *
+ * {@link assertContinuesOwnThread}: "this post continues its own author's
+ * thread".
  *
  * WHY THE EXCEPTION EXISTS. A thread is one text in several parts, not a
  * dialogue. The mechanism that makes the parts a thread is `parentPostId`, so
@@ -29,18 +53,27 @@
  * likes; what it cannot do is make a post it does not own answer to an author it
  * is not.
  *
- * AND THE UNLOCK IS NOT REACHABLE FROM THE PUBLIC REPLY ROUTES ANYWAY. This check
- * is only consulted when `CreatePostParams.continuesOwnThread` is set, which is a
- * SERVICE-level parameter: `POST /posts` builds its params from an explicit
- * whitelist of body fields and never reads one, so no request can ask for it. The
- * three-part check above is what makes the parameter safe to exist; the parameter
- * is what keeps the check off the ordinary reply paths. Neither alone is the
- * guard.
+ * AND THE UNLOCK IS NOT REACHABLE FROM THE PUBLIC REPLY ROUTES ANYWAY. Both
+ * checks are consulted only when their own SERVICE-level parameter is set
+ * (`CreatePostParams.continuesOwnThread` / `answersOperatedAccount`), and
+ * `POST /posts` builds its params from an explicit whitelist of body fields that
+ * names neither — so no request can ask for either. That is what keeps
+ * "reply to anything as an organization" out of the public API: the second case
+ * is a property of a thread being composed in one action, not a new reply
+ * permission. The structural checks are what make the parameters safe to exist;
+ * the parameters are what keep the checks off the ordinary reply paths. Neither
+ * alone is the guard.
  */
 
+import type { AccountKind } from '@oxyhq/contracts';
 import mongoose from 'mongoose';
 import { Post } from '../models/Post';
-import { PublishAsAccessError } from '../services/publishAsAccount';
+import {
+  assertCanPublishAsAccount,
+  PublishAsAccessError,
+  resolveAccountKinds,
+  type AccountMemberReader,
+} from '../services/publishAsAccount';
 
 /**
  * Throw unless this post genuinely continues `authorId`'s own thread.
@@ -106,4 +139,113 @@ export async function assertContinuesOwnThread(params: {
   //    graft its own post onto somebody else's thread and call the result a
   //    continuation.
   if (String(root?.oxyUserId ?? '') !== authorId) refuse();
+}
+
+/**
+ * Throw unless this post may answer, as `authorId`, another account's post in the
+ * SAME batch-composed thread — the second case, for a thread whose entries carry
+ * different accounts.
+ *
+ * FOUR conditions, and the two channel ones are the reason this function is
+ * separate from {@link assertContinuesOwnThread} rather than a relaxed flag on it:
+ *
+ *   1. the parent is in the thread this post declares (the same structural anchor
+ *      the first case uses — what keeps this about a thread being composed rather
+ *      than about replying to anything),
+ *   2. the PARENT's account is not a channel,
+ *   3. the PUBLISHING account is not a channel, and
+ *   4. the caller may act for the parent's account too, on the authority that
+ *      account's kind demands — which is the same gate the publishing account
+ *      already went through, asked a second time about the other end.
+ *
+ * Condition 3 is not implied by condition 2 and dropping it is the subtler
+ * mistake: a channel answering an organization is a channel in a conversation
+ * just as much as the reverse. Both are checked, from the account graph, never
+ * from the request.
+ *
+ * Condition 4 is what stops this being "an account you operate may reply to
+ * anybody". Both ends of the exchange have to be yours; a thread that reaches
+ * outside the caller's own accounts is a conversation with a third party, which
+ * is an ordinary reply and goes through the ordinary reply routes.
+ *
+ * An UNRESOLVABLE account kind refuses. This is the opposite direction from
+ * `utils/channelReplyGate`'s fail-soft, and deliberately so: there, answering
+ * "unknown" as "channel" would refuse every reply on the site during an identity
+ * outage; here, answering it as "not a channel" would admit the one thing this
+ * function exists to refuse, and the cost of being wrong is a thread that has to
+ * be posted again.
+ */
+export async function assertAnswersOperatedAccount(params: {
+  parentPostId: string | null | undefined;
+  threadId: string | null | undefined;
+  authorId: string | null;
+  authorKind: AccountKind | null;
+  callerId: string | null;
+  memberReader: AccountMemberReader | undefined;
+}): Promise<void> {
+  const refuse = (): never => {
+    throw new PublishAsAccessError(400, 'A reply cannot be published as another account');
+  };
+
+  const { parentPostId, threadId, authorId, authorKind, callerId, memberReader } = params;
+  if (!authorId || !parentPostId || !threadId) refuse();
+  if (
+    !mongoose.Types.ObjectId.isValid(String(parentPostId)) ||
+    !mongoose.Types.ObjectId.isValid(String(threadId))
+  ) {
+    refuse();
+  }
+
+  // 3, first — it needs no query. The publishing account's kind was already
+  // resolved by the authorization gate, so a channel is refused before anything
+  // is read. `null` here means the post is the CALLER's own (the gate resolves no
+  // kind when no account was named), which is not a channel by construction: a
+  // channel has no login, so it can never be the authenticated subject.
+  if (authorKind === 'channel') refuse();
+
+  const rows = await Post.find({ _id: { $in: [parentPostId, threadId] } })
+    .select('oxyUserId threadId')
+    .lean<Array<{ _id: mongoose.Types.ObjectId; oxyUserId?: string; threadId?: string }>>();
+
+  const byId = new Map(rows.map((row) => [String(row._id), row]));
+  const parent = byId.get(String(parentPostId));
+  const root = byId.get(String(threadId));
+
+  // NO existence or emptiness guard here, and that is a measured decision rather
+  // than an oversight. An absent parent or root reads as an empty account id,
+  // `resolveAccountKinds` drops falsy ids, so the kind lookup below finds nothing
+  // for it and refuses on the unknown-kind rule. Two such guards were written
+  // here first — one of them with a comment asserting it was load-bearing in this
+  // case — and mutation-testing showed nothing could tell either one's presence
+  // from its absence. A line that reads as a guard while guarding nothing is
+  // worse than no line, because the next reader budgets trust for it.
+  const parentAuthorId = String(parent?.oxyUserId ?? '');
+
+  // 1. The parent is in the declared thread — its root, or a link anchored on it.
+  if (String(parentPostId) !== String(threadId) && String(parent?.threadId ?? '') !== String(threadId)) {
+    refuse();
+  }
+
+  // 2, plus the ROOT for the same reason. A thread is one object: a channel
+  // sitting at its head makes every later entry an answer to a channel, whichever
+  // post is the immediate parent. One batched identity read for both.
+  const rootAuthorId = String(root?.oxyUserId ?? '');
+  const kinds = await resolveAccountKinds([parentAuthorId, rootAuthorId]);
+  for (const accountId of [parentAuthorId, rootAuthorId]) {
+    // An account the caller themselves owns resolves as `personal`; only an id
+    // that resolves to NOTHING is unknown, and unknown refuses — see the note on
+    // failing closed above.
+    if (!kinds.has(accountId)) refuse();
+    if (kinds.get(accountId) === 'channel') refuse();
+  }
+
+  // 4. The other end is the caller's to speak for as well. Reuses the ONE
+  // authorization gate rather than re-deriving membership — including its early
+  // return when the parent's account IS the caller's own, which is the ordinary
+  // "I started the thread, my organization answers me" shape.
+  await assertCanPublishAsAccount({
+    publishAsOxyUserId: parentAuthorId,
+    callerId,
+    memberReader,
+  });
 }

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -776,18 +776,21 @@ export interface CreateThreadPostRequest {
   /**
    * Publish THIS entry as another Oxy account the caller operates — the same
    * field, the same authorization and the same effects as
-   * {@link CreatePostRequest.publishAsOxyUserId}, decided per entry so one batch
-   * can post from several accounts.
+   * {@link CreatePostRequest.publishAsOxyUserId}, decided per entry.
    *
-   * **`beast` mode only.** In `beast` mode the entries are independent top-level
-   * posts, so each may name its own account and they may all differ. In `thread`
-   * mode they are one conversation whose continuations are REPLIES to the entry
-   * before them, and a reply can never be published as another account — so the
-   * server refuses the field outright there (400) rather than letting the author
-   * believe an identity was applied that a mid-thread post could not carry.
+   * Accepted in BOTH modes, and it wins over
+   * {@link CreateThreadRequest.publishAsOxyUserId} for the entry that carries it.
+   * In `beast` mode the entries are independent posts, so this is the only way to
+   * name an account. In `thread` mode entries carrying different accounts make the
+   * thread a CONVERSATION between them — each such entry mechanically replies to
+   * the one before it — which is coherent between organizations the caller
+   * operates and is refused outright when a CHANNEL is one of them: a channel's
+   * thread must use one account for every entry, because a post from a second
+   * account would be a reply to the channel, and a channel takes none from anyone.
    *
-   * Refused for the WHOLE request before any entry is written, like every other
-   * batch-level refusal here: half a batch cannot be undone in one action.
+   * Every refusal is raised for the WHOLE request before any entry is written,
+   * like every other batch-level refusal here: half a batch cannot be undone in
+   * one action.
    */
   publishAsOxyUserId?: string;
 }
@@ -808,14 +811,14 @@ export interface CreateThreadRequest {
    * for every entry, authorized once. Same field, same authorization and same
    * effects as {@link CreatePostRequest.publishAsOxyUserId}.
    *
-   * **`thread` mode only, and it is deliberately the OPPOSITE placement from
-   * beast mode's.** A thread is one text in several parts, so there is exactly one
-   * publisher by construction and an identity that changed mid-thread would be
-   * incoherent — hence batch-level here, and a per-entry
-   * {@link CreateThreadPostRequest.publishAsOxyUserId} is refused (400). A beast
-   * batch is n independent posts, so it is the other way round: per entry, and
-   * this field is refused there. Each mode has exactly one way to say it, so a
-   * client can never send both and have to discover which won.
+   * **`thread` mode only** — a beast batch has no thread to speak for, so the
+   * field is refused there (400) and each entry names its own account instead.
+   *
+   * It is the DEFAULT rather than the last word: an entry carrying its own
+   * {@link CreateThreadPostRequest.publishAsOxyUserId} overrides it, which is what
+   * makes a thread whose entries come from different accounts expressible. Naming
+   * it here alone is the one-voice thread, and that is the ONLY shape a `channel`
+   * may take.
    *
    * The continuations are stored as replies to their predecessor, which is how a
    * thread is joined at all — `PostCreationService` verifies each one against the


### PR DESCRIPTION
A thread could go out under **one** account. It may now use several — but only when **no channel is involved anywhere in it**.

An entry naming a different account than its parent is, mechanically, that account **replying** to the other's post. Between organizations the caller operates that is a coherent conversation. With a channel it is the thing "no replies, ever" forbids, and no operator is an exception.

## Two cases, not one widened

**Case 1** (an account continuing its OWN thread) is untouched, and stays the only path when a channel is involved. Widening it is what would let any operator answer under any of a channel's posts.

**Case 2** is a separate function. Four conditions, all read from the database:

1. the parent is in the declared thread;
2. the **parent's** account is not a channel — **and neither is the root's**, because a channel at the head makes every later entry an answer to it, whichever post is the immediate parent;
3. the **publishing** account is not a channel — a channel answering an organization is equally a channel in a conversation;
4. the caller may act for the parent's account too, through the same authority as everything else (membership for a channel, `account:act_as` for the assumable kinds).

An unknown kind **refuses**, the opposite of `channelReplyGate`'s fail-soft. There, treating unknown as a channel would refuse every reply on the site during an outage; here, treating unknown as not-a-channel admits precisely what this exists to refuse.

## The trigger is thread-scoped, not pairwise

Broader than a literal "differs from its parent", and strictly inside the same boundary. Taken literally, `[org A, org B, org B]` breaks: entry 3 matches its parent, so case 2 would not apply, and case 1 refuses it because its third condition is about the **root**. An organization could answer but could not say two paragraphs.

The root rules the thread, enforced over the whole batch rather than per link, and the refusal **names the offending channel** rather than only saying no.

Thread mode takes both placements — batch-level default, per-entry override. Beast still refuses batch-level, and may still mix a channel freely, because no entry there replies to another.

## Mutations: 12/12, and three were vacuous first time

Both mandatory ones are caught by named guards — an entry naming another account when the parent **is** a channel, and dropping the **publishing**-account test. Re-mutated independently before merge: blanking the publishing-account guard fails two named tests.

The three vacuous ones matter more than the nine that worked:

- the whole service branch could be **deleted** with the suite green — nothing covered its wiring;
- the unknown-kind refusal needed the **root** unknown, not the parent, since the parent is refused by condition 4 anyway;
- two existence guards carried a comment claiming they were load-bearing when an absent row already reads as an empty id and is refused. **That repeats a mistake recorded last round**, so the comment now says so where it happened.

## Verification

Backend **419 files / 4577 tests** · `tsc` clean across backend, frontend, mcp, e2e, shared-types.

## Known

`createThread` still passes `skipFederationDelivery: true`, so a cross-account thread emits no outbound AP — pre-existing, but a conversation between two organizations the fediverse never sees is a stranger outcome than a single post that does not federate. And the composer still gates publish-as on `threadItems.length === 0`, so none of this is reachable from the UI yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
