### PR TITLE
refactor(profile): a channel gets its own screen, and the primitives are shared

### DIFF
--- a/packages/frontend/app/(app)/c/[username].tsx
+++ b/packages/frontend/app/(app)/c/[username].tsx
@@ -1,24 +1,25 @@
 import React from 'react';
-import ProfileScreen from '@/components/ProfileScreen';
+import ChannelScreen from '@/components/ChannelScreen';
 
 /**
  * ONE channel's page.
  *
  * A channel is an Oxy ACCOUNT, so its page is that account's profile and its
- * feed is that account's author feed — the same screen every other profile
- * renders, reached through a different URL. There is nothing bespoke here on
- * purpose: a second implementation of a profile is a second place for the
- * identity rules to drift.
+ * feed is that account's author feed — but it is NOT the same screen a person
+ * gets. `ChannelScreen` composes the shared profile primitives (the account
+ * lookup, the chrome, the body, the canonicalization) with what a channel
+ * actually is: four tabs, a compact header, no banner, no poke, and the
+ * operator's way in to its settings.
  *
  * `/c/<handle>` stays distinct from `/@<handle>` because a channel is a
- * different kind of thing to follow, and the URL should say so. `ProfileScreen`
- * canonicalizes between the two off the resolved account's `kind`, so a person
- * cannot be sat on at `/c/` and a channel cannot be sat on at `/@`.
+ * different kind of thing to follow, and the URL should say so. Both screens
+ * canonicalize through the SAME `canonicalProfileHref`, so a person cannot be
+ * sat on at `/c/` and a channel cannot be sat on at `/@` — and neither screen
+ * can disagree with the other about which way to send a reader.
  *
  * The segment is named `[username]`, not `[handle]`, because that is what it
- * is: a channel account's handle IS its Oxy username, and the shared screen
- * reads exactly that param.
+ * is: a channel account's handle IS its Oxy username.
  */
 export default function ChannelAccountRoute() {
-    return <ProfileScreen tab="posts" />;
+    return <ChannelScreen />;
 }

--- a/packages/frontend/components/ChannelScreen.tsx
+++ b/packages/frontend/components/ChannelScreen.tsx
@@ -1,0 +1,459 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { View, Share } from 'react-native';
+import { Redirect, router } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+import { BloomColorScope } from '@oxyhq/bloom/theme';
+import { useTranslation } from 'react-i18next';
+import { FollowButton as OxyFollowButton, useAuth, useFollow } from '@oxyhq/services/ui/client';
+import type { AccountNode } from '@oxyhq/core';
+import { lanesService } from '@/services/lanesService';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import { logger } from '@oxyhq/core/logger';
+import type { ProfileData } from '@/hooks/useProfileData';
+
+// Icons
+import { Bell, BellActive } from '@/assets/icons/bell-icon';
+import { Icon } from '@/lib/icons';
+import { ShareIcon } from '@/assets/icons/share-icon';
+import { MoreIcon } from '@/assets/icons/more-icon';
+
+// Components
+import UserName from './UserName';
+import AnimatedTabBar from './common/AnimatedTabBar';
+import { IconButton } from '@/components/ui/Button';
+import { SEO } from '@/components/SEO';
+
+// Profile primitives
+import {
+    ChannelActions,
+    ChannelHeader,
+    ProfileContent,
+    ProfileShell,
+    useSubscription,
+    useProfileAccount,
+    useProfileChrome,
+    useProfileMoreMenu,
+    useJustFollowed,
+    buildProfileTabDescriptors,
+    profileTabIndex,
+    type LaneTabInput,
+    type ProfileTab,
+} from './Profile';
+import { SuggestedUsers } from './suggestions/SuggestedUsers';
+
+interface ChannelProfileProps {
+    username: string;
+    handle: string;
+    profileData: ProfileData | null;
+    loading: boolean;
+}
+
+/**
+ * ONE CHANNEL's page, at `/c/<handle>`.
+ *
+ * A channel is an Oxy ACCOUNT that people follow WITHOUT following the people
+ * who write for it, and its page is that account's author feed. It shares the
+ * chrome, the body, the account lookup and the canonicalization with a person's
+ * profile — those are the same job — and nothing else, because almost every
+ * other affordance on a profile is addressed to a human who can be signed in.
+ *
+ * What is ABSENT here is absent structurally, not suppressed by a flag:
+ *
+ * - **No banner.** `UpdateAccountInput` has no banner field, so there is nothing
+ *   to set and no band left empty.
+ * - **No poke.** A poke is addressed to a person; `isActAsEligibleKind` refuses
+ *   `channel`, so no human is ever signed in as one to receive it.
+ * - **No self view.** For the same reason, `isOwnProfile` can never be true for
+ *   a channel — so no edit/analytics/settings cluster, no "your own lanes"
+ *   button beside the tabs, and no fediverse badge (which is own-profile only).
+ * - **No DM.** `/ai` messages a person's Mention inbox; a channel has none.
+ * - **No "Follows you" tag.** A channel cannot follow anybody, since following
+ *   requires a session it can never have.
+ * - **Four tabs, not nine.** `profileTabsForAccountKind` drops the five a channel
+ *   account can never fill; see its docstring for the three separate reasons.
+ * - **No tab in the URL.** `/c/<handle>` is ONE route with no sub-tabs beneath
+ *   it, so its tabs are local state. Writing `/@<handle>/media` here would
+ *   navigate a channel out of its own URL family.
+ *
+ * What is ADDED is the operator's way in: a channel has no login, so its
+ * settings are reachable only from the overflow menu of whoever operates it.
+ */
+const ChannelProfile: React.FC<ChannelProfileProps> = ({
+    username,
+    handle,
+    profileData,
+    loading,
+}) => {
+    const { user: currentUser, oxyServices } = useAuth();
+    const { t } = useTranslation();
+
+    const [activeTabKey, setActiveTabKey] = useState<string>('posts');
+
+    // A lane's owner is an `oxyUserId` and a channel account is one, so a channel
+    // has lanes like any other publisher.
+    const { data: laneTabs = [] } = useQuery<LaneTabInput[]>({
+        queryKey: viewerQueryKeys.lanesForOwner(currentUser?.id, profileData?.id),
+        enabled: Boolean(profileData?.id),
+        queryFn: async () => {
+            const lanes = await lanesService.listForOwner(profileData?.id ?? '');
+            return lanes.map((lane) => ({ id: lane.id, name: lane.name }));
+        },
+    });
+
+    const tabDescriptors = useMemo(
+        () =>
+            buildProfileTabDescriptors(
+                {
+                    posts: t('profile.tabs.posts'),
+                    replies: t('profile.tabs.replies'),
+                    media: t('profile.tabs.media'),
+                    videos: t('profile.tabs.videos'),
+                    likes: t('profile.tabs.likes'),
+                    boosts: t('profile.tabs.boosts'),
+                    feeds: t('profile.tabs.feeds', { defaultValue: 'Feeds' }),
+                    starter_packs: t('profile.tabs.starter_packs', { defaultValue: 'Starter Packs' }),
+                    lists: t('profile.tabs.lists', { defaultValue: 'Lists' }),
+                },
+                laneTabs,
+                'channel',
+            ),
+        [t, laneTabs],
+    );
+
+    const activeTab = profileTabIndex(tabDescriptors, activeTabKey);
+    const activeDescriptor = tabDescriptors[activeTab];
+    const activeProfileTab: ProfileTab = activeDescriptor?.tab ?? 'posts';
+    const activeLaneId = activeDescriptor?.laneId;
+
+    const stableUserId = profileData?.id || '';
+    const {
+        followerCount: rawFollowerCount,
+        followingCount: rawFollowingCount,
+        isFollowing: isFollowingChannel = false,
+    } = useFollow(stableUserId);
+
+    // Following a channel is as good a moment to suggest similar accounts as
+    // following a person — the card is about the account just followed, and a
+    // channel is one.
+    const justFollowed = useJustFollowed(stableUserId, isFollowingChannel);
+
+    const { subscribed, loading: subLoading, toggle: toggleSubscription } = useSubscription(
+        profileData?.id,
+        currentUser?.id,
+        false,
+    );
+
+    // Whether the viewer OPERATES this channel, which is what puts its settings
+    // in reach. A channel account has no login of its own, so there is no other
+    // signal on the profile itself. This query is the reason the check lives on
+    // the channel screen and not in the shared lookup: the account graph is a
+    // real request, and a person's profile would pay for it to answer a question
+    // that can only ever be no.
+    const operatedAccountsQuery = useQuery<AccountNode[]>({
+        queryKey: viewerQueryKeys.operatedAccounts(currentUser?.id),
+        queryFn: () => oxyServices.listAccounts(),
+        enabled: Boolean(currentUser?.id) && Boolean(profileData?.id),
+    });
+    const operatesThisChannel = Boolean(
+        profileData?.id &&
+        operatedAccountsQuery.data?.some((account) => account.accountId === profileData.id),
+    );
+
+    // The chrome's compact-header offsets and the scrolled-name overlay both need
+    // to know how wide the icon cluster is: subscribe + share + more.
+    const chrome = useProfileChrome({
+        profileId: profileData?.id,
+        currentTab: activeProfileTab,
+        currentLaneId: activeLaneId,
+        headerActionCount: 3,
+        hasBannerBand: false,
+    });
+
+    const onTabPress = useCallback(
+        (index: number) => {
+            const descriptor = tabDescriptors[index];
+            if (!descriptor) return;
+            setActiveTabKey(descriptor.key);
+        },
+        [tabDescriptors],
+    );
+
+    const scrollOrSwitch = useCallback(
+        (key: string) => {
+            const index = profileTabIndex(tabDescriptors, key);
+            if (index === activeTab) {
+                chrome.scrollToContent(chrome.contentHeight);
+            } else {
+                onTabPress(index);
+            }
+        },
+        [activeTab, chrome, onTabPress, tabDescriptors],
+    );
+
+    const handlePostsPress = useCallback(() => scrollOrSwitch('posts'), [scrollOrSwitch]);
+    const handleBoostsPress = useCallback(() => scrollOrSwitch('boosts'), [scrollOrSwitch]);
+    // A channel has no replies tab, so the replies stat is never rendered and
+    // this can never fire — `ProfileContent` still requires the handler, so it
+    // jumps to `posts` rather than to a tab that is not there.
+    const handleRepliesPress = handlePostsPress;
+
+    const handleShare = useCallback(async () => {
+        if (!profileData) return;
+        try {
+            const shareUrl = `https://mention.earth/c/${handle}`;
+            const shareMessage = t('profile.share.message', {
+                name: profileData.design.displayName,
+                defaultValue: `Check out ${profileData.design.displayName}'s profile on Mention!`,
+            });
+            await Share.share({
+                message: `${shareMessage}\n\n${shareUrl}`,
+                url: shareUrl,
+                title: t('profile.share.title', {
+                    name: profileData.design.displayName,
+                    defaultValue: `${profileData.design.displayName} on Mention`,
+                }),
+            });
+        } catch {
+            logger.error('Error sharing channel');
+        }
+    }, [profileData, handle, t]);
+
+    // Operators only, and first: it is the one action in the menu that is about
+    // running this account rather than about the viewer's relationship to it.
+    // Everyone else never sees a row that would refuse them.
+    const leadingActions = useMemo(
+        () =>
+            operatesThisChannel
+                ? [
+                    {
+                        icon: <Icon name="settings-outline" size={22} className="text-foreground" />,
+                        label: t('channels.settings.title', { defaultValue: 'Channel settings' }),
+                        onPress: () => router.push(`/c/${handle}/settings`),
+                    },
+                ]
+                : undefined,
+        [operatesThisChannel, handle, t],
+    );
+
+    const handleMoreOptions = useProfileMoreMenu({
+        profileData,
+        isOwnProfile: false,
+        leadingActions,
+    });
+
+    // A channel is an Oxy account like any other, so its visibility setting is
+    // readable even though the channel-settings screen does not offer one today.
+    // Read rather than assumed: hardcoding "public" would silently expose a
+    // channel somebody had restricted through another surface.
+    const isPrivate = Boolean(
+        profileData?.privacy?.profileVisibility === 'private' ||
+        profileData?.privacy?.profileVisibility === 'followers_only',
+    );
+
+    const identity = useMemo(() => {
+        if (!profileData) return null;
+        return (
+            <>
+                <ChannelHeader
+                    displayName={profileData.design.displayName}
+                    username={profileData.username}
+                    avatarUri={profileData.design.avatar}
+                    verified={profileData.verified}
+                    isPrivate={isPrivate}
+                    privacySettings={profileData.privacy}
+                    profileId={profileData.id}
+                    UserNameComponent={UserName}
+                />
+                <View className="mt-3 mb-2">
+                    <ChannelActions
+                        profileId={profileData.id}
+                        isFollowing={profileData.isFollowing}
+                        FollowButtonComponent={OxyFollowButton}
+                    />
+                </View>
+            </>
+        );
+    }, [profileData, isPrivate]);
+
+    const summary = useMemo(() => {
+        if (!profileData) return null;
+        return (
+            <View>
+                <ProfileContent
+                    profileData={profileData}
+                    isOwnProfile={false}
+                    isPrivate={isPrivate}
+                    followingCount={rawFollowingCount ?? 0}
+                    followerCount={rawFollowerCount ?? 0}
+                    profileHandle={handle}
+                    identity={identity}
+                    showReplies={false}
+                    // A channel's secondary surfaces live in the PERSON URL
+                    // family today: `/c/<handle>` has no `about`, `followers` or
+                    // `following` route of its own, and those screens read an
+                    // account by handle without caring what kind it is. Pointing
+                    // at them keeps the rows working; giving the channel family
+                    // its own sub-routes is a separate decision, not something to
+                    // fake here.
+                    aboutHref={`/@${handle}/about`}
+                    followingHref={`/@${handle}/following`}
+                    followersHref={`/@${handle}/followers`}
+                    onPostsPress={handlePostsPress}
+                    onBoostsPress={handleBoostsPress}
+                    onRepliesPress={handleRepliesPress}
+                    onLayout={chrome.setContentHeight}
+                />
+                <SuggestedUsers visible={justFollowed} sourceUserId={profileData.id} />
+            </View>
+        );
+    }, [
+        chrome.setContentHeight,
+        justFollowed,
+        handle,
+        handleBoostsPress,
+        handlePostsPress,
+        handleRepliesPress,
+        identity,
+        isPrivate,
+        profileData,
+        rawFollowerCount,
+        rawFollowingCount,
+    ]);
+
+    const tabBar = useMemo(
+        () => (
+            <View className="flex-row items-center border-b border-border bg-background">
+                <View className="flex-1" style={{ minWidth: 0 }}>
+                    <AnimatedTabBar
+                        tabs={tabDescriptors.map((descriptor) => ({
+                            id: descriptor.key,
+                            label: descriptor.label,
+                        }))}
+                        activeTabId={activeDescriptor?.key ?? 'posts'}
+                        onTabPress={(id) => onTabPress(profileTabIndex(tabDescriptors, id))}
+                        scrollEnabled
+                        instanceId={username || 'default'}
+                    />
+                </View>
+            </View>
+        ),
+        [activeDescriptor?.key, onTabPress, tabDescriptors, username],
+    );
+
+    const headerActions = (
+        <>
+            {/* The bell is a toggle rendered as two different glyphs, so its
+                label has to carry the state a sighted user reads from the icon. */}
+            <IconButton
+                variant="icon"
+                onPress={toggleSubscription}
+                disabled={subLoading}
+                accessibilityLabel={
+                    subscribed
+                        ? t('profile.actions.unsubscribe', {
+                            handle,
+                            defaultValue: 'Stop notifying me about new posts from @{{handle}}',
+                        })
+                        : t('profile.actions.subscribe', {
+                            handle,
+                            defaultValue: 'Notify me about new posts from @{{handle}}',
+                        })
+                }
+            >
+                {subscribed ? (
+                    <BellActive size={18} className="text-primary" />
+                ) : (
+                    <Bell size={18} className="text-foreground" />
+                )}
+            </IconButton>
+            <IconButton
+                variant="icon"
+                onPress={handleShare}
+                accessibilityLabel={t('profile.actions.share', {
+                    handle,
+                    defaultValue: "Share @{{handle}}'s profile",
+                })}
+            >
+                <ShareIcon size={18} className="text-foreground" />
+            </IconButton>
+            <IconButton
+                variant="icon"
+                onPress={handleMoreOptions}
+                accessibilityLabel={t('profile.actions.more', {
+                    handle,
+                    defaultValue: 'More options for @{{handle}}',
+                })}
+            >
+                <MoreIcon size={18} className="text-foreground" />
+            </IconButton>
+        </>
+    );
+
+    return (
+        <>
+            {profileData ? (
+                <SEO
+                    title={t('seo.profile.title', {
+                        name: profileData.design.displayName,
+                        username,
+                        defaultValue: `${profileData.design.displayName} (@${username}) on Mention`,
+                    })}
+                    description={t('seo.profile.description', {
+                        name: profileData.design.displayName,
+                        bio: profileData.bio ?? '',
+                        defaultValue: `View ${profileData.design.displayName}'s profile on Mention.`,
+                    })}
+                    image={profileData.design.avatar}
+                    type="profile"
+                />
+            ) : null}
+            <ProfileShell
+                chrome={chrome}
+                loading={loading}
+                profileData={profileData}
+                banner={null}
+                headerActions={headerActions}
+                summary={summary}
+                tabBar={tabBar}
+                tabs={{
+                    tab: activeProfileTab,
+                    laneId: activeLaneId,
+                    profileId: profileData?.id,
+                    isPrivate,
+                    isOwnProfile: false,
+                    isFederated: false,
+                }}
+            />
+        </>
+    );
+};
+
+const ChannelScreen: React.FC = () => {
+    const { username, handle, profileData, loading, colorName, canonicalHref } =
+        useProfileAccount('channel');
+
+    // A `/c/<handle>` that names a person is a URL nobody should keep. The rule
+    // itself lives in `profileRoute.ts`, shared with the person screen, so the
+    // two can never send a reader back and forth between them.
+    if (canonicalHref) {
+        return <Redirect href={canonicalHref} />;
+    }
+
+    return (
+        <BloomColorScope colorPreset={colorName} asChild>
+            {/* `web:z-auto` so this wrapper does not become its own stacking
+                context and trap the sticky header chrome below the panel's
+                bleed-mask/border overlays (see ProfileShell's root). */}
+            <View className="flex-1 bg-background web:z-auto">
+                <ChannelProfile
+                    username={username}
+                    handle={handle}
+                    profileData={profileData}
+                    loading={loading}
+                />
+            </View>
+        </BloomColorScope>
+    );
+};
+
+export default ChannelScreen;

--- a/packages/frontend/components/Profile/ChannelHeader.tsx
+++ b/packages/frontend/components/Profile/ChannelHeader.tsx
@@ -1,0 +1,120 @@
+import React, { memo } from 'react';
+import { View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useTheme } from '@oxyhq/bloom/theme';
+import { ZoomableAvatar } from '@/components/ZoomableAvatar';
+import { LiveAvatar } from '@/components/ui/LiveAvatar';
+import { MEDIA_VARIANT_AVATAR_LG } from '@mention/shared-types/post';
+import { useLiveUsers } from '@/hooks/useLiveUsers';
+import { PresenceIndicator } from '@/components/PresenceIndicator';
+import { PrivateBadge } from './PrivateBadge';
+import type { ChannelActionsProps, ChannelHeaderProps } from './types';
+
+/**
+ * A CHANNEL's profile header: name on the left, a 70px avatar on the right.
+ *
+ * The compact shape is not a style preference — it is what a channel IS. There
+ * is no banner because `UpdateAccountInput` has no banner field to set, so the
+ * layout has no band for one rather than an empty band; and the avatar does not
+ * collapse on scroll because there is no banner for it to overlap in the first
+ * place. This used to be `ProfileHeaderMinimalist`, selected by a
+ * `design.minimalistMode` flag that was itself defined as `kind === 'channel'` —
+ * a layout name for an account fact, which is exactly the confusion this split
+ * removes.
+ */
+export const ChannelHeader = memo(function ChannelHeader({
+  displayName,
+  username,
+  avatarUri,
+  verified,
+  isPrivate,
+  privacySettings,
+  profileId,
+  UserNameComponent,
+  trailingBadge,
+}: ChannelHeaderProps) {
+  const theme = useTheme();
+  const { isLive } = useLiveUsers();
+  const isProfileLive = isLive(profileId);
+  return (
+    <View className="flex-row justify-between items-start mb-4 relative w-full gap-4">
+      <View className="flex-1">
+        <UserNameComponent
+          name={displayName}
+          handle={username}
+          verified={false}
+          variant="default"
+          trailingBadge={trailingBadge}
+          style={{
+            name: { fontSize: 24, fontWeight: 'bold' as const, marginTop: 10, marginBottom: 4 },
+            handle: { fontSize: 15, marginBottom: 12 },
+            container: undefined,
+          }}
+        />
+        {isPrivate && <PrivateBadge privacySettings={privacySettings} />}
+      </View>
+      <View className="relative">
+        {isProfileLive ? (
+          <View className="border-[3px] border-background bg-secondary rounded-full">
+            <LiveAvatar
+              userId={profileId}
+              source={avatarUri ?? undefined}
+              size={70}
+              variant={MEDIA_VARIANT_AVATAR_LG}
+            />
+          </View>
+        ) : (
+          <ZoomableAvatar
+            source={avatarUri}
+            size={70}
+            className="border-[3px] border-background bg-secondary"
+            style={{ width: 70, height: 70, borderRadius: 35 }}
+            imageStyle={{}}
+          />
+        )}
+        {verified && (
+          <View
+            className="absolute rounded-[10px] p-0.5 bg-background"
+            style={{ left: -6, bottom: -2 }}
+          >
+            <Ionicons name="checkmark-circle" size={18} color={theme.colors.primary} />
+          </View>
+        )}
+        {profileId && (
+          <PresenceIndicator
+            userId={profileId}
+            size="small"
+            style={{ position: 'absolute', bottom: 2, right: 2 }}
+          />
+        )}
+      </View>
+    </View>
+  );
+});
+
+/**
+ * The follow control under a channel's header.
+ *
+ * There is no poke here, and its absence is structural rather than suppressed: a
+ * poke is addressed to a person, and a channel account can never be signed in as
+ * (`isActAsEligibleKind` refuses the kind), so no human is ever at the other end
+ * to receive one. The row could not exist, which is why this component simply
+ * does not render one rather than hiding it behind a flag.
+ *
+ * There is no self view either. `isOwnProfile` is unreachable for a channel for
+ * the same reason — nobody is signed in as one — so an "Edit profile" branch
+ * would be dead code. An OPERATOR configures a channel from
+ * `/c/<handle>/settings`, reached from the profile's overflow menu.
+ */
+export const ChannelActions = memo(function ChannelActions({
+  profileId,
+  isFollowing,
+  FollowButtonComponent,
+}: ChannelActionsProps) {
+  if (!profileId) return null;
+  return (
+    <View className="flex-row items-center gap-3">
+      <FollowButtonComponent userId={profileId} initiallyFollowing={isFollowing} />
+    </View>
+  );
+});

