### PR TITLE
fix(channels): read a channel's byline setting back from a route that can answer

### DIFF
--- a/packages/backend/src/__tests__/routes/profileSettingsOperatedAccount.test.ts
+++ b/packages/backend/src/__tests__/routes/profileSettingsOperatedAccount.test.ts
@@ -234,3 +234,113 @@ describe('PUT /profile/settings/:userId — an operated account', () => {
     expect(store.has(CHANNEL)).toBe(false);
   });
 });
+
+/**
+ * `GET /profile/settings/:userId/channel` — the READ half, and the reason it is a
+ * separate endpoint from `GET /profile/settings/:userId`.
+ *
+ * Those two answer different questions. The bare route serves a VIEWER the
+ * profile-design DTO, and `buildSettingsResponseForViewer` returns the stored
+ * document only when `targetUserId === viewerUserId` — an equality that is
+ * structurally unreachable for a channel, because `isActAsEligibleKind` refuses
+ * `channel`, so no session can ever be minted whose subject is one. Every other
+ * exit of that serialiser is a fixed-key design DTO with no `channel` block, so an
+ * operator who turned the byline ON read it back as OFF for as long as this screen
+ * pointed there — while the stored value, and every post's byline, said otherwise.
+ *
+ * These assert the route through the REAL handler. Note the suite above mocks
+ * `buildSettingsResponseForViewer` to the identity function, which is precisely
+ * why it stayed green over that bug: the mock returns the whole document, so the
+ * redaction that drops `channel` never ran in a test.
+ */
+describe('GET /profile/settings/:userId/channel — an operated channel', () => {
+  beforeEach(() => {
+    store.clear();
+    gate.operableKindOf.clear();
+    gate.operableKindOf.set(CHANNEL, 'channel');
+    gate.operableKindOf.set(ORGANIZATION, 'organization');
+    vi.clearAllMocks();
+  });
+
+  /**
+   * THE regression test, and the fixture has to be ON.
+   *
+   * `false` is the default, so a test that stores `false` and expects `false`
+   * cannot tell "reads the stored value" from "always answers false" — which is
+   * exactly the broken behaviour. Only a stored `true` distinguishes them.
+   */
+  it('reads back a signPosts the operator turned ON', async () => {
+    store.set(CHANNEL, { oxyUserId: CHANNEL, channel: { signPosts: true } });
+
+    const res = await request(app).get(`/profile/settings/${CHANNEL}/channel`).expect(200);
+
+    expect(res.body.data).toEqual({ channel: { signPosts: true } });
+  });
+
+  it('reads back a signPosts that is off', async () => {
+    store.set(CHANNEL, { oxyUserId: CHANNEL, channel: { signPosts: false } });
+
+    const res = await request(app).get(`/profile/settings/${CHANNEL}/channel`).expect(200);
+
+    expect(res.body.data).toEqual({ channel: { signPosts: false } });
+  });
+
+  /**
+   * A channel nobody has ever configured has no settings row at all. That is not
+   * an error — it has simply never opted in — so it answers `false` rather than
+   * 404ing a screen whose toggle is legitimately off.
+   */
+  it('answers false for a channel with no settings row', async () => {
+    const res = await request(app).get(`/profile/settings/${CHANNEL}/channel`).expect(200);
+
+    expect(res.body.data).toEqual({ channel: { signPosts: false } });
+    // The read must not conjure a row for a channel that has none.
+    expect(store.has(CHANNEL)).toBe(false);
+  });
+
+  /**
+   * The fixture that tells `=== true` from `Boolean(signPosts)`, on the READ side.
+   *
+   * `true` / `false` / absent all agree under both readings, so a suite built from
+   * those alone stays green against the loose one. A truthy NON-boolean is the one
+   * shape that makes them disagree — and here the loose read would DISCLOSE the
+   * human who wrote the post. The column is `Boolean` in the schema, so this can
+   * only arrive from outside Mongoose (a migration, a manual repair), which is
+   * exactly the case worth failing safe on.
+   */
+  it.each([
+    ['the string "false"', 'false'],
+    ['the string "true"', 'true'],
+    ['the number 1', 1],
+    ['an object', {}],
+  ])('refuses to read %s as consent to name the writer', async (_label, value) => {
+    store.set(CHANNEL, { oxyUserId: CHANNEL, channel: { signPosts: value } });
+
+    const res = await request(app).get(`/profile/settings/${CHANNEL}/channel`).expect(200);
+
+    expect(res.body.data).toEqual({ channel: { signPosts: false } });
+  });
+
+  /**
+   * Authorization is the SAME gate as the write, with the same status codes. The
+   * asymmetry between how the two halves authorized is what produced the bug this
+   * route fixes, so each refusal is pinned on both.
+   */
+  it('refuses an account the caller does not operate, with the gate\'s status', async () => {
+    store.set(OTHER_CHANNEL, { oxyUserId: OTHER_CHANNEL, channel: { signPosts: true } });
+
+    await request(app).get(`/profile/settings/${OTHER_CHANNEL}/channel`).expect(403);
+  });
+
+  it('refuses the caller\'s own account — `channel.signPosts` means nothing there', async () => {
+    store.set(CALLER, { oxyUserId: CALLER, channel: { signPosts: true } });
+
+    await request(app).get(`/profile/settings/${CALLER}/channel`).expect(400);
+  });
+
+  it('refuses an ORGANIZATION the caller may act for', async () => {
+    store.set(ORGANIZATION, { oxyUserId: ORGANIZATION, channel: { signPosts: true } });
+
+    await request(app).get(`/profile/settings/${ORGANIZATION}/channel`).expect(400);
+  });
+});

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -93,6 +93,80 @@ router.get('/settings/:userId', async (req: AuthRequest, res: Response) => {
 });
 
 /**
+ * GET /api/profile/settings/:userId/channel — the byline setting of a channel the
+ * caller OPERATES.
+ *
+ * The READ half of the route below, and a SEPARATE endpoint from
+ * `GET /settings/:userId` on purpose. That route answers a VIEWER's question
+ * ("what may I see of this profile's design?") and a channel is never its own
+ * viewer — `isActAsEligibleKind` refuses `channel`, so no session can ever be
+ * minted whose subject is one, so `targetUserId === viewerUserId` is unreachable
+ * for a channel and the response is always the public profile-design DTO. That
+ * DTO has no `channel` key, so reading `signPosts` back off it yielded `undefined`
+ * — an operator who turned the toggle ON found it OFF on their next visit while
+ * the stored value, and every post's byline, said otherwise.
+ *
+ * Answering it here rather than widening that DTO keeps the viewer-facing payload
+ * exactly as it was: this field decides whether a human's authorship is disclosed,
+ * so it is served only to the people who may CHANGE it, gated unconditionally
+ * rather than behind a condition a later edit could fall past.
+ *
+ * Authorization is deliberately the SAME gate, with the same `channel`-kind
+ * precondition, as the write below — whoever may configure how a channel signs is
+ * whoever may read how it signs. Asymmetry between the two is what produced the
+ * bug it fixes.
+ */
+router.get(
+  '/settings/:userId/channel',
+  operatedAccountSettingsRateLimiter,
+  async (req: AuthRequest, res: Response) => {
+    const targetUserId = req.params.userId as string;
+    try {
+      const callerId = getAuthenticatedUserId(req);
+
+      const validationError = validateRequired(targetUserId, 'userId');
+      if (validationError) {
+        return sendErrorResponse(res, 400, 'Bad Request', validationError);
+      }
+
+      let authorKind: AccountKind | null;
+      try {
+        ({ authorKind } = await assertCanPublishAsAccount({
+          publishAsOxyUserId: targetUserId,
+          callerId,
+          memberReader: createUserScopedOxyServices(req),
+        }));
+      } catch (error) {
+        if (error instanceof PublishAsAccessError) {
+          return sendErrorResponse(res, error.status, 'Forbidden', error.message);
+        }
+        throw error;
+      }
+      if (authorKind !== 'channel') {
+        return sendErrorResponse(res, 400, 'Bad Request', 'That account cannot be published as');
+      }
+
+      const doc = await UserSettings.findOne({ oxyUserId: targetUserId }).lean().exec();
+
+      // `=== true` rather than a truthiness test, and the same read the write half
+      // answers with: a channel with no settings row yet has never opted in, and a
+      // truthy non-boolean that reached the column outside the schema (a migration,
+      // a manual repair) must not read as consent to name a writer.
+      return sendSuccessResponse(res, 200, {
+        channel: { signPosts: doc?.channel?.signPosts === true },
+      });
+    } catch (err) {
+      logger.error('[ProfileSettings] Error fetching operated account settings:', {
+        userId: req.user?.id,
+        targetUserId,
+        error: err,
+      });
+      return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to fetch settings');
+    }
+  },
+);
+
+/**
  * PUT /api/profile/settings/:userId — settings of an account the caller OPERATES.
  *
  * A channel account has no login, so nobody can ever authenticate AS one and use

--- a/packages/frontend/services/__tests__/channelAccountService.test.ts
+++ b/packages/frontend/services/__tests__/channelAccountService.test.ts
@@ -1,0 +1,108 @@
+/**
+ * `channelAccountService` — the channel byline toggle's client half.
+ *
+ * The read and the write do NOT share a path, and that asymmetry is deliberate
+ * rather than an oversight, so it is pinned here.
+ *
+ * `GET /profile/settings/:id` answers a VIEWER's question — it serves the profile
+ * design DTO, and returns the stored settings document only when the target IS the
+ * viewer. A channel can never be its own viewer (no session can be minted whose
+ * subject is a channel), so that response never carries a `channel` block and
+ * reading `signPosts` off it yielded `undefined` however the operator had it set.
+ * The read therefore goes to the operator-gated `/channel` sub-route.
+ *
+ * Without this test the frontend half of that fix is unpinned: pointing the read
+ * back at the bare settings path would restore the bug with every backend test
+ * still green.
+ */
+
+import { authenticatedClient } from '@/utils/api';
+
+import { channelAccountService } from '../channelAccountService';
+
+// The factory closes over nothing, so `jest.mock`'s hoisting above these imports
+// cannot land the mocks in the temporal dead zone — which is what lets the
+// imports stay first and keeps `import/first` satisfied.
+jest.mock('@/utils/api', () => ({
+  authenticatedClient: { get: jest.fn(), put: jest.fn() },
+}));
+
+const mockGet = jest.mocked(authenticatedClient.get);
+const mockPut = jest.mocked(authenticatedClient.put);
+
+const CHANNEL = 'channel-account-1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('channelAccountService.getSettings', () => {
+  it('reads from the operator-gated /channel sub-route, not the viewer settings path', async () => {
+    mockGet.mockResolvedValue({ data: { channel: { signPosts: true } } });
+
+    await channelAccountService.getSettings(CHANNEL);
+
+    expect(mockGet).toHaveBeenCalledWith(`/profile/settings/${CHANNEL}/channel`);
+  });
+
+  /**
+   * The fixture has to be ON. `false` is the default, so a stored-`false` case
+   * cannot tell "reads the value" from "always answers false" — which is exactly
+   * the behaviour this fixed.
+   */
+  it('reads back a signPosts that is ON', async () => {
+    mockGet.mockResolvedValue({ data: { channel: { signPosts: true } } });
+
+    await expect(channelAccountService.getSettings(CHANNEL)).resolves.toEqual({ signPosts: true });
+  });
+
+  it('reads back a signPosts that is off', async () => {
+    mockGet.mockResolvedValue({ data: { channel: { signPosts: false } } });
+
+    await expect(channelAccountService.getSettings(CHANNEL)).resolves.toEqual({ signPosts: false });
+  });
+
+  /**
+   * A response with no `channel` block at all — what the OLD path returned, and
+   * what a future regression would return again. It must read as off rather than
+   * as `undefined` reaching the switch.
+   */
+  it('treats a response with no channel block as off', async () => {
+    mockGet.mockResolvedValue({ data: {} });
+
+    await expect(channelAccountService.getSettings(CHANNEL)).resolves.toEqual({ signPosts: false });
+  });
+
+  /**
+   * Tells `=== true` from `Boolean(...)`: only a truthy NON-boolean makes the two
+   * readings disagree, and the loose one would name the human who wrote the post.
+   */
+  it.each([['the string "false"', 'false'], ['the number 1', 1], ['an object', {}]])(
+    'refuses to read %s as consent to name the writer',
+    async (_label, value) => {
+      mockGet.mockResolvedValue({ data: { channel: { signPosts: value } } });
+
+      await expect(channelAccountService.getSettings(CHANNEL)).resolves.toEqual({ signPosts: false });
+    },
+  );
+});
+
+describe('channelAccountService.setSignPosts', () => {
+  it('writes to the settings path the operated-account route serves', async () => {
+    mockPut.mockResolvedValue({ data: { channel: { signPosts: true } } });
+
+    await channelAccountService.setSignPosts(CHANNEL, true);
+
+    expect(mockPut).toHaveBeenCalledWith(`/profile/settings/${CHANNEL}`, {
+      channel: { signPosts: true },
+    });
+  });
+
+  it('falls back to the requested value when the server answers tersely', async () => {
+    mockPut.mockResolvedValue({ data: {} });
+
+    await expect(channelAccountService.setSignPosts(CHANNEL, true)).resolves.toEqual({
+      signPosts: true,
+    });
+  });
+});

