### PR TITLE
fix(identity): every actor a surface names follows a profile edit

### DIFF
--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -46,7 +46,7 @@ import { THREAD_LINE_WIDTH, THREAD_LINE_BORDER_RADIUS, THREAD_LINE_Z_INDEX } fro
 import { POST_ITEM_SPACING } from '@/styles/shared';
 import { SubtleHover } from '@oxyhq/bloom/subtle-hover';
 import { useThreadHoverStore } from '@/stores/threadHoverStore';
-import { mergeKnownIdentity, useKnownIdentity } from '@/stores/identityUpdates';
+import { mergeKnownIdentity, useKnownIdentities } from '@/stores/identityUpdates';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { reportFeedInteraction } from '@/utils/feedTelemetry';
 import { formatFullTimestamp } from '@/utils/dateUtils';
@@ -171,21 +171,41 @@ const PostItem: React.FC<PostItemProps> = ({
     const viewPost = storePost ?? post;
     const viewPostId = viewPost?.id ? String(viewPost.id) : undefined;
 
-    // The author, corrected against any profile edit made in this session.
+    // Every actor on this row, corrected against any profile edit made in this
+    // session.
     //
-    // `viewPost.user` is a SNAPSHOT of that identity taken when the server
-    // hydrated the post, and nothing rewrites it: the feed store's retained
-    // slice and the SQLite copy both keep it, and a remount warm-starts from
-    // that slice rather than refetching page 1. So a picture changed after a
-    // post was fetched stays wrong on that row until something throws the whole
-    // cache away — which is why a full reload looked like the only fix.
+    // Each of them is a SNAPSHOT of an identity taken when the server hydrated
+    // the post, and nothing rewrites those: the feed store's retained slice and
+    // the SQLite copy both keep them, and a remount warm-starts from that slice
+    // rather than refetching page 1. So a picture changed after a post was
+    // fetched stays wrong on that row until something throws the whole cache
+    // away — which is why a full reload looked like the only fix.
     // `stores/identityUpdates` is the one authority that knows better, and
     // resolving it HERE covers every post surface at once: a feed row, a post
     // detail, a quote card and a boosted original are all this same component.
-    const knownAuthor = useKnownIdentity(viewPost?.user?.id);
+    //
+    // All THREE actors, not just the author. They sit side by side in one row —
+    // `boostedBy` puts the reposter's picture in the same avatar cluster as the
+    // author's — so correcting one and not the others is more conspicuous than
+    // correcting none: the same person would be drawn twice, differently, in one
+    // cluster.
+    const knownIdentities = useKnownIdentities();
     const author = useMemo(
-        () => (viewPost?.user ? mergeKnownIdentity(viewPost.user, knownAuthor) : undefined),
-        [viewPost?.user, knownAuthor],
+        () => (viewPost?.user ? mergeKnownIdentity(viewPost.user, knownIdentities.get(viewPost.user.id)) : undefined),
+        [viewPost?.user, knownIdentities],
+    );
+    const reposter = useMemo(
+        () => (repostedBy ? mergeKnownIdentity(repostedBy, knownIdentities.get(repostedBy.id)) : undefined),
+        [repostedBy, knownIdentities],
+    );
+    // The collaborative byline: owner plus each accepted collaborator, drawn as
+    // the avatar cluster that replaces the solo avatar.
+    const bylineAuthors = useMemo(
+        () =>
+            viewPost?.authors?.map((entry) =>
+                mergeKnownIdentity(entry, knownIdentities.get(entry.id)),
+            ),
+        [viewPost?.authors, knownIdentities],
     );
 
     const viewerState =
@@ -372,8 +392,8 @@ const PostItem: React.FC<PostItemProps> = ({
     // Canonical handle of the BOOSTER, on the same terms as `authorHandle`: it
     // drives the "Reposted by" row's link and its hover preview from one value.
     const reposterHandle = useMemo(
-        () => getNormalizedUserHandle(repostedBy) ?? undefined,
-        [repostedBy],
+        () => getNormalizedUserHandle(reposter) ?? undefined,
+        [reposter],
     );
 
     const goToReposter = useCallback((event?: GestureResponderEvent) => {
@@ -706,7 +726,7 @@ const PostItem: React.FC<PostItemProps> = ({
     // column grows down). The icon keeps `-ml-4` to poke left into the avatar
     // gutter; repost is the outermost reason, then pinned, then reply.
     const contextRows: React.ReactNode[] = [];
-    if (repostedBy) {
+    if (reposter) {
         contextRows.push(
             <ProfileHoverCard key="reposted" username={reposterHandle}>
                 <TouchableOpacity
@@ -720,7 +740,7 @@ const PostItem: React.FC<PostItemProps> = ({
                         <BoostIcon size={13} color={theme.colors.textSecondary} />
                     </View>
                     <Text className="text-muted-foreground text-[13px] font-semibold" numberOfLines={1}>
-                        {t('post.repostedBy', { defaultValue: 'Reposted by' })} {displayNameOrHandle(repostedBy.name?.displayName, reposterHandle ? `@${reposterHandle}` : '')}
+                        {t('post.repostedBy', { defaultValue: 'Reposted by' })} {displayNameOrHandle(reposter.name?.displayName, reposterHandle ? `@${reposterHandle}` : '')}
                     </Text>
                 </TouchableOpacity>
             </ProfileHoverCard>,
@@ -845,14 +865,14 @@ const PostItem: React.FC<PostItemProps> = ({
                             isFederated: author.isFederated,
                             instance: author.instance,
                         }}
-                        authors={viewPost.authors && viewPost.authors.length > 0 ? viewPost.authors : undefined}
+                        authors={bylineAuthors && bylineAuthors.length > 0 ? bylineAuthors : undefined}
                         // `repostedBy` is the only boost that put THIS post in
                         // front of the reader. `viewPost.boost` is the other
                         // boost shape — the row IS the boost, so its author and
                         // its actor are the same account and there is nothing to
                         // pair or reorder; passing it would be a no-op wearing
                         // the clothes of a rule.
-                        boostedBy={repostedBy}
+                        boostedBy={reposter}
                         date={metadata.createdAt}
                         showBoost={Boolean(viewPost.boost) && !isNested}
                         showReply={false}

--- a/packages/frontend/components/Feed/__tests__/postAuthorIdentity.test.tsx
+++ b/packages/frontend/components/Feed/__tests__/postAuthorIdentity.test.tsx
@@ -97,11 +97,25 @@ jest.mock('@/components/Post/PostHeader', () => {
     default: (props: {
       avatarSource?: string | null;
       user?: { displayName?: string; handle?: string };
+      boostedBy?: { avatar?: string | null };
+      authors?: { id: string; avatar?: string | null }[];
     }) =>
-      ReactActual.createElement(
-        Text,
-        { testID: 'author-identity' },
-        `${props.avatarSource ?? ''}|${props.user?.displayName ?? ''}|${props.user?.handle ?? ''}`,
+      ReactActual.createElement(ReactActual.Fragment, null,
+        ReactActual.createElement(
+          Text,
+          { testID: 'author-identity' },
+          `${props.avatarSource ?? ''}|${props.user?.displayName ?? ''}|${props.user?.handle ?? ''}`,
+        ),
+        ReactActual.createElement(
+          Text,
+          { testID: 'booster-avatar' },
+          props.boostedBy?.avatar ?? '',
+        ),
+        ReactActual.createElement(
+          Text,
+          { testID: 'byline-avatars' },
+          (props.authors ?? []).map((a) => a.avatar ?? '').join(','),
+        ),
       ),
   };
 });
@@ -146,6 +160,10 @@ function renderRow() {
 
 function identityOf(renderer: TestRenderer.ReactTestRenderer): string {
   return String(renderer.root.findByProps({ testID: 'author-identity' }).props.children);
+}
+
+function probe(renderer: TestRenderer.ReactTestRenderer, testID: string): string {
+  return String(renderer.root.findByProps({ testID }).props.children);
 }
 
 afterEach(() => {
@@ -231,5 +249,84 @@ describe('a post row follows its author’s identity', () => {
 
     const renderer = renderRow();
     expect(identityOf(renderer)).toBe('avatar-before|Daily|daily');
+  });
+});
+
+/**
+ * The row draws three actors, not one.
+ *
+ * `boostedBy` puts whoever reposted the post into the SAME avatar cluster as the
+ * author, and a collaborative byline draws one avatar per collaborator there
+ * too. Correcting only the author is more conspicuous than correcting nothing:
+ * a collaborator who is also the author would be drawn twice, differently, in
+ * one cluster.
+ */
+describe('every actor on the row follows its identity', () => {
+  const BOOSTER = 'booster-1';
+  const COLLABORATOR = 'collab-1';
+
+  function renderCollabRepost() {
+    act(() => {
+      mounted = TestRenderer.create(
+        <PostItem
+          post={{
+            ...stalePost(),
+            authors: [
+              { id: CHANNEL_ID, username: 'daily', name: { displayName: 'Daily' }, avatar: 'avatar-before' },
+              { id: COLLABORATOR, username: 'co', name: { displayName: 'Co' }, avatar: 'collab-before' },
+            ],
+          } as never}
+          repostedBy={{
+            id: BOOSTER,
+            username: 'boo',
+            name: { displayName: 'Boo' },
+            avatar: 'booster-before',
+          } as never}
+        />,
+      );
+    });
+    if (!mounted) throw new Error('the row did not render');
+    return mounted;
+  }
+
+  it('starts from what the server hydrated', () => {
+    const renderer = renderCollabRepost();
+    expect(probe(renderer, 'booster-avatar')).toBe('booster-before');
+    expect(probe(renderer, 'byline-avatars')).toBe('avatar-before,collab-before');
+  });
+
+  it('repaints the reposter when THEIR profile is edited', () => {
+    const renderer = renderCollabRepost();
+
+    act(() => {
+      noteIdentityChanged({ id: BOOSTER, avatar: 'booster-after' });
+    });
+
+    expect(probe(renderer, 'booster-avatar')).toBe('booster-after');
+    // and nobody else moved
+    expect(probe(renderer, 'byline-avatars')).toBe('avatar-before,collab-before');
+  });
+
+  it('repaints one collaborator on the byline without touching the others', () => {
+    const renderer = renderCollabRepost();
+
+    act(() => {
+      noteIdentityChanged({ id: COLLABORATOR, avatar: 'collab-after' });
+    });
+
+    expect(probe(renderer, 'byline-avatars')).toBe('avatar-before,collab-after');
+    expect(probe(renderer, 'booster-avatar')).toBe('booster-before');
+  });
+
+  it('draws one person the same way wherever they appear in the row', () => {
+    const renderer = renderCollabRepost();
+
+    // The channel is both the post's author and the first byline entry.
+    act(() => {
+      noteIdentityChanged({ id: CHANNEL_ID, avatar: 'avatar-after' });
+    });
+
+    expect(identityOf(renderer)).toBe('avatar-after|Daily|daily');
+    expect(probe(renderer, 'byline-avatars')).toBe('avatar-after,collab-before');
   });
 });

--- a/packages/frontend/components/ProfileCard.tsx
+++ b/packages/frontend/components/ProfileCard.tsx
@@ -1,9 +1,10 @@
-import React, { type ReactNode } from 'react';
+import React, { useMemo, type ReactNode } from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { FollowButton } from '@oxyhq/services/ui/client';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { mergeKnownIdentity, useKnownIdentities } from '@/stores/identityUpdates';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { getNormalizedUserHandle } from '@oxyhq/core';
 import { ThemedText } from './ThemedText';
@@ -115,13 +116,29 @@ export function ProfileCard({
   const router = useRouter();
   const { t } = useTranslation();
 
+  // Corrected against any profile edit made in this session, for the same reason
+  // a post row is: `profile` is a snapshot the surface that fetched it is still
+  // holding, and nothing rewrites it. This ONE row is what search results,
+  // who-to-follow, list and starter-pack members, followers and following,
+  // engagement and collaborator lists, pokes and subscriptions all draw — so
+  // resolving it here is what makes an edit reach all of them without each of
+  // them having to remember to.
+  const knownIdentities = useKnownIdentities();
+  const resolved = useMemo(
+    () => mergeKnownIdentity(profile, knownIdentities.get(profile.id)),
+    [profile, knownIdentities],
+  );
+
   // A federated profile's canonical handle carries its instance (`user@domain`),
   // so the row never needs a separate "globe + instance" line. An unresolved
   // author has no handle at all — it must never fall back to the raw id, so a
   // profile with neither name nor handle degrades to "Unknown user" and is not
-  // pressable (no `/@<id>` links).
-  const handle = getNormalizedUserHandle(profile) ?? '';
-  const displayName = profile.name?.displayName?.trim();
+  // pressable (no `/@<id>` links). Derived from the CORRECTED profile: a rename
+  // changes the handle, and a row whose link still pointed at the old one would
+  // 404 on tap.
+  const handle = getNormalizedUserHandle(resolved) ?? '';
+
+  const displayName = resolved.name?.displayName?.trim();
   const canPress = Boolean(onPress) || handle.length > 0;
   // `UserName` owns the "display name else @handle, shown once" rule and the
   // handle line beneath it. Hand it the degraded "Unknown user" label ONLY when
@@ -152,11 +169,11 @@ export function ProfileCard({
         activeOpacity={0.7}
         accessibilityRole="button">
         <Avatar
-          source={profile.avatar || undefined}
+          source={resolved.avatar || undefined}
           size={40}
           variant={MEDIA_VARIANT_AVATAR}
-          verified={profile.verified}
-          placeholderColor={getUserPlaceholderColor(profile)}
+          verified={resolved.verified}
+          placeholderColor={getUserPlaceholderColor(resolved)}
         />
         <View className="flex-1 gap-0.5">
           {/* Identity line via the shared UserName: the name + verified /
@@ -165,10 +182,10 @@ export function ProfileCard({
           <UserName
             name={nameLabel}
             handle={handle || undefined}
-            verified={profile.verified}
-            isFederated={profile.isFederated}
-            isAgent={profile.isAgent}
-            isAutomated={profile.isAutomated}
+            verified={resolved.verified}
+            isFederated={resolved.isFederated}
+            isAgent={resolved.isAgent}
+            isAutomated={resolved.isAutomated}
             style={IDENTITY_STYLE}
           />
           {meta ? (
@@ -178,18 +195,18 @@ export function ProfileCard({
               {meta}
             </ThemedText>
           ) : null}
-          {profile.description ? (
+          {resolved.description ? (
             <ThemedText
               className="text-sm leading-5 text-muted-foreground"
               numberOfLines={2}>
-              {profile.description}
+              {resolved.description}
             </ThemedText>
           ) : null}
         </View>
       </TouchableOpacity>
       {showFollowButton && (
         <FollowButton
-          userId={profile.id}
+          userId={resolved.id}
           size="small"
           initiallyFollowing={initiallyFollowing}
           onFollowChange={onFollowChange}

--- a/packages/frontend/components/__tests__/profileCardIdentity.test.tsx
+++ b/packages/frontend/components/__tests__/profileCardIdentity.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+/**
+ * The person row follows the identity it names.
+ *
+ * `ProfileCard` is ONE component and fifteen surfaces: search results,
+ * who-to-follow, the widget, list and starter-pack members, followers and
+ * following, likers and boosters, collaborators, pokes, notification
+ * subscriptions and both feed interstitials. Each hands it a `profile` snapshot
+ * its own fetch produced, and nothing rewrites those — so a picture changed
+ * after that fetch stayed wrong on every one of them until a reload, exactly as
+ * it did on a post row. Resolving it in the row is what reaches all fifteen; a
+ * correction per surface is fifteen chances to forget one.
+ *
+ * The mocks below exist only to keep untransformed ESM out of the module graph,
+ * the same reason `PostDetailStats.test.tsx` mocks its Bloom subpaths. `Avatar`
+ * and `UserName` are the two that carry the answer, so they are stand-ins that
+ * report what they were handed rather than `null`.
+ */
+
+jest.mock('@oxyhq/bloom/avatar', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  return {
+    Avatar: (props: { source?: string | null }) =>
+      ReactActual.createElement(Text, { testID: 'card-avatar' }, props.source ?? ''),
+  };
+});
+jest.mock('@/components/UserName', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  return {
+    __esModule: true,
+    default: (props: { name?: string; handle?: string }) =>
+      ReactActual.createElement(
+        Text,
+        { testID: 'card-name' },
+        `${props.name ?? ''}|${props.handle ?? ''}`,
+      ),
+  };
+});
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user: { username?: string } | null | undefined) =>
+    user?.username ?? null,
+}));
+jest.mock('@oxyhq/services/ui/client', () => ({ FollowButton: () => null }));
+jest.mock('@oxyhq/bloom/skeleton', () => ({ Box: () => null, Group: () => null }));
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+jest.mock('@/lib/queryClient', () => ({
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+jest.mock('@oxyhq/services', () => ({
+  upsertCachedUser: jest.fn(),
+  upsertCachedUsers: jest.fn(),
+}));
+jest.mock('@/utils/userPlaceholderColor', () => ({
+  getUserPlaceholderColor: () => '#888888',
+}));
+
+// eslint-disable-next-line import/first
+import { ProfileCard } from '@/components/ProfileCard';
+// eslint-disable-next-line import/first
+import { noteIdentityChanged } from '@/lib/actorCache';
+// eslint-disable-next-line import/first
+import { resetIdentityUpdates } from '@/stores/identityUpdates';
+
+const PERSON_ID = 'person-1';
+
+let mounted: TestRenderer.ReactTestRenderer | null = null;
+
+function renderRow() {
+  act(() => {
+    mounted = TestRenderer.create(
+      <ProfileCard
+        profile={{
+          id: PERSON_ID,
+          username: 'ada',
+          name: { displayName: 'Ada' },
+          avatar: 'avatar-before',
+        }}
+      />,
+    );
+  });
+  if (!mounted) throw new Error('the row did not render');
+  return mounted;
+}
+
+function probe(renderer: TestRenderer.ReactTestRenderer, testID: string): string {
+  return String(renderer.root.findByProps({ testID }).props.children);
+}
+
+afterEach(() => {
+  const renderer = mounted;
+  if (renderer) act(() => renderer.unmount());
+  mounted = null;
+  resetIdentityUpdates();
+  jest.clearAllMocks();
+});
+
+describe('ProfileCard follows the identity it names', () => {
+  it('shows what its surface fetched when nothing has been edited', () => {
+    const renderer = renderRow();
+    expect(probe(renderer, 'card-avatar')).toBe('avatar-before');
+    expect(probe(renderer, 'card-name')).toBe('Ada|ada');
+  });
+
+  it('repaints a MOUNTED row when that profile is edited — no refetch', () => {
+    const renderer = renderRow();
+
+    act(() => {
+      noteIdentityChanged({
+        id: PERSON_ID,
+        username: 'ada',
+        name: { displayName: 'Ada Lovelace' },
+        avatar: 'avatar-after',
+      });
+    });
+
+    expect(probe(renderer, 'card-avatar')).toBe('avatar-after');
+    expect(probe(renderer, 'card-name')).toBe('Ada Lovelace|ada');
+  });
+
+  it('follows a RENAME into the handle the row links to', () => {
+    const renderer = renderRow();
+
+    act(() => {
+      noteIdentityChanged({ id: PERSON_ID, username: 'ada-l' });
+    });
+
+    // Not cosmetic: the handle is what the row navigates to, so a stale one is a
+    // tap that 404s.
+    expect(probe(renderer, 'card-name')).toBe('Ada|ada-l');
+  });
+
+  it('leaves every other person alone', () => {
+    const renderer = renderRow();
+
+    act(() => {
+      noteIdentityChanged({ id: 'someone-else', avatar: 'avatar-after' });
+    });
+
+    expect(probe(renderer, 'card-avatar')).toBe('avatar-before');
+  });
+});

--- a/packages/frontend/components/notifications/NotificationItem.tsx
+++ b/packages/frontend/components/notifications/NotificationItem.tsx
@@ -26,6 +26,7 @@ import { DoneAllIcon } from '@/assets/icons/done-all-icon';
 import { TrashIcon } from '@/assets/icons/trash-icon';
 import { getDescriptor, type TranslateFn } from './notificationDescriptors';
 import { useUserById } from '@/hooks/useCachedUser';
+import { useKnownIdentities, type IdentityUpdate } from '@/stores/identityUpdates';
 import type { GroupedNotification } from '@/utils/groupNotifications';
 import { POST_ITEM_SPACING } from '@/styles/shared';
 import { formatRelativeTimeLocalized } from '@/utils/dateUtils';
@@ -93,8 +94,23 @@ function ghostGuardedName(rawName: string | undefined | null, actorId: string | 
   return name;
 }
 
+/**
+ * The cached Oxy user a row merges over its raw actor, plus whatever a profile
+ * edit made in this session says about that person.
+ *
+ * `Partial` because an edit alone is a valid answer: a grouped actor the screen
+ * never prewarmed has no cache entry, and the overlay is still a better source
+ * than the copy the notification arrived with.
+ */
+type CachedIdentity = Partial<
+  Pick<User, 'id' | 'username' | 'name' | 'avatar' | 'verified' | 'isFederated' | 'instance' | 'federation'>
+>;
+
 /** Normalized profile handle (local `username`, federated `username@instance`). */
-function normalizedHandle(username: string | undefined | null, cached: User | undefined): string | undefined {
+function normalizedHandle(
+  username: string | undefined | null,
+  cached: CachedIdentity | undefined,
+): string | undefined {
   const handle = getNormalizedUserHandle({
     username: username ?? null,
     instance: cached?.instance ?? null,
@@ -109,7 +125,25 @@ function normalizedHandle(username: string | undefined | null, cached: User | un
  * fields win — restoring the proven fallback the old row had via the prewarmed
  * user cache — with the raw actor as the floor.
  */
-function mergeActor(actor: GroupedActor | undefined, cached: User | undefined): ResolvedActor {
+/**
+ * The best identity known for one actor: the prewarmed cache entry, with a
+ * profile edit made in this session laid over it.
+ *
+ * The edit is ALREADY in that cache entry — `lib/actorCache` put it there — so
+ * for the reactive primary this changes nothing. It matters for the grouped
+ * actors, whose cache read is not reactive: passing the overlay makes the value
+ * correct AND makes the memo that computes it depend on something that actually
+ * changes when a profile is edited, which is the only reason it re-runs at all.
+ */
+function correctedIdentity(
+  cached: User | undefined,
+  known: IdentityUpdate | undefined,
+): CachedIdentity | undefined {
+  if (!known) return cached;
+  return { ...cached, ...known };
+}
+
+function mergeActor(actor: GroupedActor | undefined, cached: CachedIdentity | undefined): ResolvedActor {
   const username = cached?.username ?? actor?.username;
   return {
     id: actor?.id ?? cached?.id ?? '',
@@ -306,19 +340,39 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
   // per-row `getUserById` on a cache miss.
   const primaryOxyId = primaryActor?.id && OXY_ID_PATTERN.test(primaryActor.id) ? primaryActor.id : undefined;
   const cachedPrimary = useUserById(primaryOxyId);
-  const resolvedPrimary = useMemo(() => mergeActor(primaryActor, cachedPrimary), [primaryActor, cachedPrimary]);
+  const knownIdentities = useKnownIdentities();
+  const resolvedPrimary = useMemo(
+    () =>
+      mergeActor(
+        primaryActor,
+        correctedIdentity(cachedPrimary, knownIdentities.get(primaryActor?.id ?? '')),
+      ),
+    [primaryActor, cachedPrimary, knownIdentities],
+  );
 
   // Grouped strip / expanded list: best-effort resolve each id from the SAME
   // prewarmed cache (non-reactive read; re-runs when the reactive primary lands,
   // which coincides with the bulk cache write).
+  //
+  //
+  // A profile edited in this session is laid over each of them. The edit is
+  // already IN the cache read below (`lib/actorCache` put it there), so this is
+  // not about the value — it is about this memo re-running at all: editing a
+  // grouped actor who is not `actors[0]` changes nothing else it watches.
   const resolvedActors = useMemo(
     () =>
       item.actors.map((actor, index) =>
         index === 0
           ? resolvedPrimary
-          : mergeActor(actor, queryClient.getQueryData<User>(sdkQueryKeys.users.detail(actor.id))),
+          : mergeActor(
+              actor,
+              correctedIdentity(
+                queryClient.getQueryData<User>(sdkQueryKeys.users.detail(actor.id)),
+                knownIdentities.get(actor.id),
+              ),
+            ),
       ),
-    [item.actors, resolvedPrimary, queryClient],
+    [item.actors, resolvedPrimary, queryClient, knownIdentities],
   );
 
   // Collab invites carry no backend preview — fetch the invited post's text via

--- a/packages/frontend/components/notifications/__tests__/NotificationActorIdentity.test.tsx
+++ b/packages/frontend/components/notifications/__tests__/NotificationActorIdentity.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { QueryClient, QueryClientProvider, notifyManager } from '@tanstack/react-query';
+import type { GroupedNotification } from '@/utils/groupNotifications';
+import type { TRawNotification } from '@/types/validation';
+
+/**
+ * A grouped notification names several people, and all of them follow a profile
+ * edit — not just the first.
+ *
+ * The row resolves `actors[0]` reactively through the user cache, so the primary
+ * was always going to pick an edit up. Every OTHER actor is resolved by a
+ * non-reactive `getQueryData` read inside a memo keyed on the primary, so
+ * editing a grouped actor who is not first changed nothing that memo watches and
+ * the row kept the picture the notification arrived with.
+ *
+ * These deliberately give the row NO cache entry for anybody. That is the
+ * sharper case: it proves the overlay itself carries the correction rather than
+ * the row happening to re-read a cache somebody else had already fixed, and it
+ * is real — a grouped actor the screen never prewarmed has no entry to read.
+ */
+
+jest.mock('@oxyhq/services/ui/client', () => ({
+  useAuth: () => ({ user: { id: 'viewer-1' } }),
+}));
+jest.mock('@/services/feedService', () => ({ feedService: { getPostById: jest.fn() } }));
+jest.mock('@/stores/postsStore', () => ({
+  usePostsStore: (selector: (state: unknown) => unknown) =>
+    selector({ cachePosts: jest.fn() }),
+}));
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('expo-image', () => {
+  const { View: RNView } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { Image: () => <RNView /> };
+});
+
+/** Reports the source it was handed, so the assertion reads the real value. */
+jest.mock('@oxyhq/bloom/avatar', () => {
+  const { Text: RNText } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    Avatar: ({ source }: { source?: string | null }) => (
+      <RNText testID="strip-avatar">{source ?? ''}</RNText>
+    ),
+  };
+});
+jest.mock('@oxyhq/bloom/button', () => ({ Button: () => null }));
+jest.mock('@oxyhq/bloom/subtle-hover', () => ({ SubtleHover: () => null }));
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({ colors: { textSecondary: '#666', primary: '#000', border: '#eee' } }),
+}));
+jest.mock('@oxyhq/bloom/toast', () => ({ toast: jest.fn() }));
+jest.mock('@oxyhq/services', () => ({
+  queryKeys: { users: { detail: (id: string) => ['users', id] } },
+  upsertCachedUser: jest.fn(),
+  upsertCachedUsers: jest.fn(),
+}));
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user?: { username?: string | null } | null): string | null => {
+    const username = (user?.username ?? '').trim().replace(/^@/, '');
+    return username.length > 0 ? username : null;
+  },
+}));
+jest.mock('@/components/UserName', () => {
+  const { Text: RNText } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { __esModule: true, default: ({ name }: { name?: string }) => <RNText>{name}</RNText> };
+});
+jest.mock('@/components/common/LinkifiedText', () => {
+  const { Text: RNText } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { LinkifiedText: ({ text }: { text?: string }) => <RNText>{text}</RNText> };
+});
+jest.mock('@/components/Fediverse/FediverseBadge', () => ({ RemoteActorBadge: () => null }));
+jest.mock('@/components/Compose/CollabAcceptSheet', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/assets/icons/done-all-icon', () => ({ DoneAllIcon: () => null }));
+jest.mock('@/assets/icons/trash-icon', () => ({ TrashIcon: () => null }));
+jest.mock('../notificationDescriptors', () => ({
+  getDescriptor: () => ({
+    icon: 'heart',
+    colorToken: 'primary',
+    actionPhrase: () => 'liked your post',
+  }),
+}));
+jest.mock('@/lib/utils', () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(' ') }));
+jest.mock('@/context/BottomSheetContext', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  return {
+    BottomSheetContext: ReactActual.createContext({
+      openBottomSheet: jest.fn(),
+      setBottomSheetContent: jest.fn(),
+    }),
+  };
+});
+jest.mock('@oxyhq/core/logger', () => ({
+  createLogger: () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }),
+}));
+// Nobody is in the user cache: the overlay alone has to carry the correction.
+jest.mock('@/hooks/useCachedUser', () => ({ useUserById: () => undefined }));
+jest.mock('@/lib/queryClient', () => ({
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+// eslint-disable-next-line import/first
+import { NotificationItem } from '../NotificationItem';
+// eslint-disable-next-line import/first
+import { noteIdentityChanged } from '@/lib/actorCache';
+// eslint-disable-next-line import/first
+import { resetIdentityUpdates } from '@/stores/identityUpdates';
+
+const PRIMARY_ID = 'actor-primary';
+const SECONDARY_ID = 'actor-secondary';
+
+notifyManager.setScheduler((callback) => callback());
+
+function groupedLike(): GroupedNotification {
+  const lead = {
+    _id: 'notif-1',
+    recipientId: 'viewer-1',
+    actorId: PRIMARY_ID,
+    type: 'like',
+    entityId: 'post-1',
+    entityType: 'post',
+    read: false,
+    createdAt: '2026-08-03T00:00:00.000Z',
+  } as unknown as TRawNotification;
+
+  return {
+    key: 'notif-1',
+    type: 'like',
+    entityId: 'post-1',
+    entityType: 'post',
+    hasUnread: true,
+    createdAt: '2026-08-03T00:00:00.000Z',
+    actors: [
+      { id: PRIMARY_ID, name: 'Primary', username: 'primary', avatar: 'primary-before' },
+      { id: SECONDARY_ID, name: 'Secondary', username: 'secondary', avatar: 'secondary-before' },
+    ],
+    totalActors: 2,
+    notificationIds: ['notif-1'],
+    leadNotification: lead,
+    isGroup: true,
+    expandable: false,
+  } as unknown as GroupedNotification;
+}
+
+let mounted: TestRenderer.ReactTestRenderer | null = null;
+let queryClient: QueryClient | null = null;
+
+function renderRow() {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  act(() => {
+    mounted = TestRenderer.create(
+      <QueryClientProvider client={queryClient as QueryClient}>
+        <NotificationItem item={groupedLike()} onMarkAsRead={jest.fn()} onDelete={jest.fn()} />
+      </QueryClientProvider>,
+    );
+  });
+  if (!mounted) throw new Error('the row did not render');
+  return mounted;
+}
+
+/** Every avatar in the collapsed strip, in render order. */
+function stripAvatars(renderer: TestRenderer.ReactTestRenderer): string[] {
+  return renderer.root
+    .findAllByProps({ testID: 'strip-avatar' })
+    .map((node) => String(node.props.children));
+}
+
+afterEach(() => {
+  const renderer = mounted;
+  if (renderer) act(() => renderer.unmount());
+  mounted = null;
+  queryClient?.clear();
+  queryClient = null;
+  resetIdentityUpdates();
+  jest.clearAllMocks();
+});
+
+describe('a grouped notification follows every actor it names', () => {
+  it('starts from the actors the notification arrived with', () => {
+    const renderer = renderRow();
+    // The positive control for the two assertions below: without it, a strip
+    // that rendered nothing would make them pass by finding nothing to disagree.
+    expect(stripAvatars(renderer)).toEqual(
+      expect.arrayContaining(['primary-before', 'secondary-before']),
+    );
+  });
+
+  it('repaints a NON-PRIMARY actor when their profile is edited', () => {
+    const renderer = renderRow();
+
+    act(() => {
+      noteIdentityChanged({ id: SECONDARY_ID, avatar: 'secondary-after' });
+    });
+
+    const avatars = stripAvatars(renderer);
+    expect(avatars).toEqual(expect.arrayContaining(['secondary-after']));
+    expect(avatars).not.toEqual(expect.arrayContaining(['secondary-before']));
+    // and the primary is untouched
+    expect(avatars).toEqual(expect.arrayContaining(['primary-before']));
+  });
+
+  it('repaints the primary actor too', () => {
+    const renderer = renderRow();
+
+    act(() => {
+      noteIdentityChanged({ id: PRIMARY_ID, avatar: 'primary-after' });
+    });
+
+    const avatars = stripAvatars(renderer);
+    expect(avatars).toEqual(expect.arrayContaining(['primary-after']));
+    expect(avatars).not.toEqual(expect.arrayContaining(['primary-before']));
+  });
+
+  it('leaves a row alone when somebody else is edited', () => {
+    const renderer = renderRow();
+
+    act(() => {
+      noteIdentityChanged({ id: 'nobody-here', avatar: 'x' });
+    });
+
+    expect(stripAvatars(renderer)).toEqual(
+      expect.arrayContaining(['primary-before', 'secondary-before']),
+    );
+  });
+});

--- a/packages/frontend/stores/identityUpdates.ts
+++ b/packages/frontend/stores/identityUpdates.ts
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from 'react';
+import { useSyncExternalStore } from 'react';
 import type { PostUser } from '@mention/shared-types';
 
 /**
@@ -60,7 +60,7 @@ import type { PostUser } from '@mention/shared-types';
  *     cache, so the edit is written through there and every incoming actor is
  *     corrected there, wherever the surface that fetched it lives.
  *   * The post rows themselves — `components/Feed/PostItem.tsx` resolves its
- *     author through {@link useKnownIdentity}, so a feed row, a post detail, a
+ *     actors through {@link useKnownIdentities}, so a feed row, a post detail, a
  *     quote card and a boosted original all correct themselves wherever their
  *     copy of the post came from (SQLite, the memory-mode slice, or a response
  *     that has not landed yet).
@@ -90,11 +90,11 @@ type IdentityName = PostUser['name'];
  * The identity fields a profile edit can change, and the only fields this module
  * ever writes. Everything else about a user — counts, viewer relationship,
  * joined date — is owned by whichever cache holds it and is never touched here.
- */
-/**
- * A type alias rather than an interface on purpose: only an alias gets TypeScript's
- * implicit index signature, and without it this is not assignable to the SDK's
- * `CacheableUser` — which is where every recorded edit is handed next.
+ *
+ * A type alias rather than an interface on purpose: only an alias gets
+ * TypeScript's implicit index signature, and without it this is not assignable
+ * to the SDK's `CacheableUser` — which is where every recorded edit is handed
+ * next.
  */
 export type IdentityUpdate = {
   id: string;
@@ -117,8 +117,23 @@ type IdentityHolder = {
   avatar?: string | null;
 };
 
-/** Recorded identities, keyed by Oxy user id. */
-const knownIdentities = new Map<string, IdentityUpdate>();
+/**
+ * Recorded identities, keyed by Oxy user id.
+ *
+ * COPY-ON-WRITE, and that is what lets a render subscribe to the whole map
+ * instead of one id at a time. A row shows several actors — its author, whoever
+ * reposted it, each collaborator on the byline — and a hook cannot be called per
+ * element of an array, so the snapshot has to be the map itself; mutating one in
+ * place would hand `useSyncExternalStore` an unchanged reference after a write
+ * and nothing would repaint. Replacing it means the reference changes exactly
+ * when the contents do.
+ *
+ * Nothing is recorded in the overwhelming majority of sessions, so this stays
+ * the one shared {@link EMPTY} instance and no subscriber ever re-renders.
+ */
+const EMPTY: ReadonlyMap<string, IdentityUpdate> = new Map();
+
+let knownIdentities: ReadonlyMap<string, IdentityUpdate> = EMPTY;
 
 type IdentityListener = () => void;
 
@@ -172,18 +187,23 @@ function serverAgrees(entry: IdentityUpdate, actor: IdentityHolder): boolean {
  * The identity recorded for a user, or `undefined` when nothing has been.
  *
  * The returned object is stable by reference until the next write for that user,
- * which is what lets {@link useKnownIdentity} hand it to `useSyncExternalStore`
+ * which is what lets {@link useKnownIdentities} hand the map to `useSyncExternalStore`
  * directly.
  */
 export function getKnownIdentity(userId: string | undefined): IdentityUpdate | undefined {
   return userId ? knownIdentities.get(userId) : undefined;
 }
 
+/** Every recorded identity. Stable by reference until one is written or retired. */
+export function getKnownIdentities(): ReadonlyMap<string, IdentityUpdate> {
+  return knownIdentities;
+}
+
 /**
  * Correct one actor with an already-read entry. PURE — a function of its two
  * arguments and nothing else, so a render may call it inside a `useMemo` without
  * reading module state from a memoized position (the React Compiler rule in
- * `~/AGENTS.md`); {@link useKnownIdentity} does the reading, through the store's
+ * `~/AGENTS.md`); {@link useKnownIdentities} does the reading, through the store's
  * own subscription.
  *
  * Returns the SAME reference when there is nothing recorded — the common case by
@@ -207,20 +227,26 @@ export function applyKnownIdentity<T extends IdentityHolder>(actor: T): T {
 }
 
 /**
- * Reactive read of the identity recorded for one user.
+ * Reactive read of every recorded identity.
  *
  * `useSyncExternalStore` rather than a `useMemo` over the map, for the reason
  * `usePostSelector` uses it over the SQLite cache: the map is external mutable
  * state, and the React Compiler freezes the first value read from one inside a
- * memoized position. The snapshot is the stored entry itself, which is stable by
- * reference until that user is written again — the contract
- * `useSyncExternalStore` requires — and is `undefined` for every user nobody has
- * edited, so a feed full of rows subscribes to a store that hands them all the
- * same nothing and never re-renders them.
+ * memoized position. Feeding the returned map to {@link mergeKnownIdentity}
+ * inside a `useMemo` is fine — it is then an ARGUMENT, and the merge is pure.
+ *
+ * The whole map rather than one id, because a row shows several actors and a
+ * hook cannot be called per element of an array. It costs nothing while nothing
+ * is recorded (one shared empty instance, so no subscriber re-renders), and a
+ * profile edit is rare enough that repainting the mounted rows once is the right
+ * trade against a subscription per actor per row.
  */
-export function useKnownIdentity(userId: string | undefined): IdentityUpdate | undefined {
-  const getSnapshot = useCallback(() => getKnownIdentity(userId), [userId]);
-  return useSyncExternalStore(subscribeToIdentityUpdates, getSnapshot, getSnapshot);
+export function useKnownIdentities(): ReadonlyMap<string, IdentityUpdate> {
+  return useSyncExternalStore(
+    subscribeToIdentityUpdates,
+    getKnownIdentities,
+    getKnownIdentities,
+  );
 }
 
 /**
@@ -234,21 +260,22 @@ export function useKnownIdentity(userId: string | undefined): IdentityUpdate | u
  */
 export function reconcileKnownIdentities(actors: readonly IdentityHolder[]): void {
   if (knownIdentities.size === 0) return;
-  let retired = false;
+  const retiring: string[] = [];
   for (const actor of actors) {
     const entry = getKnownIdentity(actor.id);
-    if (entry && serverAgrees(entry, actor)) {
-      knownIdentities.delete(entry.id);
-      retired = true;
-    }
+    if (entry && serverAgrees(entry, actor)) retiring.push(entry.id);
   }
-  if (retired) notify();
+  if (retiring.length === 0) return;
+  const next = new Map(knownIdentities);
+  for (const id of retiring) next.delete(id);
+  knownIdentities = next.size === 0 ? EMPTY : next;
+  notify();
 }
 
 /**
  * Subscribe to identity changes. Returns an unsubscribe function.
  *
- * Exported for {@link useKnownIdentity}; a component should use the hook rather
+ * Exported for {@link useKnownIdentities}; a component should use the hook rather
  * than subscribing by hand.
  */
 export function subscribeToIdentityUpdates(listener: IdentityListener): () => void {
@@ -272,7 +299,9 @@ export function subscribeToIdentityUpdates(listener: IdentityListener): () => vo
 export function recordIdentityChange(update: IdentityUpdate): IdentityUpdate | null {
   if (!update.id) return null;
   const stored: IdentityUpdate = { id: update.id, ...meaningfulFields(update) };
-  knownIdentities.set(update.id, stored);
+  const next = new Map(knownIdentities);
+  next.set(update.id, stored);
+  knownIdentities = next;
   notify();
   return stored;
 }
@@ -289,6 +318,6 @@ export function recordIdentityChange(update: IdentityUpdate): IdentityUpdate | n
  * than against a session.
  */
 export function resetIdentityUpdates(): void {
-  knownIdentities.clear();
+  knownIdentities = EMPTY;
   notify();
 }


### PR DESCRIPTION
Follows #589, which reached a post's **author** and the actor cache. The rest of the app still showed whatever picture and name each surface happened to fetch — so an edit was instant in some places and stale in others, which is *more* conspicuous than being stale everywhere: the same person gets drawn twice, differently, on one screen.

## Three components, each standing in for many surfaces

**`PostItem` now resolves all three of its actors, not just the author.** #588 wired `boostedBy`, so whoever reposted a post is drawn in the **same avatar cluster** as its author, and a collaborative byline puts one avatar per collaborator in that cluster too. A collaborator who is also the author would have been drawn twice from two different snapshots.

**`ProfileCard` is one row and fifteen surfaces:** search results, who-to-follow and its widget, list and starter-pack members, followers and following, likers and boosters, collaborators, pokes, notification subscriptions, both feed interstitials. Each hands it a snapshot its own fetch produced and nothing rewrites those, so resolving it in the row reaches all fifteen — a correction per surface is fifteen chances to miss one. Its **handle** comes from the corrected profile too: a rename changes the handle, the row navigates to it, so a stale one is a tap that 404s.

**Notifications were half covered**, which only reading the row showed. `actors[0]` resolves reactively through the user cache and was always going to pick an edit up; every *other* actor in a grouped row is resolved by a non-reactive `getQueryData` inside a memo keyed on the primary, so editing somebody who is not first changed nothing that memo watched. The overlay is now a real input to that merge rather than a bare dependency — ESLint flagged the bare version as unnecessary, and a dependency nothing reads is one the next person deletes, taking the fix with it.

The overlay store is copy-on-write so a render can subscribe to the whole map (a row shows several actors, and a hook cannot be called per array element). It stays the one shared empty instance while nothing is recorded — every session that edits no profile — so no subscriber re-renders.

## What keeps this from rotting

`lib/actorCache` (from #589) is the **only door** into the SDK's user cache. That is not a convention, it is a test: it fails if any other module imports `upsertCachedUser`/`upsertCachedUsers`, and it **names the offending file**, with a vacuity floor on the traversal so a broken scan cannot pass silently. A tenth surface cannot inherit this bug in silence — it has to walk past a red test that points at it.

## Still not covered

- **Clearing a picture is still not instant.** `upsertCachedUser` cannot express an authoritative clear — `null`/`''` are treated as degraded and dropped by contract — so this mirrors the SDK rather than running two disagreeing merge rules. Being fixed upstream in `@oxyhq/core` by another agent, along with `updateAccount` not busting `GET:/profiles/username/` or `GET:/users/<id>`. Untouched here.
- Actors embedded in surfaces that neither `PostItem`, `ProfileCard` nor the user cache reach are still snapshot-bound; none is known today, and the door test is what surfaces the next one.

## Verification

`tsc --noEmit` clean · **147 suites / 1350 tests** · `lint:frontend` 0 errors (4 pre-existing `import/first` warnings) · `bun.lock` untouched · rebased onto `main` after #588, #589 and #590 (checked #590's new `AccountInfoScreen`/`ChannelHeader`/`ProfileShell` render from `useProfileData` → the guarded cache, so they add no gap).

Mutation-tested, each producing a **named** failure: reposter not corrected (1), byline not corrected (2), `ProfileCard` not corrected (2), handle taken from the stale profile (1), grouped notification actors not corrected (1), primary notification actor not corrected (1) — the last two failing *different* tests, so each discriminates what it names.

The notification suite was written before the machine ran out of inodes and had never been executed; on first run it failed on a wrong `getDescriptor` mock shape, and it also contained a filter whose predicate ended in `|| true` and therefore filtered nothing. Both fixed rather than shipped green-by-accident.

**No browser proof.** Prod CORS rejects a LAN origin and I have no session for a channel-operating account. The tests do drive real mounted React trees repainting from the signal with no refetch, but I did not watch a picture change in a real tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)