--- a/packages/frontend/components/Profile/ProfileContent.tsx
+++ b/packages/frontend/components/Profile/ProfileContent.tsx
@@ -1,26 +1,16 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import { View, Text, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useTranslation } from 'react-i18next';
-import UserName from '@/components/UserName';
 import { LinkifiedText } from '@/components/common/LinkifiedText';
-import {
-  ProfileHeaderDefault,
-  ProfileHeaderMinimalist,
-  ProfileActions,
-} from './ProfileHeader';
 import { ProfileStats } from './ProfileStats';
 import { ProfileMeta } from './ProfileMeta';
 import { LinkSummary } from './LinkSummary';
 import { ProfileMedia } from './ProfileMedia';
 import { FollowedByRow } from './FollowedByRow';
 import { ProfileCommunities } from './ProfileCommunities';
-import { PrivateBadge } from './PrivateBadge';
-import { LAYOUT, profileTabsForAccountKind } from './types';
+import { LAYOUT } from './types';
 import type { ProfileContentProps } from './types';
-import { getNormalizedUserHandle } from '@oxyhq/core';
-import { useAuth } from '@oxyhq/services/ui/client';
-import { FediverseSharingBadge } from '@/components/Fediverse/FediverseBadge';
 import { mergeBioAndProfileLinks } from '@/utils/mergeBioAndProfileLinks';
 import { useAppearanceStore } from '@/stores/appearanceStore';
 import { useExpandableText } from '@/hooks/useExpandableText';