--- a/packages/frontend/services/channelAccountService.ts
+++ b/packages/frontend/services/channelAccountService.ts
@@ -36,9 +36,17 @@ export interface ChannelAccountSettings {
  * nothing would leave an operator believing their writers are anonymous.
  */
 class ChannelAccountService {
+  /**
+   * Read from `/channel` rather than from the bare `${SETTINGS_PATH}/:id` the
+   * write below uses, because those two paths answer different questions.
+   * `GET /profile/settings/:id` serves a VIEWER the profile-design DTO, and a
+   * channel is never its own viewer — no session can be minted whose subject is a
+   * channel — so that response never carries a `channel` block at all and this
+   * read came back `false` however the operator had it set.
+   */
   async getSettings(oxyUserId: string): Promise<ChannelAccountSettings> {
     const res = await authenticatedClient.get<{ channel?: Partial<ChannelAccountSettings> }>(
-      `${SETTINGS_PATH}/${encodeURIComponent(oxyUserId)}`,
+      `${SETTINGS_PATH}/${encodeURIComponent(oxyUserId)}/channel`,
     );
     return { signPosts: res.data?.channel?.signPosts === true };
   }


### PR DESCRIPTION
## The symptom

Turning **"Name the writer"** on for a channel saved, and *worked* — posts named their writer, the feature was visibly live. But reopening the channel's settings screen showed the toggle **OFF**.

## The finding

**`GET /profile/settings/:userId` and `PUT /profile/settings/:userId` answer different questions.** They share a path, so the client service assumed they were symmetric. They never were.

The GET is a **viewer's profile-design read**. `buildSettingsResponseForViewer` (`packages/backend/src/utils/userSettings.ts:88`) returns the stored document only when `targetUserId === viewerUserId`; its other two exits are fixed-key design DTOs with no `channel` block.

For a channel that equality is **structurally unreachable** — `isActAsEligibleKind` refuses `channel`, so no session can ever be minted whose subject is one, so a channel is never its own viewer. The route could never take the branch that would have carried the field.

Executed against the real handler with `channel.signPosts: true` genuinely stored:

```
"body": { "data": { "oxyUserId": "channel-account-1" } },
"frontendReadsSignPostsAs": false
```

No `channel` key at any depth. The client's `res.data?.channel?.signPosts === true` read `undefined === true` → `false`. Deterministic, every time — not a cache and not a race.

**Why the suite was green over it:** `packages/backend/src/__tests__/routes/profileSettingsOperatedAccount.test.ts:122` mocks `buildSettingsResponseForViewer` with the identity function, so the redaction that drops `channel` never ran in a test.

It looked correct in-session because the mutation's `onSuccess` writes the server's answer straight into the query cache — which is exactly why it only reappeared after a remount.

Ruled out by observation, not assumption: the SDK GET cache (`createLinkedClient` does `enableCache: config.enableCache ?? false`, and Mention passes only `{ baseURL }`), and form-init-without-resync (the `Switch` binds to query data, no local state).

## The fix

A new operator-gated **`GET /profile/settings/:userId/channel`**, rather than widening the viewer DTO. This field decides whether a human's authorship is disclosed, so it goes only to the people who may change it, gated unconditionally rather than behind a condition a later edit could fall past — and profile views pay no new Oxy round trip. Authorization is the same `assertCanPublishAsAccount` gate with the same `channel`-kind precondition as the write, because asymmetry between the two halves is what caused this.

## Tests

Fixtures chosen against the vacuity traps this bug punishes:

- **stored ON** — a `false` fixture cannot tell "reads the value" from "always answers false", which *is* the bug;
- **truthy non-boolean** (`'false'`, `'true'`, `1`, `{}`) — the only shape that tells `=== true` from `Boolean(...)`, where the loose read would disclose a writer;
- no settings row; 403 non-operated; 400 own-account and 400 `organization`.

Plus a frontend test pinning the request path — without it the client half is unpinned and a revert restores the bug with every backend test still green.

**Mutation-tested**, each caught by a *named* test, file restored identical after each:

| mutation | named failure |
|---|---|
| `=== true` → `Boolean(...)` | the 4 truthy-non-boolean cases |
| read always `false` (the original bug's behaviour) | *reads back a signPosts the operator turned ON* |
| drop the `channel`-kind precondition | own-account + organization |
| skip the operator gate | 403 + own-account + organization |
| client path → the old viewer route | *reads from the operator-gated /channel sub-route…* |

## Gates run on this branch, post-rebase

- backend `bun run test` — **431 files / 4702 tests**, exit 0
- frontend `bun run test:coverage` — **148 suites / 1359 tests**, exit 0
- `bunx tsc --noEmit` — clean, backend **and** frontend
- `bun run lint:frontend` — 0 errors (4 warnings, all pre-existing in files not touched here)

## Not fixed here, deliberately

After `profileMutation` succeeds nothing appears to invalidate `viewerQueryKeys.operatedAccounts`, so the seeded `account` baseline may stay stale and the Save button's dirty check may not settle. **Unverified, a different bug, and in a file another agent has open** — flagged only, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)