### PR TITLE
fix(post): channel byline naming, boost avatar ordering

### DIFF
--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -474,15 +474,24 @@ const PostItem: React.FC<PostItemProps> = ({
     const collaborators = viewPost?.authors;
     const isCollab = (collaborators?.length ?? 0) > 1;
 
-    // Open the collaborators list — the byline shows first names only, so this is
-    // where the full @usernames live. Content is already on the post (no fetch).
+    // Open the author list — the byline shows first names only, so this is where
+    // the full @usernames live. Content is already on the post (no fetch).
+    //
+    // A signed CHANNEL post lands here too, and "Collaborators" is wrong for it:
+    // nobody co-authored anything, one account published what one person wrote.
+    // `writer` is the role hydration gives only that person, so it is what picks
+    // the heading.
     const openCollaboratorsList = useCallback(() => {
         if (!collaborators || collaborators.length <= 1) return;
+        const namesWriter = collaborators.some((a) => a.role === 'writer');
+        const label = namesWriter
+            ? t('collab.writtenByTitle', { defaultValue: 'Published by' })
+            : t('collab.collaboratorsTitle', { defaultValue: 'Collaborators' });
         showContentDialog({
-            label: t('collab.collaboratorsTitle', { defaultValue: 'Collaborators' }),
+            label,
             render: (close) => (
                 <Suspense fallback={null}>
-                    <CollaboratorsList authors={collaborators} onClose={close} />
+                    <CollaboratorsList authors={collaborators} onClose={close} title={label} />
                 </Suspense>
             ),
         });
@@ -819,6 +828,13 @@ const PostItem: React.FC<PostItemProps> = ({
                             instance: viewPost.user.instance,
                         }}
                         authors={viewPost.authors && viewPost.authors.length > 0 ? viewPost.authors : undefined}
+                        // `repostedBy` is the only boost that put THIS post in
+                        // front of the reader. `viewPost.boost` is the other
+                        // boost shape — the row IS the boost, so its author and
+                        // its actor are the same account and there is nothing to
+                        // pair or reorder; passing it would be a no-op wearing
+                        // the clothes of a rule.
+                        boostedBy={repostedBy}
                         date={metadata.createdAt}
                         showBoost={Boolean(viewPost.boost) && !isNested}
                         showReply={false}

--- a/packages/frontend/components/Feed/__tests__/PostItemAuthorship.test.tsx
+++ b/packages/frontend/components/Feed/__tests__/PostItemAuthorship.test.tsx
@@ -1,0 +1,284 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { PostVisibility } from '@mention/shared-types';
+import type { HydratedAuthor, HydratedPost, PostUser } from '@mention/shared-types';
+
+import PostItem from '../PostItem';
+
+/**
+ * `PostItem` decides two things about authorship that only it can see, and both
+ * are invisible from `PostHeader`'s own tests:
+ *
+ *  1. WHICH HEADING the author dialog opens with. A signed channel post reaches
+ *     the same panel as a collaboration, and only the byline roles distinguish
+ *     them — `writer` exists on no other byline, so it, not the account kind, is
+ *     what picks "Published by" over "Collaborators".
+ *  2. THAT THE BOOSTER REACHES THE HEADER AT ALL. `PostHeader` pairs and
+ *     reorders the avatar cluster from `boostedBy`; the prop sat declared and
+ *     unpassed, so every one of those rules was dead code in the app while
+ *     passing its own unit tests. This pins the wire, and pins that the id in it
+ *     is the one `HydratedAuthor.id` is compared against — the two coming from
+ *     different id spaces is the failure that reorders nothing, silently.
+ */
+
+interface CapturedHeaderProps {
+  boostedBy?: PostUser;
+  authors?: HydratedAuthor[];
+  onPressCollaborators?: () => void;
+}
+const mockHeaderProps: CapturedHeaderProps[] = [];
+jest.mock('../../Post/PostHeader', () => ({
+  __esModule: true,
+  default: (props: CapturedHeaderProps) => {
+    mockHeaderProps.push(props);
+    return null;
+  },
+  HEADER_CONTENT_GAP: 4,
+  POST_CONTEXT_ROW_HEIGHT: 18,
+}));
+
+/**
+ * How the test reads what `PostItem` handed the dialog surface: a `<Suspense>`
+ * wrapping the lazy author panel. The panel's own `title` is a SEPARATE prop
+ * from the dialog's `label`, and a fix that sets only one leaves the other's
+ * header wrong, so both are read.
+ */
+interface AuthorPanelProps {
+  title?: string;
+}
+interface CapturedDialog {
+  label: string;
+  render: (
+    close: () => void,
+  ) => React.ReactElement<{ children?: React.ReactElement<AuthorPanelProps> }>;
+}
+const mockDialogs: CapturedDialog[] = [];
+jest.mock('@/components/common/ContentDialog', () => ({
+  showContentDialog: (dialog: CapturedDialog) => {
+    mockDialogs.push(dialog);
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => '/',
+}));
+
+jest.mock('../../../stores/postsStore', () => ({ usePostSelector: () => undefined }));
+
+jest.mock('@/stores/threadHoverStore', () => ({
+  useThreadHoverStore: (selector: (state: unknown) => unknown) =>
+    selector({ setHoveredSlice: () => undefined, hoveredSliceKey: null }),
+}));
+
+// The real `BottomSheetContext` is used — `useContext` needs a genuine context
+// object and its defaults already no-op — so only the untransformed Bloom module
+// it imports is stubbed. Nothing in these tests opens a bottom sheet.
+jest.mock('@oxyhq/bloom/bottom-sheet', () => ({ BottomSheet: 'BottomSheet' }));
+
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({ colors: { textSecondary: '#8899a6', border: '#e1e8ed' } }),
+}));
+jest.mock('@oxyhq/bloom/hooks', () => ({ useImagePreload: () => undefined }));
+jest.mock('@oxyhq/bloom/subtle-hover', () => ({ SubtleHover: () => null }));
+
+jest.mock('@expo/vector-icons/Ionicons', () => 'Ionicons');
+jest.mock('@/assets/icons/pin-icon', () => ({ PinIcon: () => null }));
+jest.mock('@/assets/icons/boost-icon', () => ({ BoostIcon: () => null }));
+
+jest.mock('../../Post/PostContentText', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../Post/PostLanguageChip', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../Post/PostLaneChip', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../Post/ContentWarning', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../Post/PostActions', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../Post/PostDetailStats', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../Post/PostLocation', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../Post/PostAttachmentsRow', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../ProfileHoverCard', () => ({
+  ProfileHoverCard: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('@/hooks/usePostLike', () => ({ usePostLike: () => () => undefined }));
+jest.mock('@/hooks/usePostVote', () => ({
+  usePostVote: () => ({ toggleDownvote: () => undefined }),
+}));
+jest.mock('@/hooks/usePostSave', () => ({ usePostSave: () => () => undefined }));
+jest.mock('@/hooks/usePostBoost', () => ({ usePostBoost: () => () => undefined }));
+jest.mock('@/hooks/usePostShare', () => ({ usePostShare: () => () => undefined }));
+jest.mock('@/hooks/usePostActions', () => ({ usePostActions: () => ({}) }));
+jest.mock('@/hooks/usePostLanguage', () => ({
+  usePostLanguage: () => ({
+    options: [],
+    activeTag: null,
+    displayText: null,
+    isTranslating: false,
+    isTranslated: false,
+    selectLanguage: () => undefined,
+    toggleReaderTranslation: () => undefined,
+  }),
+}));
+
+jest.mock('@/components/common/ActionMenu', () => ({ showActionMenu: () => undefined }));
+jest.mock('@/utils/feedTelemetry', () => ({ reportFeedInteraction: () => undefined }));
+
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user: { username?: string } | null | undefined) =>
+    user?.username ?? null,
+}));
+
+// Resolves against the real `en.json` and ignores `defaultValue`: the headings
+// are the assertion, so a deleted key must render its raw name and fail rather
+// than fall back to a default that reads identically.
+jest.mock('react-i18next', () => {
+  const strings: Record<string, string> = require('@/locales/en.json');
+  return { useTranslation: () => ({ t: (key: string) => strings[key] ?? key }) };
+});
+
+// --- fixtures ---
+
+const channel: HydratedAuthor = {
+  id: 'acct-notas',
+  username: 'notas',
+  kind: 'channel',
+  name: { displayName: 'Notas de Nate' },
+  role: 'owner',
+  status: 'accepted',
+};
+
+const writer: HydratedAuthor = {
+  id: 'acct-nate',
+  username: 'nate',
+  kind: 'personal',
+  name: { displayName: 'Nate Isern' },
+  role: 'writer',
+  status: 'accepted',
+};
+
+const owner: HydratedAuthor = {
+  id: 'acct-ana',
+  username: 'ana',
+  kind: 'personal',
+  name: { displayName: 'Ana Torres' },
+  role: 'owner',
+  status: 'accepted',
+};
+
+const collaborator: HydratedAuthor = {
+  id: 'acct-luis',
+  username: 'luis',
+  kind: 'personal',
+  name: { displayName: 'Luis Prado' },
+  role: 'collaborator',
+  status: 'accepted',
+};
+
+const boosterUser: PostUser = {
+  id: 'acct-mar',
+  username: 'mar',
+  kind: 'personal',
+  name: { displayName: 'Mar Ruiz' },
+};
+
+function postWith(authors: HydratedAuthor[]): HydratedPost {
+  return {
+    id: 'post-1',
+    user: authors[0],
+    authors,
+    content: { text: 'hola' },
+    attachments: {},
+    metadata: {
+      visibility: PostVisibility.PUBLIC,
+      createdAt: '2026-08-01T10:00:00.000Z',
+      updatedAt: '2026-08-01T10:00:00.000Z',
+    },
+    engagement: { likes: 0, downvotes: 0, boosts: 0, replies: 0 },
+    viewerState: {
+      isOwner: false,
+      isCollaborator: false,
+      isLiked: false,
+      isDownvoted: false,
+      isBoosted: false,
+      isSaved: false,
+    },
+    permissions: { canReply: true, canDelete: false, canPin: false, canViewSources: false },
+  };
+}
+
+function render(element: React.ReactElement) {
+  act(() => {
+    TestRenderer.create(element);
+  });
+}
+
+/** The props of the header this render produced. */
+function lastHeader(): CapturedHeaderProps {
+  return mockHeaderProps[mockHeaderProps.length - 1];
+}
+
+/**
+ * Opens the author dialog the way the avatar cluster does. The element tree is
+ * read rather than rendered: the panel is `lazy()`, so resolving it would only
+ * re-assert the prop through another mock.
+ */
+function openAuthorDialog(): { label: string; panelTitle?: string } {
+  act(() => {
+    lastHeader().onPressCollaborators?.();
+  });
+  const dialog = mockDialogs[mockDialogs.length - 1];
+  return {
+    label: dialog.label,
+    panelTitle: dialog.render(() => undefined).props.children?.props.title,
+  };
+}
+
+describe('PostItem author dialog heading', () => {
+  beforeEach(() => {
+    mockHeaderProps.length = 0;
+    mockDialogs.length = 0;
+  });
+
+  it('says "Published by" when the byline names a writer — nobody co-authored anything', () => {
+    render(<PostItem post={postWith([channel, writer])} />);
+    expect(openAuthorDialog()).toEqual({ label: 'Published by', panelTitle: 'Published by' });
+  });
+
+  it('says "Collaborators" for a genuine collaboration', () => {
+    render(<PostItem post={postWith([owner, collaborator])} />);
+    expect(openAuthorDialog()).toEqual({ label: 'Collaborators', panelTitle: 'Collaborators' });
+  });
+
+  it('does not open at all for a solo post', () => {
+    render(<PostItem post={postWith([owner])} />);
+    expect(lastHeader().onPressCollaborators).toBeUndefined();
+  });
+});
+
+describe('PostItem boost wiring', () => {
+  beforeEach(() => {
+    mockHeaderProps.length = 0;
+    mockDialogs.length = 0;
+  });
+
+  it('hands the header the BOOSTER, in the id space the authors carry', () => {
+    // `feedRows` unwraps a boost into (original post, `repostedBy` = the boost
+    // actor), and both that actor and every `authors[]` entry are the canonical
+    // Oxy `PostUser` keyed by Oxy user id — so the header's `id` comparison
+    // finds a match when there is one.
+    render(<PostItem post={postWith([channel, writer])} repostedBy={writer} />);
+    expect(lastHeader().boostedBy?.id).toBe(writer.id);
+    expect(lastHeader().authors?.map((author) => author.id)).toContain(
+      lastHeader().boostedBy?.id,
+    );
+  });
+
+  it('hands over an outside booster too — the header decides what to do with them', () => {
+    render(<PostItem post={postWith([owner])} repostedBy={boosterUser} />);
+    expect(lastHeader().boostedBy?.id).toBe(boosterUser.id);
+    expect(lastHeader().authors?.map((author) => author.id)).not.toContain(boosterUser.id);
+  });
+
+  it('leaves it unset when no boost surfaced the row', () => {
+    render(<PostItem post={postWith([channel, writer])} />);
+    expect(lastHeader().boostedBy).toBeUndefined();
+  });
+});

--- a/packages/frontend/components/Post/CollaboratorsList.tsx
+++ b/packages/frontend/components/Post/CollaboratorsList.tsx
@@ -17,6 +17,12 @@ interface CollaboratorsListProps {
    */
   authors: PostUser[];
   onClose: () => void;
+  /**
+   * Overrides the header. A signed CHANNEL post lists the channel and the
+   * person who wrote it, who are not collaborators — nobody co-authored
+   * anything, one account published what one person wrote.
+   */
+  title?: string;
 }
 
 /**
@@ -29,7 +35,7 @@ interface CollaboratorsListProps {
  * Rendered on the shared content-dialog surface (`showContentDialog`), the same
  * one the post's ⋯ menu uses — centered card on desktop, bottom sheet on mobile.
  */
-const CollaboratorsList: React.FC<CollaboratorsListProps> = ({ authors, onClose }) => {
+const CollaboratorsList: React.FC<CollaboratorsListProps> = ({ authors, onClose, title }) => {
   const router = useRouter();
   const { t } = useTranslation();
 
@@ -62,7 +68,7 @@ const CollaboratorsList: React.FC<CollaboratorsListProps> = ({ authors, onClose 
     <View className="flex-1 bg-background">
       <Header
         options={{
-          title: t('collab.collaboratorsTitle', { defaultValue: 'Collaborators' }),
+          title: title ?? t('collab.collaboratorsTitle', { defaultValue: 'Collaborators' }),
           rightComponents: [
             <IconButton variant="icon"
               key="close"

--- a/packages/frontend/components/Post/PostHeader.tsx
+++ b/packages/frontend/components/Post/PostHeader.tsx
@@ -12,7 +12,7 @@ import { RemoteActorBadge } from '@/components/Fediverse/FediverseBadge';
 import { BoostIcon } from '@/assets/icons/boost-icon';
 import { formatTimeAgo } from '@/utils/dateUtils';
 import { displayNameOrHandle } from '@/utils/displayName';
-import type { HydratedAuthor } from '@mention/shared-types';
+import type { HydratedAuthor, PostUser } from '@mention/shared-types';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { HIT_SLOP_MD } from '@/styles/hitSlop';
 
@@ -125,9 +125,11 @@ interface PostHeaderProps {
   onPressUser?: () => void;
   onPressAvatar?: () => void;
   /**
-   * Collaborative posts only (owner + ≥1 accepted collaborator): tapping the
-   * avatar — which represents the group — opens the collaborators list instead of
-   * a single profile. Ignored for solo posts, which keep {@link onPressAvatar}.
+   * Collaborative BYLINES only (owner + ≥1 accepted collaborator, or a channel
+   * naming its writer): tapping the avatar — which represents the group — opens
+   * the author list instead of a single profile. Ignored for a solo byline,
+   * which keeps {@link onPressAvatar} even when {@link boostedBy} pairs a second
+   * avatar beside the author's.
    */
   onPressCollaborators?: () => void;
   onPressMenu?: () => void;
@@ -139,6 +141,13 @@ interface PostHeaderProps {
    * would pop over the editor.
    */
   disableHoverCard?: boolean;
+  /**
+   * The account whose BOOST brought this post into the reader's feed, when that
+   * is why they are seeing it — the same actor the "Reposted by" context row
+   * names. Joins the AVATAR cluster and never the byline; see `clusterMembers`
+   * for which end it joins and why.
+   */
+  boostedBy?: PostUser;
 }
 
 interface HeaderAuthor {
@@ -171,6 +180,7 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   onPressMenu,
   onPressAuthor,
   disableHoverCard,
+  boostedBy,
 }) => {
   const theme = useTheme();
   const { t } = useTranslation();
@@ -184,37 +194,96 @@ const PostHeader: React.FC<PostHeaderProps> = ({
     () =>
       (authors ?? []).map((a) => {
         const handle = getNormalizedUserHandle(a) ?? '';
-        // First name only: the structured `name.first`, else the first token of
-        // the display name, else the normalized `@handle` (never a raw id).
-        const firstName =
-          a.name?.first?.trim() ||
-          a.name?.displayName?.trim()?.split(/\s+/)?.[0] ||
-          (handle ? `@${handle}` : '');
+        // A collaborative byline reads "Ana and Luis", so a PERSON contributes a
+        // first name: the structured `name.first`, else the first token of the
+        // display name, else the normalized `@handle` (never a raw id).
+        //
+        // A non-personal account has a TITLE, not a given name, and splitting it
+        // is wrong in a way that looks like truncation: "Notas de Nate" rendered
+        // as "Notas". That is the same distinction `name_display` exists for —
+        // an organization or a channel sets `displayName` and leaves
+        // `first`/`last` unset precisely so nobody composes a name from parts it
+        // does not have.
+        const isPerson = a.kind === undefined || a.kind === 'personal';
+        const wholeName = a.name?.displayName?.trim();
+        const firstName = isPerson
+          ? a.name?.first?.trim() ||
+            wholeName?.split(/\s+/)?.[0] ||
+            (handle ? `@${handle}` : '')
+          : wholeName || (handle ? `@${handle}` : '');
         return { firstName, handle };
       }),
     [authors],
   );
-  const isCollabHeader = headerAuthors.length > 1;
-  const hasDisplayName = !isCollabHeader && !!user.displayName?.trim();
+  // The BYLINE is collaborative when more than one person is NAMED. It is read
+  // off `authors` alone, so nothing below can grow it: a booster never earns a
+  // name, and an author who boosted keeps their place in the sentence.
+  const isCollabByline = headerAuthors.length > 1;
+  const hasDisplayName = !isCollabByline && !!user.displayName?.trim();
 
-  // Collaborative posts render a single cluster of every author's avatar in the
-  // slot a solo post's avatar occupies. Each member's `avatar` (a bare Oxy file
-  // id OR an absolute federated URL) is routed straight into Bloom's `Avatar`
-  // source via the group's `uri` — the SAME ImageResolver plumbing the solo
-  // avatar uses (variant applied at the group level). `displayName`/`username`
-  // drive accessibility only. Empty for solo posts (the cluster is not rendered).
+  // `writer` is the role hydration gives the human behind a SIGNED channel post,
+  // and it exists on no other byline — so it, not the account kind, is what says
+  // "this is a channel naming its writer".
+  const bylineNamesWriter = useMemo(
+    () => (authors ?? []).some((a) => a.role === 'writer'),
+    [authors],
+  );
+
+  // Who is in the avatar cluster, and in what order.
+  //
+  // The cluster is the post's AUTHORS. When a boost is why the reader is seeing
+  // this row, the booster joins it — and which end they join is not a style
+  // choice, it is what they are to this post:
+  //
+  //  - An author who boosted it LEADS. Both members genuinely authored it (a
+  //    signed channel post is the case that produces this: the channel and the
+  //    person who wrote it), so the lead says which of those relationships
+  //    surfaced the row — someone following the writer got here through the
+  //    writer, someone following the channel through the channel.
+  //  - Anyone else TRAILS. They authored nothing, so the second avatar is
+  //    attribution, not a byline entry, and leading with it would read as one.
+  //
+  // Trailing is confined to a SOLO byline on purpose. A multi-author cluster is
+  // the byline made visual and tapping it opens a list of exactly those authors,
+  // so an extra avatar with no row in that list is a mismatch the reader cannot
+  // resolve — and the "Reposted by" context row above already names the booster.
+  //
+  // An orphan federated post carries no `authors` at all, so there is no
+  // author-shaped record to pair the booster with; it keeps its solo avatar.
+  const clusterMembers = useMemo<PostUser[]>(() => {
+    const members: PostUser[] = [...(authors ?? [])];
+    if (!boostedBy) return members;
+    const boosterIndex = members.findIndex((member) => member.id === boostedBy.id);
+    if (boosterIndex > 0) {
+      const [lead] = members.splice(boosterIndex, 1);
+      members.unshift(lead);
+    } else if (boosterIndex < 0 && members.length === 1) {
+      members.push(boostedBy);
+    }
+    return members;
+  }, [authors, boostedBy]);
+
+  // Each member's `avatar` (a bare Oxy file id OR an absolute federated URL) is
+  // routed straight into Bloom's `Avatar` source via the group's `uri` — the
+  // SAME ImageResolver plumbing the solo avatar uses (variant applied at the
+  // group level). `displayName`/`username` drive accessibility only. Empty
+  // whenever one avatar says everything, in which case the solo avatar renders.
   const collabAvatars = useMemo<AvatarGroupItem[]>(
     () =>
-      isCollabHeader
-        ? (authors ?? []).map((a) => ({
-            id: a.id,
-            uri: a.avatar,
-            displayName: displayNameOrHandle(a.name?.displayName, getNormalizedUserHandle(a) ?? ''),
-            username: a.username,
+      clusterMembers.length > 1
+        ? clusterMembers.map((member) => ({
+            id: member.id,
+            uri: member.avatar,
+            displayName: displayNameOrHandle(
+              member.name?.displayName,
+              getNormalizedUserHandle(member) ?? '',
+            ),
+            username: member.username,
           }))
         : [],
-    [authors, isCollabHeader],
+    [clusterMembers],
   );
+  const showAvatarCluster = collabAvatars.length > 1;
 
   // `contextTop` rows are the first children of the flex-1 content column, so the
   // name row is pushed down by each fixed-height context row plus the column gap.
@@ -226,26 +295,46 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   return (
     <View style={{ paddingHorizontal }}>
       <View className="flex-row items-start justify-between">
-        {isCollabHeader ? (
-          // The collab avatar represents the whole group: a magnetic bubble
-          // cluster of every author's avatar that opens the collaborators list
-          // on tap (the sheet lists each @username). `size` is the cluster box
-          // diameter, matched to the solo avatar so the layout never shifts.
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessibilityLabel={t('collab.viewCollaborators', { defaultValue: 'View collaborators' })}
-            disabled={!onPressCollaborators}
-            onPress={onPressCollaborators}
-            style={{ marginTop: headerTopOffset, marginRight: 12 }}
+        {showAvatarCluster ? (
+          // A magnetic bubble cluster in the slot the solo avatar occupies —
+          // `size` is the cluster box diameter, matched to the solo avatar so
+          // the layout never shifts.
+          //
+          // What a tap means follows the byline, not the cluster: a
+          // collaborative byline's cluster stands for the whole group and opens
+          // the author list (which lists each @username), while an
+          // attribution pair still has ONE author, so it goes where that
+          // author's avatar has always gone. The pair keeps the author's hover
+          // preview for the same reason; the group has no single subject to
+          // preview, so `username` is withheld and the card renders inert.
+          //
+          // The cluster is a Bloom `AvatarGroup` and not a `LiveAvatar`, so a
+          // reposted row cannot carry the Syra live badge — the badge belongs to
+          // one person and this slot no longer represents one.
+          <ProfileHoverCard
+            username={isCollabByline ? undefined : user.handle}
+            disable={disableHoverCard}
           >
-            <AvatarGroup
-              layout="cluster"
-              items={collabAvatars}
-              size={avatarSize}
-              variant={avatarVariant}
-              max={20}
-            />
-          </TouchableOpacity>
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessibilityLabel={
+                isCollabByline
+                  ? t('collab.viewCollaborators', { defaultValue: 'View collaborators' })
+                  : displayNameOrHandle(user.displayName, user.handle ? `@${user.handle}` : '')
+              }
+              disabled={isCollabByline ? !onPressCollaborators : !onPressAvatar}
+              onPress={isCollabByline ? onPressCollaborators : onPressAvatar}
+              style={{ marginTop: headerTopOffset, marginRight: 12 }}
+            >
+              <AvatarGroup
+                layout="cluster"
+                items={collabAvatars}
+                size={avatarSize}
+                variant={avatarVariant}
+                max={20}
+              />
+            </TouchableOpacity>
+          </ProfileHoverCard>
         ) : (
           <ProfileHoverCard username={user.handle} disable={disableHoverCard}>
             <LiveAvatar
@@ -267,7 +356,7 @@ const PostHeader: React.FC<PostHeaderProps> = ({
                 aggressively); the trailing "\u00B7 time" never wraps and stays visible.
                 With NO display name the @handle becomes the bold primary (rendered
                 ONCE here \u2014 the trailing muted handle is suppressed), never blank. */}
-            {isCollabHeader ? (
+            {isCollabByline ? (
               <View className="flex-row items-end flex-shrink" style={{ minWidth: 0 }}>
                 <Text
                   className="text-foreground text-[15px] font-semibold leading-tight"
@@ -276,7 +365,18 @@ const PostHeader: React.FC<PostHeaderProps> = ({
                 >
                   {headerAuthors.map((a, i) => {
                     const isLast = i === headerAuthors.length - 1;
-                    const separator = i === 0 ? '' : isLast ? t('collab.and', { defaultValue: ' and ' }) : ', ';
+                    // A channel signing with its writer is not a list of
+                    // co-authors: the channel published it and a person wrote
+                    // it, so the byline reads "Notas de Nate by Nate". `and`
+                    // would claim they authored it jointly.
+                    const separator =
+                      i === 0
+                        ? ''
+                        : isLast
+                          ? bylineNamesWriter
+                            ? t('collab.by', { defaultValue: ' by ' })
+                            : t('collab.and', { defaultValue: ' and ' })
+                          : ', ';
                     // Each first name links to that author's own profile; falls
                     // back to plain text when the author has no resolvable handle.
                     const goToProfile =

--- a/packages/frontend/components/Post/__tests__/CollaboratorsList.test.tsx
+++ b/packages/frontend/components/Post/__tests__/CollaboratorsList.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import type { PostUser } from '@mention/shared-types';
+
+import CollaboratorsList from '../CollaboratorsList';
+
+/**
+ * The panel behind a multi-author post's avatar cluster.
+ *
+ * It is one panel serving two different facts, and the heading is the only thing
+ * that distinguishes them: several people co-wrote a post ("Collaborators"), or
+ * ONE account published what ONE person wrote and chose to say so ("Published
+ * by"). Calling the second one a collaboration says the channel and its writer
+ * are peers on the post, which is exactly the relationship a channel exists to
+ * NOT have. The caller decides — the panel has no `role` to read, because it
+ * takes plain `PostUser` rows.
+ */
+
+const mockHeaderTitles: (string | undefined)[] = [];
+jest.mock('@/components/Header', () => ({
+  Header: ({ options }: { options?: { title?: string } }) => {
+    mockHeaderTitles.push(options?.title);
+    return null;
+  },
+}));
+
+jest.mock('@/components/ui/Button', () => ({ IconButton: () => null }));
+jest.mock('@/assets/icons/close-icon', () => ({ CloseIcon: () => null }));
+jest.mock('@/components/ProfileCard', () => ({ ProfileCard: () => null }));
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('@oxyhq/core', () => ({ getNormalizedUserHandle: () => 'nate' }));
+
+// Resolves against the real `en.json` and ignores `defaultValue`, so a deleted
+// key renders its raw name and fails rather than silently falling back.
+jest.mock('react-i18next', () => {
+  const strings: Record<string, string> = require('@/locales/en.json');
+  return { useTranslation: () => ({ t: (key: string) => strings[key] ?? key }) };
+});
+
+const authors: PostUser[] = [
+  { id: 'acct-notas', username: 'notas', name: { displayName: 'Notas de Nate' } },
+  { id: 'acct-nate', username: 'nate', name: { displayName: 'Nate Isern' } },
+];
+
+function renderList(title?: string) {
+  act(() => {
+    TestRenderer.create(
+      <CollaboratorsList authors={authors} onClose={jest.fn()} title={title} />,
+    );
+  });
+  return mockHeaderTitles[mockHeaderTitles.length - 1];
+}
+
+describe('CollaboratorsList heading', () => {
+  beforeEach(() => {
+    mockHeaderTitles.length = 0;
+  });
+
+  it('says "Collaborators" when the caller names no other relationship', () => {
+    expect(renderList(undefined)).toBe('Collaborators');
+  });
+
+  it('uses the caller’s heading — a channel naming its writer is not a collaboration', () => {
+    expect(renderList('Published by')).toBe('Published by');
+  });
+});

--- a/packages/frontend/components/Post/__tests__/PostHeaderByline.test.tsx
+++ b/packages/frontend/components/Post/__tests__/PostHeaderByline.test.tsx
@@ -1,0 +1,422 @@
+import React from 'react';
+import TestRenderer, { act, type ReactTestInstance } from 'react-test-renderer';
+import type { HydratedAuthor, PostUser } from '@mention/shared-types';
+
+import PostHeader from '../PostHeader';
+
+/**
+ * The identity row every post is drawn with, and the three decisions it makes
+ * that nothing else can catch when they break — each one renders a plausible,
+ * confidently wrong row rather than an error:
+ *
+ *  1. WHICH NAME. A person contributes a FIRST name, because a collaborative
+ *     byline is a sentence ("Ana and Luis"). A non-personal account has a TITLE
+ *     and no `first`/`last`, so splitting it truncates: "Notas de Nate" became
+ *     "Notas".
+ *  2. WHICH SEPARATOR. `and` claims joint authorship. A channel naming its
+ *     writer did not co-author anything with them, so it reads `by`.
+ *  3. WHICH AVATARS, IN WHICH ORDER. The cluster answers "how did this row reach
+ *     me", so an author who boosted it LEADS and a non-author who boosted it
+ *     TRAILS — opposite ends, because one of them authored the post and the
+ *     other did not.
+ *
+ * The two orderings in (3) are asserted against each other rather than against a
+ * single expected array: an implementation that never reorders and one that
+ * always reorders each satisfy exactly one of them, so both directions are
+ * needed before either means anything.
+ */
+
+// Each of these is mocked to a HOST element name rather than a component, so the
+// props the header computed survive into the rendered tree verbatim — the
+// cluster's `items` order is read as the array the header built, not as a
+// re-encoding of it — and none of them contributes text `collectText` would
+// then have to filter back out.
+jest.mock('@expo/vector-icons/Ionicons', () => 'Ionicons');
+jest.mock('@/components/ui/LiveAvatar', () => ({ LiveAvatar: 'LiveAvatar' }));
+jest.mock('@oxyhq/bloom/avatar-group', () => ({ AvatarGroup: 'AvatarGroup' }));
+jest.mock('../../UserName', () => ({ __esModule: true, default: 'UserName' }));
+
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({ colors: { textSecondary: '#8899a6' } }),
+}));
+
+jest.mock('@/components/Fediverse/FediverseBadge', () => ({ RemoteActorBadge: () => null }));
+jest.mock('@/assets/icons/boost-icon', () => ({ BoostIcon: () => null }));
+
+/**
+ * `t` resolves against the REAL `en.json` and deliberately IGNORES
+ * `defaultValue`. The separator assertions are about which KEY the header
+ * chooses, and every key here happens to have a default identical to its English
+ * string — so honouring the default would let a deleted `collab.by` render " by "
+ * anyway and pass. Ignoring it makes a missing key render the raw key and fail.
+ */
+jest.mock('react-i18next', () => {
+  const strings: Record<string, string> = require('@/locales/en.json');
+  return {
+    useTranslation: () => ({ t: (key: string) => strings[key] ?? key }),
+  };
+});
+
+// `@oxyhq/core` is not transformed in this suite. Mocked with the REAL rule so
+// the federated `user@domain` handle path is genuinely exercised.
+function mockHandlePart(value?: string | null): string | null {
+  const trimmed = value?.trim().replace(/^@+/, '');
+  if (!trimmed || /[/?#]/.test(trimmed)) return null;
+  return trimmed;
+}
+function mockNormalizedHandle(user: {
+  username?: string | null;
+  instance?: string | null;
+  isFederated?: boolean | null;
+  federation?: { domain?: string | null } | null;
+} | null | undefined): string | null {
+  const username = mockHandlePart(user?.username);
+  if (!username) return null;
+  const instance = mockHandlePart(user?.instance ?? user?.federation?.domain);
+  if (user?.isFederated === true && instance && !username.includes('@')) {
+    return `${username}@${instance}`;
+  }
+  return username;
+}
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user: unknown) =>
+    mockNormalizedHandle(user as Parameters<typeof mockNormalizedHandle>[0]),
+}));
+
+// --- fixtures ---
+
+/** The channel: a TITLE, no `first`/`last` — the shape `kind` exists to mark. */
+const channel: HydratedAuthor = {
+  id: 'acct-notas',
+  username: 'notas',
+  kind: 'channel',
+  name: { displayName: 'Notas de Nate' },
+  avatar: 'file-notas',
+  role: 'owner',
+  status: 'accepted',
+};
+
+/** The person the channel discloses. A `writer` exists on no other byline. */
+const writer: HydratedAuthor = {
+  id: 'acct-nate',
+  username: 'nate',
+  kind: 'personal',
+  name: { displayName: 'Nate Isern' },
+  avatar: 'file-nate',
+  role: 'writer',
+  status: 'accepted',
+};
+
+const collaborator = (id: string, username: string, displayName: string): HydratedAuthor => ({
+  id,
+  username,
+  kind: 'personal',
+  name: { displayName },
+  avatar: `file-${username}`,
+  role: 'collaborator',
+  status: 'accepted',
+});
+
+const booster: PostUser = {
+  id: 'acct-mar',
+  username: 'mar',
+  kind: 'personal',
+  name: { displayName: 'Mar Ruiz' },
+  avatar: 'file-mar',
+};
+
+// --- harness ---
+
+type HeaderProps = React.ComponentProps<typeof PostHeader>;
+
+function render(props: Partial<HeaderProps> = {}): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(
+      <PostHeader
+        user={{ displayName: 'Notas de Nate', handle: 'notas' }}
+        onPressAuthor={jest.fn()}
+        {...props}
+      />,
+    );
+  });
+  return renderer;
+}
+
+/** Every string the header rendered, in order. */
+function collectText(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === 'string' ? child : collectText(child)))
+    .join('');
+}
+
+/**
+ * The collaborative byline's own `Text`, found by `numberOfLines={2}` — the only
+ * two-line text in the header (the trailing `@handle` is one line). Returns null
+ * for a solo identity line, which renders no byline at all.
+ */
+function bylineText(renderer: TestRenderer.ReactTestRenderer): string | null {
+  const found = renderer.root.findAll(
+    (node) => typeof node.type === 'string' && node.props?.numberOfLines === 2,
+  );
+  return found.length > 0 ? collectText(found[0]) : null;
+}
+
+/** Cluster member ids, in render order. Null when no cluster was rendered. */
+function clusterIds(renderer: TestRenderer.ReactTestRenderer): string[] | null {
+  const found = renderer.root.findAll((node) => String(node.type) === 'AvatarGroup');
+  if (found.length === 0) return null;
+  const items: { id?: string }[] = found[0].props.items ?? [];
+  return items.map((item) => item.id ?? '?');
+}
+
+function hasSoloAvatar(renderer: TestRenderer.ReactTestRenderer): boolean {
+  return renderer.root.findAll((node) => String(node.type) === 'LiveAvatar').length > 0;
+}
+
+/**
+ * Every name the solo identity line rendered. An assertion that the byline did
+ * not GROW needs this rather than a search of the rendered text: a booster
+ * wrongly promoted into `headerAuthors` replaces the solo line entirely, so
+ * "their name is absent from the tree" is true either way.
+ */
+function soloNames(renderer: TestRenderer.ReactTestRenderer): string[] {
+  return renderer.root
+    .findAll((node) => String(node.type) === 'UserName')
+    .map((node) => String(node.props.name ?? ''));
+}
+
+function clusterPressable(renderer: TestRenderer.ReactTestRenderer): ReactTestInstance | null {
+  const found = renderer.root.findAll(
+    (node) => node.props?.accessibilityRole === 'button' && 'disabled' in (node.props ?? {}),
+  );
+  return found.length > 0 ? found[0] : null;
+}
+
+describe('PostHeader byline names', () => {
+  it('keeps a non-personal account’s whole title while a person still gives a first name', () => {
+    // BOTH halves in one row on purpose: an implementation that splits nothing
+    // renders "Notas de Nate by Nate Isern", one that splits everything renders
+    // "Notas by Nate". Only the mixed expectation rejects both.
+    expect(bylineText(render({ authors: [channel, writer] }))).toBe('Notas de Nate by Nate');
+  });
+
+  it('splits a person’s display name even with no `name.first` to read', () => {
+    const authors = [
+      collaborator('acct-ana', 'ana', 'Ana Torres'),
+      collaborator('acct-luis', 'luis', 'Luis Prado'),
+    ];
+    expect(bylineText(render({ authors }))).toBe('Ana and Luis');
+  });
+
+  it('treats an author with NO `kind` as a person', () => {
+    // The shape that tells `kind === undefined || kind === 'personal'` from a
+    // bare `kind === 'personal'`: a degraded or federated author summary carries
+    // no `kind` at all, and reading its absence as "not a person" would stop
+    // splitting every one of them. Every other fixture here states a `kind`, so
+    // without this one both readings pass.
+    const authors: HydratedAuthor[] = [
+      { ...collaborator('acct-ana', 'ana', 'Ana Torres'), kind: undefined },
+      { ...collaborator('acct-luis', 'luis', 'Luis Prado'), kind: undefined },
+    ];
+    expect(bylineText(render({ authors }))).toBe('Ana and Luis');
+  });
+
+  it('prefers the structured `name.first` for a person', () => {
+    const authors: HydratedAuthor[] = [
+      { ...collaborator('acct-ana', 'ana', 'Ana Torres'), name: { displayName: 'Ana Torres', first: 'Anabel' } },
+      collaborator('acct-luis', 'luis', 'Luis Prado'),
+    ];
+    expect(bylineText(render({ authors }))).toBe('Anabel and Luis');
+  });
+
+  it('ignores `name.first` for a non-personal account, whose title is the name', () => {
+    // A channel with a stray `first` is exactly the case where reading the
+    // structured field first would resurrect the truncation this rule removed.
+    const titled: HydratedAuthor = {
+      ...channel,
+      name: { displayName: 'Notas de Nate', first: 'Notas' },
+    };
+    expect(bylineText(render({ authors: [titled, writer] }))).toBe('Notas de Nate by Nate');
+  });
+
+  it('falls back to the normalized @handle — never a raw id — when there is no name', () => {
+    const nameless: HydratedAuthor = { ...channel, name: {} };
+    const federated: HydratedAuthor = {
+      ...collaborator('acct-remote', 'remote', ''),
+      name: {},
+      isFederated: true,
+      instance: 'mastodon.social',
+      role: 'writer',
+    };
+    expect(bylineText(render({ authors: [nameless, federated] }))).toBe(
+      '@notas by @remote@mastodon.social',
+    );
+  });
+
+  it('contributes NOTHING for an author with neither a name nor a handle', () => {
+    // The ghost-handle rule: a degraded author renders an empty handle, so there
+    // is no last resort to fall back to and the raw id must not become one. Two
+    // things the fixtures have to get right, and each was wrong first. The
+    // fixture must actually LACK a handle — with one, every fallback order
+    // produces the same string and the assertion cannot fail. And it must run on
+    // BOTH sides of the person split, because each branch spells its own last
+    // resort and a fixture on one side cannot see the other's.
+    const ghost = (kind: HydratedAuthor['kind']): HydratedAuthor => ({
+      id: `acct-ghost-${kind}`,
+      username: '',
+      kind,
+      name: {},
+      role: 'collaborator',
+      status: 'accepted',
+    });
+    const luis = collaborator('acct-luis', 'luis', 'Luis Prado');
+
+    for (const kind of ['personal', 'channel'] as const) {
+      const text = bylineText(render({ authors: [ghost(kind), luis] }));
+      expect(text).toBe(' and Luis');
+      expect(text).not.toContain('acct-ghost');
+    }
+  });
+});
+
+describe('PostHeader byline separator', () => {
+  it('reads `by` when the byline names a writer', () => {
+    expect(bylineText(render({ authors: [channel, writer] }))).toContain(' by ');
+  });
+
+  it('reads `and` when it does not — nobody is a writer', () => {
+    const authors = [
+      collaborator('acct-ana', 'ana', 'Ana Torres'),
+      collaborator('acct-luis', 'luis', 'Luis Prado'),
+    ];
+    const text = bylineText(render({ authors }));
+    expect(text).toContain(' and ');
+    expect(text).not.toContain(' by ');
+  });
+
+  it('keeps commas before the final separator for three collaborators', () => {
+    const authors = [
+      collaborator('acct-ana', 'ana', 'Ana Torres'),
+      collaborator('acct-luis', 'luis', 'Luis Prado'),
+      collaborator('acct-eva', 'eva', 'Eva Sanz'),
+    ];
+    expect(bylineText(render({ authors }))).toBe('Ana, Luis and Eva');
+  });
+});
+
+describe('PostHeader avatar cluster order', () => {
+  it('leads with the channel when nothing boosted the row', () => {
+    expect(clusterIds(render({ authors: [channel, writer] }))).toEqual([channel.id, writer.id]);
+  });
+
+  it('leads with the WRITER when the writer’s boost surfaced the row', () => {
+    // The opposite of the previous case, from the same authors — which is what
+    // makes either assertion mean anything.
+    expect(clusterIds(render({ authors: [channel, writer], boostedBy: writer }))).toEqual([
+      writer.id,
+      channel.id,
+    ]);
+  });
+
+  it('leaves the order alone when the CHANNEL’s own boost surfaced the row', () => {
+    expect(clusterIds(render({ authors: [channel, writer], boostedBy: channel }))).toEqual([
+      channel.id,
+      writer.id,
+    ]);
+  });
+
+  it('never reorders the NAMES, whichever avatar leads', () => {
+    const led = render({ authors: [channel, writer], boostedBy: writer });
+    expect(bylineText(led)).toBe('Notas de Nate by Nate');
+  });
+});
+
+describe('PostHeader ordinary repost', () => {
+  const soloAuthor = collaborator('acct-ana', 'ana', 'Ana Torres');
+  const soloUser: HeaderProps['user'] = { displayName: 'Ana Torres', handle: 'ana' };
+
+  it('pairs the author with the booster — author first, booster second', () => {
+    const renderer = render({ user: soloUser, authors: [soloAuthor], boostedBy: booster });
+    // Opposite end from the channel case above: the booster authored nothing, so
+    // the second avatar is attribution rather than a byline entry.
+    expect(clusterIds(renderer)).toEqual([soloAuthor.id, booster.id]);
+  });
+
+  it('names ONLY the author — the pair is not a collaborative byline', () => {
+    const renderer = render({ user: soloUser, authors: [soloAuthor], boostedBy: booster });
+    expect(bylineText(renderer)).toBeNull();
+    expect(soloNames(renderer)).toEqual(['Ana Torres']);
+  });
+
+  it('keeps a single avatar when no boost surfaced the row', () => {
+    const renderer = render({ user: soloUser, authors: [soloAuthor] });
+    expect(clusterIds(renderer)).toBeNull();
+    expect(hasSoloAvatar(renderer)).toBe(true);
+  });
+
+  it('does not pair when the booster is the author themselves', () => {
+    const renderer = render({ user: soloUser, authors: [soloAuthor], boostedBy: soloAuthor });
+    expect(clusterIds(renderer)).toBeNull();
+    expect(hasSoloAvatar(renderer)).toBe(true);
+  });
+
+  it('leaves a COLLABORATIVE cluster alone when an outsider boosted it', () => {
+    // The cluster there is the byline made visual and its tap lists exactly
+    // those authors, so a third avatar would have no row to open.
+    const authors = [
+      collaborator('acct-ana', 'ana', 'Ana Torres'),
+      collaborator('acct-luis', 'luis', 'Luis Prado'),
+    ];
+    expect(clusterIds(render({ authors, boostedBy: booster }))).toEqual([
+      'acct-ana',
+      'acct-luis',
+    ]);
+  });
+
+  it('keeps the solo avatar when there are no authors to pair the booster with', () => {
+    // An orphan federated post carries no `authors[]`, so there is no
+    // author-shaped record to put beside the booster.
+    const renderer = render({ user: soloUser, boostedBy: booster });
+    expect(clusterIds(renderer)).toBeNull();
+    expect(hasSoloAvatar(renderer)).toBe(true);
+  });
+});
+
+describe('PostHeader cluster press target', () => {
+  it('opens the author list for a collaborative byline', () => {
+    const onPressCollaborators = jest.fn();
+    const onPressAvatar = jest.fn();
+    const renderer = render({
+      authors: [channel, writer],
+      onPressCollaborators,
+      onPressAvatar,
+    });
+
+    act(() => {
+      clusterPressable(renderer)?.props.onPress();
+    });
+
+    expect(onPressCollaborators).toHaveBeenCalledTimes(1);
+    expect(onPressAvatar).not.toHaveBeenCalled();
+  });
+
+  it('opens the author’s own profile for an attribution pair — there is one author', () => {
+    const onPressCollaborators = jest.fn();
+    const onPressAvatar = jest.fn();
+    const renderer = render({
+      user: { displayName: 'Ana Torres', handle: 'ana' },
+      authors: [collaborator('acct-ana', 'ana', 'Ana Torres')],
+      boostedBy: booster,
+      onPressCollaborators,
+      onPressAvatar,
+    });
+
+    act(() => {
+      clusterPressable(renderer)?.props.onPress();
+    });
+
+    expect(onPressAvatar).toHaveBeenCalledTimes(1);
+    expect(onPressCollaborators).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -133,6 +133,8 @@
   "collab.searchPlaceholder": "Search people to collaborate with",
   "collab.noResults": "No users found",
   "collab.and": " and ",
+  "collab.by": " by ",
+  "collab.writtenByTitle": "Published by",
   "collab.acceptTitle": "Accept invite?",
   "collab.acceptSubtitle": "{{name}} invited you to collaborate on their post.",
   "collab.acceptAttribution": "Your username will be added to this post as a co-author.",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -168,6 +168,8 @@
   "collab.searchPlaceholder": "Buscar personas para colaborar",
   "collab.noResults": "No se encontraron usuarios",
   "collab.and": " y ",
+  "collab.by": " por ",
+  "collab.writtenByTitle": "Publicado por",
   "collab.acceptTitle": "¿Aceptar invitación?",
   "collab.acceptSubtitle": "{{name}} te invitó a colaborar en su publicación.",
   "collab.acceptAttribution": "Tu nombre de usuario se añadirá a esta publicación como coautor.",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -575,6 +575,8 @@
   "collab.searchPlaceholder": "Cerca persone con cui collaborare",
   "collab.noResults": "Nessun utente trovato",
   "collab.and": " e ",
+  "collab.by": " di ",
+  "collab.writtenByTitle": "Pubblicato da",
   "collab.acceptTitle": "Accettare l'invito?",
   "collab.acceptSubtitle": "{{name}} ti ha invitato a collaborare al suo post.",
   "collab.acceptAttribution": "Il tuo username verrà aggiunto a questo post come coautore.",


### PR DESCRIPTION
## Summary

- A non-personal account (channel) now contributes its whole display name to the byline instead of being split like a person's given name — a channel called "Notas de Nate" was rendering as just "Notas".
- The byline separator reads `by` rather than `and` when one of the names is the writer behind a signed channel post — they did not co-author the post with the channel.
- The avatar cluster reorders by provenance: the booster leads when they are one of the post's authors, and trails when they are not.
- Ordinary reposts now show two avatars and one name — the original author's avatar in front, the booster's behind.
- `boostedBy` is wired from `repostedBy` in `PostItem`, which was the bug: the reordering logic already existed in `PostHeader` and was correct, but no caller ever passed it, so it never fired in the app.

## Known regression

A reposted solo row loses the Syra live badge, because the pair now renders through Bloom's `AvatarGroup` rather than `LiveAvatar`, and that badge belongs to one person.

## Test plan

Gates already run by the implementing agent (not re-run here):
- [x] `tsc` — 0 errors
- [x] `test:coverage` — 1263/1263 (baseline 1233)
- [x] `lint:frontend` — 0 errors
- [x] `validate:i18n` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->