@@ -29,160 +19,78 @@ import { useExpandableText } from '@/hooks/useExpandableText';
 const BIO_COLLAPSE_CHARS = 200;
 
 /**
- * Main profile content section
- * Contains header, bio, meta info, stats, and communities
+ * Everything on a profile page between the identity block and the tab strip.
+ *
+ * Shared by both profile screens, and the sharing is the point: bio, joined
+ * date, follow-graph stats, pinned media, mutual followers, links and
+ * communities are the same reading of an account whoever it belongs to. What
+ * differs — which header, which URL family the rows link into, whether a
+ * replies stat is honest — arrives as props, so there is one implementation of
+ * each row rather than one per screen.
  */
 export const ProfileContent = memo(function ProfileContent({
   profileData,
-  avatarUri,
   isOwnProfile,
   isPrivate,
-  currentUsername,
   followingCount,
   followerCount,
-  username,
-  FollowButtonComponent,
+  profileHandle,
+  identity,
+  showReplies,
+  aboutHref,
+  followingHref,
+  followersHref,
   onPostsPress,
   onBoostsPress,
   onRepliesPress,
   onLayout,
 }: ProfileContentProps) {
   const { t } = useTranslation();
-  const { user, isAuthenticated } = useAuth();
   const design = profileData.design;
-  const minimalistMode = design.minimalistMode;
-  // Own, non-federated profile opted into fediverse sharing (absent flag ⇒ on):
-  // a tappable badge next to the handle explaining the fediverse.
-  const fediverseBadge =
-    isOwnProfile && !profileData.isFederated && user?.fediverseSharing !== false ? (
-      <FediverseSharingBadge size={20} />
-    ) : undefined;
-  // Passive "Follows you" tag rendered inline to the right of the @handle when
-  // this profile follows the viewer. Requires an authenticated viewer (a signed-
-  // out visitor has no "you") and is never shown on the viewer's own profile.
-  const followsYouTag =
-    !isOwnProfile && isAuthenticated && profileData.followsYou ? (
-      <View className="bg-secondary px-2 py-0.5 rounded-full">
-        <Text className="text-secondary-foreground text-xs font-medium" numberOfLines={1}>
-          {t('profile.followsYou', { defaultValue: 'Follows you' })}
-        </Text>
-      </View>
-    ) : undefined;
-  const profileHandle = getNormalizedUserHandle({
-    username: profileData.username || username,
-    instance: profileData.instance,
-    isFederated: profileData.isFederated,
-  }) || username;
-  const collapseLongBio = useAppearanceStore((s) => s.mySettings?.appearance?.collapseLongBio) ?? true;
+  const collapseLongBio =
+    useAppearanceStore((s) => s.mySettings?.appearance?.collapseLongBio) ?? true;
   // `collapseLongBio` is passed as the reset key so toggling it in Settings
   // collapses the bio back to false instead of leaving it stuck expanded.
-  const bioExpand = useExpandableText(profileData.bio ?? '', collapseLongBio ? BIO_COLLAPSE_CHARS : Infinity, collapseLongBio);
+  const bioExpand = useExpandableText(
+    profileData.bio ?? '',
+    collapseLongBio ? BIO_COLLAPSE_CHARS : Infinity,
+    collapseLongBio,
+  );
 
   const handleLayout = (event: LayoutChangeEvent) => {
     onLayout?.(event.nativeEvent.layout.height);
   };
 
-  const userNameStyle = useMemo(() => ({
-    name: { fontSize: 24, fontWeight: 'bold' as const, marginTop: 10, marginBottom: 4 },
-    handle: { fontSize: 15, marginBottom: 12 },
-    container: undefined,
-  }), []);
-
   return (
     <View
       className="bg-background"
-      style={[
-        { paddingHorizontal: LAYOUT.DEFAULT_PADDING, paddingBottom: LAYOUT.DEFAULT_PADDING },
-        minimalistMode && { paddingTop: 0, marginTop: 0 },
-      ]}
+      style={{
+        paddingHorizontal: LAYOUT.DEFAULT_PADDING,
+        paddingBottom: LAYOUT.DEFAULT_PADDING,
+      }}
       onLayout={handleLayout}
     >
-      {minimalistMode ? (
-        <ProfileHeaderMinimalist
-          displayName={design.displayName}
-          username={profileData.username}
-          avatarUri={avatarUri}
-          verified={profileData.verified}
-          isPrivate={isPrivate}
-          privacySettings={profileData.privacy}
-          isOwnProfile={isOwnProfile}
-          profileId={profileData.id}
-          trailingBadge={fediverseBadge}
-          UserNameComponent={UserName}
-        />
-      ) : (
-        <ProfileHeaderDefault
-          username={profileData.username}
-          avatarUri={avatarUri}
-          isOwnProfile={isOwnProfile}
-          isFederated={profileData.isFederated}
-          actorUri={profileData.actorUri}
-          isFollowing={profileData.isFollowing}
-          currentUsername={currentUsername}
-          profileId={profileData.id}
-          FollowButtonComponent={FollowButtonComponent}
-        />
-      )}
+      {identity}
 
-      {/* Action buttons for minimalist mode */}
-      {minimalistMode && (
-        <View className="mt-3 mb-2">
-          <ProfileActions
-            isOwnProfile={isOwnProfile}
-            isFederated={profileData.isFederated}
-            actorUri={profileData.actorUri}
-            currentUsername={currentUsername}
-            profileUsername={profileData.username}
-            profileId={profileData.id}
-            isFollowing={profileData.isFollowing}
-            FollowButtonComponent={FollowButtonComponent}
-          />
-        </View>
-      )}
-
-      {/* Name and handle for default mode */}
-      {!minimalistMode && (
-        <View>
-          <UserName
-            name={design?.displayName}
-            handle={profileData.username}
-            verified={profileData.verified}
-            isFederated={profileData.isFederated}
-            copyableHandle
-            variant="default"
-            style={userNameStyle}
-            trailingBadge={fediverseBadge}
-            handleTrailing={followsYouTag}
-          />
-          {isPrivate && (
-            <View className="flex-row items-center gap-2 flex-wrap">
-              <PrivateBadge privacySettings={profileData.privacy} />
-            </View>
-          )}
-        </View>
-      )}
-
-      {/* Bio — in BOTH layouts. It used to be default-only, which was tolerable
-          while minimalist was a layout a person opted into for themselves; it is
-          now the one and only layout a CHANNEL gets, and a channel's bio is the
-          only place its page says what it publishes. It is also not a
-          view-layer nicety: the same text ships on the user DTO and federates as
-          the actor's ActivityPub `summary`, so hiding it here made the page
-          disagree with what the rest of the network already reads — and with the
-          operator's own edit form, which offers the field. */}
+      {/* Bio. Not a view-layer nicety: the same text ships on the user DTO and
+          federates as the actor's ActivityPub `summary`, so hiding it here would
+          make the page disagree with what the rest of the network already reads
+          — and with the owner's own edit form, which offers the field. For a
+          channel it is also the only place the page says what it publishes. */}
       {profileData.bio && (
         <LinkifiedText
           text={bioExpand.displayText}
           className="text-foreground"
           style={{ fontSize: 15, lineHeight: 20, marginBottom: 12 }}
-          suffix={bioExpand.isTruncated ? (
-            <Text
-              className="text-primary"
-              onPress={bioExpand.toggle}
-            >
-              {bioExpand.isExpanded ? ` ${t('common.showLess', 'Show less')}` : ` ${t('profile.bio.readMore', 'Read more')}`}
-            </Text>
-          ) : null}
+          suffix={
+            bioExpand.isTruncated ? (
+              <Text className="text-primary" onPress={bioExpand.toggle}>
+                {bioExpand.isExpanded
+                  ? ` ${t('common.showLess', 'Show less')}`
+                  : ` ${t('profile.bio.readMore', 'Read more')}`}
+              </Text>
+            ) : null
+          }
         />
       )}
 
@@ -195,7 +103,11 @@ export const ProfileContent = memo(function ProfileContent({
               className="flex-row items-center py-1.5 border-b border-border gap-2"
               style={{ borderBottomWidth: StyleSheet.hairlineWidth }}
             >
-              <Text className="text-muted-foreground text-[13px] font-semibold" style={{ width: 100 }} numberOfLines={1}>
+              <Text
+                className="text-muted-foreground text-[13px] font-semibold"
+                style={{ width: 100 }}
+                numberOfLines={1}
+              >
                 {field.name}
               </Text>
               <LinkifiedText
@@ -215,8 +127,7 @@ export const ProfileContent = memo(function ProfileContent({
       <ProfileMeta
         location={profileData.primaryLocation}
         createdAt={profileData.createdAt}
-        username={username}
-        profileHandle={profileHandle}
+        aboutHref={aboutHref}
       />
 
       {/* Stats (following, followers, posts) */}
@@ -227,12 +138,9 @@ export const ProfileContent = memo(function ProfileContent({
           postsCount={profileData.postsCount ?? 0}
           boostsCount={profileData.boostsCount ?? 0}
           repliesCount={profileData.repliesCount ?? 0}
-          // The same derivation the tab strip uses, so the stat and the tab it
-          // jumps to appear and disappear together.
-          showReplies={profileTabsForAccountKind(profileData.kind).includes('replies')}
-          profileUsername={profileData.username}
-          profileHandle={profileHandle}
-          username={username}
+          showReplies={showReplies}
+          followingHref={followingHref}
+          followersHref={followersHref}
           onPostsPress={onPostsPress}
           onBoostsPress={onBoostsPress}
           onRepliesPress={onRepliesPress}
@@ -251,7 +159,13 @@ export const ProfileContent = memo(function ProfileContent({
       <FollowedByRow profileId={profileData.id} username={profileHandle} />
 
       {/* Links (Instagram-style summary row + bottom sheet) */}
-      <LinkSummary links={mergeBioAndProfileLinks(profileData.linksMetadata, profileData.links, profileData.bio)} />
+      <LinkSummary
+        links={mergeBioAndProfileLinks(
+          profileData.linksMetadata,
+          profileData.links,
+          profileData.bio,
+        )}
+      />
 
       {/* Communities */}
       {profileData.communities &&

--- a/packages/frontend/components/Profile/ProfileHeader.tsx
+++ b/packages/frontend/components/Profile/ProfileHeader.tsx
@@ -12,17 +12,12 @@ import { useLiveUsers } from '@/hooks/useLiveUsers';
 import { useLayoutScroll } from '@/context/LayoutScrollContext';
 import { AnalyticsIcon } from '@/assets/icons/analytics-icon';
 import { Gear } from '@/assets/icons/gear-icon';
-import { PrivateBadge } from './PrivateBadge';
 import { PresenceIndicator } from '@/components/PresenceIndicator';
 import { FrostedIconButton } from '@oxyhq/bloom/frosted-icon-button';
 import { usePoke } from './hooks/usePoke';
 import { useFederatedFollowSync } from './hooks/useFederatedFollowSync';
 import { LAYOUT } from './types';
-import type {
-  FollowButtonComponent as FollowButtonComponentType,
-  ProfileHeaderDefaultProps,
-  ProfileHeaderMinimalistProps,
-} from './types';
+import type { ProfileHeaderProps } from './types';
 
 // Shrink the 90px header avatar toward these values as the profile scrolls. The
 // same constants drive both the ZoomableAvatar (non-live) collapse and the live
@@ -31,7 +26,14 @@ const PROFILE_AVATAR_COLLAPSE_MIN_SCALE = 0.45;
 const PROFILE_AVATAR_COLLAPSE_TRANSLATE_Y = 16;
 
 /**
- * Default profile header with avatar on left
+ * A PERSON's profile header: a 90px avatar overlapping the banner on the left,
+ * the poke + follow controls on the right, and — on the viewer's own profile —
+ * edit/analytics/settings instead.
+ *
+ * Person-only, and every part of it says so. The avatar collapses on scroll
+ * because it overlaps a banner; the poke is addressed to somebody who can
+ * receive one; the self view exists because a person can be signed in as
+ * themselves. A channel satisfies none of those, and gets `ChannelHeader`.
  */
 // Static header actions hoisted to stable module-level refs: FrostedIconButton is
 // memo'd, so fresh inline handlers/icon elements each render would defeat the memo.
@@ -40,7 +42,7 @@ const goSettings = () => router.push('/settings');
 const ANALYTICS_ICON = <AnalyticsIcon size={20} className="text-foreground" />;
 const SETTINGS_ICON = <Gear size={20} className="text-foreground" />;
 
-export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
+export const ProfileHeader = memo(function ProfileHeader({
   username,
   avatarUri,
   isOwnProfile,
@@ -50,7 +52,7 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
   actorUri,
   isFollowing: initialIsFollowing,
   FollowButtonComponent,
-}: ProfileHeaderDefaultProps) {
+}: ProfileHeaderProps) {
   const theme = useTheme();
   const { t } = useTranslation();
   const canPoke = !isFederated;
@@ -166,154 +168,6 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
           </View>
         ) : null}
       </View>
-    </View>
-  );
-});
-
-/**
- * Minimalist profile header with avatar on right
- */
-export const ProfileHeaderMinimalist = memo(function ProfileHeaderMinimalist({
-  displayName,
-  username,
-  avatarUri,
-  verified,
-  isPrivate,
-  privacySettings,
-  profileId,
-  isOwnProfile,
-  UserNameComponent,
-  trailingBadge,
-}: ProfileHeaderMinimalistProps) {
-  const theme = useTheme();
-  const { isLive } = useLiveUsers();
-  const isProfileLive = isLive(profileId);
-  return (
-    <View className="flex-row justify-between items-start mb-4 relative w-full gap-4">
-      <View className="flex-1">
-        <UserNameComponent
-          name={displayName}
-          handle={username}
-          verified={false}
-          variant="default"
-          trailingBadge={trailingBadge}
-          style={{
-            name: { fontSize: 24, fontWeight: 'bold' as const, marginTop: 10, marginBottom: 4 },
-            handle: { fontSize: 15, marginBottom: 12 },
-            container: undefined,
-          }}
-        />
-        {isPrivate && <PrivateBadge privacySettings={privacySettings} />}
-      </View>
-      <View className="relative">
-        {isProfileLive ? (
-          <View className="border-[3px] border-background bg-secondary rounded-full">
-            <LiveAvatar userId={profileId} source={avatarUri ?? undefined} size={70} variant={MEDIA_VARIANT_AVATAR_LG} />
-          </View>
-        ) : (
-          <ZoomableAvatar
-            source={avatarUri}
-            size={70}
-            className="border-[3px] border-background bg-secondary"
-            style={{ width: 70, height: 70, borderRadius: 35 }}
-            imageStyle={{}}
-          />
-        )}
-        {verified && (
-          <View className="absolute rounded-[10px] p-0.5 bg-background" style={{ left: -6, bottom: -2 }}>
-            <Ionicons name="checkmark-circle" size={18} color={theme.colors.primary} />
-          </View>
-        )}
-        {!isOwnProfile && profileId && (
-          <PresenceIndicator
-            userId={profileId}
-            size="small"
-            style={{ position: 'absolute', bottom: 2, right: 2 }}
-          />
-        )}
-      </View>
-    </View>
-  );
-});
-
-/**
- * Profile action buttons for minimalist mode
- */
-export const ProfileActions = memo(function ProfileActions({
-  isOwnProfile,
-  isFederated,
-  actorUri,
-  currentUsername,
-  profileUsername,
-  profileId,
-  isFollowing,
-  FollowButtonComponent,
-}: {
-  isOwnProfile: boolean;
-  isFederated?: boolean;
-  actorUri?: string;
-  currentUsername?: string;
-  profileUsername?: string;
-  profileId?: string;
-  isFollowing?: boolean;
-  FollowButtonComponent: FollowButtonComponentType;
-}) {
-  const theme = useTheme();
-  const { t } = useTranslation();
-  const canPoke = !isFederated;
-  const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || Boolean(isFederated));
-  useFederatedFollowSync(profileId, isFederated, actorUri);
-
-  if (!isOwnProfile || currentUsername !== profileUsername) {
-    if (!profileId) return null;
-    return (
-      <View className="flex-row items-center gap-3">
-        {canPoke && (
-          <FrostedIconButton
-            size="md"
-            onPress={togglePoke}
-            disabled={pokeLoading}
-            active={poked}
-            accessibilityLabel={poked ? 'Unpoke' : 'Poke'}
-            icon={
-              <Ionicons
-                name={poked ? 'hand-right' : 'hand-right-outline'}
-                size={18}
-                color={poked ? theme.colors.primaryForeground : theme.colors.text}
-              />
-            }
-          />
-        )}
-        <FollowButtonComponent
-          userId={profileId}
-          initiallyFollowing={isFollowing}
-        />
-      </View>
-    );
-  }
-
-  return (
-    <View className="flex-row items-center gap-3">
-      <TouchableOpacity
-        className="border border-border bg-background rounded-full px-6 py-2"
-        onPress={() => router.push('/edit-profile')}
-        accessibilityRole="button"
-        accessibilityLabel={t('profile.editProfile')}
-      >
-        <Text className="text-foreground text-sm font-semibold">{t('profile.editProfile')}</Text>
-      </TouchableOpacity>
-      <FrostedIconButton
-        size="md"
-        onPress={goInsights}
-        accessibilityLabel="Analytics"
-        icon={ANALYTICS_ICON}
-      />
-      <FrostedIconButton
-        size="md"
-        onPress={goSettings}
-        accessibilityLabel="Settings"
-        icon={SETTINGS_ICON}
-      />
     </View>
   );
 });

--- a/packages/frontend/components/Profile/ProfileMeta.tsx
+++ b/packages/frontend/components/Profile/ProfileMeta.tsx
@@ -6,7 +6,6 @@ import { LocationIcon } from '@/assets/icons/location-icon';
 import { CalendarIcon } from '@/assets/icons/calendar-icon';
 import { ChevronRightIcon } from '@/assets/icons/chevron-right-icon';
 import type { ProfileMetaProps } from './types';
-import { getNormalizedUserHandle } from '@oxyhq/core';
 
 /**
  * Profile metadata component
@@ -15,14 +14,12 @@ import { getNormalizedUserHandle } from '@oxyhq/core';
 export const ProfileMeta = memo(function ProfileMeta({
   location,
   createdAt,
-  username,
-  profileHandle,
+  aboutHref,
 }: ProfileMetaProps) {
   const { t } = useTranslation();
 
   const hasLocation = Boolean(location);
   const hasJoinDate = Boolean(createdAt);
-  const targetHandle = getNormalizedUserHandle({ username: profileHandle || username });
 
   const formatJoinDate = useCallback((date: string) => {
     return new Date(date).toLocaleDateString('en-US', {
@@ -30,6 +27,10 @@ export const ProfileMeta = memo(function ProfileMeta({
       year: 'numeric',
     });
   }, []);
+
+  const openAbout = useCallback(() => {
+    if (aboutHref) router.push(aboutHref);
+  }, [aboutHref]);
 
   if (!hasLocation && !hasJoinDate) {
     return null;
@@ -49,19 +50,15 @@ export const ProfileMeta = memo(function ProfileMeta({
       {createdAt && (
         <TouchableOpacity
           className="flex-row items-center gap-1"
-          onPress={() => {
-            if (targetHandle) {
-              router.push(`/@${targetHandle}/about`);
-            }
-          }}
-          disabled={!targetHandle}
+          onPress={openAbout}
+          disabled={!aboutHref}
           activeOpacity={0.7}
         >
           <CalendarIcon size={16} className="text-muted-foreground" />
           <Text className="text-muted-foreground text-[15px]">
             {t('profile.joined')} {formatJoinDate(createdAt)}
           </Text>
-          <ChevronRightIcon size={16} className="text-muted-foreground" />
+          {aboutHref ? <ChevronRightIcon size={16} className="text-muted-foreground" /> : null}
         </TouchableOpacity>
       )}
     </View>

--- a/packages/frontend/components/Profile/ProfileShell.tsx
+++ b/packages/frontend/components/Profile/ProfileShell.tsx
@@ -1,0 +1,397 @@
+import React from 'react';
+import { Animated, ImageBackground, Platform, StatusBar, StyleSheet, Text, View } from 'react-native';
+import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '@oxyhq/bloom/theme';
+import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types/post';
+import UserName from '@/components/UserName';
+import { BottomBarAwareFab } from '@/components/BottomBarAwareFab';
+import { EmptyState } from '@/components/common/EmptyState';
+import { NoUpdatesIllustration } from '@/assets/illustrations/NoUpdates';
+import { ComposeIcon } from '@/assets/icons/compose-icon';
+import { PANEL_HEADER_HEIGHT } from '@/components/shell/PanelChrome';
+import { useSafeBack } from '@/hooks/useSafeBack';
+import type { ProfileData } from '@/hooks/useProfileData';
+import { ProfileSkeleton } from './ProfileSkeleton';
+import { ProfileTabs } from './ProfileTabs';
+import { LAYOUT, shouldFeedOwnProfileScroll, shouldGridOwnProfileScroll } from './types';
+import type { ProfileTabsProps } from './types';
+import type { ProfileChrome } from './hooks/useProfileChrome';
+
+const IS_WEB = Platform.OS === 'web';
+
+// Banner image wrapped for the pull-to-zoom parallax (scale driven by the shared
+// scrollY). Created once at module scope so it is a stable component type.
+const AnimatedImageBackground = Animated.createAnimatedComponent(ImageBackground);
+
+/** Full height of the banner band. */
+const BANNER_HEIGHT = LAYOUT.HEADER_HEIGHT_EXPANDED + LAYOUT.HEADER_HEIGHT_NARROWED;
+
+export interface ProfileShellProps {
+  chrome: ProfileChrome;
+  loading: boolean;
+  profileData: ProfileData | null;
+  /**
+   * The banner band, or `null` for a layout that has none. A channel passes
+   * `null`: the account has no banner field to set, so there is nothing to
+   * reach — not a band left empty.
+   */
+  banner: { uri?: string } | null;
+  /** The top-right icon cluster's contents. */
+  headerActions: React.ReactNode;
+  /**
+   * Identity block, stats and everything above the tab strip.
+   *
+   * A single ELEMENT rather than a `ReactNode`, because on native the
+   * virtualized-list branch hands it straight to FlashList as
+   * `ListHeaderComponent`, which takes an element and not a fragment or a text
+   * node.
+   */
+  summary: React.ReactElement | null;
+  /** The tab strip itself, sticky in the second tier. Same element constraint. */
+  tabBar: React.ReactElement | null;
+  /** Which surface the active tab renders. */
+  tabs: ProfileTabsProps;
+}
+
+/**
+ * The chrome and scroll model every profile page shares, whoever the account is.
+ *
+ * This is the half of a profile screen that is genuinely common: the banner
+ * fade, the pinned header band, the two sticky tiers, the compact-name overlay,
+ * the three-way scroll ownership (web document / native virtualized list /
+ * native ScrollView), the skeleton and not-found states, and the compose FAB.
+ * None of it depends on whether the account is a person or a channel — the
+ * differences arrive as slots and as {@link ProfileShellProps.banner}.
+ *
+ * It exists so that splitting the two screens does not duplicate this. Every
+ * layer below carries hand-tuned z-indices, negative margins and pointer-event
+ * rules that only make sense relative to each other; a second copy would be
+ * correct for exactly as long as nobody touched either.
+ */
+export function ProfileShell({
+  chrome,
+  loading,
+  profileData,
+  banner,
+  headerActions,
+  summary,
+  tabBar,
+  tabs,
+}: ProfileShellProps) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const safeBack = useSafeBack();
+
+  const nativeFeedOwnsScroll = shouldFeedOwnProfileScroll({
+    tab: tabs.tab,
+    isWeb: IS_WEB,
+    isPrivate: tabs.isPrivate,
+    isOwnProfile: tabs.isOwnProfile,
+  });
+  const nativeGridOwnsScroll = shouldGridOwnProfileScroll({
+    tab: tabs.tab,
+    isWeb: IS_WEB,
+    isPrivate: tabs.isPrivate,
+    isOwnProfile: tabs.isOwnProfile,
+  });
+  const nativeListOwnsScroll = nativeFeedOwnsScroll || nativeGridOwnsScroll;
+
+  return (
+    /* WEB: `web:z-auto` stops this screen wrapper from being its own stacking
+       context (RN-web otherwise renders every View as `position:relative;
+       z-index:0`, which would TRAP the sticky header chrome below it). With
+       `z-index:auto` the profile chrome (banner z-1, action cluster + compact
+       name z-101) competes directly in the rounded panel's stacking context, so
+       it paints ABOVE the bleed-mask overlay (z-30) and the feed (z-3) but below
+       the panel border frame (z-120) — exactly like the home header. No effect
+       on native. */
+    <View
+      className="flex-1 bg-background web:z-auto relative flex-col"
+      style={[{ overflow: 'visible' }, chrome.themedStyles.container]}
+    >
+      <StatusBar barStyle={theme.isDark ? 'light-content' : 'dark-content'} />
+
+      {loading ? (
+        <ProfileSkeleton />
+      ) : !profileData ? (
+        <EmptyState
+          customIcon={<NoUpdatesIllustration width={200} height={200} />}
+          title={t('profile.notFound.title', { defaultValue: 'Profile not found' })}
+          subtitle={t('profile.notFound.message', {
+            defaultValue:
+              "This profile couldn't be loaded. The user may not exist or their server may be unavailable.",
+          })}
+          action={{ label: t('common.goBack', { defaultValue: 'Go Back' }), onPress: safeBack }}
+        />
+      ) : (
+        <>
+          {/* Banner. NATIVE: `absolute left-0 right-0 top:0` (height 170,
+              zIndex 1) over the NON-scrolling root — the content scrolls OVER
+              it, and the `bg-background` overlay fades it out over the first
+              120px via `headerBackgroundOpacity`. WEB: there is no inner
+              ScrollView (the DOCUMENT scrolls), so an `absolute` banner would
+              scroll away. Instead it is `web:sticky` + `panelStickyTopInset`
+              (pinned to the rounded panel's PANEL_TOP_INSET top-gutter inset —
+              from the single shared constant, no literal `top-2` here — and
+              sticky's containing block is the panel column, so it stays INSIDE
+              the panel, never viewport-fixed). The negative bottom margin
+              (`-170px`) cancels its flow height so the content's own
+              `marginTop + paddingTop` offset is NOT double-counted — the banner
+              occupies 0 net flow and the content still starts ~170px down and
+              scrolls over it, then fades to the background, exactly as on
+              native. Its `web:z-[1]` keeps it BELOW the content (`zIndex: 3`),
+              preserving native's content-over-banner layering. */}
+          {banner &&
+            (banner.uri ? (
+              <View
+                className="left-0 right-0 overflow-hidden web:sticky web:z-[1] web:[margin-bottom:-170px]"
+                style={[webStickyChrome.banner, chrome.panelStickyTopInset, { height: BANNER_HEIGHT }]}
+              >
+                <AnimatedImageBackground
+                  source={{ uri: banner.uri }}
+                  className="absolute left-0 right-0 top-0 overflow-hidden"
+                  style={{ height: BANNER_HEIGHT, transform: [{ scale: chrome.bannerScale }] }}
+                />
+                <Animated.View
+                  className="absolute left-0 right-0 top-0 overflow-hidden bg-background"
+                  style={{
+                    height: BANNER_HEIGHT,
+                    zIndex: 1,
+                    pointerEvents: 'none',
+                    opacity: chrome.headerBackgroundOpacity,
+                  }}
+                />
+              </View>
+            ) : (
+              <View
+                className="left-0 right-0 overflow-hidden bg-primary/[0.125] web:sticky web:z-[1] web:[margin-bottom:-170px]"
+                style={[webStickyChrome.banner, chrome.panelStickyTopInset, { height: BANNER_HEIGHT }]}
+              >
+                <Animated.View
+                  className="bg-background"
+                  style={[StyleSheet.absoluteFill, { opacity: chrome.headerBackgroundOpacity }]}
+                />
+              </View>
+            ))}
+
+          {/* Pinned header-band surface (WEB only). When the header chrome is
+              pinned in contact with the tab bar, the action cluster +
+              compact-name overlay are 0-flow-height anchors with NO background
+              of their own — so the scrolling feed (z-3) would show THROUGH the
+              header band while the opaque tabs (`bg-background`) sit right
+              below, reading as an incoherent transparent-header / opaque-tabs
+              split. This sticky surface fills the 48px header band with the SAME
+              `bg-background` token the tab bar uses, so header + tabs read as
+              ONE cohesive opaque bar. Its opacity is driven by the SAME
+              `headerBackgroundOpacity` as the banner fade: 0 when expanded (the
+              banner shows through — restored parallax preserved) → 1 once
+              scrolled (opaque, matching the tabs). `web:z-[100]` paints it ABOVE
+              the feed content (z-3) and the tabs (z-5) but BELOW the chrome
+              icons/name overlay (z-101). It intentionally receives web pointer
+              events to prevent clicks from reaching covered feed content while
+              the band is opaque; the higher z-101 header controls remain
+              interactive. The `-48px` bottom margin keeps it a 0-flow overlay.
+              Empty on native, where the chrome is an absolute overlay over the
+              non-scrolling root. */}
+          {IS_WEB && (
+            <View
+              className="left-0 right-0 web:sticky web:z-[100] web:pointer-events-auto web:[margin-bottom:-48px]"
+              style={[chrome.panelStickyTopInset, { height: PANEL_HEADER_HEIGHT }]}
+            >
+              <Animated.View
+                className="bg-background"
+                style={[StyleSheet.absoluteFill, { opacity: chrome.headerBackgroundOpacity }]}
+              />
+            </View>
+          )}
+
+          {/* Header actions cluster. NATIVE: `absolute`, `top: insets.top+6`,
+              `right: DEFAULT_PADDING-8`, zIndex 10 — pinned at the top of the
+              non-scrolling root. WEB: the cluster lives inside a full-width
+              `web:sticky` + `panelStickyTopInset` wrapper pinned to the panel's
+              top-gutter inset (same pattern as the PanelStickyHeader the home
+              header uses). The wrapper has 0 flow height (its only child is
+              `absolute`) and is `pointer-events-none` so it never blocks the
+              feed; the cluster itself re-enables pointer events. */}
+          <View
+            className="left-0 right-0 web:sticky web:z-[101] web:pointer-events-none"
+            style={[webStickyChrome.chromeAnchor, chrome.panelStickyTopInset]}
+          >
+            <View
+              className="absolute flex-row items-center gap-1 web:pointer-events-auto"
+              style={[
+                { zIndex: 10, right: LAYOUT.DEFAULT_PADDING - 8 },
+                chrome.themedStyles.headerActions,
+              ]}
+            >
+              {headerActions}
+            </View>
+          </View>
+
+          {/* Compact name overlay (avatar + name + posts-count), fading in via
+              `headerNameOpacity` once the real name scrolls past.
+
+              It is `aria-hidden` because it is a purely visual restatement of
+              the avatar, name, verified badge and post count the summary below
+              already renders — a screen reader would otherwise announce that
+              identity twice on every profile, and the overlay holds nothing
+              focusable to lose. One prop covers all three platforms: RN's View
+              maps `aria-hidden` onto `accessibilityElementsHidden` (iOS) AND
+              `importantForAccessibility: 'no-hide-descendants'` (Android), and
+              react-native-web emits the DOM attribute. */}
+          <View
+            className="left-0 right-0 web:sticky web:z-[101] web:pointer-events-none"
+            style={[webStickyChrome.chromeAnchor, chrome.panelStickyTopInset]}
+          >
+            <Animated.View
+              className="absolute"
+              aria-hidden
+              style={[
+                {
+                  zIndex: 10,
+                  left: LAYOUT.DEFAULT_PADDING,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 10,
+                },
+                chrome.themedStyles.headerNameOverlay,
+                { opacity: chrome.headerNameOpacity },
+                { pointerEvents: 'none' },
+              ]}
+            >
+              <Avatar source={profileData.design.avatar} size={32} variant={MEDIA_VARIANT_AVATAR} />
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <UserName
+                  name={profileData.design.displayName}
+                  verified={profileData.verified}
+                  style={{ name: { fontSize: 18, fontWeight: 'bold', marginBottom: -3 } }}
+                  unifiedColors={true}
+                />
+                <Text className="text-muted-foreground text-[13px]" numberOfLines={1}>
+                  {t('profile.postsCount', {
+                    count: profileData.postsCount,
+                    defaultValue: `${profileData.postsCount} posts`,
+                  })}
+                </Text>
+              </View>
+            </Animated.View>
+          </View>
+
+          {/* Main scroll content.
+
+              NATIVE FEED TABS: Feed's FlashList owns the scroll and receives the
+              summary as `ListHeaderComponent` and the tabs as a separate sticky
+              data row, keeping post rows virtualized without pinning the whole
+              summary. NATIVE GRID TABS: ProfileGridList's FlashList owns the
+              scroll with the same header/sticky-tab contract. The
+              Animated.ScrollView remains the sole owner only for the bounded
+              card tabs.
+
+              WEB: the DOCUMENT scrolls (no inner ScrollView — that would break
+              the document-scroll model the home/explore screens use). The body
+              renders in normal flow inside a plain `View`; the header/banner/
+              name-overlay animations read the same `scrollY`, fed by the window
+              'scroll' listener in LayoutScrollContext. */}
+          {IS_WEB ? (
+            <View
+              style={[
+                { zIndex: 3 },
+                chrome.themedStyles.scrollView,
+                chrome.themedStyles.contentContainer,
+              ]}
+            >
+              {summary}
+
+              {/* Tabs — sticky in the SECOND tier, pinned flush BELOW the header
+                  chrome band (`panelStickyTabsTopInset` = PANEL_TOP_INSET +
+                  PANEL_HEADER_HEIGHT while framed, the same 56px offset the home
+                  screen's `level={1}` tab bar uses; it collapses to just
+                  PANEL_HEADER_HEIGHT at full-bleed, in lockstep with the first
+                  tier). The banner fade, action cluster and compact-name overlay
+                  all pin at the FIRST tier; pinning the tab bar at that same
+                  inset made the two bands occupy the same vertical space and
+                  OVERLAP. It lives inside the z-3 content wrapper, so `web:z-[5]`
+                  keeps it above the feed content, and the `bg-background` on
+                  AnimatedTabBar keeps the feed from showing through. */}
+              <View className="web:sticky web:z-[5]" style={chrome.panelStickyTabsTopInset}>
+                {tabBar}
+              </View>
+
+              <ProfileTabs {...tabs} />
+            </View>
+          ) : nativeListOwnsScroll ? (
+            <View style={[{ zIndex: 3, flex: 1, minHeight: 0 }, chrome.themedStyles.scrollView]}>
+              <ProfileTabs
+                {...tabs}
+                listOwnsScroll
+                listHeaderComponent={summary}
+                listStickyHeaderComponent={tabBar}
+                listContentContainerStyle={chrome.themedStyles.contentContainer}
+                listOnScroll={nativeGridOwnsScroll ? chrome.onScroll : undefined}
+                listScrollRef={nativeGridOwnsScroll ? chrome.assignScrollRef : undefined}
+              />
+            </View>
+          ) : (
+            <Animated.ScrollView
+              ref={chrome.assignScrollRef}
+              showsVerticalScrollIndicator={false}
+              onScroll={chrome.onScroll}
+              scrollEventThrottle={16}
+              style={[{ zIndex: 3 }, chrome.themedStyles.scrollView]}
+              contentContainerStyle={chrome.themedStyles.contentContainer}
+              stickyHeaderIndices={[1]}
+              nestedScrollEnabled={true}
+              removeClippedSubviews={true}
+              disableIntervalMomentum={true}
+              decelerationRate="normal"
+            >
+              {/* Summary wrapper keeps stickyHeaderIndices stable. */}
+              {summary}
+              {tabBar}
+              <ProfileTabs {...tabs} />
+            </Animated.ScrollView>
+          )}
+
+          {/* FAB that rides the BottomBar's show/hide (web mobile). */}
+          <BottomBarAwareFab
+            onPress={() => router.push('/compose')}
+            icon={<ComposeIcon size={20} className="text-primary-foreground" />}
+            accessibilityLabel={t('compose.newPost', { defaultValue: 'New post' })}
+          />
+        </>
+      )}
+    </View>
+  );
+}
+
+// WEB vs NATIVE positioning for the profile header chrome (banner, action
+// cluster, compact-name overlay). NATIVE pins each piece `absolute` to the top
+// of the NON-scrolling root (the content scrolls over them inside the inner
+// Animated.ScrollView). WEB has no inner ScrollView — the DOCUMENT scrolls — so
+// each piece pins via `web:sticky` + the shared `panelStickyTopInset` style (the
+// rounded panel's PANEL_TOP_INSET top-gutter inset, from the single PanelChrome
+// source of truth — no literal `top-2` here). `position: sticky` keeps the panel
+// column as its containing block, so the chrome stays INSIDE the rounded center
+// panel (never viewport-fixed), mirroring the home header's PanelStickyHeader.
+// These bespoke overlapping layers keep their own `web:z-[…]`, negative margins
+// and pointer-events, so they consume `panelStickyTopInset` rather than the full
+// <PanelStickyHeader> wrapper (which would flatten their z-layout and break the
+// banner/name fades). The web `position`/`z` live in NativeWind classes; this
+// StyleSheet only supplies the native `absolute` anchor (web entries are empty
+// so the classes win).
+const webStickyChrome = StyleSheet.create({
+  banner: {
+    ...Platform.select({
+      web: {},
+      default: { position: 'absolute' as const, top: 0, zIndex: 1 },
+    }),
+  },
+  chromeAnchor: {
+    ...Platform.select({
+      web: {},
+      default: { position: 'absolute' as const, top: 0, zIndex: 10 },
+    }),
+  },
+});

--- a/packages/frontend/components/Profile/ProfileSkeleton.tsx
+++ b/packages/frontend/components/Profile/ProfileSkeleton.tsx
@@ -17,7 +17,7 @@ import { LAYOUT } from './types';
  *    applies (ProfileScreen's scrollView + contentContainer), so every element
  *    below lands at its identical final Y;
  *  - the avatar (90px, 3px background ring) overlapping the banner by 45px — the
- *    exact `marginTop: -45` ProfileHeaderDefault uses — with a placeholder
+ *    exact `marginTop: -45` ProfileHeader uses — with a placeholder
  *    action row (button + icon) on the right;
  *  - display-name + handle bars, a 2-line bio, the meta row and the stats row
  *    (mirroring ProfileContent → ProfileMeta / ProfileStats);
@@ -33,7 +33,7 @@ import { LAYOUT } from './types';
 // banner rendered in ProfileScreen).
 const BANNER_HEIGHT = LAYOUT.HEADER_HEIGHT_EXPANDED + LAYOUT.HEADER_HEIGHT_NARROWED;
 // Header avatar footprint + the negative pull that overlaps it onto the banner
-// (mirrors ProfileHeaderDefault: a 90px avatar with `marginTop: -45`).
+// (mirrors ProfileHeader: a 90px avatar with `marginTop: -45`).
 const AVATAR_SIZE = 90;
 const AVATAR_RING = 3;
 const HEADER_OVERLAP = 45;
@@ -88,7 +88,7 @@ export const ProfileSkeleton = memo(function ProfileSkeleton() {
         {/* Profile info block — mirrors ProfileContent's padding + background. */}
         <View className="bg-background px-4 pb-4">
           {/* Header row: avatar overlapping the banner + action placeholders.
-              `marginTop: -45` matches ProfileHeaderDefault so the avatar lands
+              `marginTop: -45` matches ProfileHeader so the avatar lands
               at the identical Y. */}
           <View className="flex-row justify-between items-end mb-2.5" style={{ marginTop: -HEADER_OVERLAP }}>
             <Skeleton.Circle

--- a/packages/frontend/components/Profile/ProfileStats.tsx
+++ b/packages/frontend/components/Profile/ProfileStats.tsx
@@ -4,7 +4,6 @@ import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { formatCompactNumber } from '@/utils/formatNumber';
 import type { ProfileStatsProps } from './types';
-import { getNormalizedUserHandle } from '@oxyhq/core';
 
 /**
  * Profile statistics component
@@ -17,27 +16,21 @@ export const ProfileStats = memo(function ProfileStats({
   boostsCount,
   repliesCount,
   showReplies = true,
-  profileUsername,
-  profileHandle,
-  username,
+  followingHref,
+  followersHref,
   onPostsPress,
   onBoostsPress,
   onRepliesPress,
 }: ProfileStatsProps) {
   const { t } = useTranslation();
-  const displayUsername = getNormalizedUserHandle({ username: profileHandle || profileUsername || username });
 
   const handleFollowingPress = useCallback(() => {
-    if (displayUsername) {
-      router.push(`/@${displayUsername}/following`);
-    }
-  }, [displayUsername]);
+    if (followingHref) router.push(followingHref);
+  }, [followingHref]);
 
   const handleFollowersPress = useCallback(() => {
-    if (displayUsername) {
-      router.push(`/@${displayUsername}/followers`);
-    }
-  }, [displayUsername]);
+    if (followersHref) router.push(followersHref);
+  }, [followersHref]);
 
   return (
     <View className="gap-2.5" style={styles.container}>
@@ -45,7 +38,7 @@ export const ProfileStats = memo(function ProfileStats({
         className="gap-1"
         style={styles.statItem}
         onPress={handleFollowingPress}
-        disabled={!displayUsername}
+        disabled={!followingHref}
       >
         <Text className="text-foreground" style={styles.statNumber}>
           {formatCompactNumber(followingCount ?? 0)}
@@ -59,7 +52,7 @@ export const ProfileStats = memo(function ProfileStats({
         className="gap-1"
         style={styles.statItem}
         onPress={handleFollowersPress}
-        disabled={!displayUsername}
+        disabled={!followersHref}
       >
         <Text className="text-foreground" style={styles.statNumber}>
           {formatCompactNumber(followerCount ?? 0)}

--- a/packages/frontend/components/Profile/__tests__/channelScreenSeparation.test.ts
+++ b/packages/frontend/components/Profile/__tests__/channelScreenSeparation.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FRONTEND = join(__dirname, '..', '..', '..');
+
+// Production source only. Tests are excluded because a check that names the
+// identifier it forbids would otherwise match itself — and because a test is
+// allowed to talk about code that no longer exists.
+const SKIPPED_DIRS = new Set(['node_modules', '.expo', 'dist', '__tests__', '__mocks__']);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIPPED_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+const SOURCE_FILES = walk(join(FRONTEND, 'components')).concat(
+  walk(join(FRONTEND, 'app')),
+  walk(join(FRONTEND, 'hooks')),
+);
+
+function read(...segments: string[]): string {
+  return readFileSync(join(FRONTEND, ...segments), 'utf8');
+}
+
+/**
+ * Source with comments removed.
+ *
+ * A grep for a removed identifier has to distinguish USING it from RECORDING
+ * that it is gone — the docstrings that explain why `minimalistMode` was
+ * deleted name it, and a check that cannot tell those apart either fires on
+ * every honest explanation or forces the explanations out of the code.
+ */
+function code(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+/**
+ * A channel's page and a person's page are two SCREENS, not one screen with
+ * conditions. These assertions pin the parts of that separation that a future
+ * edit could quietly undo — each one names a defect that was reported, so a
+ * failure here says which symptom is coming back.
+ */
+describe('channel and person profiles are separate screens', () => {
+  // Vacuity floor: a broken walk would make every "does not contain" assertion
+  // below pass by scanning nothing.
+  it('scanned a plausible number of source files', () => {
+    expect(SOURCE_FILES.length).toBeGreaterThan(300);
+  });
+
+  /**
+   * DEFECT: the poke button appeared on a channel.
+   *
+   * A poke is addressed to a person, and `isActAsEligibleKind` refuses
+   * `channel`, so nobody is ever signed in as one to receive it. The fix is
+   * structural: the channel's header components do not render a poke, so there
+   * is no flag to get wrong and no `isChannel` prop threaded through a shared
+   * component to forget at a call site.
+   */
+  it('never reaches the poke from the channel screen', () => {
+    const channelSources = [
+      read('components', 'ChannelScreen.tsx'),
+      read('components', 'Profile', 'ChannelHeader.tsx'),
+    ];
+    for (const source of channelSources) {
+      expect(code(source)).not.toMatch(/\busePoke\b/);
+    }
+  });
+
+  it('keeps the poke on the person header, so the check above is not vacuous', () => {
+    // Without this, deleting the poke everywhere would satisfy the assertion
+    // above while removing the feature.
+    expect(read('components', 'Profile', 'ProfileHeader.tsx')).toMatch(/usePoke/);
+  });
+
+  it('imports usePoke from exactly one component', () => {
+    const importers = SOURCE_FILES.filter((file) =>
+      /from '\.\/hooks\/usePoke'|from '@\/components\/Profile\/hooks\/usePoke'/.test(
+        readFileSync(file, 'utf8'),
+      ),
+    ).map((f) => f.slice(FRONTEND.length + 1));
+
+    expect(importers).toEqual([join('components', 'Profile', 'ProfileHeader.tsx')]);
+  });
+
+  /**
+   * The canonicalization between `/@` and `/c/` is the ONE piece that cannot be
+   * duplicated: two screens each deciding where to redirect can build a bounce
+   * loop between them. Both screens must reach it through the shared helper.
+   */
+  it('routes both screens through the one canonicalization', () => {
+    for (const screen of ['ProfileScreen.tsx', 'ChannelScreen.tsx']) {
+      const source = code(read('components', screen));
+      expect(source).toMatch(/useProfileAccount\(/);
+      expect(source).toMatch(/canonicalHref/);
+      // A screen that builds its own redirect target has left the shared rule.
+      expect(source).not.toMatch(/<Redirect href={`/);
+    }
+  });
+
+  /**
+   * `design.minimalistMode` was a LAYOUT name for an account fact — it was
+   * defined as `kind === 'channel'` — and selecting the header off it is what
+   * made the two screens one. It is gone; nothing should reintroduce it.
+   */
+  it('has no minimalistMode flag left anywhere', () => {
+    const offenders = SOURCE_FILES.filter((file) =>
+      /\bminimalistMode\b/.test(code(readFileSync(file, 'utf8'))),
+    ).map((f) => f.slice(FRONTEND.length + 1));
+
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * DEFECT: rows on a channel page opened person-shaped URLs.
+   *
+   * The shared rows (joined date, follower/following counts) must not build a
+   * URL family of their own — they are rendered by both screens and cannot know
+   * which one they are on. Each takes an explicit href instead.
+   */
+  it('keeps the URL family out of the shared meta and stats rows', () => {
+    for (const row of ['ProfileMeta.tsx', 'ProfileStats.tsx']) {
+      const source = code(read('components', 'Profile', row));
+      expect(source).not.toMatch(/`\/@\$\{/);
+      expect(source).not.toMatch(/`\/c\/\$\{/);
+    }
+  });
+});

--- a/packages/frontend/components/Profile/__tests__/profileRoute.test.ts
+++ b/packages/frontend/components/Profile/__tests__/profileRoute.test.ts
@@ -1,0 +1,173 @@
+import type { AccountKind } from '@oxyhq/core';
+import {
+  canonicalProfileHref,
+  profileBasePath,
+  profileRouteFamilyForKind,
+  type ProfileRouteFamily,
+} from '@/components/Profile/profileRoute';
+
+/**
+ * Every kind the account graph can hand back, so "a kind Oxy adds later" cannot
+ * quietly acquire its own URL family by being forgotten here.
+ */
+const ALL_KINDS: (AccountKind | undefined)[] = [
+  undefined,
+  'personal',
+  'organization',
+  'project',
+  'bot',
+  'channel',
+];
+
+const FAMILIES: ProfileRouteFamily[] = ['person', 'channel'];
+
+describe('profileRouteFamilyForKind', () => {
+  it('sends a channel to the channel family', () => {
+    expect(profileRouteFamilyForKind('channel')).toBe('channel');
+  });
+
+  it.each(ALL_KINDS.filter((kind) => kind !== 'channel'))(
+    'sends kind %s to the person family',
+    (kind) => {
+      expect(profileRouteFamilyForKind(kind)).toBe('person');
+    },
+  );
+
+  it('reads an absent kind as a person, never as a channel', () => {
+    // Every federated and unresolved profile arrives without a kind. Reading
+    // that as a channel would route the whole fediverse through `/c/`.
+    expect(profileRouteFamilyForKind(undefined)).toBe('person');
+  });
+});
+
+describe('profileBasePath', () => {
+  it('serves a channel at /c/<handle>', () => {
+    expect(profileBasePath('channel', 'news')).toBe('/c/news');
+  });
+
+  it('serves a person at /@<handle>', () => {
+    expect(profileBasePath('person', 'nate')).toBe('/@nate');
+  });
+
+  it('keeps a federated handle whole', () => {
+    expect(profileBasePath('person', 'nate@example.social')).toBe('/@nate@example.social');
+  });
+});
+
+describe('canonicalProfileHref', () => {
+  it('redirects a channel sat on the person route', () => {
+    expect(
+      canonicalProfileHref({
+        routedFamily: 'person',
+        kind: 'channel',
+        handle: 'news',
+        resolved: true,
+      }),
+    ).toBe('/c/news');
+  });
+
+  it('redirects a person sat on the channel route', () => {
+    expect(
+      canonicalProfileHref({
+        routedFamily: 'channel',
+        kind: 'personal',
+        handle: 'nate',
+        resolved: true,
+      }),
+    ).toBe('/@nate');
+  });
+
+  it('stays put when the route already matches the account', () => {
+    expect(
+      canonicalProfileHref({
+        routedFamily: 'channel',
+        kind: 'channel',
+        handle: 'news',
+        resolved: true,
+      }),
+    ).toBeNull();
+    expect(
+      canonicalProfileHref({
+        routedFamily: 'person',
+        kind: 'personal',
+        handle: 'nate',
+        resolved: true,
+      }),
+    ).toBeNull();
+  });
+
+  // The account's kind is only knowable once it has resolved. Redirecting on a
+  // guess would bounce every channel through `/@` on each cold load, and the
+  // reader would watch it happen.
+  it('does not redirect before the account resolves', () => {
+    expect(
+      canonicalProfileHref({
+        routedFamily: 'person',
+        kind: undefined,
+        handle: 'news',
+        resolved: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('does not redirect without a handle to redirect to', () => {
+    expect(
+      canonicalProfileHref({
+        routedFamily: 'channel',
+        kind: 'personal',
+        handle: '',
+        resolved: true,
+      }),
+    ).toBeNull();
+  });
+
+  /**
+   * THE property this module exists for.
+   *
+   * Two screens each deciding where to send a reader is how a bounce loop gets
+   * built: `/c/x` sends to `/@x`, `/@x` sends back, and the browser spins. One
+   * shared rule makes that impossible, and this is the assertion that says so —
+   * following the redirect ONCE must always land somewhere that redirects no
+   * further, for every combination of arrival route and account kind.
+   */
+  it('reaches a fixed point in one hop, from every route and every kind', () => {
+    for (const routedFamily of FAMILIES) {
+      for (const kind of ALL_KINDS) {
+        const first = canonicalProfileHref({
+          routedFamily,
+          kind,
+          handle: 'acct',
+          resolved: true,
+        });
+        if (first === null) continue;
+
+        // Where the redirect actually landed the reader, read off the URL rather
+        // than assumed — that is the whole point of following it.
+        const landedFamily: ProfileRouteFamily = String(first).startsWith('/c/')
+          ? 'channel'
+          : 'person';
+        const second = canonicalProfileHref({
+          routedFamily: landedFamily,
+          kind,
+          handle: 'acct',
+          resolved: true,
+        });
+        expect(second).toBeNull();
+      }
+    }
+  });
+
+  // A vacuity floor for the loop test above: if `canonicalProfileHref` ever
+  // returned null for everything, the loop would pass by never redirecting at
+  // all. Exactly half the (family × kind) grid must redirect — one family is
+  // always wrong for any given kind.
+  it('actually redirects half the grid, so the fixed-point test is not vacuous', () => {
+    const redirects = FAMILIES.flatMap((routedFamily) =>
+      ALL_KINDS.map((kind) =>
+        canonicalProfileHref({ routedFamily, kind, handle: 'acct', resolved: true }),
+      ),
+    ).filter((href) => href !== null);
+
+    expect(redirects).toHaveLength(ALL_KINDS.length);
+  });
+});

--- a/packages/frontend/components/Profile/hooks/useJustFollowed.ts
+++ b/packages/frontend/components/Profile/hooks/useJustFollowed.ts
@@ -1,0 +1,46 @@
+import { useRef, useState } from 'react';
+
+/**
+ * Whether the viewer just followed THIS account, in this visit.
+ *
+ * Distinguishes a follow the viewer performed from a follow they already had,
+ * which is what lets the profile offer suggestions on the ACTION without
+ * ambushing every revisit to an account they have followed for a year.
+ *
+ * The transition is computed during render rather than in an effect, because an
+ * effect chain here would fire once on hydration — the follow store seeds
+ * asynchronously — and read that seed as a follow the viewer just performed.
+ * The three refs are what tell the three cases apart: a different account, the
+ * first settled value for this one, and a real change afterwards.
+ *
+ * Shared by both profile screens. The rule has nothing to do with what kind of
+ * account is being followed, and it is subtle enough that a second copy would be
+ * a second chance to get the hydration case wrong.
+ */
+export function useJustFollowed(userId: string, isFollowing: boolean): boolean {
+  const [justFollowed, setJustFollowed] = useState(false);
+  const settledRef = useRef(false);
+  const prevFollowRef = useRef(isFollowing);
+  const prevUserIdRef = useRef(userId);
+
+  if (prevUserIdRef.current !== userId) {
+    // Navigated to a different account: nothing carries over.
+    prevUserIdRef.current = userId;
+    settledRef.current = false;
+    prevFollowRef.current = false;
+    if (justFollowed) setJustFollowed(false);
+  } else if (!settledRef.current) {
+    // First settled value for this account — store hydration, not an action.
+    settledRef.current = true;
+    prevFollowRef.current = isFollowing;
+  } else if (isFollowing !== prevFollowRef.current) {
+    if (isFollowing) {
+      setJustFollowed(true);
+    } else if (justFollowed) {
+      setJustFollowed(false);
+    }
+    prevFollowRef.current = isFollowing;
+  }
+
+  return justFollowed;
+}

--- a/packages/frontend/components/Profile/hooks/useProfileAccount.ts
+++ b/packages/frontend/components/Profile/hooks/useProfileAccount.ts
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { useLocalSearchParams, type Href } from 'expo-router';
+import { getNormalizedUserHandle } from '@oxyhq/core';
+import type { AppColorName } from '@oxyhq/bloom/theme';
+import { useProfileData, type ProfileData } from '@/hooks/useProfileData';
+import { useProfileScreenColor } from '@/hooks/useProfileScreenColor';
+import { canonicalProfileHref, type ProfileRouteFamily } from '../profileRoute';
+
+export interface ProfileAccount {
+  /** The `[username]` segment with a leading `@` stripped. */
+  username: string;
+  /** The canonical handle — `user` locally, `user@domain` when federated. */
+  handle: string;
+  isFederated: boolean;
+  profileData: ProfileData | null;
+  loading: boolean;
+  /** Bloom colour preset for the profile's scope. */
+  colorName: AppColorName | undefined;
+  /** Where this reader belongs instead, or `null` when already canonical. */
+  canonicalHref: Href | null;
+}
+
+/**
+ * Resolving WHICH account a profile URL names, for both `/@<handle>` and
+ * `/c/<handle>`.
+ *
+ * Deliberately one hook rather than one per screen. The two screens are separate
+ * because a channel and a person are different things to READ, but they are the
+ * same thing to LOOK UP: one `[username]` segment, one federated-handle rule, one
+ * Oxy fetch, one colour scope, and — the piece that genuinely cannot be
+ * duplicated — one canonicalization. Splitting the lookup as well is how the two
+ * URL families end up disagreeing about what a handle means.
+ *
+ * `routedFamily` is the only thing a caller supplies, and it says which route
+ * FILE is mounted, never what the account is. What the account is comes back in
+ * `profileData.kind`, and `canonicalHref` is how the two are reconciled.
+ */
+export function useProfileAccount(routedFamily: ProfileRouteFamily): ProfileAccount {
+  const { username: urlUsername } = useLocalSearchParams<{ username: string }>();
+  const username = (urlUsername?.startsWith('@') ? urlUsername.slice(1) : urlUsername) || '';
+
+  // A federated handle carries its instance in the segment itself. Channels are
+  // local-only accounts, so this can only ever be true on the person route — but
+  // it is read the same way on both, because the rule belongs to the handle, not
+  // to the screen.
+  const isFederated = username.includes('@');
+  const { data: profileData, loading } = useProfileData(username);
+  const { colorName } = useProfileScreenColor({
+    username,
+    designColor: profileData?.design?.color,
+  });
+
+  const handle = useMemo<string>(
+    () =>
+      getNormalizedUserHandle({
+        username: profileData?.username || username,
+        instance: profileData?.instance,
+        isFederated: profileData?.isFederated,
+      }) || username,
+    [profileData?.username, profileData?.instance, profileData?.isFederated, username],
+  );
+
+  const canonicalHref = canonicalProfileHref({
+    routedFamily,
+    kind: profileData?.kind,
+    handle,
+    resolved: Boolean(profileData),
+  });
+
+  return { username, handle, isFederated, profileData, loading, colorName, canonicalHref };
+}

--- a/packages/frontend/components/Profile/hooks/useProfileChrome.ts
+++ b/packages/frontend/components/Profile/hooks/useProfileChrome.ts
@@ -1,0 +1,159 @@
+import { useMemo, useState } from 'react';
+import { Animated } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  usePanelStickyTopInset,
+  usePanelStickyTabsTopInset,
+} from '@/components/shell/PanelChrome';
+import { useProfileScroll } from './useProfileScroll';
+import { LAYOUT } from '../types';
+import type { ProfileTab } from '../types';
+
+/**
+ * Top-right header action icon metrics. `IconButton variant="icon"` renders a
+ * 32×32 touch target and the cluster uses NativeWind `gap-1` (4px); the overlay
+ * reserves that span plus breathing room so a long display name truncates
+ * instead of sliding under the icons.
+ */
+const HEADER_ACTION_ICON_SIZE = 32;
+const HEADER_ACTION_ICON_GAP = 4;
+const HEADER_OVERLAY_ICON_CLEARANCE = 12;
+
+/** Vertical room the compact header layout leaves for the action cluster. */
+const COMPACT_HEADER_CONTENT_OFFSET = 60;
+
+export interface ProfileChromeOptions {
+  profileId?: string;
+  currentTab: ProfileTab;
+  currentLaneId?: string;
+  /** How many icons the top-right cluster renders; sizes the name overlay. */
+  headerActionCount: number;
+  /**
+   * Whether this profile has a banner band above the content. A person's does
+   * (a tinted placeholder stands in when no image is set); a channel's does not
+   * — the account has no banner to set, so the layout has no band for one.
+   */
+  hasBannerBand: boolean;
+}
+
+export type ProfileChrome = ReturnType<typeof useProfileChrome>;
+
+/**
+ * The profile page's scroll-driven chrome: the shared `scrollY`, the three
+ * interpolations that ride it, the panel insets and the measured summary height.
+ *
+ * One owner for both profile screens. The chrome is where the two are MOST
+ * alike — same banner fade curve, same compact-name reveal, same sticky tiers,
+ * same three-way scroll ownership downstream — and it is also the part most
+ * expensive to have drift, since every value here is a magic number tuned
+ * against the others. What the two screens differ on arrives as options
+ * ({@link ProfileChromeOptions.hasBannerBand}, the action count), never as a
+ * second copy of the curve.
+ */
+export function useProfileChrome({
+  profileId,
+  currentTab,
+  currentLaneId,
+  headerActionCount,
+  hasBannerBand,
+}: ProfileChromeOptions) {
+  const insets = useSafeAreaInsets();
+
+  // Web sticky-chrome top insets, from the shared PanelChrome source of truth.
+  // They carry the panel's `PANEL_TOP_INSET` gutter while the rounded shell
+  // frame is shown (>=500px) and collapse to 0 at full-bleed so the banner /
+  // header band / tab bar pin flush to the viewport top.
+  const panelStickyTopInset = usePanelStickyTopInset();
+  const panelStickyTabsTopInset = usePanelStickyTabsTopInset();
+
+  const { scrollY, onScroll, assignScrollRef, scrollToContent } = useProfileScroll({
+    profileId,
+    currentTab,
+    currentLaneId,
+  });
+
+  // Measured height of the profile summary; drives the compact-name reveal.
+  const [contentHeight, setContentHeight] = useState(0);
+
+  const headerBackgroundOpacity = useMemo(
+    () =>
+      scrollY.interpolate({
+        inputRange: [0, LAYOUT.HEADER_HEIGHT_EXPANDED],
+        outputRange: [0, 1],
+        extrapolate: 'clamp',
+      }),
+    [scrollY],
+  );
+
+  // Pull-to-zoom banner parallax: on overscroll (negative offset, i.e. pulling
+  // the content down past the top) the banner scales 1 → 1.5. On web
+  // `window.scrollY` never goes negative, so this stays clamped at 1 (no
+  // rubber-band there) while native's bouncing ScrollView drives the zoom.
+  const bannerScale = useMemo(
+    () =>
+      scrollY.interpolate({
+        inputRange: [-150, 0],
+        outputRange: [1.5, 1],
+        extrapolateLeft: 'extend',
+        extrapolateRight: 'clamp',
+      }),
+    [scrollY],
+  );
+
+  // Guard the pre-measurement window: until the summary's onLayout reports a
+  // real height, `contentHeight` is 0, which would make the interpolation input
+  // range [-20, 20] resolve to ~0.5 at scrollY=0 and paint the overlay on top of
+  // the header icons and the profile content. Keep the threshold strictly
+  // positive and force opacity 0 until measured.
+  const headerNameOpacity = useMemo<Animated.AnimatedInterpolation<number> | number>(() => {
+    if (contentHeight <= 0) return 0;
+    // Reveal a touch later than the exact content height so the overlay only
+    // appears once the real name has scrolled out of view.
+    const revealStart = Math.max(contentHeight - 20, 1);
+    return scrollY.interpolate({
+      inputRange: [revealStart, contentHeight + 20],
+      outputRange: [0, 1],
+      extrapolate: 'clamp',
+    });
+  }, [scrollY, contentHeight]);
+
+  const headerOverlayRight = useMemo(
+    () =>
+      LAYOUT.DEFAULT_PADDING -
+      8 +
+      headerActionCount * HEADER_ACTION_ICON_SIZE +
+      (headerActionCount - 1) * HEADER_ACTION_ICON_GAP +
+      HEADER_OVERLAY_ICON_CLEARANCE,
+    [headerActionCount],
+  );
+
+  const themedStyles = useMemo(
+    () => ({
+      container: { paddingTop: insets.top },
+      headerActions: { top: insets.top + 6 },
+      headerNameOverlay: { top: insets.top + 6, right: headerOverlayRight },
+      scrollView: { marginTop: hasBannerBand ? LAYOUT.HEADER_HEIGHT_NARROWED : 0 },
+      contentContainer: {
+        paddingTop: hasBannerBand
+          ? LAYOUT.HEADER_HEIGHT_EXPANDED - insets.top
+          : insets.top + COMPACT_HEADER_CONTENT_OFFSET,
+      },
+    }),
+    [insets.top, hasBannerBand, headerOverlayRight],
+  );
+
+  return {
+    scrollY,
+    onScroll,
+    assignScrollRef,
+    scrollToContent,
+    contentHeight,
+    setContentHeight,
+    headerBackgroundOpacity,
+    bannerScale,
+    headerNameOpacity,
+    themedStyles,
+    panelStickyTopInset,
+    panelStickyTabsTopInset,
+  };
+}

--- a/packages/frontend/components/Profile/hooks/useProfileMoreMenu.tsx
+++ b/packages/frontend/components/Profile/hooks/useProfileMoreMenu.tsx
@@ -1,0 +1,209 @@
+import React, { useCallback, useContext } from 'react';
+import { toast } from '@oxyhq/bloom/toast';
+import { useTheme } from '@oxyhq/bloom/theme';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '@oxyhq/services/ui/client';
+import { BottomSheetContext } from '@/context/BottomSheetContext';
+import { showActionMenu } from '@/components/common/ActionMenu';
+import type { ActionMenuAction } from '@/components/common/actionMenuGroups';
+import { ReportModal } from '@/components/report/ReportModal';
+import { AddToListSheet } from '@/components/Lists/AddToListSheet';
+import { AddToStarterPackSheet } from '@/components/AddToStarterPackSheet';
+import { muteService } from '@/services/muteService';
+import { reportService } from '@/services/reportService';
+import { confirmDialog } from '@/utils/alerts';
+import { List as ListIcon } from '@/assets/icons/list-icon';
+import { StarterPackIcon } from '@/assets/icons/starter-pack-icon';
+import { MuteIcon } from '@/assets/icons/mute-icon';
+import { BlockIcon } from '@/assets/icons/block-icon';
+import { ReportIcon } from '@/assets/icons/report-icon';
+import type { ProfileData } from '@/hooks/useProfileData';
+
+export interface ProfileMoreMenuOptions {
+  profileData: ProfileData | null;
+  isOwnProfile: boolean;
+  /**
+   * Rows shown ABOVE the shared ones, for actions that are about RUNNING this
+   * account rather than about the viewer's relationship to it. A channel's
+   * operator gets its settings here; everybody else never sees a row that would
+   * refuse them.
+   */
+  leadingActions?: ActionMenuAction[];
+}
+
+/**
+ * The "…" menu on a profile: add to lists / starter packs, mute, block, report.
+ *
+ * Shared by both profile screens because it is entirely about the VIEWER's
+ * relationship to an account, and that relationship does not change shape when
+ * the account is a channel — a channel can be listed, muted, blocked and
+ * reported exactly like anybody else. What differs is what an OPERATOR may
+ * additionally do, which arrives as {@link ProfileMoreMenuOptions.leadingActions}
+ * rather than as a branch in here.
+ */
+export function useProfileMoreMenu({
+  profileData,
+  isOwnProfile,
+  leadingActions,
+}: ProfileMoreMenuOptions): () => void {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const { oxyServices } = useAuth();
+  const bottomSheet = useContext(BottomSheetContext);
+
+  return useCallback(() => {
+    if (!profileData || isOwnProfile) return;
+
+    const displayUsername = profileData.username;
+
+    const handleMute = async () => {
+      const success = await muteService.muteUser(profileData.id);
+      if (success) {
+        toast(
+          t('profile.muted', {
+            username: displayUsername,
+            defaultValue: `@${displayUsername} has been muted`,
+          }),
+          { type: 'success' },
+        );
+      } else {
+        toast(t('profile.muteFailed', { defaultValue: 'Failed to mute user' }), { type: 'error' });
+      }
+    };
+
+    const handleBlock = async () => {
+      const confirmed = await confirmDialog({
+        title: t('profile.blockUser', { defaultValue: `Block @${displayUsername}` }),
+        message: t('profile.blockConfirm', {
+          username: displayUsername,
+          defaultValue: `They won't be able to find your profile, posts, or mentions. They won't be notified that you blocked them.`,
+        }),
+        okText: t('profile.block', { defaultValue: 'Block' }),
+        cancelText: t('common.cancel', { defaultValue: 'Cancel' }),
+        destructive: true,
+      });
+      // Backing out of the confirm returns to where it was opened from — the
+      // menu — instead of dumping the user back on the profile with nothing to
+      // show for the trip.
+      if (!confirmed) {
+        openMenu();
+        return;
+      }
+      try {
+        await oxyServices.blockUser(profileData.id);
+        toast(
+          t('profile.blocked', {
+            username: displayUsername,
+            defaultValue: `@${displayUsername} has been blocked`,
+          }),
+          { type: 'success' },
+        );
+      } catch {
+        toast(t('profile.blockFailed', { defaultValue: 'Failed to block user' }), { type: 'error' });
+      }
+    };
+
+    const handleReport = () => {
+      bottomSheet.setBottomSheetContent(
+        <ReportModal
+          visible={true}
+          onClose={() => bottomSheet.openBottomSheet(false)}
+          onSubmit={async (categories, details) => {
+            const success = await reportService.reportUser(profileData.id, categories, details);
+            if (success) {
+              toast(
+                t('report.thankYou', {
+                  defaultValue: 'Thank you for helping keep our community safe.',
+                }),
+                { type: 'success' },
+              );
+            } else {
+              toast(t('report.failed', { defaultValue: 'Failed to submit report.' }), {
+                type: 'error',
+              });
+            }
+          }}
+        />,
+      );
+      bottomSheet.openBottomSheet(true);
+    };
+
+    const handleAddToList = () => {
+      bottomSheet.setBottomSheetContent(
+        <AddToListSheet
+          targetUserId={profileData.id}
+          targetLabel={`@${displayUsername}`}
+          onClose={() => bottomSheet.openBottomSheet(false)}
+        />,
+      );
+      bottomSheet.openBottomSheet(true);
+    };
+
+    const handleAddToStarterPack = () => {
+      bottomSheet.setBottomSheetContent(
+        <AddToStarterPackSheet
+          targetUserId={profileData.id}
+          targetLabel={`@${displayUsername}`}
+          onClose={() => bottomSheet.openBottomSheet(false)}
+        />,
+      );
+      bottomSheet.openBottomSheet(true);
+    };
+
+    const actions: ActionMenuAction[] = [
+      ...(leadingActions ?? []),
+      {
+        icon: <ListIcon size={22} className="text-foreground" />,
+        label: t('lists.addTo.menuItem', { defaultValue: 'Add/remove from lists' }),
+        onPress: handleAddToList,
+      },
+      {
+        icon: <StarterPackIcon size={22} className="text-foreground" />,
+        label: t('starterPacks.addTo.menuItem', {
+          defaultValue: 'Add/remove from starter packs',
+        }),
+        onPress: handleAddToStarterPack,
+      },
+      {
+        icon: <MuteIcon size={22} className="text-foreground" />,
+        label: t('profile.muteUser', {
+          username: displayUsername,
+          defaultValue: `Mute @${displayUsername}`,
+        }),
+        onPress: handleMute,
+      },
+    ];
+
+    const destructiveActions: ActionMenuAction[] = [
+      {
+        icon: <BlockIcon size={22} color={theme.colors.error} />,
+        label: t('profile.blockUser', {
+          username: displayUsername,
+          defaultValue: `Block @${displayUsername}`,
+        }),
+        onPress: handleBlock,
+        color: theme.colors.error,
+      },
+      {
+        icon: <ReportIcon size={22} color={theme.colors.error} />,
+        label: t('profile.reportUser', { defaultValue: 'Report' }),
+        onPress: handleReport,
+        color: theme.colors.error,
+      },
+    ];
+
+    // Named so the block flow can reopen the exact same menu after a cancelled
+    // confirm.
+    function openMenu() {
+      showActionMenu({
+        label: t('profile.moreOptions', {
+          username: displayUsername,
+          defaultValue: `Options for @${displayUsername}`,
+        }),
+        groups: [actions, destructiveActions],
+      });
+    }
+
+    openMenu();
+  }, [profileData, isOwnProfile, leadingActions, theme, t, bottomSheet, oxyServices]);
+}

--- a/packages/frontend/components/Profile/index.ts
+++ b/packages/frontend/components/Profile/index.ts
@@ -1,13 +1,20 @@
 // Types
 export * from './types';
+export * from './profileRoute';
 
 // Hooks
 export { useSubscription } from './hooks/useSubscription';
 export { useProfileScroll } from './hooks/useProfileScroll';
+export { useProfileAccount } from './hooks/useProfileAccount';
+export { useProfileChrome } from './hooks/useProfileChrome';
+export { useProfileMoreMenu } from './hooks/useProfileMoreMenu';
+export { useJustFollowed } from './hooks/useJustFollowed';
 
 // Components
 export { ProfileSkeleton } from './ProfileSkeleton';
-export { ProfileHeaderDefault, ProfileHeaderMinimalist, ProfileActions } from './ProfileHeader';
+export { ProfileShell } from './ProfileShell';
+export { ProfileHeader } from './ProfileHeader';
+export { ChannelHeader, ChannelActions } from './ChannelHeader';
 export { ProfileStats } from './ProfileStats';
 export { ProfileMeta } from './ProfileMeta';
 export { ProfileCommunities } from './ProfileCommunities';
@@ -18,19 +25,3 @@ export { ProfileContent } from './ProfileContent';
 // Re-export existing components
 export { default as MediaGrid } from './MediaGrid';
 export { default as VideosGrid } from './VideosGrid';
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/frontend/components/Profile/profileRoute.ts
+++ b/packages/frontend/components/Profile/profileRoute.ts
@@ -1,0 +1,56 @@
+import type { Href } from 'expo-router';
+import type { AccountKind } from '@oxyhq/core';
+
+/**
+ * Which URL family a profile page belongs to.
+ *
+ * A channel account's page is `/c/<handle>`, everybody else's is `/@<handle>`.
+ * The two are never interchangeable, and the ACCOUNT's own kind is the only
+ * thing that decides which — nothing about the URL a reader arrived on does.
+ */
+export type ProfileRouteFamily = 'channel' | 'person';
+
+/** The family the account itself belongs to. An absent kind reads as a person. */
+export function profileRouteFamilyForKind(kind: AccountKind | undefined): ProfileRouteFamily {
+  return kind === 'channel' ? 'channel' : 'person';
+}
+
+/** The route a given family serves a handle at. */
+export function profileBasePath(family: ProfileRouteFamily, handle: string): Href {
+  return family === 'channel' ? `/c/${handle}` : `/@${handle}`;
+}
+
+/**
+ * Where a reader sitting on `routedFamily` for this account should actually be,
+ * or `null` when they are already there.
+ *
+ * This is the ONE canonicalization, deliberately shared by both screens rather
+ * than implemented in each. Two screens each deciding where to redirect is how a
+ * bounce loop gets built: it takes only one disagreement about what an absent
+ * `kind` means for `/c/x` to send to `/@x` while `/@x` sends back. Here there is
+ * a single rule and a single reading of `kind`, so "already canonical" and "go
+ * there" are answered by the same expression — see the fixed-point test.
+ *
+ * It is a CANONICALIZATION, not a gate: the kind is only knowable once the
+ * account has resolved, so both URLs are legitimately reachable and whichever
+ * one a reader arrives on, the one they end up sitting on is the one that
+ * account owns. Both directions matter — a post row links every author to
+ * `/@<handle>` (the DTO says nothing about account kind), so that is how a
+ * reader reaches a channel at all.
+ *
+ * Returns `null` while the account is unresolved: redirecting on a guess would
+ * bounce every channel through `/@` on each cold load.
+ */
+export function canonicalProfileHref(params: {
+  routedFamily: ProfileRouteFamily;
+  kind: AccountKind | undefined;
+  /** Resolved, never the raw URL segment — the redirect target must be canonical. */
+  handle: string;
+  /** False while the account is still resolving. */
+  resolved: boolean;
+}): Href | null {
+  if (!params.resolved || !params.handle) return null;
+  const target = profileRouteFamilyForKind(params.kind);
+  if (target === params.routedFamily) return null;
+  return profileBasePath(target, params.handle);
+}

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -1,4 +1,5 @@
 import type { ViewStyle, TextStyle, StyleProp } from 'react-native';
+import type { Href } from 'expo-router';
 import type { AccountKind } from '@oxyhq/core';
 import type { ProfileData } from '@/hooks/useProfileData';
 
@@ -298,32 +299,43 @@ export interface UserNameProps {
 
 export type UserNameComponent = React.ComponentType<UserNameProps>;
 
-// Profile header props (shared between default and minimalist). Only the
-// minimalist header renders the name itself; the default header leaves that to
-// the `UserName` block the parent renders beneath it, so the name/verified/
-// component trio belongs to the minimalist contract alone.
+// What both headers need to draw an account at all. Everything past this point
+// differs, which is why there are two headers rather than one with flags.
 export interface ProfileHeaderBaseProps {
   username?: string;
   avatarUri?: string;
+  /** Drives the live-avatar swap and the presence dot; both are skipped without it. */
+  profileId?: string;
 }
 
-export interface ProfileHeaderMinimalistProps extends ProfileHeaderBaseProps {
+/**
+ * A CHANNEL's header. It renders the name ITSELF, because the name sits beside
+ * the avatar in the compact layout rather than beneath it.
+ */
+export interface ChannelHeaderProps extends ProfileHeaderBaseProps {
   displayName?: string;
   verified?: boolean;
   UserNameComponent: UserNameComponent;
   isPrivate: boolean;
   privacySettings?: ProfileData['privacy'];
-  /** Drives the live-avatar swap and the presence dot; both are skipped without it. */
-  profileId?: string;
-  isOwnProfile?: boolean;
   /** Extra element rendered inline after the name (e.g. the fediverse badge). */
   trailingBadge?: React.ReactNode;
 }
 
-export interface ProfileHeaderDefaultProps extends ProfileHeaderBaseProps {
+/** The follow control under a channel's header. */
+export interface ChannelActionsProps {
+  profileId?: string;
+  isFollowing?: boolean;
+  FollowButtonComponent: FollowButtonComponent;
+}
+
+/**
+ * A PERSON's header. It leaves the name to the `UserName` block the parent
+ * renders beneath it, so no name/verified props appear here.
+ */
+export interface ProfileHeaderProps extends ProfileHeaderBaseProps {
   isOwnProfile: boolean;
   currentUsername?: string;
-  profileId?: string;
   isFederated?: boolean;
   actorUri?: string;
   isFollowing?: boolean;
@@ -345,9 +357,14 @@ export interface ProfileStatsProps {
    * disagree.
    */
   showReplies?: boolean;
-  profileUsername?: string;
-  profileHandle?: string;
-  username: string;
+  /**
+   * Where the follow-graph stats lead. Passed in rather than built from a handle
+   * because the two URL families answer it differently, and a stat row is the
+   * wrong place to know which family it is on. `null` renders the count without
+   * making it a link.
+   */
+  followingHref: Href | null;
+  followersHref: Href | null;
   onPostsPress: () => void;
   onBoostsPress: () => void;
   onRepliesPress: () => void;
@@ -367,8 +384,13 @@ export interface ProfileActionsProps {
 export interface ProfileMetaProps {
   location?: string;
   createdAt?: string;
-  username: string;
-  profileHandle?: string;
+  /**
+   * Where the join-date row leads — the account's "about" surface. Passed in for
+   * the same reason as {@link ProfileStatsProps.followingHref}: the row does not
+   * know which URL family it is on. `null` renders the date as plain text with
+   * no chevron, rather than a link that goes somewhere wrong.
+   */
+  aboutHref: Href | null;
 }
 
 // Community interface
@@ -409,14 +431,25 @@ export interface PrivateBadgeProps {
 // Profile content (main info section) props
 export interface ProfileContentProps {
   profileData: ProfileData;
-  avatarUri?: string;
   isOwnProfile: boolean;
   isPrivate: boolean;
-  currentUsername?: string;
   followingCount: number;
   followerCount: number;
-  username: string;
-  FollowButtonComponent: FollowButtonComponent;
+  /** The canonical handle, for surfaces that address the account by name. */
+  profileHandle: string;
+  /**
+   * The identity block: header, and for a person the name/handle line beneath
+   * it. A SLOT rather than a branch — which header an account gets, and whether
+   * its name sits beside the avatar or below it, is the single biggest
+   * difference between the two screens, and everything below this line is the
+   * part that genuinely does not care.
+   */
+  identity: React.ReactNode;
+  /** Whether the replies stat is shown; see {@link ProfileStatsProps.showReplies}. */
+  showReplies: boolean;
+  aboutHref: Href | null;
+  followingHref: Href | null;
+  followersHref: Href | null;
   onPostsPress: () => void;
   onBoostsPress: () => void;
   onRepliesPress: () => void;

--- a/packages/frontend/components/ProfileScreen.tsx
+++ b/packages/frontend/components/ProfileScreen.tsx
@@ -1,92 +1,53 @@
-import React, { useMemo, useCallback, useState, useEffect, useContext, useRef } from 'react';
-import {
-    Animated,
-    ImageBackground,
-    StatusBar,
-    StyleSheet,
-    Text,
-    TouchableOpacity,
-    View,
-    Share,
-    Platform,
-} from 'react-native';
-import { toast } from '@oxyhq/bloom/toast';
-import { Redirect, router, useLocalSearchParams, usePathname, type Href } from 'expo-router';
+import React, { useMemo, useCallback, useState, useEffect } from 'react';
+import { Text, TouchableOpacity, View, Share } from 'react-native';
+import { Redirect, router, type Href } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { BloomColorScope, useTheme } from '@oxyhq/bloom/theme';
+import { BloomColorScope } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
 import { FollowButton as OxyFollowButton, useAuth, useFollow } from '@oxyhq/services/ui/client';
-import { useProfileData, type ProfileData } from '@/hooks/useProfileData';
-import { useProfileScreenColor } from '@/hooks/useProfileScreenColor';
 import { usePostsStore } from '@/stores/postsStore';
-import { BottomSheetContext } from '@/context/BottomSheetContext';
-import { muteService } from '@/services/muteService';
 import { lanesService } from '@/services/lanesService';
-import { reportService } from '@/services/reportService';
 import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
-import { showActionMenu } from '@/components/common/ActionMenu';
-import type { ActionMenuAction } from '@/components/common/actionMenuGroups';
-import { ReportModal } from '@/components/report/ReportModal';
-import { AddToListSheet } from '@/components/Lists/AddToListSheet';
-import { AddToStarterPackSheet } from '@/components/AddToStarterPackSheet';
-import { confirmDialog } from '@/utils/alerts';
 import { openExternalLink } from '@/utils/openExternalLink';
 import type { FeedType } from '@mention/shared-types';
 import { logger } from '@oxyhq/core/logger';
-import { useSafeBack } from '@/hooks/useSafeBack';
-import { NoUpdatesIllustration } from '@/assets/illustrations/NoUpdates';
-import { EmptyState } from '@/components/common/EmptyState';
-import { getNormalizedUserHandle, type AccountNode } from '@oxyhq/core';
-import { usePanelStickyTopInset, usePanelStickyTabsTopInset, PANEL_HEADER_HEIGHT } from '@/components/shell/PanelChrome';
+import type { ProfileData } from '@/hooks/useProfileData';
 
 // Icons
 import { Bell, BellActive } from '@/assets/icons/bell-icon';
 import { Icon } from '@/lib/icons';
 import { ShareIcon } from '@/assets/icons/share-icon';
-import { ComposeIcon } from '@/assets/icons/compose-icon';
 import { MailIcon } from '@/assets/icons/mail-icon';
 import { MoreIcon } from '@/assets/icons/more-icon';
 import { ExternalLinkIcon } from '@/assets/icons/external-link-icon';
-import { List as ListIcon } from '@/assets/icons/list-icon';
-import { StarterPackIcon } from '@/assets/icons/starter-pack-icon';
-import { MuteIcon } from '@/assets/icons/mute-icon';
-import { BlockIcon } from '@/assets/icons/block-icon';
-import { ReportIcon } from '@/assets/icons/report-icon';
 
 // Components
-import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types/post';
 import UserName from './UserName';
 import AnimatedTabBar from './common/AnimatedTabBar';
-import { BottomBarAwareFab } from '@/components/BottomBarAwareFab';
 import { IconButton } from '@/components/ui/Button';
 import { SEO } from '@/components/SEO';
+import { FediverseSharingBadge } from '@/components/Fediverse/FediverseBadge';
 
 // Profile components
 import {
-    ProfileSkeleton,
     ProfileContent,
-    ProfileTabs,
+    ProfileHeader,
+    ProfileShell,
+    PrivateBadge,
     useSubscription,
-    useProfileScroll,
+    useProfileAccount,
+    useProfileChrome,
+    useProfileMoreMenu,
+    useJustFollowed,
     buildProfileTabDescriptors,
     laneTabKey,
     profileTabIndex,
-    LAYOUT,
-    shouldFeedOwnProfileScroll,
-    shouldGridOwnProfileScroll,
+    profileTabsForAccountKind,
     type LaneTabInput,
     type ProfileScreenProps,
     type ProfileTab,
 } from './Profile';
 import { SuggestedUsers } from './suggestions/SuggestedUsers';
-
-const IS_WEB = Platform.OS === 'web';
-
-// Banner image wrapped for the pull-to-zoom parallax (scale driven by the shared
-// scrollY). Created once at module scope so it is a stable component type.
-const AnimatedImageBackground = Animated.createAnimatedComponent(ImageBackground);
 
 // Helper functions
 const isProfilePrivate = (
@@ -104,48 +65,37 @@ const isProfilePrivate = (
 // Feed types for clearing cache
 const FEED_TYPES: FeedType[] = ['posts', 'replies', 'media', 'likes', 'boosts'];
 
-// Top-right header action icon metrics (IconButton `variant="icon"` renders a
-// 32×32 touch target; the cluster uses NativeWind `gap-1` = 4px). Used to size
-// the scrolled name overlay so it never overlaps the icons.
-const HEADER_ACTION_ICON_SIZE = 32;
-const HEADER_ACTION_ICON_GAP = 4;
-const HEADER_OVERLAY_ICON_CLEARANCE = 12;
-
-/**
- * Profile Screen - Main orchestrator component
- * Follows industry best practices with clean separation of concerns
- */
-interface MentionProfileContentProps extends ProfileScreenProps {
+interface PersonProfileProps extends ProfileScreenProps {
     username: string;
+    handle: string;
     isFederated: boolean;
     profileData: ProfileData | null;
     loading: boolean;
 }
 
-const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
+/**
+ * ONE PERSON's profile page, at `/@<handle>`.
+ *
+ * Person-shaped throughout, and deliberately so: it has a banner, a poke, the
+ * full tab strip, a self view with edit/analytics/settings, and sub-routes under
+ * its own URL family. A CHANNEL satisfies none of that and has its own screen
+ * (`ChannelScreen`); the two share the chrome, the body, the account lookup and
+ * the canonicalization, and nothing else.
+ */
+const PersonProfile: React.FC<PersonProfileProps> = ({
     tab = 'posts',
     laneId,
     username,
+    handle,
     isFederated,
     profileData,
     loading,
 }) => {
-    const { user: currentUser, oxyServices } = useAuth();
-    const theme = useTheme();
+    const { user: currentUser } = useAuth();
     const { t } = useTranslation();
-    const insets = useSafeAreaInsets();
-    const bottomSheet = useContext(BottomSheetContext);
 
-    // Web sticky-chrome top insets, resolved from the shared PanelChrome source
-    // of truth. They carry the panel's `PANEL_TOP_INSET` gutter while the rounded
-    // shell frame is shown (>=500px, same breakpoint as the sidebar) and collapse
-    // to 0 at full-bleed so the profile banner / header band / tab bar pin flush
-    // to the viewport top instead of leaving a stray gutter band.
-    const panelStickyTopInset = usePanelStickyTopInset();
-    const panelStickyTabsTopInset = usePanelStickyTabsTopInset();
-
-    // Active tab — use local state so tab switching doesn't trigger router
-    // navigation. Held as the tab's KEY, not its index: the strip's length now
+    // Active tab — local state so tab switching doesn't trigger router
+    // navigation. Held as the tab's KEY, not its index: the strip's length
     // depends on how many lanes the publisher has, so an index means a different
     // tab before and after that list loads. A lane deep link therefore paints
     // `posts` for one frame and settles on the lane once its key resolves.
@@ -165,11 +115,9 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
         },
     });
 
-    // Tabs — every PERSON (federated included) gets the full static strip, since
-    // the data behind each tab is in Oxy/Mention's DB either way; a channel
-    // account gets the subset its kind can actually fill, which
-    // `buildProfileTabDescriptors` derives from the kind itself. Lane tabs are
-    // spliced in after `posts` for both.
+    // Every person — federated included — gets the full static strip, since the
+    // data behind each tab is in Oxy/Mention's DB either way. Lane tabs are
+    // spliced in after `posts`.
     const tabDescriptors = useMemo(
         () =>
             buildProfileTabDescriptors(
@@ -195,128 +143,61 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
     const activeProfileTab: ProfileTab = activeDescriptor?.tab ?? 'posts';
     const activeLaneId = activeDescriptor?.laneId;
 
-    const safeBack = useSafeBack();
-
-    // Profile content height for scroll-to functionality
-    const [profileContentHeight, setProfileContentHeight] = useState(0);
-
-    // Scroll handling
-    const { scrollY, onScroll, assignScrollRef, scrollToContent } = useProfileScroll({
-        profileId: profileData?.id,
-        currentTab: activeProfileTab,
-        currentLaneId: activeLaneId,
-    });
-
     // Follow data — federated users are stored in Oxy, so useFollow works with their Oxy ID
     const stableUserId = profileData?.id || '';
-    const { followerCount: rawFollowerCount, followingCount: rawFollowingCount, isFollowing: isFollowingProfileUser = false } = useFollow(stableUserId);
+    const {
+        followerCount: rawFollowerCount,
+        followingCount: rawFollowingCount,
+        isFollowing: isFollowingProfileUser = false,
+    } = useFollow(stableUserId);
     const followerCount = rawFollowerCount ?? 0;
     const followingCount = rawFollowingCount ?? 0;
 
-    // Track "just followed" — show suggestions only on the follow action, not on revisits
-    const [justFollowed, setJustFollowed] = useState(false);
-    const followSettledRef = useRef(false);
-    const prevFollowRef = useRef(isFollowingProfileUser);
-    const prevUserIdRef = useRef(stableUserId);
+    // Show suggestions only on the follow ACTION, never on a revisit.
+    const justFollowed = useJustFollowed(stableUserId, isFollowingProfileUser);
 
-    // Compute follow transition during render instead of chained effects
-    if (prevUserIdRef.current !== stableUserId) {
-        // Reset tracking when navigating to a different profile
-        prevUserIdRef.current = stableUserId;
-        followSettledRef.current = false;
-        prevFollowRef.current = false;
-        if (justFollowed) setJustFollowed(false);
-    } else if (!followSettledRef.current) {
-        // Skip initial store hydration
-        followSettledRef.current = true;
-        prevFollowRef.current = isFollowingProfileUser;
-    } else if (isFollowingProfileUser !== prevFollowRef.current) {
-        // Detect user-initiated follow/unfollow
-        if (isFollowingProfileUser) {
-            setJustFollowed(true);
-        } else if (justFollowed) {
-            setJustFollowed(false);
-        }
-        prevFollowRef.current = isFollowingProfileUser;
-    }
-
-    // Subscription handling
     const { subscribed, loading: subLoading, toggle: toggleSubscription } = useSubscription(
         profileData?.id,
         currentUser?.id,
-        currentUser?.id === profileData?.id
+        currentUser?.id === profileData?.id,
     );
 
-    // Computed values
     const design = profileData?.design;
     const avatarUri = design?.avatar;
-    // A stored banner is shown whenever there is one. The `coverPhotoEnabled`
-    // gate that used to gate it here went with the "Profile Style" picker that
-    // was its only writer — left in place it would have kept suppressing the
-    // banner of everyone who ever picked Minimalist, with no control anywhere
-    // left to turn it back on. Whether a banner renders AT ALL is decided one
-    // level up, by `minimalistMode`.
+    // A stored banner is shown whenever there is one. Whether the banner BAND
+    // exists at all is not in question here — a person's layout has one, and an
+    // account with no image set gets the tinted placeholder.
     const bannerUri = design?.bannerUrl;
-    const minimalistMode = design?.minimalistMode ?? false;
-    const profileHandle = useMemo(() => {
-        return getNormalizedUserHandle({
-            username: profileData?.username || username,
-            instance: profileData?.instance,
-            isFederated: profileData?.isFederated,
-        }) || username;
-    }, [profileData?.username, profileData?.instance, profileData?.isFederated, username]);
 
-    // A CHANNEL account's page lives at `/c/<handle>`, a person's at
-    // `/@<handle>`. Two routes that are never interchangeable, and the account's
-    // own kind is the only thing that decides which — nothing about the URL the
-    // reader arrived on does.
-    const isChannelAccount = profileData?.kind === 'channel';
-    const profileBasePath = isChannelAccount ? `/c/${profileHandle}` : `/@${profileHandle}`;
-
-    // Whether the viewer OPERATES this channel, which is what puts its settings
-    // in reach. A channel account has no login of its own, so `isOwnProfile` can
-    // never be true for one and there is no other signal on the profile itself.
-    //
-    // Gated on the profile actually BEING a channel: the account graph is a real
-    // request, and every other profile in the app would pay for it to answer a
-    // question that can only be yes on this one.
-    const operatedAccountsQuery = useQuery<AccountNode[]>({
-        queryKey: viewerQueryKeys.operatedAccounts(currentUser?.id),
-        queryFn: () => oxyServices.listAccounts(),
-        enabled: isChannelAccount && Boolean(currentUser?.id) && Boolean(profileData?.id),
-    });
-    const operatesThisChannel = Boolean(
-        profileData?.id &&
-        operatedAccountsQuery.data?.some((account) => account.accountId === profileData.id),
-    );
-
-    // Memoized checks
     const isOwnProfile = useMemo(() => {
         if (isFederated) return false;
         if (!currentUser?.id || !profileData?.id) return false;
         return currentUser.id === profileData.id;
     }, [currentUser?.id, profileData?.id, isFederated]);
 
-    // User's profile color hex for passing to buttons
     const isPrivate = useMemo(
         () => isProfilePrivate(profileData, profileData?.privacy),
-        [profileData]
+        [profileData],
     );
 
-    const nativeFeedOwnsScroll = shouldFeedOwnProfileScroll({
-        tab: activeProfileTab,
-        isWeb: IS_WEB,
-        isPrivate,
-        isOwnProfile,
+    // Number of action icons in the top-right cluster; sizes the scrolled name
+    // overlay so a long display name truncates instead of sliding under them.
+    const headerActionCount = useMemo(() => {
+        let count = 1; // share is always present
+        if (!isOwnProfile) count += 2; // subscribe + more
+        // DM is local-only — remote (federated) actors have no Mention inbox.
+        if (!isOwnProfile && !isFederated) count += 1;
+        if (isFederated) count += 1; // open-on-instance
+        return count;
+    }, [isOwnProfile, isFederated]);
+
+    const chrome = useProfileChrome({
+        profileId: profileData?.id,
+        currentTab: activeProfileTab,
+        currentLaneId: activeLaneId,
+        headerActionCount,
+        hasBannerBand: true,
     });
-    const nativeGridOwnsScroll = shouldGridOwnProfileScroll({
-        tab: activeProfileTab,
-        isWeb: IS_WEB,
-        isPrivate,
-        isOwnProfile,
-    });
-    const nativeListOwnsScroll =
-        nativeFeedOwnsScroll || nativeGridOwnsScroll;
 
     // Clear cached feed data for private profiles
     useEffect(() => {
@@ -328,29 +209,23 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
         }
     }, [isPrivate, isOwnProfile, profileData?.id]);
 
-    // Handlers
     const onTabPress = useCallback(
         (index: number) => {
             if (!username) return;
             const descriptor = tabDescriptors[index];
             if (!descriptor) return;
             setActiveTabKey(descriptor.key);
-            // A channel account's page is ONE route (`/c/<handle>`) with no tab
-            // segments beneath it, so its tabs are local state and there is
-            // nothing to replace. Writing `/@<handle>/media` here would navigate
-            // a channel out of its own URL family.
-            if (isChannelAccount) return;
-            // Update URL silently for deep-linking / sharing without triggering
-            // navigation. A lane tab routes by id under its own segment, so it
-            // can never collide with a static tab's file name.
+            // Update the URL silently for deep-linking / sharing without
+            // triggering navigation. A lane tab routes by id under its own
+            // segment, so it can never collide with a static tab's file name.
             const path: Href = descriptor.laneId
-                ? `/@${profileHandle}/lane/${descriptor.laneId}`
+                ? `/@${handle}/lane/${descriptor.laneId}`
                 : descriptor.tab === 'posts'
-                    ? `/@${profileHandle}`
-                    : `/@${profileHandle}/${descriptor.tab}`;
+                    ? `/@${handle}`
+                    : `/@${handle}/${descriptor.tab}`;
             router.replace(path);
         },
-        [username, profileHandle, tabDescriptors, isChannelAccount]
+        [username, handle, tabDescriptors],
     );
 
     // The stats row jumps to a tab BY NAME. Resolving the index at press time is
@@ -361,12 +236,12 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
         (key: string) => {
             const index = profileTabIndex(tabDescriptors, key);
             if (index === activeTab) {
-                scrollToContent(profileContentHeight);
+                chrome.scrollToContent(chrome.contentHeight);
             } else {
                 onTabPress(index);
             }
         },
-        [activeTab, profileContentHeight, onTabPress, scrollToContent, tabDescriptors],
+        [activeTab, chrome, onTabPress, tabDescriptors],
     );
 
     const handlePostsPress = useCallback(() => scrollOrSwitch('posts'), [scrollOrSwitch]);
@@ -375,14 +250,12 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
 
     const handleShare = useCallback(async () => {
         if (!profileData) return;
-
         try {
-            const shareUrl = `https://mention.earth${profileBasePath}`;
+            const shareUrl = `https://mention.earth/@${handle}`;
             const shareMessage = t('profile.share.message', {
                 name: profileData.design.displayName,
                 defaultValue: `Check out ${profileData.design.displayName}'s profile on Mention!`,
             });
-
             await Share.share({
                 message: `${shareMessage}\n\n${shareUrl}`,
                 url: shareUrl,
@@ -394,142 +267,10 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
         } catch {
             logger.error('Error sharing profile');
         }
-    }, [profileData, profileBasePath, t]);
+    }, [profileData, handle, t]);
 
-    // More options menu (block, mute, report)
-    const handleMoreOptions = useCallback(() => {
-        if (!profileData || isOwnProfile) return;
+    const handleMoreOptions = useProfileMoreMenu({ profileData, isOwnProfile });
 
-        const displayUsername = profileData.username;
-
-        const handleMute = async () => {
-            const success = await muteService.muteUser(profileData.id);
-            if (success) {
-                toast(t('profile.muted', { username: displayUsername, defaultValue: `@${displayUsername} has been muted` }), { type: 'success' });
-            } else {
-                toast(t('profile.muteFailed', { defaultValue: 'Failed to mute user' }), { type: 'error' });
-            }
-        };
-
-        const handleBlock = async () => {
-            const confirmed = await confirmDialog({
-                title: t('profile.blockUser', { defaultValue: `Block @${displayUsername}` }),
-                message: t('profile.blockConfirm', { username: displayUsername, defaultValue: `They won't be able to find your profile, posts, or mentions. They won't be notified that you blocked them.` }),
-                okText: t('profile.block', { defaultValue: 'Block' }),
-                cancelText: t('common.cancel', { defaultValue: 'Cancel' }),
-                destructive: true,
-            });
-            // Backing out of the confirm returns to where it was opened from —
-            // the menu — instead of dumping the user back on the profile with
-            // nothing to show for the trip.
-            if (!confirmed) {
-                openMenu();
-                return;
-            }
-            try {
-                await oxyServices.blockUser(profileData.id);
-                toast(t('profile.blocked', { username: displayUsername, defaultValue: `@${displayUsername} has been blocked` }), { type: 'success' });
-            } catch {
-                toast(t('profile.blockFailed', { defaultValue: 'Failed to block user' }), { type: 'error' });
-            }
-        };
-
-        const handleReport = () => {
-            bottomSheet.setBottomSheetContent(
-                <ReportModal
-                    visible={true}
-                    onClose={() => bottomSheet.openBottomSheet(false)}
-                    onSubmit={async (categories, details) => {
-                        const success = await reportService.reportUser(profileData.id, categories, details);
-                        if (success) {
-                            toast(t('report.thankYou', { defaultValue: 'Thank you for helping keep our community safe.' }), { type: 'success' });
-                        } else {
-                            toast(t('report.failed', { defaultValue: 'Failed to submit report.' }), { type: 'error' });
-                        }
-                    }}
-                />
-            );
-            bottomSheet.openBottomSheet(true);
-        };
-
-        const handleAddToList = () => {
-            bottomSheet.setBottomSheetContent(
-                <AddToListSheet
-                    targetUserId={profileData.id}
-                    targetLabel={`@${displayUsername}`}
-                    onClose={() => bottomSheet.openBottomSheet(false)}
-                />
-            );
-            bottomSheet.openBottomSheet(true);
-        };
-
-        const handleAddToStarterPack = () => {
-            bottomSheet.setBottomSheetContent(
-                <AddToStarterPackSheet
-                    targetUserId={profileData.id}
-                    targetLabel={`@${displayUsername}`}
-                    onClose={() => bottomSheet.openBottomSheet(false)}
-                />
-            );
-            bottomSheet.openBottomSheet(true);
-        };
-
-        const actions: ActionMenuAction[] = [
-            // Operators only, and first: it is the one action here that is about
-            // running this account rather than about the viewer's relationship
-            // to it. Everyone else never sees a row that would refuse them.
-            ...(operatesThisChannel
-                ? [{
-                    icon: <Icon name="settings-outline" size={22} className="text-foreground" />,
-                    label: t('channels.settings.title', { defaultValue: 'Channel settings' }),
-                    onPress: () => router.push(`/c/${profileHandle}/settings`),
-                }]
-                : []),
-            {
-                icon: <ListIcon size={22} className="text-foreground" />,
-                label: t('lists.addTo.menuItem', { defaultValue: 'Add/remove from lists' }),
-                onPress: handleAddToList,
-            },
-            {
-                icon: <StarterPackIcon size={22} className="text-foreground" />,
-                label: t('starterPacks.addTo.menuItem', { defaultValue: 'Add/remove from starter packs' }),
-                onPress: handleAddToStarterPack,
-            },
-            {
-                icon: <MuteIcon size={22} className="text-foreground" />,
-                label: t('profile.muteUser', { username: displayUsername, defaultValue: `Mute @${displayUsername}` }),
-                onPress: handleMute,
-            },
-        ];
-
-        const destructiveActions: ActionMenuAction[] = [
-            {
-                icon: <BlockIcon size={22} color={theme.colors.error} />,
-                label: t('profile.blockUser', { username: displayUsername, defaultValue: `Block @${displayUsername}` }),
-                onPress: handleBlock,
-                color: theme.colors.error,
-            },
-            {
-                icon: <ReportIcon size={22} color={theme.colors.error} />,
-                label: t('profile.reportUser', { defaultValue: 'Report' }),
-                onPress: handleReport,
-                color: theme.colors.error,
-            },
-        ];
-
-        // Named so the block flow can reopen the exact same menu after a
-        // cancelled confirm.
-        function openMenu() {
-            showActionMenu({
-                label: t('profile.moreOptions', { username: displayUsername, defaultValue: `Options for @${displayUsername}` }),
-                groups: [actions, destructiveActions],
-            });
-        }
-
-        openMenu();
-    }, [profileData, isOwnProfile, theme, t, bottomSheet, oxyServices, operatesThisChannel, profileHandle]);
-
-    // DM button handler
     const handleDM = useCallback(() => {
         if (!profileData?.id) return;
         const params = new URLSearchParams({
@@ -544,144 +285,116 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
         if (profileData?.actorUri) openExternalLink(profileData.actorUri);
     }, [profileData?.actorUri]);
 
-    // Animations
-    const headerBackgroundOpacity = useMemo(
-        () =>
-            scrollY.interpolate({
-                inputRange: [0, LAYOUT.HEADER_HEIGHT_EXPANDED],
-                outputRange: [0, 1],
-                extrapolate: 'clamp',
-            }),
-        [scrollY]
-    );
-
-    // Pull-to-zoom banner parallax: on overscroll (negative scroll offset, i.e.
-    // pulling the content down past the top) the banner scales 1 → 1.5. Uses the
-    // same `scrollY` Animated.Value as the banner fade above for consistency; on
-    // web `window.scrollY` never goes negative, so this stays clamped at 1 (no
-    // rubber-band there) while native's bouncing ScrollView drives the zoom.
-    const bannerScale = useMemo(
-        () =>
-            scrollY.interpolate({
-                inputRange: [-150, 0],
-                outputRange: [1.5, 1],
-                extrapolateLeft: 'extend',
-                extrapolateRight: 'clamp',
-            }),
-        [scrollY]
-    );
-
-    // Header name overlay opacity - shows when scrolled past profile content.
-    // Guard against the pre-measurement window: until ProfileContent's onLayout
-    // reports a real height, profileContentHeight is 0, which would make the
-    // interpolation input range [-20, 20] resolve to ~0.5 at scrollY=0 and paint
-    // the overlay (avatar + name) on top of the header icons and profile content.
-    // Keep the threshold strictly positive and force opacity 0 until measured.
-    const headerNameOpacity = useMemo(() => {
-        if (profileContentHeight <= 0) {
-            return 0;
-        }
-        // Reveal a touch later than the exact content height so the overlay only
-        // appears once the real name has scrolled out of view.
-        const revealStart = Math.max(profileContentHeight - 20, 1);
-        return scrollY.interpolate({
-            inputRange: [revealStart, profileContentHeight + 20],
-            outputRange: [0, 1],
-            extrapolate: 'clamp',
-        });
-    }, [scrollY, profileContentHeight]);
-
-    // Number of action icons rendered in the top-right cluster. Drives the right
-    // boundary of the scrolled name overlay so a long display name truncates
-    // instead of sliding under the icons.
-    const headerActionCount = useMemo(() => {
-        let count = 1; // share is always present
-        if (!isOwnProfile) count += 2; // subscribe + more
-        // DM is local-only — remote (federated) actors have no Mention inbox.
-        if (!isOwnProfile && !isFederated) count += 1; // DM
-        if (isFederated) count += 1; // open-on-instance
-        return count;
-    }, [isOwnProfile, isFederated]);
-
-    // Each IconButton is HEADER_ACTION_ICON_SIZE wide with HEADER_ACTION_ICON_GAP
-    // between them; the cluster is offset from the right edge by
-    // (DEFAULT_PADDING - 8). Reserve that span (plus breathing room) so the
-    // overlay never collides with the icons.
-    const headerOverlayRight = useMemo(
-        () =>
-            (LAYOUT.DEFAULT_PADDING - 8) +
-            headerActionCount * HEADER_ACTION_ICON_SIZE +
-            (headerActionCount - 1) * HEADER_ACTION_ICON_GAP +
-            HEADER_OVERLAY_ICON_CLEARANCE,
-        [headerActionCount]
-    );
-
-    // Dynamic styles
-    const themedStyles = useMemo(
+    const userNameStyle = useMemo(
         () => ({
-            container: { paddingTop: insets.top },
-            headerActions: { top: insets.top + 6 },
-            headerNameOverlay: { top: insets.top + 6, right: headerOverlayRight },
-            scrollView: { marginTop: minimalistMode ? 0 : LAYOUT.HEADER_HEIGHT_NARROWED },
-            contentContainer: {
-                paddingTop: minimalistMode
-                    ? insets.top + 60
-                    : LAYOUT.HEADER_HEIGHT_EXPANDED - insets.top,
-            },
+            name: { fontSize: 24, fontWeight: 'bold' as const, marginTop: 10, marginBottom: 4 },
+            handle: { fontSize: 15, marginBottom: 12 },
+            container: undefined,
         }),
-        [insets.top, minimalistMode, headerOverlayRight]
+        [],
     );
 
-    const profileSummary = useMemo(() => {
+    const identity = useMemo(() => {
+        if (!profileData) return null;
+        // Own, non-federated profile opted into fediverse sharing (absent flag ⇒
+        // on): a tappable badge next to the handle explaining the fediverse.
+        const fediverseBadge =
+            isOwnProfile && !profileData.isFederated && currentUser?.fediverseSharing !== false ? (
+                <FediverseSharingBadge size={20} />
+            ) : undefined;
+        // Passive "Follows you" tag inline to the right of the @handle when this
+        // profile follows the viewer. Never shown on the viewer's own profile.
+        const followsYouTag =
+            !isOwnProfile && currentUser?.id && profileData.followsYou ? (
+                <View className="bg-secondary px-2 py-0.5 rounded-full">
+                    <Text className="text-secondary-foreground text-xs font-medium" numberOfLines={1}>
+                        {t('profile.followsYou', { defaultValue: 'Follows you' })}
+                    </Text>
+                </View>
+            ) : undefined;
+        return (
+            <>
+                <ProfileHeader
+                    username={profileData.username}
+                    avatarUri={avatarUri}
+                    isOwnProfile={isOwnProfile}
+                    isFederated={profileData.isFederated}
+                    actorUri={profileData.actorUri}
+                    isFollowing={profileData.isFollowing}
+                    currentUsername={currentUser?.username}
+                    profileId={profileData.id}
+                    FollowButtonComponent={OxyFollowButton}
+                />
+                <View>
+                    <UserName
+                        name={profileData.design.displayName}
+                        handle={profileData.username}
+                        verified={profileData.verified}
+                        isFederated={profileData.isFederated}
+                        copyableHandle
+                        variant="default"
+                        style={userNameStyle}
+                        trailingBadge={fediverseBadge}
+                        handleTrailing={followsYouTag}
+                    />
+                    {isPrivate && (
+                        <View className="flex-row items-center gap-2 flex-wrap">
+                            <PrivateBadge privacySettings={profileData.privacy} />
+                        </View>
+                    )}
+                </View>
+            </>
+        );
+    }, [profileData, isOwnProfile, isPrivate, avatarUri, currentUser, userNameStyle, t]);
+
+    const summary = useMemo(() => {
         if (!profileData) return null;
         return (
             <View>
                 <ProfileContent
                     profileData={profileData}
-                    avatarUri={avatarUri}
                     isOwnProfile={isOwnProfile}
                     isPrivate={isPrivate}
-                    currentUsername={currentUser?.username}
                     followingCount={followingCount}
                     followerCount={followerCount}
-                    username={username}
-                    FollowButtonComponent={OxyFollowButton}
+                    profileHandle={handle}
+                    identity={identity}
+                    showReplies={profileTabsForAccountKind(profileData.kind).includes('replies')}
+                    aboutHref={`/@${handle}/about`}
+                    followingHref={`/@${handle}/following`}
+                    followersHref={`/@${handle}/followers`}
                     onPostsPress={handlePostsPress}
                     onBoostsPress={handleBoostsPress}
                     onRepliesPress={handleRepliesPress}
-                    onLayout={setProfileContentHeight}
+                    onLayout={chrome.setContentHeight}
                 />
                 {!isOwnProfile && (
-                    <SuggestedUsers
-                        visible={justFollowed}
-                        sourceUserId={profileData.id}
-                    />
+                    <SuggestedUsers visible={justFollowed} sourceUserId={profileData.id} />
                 )}
             </View>
         );
     }, [
-        avatarUri,
-        currentUser?.username,
+        chrome.setContentHeight,
         followerCount,
         followingCount,
+        handle,
         handleBoostsPress,
         handlePostsPress,
         handleRepliesPress,
+        identity,
         isOwnProfile,
         isPrivate,
         justFollowed,
         profileData,
-        username,
     ]);
 
     // The tab bar, and — on the viewer's OWN profile only — the way in to their
     // lanes. It belongs beside these tabs because a lane's whole effect is on
     // which of them a post lands on, and because the composer's lane icon was
-    // otherwise the only door to the screen that manages them. Not a sidebar
-    // entry: every item there needs an `icon`/`iconActive` pair and no lane glyph
-    // exists. The row carries the hairline so it stays continuous under the
-    // button, which sits outside the tab bar's own bordered box.
-    const profileTabBar = useMemo(
+    // otherwise the only door to the screen that manages them. The row carries
+    // the hairline so it stays continuous under the button, which sits outside
+    // the tab bar's own bordered box.
+    const tabBar = useMemo(
         () => (
             <View className="flex-row items-center border-b border-border bg-background">
                 <View className="flex-1" style={{ minWidth: 0 }}>
@@ -712,6 +425,85 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
         [activeDescriptor?.key, onTabPress, tabDescriptors, username, isOwnProfile, t],
     );
 
+    const headerActions = (
+        <>
+            {/* The bell is a toggle rendered as two different glyphs, so its
+                label has to carry the state a sighted user reads from the icon —
+                a static "Notifications" would leave a screen reader unable to
+                tell subscribed from not. */}
+            {!isOwnProfile && (
+                <IconButton
+                    variant="icon"
+                    onPress={toggleSubscription}
+                    disabled={subLoading}
+                    accessibilityLabel={
+                        subscribed
+                            ? t('profile.actions.unsubscribe', {
+                                handle,
+                                defaultValue: 'Stop notifying me about new posts from @{{handle}}',
+                            })
+                            : t('profile.actions.subscribe', {
+                                handle,
+                                defaultValue: 'Notify me about new posts from @{{handle}}',
+                            })
+                    }
+                >
+                    {subscribed ? (
+                        <BellActive size={18} className="text-primary" />
+                    ) : (
+                        <Bell size={18} className="text-foreground" />
+                    )}
+                </IconButton>
+            )}
+            {!isOwnProfile && !isFederated && (
+                <IconButton
+                    variant="icon"
+                    onPress={handleDM}
+                    accessibilityLabel={t('profile.actions.message', {
+                        handle,
+                        defaultValue: 'Message @{{handle}}',
+                    })}
+                >
+                    <MailIcon size={18} className="text-foreground" />
+                </IconButton>
+            )}
+            {isFederated && (
+                <IconButton
+                    variant="icon"
+                    onPress={handleOpenOnInstance}
+                    accessibilityLabel={t('profile.actions.openOnInstance', {
+                        handle,
+                        defaultValue: 'Open @{{handle}} on their home instance',
+                    })}
+                >
+                    <ExternalLinkIcon size={18} className="text-foreground" />
+                </IconButton>
+            )}
+            <IconButton
+                variant="icon"
+                onPress={handleShare}
+                accessibilityLabel={t('profile.actions.share', {
+                    handle,
+                    defaultValue: "Share @{{handle}}'s profile",
+                })}
+            >
+                <ShareIcon size={18} className="text-foreground" />
+            </IconButton>
+            {!isOwnProfile && (
+                <IconButton
+                    variant="icon"
+                    onPress={handleMoreOptions}
+                    accessibilityLabel={t('profile.actions.more', {
+                        handle,
+                        defaultValue: 'More options for @{{handle}}',
+                    })}
+                >
+                    <MoreIcon size={18} className="text-foreground" />
+                </IconButton>
+            )}
+        </>
+    );
+
     return (
         <>
             {profileData ? (
@@ -738,484 +530,53 @@ const MentionProfileContent: React.FC<MentionProfileContentProps> = ({
                     type="profile"
                 />
             ) : null}
-            {/* WEB: `web:z-auto` stops this screen wrapper from being its own
-                stacking context (RN-web otherwise renders every View as
-                `position:relative; z-index:0`, which would TRAP the sticky header
-                chrome below it). With `z-index:auto` the profile chrome (banner
-                z-1, action cluster + compact name z-101) competes directly in the
-                rounded panel's stacking context, so the action/name chrome paints
-                ABOVE the bleed-mask overlay (z-30) and the feed (z-3) but below the
-                panel border frame (z-120) — exactly like the home header. No effect
-                on native. */}
-            <View className="flex-1 bg-background web:z-auto relative flex-col" style={[{ overflow: 'visible' }, themedStyles.container]}>
-                <StatusBar barStyle={theme.isDark ? 'light-content' : 'dark-content'} />
-
-                {loading ? (
-                    <ProfileSkeleton />
-                ) : !profileData ? (
-                    <EmptyState
-                        customIcon={<NoUpdatesIllustration width={200} height={200} />}
-                        title={t('profile.notFound.title', { defaultValue: 'Profile not found' })}
-                        subtitle={t('profile.notFound.message', { defaultValue: "This profile couldn't be loaded. The user may not exist or their server may be unavailable." })}
-                        action={{ label: t('common.goBack', { defaultValue: 'Go Back' }), onPress: safeBack }}
-                    />
-                ) : (
-                    <>
-                        {/* Banner. NATIVE: `absolute left-0 right-0 top:0`
-                            (height 170, zIndex 1) over the NON-scrolling root — the
-                            content scrolls OVER it, and the `bg-background` overlay
-                            fades it out over the first 120px via
-                            `headerBackgroundOpacity`. WEB: there is no inner
-                            ScrollView (the DOCUMENT scrolls), so an `absolute` banner
-                            would scroll away. Instead it is `web:sticky` +
-                            `panelStickyTopInset` (pinned to the rounded panel's
-                            PANEL_TOP_INSET top-gutter inset — from the single shared
-                            constant, no literal `top-2` here — and sticky's
-                            containing block is the panel column, so it stays
-                            INSIDE the panel, never viewport-fixed). The negative
-                            bottom margin (`-170px`) cancels its flow height so the
-                            content's own `marginTop + paddingTop` offset is NOT
-                            double-counted — the banner occupies 0 net flow and the
-                            content still starts ~170px down and scrolls over it, then
-                            the banner fades to the background, exactly as on native.
-                            Its `web:z-[1]` keeps it BELOW the content (`zIndex: 3`),
-                            preserving native's content-over-banner layering. */}
-                        {!minimalistMode &&
-                            (bannerUri ? (
-                                <View
-                                    className="left-0 right-0 overflow-hidden web:sticky web:z-[1] web:[margin-bottom:-170px]"
-                                    style={[webStickyChrome.banner, panelStickyTopInset, { height: LAYOUT.HEADER_HEIGHT_EXPANDED + LAYOUT.HEADER_HEIGHT_NARROWED }]}
-                                >
-                                    <AnimatedImageBackground
-                                        source={{ uri: bannerUri }}
-                                        className="absolute left-0 right-0 top-0 overflow-hidden"
-                                        style={{
-                                            height: LAYOUT.HEADER_HEIGHT_EXPANDED + LAYOUT.HEADER_HEIGHT_NARROWED,
-                                            transform: [{ scale: bannerScale }],
-                                        }}
-                                    />
-                                    <Animated.View
-                                        className="absolute left-0 right-0 top-0 overflow-hidden bg-background"
-                                        style={{
-                                            height: LAYOUT.HEADER_HEIGHT_EXPANDED + LAYOUT.HEADER_HEIGHT_NARROWED,
-                                            zIndex: 1,
-                                            pointerEvents: 'none',
-                                            opacity: headerBackgroundOpacity,
-                                        }}
-                                    />
-                                </View>
-                            ) : (
-                                <View
-                                    className="left-0 right-0 overflow-hidden bg-primary/[0.125] web:sticky web:z-[1] web:[margin-bottom:-170px]"
-                                    style={[webStickyChrome.banner, panelStickyTopInset, { height: LAYOUT.HEADER_HEIGHT_EXPANDED + LAYOUT.HEADER_HEIGHT_NARROWED }]}
-                                >
-                                    <Animated.View
-                                        className="bg-background"
-                                        style={[
-                                            StyleSheet.absoluteFill,
-                                            {
-                                                opacity: headerBackgroundOpacity,
-                                            },
-                                        ]}
-                                    />
-                                </View>
-                            ))}
-
-                        {/* Pinned header-band surface (WEB only). When the header
-                            chrome is pinned in contact with the tab bar, the action
-                            cluster + compact-name overlay are 0-flow-height anchors
-                            with NO background of their own — so the scrolling feed
-                            (z-3) would show THROUGH the header band while the opaque
-                            tabs (`bg-background`) sit right below, reading as an
-                            incoherent transparent-header / opaque-tabs split. This
-                            sticky surface fills the 48px header band (PANEL_TOP_INSET
-                            .. PANEL_TOP_INSET + PANEL_HEADER_HEIGHT, i.e. flush with
-                            the tabs at top:56) with the SAME `bg-background` token the
-                            tab bar uses, so header + tabs read as ONE cohesive opaque
-                            bar. Its opacity is driven by the SAME
-                            `headerBackgroundOpacity` as the banner fade: 0 when
-                            expanded (the banner shows through — restored parallax
-                            preserved) → 1 once scrolled (opaque, matching the tabs).
-                            `web:z-[100]` paints it ABOVE the feed content (z-3) and the
-                            tabs (z-5) but BELOW the chrome icons/name overlay (z-101),
-                            so the icons stay on top. It intentionally receives web
-                            pointer events to prevent clicks from reaching covered feed
-                            content while the band is opaque; the higher z-101 header
-                            controls remain interactive. The `-48px` bottom margin
-                            (cancels its flow height, like the banner's `-170px`)
-                            keeps it a 0-flow overlay. Empty on native, where the chrome
-                            is an absolute overlay over the non-scrolling root. */}
-                        {IS_WEB && (
-                            <View
-                                className="left-0 right-0 web:sticky web:z-[100] web:pointer-events-auto web:[margin-bottom:-48px]"
-                                style={[panelStickyTopInset, { height: PANEL_HEADER_HEIGHT }]}
-                            >
-                                <Animated.View
-                                    className="bg-background"
-                                    style={[StyleSheet.absoluteFill, { opacity: headerBackgroundOpacity }]}
-                                />
-                            </View>
-                        )}
-
-                        {/* Header actions cluster (subscribe / DM / open-instance /
-                            share / more). NATIVE: `absolute`, `top: insets.top+6`,
-                            `right: DEFAULT_PADDING-8`, zIndex 10 — pinned at the top
-                            of the non-scrolling root. WEB: the cluster lives inside a
-                            full-width `web:sticky` + `panelStickyTopInset` wrapper
-                            pinned to the panel's PANEL_TOP_INSET top-gutter inset
-                            (same pattern as the PanelStickyHeader the home header
-                            uses — sticky's containing block is the panel column, so
-                            the cluster stays INSIDE the panel, never viewport-fixed).
-                            The wrapper has 0 flow height (its only child is
-                            `absolute`) and is `pointer-events-none` so it never blocks
-                            the feed; the cluster itself re-enables pointer events. Its
-                            `web:z-[101]` matches the home header so it paints above
-                            the feed/content (z-3) and the bleed mask (z-30) but below
-                            the panel's border frame (z-120). */}
-                        <View className="left-0 right-0 web:sticky web:z-[101] web:pointer-events-none" style={[webStickyChrome.chromeAnchor, panelStickyTopInset]}>
-                            <View
-                                className="absolute flex-row items-center gap-1 web:pointer-events-auto"
-                                style={[{ zIndex: 10, right: LAYOUT.DEFAULT_PADDING - 8 }, themedStyles.headerActions]}
-                            >
-                                {/* The bell is a toggle rendered as two different
-                                    glyphs, so its label has to carry the state a
-                                    sighted user reads from the icon — a static
-                                    "Notifications" would leave a screen reader
-                                    unable to tell subscribed from not. */}
-                                {!isOwnProfile && (
-                                    <IconButton
-                                        variant="icon"
-                                        onPress={toggleSubscription}
-                                        disabled={subLoading}
-                                        accessibilityLabel={
-                                            subscribed
-                                                ? t('profile.actions.unsubscribe', {
-                                                    handle: profileHandle,
-                                                    defaultValue: 'Stop notifying me about new posts from @{{handle}}',
-                                                })
-                                                : t('profile.actions.subscribe', {
-                                                    handle: profileHandle,
-                                                    defaultValue: 'Notify me about new posts from @{{handle}}',
-                                                })
-                                        }
-                                    >
-                                        {subscribed ? (
-                                            <BellActive size={18} className="text-primary" />
-                                        ) : (
-                                            <Bell size={18} className="text-foreground" />
-                                        )}
-                                    </IconButton>
-                                )}
-                                {!isOwnProfile && !isFederated && (
-                                    <IconButton
-                                        variant="icon"
-                                        onPress={handleDM}
-                                        accessibilityLabel={t('profile.actions.message', {
-                                            handle: profileHandle,
-                                            defaultValue: 'Message @{{handle}}',
-                                        })}
-                                    >
-                                        <MailIcon size={18} className="text-foreground" />
-                                    </IconButton>
-                                )}
-                                {isFederated && (
-                                    <IconButton
-                                        variant="icon"
-                                        onPress={handleOpenOnInstance}
-                                        accessibilityLabel={t('profile.actions.openOnInstance', {
-                                            handle: profileHandle,
-                                            defaultValue: 'Open @{{handle}} on their home instance',
-                                        })}
-                                    >
-                                        <ExternalLinkIcon size={18} className="text-foreground" />
-                                    </IconButton>
-                                )}
-                                <IconButton
-                                    variant="icon"
-                                    onPress={handleShare}
-                                    accessibilityLabel={t('profile.actions.share', {
-                                        handle: profileHandle,
-                                        defaultValue: "Share @{{handle}}'s profile",
-                                    })}
-                                >
-                                    <ShareIcon size={18} className="text-foreground" />
-                                </IconButton>
-                                {!isOwnProfile && (
-                                    <IconButton
-                                        variant="icon"
-                                        onPress={handleMoreOptions}
-                                        accessibilityLabel={t('profile.actions.more', {
-                                            handle: profileHandle,
-                                            defaultValue: 'More options for @{{handle}}',
-                                        })}
-                                    >
-                                        <MoreIcon size={18} className="text-foreground" />
-                                    </IconButton>
-                                )}
-                            </View>
-                        </View>
-
-                        {/* Compact name overlay (avatar + name + posts-count), fades
-                            in via `headerNameOpacity` once the real name scrolls past.
-                            NATIVE: `absolute`, `top: insets.top+6`, `left:
-                            DEFAULT_PADDING`, `right: headerOverlayRight` (truncates
-                            before the action icons), zIndex 10. WEB: same full-width
-                            `web:sticky` + `panelStickyTopInset` wrapper as the
-                            actions cluster, so it pins to the panel's PANEL_TOP_INSET
-                            top-gutter inset INSIDE the panel (never viewport-fixed).
-                            The fade is driven by the same
-                            window-fed `scrollY` interpolation as native. The overlay
-                            is `pointer-events-none` (matching native), and the wrapper
-                            consumes 0 net flow height.
-
-                            It is `aria-hidden` because it is a purely visual restatement
-                            of the avatar, name, verified badge and post count the profile
-                            summary below already renders — a screen reader would otherwise
-                            announce that identity twice on every profile, and the overlay
-                            holds nothing focusable to lose. One prop covers all three
-                            platforms: RN's View maps `aria-hidden` onto
-                            `accessibilityElementsHidden` (iOS) AND
-                            `importantForAccessibility: 'no-hide-descendants'` (Android),
-                            and react-native-web emits the DOM attribute. */}
-                        <View className="left-0 right-0 web:sticky web:z-[101] web:pointer-events-none" style={[webStickyChrome.chromeAnchor, panelStickyTopInset]}>
-                            <Animated.View
-                                className="absolute"
-                                aria-hidden
-                                style={[
-                                    { zIndex: 10, left: LAYOUT.DEFAULT_PADDING, flexDirection: 'row', alignItems: 'center', gap: 10 },
-                                    themedStyles.headerNameOverlay,
-                                    { opacity: headerNameOpacity },
-                                    { pointerEvents: 'none' },
-                                ]}
-                            >
-                                <Avatar
-                                    source={avatarUri}
-                                    size={32}
-                                    variant={MEDIA_VARIANT_AVATAR}
-                                />
-                                <View style={{ flex: 1, minWidth: 0 }}>
-                                    <UserName
-                                        name={profileData.design.displayName}
-                                        verified={profileData.verified}
-                                        style={{ name: { fontSize: 18, fontWeight: 'bold', marginBottom: -3 } }}
-                                        unifiedColors={true}
-                                    />
-                                    <Text className="text-muted-foreground text-[13px]" numberOfLines={1}>
-                                        {t('profile.postsCount', {
-                                            count: profileData.postsCount,
-                                            defaultValue: `${profileData.postsCount} posts`,
-                                        })}
-                                    </Text>
-                                </View>
-                            </Animated.View>
-                        </View>
-
-                        {/* Main scroll content.
-
-                            NATIVE FEED TABS: Feed's FlashList owns the scroll and
-                            receives profile info as `ListHeaderComponent` and
-                            tabs as a separate sticky data row, keeping post rows
-                            virtualized without pinning the whole summary.
-                            NATIVE GRID TABS: ProfileGridList's FlashList owns the
-                            scroll with the same header/sticky-tab row contract.
-                            The existing Animated.ScrollView remains the sole
-                            owner only for the bounded card tabs.
-
-                            WEB: the DOCUMENT scrolls (no inner ScrollView — that
-                            would break the document-scroll model the home/explore
-                            screens use). The body renders in normal flow inside a
-                            plain `View`; the header/banner/name-overlay animations
-                            read the same `scrollY` shared value, now fed by the
-                            window 'scroll' listener in LayoutScrollContext. The tab
-                            bar pins via `web:sticky` (its own `bg-background` keeps
-                            the feed from showing through). */}
-                        {IS_WEB ? (
-                            <View style={[{ zIndex: 3 }, themedStyles.scrollView, themedStyles.contentContainer]}>
-                                {/* Profile info + suggestions */}
-                                {profileSummary}
-
-                                {/* Tabs — sticky in the SECOND tier, pinned flush
-                                    BELOW the header chrome band (`web:sticky` +
-                                    `panelStickyTabsTopInset` = PANEL_TOP_INSET +
-                                    PANEL_HEADER_HEIGHT while framed, the same 56px
-                                    offset the home screen's `level={1}` tab bar uses;
-                                    it collapses to just PANEL_HEADER_HEIGHT at
-                                    full-bleed, in lockstep with the first-tier inset).
-                                    The banner fade, action cluster and compact-name
-                                    overlay above all pin at the FIRST tier
-                                    (`panelStickyTopInset`, PANEL_TOP_INSET while framed,
-                                    0 at full-bleed); pinning the tab bar at that same
-                                    inset made the two bands occupy the same vertical
-                                    space and OVERLAP. Stacking the tabs one header
-                                    height down lands them directly under the header
-                                    chrome — header on top, tabs flush below — while
-                                    the document scrolls (mirrors native's
-                                    `stickyHeaderIndices={[1]}` pinning below the
-                                    absolute header overlay). It lives inside the z-3
-                                    content wrapper, so `web:z-[5]` keeps it above the
-                                    feed content (which scrolls under it); the
-                                    `bg-background` on AnimatedTabBar keeps the feed
-                                    from showing through, and the pinned tab bar paints
-                                    over the lower-z banner that sits behind it. */}
-                                <View className="web:sticky web:z-[5]" style={panelStickyTabsTopInset}>
-                                    {profileTabBar}
-                                </View>
-
-                                {/* Tab content */}
-                                <ProfileTabs
-                                    tab={activeProfileTab}
-                                    laneId={activeLaneId}
-                                    profileId={profileData?.id}
-                                    isPrivate={isPrivate}
-                                    isOwnProfile={isOwnProfile}
-                                    isFederated={isFederated}
-                                    actorUri={profileData?.actorUri}
-                                />
-                            </View>
-                        ) : nativeListOwnsScroll ? (
-                            <View
-                                style={[
-                                    {
-                                        zIndex: 3,
-                                        flex: 1,
-                                        minHeight: 0,
-                                    },
-                                    themedStyles.scrollView,
-                                ]}
-                            >
-                                <ProfileTabs
-                                    tab={activeProfileTab}
-                                    laneId={activeLaneId}
-                                    profileId={profileData.id}
-                                    isPrivate={isPrivate}
-                                    isOwnProfile={isOwnProfile}
-                                    isFederated={isFederated}
-                                    actorUri={profileData.actorUri}
-                                    listOwnsScroll
-                                    listHeaderComponent={profileSummary}
-                                    listStickyHeaderComponent={profileTabBar}
-                                    listContentContainerStyle={themedStyles.contentContainer}
-                                    listOnScroll={nativeGridOwnsScroll ? onScroll : undefined}
-                                    listScrollRef={nativeGridOwnsScroll ? assignScrollRef : undefined}
-                                />
-                            </View>
-                        ) : (
-                            <Animated.ScrollView
-                                ref={assignScrollRef}
-                                showsVerticalScrollIndicator={false}
-                                onScroll={onScroll}
-                                scrollEventThrottle={16}
-                                style={[{ zIndex: 3 }, themedStyles.scrollView]}
-                                contentContainerStyle={themedStyles.contentContainer}
-                                stickyHeaderIndices={[1]}
-                                nestedScrollEnabled={true}
-                                removeClippedSubviews={true}
-                                disableIntervalMomentum={true}
-                                decelerationRate="normal"
-                            >
-                                {/* Profile info + suggestions wrapper (keeps stickyHeaderIndices stable) */}
-                                {profileSummary}
-
-                                {/* Tabs */}
-                                {profileTabBar}
-
-                                {/* Tab content */}
-                                <ProfileTabs
-                                    tab={activeProfileTab}
-                                    laneId={activeLaneId}
-                                    profileId={profileData.id}
-                                    isPrivate={isPrivate}
-                                    isOwnProfile={isOwnProfile}
-                                    isFederated={isFederated}
-                                    actorUri={profileData?.actorUri}
-                                />
-                            </Animated.ScrollView>
-                        )}
-
-                        {/* FAB that rides the BottomBar's show/hide (web mobile). */}
-                        <BottomBarAwareFab
-                            onPress={() => router.push('/compose')}
-                            icon={<ComposeIcon size={20} className="text-primary-foreground" />}
-                            accessibilityLabel={t('compose.newPost', { defaultValue: 'New post' })}
-                        />
-
-                    </>
-                )}
-            </View>
+            <ProfileShell
+                chrome={chrome}
+                loading={loading}
+                profileData={profileData}
+                banner={{ uri: bannerUri }}
+                headerActions={headerActions}
+                summary={summary}
+                tabBar={tabBar}
+                tabs={{
+                    tab: activeProfileTab,
+                    laneId: activeLaneId,
+                    profileId: profileData?.id,
+                    isPrivate,
+                    isOwnProfile,
+                    isFederated,
+                    actorUri: profileData?.actorUri,
+                }}
+            />
         </>
     );
 };
 
-// WEB vs NATIVE positioning for the profile header chrome (banner, action
-// cluster, compact-name overlay). NATIVE pins each piece `absolute` to the top
-// of the NON-scrolling root (the content scrolls over them inside the inner
-// Animated.ScrollView). WEB has no inner ScrollView — the DOCUMENT scrolls — so
-// each piece pins via `web:sticky` + the shared `panelStickyTopInset` style
-// (the rounded panel's PANEL_TOP_INSET top-gutter inset, from the single
-// PanelChrome source of truth — no literal `top-2` here). `position: sticky`
-// keeps the panel column as its containing block, so the chrome stays INSIDE the
-// rounded center panel (never viewport-fixed), mirroring the home header's
-// PanelStickyHeader. These bespoke overlapping layers keep their own `web:z-[…]`,
-// negative margins and pointer-events, so they consume `panelStickyTopInset`
-// rather than the full <PanelStickyHeader> wrapper (which would flatten their
-// z-layout and break the banner/name fades). The web `position`/`z` live in
-// NativeWind classes; this StyleSheet only supplies the native `absolute` anchor
-// (web entries are empty so the classes win).
-const webStickyChrome = StyleSheet.create({
-    banner: {
-        ...Platform.select({
-            web: {},
-            default: { position: 'absolute' as const, top: 0, zIndex: 1 },
-        }),
-    },
-    chromeAnchor: {
-        ...Platform.select({
-            web: {},
-            default: { position: 'absolute' as const, top: 0, zIndex: 10 },
-        }),
-    },
-});
+const ProfileScreen: React.FC<ProfileScreenProps> = ({ tab = 'posts', laneId }) => {
+    const { username, handle, isFederated, profileData, loading, colorName, canonicalHref } =
+        useProfileAccount('person');
 
-const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts', laneId }) => {
-    let { username: urlUsername } = useLocalSearchParams<{ username: string }>();
-    if (urlUsername?.startsWith('@')) {
-        urlUsername = urlUsername.slice(1);
-    }
-    const username = urlUsername || '';
-    const isFederated = username.includes('@');
-    const { data: profileData, loading } = useProfileData(username);
-    const { colorName: profileColorName } = useProfileScreenColor({
-        username,
-        designColor: profileData?.design?.color,
-    });
-
-    // A channel account's page is `/c/<handle>`; everybody else's is
-    // `/@<handle>`. The kind is only knowable once the account has resolved, so
-    // this is a CANONICALIZATION rather than a gate: whichever URL a reader
-    // arrives on, the one they end up sitting on is the one that account owns.
-    //
-    // Both directions matter. A post row links every author to `/@<handle>` —
-    // the DTO says nothing about account kind — so that is how a reader reaches
-    // a channel, and it must land them at `/c/`. And a `/c/<handle>` that names
-    // a person is a URL nobody should keep.
-    const routedAsChannel = usePathname().startsWith('/c/');
-    const isChannelAccount = profileData?.kind === 'channel';
-    if (profileData && routedAsChannel !== isChannelAccount) {
-        const canonical: Href = isChannelAccount ? `/c/${username}` : `/@${username}`;
-        return <Redirect href={canonical} />;
+    // A channel account's page is `/c/<handle>`. Sitting on `/@<handle>` for one
+    // is a URL nobody should keep — a post row links every author to `/@`, since
+    // the DTO says nothing about account kind, so this is how a reader reaches a
+    // channel at all. The rule itself lives in `profileRoute.ts`, shared with the
+    // channel screen so the two can never disagree about which way to send.
+    if (canonicalHref) {
+        return <Redirect href={canonicalHref} />;
     }
 
     return (
-        <BloomColorScope colorPreset={profileColorName} asChild>
+        <BloomColorScope colorPreset={colorName} asChild>
             {/* `web:z-auto` so this profile wrapper does not become its own
                 stacking context and trap the sticky header chrome below the
-                panel's bleed-mask/border overlays (see MentionProfileContent's
-                root for the full rationale). No effect on native. */}
+                panel's bleed-mask/border overlays (see ProfileShell's root for
+                the full rationale). No effect on native. */}
             <View className="flex-1 bg-background web:z-auto">
-                <MentionProfileContent
+                <PersonProfile
                     tab={tab}
                     laneId={laneId}
                     username={username}
+                    handle={handle}
                     isFederated={isFederated}
                     profileData={profileData}
                     loading={loading}
@@ -1225,5 +586,4 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts', laneId })
     );
 };
 
-
-export default MentionProfile;
+export default ProfileScreen;

--- a/packages/frontend/components/common/__tests__/actionMenu.test.ts
+++ b/packages/frontend/components/common/__tests__/actionMenu.test.ts
@@ -94,7 +94,11 @@ describe('action menu wiring', () => {
       // host rather than hand-rolling a third one.
       join('app', '(app)', 'lanes.tsx'),
       join('components', 'Feed', 'PostItem.tsx'),
-      join('components', 'ProfileScreen.tsx'),
+      // The profile overflow menu. It lives in a hook rather than on a screen
+      // because BOTH profile screens open the same menu — a person's and a
+      // channel's — and the rows are identical apart from the operator's
+      // channel-settings entry, which arrives as a prop.
+      join('components', 'Profile', 'hooks', 'useProfileMoreMenu.tsx'),
     ]);
   });
 

--- a/packages/frontend/hooks/useProfileData.ts
+++ b/packages/frontend/hooks/useProfileData.ts
@@ -29,24 +29,6 @@ export interface ProfileDesign {
   displayName: string;
   bannerUrl?: string;
   avatar?: string;
-  /**
-   * The compact profile header. DERIVED from the account kind — a channel gets
-   * it, everybody else gets the default layout — never chosen.
-   *
-   * The causality runs THIS way round, and it matters: a channel has no banner,
-   * so it gets the layout that has none. Not "minimalist happens to hide the
-   * banner, so a channel's is unreachable" — there is nothing to reach.
-   * `UpdateAccountInput` has no banner field and `PUT /profile/settings/:userId`
-   * accepts only `channel.signPosts`; that is the design, not an omission, and
-   * adding either would be building a surface the layout deliberately does not
-   * have.
-   * There is no stored setting behind this and no picker: the "Profile Style"
-   * control and BOTH of its columns (`minimalistMode`, `coverPhotoEnabled`) were
-   * removed, so an account that once picked minimalist now renders exactly like
-   * any other person's — banner included, which is why `coverPhotoEnabled` had
-   * to go with it rather than linger as a suppression nothing could undo.
-   */
-  minimalistMode: boolean;
   color?: string;
   /** Pinned Syra profile media — a song XOR a podcast — when the user has set one (and the viewer has access). */
   profileMedia?: ProfileMedia;
@@ -145,9 +127,6 @@ function computeDesign(
     displayName: displayNameOrHandle(profile.name.displayName, profile.username),
     bannerUrl: bannerUrl?.startsWith('http') ? bannerUrl : undefined,
     avatar: profile.avatar ?? undefined,
-    // Read off the ACCOUNT, not off the appearance settings: the layout is a
-    // property of what the account is, not a preference it stores.
-    minimalistMode: profile.kind === 'channel',
     color:
       presetColor ||
       HEX_TO_APP_COLOR[appearance?.appearance?.primaryColor ?? ''] ||


### PR DESCRIPTION
`/c/<handle>` rendered `ProfileScreen`. The reasoning was that a second profile implementation is a second place for the identity rules to drift — sound, and wrong about **which thing** was being shared.

Four defects in a row were the same shape: the shared screen doing person things on a channel. Poke, the "Joined" row, the tab set, the layout, the settings entry, the canonicalization. Each new request added another `if (isChannel)`.

**The proof was already in the code:** `minimalistMode` was `profile.kind === 'channel'`. "Minimalist" was never a layout preference — it was **the channel flag wearing a layout's name**, and it was the single branch keeping the two screens one. Deleted, with a test that fails if it returns.

## Separate screens, shared primitives

`ProfileScreen` drops **1229 → 589** lines with **zero** channel branches; `ChannelScreen` (459) composes the same pieces differently.

Nothing was copied. Each of these has exactly one owner:

| primitive | why it cannot be duplicated |
|---|---|
| `profileRoute.ts` (canonicalization) | two copies of the redirect can build a loop between `/@` and `/c/` |
| `useProfileAccount` | param → handle → fetch → colour, one entry for both |
| `ProfileShell` | banner, sticky tiers, the three-way scroll ownership |
| `useProfileChrome`, `useProfileMoreMenu`, `useJustFollowed` | shared behaviour, composed per screen |

## The poke fix I started was wrong twice

It did not compile — and the component I edited is one a channel **never renders**: since `minimalistMode === (kind === 'channel')`, the default header was dead on that path. Only the actions copy was live, and `usePoke`'s skip flag never included channel, so the status request fired anyway.

No flag now: the channel header does not render poke and does not reach the hook, and a test asserts it.

## Verification

**139 suites / 1257 tests** (baseline 137/1233), `tsc` clean, lint 0 errors.

Six mutants, all killed by named tests — including reintroducing `minimalistMode`, putting `usePoke` back into the channel header, deleting it from the person one, and making the redirect never fire (killed by a vacuity floor, which is what stops the fixed-point test passing trivially). Re-verified independently before merge.

## Deliberately not in this PR

- **The three-dot menu** (no delete/edit/pin on a channel post) is delivery 2 — and my diagnosis stopped a layer short: the server does not consult `authorship` at all, it puts the viewer in the QUERY (`findOneAndDelete({ _id, oxyUserId: userId })`). A DTO-only fix produces a button that **404s**.
- **The "Joined" row** could not be reproduced statically: it pushes `/@<handle>/about`, which *resolves* for a channel. That is a wrong URL family, not a broken screen. The href is now an explicit caller decision, behaviour byte-identical, pending a product call.
- Flagged, unchanged: `ProfileSkeleton` still mirrors the person layout, and `PresenceIndicator` renders for accounts that can never be online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->