### PR TITLE
fix(test): cut the mention-summary chain that broke a toolbar suite

### DIFF
--- a/packages/frontend/components/Compose/__tests__/ComposeThreadItemToolbar.test.tsx
+++ b/packages/frontend/components/Compose/__tests__/ComposeThreadItemToolbar.test.tsx
@@ -59,6 +59,16 @@ jest.mock('@oxyhq/bloom/pressable-scale', () => {
   return { PressableScale: TouchableOpacity };
 });
 
+// Cut at the component boundary, like the header and the text input below.
+// `ComposeMentionSummary` reaches `useProfileLinkMentions` -> `utils/api` ->
+// `lib/oxyServices`, which is ESM and blows the suite up before a single case
+// runs — and this file is about which CONTROLS a box draws, so the summary is
+// noise either way. The chain appeared under it without this file changing.
+jest.mock('@/components/Compose/ComposeMentionSummary', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 jest.mock('@/components/Compose/ComposeIdentityHeader', () => {
   const { View: RNView } = jest.requireActual<typeof import('react-native')>('react-native');
   return { __esModule: true, default: RNView };


### PR DESCRIPTION
`main` is red on **Test frontend**. `ComposeThreadItemToolbar.test.tsx` fails to **run**:

```
SyntaxError: Cannot use import statement outside a module
  at lib/oxyServices.ts → utils/api.ts → hooks/useProfileLinkMentions.ts
  → components/Compose/ComposeMentionSummary.tsx → components/Compose/ComposeThreadItem.tsx
```

**Neither side is wrong on its own**, which is why nothing caught it before merge: the test landed in `53ee2b3f` with CI green, and `e15ac552` added the mention-summary chain under the component it renders. CI went red at that commit without either change touching the other — both PRs were green in isolation.

Cut at the **component boundary**, exactly as this file already does for `ComposeIdentityHeader` and `MentionTextInput`, rather than mocking `utils/api` deep in the chain. The suite is about which *controls* a box draws, so the mention summary is noise to it either way — and a boundary mock does not have to be revisited the next time the chain under it changes.

**137 suites / 1233 tests green**, coverage thresholds met.

Unblocks `main` and #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)