### PR TITLE
fix(identity): a profile edit reaches the surfaces already holding it

### DIFF
--- a/packages/frontend/app/(app)/[username]/connections.tsx
+++ b/packages/frontend/app/(app)/[username]/connections.tsx
@@ -12,10 +12,9 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ThemedView } from '@/components/ThemedView';
 import { VirtualList } from '@oxyhq/bloom/list';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
-import { queryClient } from '@/lib/queryClient';
 import { BloomColorScope, useTheme } from '@oxyhq/bloom/theme';
 import AnimatedTabBar from '@/components/common/AnimatedTabBar';
-import { upsertCachedUsers } from '@oxyhq/services';
+import { cacheActors } from '@/lib/actorCache';
 import { useAuth } from '@oxyhq/services/ui/client';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Error as ErrorComponent } from '@/components/Error';
@@ -179,7 +178,7 @@ function ConnectionsContent({
       const followersList = await oxyServices.getUserFollowers(profileData.id);
       const list = followersList.followers;
       setFollowers(list);
-      upsertCachedUsers(queryClient, list);
+      cacheActors(list);
     } catch (err) {
       // Followers are public; on an auth error show the empty state rather than
       // a scary error for logged-out visitors.
@@ -203,7 +202,7 @@ function ConnectionsContent({
       const followingList = await oxyServices.getUserFollowing(profileData.id);
       const list = followingList.following;
       setFollowing(list);
-      upsertCachedUsers(queryClient, list);
+      cacheActors(list);
     } catch (err) {
       // Following lists are public; on an auth error show the empty state rather
       // than a scary error for logged-out visitors.
@@ -268,7 +267,7 @@ function ConnectionsContent({
       try {
         const result = await oxyServices.getUserMutuals(targetId, { limit: 50 });
         const list = result.mutuals;
-        upsertCachedUsers(queryClient, list);
+        cacheActors(list);
         return list;
       } catch (err) {
         // Mutuals require a viewer; on an auth error (no usable bearer yet on

--- a/packages/frontend/app/(app)/c/[username]/settings.tsx
+++ b/packages/frontend/app/(app)/c/[username]/settings.tsx
@@ -12,7 +12,6 @@ import { toast } from '@oxyhq/bloom/toast';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { SettingsListGroup, SettingsListItem } from '@oxyhq/bloom/settings-list';
 import { OxyAuthPrompt, useAuth } from '@oxyhq/services/ui/client';
-import { upsertCachedUser } from '@oxyhq/services';
 import { createLogger } from '@oxyhq/core/logger';
 import { getNormalizedUserHandle, type AccountNode } from '@oxyhq/core';
 
@@ -23,6 +22,7 @@ import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { useSafeBack } from '@/hooks/useSafeBack';
 import { EmptyState } from '@/components/common/EmptyState';
 import { channelAccountService, type ChannelAccountSettings } from '@/services/channelAccountService';
+import { noteIdentityChanged } from '@/lib/actorCache';
 import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
 import { getErrorMessage } from '@/utils/apiError';
 import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types/post';
@@ -210,17 +210,22 @@ function ChannelAccountSettingsForm({ channel }: { channel: AccountNode }) {
         bio: trimmedBio.length > 0 ? trimmedBio : null,
         avatar: avatar.length > 0 ? avatar : null,
       }),
-    onSuccess: async (updated) => {
-      // The channel's page reads the SDK's user cache, so the authoritative
-      // account goes in through the SDK's own merge-upsert. A plain
-      // `setQueryData` would REPLACE the entry and strip the viewer
-      // `relationship` and `_count` an account object does not carry.
-      upsertCachedUser(queryClient, updated.account, viewerId);
-      // The operated-accounts list feeds this screen, the channels screen and
-      // the composer's publish-as picker, all of which show the name.
-      await queryClient.invalidateQueries({
-        queryKey: viewerQueryKeys.operatedAccounts(viewerId),
-      });
+    onSuccess: (updated) => {
+      // A channel's name and picture are held by more caches than this screen
+      // can see — the SDK's user cache behind its page, the operated-accounts
+      // list behind the composer's publish-as picker, and a copy embedded in
+      // every post the channel has ever published. `noteIdentityChanged` is the
+      // single authority that reaches all of them; writing any one of them from
+      // here is how the others get forgotten.
+      noteIdentityChanged(
+        {
+          id: updated.account.id,
+          username: updated.account.username,
+          name: updated.account.name,
+          avatar: updated.account.avatar,
+        },
+        viewerId,
+      );
       toast.success(
         t('channels.settings.profileSaved', { defaultValue: 'Channel updated' }),
       );

--- a/packages/frontend/app/(app)/notifications.tsx
+++ b/packages/frontend/app/(app)/notifications.tsx
@@ -315,7 +315,7 @@ const NotificationsScreen: React.FC = () => {
 
     useQuery({
         queryKey: viewerQueryKeys.notificationActors(user?.id, unpopulatedActorIds),
-        queryFn: () => prewarmUsersByIds(unpopulatedActorIds, (ids) => oxyServices.getUsersByIds(ids), queryClient),
+        queryFn: () => prewarmUsersByIds(unpopulatedActorIds, (ids) => oxyServices.getUsersByIds(ids)),
         enabled: canUsePrivateApi && !!oxyServices && unpopulatedActorIds.length > 0,
         staleTime: 5 * 60 * 1000,
     });

--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -46,6 +46,7 @@ import { THREAD_LINE_WIDTH, THREAD_LINE_BORDER_RADIUS, THREAD_LINE_Z_INDEX } fro
 import { POST_ITEM_SPACING } from '@/styles/shared';
 import { SubtleHover } from '@oxyhq/bloom/subtle-hover';
 import { useThreadHoverStore } from '@/stores/threadHoverStore';
+import { mergeKnownIdentity, useKnownIdentity } from '@/stores/identityUpdates';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { reportFeedInteraction } from '@/utils/feedTelemetry';
 import { formatFullTimestamp } from '@/utils/dateUtils';
@@ -170,6 +171,23 @@ const PostItem: React.FC<PostItemProps> = ({
     const viewPost = storePost ?? post;
     const viewPostId = viewPost?.id ? String(viewPost.id) : undefined;
 
+    // The author, corrected against any profile edit made in this session.
+    //
+    // `viewPost.user` is a SNAPSHOT of that identity taken when the server
+    // hydrated the post, and nothing rewrites it: the feed store's retained
+    // slice and the SQLite copy both keep it, and a remount warm-starts from
+    // that slice rather than refetching page 1. So a picture changed after a
+    // post was fetched stays wrong on that row until something throws the whole
+    // cache away — which is why a full reload looked like the only fix.
+    // `stores/identityUpdates` is the one authority that knows better, and
+    // resolving it HERE covers every post surface at once: a feed row, a post
+    // detail, a quote card and a boosted original are all this same component.
+    const knownAuthor = useKnownIdentity(viewPost?.user?.id);
+    const author = useMemo(
+        () => (viewPost?.user ? mergeKnownIdentity(viewPost.user, knownAuthor) : undefined),
+        [viewPost?.user, knownAuthor],
+    );
+
     const viewerState =
         viewPost?.viewerState ?? { isOwner: false, isCollaborator: false, isLiked: false, isDownvoted: false, isBoosted: false, isSaved: false };
 
@@ -267,7 +285,7 @@ const PostItem: React.FC<PostItemProps> = ({
     // A CHANNEL post has no separate signature to paint: a channel is an Oxy
     // account, so it IS the author and its avatar arrives in `user.avatar` like
     // anybody else's.
-    const avatarSource = viewPost?.user?.avatar;
+    const avatarSource = author?.avatar;
     const avatarVariant = MEDIA_VARIANT_AVATAR;
 
     // Preload only makes sense when the avatar is already an absolute URL —
@@ -330,8 +348,8 @@ const PostItem: React.FC<PostItemProps> = ({
     // value so they can never diverge. Empty for a degraded/unresolvable author
     // (empty handle) → no `@handle` shown and no tappable link.
     const authorHandle = useMemo(
-        () => getNormalizedUserHandle(viewPost.user) ?? undefined,
-        [viewPost.user],
+        () => (author ? getNormalizedUserHandle(author) ?? undefined : undefined),
+        [author],
     );
 
     // The avatar and the identity line both open the author's own profile.
@@ -612,7 +630,7 @@ const PostItem: React.FC<PostItemProps> = ({
         ],
     );
 
-    if (!viewPost || !viewPost.user) {
+    if (!viewPost || !author) {
         return null;
     }
 
@@ -639,7 +657,7 @@ const PostItem: React.FC<PostItemProps> = ({
     const replyContextRow = resolveReplyContextRow({ post: viewPost, isNested });
 
     const postAuthor = displayNameOrHandle(
-        viewPost.user.name?.displayName,
+        author.name?.displayName,
         authorHandle ? `@${authorHandle}` : '',
     );
     const postTextSummary = content.text
@@ -821,11 +839,11 @@ const PostItem: React.FC<PostItemProps> = ({
                 <View style={{ gap: headerToBlocksGap }}>
                     <PostHeader
                         user={{
-                            displayName: viewPost.user.name?.displayName,
+                            displayName: author.name?.displayName,
                             handle: authorHandle || '',
-                            verified: viewPost.user.verified,
-                            isFederated: viewPost.user.isFederated,
-                            instance: viewPost.user.instance,
+                            verified: author.verified,
+                            isFederated: author.isFederated,
+                            instance: author.instance,
                         }}
                         authors={viewPost.authors && viewPost.authors.length > 0 ? viewPost.authors : undefined}
                         // `repostedBy` is the only boost that put THIS post in
@@ -842,7 +860,7 @@ const PostItem: React.FC<PostItemProps> = ({
                         contextTop={contextRows.length > 0 ? contextRows : undefined}
                         avatarSource={avatarSource}
                         avatarVariant={avatarVariant}
-                        authorUserId={viewPost.user.id || undefined}
+                        authorUserId={author.id || undefined}
                         onPressUser={goToAuthorProfile}
                         onPressAvatar={goToAuthorProfile}
                         onPressCollaborators={isCollab ? openCollaboratorsList : undefined}

--- a/packages/frontend/components/Feed/__tests__/postAuthorIdentity.test.tsx
+++ b/packages/frontend/components/Feed/__tests__/postAuthorIdentity.test.tsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+/**
+ * A post row shows the CURRENT picture and name of its author, not the one the
+ * server happened to hydrate the post with.
+ *
+ * The bug these pin: changing a channel's picture saved correctly and then did
+ * not appear on any of its posts until a full reload. The server is fine — it is
+ * told about the write and re-asking returns the new picture — but nothing
+ * re-asks: `post.user` is frozen in the feed store's retained slice and in
+ * SQLite, and a remount warm-starts from that slice instead of refetching page
+ * 1. A reload was the only thing throwing all of it away.
+ * `stores/identityUpdates` is what knows better, and `PostItem` is where a post
+ * surface consults it — one place for feed rows, post details, quote cards and
+ * boosted originals alike, since all four are this component.
+ *
+ * `PostHeader` stands in for Bloom's avatar so the assertion reads the exact
+ * values `PostItem` hands down. Everything else mocked here is mocked for one
+ * reason only — it drags untransformed ESM into the module graph at import time
+ * (the same reason `PostDetailStats.test.tsx` mocks its Bloom subpaths).
+ */
+
+jest.mock('@/lib/oxyServices', () => ({ oxyServices: {} }));
+jest.mock('@/utils/api', () => ({ authenticatedClient: {}, publicClient: {} }));
+jest.mock('@oxyhq/services', () => ({
+  upsertCachedUser: jest.fn(),
+  upsertCachedUsers: jest.fn(),
+}));
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user: { username?: string } | null | undefined) =>
+    user?.username ?? null,
+}));
+jest.mock('@oxyhq/bloom/theme', () => ({ useTheme: () => ({ colors: {} }) }));
+jest.mock('@oxyhq/bloom/hooks', () => ({ useImagePreload: () => undefined }));
+jest.mock('@oxyhq/bloom/subtle-hover', () => ({
+  SubtleHover: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+jest.mock('@/components/ProfileHoverCard', () => ({
+  ProfileHoverCard: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => '/',
+}));
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+jest.mock('@/stores/postsStore', () => ({ usePostSelector: () => null }));
+jest.mock('@/hooks/usePostLike', () => ({ usePostLike: () => ({}) }));
+jest.mock('@/hooks/usePostVote', () => ({ usePostVote: () => ({}) }));
+jest.mock('@/hooks/usePostSave', () => ({ usePostSave: () => ({}) }));
+jest.mock('@/hooks/usePostBoost', () => ({ usePostBoost: () => ({}) }));
+jest.mock('@/hooks/usePostShare', () => ({ usePostShare: () => ({}) }));
+jest.mock('@/hooks/usePostActions', () => ({ usePostActions: () => ({}) }));
+jest.mock('@/hooks/usePostLanguage', () => ({
+  usePostLanguage: () => ({
+    options: [],
+    activeTag: undefined,
+    isTranslating: false,
+    selectLanguage: () => undefined,
+  }),
+}));
+jest.mock('@/context/BottomSheetContext', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  return { BottomSheetContext: ReactActual.createContext(null) };
+});
+jest.mock('@/components/Post/PostContentText', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/Post/PostLanguageChip', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/Post/PostLaneChip', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/Post/ContentWarning', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/Post/PostActions', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/Post/PostDetailStats', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/Post/PostLocation', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/Post/PostAttachmentsRow', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/common/ActionMenu', () => ({ showActionMenu: jest.fn() }));
+jest.mock('@/components/common/ContentDialog', () => ({ showContentDialog: jest.fn() }));
+jest.mock('@/lib/queryClient', () => ({
+  queryClient: { invalidateQueries: jest.fn(), setQueryData: jest.fn(), getQueryData: jest.fn() },
+}));
+
+/**
+ * The identity slot of the post header, rendered as one string so a single
+ * assertion covers the picture AND the name — a rename has exactly the same
+ * problem as a new picture and is fixed by the same signal, so a test that
+ * watched only the avatar would let half of it rot.
+ */
+jest.mock('@/components/Post/PostHeader', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  return {
+    __esModule: true,
+    HEADER_CONTENT_GAP: 4,
+    POST_CONTEXT_ROW_HEIGHT: 20,
+    default: (props: {
+      avatarSource?: string | null;
+      user?: { displayName?: string; handle?: string };
+    }) =>
+      ReactActual.createElement(
+        Text,
+        { testID: 'author-identity' },
+        `${props.avatarSource ?? ''}|${props.user?.displayName ?? ''}|${props.user?.handle ?? ''}`,
+      ),
+  };
+});
+
+// eslint-disable-next-line import/first
+import PostItem from '../PostItem';
+// eslint-disable-next-line import/first
+import { precacheActorsFromPosts } from '@/lib/precacheActorsFromPosts';
+// eslint-disable-next-line import/first
+import { noteIdentityChanged } from '@/lib/actorCache';
+// eslint-disable-next-line import/first
+import { resetIdentityUpdates } from '@/stores/identityUpdates';
+
+const CHANNEL_ID = 'channel-1';
+
+/** One post authored by the channel, as the server hydrated it before the edit. */
+function stalePost() {
+  return {
+    id: 'post-1',
+    content: {},
+    metadata: { createdAt: '2026-08-02T00:00:00.000Z' },
+    user: {
+      id: CHANNEL_ID,
+      username: 'daily',
+      name: { displayName: 'Daily' },
+      avatar: 'avatar-before',
+      kind: 'channel',
+    },
+  };
+}
+
+/** The row currently on screen, unmounted by `afterEach` so no test leaks one. */
+let mounted: TestRenderer.ReactTestRenderer | null = null;
+
+function renderRow() {
+  act(() => {
+    mounted = TestRenderer.create(<PostItem post={stalePost() as never} />);
+  });
+  if (!mounted) throw new Error('the row did not render');
+  return mounted;
+}
+
+function identityOf(renderer: TestRenderer.ReactTestRenderer): string {
+  return String(renderer.root.findByProps({ testID: 'author-identity' }).props.children);
+}
+
+afterEach(() => {
+  const renderer = mounted;
+  if (renderer) act(() => renderer.unmount());
+  mounted = null;
+  resetIdentityUpdates();
+  jest.clearAllMocks();
+});
+
+describe('a post row follows its author’s identity', () => {
+  it('shows the hydrated author when nothing has been edited', () => {
+    const renderer = renderRow();
+    expect(identityOf(renderer)).toBe('avatar-before|Daily|daily');
+  });
+
+  it('repaints a MOUNTED row when the author’s profile is edited — no refetch, no new post data', () => {
+    const renderer = renderRow();
+    expect(identityOf(renderer)).toBe('avatar-before|Daily|daily');
+
+    act(() => {
+      noteIdentityChanged({
+        id: CHANNEL_ID,
+        username: 'daily',
+        name: { displayName: 'Daily Digest' },
+        avatar: 'avatar-after',
+      });
+    });
+
+    // The row was never handed a new post, and nothing refetched — the same
+    // hydrated DTO is still its `post` prop.
+    expect(identityOf(renderer)).toBe('avatar-after|Daily Digest|daily');
+  });
+
+  it('shows the edited identity on a row mounted AFTER the edit', () => {
+    act(() => {
+      noteIdentityChanged({ id: CHANNEL_ID, avatar: 'avatar-after' });
+    });
+
+    const renderer = renderRow();
+    expect(identityOf(renderer)).toBe('avatar-after|Daily|daily');
+  });
+
+  it('survives a later feed response that still carries the pre-edit author', () => {
+    const renderer = renderRow();
+    act(() => {
+      noteIdentityChanged({ id: CHANNEL_ID, avatar: 'avatar-after' });
+    });
+    expect(identityOf(renderer)).toBe('avatar-after|Daily|daily');
+
+    // The channel's own page loads a page of its posts. Every one of them is
+    // authored by the account whose picture just changed, and the server is
+    // still answering with the old one.
+    act(() => {
+      precacheActorsFromPosts([stalePost()]);
+    });
+
+    expect(identityOf(renderer)).toBe('avatar-after|Daily|daily');
+  });
+
+  it('stands down once the server catches up, so a later change elsewhere is not pinned', () => {
+    act(() => {
+      noteIdentityChanged({ id: CHANNEL_ID, avatar: 'avatar-after' });
+    });
+
+    // Hydration now carries the edit — the overlay has done its job.
+    act(() => {
+      precacheActorsFromPosts([
+        { ...stalePost(), user: { ...stalePost().user, avatar: 'avatar-after' } },
+      ]);
+    });
+
+    // A picture changed somewhere else afterwards (another device,
+    // accounts.oxy.so) must not be overridden by what this session once wrote.
+    const renderer = renderRow();
+    expect(identityOf(renderer)).toBe('avatar-before|Daily|daily');
+  });
+
+  it('leaves every other author alone', () => {
+    act(() => {
+      noteIdentityChanged({ id: 'someone-else', avatar: 'avatar-after' });
+    });
+
+    const renderer = renderRow();
+    expect(identityOf(renderer)).toBe('avatar-before|Daily|daily');
+  });
+});

--- a/packages/frontend/components/Feed/interstitials/SimilarAccountsInterstitial.tsx
+++ b/packages/frontend/components/Feed/interstitials/SimilarAccountsInterstitial.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { router, type Href } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { upsertCachedUsers } from '@oxyhq/services';
+import { cacheActors } from '@/lib/actorCache';
 import { useAuth } from '@oxyhq/services/ui/client';
 import { getNormalizedUserHandle, type User } from '@oxyhq/core';
 import {
@@ -12,7 +12,6 @@ import {
   type ProfileCardData,
 } from '@/components/ProfileCard';
 import { useUserById } from '@/hooks/useCachedUser';
-import { queryClient } from '@/lib/queryClient';
 import { enrichMissingAvatars } from '@/utils/userEnrichment';
 import { DismissButton } from './DismissButton';
 import { InterstitialShell, type InterstitialItemContext } from './InterstitialShell';
@@ -67,11 +66,10 @@ export function SimilarAccountsInterstitial({
       if (!subjectId) return [];
       const similar = await oxyServices.getSimilarProfiles(subjectId);
       if (similar.length > 0) {
-        upsertCachedUsers(queryClient, similar);
+        cacheActors(similar);
         void enrichMissingAvatars(
           similar.map((profile) => ({ ...profile, avatar: profile.avatar ?? undefined })),
           (ids) => oxyServices.getUsersByIds(ids),
-          queryClient,
         );
       }
       // Cached RAW, exactly as the sibling surface caches it — the entry is

--- a/packages/frontend/components/suggestions/SuggestedUsers.tsx
+++ b/packages/frontend/components/suggestions/SuggestedUsers.tsx
@@ -2,10 +2,9 @@ import React, { memo, useState, useMemo, useCallback } from 'react';
 import { View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
-import { upsertCachedUsers } from '@oxyhq/services';
+import { cacheActors } from '@/lib/actorCache';
 import { useAuth } from '@oxyhq/services/ui/client';
 import { ThemedText } from '@/components/ThemedText';
-import { queryClient } from '@/lib/queryClient';
 import { enrichMissingAvatars } from '@/utils/userEnrichment';
 import { SuggestedUserCard } from './SuggestedUserCard';
 import type { SuggestedUserData } from './SuggestedUserCard';
@@ -55,11 +54,10 @@ export const SuggestedUsers = memo(function SuggestedUsers({
       const similar: unknown = await oxyServices.getSimilarProfiles(src);
       const list: ProfileData[] = Array.isArray(similar) ? similar : [];
       if (list.length > 0) {
-        upsertCachedUsers(queryClient, list);
+        cacheActors(list);
         void enrichMissingAvatars(
           list.slice(0, maxCards),
           (ids) => oxyServices.getUsersByIds(ids),
-          queryClient,
         );
       }
       return list;

--- a/packages/frontend/hooks/useRecommendations.ts
+++ b/packages/frontend/hooks/useRecommendations.ts
@@ -21,10 +21,9 @@
 
 import { useCallback, useMemo } from 'react';
 import { useInfiniteQuery, useQuery, keepPreviousData } from '@tanstack/react-query';
-import { upsertCachedUsers } from '@oxyhq/services';
+import { cacheActors } from '@/lib/actorCache';
 import { useAuth } from '@oxyhq/services/ui/client';
 import type { User } from '@oxyhq/core';
-import { queryClient } from '@/lib/queryClient';
 import { enrichMissingAvatars } from '@/utils/userEnrichment';
 import { isAuthError } from '@/utils/authErrors';
 import { logger } from '@oxyhq/core/logger';
@@ -82,8 +81,8 @@ async function loadRecommendationsPage(
     const page = await fetchRecommendationsPage({ excludeTypes, limit, cursor });
     const users = page.recommendations.filter((u) => u.id.length > 0);
     if (users.length > 0) {
-      upsertCachedUsers(queryClient, users);
-      void enrichMissingAvatars(users, getUsersByIds, queryClient);
+      cacheActors(users);
+      void enrichMissingAvatars(users, getUsersByIds);
     }
     return { ...page, recommendations: users };
   } catch (err) {

--- a/packages/frontend/lib/__tests__/actorCache.test.ts
+++ b/packages/frontend/lib/__tests__/actorCache.test.ts
@@ -1,0 +1,241 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import { queryClient as mockQueryClient } from '@/lib/queryClient';
+import { getKnownIdentity, resetIdentityUpdates } from '@/stores/identityUpdates';
+import { cacheActor, cacheActors, noteIdentityChanged } from '../actorCache';
+
+/**
+ * The one door into the SDK's user cache.
+ *
+ * Six surfaces prime that cache with users they fetched, and the SDK merge they
+ * all reach overrides a real value with a real value — so ANY of them can put a
+ * server copy that predates a profile edit back over that edit. Guarding them
+ * individually would be six guards; they share a door instead, and these pin
+ * both that the door corrects what passes through it AND that nothing walks
+ * around it.
+ *
+ * The MERGE itself is the SDK's own contract (verified in `@oxyhq/services`).
+ * What Mention owns, and what these assert, is the wiring: what is handed to it,
+ * keyed to which viewer, with which fields.
+ */
+
+const mockUpsertCachedUser = jest.fn();
+const mockUpsertCachedUsers = jest.fn();
+jest.mock('@oxyhq/services', () => ({
+  upsertCachedUser: (...args: unknown[]) => mockUpsertCachedUser(...args),
+  upsertCachedUsers: (...args: unknown[]) => mockUpsertCachedUsers(...args),
+}));
+
+jest.mock('@/lib/queryClient', () => ({
+  queryClient: { __sentinel: 'queryClient', invalidateQueries: jest.fn() },
+}));
+
+const invalidateQueries = mockQueryClient.invalidateQueries as unknown as jest.Mock;
+
+/** The users handed to the batch upsert on its last call. */
+function lastBatch(): unknown[] {
+  expect(mockUpsertCachedUsers).toHaveBeenCalled();
+  const calls = mockUpsertCachedUsers.mock.calls;
+  const [client, users] = calls[calls.length - 1];
+  expect(client).toBe(mockQueryClient);
+  return users as unknown[];
+}
+
+beforeEach(() => {
+  mockUpsertCachedUser.mockReset();
+  mockUpsertCachedUsers.mockReset();
+  invalidateQueries.mockReset();
+});
+
+afterEach(() => {
+  resetIdentityUpdates();
+});
+
+describe('noteIdentityChanged', () => {
+  it('hands the edit to the SDK merge-upsert, scoped to the acting viewer', () => {
+    noteIdentityChanged(
+      {
+        id: 'channel-1',
+        username: 'daily',
+        name: { displayName: 'Daily Digest' },
+        avatar: 'avatar-after',
+      },
+      'viewer-1',
+    );
+
+    expect(mockUpsertCachedUser).toHaveBeenCalledTimes(1);
+    expect(mockUpsertCachedUser).toHaveBeenCalledWith(
+      mockQueryClient,
+      {
+        id: 'channel-1',
+        username: 'daily',
+        name: { displayName: 'Daily Digest' },
+        avatar: 'avatar-after',
+      },
+      'viewer-1',
+    );
+    expect(getKnownIdentity('channel-1')).toEqual({
+      id: 'channel-1',
+      username: 'daily',
+      name: { displayName: 'Daily Digest' },
+      avatar: 'avatar-after',
+    });
+  });
+
+  it('invalidates the operated-accounts list and nothing else in its family', () => {
+    noteIdentityChanged({ id: 'channel-1', avatar: 'avatar-after' }, 'viewer-1');
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+    const { predicate } = invalidateQueries.mock.calls[0][0];
+    expect(predicate({ queryKey: viewerQueryKeys.operatedAccounts('viewer-1') })).toBe(true);
+    expect(
+      predicate({ queryKey: viewerQueryKeys.channelAccountSettings('viewer-1', 'channel-1') }),
+    ).toBe(false);
+    expect(predicate({ queryKey: viewerQueryKeys.notifications('viewer-1') })).toBe(false);
+  });
+
+  it('does not reconcile the edit against itself', () => {
+    // Routed through `cacheActor`, the write would arrive as an actor that
+    // "agrees" with what it just recorded and retire the entry on the spot —
+    // leaving nothing to correct the very next feed response with.
+    noteIdentityChanged({ id: 'channel-1', avatar: 'avatar-after' });
+
+    expect(getKnownIdentity('channel-1')).toEqual({ id: 'channel-1', avatar: 'avatar-after' });
+  });
+
+  it('touches no cache for a write with no id', () => {
+    noteIdentityChanged({ id: '', avatar: 'avatar-after' });
+
+    expect(mockUpsertCachedUser).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+});
+
+describe('cacheActors / cacheActor', () => {
+  it('corrects an actor a profile edit has since superseded', () => {
+    noteIdentityChanged({ id: 'channel-1', username: 'daily', avatar: 'avatar-after' });
+
+    cacheActors([{ id: 'channel-1', username: 'daily', avatar: 'avatar-before' }]);
+
+    expect(lastBatch()).toEqual([
+      { id: 'channel-1', username: 'daily', avatar: 'avatar-after' },
+    ]);
+  });
+
+  it('corrects a single actor the same way', () => {
+    noteIdentityChanged({ id: 'channel-1', avatar: 'avatar-after' });
+
+    cacheActor({ id: 'channel-1', username: 'daily', avatar: 'avatar-before' });
+
+    expect(mockUpsertCachedUser).toHaveBeenLastCalledWith(mockQueryClient, {
+      id: 'channel-1',
+      username: 'daily',
+      avatar: 'avatar-after',
+    });
+  });
+
+  it('leaves every other actor in the batch untouched', () => {
+    noteIdentityChanged({ id: 'channel-1', avatar: 'avatar-after' });
+
+    cacheActors([
+      { id: 'channel-1', username: 'daily', avatar: 'avatar-before' },
+      { id: 'someone-else', username: 'else', avatar: 'their-avatar' },
+    ]);
+
+    expect(lastBatch()).toEqual([
+      { id: 'channel-1', username: 'daily', avatar: 'avatar-after' },
+      { id: 'someone-else', username: 'else', avatar: 'their-avatar' },
+    ]);
+  });
+
+  it('retires the correction once a surface carries the edit, and stops correcting', () => {
+    noteIdentityChanged({ id: 'channel-1', username: 'daily', avatar: 'avatar-after' });
+
+    cacheActors([{ id: 'channel-1', username: 'daily', avatar: 'avatar-after' }]);
+    expect(getKnownIdentity('channel-1')).toBeUndefined();
+
+    // So a value that differs AFTERWARDS is a genuine change made somewhere else
+    // — another device, accounts.oxy.so — and must reach the cache unedited.
+    cacheActors([{ id: 'channel-1', username: 'daily', avatar: 'avatar-elsewhere' }]);
+    expect(lastBatch()).toEqual([
+      { id: 'channel-1', username: 'daily', avatar: 'avatar-elsewhere' },
+    ]);
+  });
+
+  it('retires from a SINGLE-actor surface too', () => {
+    noteIdentityChanged({ id: 'channel-1', avatar: 'avatar-after' });
+
+    cacheActor({ id: 'channel-1', avatar: 'avatar-after' });
+    expect(getKnownIdentity('channel-1')).toBeUndefined();
+  });
+
+  it.each<[string, unknown]>([
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty array', []],
+  ])('does not touch the cache for %s', (_label, input) => {
+    cacheActors(input as never);
+    expect(mockUpsertCachedUsers).not.toHaveBeenCalled();
+  });
+
+  it('does not touch the cache for a missing single actor', () => {
+    cacheActor(null);
+    expect(mockUpsertCachedUser).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Nothing walks around the door.
+ *
+ * Six surfaces used to call the SDK upserts directly, and a seventh added later
+ * would inherit the bug in silence — the correction simply would not run for it,
+ * with no error and no failing test anywhere. A guard per surface is the shape
+ * that quietly becomes five of six; this asserts the property that makes one
+ * guard sufficient, which is that `lib/actorCache.ts` is the only importer.
+ */
+describe('the door is the only way in', () => {
+  const FRONTEND_ROOT = path.resolve(__dirname, '../..');
+  const SKIP_DIRS = new Set([
+    'node_modules', '.expo', 'dist', 'android', 'ios', 'coverage', '.git',
+  ]);
+
+  /** Every `.ts`/`.tsx` under the frontend package, tests excluded. */
+  function sourceFiles(dir: string, out: string[] = []): string[] {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith('.') && entry.name !== '.') continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name) || entry.name === '__tests__') continue;
+        sourceFiles(full, out);
+      } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  const files = sourceFiles(FRONTEND_ROOT);
+
+  it('scanned a plausible number of source files', () => {
+    // A traversal that silently found nothing would make the assertion below
+    // pass for the wrong reason.
+    expect(files.length).toBeGreaterThan(300);
+  });
+
+  it('is the only module importing the SDK user-cache upserts', () => {
+    const importers = files.filter((file) => {
+      const source = fs.readFileSync(file, 'utf8');
+      // The IMPORT, not a mention in prose — several files name these helpers in
+      // their docstrings, and a docstring cannot walk around anything.
+      return /import\s*\{[^}]*\bupsertCachedUsers?\b[^}]*\}\s*from\s*['"]@oxyhq\/services['"]/.test(
+        source,
+      );
+    });
+
+    expect(importers.map((file) => path.relative(FRONTEND_ROOT, file))).toEqual([
+      'lib/actorCache.ts',
+    ]);
+  });
+});

--- a/packages/frontend/lib/__tests__/precacheActorsFromPosts.test.ts
+++ b/packages/frontend/lib/__tests__/precacheActorsFromPosts.test.ts
@@ -17,11 +17,17 @@
  */
 
 import { queryClient as mockQueryClient } from '@/lib/queryClient';
+import { noteIdentityChanged } from '@/lib/actorCache';
+import { resetIdentityUpdates } from '@/stores/identityUpdates';
 import { precacheActorsFromPosts } from '../precacheActorsFromPosts';
 
 const mockUpsertCachedUsers = jest.fn();
 jest.mock('@oxyhq/services', () => ({
   upsertCachedUsers: (...args: unknown[]) => mockUpsertCachedUsers(...args),
+  // `stores/identityUpdates` writes the edit through the SDK's single-user
+  // upsert; this file is about what reaches the BATCH one, so it only has to
+  // exist.
+  upsertCachedUser: jest.fn(),
 }));
 
 /**
@@ -32,7 +38,9 @@ jest.mock('@oxyhq/services', () => ({
  * still be undefined when the mock is hoisted above it — and both the module
  * under test and this file import that one shared reference.
  */
-jest.mock('@/lib/queryClient', () => ({ queryClient: { __sentinel: 'queryClient' } }));
+jest.mock('@/lib/queryClient', () => ({
+  queryClient: { __sentinel: 'queryClient', invalidateQueries: jest.fn() },
+}));
 
 /** The users the upsert was asked to prime on its single call. */
 function upsertedUsers(): unknown[] {
@@ -120,5 +128,106 @@ describe('precacheActorsFromPosts — no-op inputs', () => {
   it('ignores non-object entries in the batch', () => {
     precacheActorsFromPosts([null, 42, 'post', { user: { id: 'author-5' } }]);
     expect(upsertedUsers()).toEqual([{ id: 'author-5' }]);
+  });
+});
+
+/**
+ * The merge-upsert this file delegates to is a MERGE, which is exactly why a
+ * stale author is dangerous here rather than harmless: a real avatar id
+ * overrides a real avatar id, so the pre-edit picture wins on arrival. Verified
+ * against the SDK's own implementation — seed an entry, upsert an edit, then
+ * upsert a hydrated author still carrying the old picture, and the entry is back
+ * to the old picture.
+ *
+ * Whether a given response IS stale is a race (the server is told about the
+ * write and drops its identity caches on receipt), and that is the point: on a
+ * channel's own page every post in the response is authored by the account whose
+ * picture just changed, so losing that race decides what its header shows. The
+ * correction removes the race from the answer.
+ */
+describe('precacheActorsFromPosts — an identity the viewer just edited', () => {
+  const EDITED = 'channel-1';
+
+  /** The users handed to the upsert on its LAST call. */
+  function lastUpsertedUsers(): unknown[] {
+    const calls = mockUpsertCachedUsers.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1][1] as unknown[];
+  }
+
+  /** That account as the server still hydrates it: the picture from before the edit. */
+  function staleAuthorPost() {
+    return { user: { id: EDITED, username: 'daily', avatar: 'avatar-before' } };
+  }
+
+  afterEach(() => {
+    resetIdentityUpdates();
+  });
+
+  it('corrects a stale author on its way into the cache', () => {
+    noteIdentityChanged({ id: EDITED, username: 'daily', avatar: 'avatar-after' });
+
+    precacheActorsFromPosts([staleAuthorPost()]);
+
+    expect(lastUpsertedUsers()).toEqual([
+      { id: EDITED, username: 'daily', avatar: 'avatar-after' },
+    ]);
+  });
+
+  it('leaves every other author in the same batch untouched', () => {
+    noteIdentityChanged({ id: EDITED, avatar: 'avatar-after' });
+
+    precacheActorsFromPosts([
+      staleAuthorPost(),
+      { user: { id: 'someone-else', username: 'else', avatar: 'their-avatar' } },
+    ]);
+
+    expect(lastUpsertedUsers()).toEqual([
+      { id: EDITED, username: 'daily', avatar: 'avatar-after' },
+      { id: 'someone-else', username: 'else', avatar: 'their-avatar' },
+    ]);
+  });
+
+  it('retires the correction once hydration carries the edit, and stops correcting', () => {
+    noteIdentityChanged({ id: EDITED, username: 'daily', avatar: 'avatar-after' });
+
+    // The server has caught up: this batch already names the new picture.
+    precacheActorsFromPosts([
+      { user: { id: EDITED, username: 'daily', avatar: 'avatar-after' } },
+    ]);
+
+    // So a value that differs AFTERWARDS is a genuine change made somewhere else
+    // — another device, accounts.oxy.so — and must reach the cache unedited.
+    precacheActorsFromPosts([
+      { user: { id: EDITED, username: 'daily', avatar: 'avatar-changed-elsewhere' } },
+    ]);
+
+    expect(lastUpsertedUsers()).toEqual([
+      { id: EDITED, username: 'daily', avatar: 'avatar-changed-elsewhere' },
+    ]);
+  });
+
+  it('does not retire on a batch that agrees about only SOME of the edit', () => {
+    noteIdentityChanged({
+      id: EDITED,
+      username: 'daily',
+      name: { displayName: 'Daily Digest' },
+      avatar: 'avatar-after',
+    });
+
+    // The picture caught up, the name did not — that is not the server agreeing.
+    precacheActorsFromPosts([
+      { user: { id: EDITED, username: 'daily', avatar: 'avatar-after', name: { displayName: 'Daily' } } },
+    ]);
+    precacheActorsFromPosts([staleAuthorPost()]);
+
+    expect(lastUpsertedUsers()).toEqual([
+      {
+        id: EDITED,
+        username: 'daily',
+        name: { displayName: 'Daily Digest' },
+        avatar: 'avatar-after',
+      },
+    ]);
   });
 });

--- a/packages/frontend/lib/__tests__/viewerQueryKeys.test.ts
+++ b/packages/frontend/lib/__tests__/viewerQueryKeys.test.ts
@@ -175,6 +175,23 @@ describe('viewer-scoped private cache', () => {
     )).toBe(false);
   });
 
+  it('matches the operated-accounts list without matching its channel-settings sibling', () => {
+    // An identity write invalidates the accounts LIST (the composer's publish-as
+    // picker reads it) and must leave the Mention-owned per-channel settings row
+    // alone — both live in the `accounts` family, so the family alone is too wide.
+    expect(
+      viewerQueryKeys.isOperatedAccounts(viewerQueryKeys.operatedAccounts('viewer-a')),
+    ).toBe(true);
+    expect(
+      viewerQueryKeys.isOperatedAccounts(
+        viewerQueryKeys.channelAccountSettings('viewer-a', 'acct-1'),
+      ),
+    ).toBe(false);
+    expect(
+      viewerQueryKeys.isOperatedAccounts(viewerQueryKeys.notifications('viewer-a')),
+    ).toBe(false);
+  });
+
   it('removes only A when the active account switches A to B', async () => {
     const queryClient = new QueryClient();
     const aSearch = viewerQueryKeys.search('viewer-a', 'saved', 'oxy', true);

--- a/packages/frontend/lib/actorCache.ts
+++ b/packages/frontend/lib/actorCache.ts
@@ -1,0 +1,85 @@
+import { upsertCachedUser, upsertCachedUsers, type CacheableUser } from '@oxyhq/services';
+import { queryClient } from '@/lib/queryClient';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import {
+  applyKnownIdentity,
+  recordIdentityChange,
+  reconcileKnownIdentities,
+  type IdentityUpdate,
+} from '@/stores/identityUpdates';
+
+/**
+ * The ONE door into the SDK's user cache — Mention's in-memory actor cache.
+ *
+ * Six surfaces fetch users and prime that cache with what they got: the feed's
+ * post authors, the recommendation rail, the suggested-users card, the profile
+ * interstitial, the followers/following lists and the mention picker's
+ * enrichment. Each of them was calling the SDK's merge-upsert directly, and the
+ * merge overrides a real value with a real value — so ANY of them could put a
+ * server copy that predates a profile edit back over that edit, which is exactly
+ * what the feed was doing on a channel's own page.
+ *
+ * Guarding them one by one would be six guards, and six guards is the shape that
+ * quietly becomes five when somebody adds a seventh surface. They all pass the
+ * SAME singleton query client to the SAME two SDK functions, so they can all
+ * pass through here instead, and the correction is written once. That is also
+ * why this module — not the store behind it — is the thing new code should
+ * import: it is enforceable by grep (`@oxyhq/services`'s upserts have exactly
+ * one caller in the app, this file) in a way that "remember to correct your
+ * actors" is not.
+ *
+ * It owns the WRITE half of identity as well ({@link noteIdentityChanged}),
+ * because a profile edit is the same question from the other side: the cache
+ * this module fronts is one of the two places that edit has to reach. The other
+ * is the post rows, which read `stores/identityUpdates` directly.
+ *
+ * The dependency runs one way — this may import the overlay store, never the
+ * reverse. The store is in `PostItem`'s module graph and must stay free of the
+ * SDK barrel; see the note at the top of `stores/identityUpdates.ts`.
+ */
+
+/**
+ * Prime the cache with actors a surface just fetched.
+ *
+ * Reconciles FIRST: an actor the server has caught up with retires its overlay
+ * entry, so the correction that follows is a no-op from then on and an identity
+ * changed somewhere else is never pinned to what this session wrote.
+ */
+export function cacheActors(actors: readonly CacheableUser[] | null | undefined): void {
+  if (!Array.isArray(actors) || actors.length === 0) return;
+  reconcileKnownIdentities(actors);
+  upsertCachedUsers(queryClient, actors.map(applyKnownIdentity));
+}
+
+/** {@link cacheActors} for a single actor. */
+export function cacheActor(actor: CacheableUser | null | undefined): void {
+  if (!actor) return;
+  reconcileKnownIdentities([actor]);
+  upsertCachedUser(queryClient, applyKnownIdentity(actor));
+}
+
+/**
+ * Record that a profile edit landed, and tell every cache holding a copy of that
+ * identity. Call this only after the server has accepted the write: a failed
+ * edit leaves every surface exactly as the caches already have it.
+ */
+export function noteIdentityChanged(update: IdentityUpdate, viewerId?: string): void {
+  const stored = recordIdentityChange(update);
+  if (!stored) return;
+
+  // The SDK's canonical merge-upsert writes BOTH keys its user hooks read (by-id
+  // and the viewer-scoped by-username) and merges rather than replaces — so the
+  // profile screen, the hover card and every `useUserById` card get the edit
+  // without losing the counts and viewer relationship an authoritative profile
+  // fetch had already stored. Not routed through `cacheActor`: this is the
+  // authority for that identity, so it must not be reconciled against itself.
+  upsertCachedUser(queryClient, stored, viewerId);
+
+  // The operated-accounts list embeds each account's profile and feeds the
+  // channels screen, the composer's publish-as picker and the channel settings
+  // screen itself. It is a list of accounts rather than an actor cache, so the
+  // upsert above cannot reach it.
+  void queryClient.invalidateQueries({
+    predicate: (query) => viewerQueryKeys.isOperatedAccounts(query.queryKey),
+  });
+}

--- a/packages/frontend/lib/precacheActorsFromPosts.ts
+++ b/packages/frontend/lib/precacheActorsFromPosts.ts
@@ -4,14 +4,14 @@
  * Replaces the former SQLite user-priming pass (which wrote embedded post
  * authors into a local table — a silent no-op on web). Now it merge-upserts those
  * user objects into the shared React Query cache via the SDK's
- * `upsertCachedUsers`, so avatars and names populate on web (and native) the
+ * `lib/actorCache`, so avatars and names populate on web (and native) the
  * moment a feed response arrives — WITHOUT a sparse feed author clobbering the
  * `createdAt`, viewer `relationship`, or `_count` an authoritative profile fetch
  * already stored.
  */
 
-import { upsertCachedUsers, type CacheableUser } from '@oxyhq/services';
-import { queryClient } from '@/lib/queryClient';
+import type { CacheableUser } from '@oxyhq/services';
+import { cacheActors } from '@/lib/actorCache';
 
 /**
  * A post-shaped record carrying actors from the canonical hydration contract.
@@ -51,7 +51,12 @@ export function precacheActorsFromPosts(
     if (p.boost?.actor) users.push(p.boost.actor);
   }
 
-  if (users.length > 0) {
-    upsertCachedUsers(queryClient, users);
-  }
+  // Through `lib/actorCache`, like every other surface that primes an actor:
+  // the merge it fronts overrides a real value with a real value, so a response
+  // whose authors were hydrated before a profile write propagated would put the
+  // PRE-EDIT name and picture back over the edit. On a channel's own page every
+  // post in the response is authored by the account whose picture just changed,
+  // which is what made this the surface the bug was found on — but not the only
+  // one that could cause it, which is why the correction is not here.
+  cacheActors(users);
 }

--- a/packages/frontend/lib/recommendations.ts
+++ b/packages/frontend/lib/recommendations.ts
@@ -22,7 +22,7 @@ export type RecommendationExcludeType = 'federated' | 'agent' | 'automated';
  * canonical `name.displayName`, optional federation/automation metadata,
  * `_count`) intersected with the extra fields `formatProfileResult` actually
  * returns (`avatar`, `bio`/`description`, `verified`). The index signature keeps
- * it assignable to the SDK cache-upsert helper (`upsertCachedUsers`, whose
+ * it assignable to the actor-cache upsert (`cacheActors`, whose
  * `CacheableUser`) and to `enrichMissingAvatars`, and to the surfaces' card
  * shapes, without enumerating every passthrough field.
  */

--- a/packages/frontend/lib/viewerQueryKeys.ts
+++ b/packages/frontend/lib/viewerQueryKeys.ts
@@ -465,6 +465,15 @@ export const viewerQueryKeys = {
     viewerQueryKeys.isFamily(queryKey, 'appearance') &&
     queryKey[3] === 'user' &&
     queryKey[4] === userId,
+  /**
+   * Whichever viewer's {@link viewerQueryKeys.operatedAccounts} list this is.
+   * The `accounts` family also holds `channelAccountSettings`, which a profile
+   * edit never changes, so the family alone is too wide — and a caller that
+   * reached past `isFamily` into `queryKey[3]` itself would be the second place
+   * that knows this key's shape.
+   */
+  isOperatedAccounts: (queryKey: readonly unknown[]): boolean =>
+    viewerQueryKeys.isFamily(queryKey, 'accounts') && queryKey[3] === 'operated',
 };
 
 /** The single factory for every Mention-owned React Query key. */

--- a/packages/frontend/stores/__tests__/identityUpdates.test.ts
+++ b/packages/frontend/stores/__tests__/identityUpdates.test.ts
@@ -1,0 +1,154 @@
+import {
+  applyKnownIdentity,
+  getKnownIdentity,
+  mergeKnownIdentity,
+  reconcileKnownIdentities,
+  recordIdentityChange,
+  resetIdentityUpdates,
+  subscribeToIdentityUpdates,
+} from '../identityUpdates';
+
+/**
+ * The overlay store: the STATE half of an identity write, and the half every
+ * rendered post row reads.
+ *
+ * The cache half — writing the edit through to React Query and correcting
+ * incoming actors — belongs to `lib/actorCache.ts` and is pinned by
+ * `lib/__tests__/actorCache.test.ts`. The split is not cosmetic: this module is
+ * in `PostItem`'s module graph, so it must not import the SDK, and these tests
+ * mock nothing at all, which is the cheap standing proof that it does not.
+ */
+
+afterEach(() => {
+  resetIdentityUpdates();
+});
+
+describe('recordIdentityChange', () => {
+  it('stores and returns exactly the fields the edit carried', () => {
+    // A save that changed the picture alone must not also assert a name — the
+    // overlay would then pin whatever the writer was holding, and would later
+    // "agree" with the server about a value nobody edited.
+    const stored = recordIdentityChange({ id: 'channel-1', avatar: 'avatar-after' });
+
+    expect(stored).toEqual({ id: 'channel-1', avatar: 'avatar-after' });
+    expect(getKnownIdentity('channel-1')).toBe(stored);
+  });
+
+  it.each<[string, { username?: string; avatar?: string | null; name?: { displayName?: string } }]>([
+    ['an empty username', { username: '   ' }],
+    ['a cleared picture', { avatar: null }],
+    ['an emptied picture', { avatar: '' }],
+    ['an emptied display name', { name: { displayName: '  ' } }],
+  ])('never records %s, so no cache can be degraded by one', (_label, fields) => {
+    expect(recordIdentityChange({ id: 'channel-1', ...fields })).toEqual({ id: 'channel-1' });
+  });
+
+  it('refuses a write with no id — there is nothing to key it on', () => {
+    expect(recordIdentityChange({ id: '', avatar: 'avatar-after' })).toBeNull();
+    expect(getKnownIdentity('')).toBeUndefined();
+  });
+});
+
+describe('the recorded identity', () => {
+  it('notifies subscribers when it is written, retired and reset', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToIdentityUpdates(listener);
+
+    recordIdentityChange({ id: 'channel-1', avatar: 'avatar-after' });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    reconcileKnownIdentities([{ id: 'channel-1', avatar: 'avatar-after' }]);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    resetIdentityUpdates();
+    expect(listener).toHaveBeenCalledTimes(3);
+
+    unsubscribe();
+    recordIdentityChange({ id: 'channel-1', avatar: 'avatar-later' });
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not notify when a batch agrees with nothing', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToIdentityUpdates(listener);
+
+    // Nothing recorded at all, then a recorded entry the batch disagrees with:
+    // a subscriber woken here would re-render every post row on every page.
+    reconcileKnownIdentities([{ id: 'channel-1', avatar: 'avatar-before' }]);
+    expect(listener).not.toHaveBeenCalled();
+
+    recordIdentityChange({ id: 'channel-1', avatar: 'avatar-after' });
+    listener.mockClear();
+    reconcileKnownIdentities([{ id: 'channel-1', avatar: 'avatar-before' }]);
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it('is stable by reference until that user is written again', () => {
+    recordIdentityChange({ id: 'channel-1', avatar: 'avatar-after' });
+    const first = getKnownIdentity('channel-1');
+    expect(getKnownIdentity('channel-1')).toBe(first);
+
+    // `useKnownIdentity` hands this straight to `useSyncExternalStore`, which
+    // loops forever on a snapshot that allocates.
+    recordIdentityChange({ id: 'someone-else', avatar: 'other' });
+    expect(getKnownIdentity('channel-1')).toBe(first);
+
+    recordIdentityChange({ id: 'channel-1', avatar: 'avatar-later' });
+    expect(getKnownIdentity('channel-1')).not.toBe(first);
+  });
+
+  it('reads as nothing for an unknown or absent id', () => {
+    expect(getKnownIdentity('nobody')).toBeUndefined();
+    expect(getKnownIdentity(undefined)).toBeUndefined();
+  });
+});
+
+describe('merging an actor', () => {
+  const actor = { id: 'channel-1', username: 'daily', avatar: 'avatar-before' };
+
+  it('returns the same reference when nothing is recorded', () => {
+    expect(mergeKnownIdentity(actor, undefined)).toBe(actor);
+    expect(applyKnownIdentity(actor)).toBe(actor);
+  });
+
+  it('overrides only the recorded fields', () => {
+    recordIdentityChange({ id: 'channel-1', avatar: 'avatar-after' });
+
+    expect(applyKnownIdentity({ ...actor, verified: true })).toEqual({
+      id: 'channel-1',
+      username: 'daily',
+      avatar: 'avatar-after',
+      verified: true,
+    });
+  });
+
+  it('never writes the recorded id over the actor it is merged into', () => {
+    recordIdentityChange({ id: 'channel-1', avatar: 'avatar-after' });
+
+    expect(applyKnownIdentity({ id: 'channel-1' }).id).toBe('channel-1');
+    expect(mergeKnownIdentity({ id: 'other' }, getKnownIdentity('channel-1')).id).toBe('other');
+  });
+});
+
+describe('reconciling against the server', () => {
+  it('is a no-op when nothing has been recorded', () => {
+    reconcileKnownIdentities([{ id: 'channel-1', avatar: 'avatar-before' }]);
+    expect(getKnownIdentity('channel-1')).toBeUndefined();
+  });
+
+  it('accepts the plain-string display name the looser actor objects carry', () => {
+    recordIdentityChange({ id: 'channel-1', name: { displayName: 'Daily Digest' } });
+
+    reconcileKnownIdentities([{ id: 'channel-1', name: 'Daily Digest' }]);
+    expect(getKnownIdentity('channel-1')).toBeUndefined();
+  });
+
+  it('keeps an entry an actor with no id cannot speak for', () => {
+    recordIdentityChange({ id: 'channel-1', avatar: 'avatar-after' });
+
+    reconcileKnownIdentities([{ avatar: 'avatar-after' }]);
+    expect(getKnownIdentity('channel-1')).toEqual({ id: 'channel-1', avatar: 'avatar-after' });
+  });
+});

--- a/packages/frontend/stores/identityUpdates.ts
+++ b/packages/frontend/stores/identityUpdates.ts
@@ -1,0 +1,294 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import type { PostUser } from '@mention/shared-types';
+
+/**
+ * The single authority for "a profile edit changed an identity that other
+ * surfaces are holding their own copy of".
+ *
+ * The write class this owns is a person's or a channel's IDENTITY — the display
+ * name, the handle and the picture. Today one screen performs it
+ * (`app/(app)/c/[username]/settings.tsx`, the only door a channel's profile
+ * has), but nothing here is channel-specific: an identity is an identity.
+ *
+ * It sits beside `stores/engagementInvalidation` and `stores/laneInvalidation`,
+ * which own the other two write classes, and it exists for the same reason they
+ * do — Mention holds one fact in several caches that cannot see each other, so a
+ * write has to speak to all of them from ONE place or they drift. Read
+ * `engagementInvalidation`'s docstring for that seam; this file only records
+ * where an identity DIFFERS from a list membership, because the difference
+ * decides the whole design.
+ *
+ * **The SERVER is not the problem, and checking that first is what makes the
+ * rest of this the right shape.** oxy-api publishes `oxy:user:invalidate` on the
+ * account write and Mention's backend drops its identity caches on receipt
+ * (`packages/backend/src/services/userInvalidationSubscriber.ts`), so a fresh
+ * ASK returns the new picture almost immediately. Delivery is at-most-once by
+ * design and degrades to the `usersummary:v5:<id>` TTL (ten minutes) if the
+ * message is lost, but that is the degraded case, not the normal one. Reloading
+ * the page therefore shows the edit — which is precisely the observation that
+ * locates the bug on this side of the wire.
+ *
+ * What has no signal is the copies the CLIENT IS ALREADY HOLDING, and none of
+ * them re-ask:
+ *
+ *   * the React Query user entry. The write merges into it but leaves its
+ *     freshness alone (that is `upsertCachedUser`'s contract for an existing
+ *     entry), and `useUserByUsername` pairs a five-minute `staleTime` with
+ *     `refetchOnMount: true`, which deliberately does NOT refetch an entry that
+ *     is still fresh.
+ *   * every `post.user` already embedded in a rendered post — in the feed
+ *     store's retained slice and in SQLite. Nothing rewrites those, and a
+ *     remount warm-starts from the retained slice rather than refetching page 1.
+ *
+ * A full reload is the only thing that discards all of them at once, which is
+ * exactly why one appeared to be required.
+ *
+ * **And the write is actively undone.** Every feed response is fed through
+ * `lib/precacheActorsFromPosts` into the SDK's user cache, and that merge
+ * overrides a real value with a real value — so a response whose authors were
+ * hydrated before the invalidation landed puts the pre-edit picture straight
+ * back over what this write stored. On a channel's own page every post in that
+ * response is authored by the account whose picture just changed, so the header
+ * is decided by a race it should not be in.
+ *
+ * Hence an OVERLAY rather than an invalidation: the edit is recorded here, and
+ * a server copy that still predates it is corrected on its way in
+ * (`applyKnownIdentity`) instead of being allowed to win. Two consumers, and
+ * between them they cover both caches:
+ *
+ *   * React Query — `lib/actorCache.ts` is the one door into the SDK's user
+ *     cache, so the edit is written through there and every incoming actor is
+ *     corrected there, wherever the surface that fetched it lives.
+ *   * The post rows themselves — `components/Feed/PostItem.tsx` resolves its
+ *     author through {@link useKnownIdentity}, so a feed row, a post detail, a
+ *     quote card and a boosted original all correct themselves wherever their
+ *     copy of the post came from (SQLite, the memory-mode slice, or a response
+ *     that has not landed yet).
+ *
+ * **This module holds STATE ONLY — no query client, no SDK.** It is imported by
+ * `PostItem`, so it is in the module graph of every screen that renders a post
+ * and of every test that renders one; pulling the SDK barrel in through here
+ * puts it in all of them too. That is not hypothetical tidiness: it broke a
+ * sibling's `PostItem` suite the first time this file imported it. The write
+ * side lives in `lib/actorCache.ts`, which may depend on this and not the other
+ * way round.
+ *
+ * **An entry retires itself.** It is not a permanent override — it is a bridge
+ * over the window in which a hydrated copy still predates the edit, so it is
+ * dropped the moment one AGREES with it ({@link reconcileKnownIdentities},
+ * called from the same ingestion point). With the server-side invalidation above
+ * that is usually the very next page, which is the point: no clock and no TTL to
+ * keep in step with a backend constant, and an identity changed somewhere else —
+ * another device, accounts.oxy.so — is never pinned to a value this session
+ * happened to write.
+ */
+
+/** The canonical structured name, as it rides on every post author. */
+type IdentityName = PostUser['name'];
+
+/**
+ * The identity fields a profile edit can change, and the only fields this module
+ * ever writes. Everything else about a user — counts, viewer relationship,
+ * joined date — is owned by whichever cache holds it and is never touched here.
+ */
+/**
+ * A type alias rather than an interface on purpose: only an alias gets TypeScript's
+ * implicit index signature, and without it this is not assignable to the SDK's
+ * `CacheableUser` — which is where every recorded edit is handed next.
+ */
+export type IdentityUpdate = {
+  id: string;
+  username?: string;
+  name?: IdentityName;
+  avatar?: string | null;
+};
+
+/**
+ * Any actor-shaped object whose identity can be corrected. `name` admits the
+ * plain string spelling as well, because the SDK's cache boundary
+ * (`CacheableUser`) accepts a bare display string from the looser actor objects
+ * — the overlay only ever writes the canonical object shape, so widening the
+ * constraint costs nothing and lets one function serve both boundaries.
+ */
+type IdentityHolder = {
+  id?: string;
+  username?: string;
+  name?: IdentityName | string;
+  avatar?: string | null;
+};
+
+/** Recorded identities, keyed by Oxy user id. */
+const knownIdentities = new Map<string, IdentityUpdate>();
+
+type IdentityListener = () => void;
+
+const listeners = new Set<IdentityListener>();
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/**
+ * Only the fields the edit actually carried. A field the write did not mention
+ * must not be recorded, or the overlay would pin whatever the writer happened to
+ * be holding — and, worse, would then "agree" with a server copy on a value
+ * nobody edited.
+ *
+ * Empty and cleared values are dropped rather than recorded, which mirrors the
+ * SDK's own merge (`upsertCachedUser` never lets a degraded value overwrite a
+ * good one) so identity resolves under ONE rule everywhere instead of two that
+ * disagree at the edges. The cost is that CLEARING a picture does not appear
+ * instantly — it takes the same path it takes today — and that limit belongs to
+ * the SDK's merge contract rather than to this file.
+ */
+function meaningfulFields(update: IdentityUpdate): Omit<IdentityUpdate, 'id'> {
+  const fields: Omit<IdentityUpdate, 'id'> = {};
+  if (update.username && update.username.trim() !== '') {
+    fields.username = update.username;
+  }
+  if (update.name?.displayName && update.name.displayName.trim() !== '') {
+    fields.name = update.name;
+  }
+  if (update.avatar && update.avatar.trim() !== '') {
+    fields.avatar = update.avatar;
+  }
+  return fields;
+}
+
+/** Whether an incoming actor already carries everything a recorded entry holds. */
+function serverAgrees(entry: IdentityUpdate, actor: IdentityHolder): boolean {
+  if (entry.username !== undefined && actor.username !== entry.username) return false;
+  if (entry.avatar !== undefined && actor.avatar !== entry.avatar) return false;
+  if (entry.name !== undefined) {
+    const incoming = typeof actor.name === 'string' ? actor.name : actor.name?.displayName;
+    if (incoming !== entry.name.displayName) return false;
+  }
+  return true;
+}
+
+/**
+ * The identity recorded for a user, or `undefined` when nothing has been.
+ *
+ * The returned object is stable by reference until the next write for that user,
+ * which is what lets {@link useKnownIdentity} hand it to `useSyncExternalStore`
+ * directly.
+ */
+export function getKnownIdentity(userId: string | undefined): IdentityUpdate | undefined {
+  return userId ? knownIdentities.get(userId) : undefined;
+}
+
+/**
+ * Correct one actor with an already-read entry. PURE — a function of its two
+ * arguments and nothing else, so a render may call it inside a `useMemo` without
+ * reading module state from a memoized position (the React Compiler rule in
+ * `~/AGENTS.md`); {@link useKnownIdentity} does the reading, through the store's
+ * own subscription.
+ *
+ * Returns the SAME reference when there is nothing recorded — the common case by
+ * far — so a hot path never allocates a new object per row.
+ */
+export function mergeKnownIdentity<T extends IdentityHolder>(
+  actor: T,
+  entry: IdentityUpdate | undefined,
+): T {
+  if (!entry) return actor;
+  const { id: _id, ...fields } = entry;
+  return { ...actor, ...fields };
+}
+
+/**
+ * Correct one actor against what this session knows about it. For ingestion
+ * paths, which have no render to subscribe from.
+ */
+export function applyKnownIdentity<T extends IdentityHolder>(actor: T): T {
+  return mergeKnownIdentity(actor, getKnownIdentity(actor.id));
+}
+
+/**
+ * Reactive read of the identity recorded for one user.
+ *
+ * `useSyncExternalStore` rather than a `useMemo` over the map, for the reason
+ * `usePostSelector` uses it over the SQLite cache: the map is external mutable
+ * state, and the React Compiler freezes the first value read from one inside a
+ * memoized position. The snapshot is the stored entry itself, which is stable by
+ * reference until that user is written again — the contract
+ * `useSyncExternalStore` requires — and is `undefined` for every user nobody has
+ * edited, so a feed full of rows subscribes to a store that hands them all the
+ * same nothing and never re-renders them.
+ */
+export function useKnownIdentity(userId: string | undefined): IdentityUpdate | undefined {
+  const getSnapshot = useCallback(() => getKnownIdentity(userId), [userId]);
+  return useSyncExternalStore(subscribeToIdentityUpdates, getSnapshot, getSnapshot);
+}
+
+/**
+ * Drop every recorded identity that the incoming actors now agree with.
+ *
+ * Called with each batch of server-hydrated authors, which is exactly the moment
+ * the question can be answered: the overlay exists to cover the window in which
+ * post hydration still carries the old value, so it has done its job as soon as
+ * hydration carries the new one. One Oxy account is one Redis entry, so
+ * agreement is all-or-nothing per user rather than per field.
+ */
+export function reconcileKnownIdentities(actors: readonly IdentityHolder[]): void {
+  if (knownIdentities.size === 0) return;
+  let retired = false;
+  for (const actor of actors) {
+    const entry = getKnownIdentity(actor.id);
+    if (entry && serverAgrees(entry, actor)) {
+      knownIdentities.delete(entry.id);
+      retired = true;
+    }
+  }
+  if (retired) notify();
+}
+
+/**
+ * Subscribe to identity changes. Returns an unsubscribe function.
+ *
+ * Exported for {@link useKnownIdentity}; a component should use the hook rather
+ * than subscribing by hand.
+ */
+export function subscribeToIdentityUpdates(listener: IdentityListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Record a profile edit in the overlay and return exactly what was stored.
+ *
+ * STATE ONLY, and not the entry point: a recorded edit that no cache is told
+ * about corrects the rows that happen to re-render and nothing else. Call
+ * `noteIdentityChanged` in `lib/actorCache.ts`, which does this and the cache
+ * writes together. It is separate solely so this module can stay free of the SDK
+ * (see the note at the top), which is why it is the only caller.
+ *
+ * Returns `null` for an id-less write — there is nothing to key it on.
+ */
+export function recordIdentityChange(update: IdentityUpdate): IdentityUpdate | null {
+  if (!update.id) return null;
+  const stored: IdentityUpdate = { id: update.id, ...meaningfulFields(update) };
+  knownIdentities.set(update.id, stored);
+  notify();
+  return stored;
+}
+
+/**
+ * Drop every recorded identity. For tests.
+ *
+ * Deliberately NOT wired into the account switch, unlike the reset of every
+ * store beside it: a channel's picture is the same picture whoever is signed in,
+ * so what is recorded here stays TRUE across a switch — and the switch clears
+ * the caches that hold the stale copy, which is precisely when a correction is
+ * most needed (an operator changing a channel's picture and then switching into
+ * that channel is one flow, not two). Entries retire against the server rather
+ * than against a session.
+ */
+export function resetIdentityUpdates(): void {
+  knownIdentities.clear();
+  notify();
+}

--- a/packages/frontend/utils/userEnrichment.ts
+++ b/packages/frontend/utils/userEnrichment.ts
@@ -1,11 +1,12 @@
-import type { QueryClient } from '@tanstack/react-query';
-import { queryKeys, upsertCachedUser } from '@oxyhq/services';
+import { queryKeys } from '@oxyhq/services';
+import { cacheActor } from '@/lib/actorCache';
+import { queryClient } from '@/lib/queryClient';
 import type { User } from '@oxyhq/core';
 
 /**
  * For each user missing an avatar, fetch the full profiles in a SINGLE bulk
  * request and merge-upsert them into the React Query cache (the single in-memory
- * actor cache) via the SDK's `upsertCachedUser`. This avoids the classic N+1 —
+ * actor cache) via `lib/actorCache`. This avoids the classic N+1 —
  * one HTTP request per missing user — by routing the misses through
  * `oxyServices.getUsersByIds` (chunked 100/req, deduped) instead of looping
  * `getUserById`. The merge-upsert fills the avatar without stripping any field an
@@ -19,7 +20,6 @@ import type { User } from '@oxyhq/core';
 export function enrichMissingAvatars(
   users: readonly { id: string; avatar?: string; [k: string]: unknown }[],
   getUsersByIds: (ids: string[]) => Promise<User[]>,
-  queryClient: QueryClient,
 ): Promise<void> {
   const missingIds = users
     .filter((u) => !u.avatar || !u.avatar.startsWith('http'))
@@ -31,7 +31,7 @@ export function enrichMissingAvatars(
     .then((fetched) => {
       for (const user of fetched) {
         if (user?.id) {
-          upsertCachedUser(queryClient, user);
+          cacheActor(user);
         }
       }
     })
@@ -43,16 +43,20 @@ export function enrichMissingAvatars(
 /**
  * Warm the React Query user cache for a set of user ids in a SINGLE bulk request,
  * skipping ids already cached at `queryKeys.users.detail(id)`. Each fetched
- * profile is merge-upserted via the SDK's `upsertCachedUser` so per-row reads
+ * profile is merge-upserted via `lib/actorCache` so per-row reads
  * (e.g. a list whose rows resolve a user by id) hit the warm cache instead of
  * firing one HTTP request per row — the classic N+1 — without clobbering any
  * field an authoritative fetch already stored. Best-effort: resolves to `[]` on
  * failure so callers degrade to their own per-row resolution.
+ *
+ * Reads and writes the app's singleton client directly rather than taking one:
+ * the write goes through `lib/actorCache`, which is bound to that singleton, so
+ * a caller passing a DIFFERENT client would have this skipping ids cached in one
+ * cache while priming another.
  */
 export function prewarmUsersByIds(
   ids: readonly string[],
   getUsersByIds: (ids: string[]) => Promise<User[]>,
-  queryClient: QueryClient,
 ): Promise<User[]> {
   const toFetch = Array.from(new Set(ids.filter((id) => id.length > 0))).filter(
     (id) => !queryClient.getQueryData(queryKeys.users.detail(id)),
@@ -63,7 +67,7 @@ export function prewarmUsersByIds(
     .then((fetched) => {
       for (const user of fetched) {
         if (user?.id) {
-          upsertCachedUser(queryClient, user);
+          cacheActor(user);
         }
       }
       return fetched;


### PR DESCRIPTION
Changing a channel's picture from `/c/<handle>/settings` saved correctly and then did not appear until the page was reloaded — not on the channel screen, not on its posts.

## The server was fine, and checking that first decided the shape

oxy-api publishes `oxy:user:invalidate` on the account write and Mention's backend drops its identity caches on receipt (`services/userInvalidationSubscriber.ts`), so re-asking returns the new picture. **Nothing re-asks:**

- `post.user` is a snapshot frozen in the feed store's retained slice and in SQLite, and a remount warm-starts from that slice rather than refetching page 1.
- the React Query user entry has the edit merged in but keeps its freshness, and `useUserByUsername` pairs a 5-minute `staleTime` with `refetchOnMount: true`, which deliberately skips a fresh entry.

A full reload was the only thing throwing all of it away at once. That is exactly what was reported.

**The write was also being undone.** Six surfaces prime the SDK's user cache with users they fetched, and that merge overrides a real avatar id with a real avatar id — so any response hydrated before the write propagated puts the pre-edit picture back over it. Verified against the real SDK merge: seed → upsert edit → upsert a hydrated author still carrying the old picture ⇒ back to the old picture. The feed is where it was found (on a channel's own page every post in the response is authored by the account whose picture just changed) but never the only surface that could cause it.

## Shape

- `stores/identityUpdates` records the edit. **State only, no SDK import** — it is in `PostItem`'s module graph, so anything it pulls in lands in every screen and every test that renders a post (this broke a sibling's `PostItem` suite the first time it imported the barrel).
- `lib/actorCache` is the **one door** into the user cache. Guarding six call sites would have been six guards, and six guards is the shape that quietly becomes five when somebody adds a seventh surface. They all passed the same singleton client to the same two SDK functions, so they now pass through one place. A test asserts that door is the only importer of `upsertCachedUser`/`upsertCachedUsers`, with a vacuity floor on the traversal, so a seventh surface cannot silently inherit the bug.
- `PostItem` resolves its author through the overlay — feed rows, post details, quote cards and boosted originals are all that one component, on both the SQLite and memory-mode paths.
- An entry **retires itself** as soon as a fetched copy agrees. No clock, no TTL to keep in step with a backend constant, and an identity changed on another device is never pinned to what this session wrote.

Carries the whole identity, not just the picture — a rename is the same bug, made by the same save.

## Deliberately NOT covered (follow-up)

- **`repostedBy` and `authors[]`** — other actors on the same row. `f54db41e` has just wired `boostedBy` into the avatar cluster, so a reposter's picture is now visible there and equally stale.
- **Notifications and search** hold their own copies of an actor outside the post DTO.
- **Clearing a picture is still not instant.** `upsertCachedUser` cannot express an authoritative clear — `null`/`''` are treated as degraded and dropped by contract — so this mirrors the SDK rather than running two disagreeing merge rules. That gap is being fixed upstream in `@oxyhq/core`, along with `updateAccount` not busting `GET:/profiles/username/` or `GET:/users/<id>`.

## Verification

`tsc --noEmit` clean · 145 suites / 1329 tests · `lint:frontend` 0 errors (4 pre-existing `import/first` warnings) · `bun.lock` untouched.

Mutation-tested, each producing a named failure: PostItem not consulting the overlay (3), the correction dropped from the door (6), the retirement dropped (1), a seventh surface importing the SDK directly (1, and it names the offending path), the scan traversal finding nothing (1).

**No browser proof.** Prod CORS rejects a LAN origin and I have no session for a channel-operating account. The tests do exercise a real mounted React tree repainting from the signal with no refetch, which is the closest offline equivalent — but I did not watch the picture change in a real tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->