### PR TITLE
fix(notifications): route a channel's notifications to its operators

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -36,6 +36,9 @@ import { registerContentRoomHandlers } from './src/services/ContentRoomLifecycle
 import { engagementOutboxDispatcher } from './src/services/EngagementOutboxDispatcher';
 import { moderationOutboxDispatcher } from './src/services/moderation/ModerationOutboxDispatcher';
 
+import { resolveNotificationInboxIds } from './src/services/notificationInbox';
+import { createUserScopedOxyServices } from './src/utils/oxyHelpers';
+
 // Models
 import Notification from "./src/models/Notification";
 import {
@@ -286,10 +289,59 @@ notificationsNamespace.on("connection", (socket: AuthenticatedSocket) => {
   socket.join(userRoom);
   logger.debug('Authenticated client joined notification room');
 
+  // Also join the room of every CHANNEL this person operates.
+  //
+  // A channel has no session, so nothing ever joined `user:<channelId>` and the
+  // emit `createNotification` already makes for a channel-addressed row went to
+  // an empty room. Joining here is what delivers it live, with NO change to the
+  // write path — and the notifications socket is the only live path the client
+  // has (it applies targeted cache patches and never polls), so without this a
+  // channel's engagement would not surface until a manual refresh.
+  //
+  // The room is derived from Oxy's answer for this socket's own verified bearer,
+  // never from anything the client sent. Fail-soft: a resolve failure leaves the
+  // operator with their personal room, exactly as before.
+  //
+  // Resolved ONCE, at connect. A membership revoked mid-connection therefore
+  // keeps delivering live rows until this socket reconnects — every DURABLE
+  // surface (list, unread count, mark-read, delete) re-resolves within the
+  // `notificationInbox` cache TTL and cuts off much sooner. The payload is
+  // engagement metadata on a public post, which is why that window is acceptable
+  // here and would not be for the read routes.
+  const socketBearer = typeof socket.handshake.auth?.token === 'string'
+    ? socket.handshake.auth.token
+    : undefined;
+  if (socketBearer) {
+    void resolveNotificationInboxIds(userId, createUserScopedOxyServices({ accessToken: socketBearer }))
+      .then((recipientIds) => {
+        if (!socket.connected) return;
+        for (const recipientId of recipientIds) {
+          if (recipientId !== userId) socket.join(`user:${recipientId}`);
+        }
+      })
+      .catch((error: unknown) => {
+        logger.warn('[Notifications] failed to join operated-channel rooms', {
+          error: error instanceof Error ? error.message : 'unknown',
+        });
+      });
+  }
+
   socket.on("error", (error: Error) => {
     logger.error("Notifications socket error", error);
   });
 
+  // THE TWO READ-STATE HANDLERS BELOW STAY SCOPED TO THE PERSON, NOT TO THE
+  // CHANNEL ROOMS JOINED ABOVE — deliberately, and this is the one place that
+  // says so.
+  //
+  // The app never emits either of them: `useRealtimeNotifications` only LISTENS,
+  // and mark-read/mark-all-read go over HTTP (`PATCH /notifications/:id/read`,
+  // `PATCH /notifications/read-all`), where the scope is re-resolved per request
+  // and covers a channel's rows. Widening these would mean authorizing a WRITE
+  // from a set resolved once at connect, which a long-lived socket can outlive by
+  // hours — a worse staleness window than the one the HTTP routes have, spent on
+  // handlers nothing calls. Left narrow, they simply find no channel row and
+  // no-op, which is the direction that fails closed.
   socket.on("markNotificationRead", socketRateLimiter.wrap(socket, 'markNotificationRead', async ({ notificationId }: { notificationId?: string }) => {
     try {
       if (!socket.user?.id) return;

--- a/packages/backend/src/__tests__/routes/notificationsChannelInbox.test.ts
+++ b/packages/backend/src/__tests__/routes/notificationsChannelInbox.test.ts
@@ -1,0 +1,420 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A channel's notifications, at the surface an operator actually reads.
+ *
+ * `notificationInboxScope.test.ts` pins WHO the recipients are; this suite pins
+ * what that means for `GET /notifications` and the write surfaces beside it. Two
+ * things are being defended, and the fixtures are built so that the correct and
+ * the broken implementation disagree on each:
+ *
+ *  1. **THE WRITER'S ANONYMITY.** A channel post carries `writtenByOxyUserId`, and
+ *     `UserSettings.channel.signPosts` — decided server-side, on the post — is the
+ *     WHOLE disclosure. A notification must not become a second door. Two shapes
+ *     would open one: shipping the id on the payload, and routing by it (so the
+ *     rows an operator receives partition the channel's posts by author). The
+ *     fixtures below give the channel TWO operators and give its post a writer who
+ *     is one of them, which is exactly the arrangement where the two routings
+ *     disagree — with a single operator, "everyone" and "the writer" produce the
+ *     same page and neither test means anything. `WRITER_ID` is asserted PRESENT
+ *     on the row the route reads before it is asserted absent from the response,
+ *     so the leak check cannot pass by the fixture simply never carrying it.
+ *
+ *  2. **The scope reaches every recipient-filtered query.** A page the operator
+ *     can see but not mark read, delete or have counted is worse than no page at
+ *     all, so each handler is checked against the query it actually issued.
+ */
+
+const mocks = vi.hoisted(() => ({
+  notificationFind: vi.fn(),
+  notificationCountDocuments: vi.fn(),
+  notificationFindOneAndUpdate: vi.fn(),
+  notificationFindOneAndDelete: vi.fn(),
+  notificationUpdateMany: vi.fn(),
+  postFind: vi.fn(),
+  hydratePosts: vi.fn(),
+  getUsersByIds: vi.fn(),
+  createScopedOxyClient: vi.fn(),
+  loadShowSensitiveContent: vi.fn(),
+  loadMuteWords: vi.fn(),
+  resolveNotificationInboxIds: vi.fn(),
+}));
+
+vi.mock('../../services/safety/viewerSafety', () => ({
+  loadShowSensitiveContent: mocks.loadShowSensitiveContent,
+  loadMuteWords: mocks.loadMuteWords,
+}));
+
+vi.mock('../../middleware/rateLimiter', () => ({
+  apiRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock('../../models/Notification', () => ({
+  default: {
+    find: mocks.notificationFind,
+    countDocuments: mocks.notificationCountDocuments,
+    findOneAndUpdate: mocks.notificationFindOneAndUpdate,
+    findOneAndDelete: mocks.notificationFindOneAndDelete,
+    updateMany: mocks.notificationUpdateMany,
+  },
+}));
+
+vi.mock('../../models/Post', () => ({
+  default: { find: mocks.postFind },
+}));
+
+vi.mock('../../models/PushToken', () => ({
+  default: { deleteOne: vi.fn(), findOneAndUpdate: vi.fn() },
+}));
+
+vi.mock('../../services/PostHydrationService', () => ({
+  postHydrationService: { hydratePosts: mocks.hydratePosts },
+}));
+
+vi.mock('../../services/notificationInbox', () => ({
+  resolveNotificationInboxIds: mocks.resolveNotificationInboxIds,
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createScopedOxyClient: mocks.createScopedOxyClient,
+  createUserScopedOxyServices: () => ({ listAccounts: async () => [] }),
+  getServiceOxyClient: () => ({ getUsersByIds: mocks.getUsersByIds }),
+}));
+
+vi.mock('../../utils/mediaResolver', () => ({
+  resolveAvatarUrl: (value?: string) => value,
+}));
+
+vi.mock('../../utils/push', () => ({ sendPushToUser: vi.fn() }));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import notificationsRouter from '../../routes/notifications';
+// Imported for its TYPE only, so a mute fixture with the wrong field name is a
+// compile error rather than a rule that silently never compiles (which is
+// indistinguishable from a rule the row correctly survived).
+import type { MuteWordRule } from '../../services/safety/muteWordMatcher';
+
+const OPERATOR_A = 'operator-a';
+const OPERATOR_B = 'operator-b';
+const CHANNEL = 'channel-1';
+const ACTOR = 'actor-1';
+const STRANGER = 'stranger-author';
+
+/**
+ * The human who wrote the channel's post. A distinctive value on purpose: the
+ * leak assertions search the serialized response for this exact string, so it has
+ * to be one that could not appear for any other reason.
+ */
+const WRITER_ID = 'writer-6981c9178fcdefaf81988ffb';
+
+const CHANNEL_POST_ID = new mongoose.Types.ObjectId('507f1f77bcf86cd799439011');
+const OWN_POST_ID = new mongoose.Types.ObjectId('507f1f77bcf86cd799439013');
+const STRANGER_POST_ID = new mongoose.Types.ObjectId('507f1f77bcf86cd799439015');
+const CHANNEL_NOTIFICATION_ID = new mongoose.Types.ObjectId('507f1f77bcf86cd799439012');
+const OWN_NOTIFICATION_ID = new mongoose.Types.ObjectId('507f1f77bcf86cd799439014');
+const STRANGER_NOTIFICATION_ID = new mongoose.Types.ObjectId('507f1f77bcf86cd799439016');
+
+/** Somebody liked the CHANNEL's post: the row is addressed to the channel. */
+function channelNotificationRow() {
+  return {
+    _id: CHANNEL_NOTIFICATION_ID,
+    recipientId: CHANNEL,
+    actorId: ACTOR,
+    type: 'like',
+    entityType: 'post',
+    entityId: CHANNEL_POST_ID,
+    read: false,
+    createdAt: new Date('2026-01-02T00:00:00.000Z'),
+  };
+}
+
+/** Somebody liked the OPERATOR's own post: addressed to the person. */
+function personalNotificationRow(viewerId: string) {
+  return {
+    _id: OWN_NOTIFICATION_ID,
+    recipientId: viewerId,
+    actorId: ACTOR,
+    type: 'like',
+    entityType: 'post',
+    entityId: OWN_POST_ID,
+    read: false,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+/**
+ * A reply on a STRANGER's post, addressed to the viewer personally — the control
+ * for the muted-word case, where it must be dropped while the channel's row is
+ * kept.
+ */
+function strangerNotificationRow() {
+  return {
+    _id: STRANGER_NOTIFICATION_ID,
+    recipientId: OPERATOR_A,
+    actorId: ACTOR,
+    type: 'like' as const,
+    entityType: 'post',
+    entityId: STRANGER_POST_ID,
+    read: false,
+    createdAt: new Date('2026-01-03T00:00:00.000Z'),
+  };
+}
+
+function mockNotificationPage(rows: ReturnType<typeof channelNotificationRow>[]) {
+  const lean = vi.fn().mockResolvedValue(rows);
+  const limit = vi.fn().mockReturnValue({ lean });
+  const sort = vi.fn().mockReturnValue({ limit });
+  mocks.notificationFind.mockReturnValue({ sort });
+  mocks.notificationCountDocuments.mockResolvedValue(rows.length);
+}
+
+/**
+ * The RAW post rows the route reads. The channel's post carries
+ * `writtenByOxyUserId`, which is the whole point: the writer id is genuinely in
+ * the data the handler touches, so its absence from the response is a fact about
+ * the handler and not about the fixture.
+ */
+function mockRawPosts(writtenBy: string = WRITER_ID) {
+  const lean = vi.fn().mockResolvedValue([
+    {
+      _id: CHANNEL_POST_ID,
+      oxyUserId: CHANNEL,
+      writtenByOxyUserId: writtenBy,
+      content: { variants: [{ type: 'author', text: 'the channel published this' }] },
+      visibility: 'public',
+      status: 'published',
+    },
+    {
+      _id: OWN_POST_ID,
+      oxyUserId: OPERATOR_A,
+      content: { variants: [{ type: 'author', text: 'my own post' }] },
+      visibility: 'public',
+      status: 'published',
+    },
+  ]);
+  mocks.postFind.mockReturnValue({ lean });
+}
+
+function makeApp(viewerId: string) {
+  const app = express();
+  app.use((req, _res, next) => {
+    (req as typeof req & { user: { id: string } }).user = { id: viewerId };
+    next();
+  });
+  app.use('/', notificationsRouter);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // BOTH operators resolve the SAME scope — the set is a property of the channel.
+  mocks.resolveNotificationInboxIds.mockImplementation(async (viewerId: string) => [viewerId, CHANNEL]);
+  mocks.getUsersByIds.mockResolvedValue([
+    { id: ACTOR, username: 'liker', name: { displayName: 'A Liker' } },
+    { id: CHANNEL, username: 'techweekly', name: { displayName: 'Tech Weekly' } },
+  ]);
+  mocks.createScopedOxyClient.mockReturnValue({ scope: 'viewer' });
+  mocks.loadShowSensitiveContent.mockResolvedValue(false);
+  mocks.loadMuteWords.mockResolvedValue([]);
+  mocks.hydratePosts.mockResolvedValue([
+    { id: String(CHANNEL_POST_ID), content: { text: 'the channel published this' }, user: { id: CHANNEL } },
+    { id: String(OWN_POST_ID), content: { text: 'my own post' }, user: { id: OPERATOR_A } },
+  ]);
+  mockNotificationPage([channelNotificationRow(), personalNotificationRow(OPERATOR_A)]);
+  mockRawPosts();
+});
+
+describe('fixture shape (vacuity floor)', () => {
+  it('gives the channel more than one operator', () => {
+    // With a single operator, "notify every operator" and "notify the writer"
+    // produce the same page, and neither anonymity case below could tell them
+    // apart.
+    expect(OPERATOR_A).not.toBe(OPERATOR_B);
+  });
+
+  it('puts a writer id on the row the handler actually reads', async () => {
+    // If this stops holding, every "does not leak the writer" assertion is
+    // vacuous — it would be asserting the absence of something nothing had.
+    const posts = await mocks.postFind().lean();
+    expect(JSON.stringify(posts)).toContain(WRITER_ID);
+  });
+
+  it('uses a writer id that cannot appear in a response for any other reason', () => {
+    // The leak check is a substring search over the serialized body, so the id
+    // must not collide with an operator, the channel, or the actor — otherwise a
+    // legitimate `recipientId`/`actorId` would fail it (or mask a real leak).
+    expect([OPERATOR_A, OPERATOR_B, CHANNEL, ACTOR]).not.toContain(WRITER_ID);
+  });
+});
+
+describe("GET /notifications — a channel operator's inbox", () => {
+  it('queries every recipient id the scope covers, not just the viewer', async () => {
+    await request(makeApp(OPERATOR_A)).get('/').expect(200);
+
+    expect(mocks.notificationFind).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientId: { $in: [OPERATOR_A, CHANNEL] } }),
+    );
+    expect(mocks.notificationCountDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientId: { $in: [OPERATOR_A, CHANNEL] }, read: false }),
+    );
+  });
+
+  it('names the channel on its rows and leaves the viewer’s own rows unmarked', async () => {
+    const response = await request(makeApp(OPERATOR_A)).get('/').expect(200);
+
+    const channelRow = response.body.notifications.find(
+      (n: { _id: string }) => n._id === String(CHANNEL_NOTIFICATION_ID),
+    );
+    const ownRow = response.body.notifications.find(
+      (n: { _id: string }) => n._id === String(OWN_NOTIFICATION_ID),
+    );
+
+    expect(channelRow.recipientId_populated).toMatchObject({
+      _id: CHANNEL,
+      username: 'techweekly',
+      name: { displayName: 'Tech Weekly' },
+    });
+    // Absence is the signal for "this one is mine" — populating it for the viewer
+    // would make every row look like a channel's.
+    expect(ownRow).not.toHaveProperty('recipientId_populated');
+  });
+
+  it('NEVER discloses who wrote the channel post', async () => {
+    const response = await request(makeApp(OPERATOR_A)).get('/').expect(200);
+
+    // Anywhere in the payload, under any key. `writtenByOxyUserId` is deliberately
+    // absent from every DTO; a notification must not be the exception.
+    expect(JSON.stringify(response.body)).not.toContain(WRITER_ID);
+  });
+
+  it('gives the writer and a non-writing operator the SAME page', async () => {
+    // The one arrangement where "every operator" and "the writer" disagree: the
+    // channel's post was written by OPERATOR_A, and OPERATOR_B wrote nothing.
+    // Keyed on `writtenByOxyUserId`, B's page would be missing the channel row —
+    // and that ABSENCE would itself tell B that A wrote it.
+    mockRawPosts(OPERATOR_A);
+
+    const asWriter = await request(makeApp(OPERATOR_A)).get('/').expect(200);
+    const asOther = await request(makeApp(OPERATOR_B)).get('/').expect(200);
+
+    const channelRowsFor = (body: { notifications: { _id: string; recipientId: string }[] }) =>
+      body.notifications.filter((n) => n.recipientId === CHANNEL).map((n) => n._id);
+
+    expect(channelRowsFor(asWriter.body)).toEqual([String(CHANNEL_NOTIFICATION_ID)]);
+    expect(channelRowsFor(asOther.body)).toEqual(channelRowsFor(asWriter.body));
+  });
+
+  it("treats the channel's post as the operator's own work for the muted-word gate", async () => {
+    // The post's owner is the CHANNEL, so `viewerState.isOwner` is false for a
+    // person — without the operated-channel check the operator's own muted word
+    // would silently delete their channel's engagement.
+    //
+    // The STRANGER's post is the control, and it is what makes this test able to
+    // fail: it carries the same muted word and must be dropped. Without it, a
+    // mute rule that never compiled (a wrong field name is enough) would look
+    // exactly like a rule the channel row correctly survived.
+    const muted: MuteWordRule[] = [
+      { value: 'kerfuffle', targets: ['content'], actorTarget: 'all' },
+    ];
+    mocks.loadMuteWords.mockResolvedValue(muted);
+    mockNotificationPage([
+      channelNotificationRow(),
+      strangerNotificationRow(),
+      personalNotificationRow(OPERATOR_A),
+    ]);
+    mocks.hydratePosts.mockResolvedValue([
+      { id: String(CHANNEL_POST_ID), content: { text: 'a kerfuffle, published here' }, user: { id: CHANNEL } },
+      { id: String(STRANGER_POST_ID), content: { text: 'a kerfuffle elsewhere' }, user: { id: STRANGER } },
+      { id: String(OWN_POST_ID), content: { text: 'my own post' }, user: { id: OPERATOR_A } },
+    ]);
+
+    const response = await request(makeApp(OPERATOR_A)).get('/').expect(200);
+    const ids = response.body.notifications.map((n: { _id: string }) => n._id);
+
+    // The rule is live: it removed the stranger's row.
+    expect(ids).not.toContain(String(STRANGER_NOTIFICATION_ID));
+    // And it did NOT remove the operator's own channel's engagement.
+    expect(ids).toContain(String(CHANNEL_NOTIFICATION_ID));
+  });
+});
+
+describe('the write surfaces honour the same scope', () => {
+  it('marks a channel notification read', async () => {
+    mocks.notificationFindOneAndUpdate.mockResolvedValue({
+      _id: CHANNEL_NOTIFICATION_ID,
+      actorId: ACTOR,
+      toObject: () => ({ _id: CHANNEL_NOTIFICATION_ID, actorId: ACTOR }),
+    });
+
+    const app = makeApp(OPERATOR_A);
+    app.set('notificationsNamespace', { to: () => ({ emit: () => undefined }) });
+
+    await request(app).patch(`/${CHANNEL_NOTIFICATION_ID}/read`).expect(200);
+
+    expect(mocks.notificationFindOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientId: { $in: [OPERATOR_A, CHANNEL] } }),
+      { read: true },
+      { new: true },
+    );
+  });
+
+  it('clears the channel rows on mark-all-read, or the badge never reaches zero', async () => {
+    mocks.notificationUpdateMany.mockResolvedValue({ modifiedCount: 1 });
+
+    const app = makeApp(OPERATOR_A);
+    app.set('notificationsNamespace', { to: () => ({ emit: () => undefined }) });
+
+    await request(app).patch('/read-all').expect(200);
+
+    expect(mocks.notificationUpdateMany).toHaveBeenCalledWith(
+      { recipientId: { $in: [OPERATOR_A, CHANNEL] } },
+      { read: true },
+    );
+  });
+
+  it('counts the channel rows in the unread badge', async () => {
+    mocks.notificationCountDocuments.mockResolvedValue(3);
+
+    const response = await request(makeApp(OPERATOR_A)).get('/unread-count').expect(200);
+
+    expect(response.body.count).toBe(3);
+    expect(mocks.notificationCountDocuments).toHaveBeenCalledWith({
+      recipientId: { $in: [OPERATOR_A, CHANNEL] },
+      read: false,
+    });
+  });
+
+  it('deletes a channel notification', async () => {
+    mocks.notificationFindOneAndDelete.mockResolvedValue({ _id: CHANNEL_NOTIFICATION_ID });
+
+    const app = makeApp(OPERATOR_A);
+    app.set('notificationsNamespace', { to: () => ({ emit: () => undefined }) });
+
+    await request(app).delete(`/${CHANNEL_NOTIFICATION_ID}`).expect(200);
+
+    expect(mocks.notificationFindOneAndDelete).toHaveBeenCalledWith({
+      _id: String(CHANNEL_NOTIFICATION_ID),
+      recipientId: { $in: [OPERATOR_A, CHANNEL] },
+    });
+  });
+
+  it('refuses a notification outside the scope', async () => {
+    // The scope IS the authorization: a stranger's id resolves to their own inbox
+    // only, so the same query finds nothing.
+    mocks.resolveNotificationInboxIds.mockImplementation(async (viewerId: string) => [viewerId]);
+    mocks.notificationFindOneAndDelete.mockResolvedValue(null);
+
+    await request(makeApp('stranger-1')).delete(`/${CHANNEL_NOTIFICATION_ID}`).expect(404);
+
+    expect(mocks.notificationFindOneAndDelete).toHaveBeenCalledWith({
+      _id: String(CHANNEL_NOTIFICATION_ID),
+      recipientId: { $in: ['stranger-1'] },
+    });
+  });
+});

--- a/packages/backend/src/__tests__/routes/notificationsPrivacy.test.ts
+++ b/packages/backend/src/__tests__/routes/notificationsPrivacy.test.ts
@@ -49,7 +49,15 @@ vi.mock('../../services/PostHydrationService', () => ({
 
 vi.mock('../../utils/oxyHelpers', () => ({
   createScopedOxyClient: mocks.createScopedOxyClient,
+  createUserScopedOxyServices: () => undefined,
   getServiceOxyClient: () => ({ getUsersByIds: mocks.getUsersByIds }),
+}));
+
+// Which recipient ids the viewer's inbox covers is `notificationInboxScope.test.ts`'s
+// subject; here it is held at "just the viewer" so these cases stay about the
+// privacy of what a notification may reveal.
+vi.mock('../../services/notificationInbox', () => ({
+  resolveNotificationInboxIds: async (viewerId: string) => [viewerId],
 }));
 
 vi.mock('../../utils/mediaResolver', () => ({

--- a/packages/backend/src/__tests__/routes/notificationsSafety.test.ts
+++ b/packages/backend/src/__tests__/routes/notificationsSafety.test.ts
@@ -40,7 +40,15 @@ vi.mock('../../services/PostHydrationService', () => ({
 
 vi.mock('../../utils/oxyHelpers', () => ({
   createScopedOxyClient: mocks.createScopedOxyClient,
+  createUserScopedOxyServices: () => undefined,
   getServiceOxyClient: () => ({ getUsersByIds: mocks.getUsersByIds }),
+}));
+
+// Which recipient ids the viewer's inbox covers is `notificationInboxScope.test.ts`'s
+// subject; here it is held at "just the viewer" so these cases stay about the
+// sensitive-content and muted-word gates.
+vi.mock('../../services/notificationInbox', () => ({
+  resolveNotificationInboxIds: async (viewerId: string) => [viewerId],
 }));
 
 vi.mock('../../utils/mediaResolver', () => ({

--- a/packages/backend/src/__tests__/services/notificationInboxScope.test.ts
+++ b/packages/backend/src/__tests__/services/notificationInboxScope.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AccountMember, AccountNode } from '@oxyhq/core';
+
+/**
+ * WHO receives a channel's notifications — `listOperatedChannelIds` and the
+ * inbox scope built on top of it.
+ *
+ * Two rules are load-bearing here, and each one has a wrong version that reads as
+ * correct. Every fixture below exists to make the right and the wrong version
+ * DISAGREE, which is the only thing that makes a green run mean anything:
+ *
+ *  1. **Every operator, and the set never depends on the post.** A channel's
+ *     notifications go to all of its active members. The forbidden alternative is
+ *     routing by `Post.writtenByOxyUserId`: the set of notifications each operator
+ *     then receives is a per-post partition that ENCODES who wrote what, which on
+ *     a two-operator channel is total. Nothing in this module is given a post at
+ *     all, and `notificationsChannelInbox.test.ts` pins the observable end of it.
+ *     Guarded here by a channel with TWO operators — a suite where every channel
+ *     has one operator cannot tell "all of them" from "the first one".
+ *
+ *  2. **Channels only.** An organization / project / bot CAN be acted as, and that
+ *     switch is gated on `account:act_as` — which a `viewer` or `billing` member
+ *     does not hold. Expanding those kinds into a member's personal inbox would
+ *     hand out exactly the view the switch refuses. The fixture that makes this
+ *     testable is an organization whose membership DOES carry `account:act_as`:
+ *     it is the one shape where "filter to channel" and "any account I may act
+ *     for" answer differently. Without it, deleting the kind filter passes.
+ *
+ * The membership shapes are chosen the same way. A channel membership deliberately
+ * WITHOUT `account:act_as` distinguishes the real predicate from "everything needs
+ * act_as"; an `invited` membership (a truthy, non-`active` status) distinguishes
+ * `status === 'active'` from `Boolean(status)`.
+ */
+
+const mocks = vi.hoisted(() => ({
+  redisGet: vi.fn(),
+  redisSetEx: vi.fn(),
+  isReady: true,
+}));
+
+vi.mock('../../utils/redis', () => ({
+  getRedisClient: () => ({
+    get isReady() {
+      return mocks.isReady;
+    },
+    get: mocks.redisGet,
+    setEx: mocks.redisSetEx,
+  }),
+}));
+
+// `resolveUserSummaries` is the Redis/Oxy identity path pulled in transitively by
+// `publishAsAccount`; nothing in this suite resolves an account kind through it
+// (the kind arrives on the `AccountNode`).
+vi.mock('../../services/PostHydrationService', () => ({
+  resolveUserSummaries: vi.fn(async () => new Map()),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  listOperatedChannelIds,
+  membershipAuthorizesActingFor,
+  type OperatedAccountReader,
+} from '../../services/publishAsAccount';
+import { resolveNotificationInboxIds } from '../../services/notificationInbox';
+
+const VIEWER = 'viewer-1';
+const OTHER_OPERATOR = 'operator-2';
+
+const CHANNEL_ONE = 'channel-one';
+const CHANNEL_TWO = 'channel-two';
+const CHANNEL_INVITED = 'channel-invited';
+const CHANNEL_REMOVED = 'channel-removed';
+const CHANNEL_UNMEMBERED = 'channel-unmembered';
+const ORGANIZATION = 'org-1';
+
+/** The permission sets Oxy derives from its roles, as they arrive on the wire. */
+const OWNER_PERMISSIONS = ['account:read', 'account:update', 'account:act_as', 'members:read'];
+/** `viewer` — a real, active member who deliberately may NOT act as the account. */
+const VIEWER_PERMISSIONS = ['account:read', 'members:read', 'children:read'];
+
+function membership(overrides: Partial<AccountMember> = {}): AccountMember {
+  return {
+    _id: 'member-row',
+    accountId: 'account-1',
+    memberUserId: VIEWER,
+    role: 'viewer',
+    permissions: VIEWER_PERMISSIONS,
+    inherit: true,
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function node(
+  accountId: string,
+  kind: AccountNode['kind'],
+  callerMembership: AccountMember | null,
+): AccountNode {
+  return {
+    accountId,
+    kind,
+    parentAccountId: null,
+    // The Oxy user behind the account. Only `accountId`/`kind`/`callerMembership`
+    // are read here; the DTO is filled in enough to be a real node.
+    account: { id: accountId, username: accountId, name: { displayName: accountId } } as AccountNode['account'],
+    relationship: callerMembership ? 'member' : 'self',
+    callerMembership,
+  };
+}
+
+/**
+ * The forest as Oxy answers it for VIEWER. Every entry is a distinct reason to be
+ * included or excluded — see the suite docstring; `fixtureShape` below asserts the
+ * composition so a future edit cannot quietly make this vacuous.
+ */
+function forest(): AccountNode[] {
+  return [
+    // The viewer's own personal account: no membership row, ownership implicit.
+    node(VIEWER, 'personal', null),
+    // INCLUDED — active member, and pointedly WITHOUT `account:act_as`.
+    node(CHANNEL_ONE, 'channel', membership({ accountId: CHANNEL_ONE })),
+    // INCLUDED — a SECOND channel, so "all of them" ≠ "the first one".
+    node(CHANNEL_TWO, 'channel', membership({ accountId: CHANNEL_TWO, role: 'owner', permissions: OWNER_PERMISSIONS })),
+    // EXCLUDED — an act-as-eligible kind whose membership DOES carry act_as.
+    node(ORGANIZATION, 'organization', membership({ accountId: ORGANIZATION, role: 'owner', permissions: OWNER_PERMISSIONS })),
+    // EXCLUDED — a channel whose membership was never accepted.
+    node(CHANNEL_INVITED, 'channel', membership({ accountId: CHANNEL_INVITED, status: 'invited' })),
+    // EXCLUDED — a channel this person was removed from.
+    node(CHANNEL_REMOVED, 'channel', membership({ accountId: CHANNEL_REMOVED, status: 'removed' })),
+    // EXCLUDED — a channel with no membership row at all.
+    node(CHANNEL_UNMEMBERED, 'channel', null),
+  ];
+}
+
+function readerReturning(accounts: AccountNode[]): OperatedAccountReader & { calls: number } {
+  const reader = {
+    calls: 0,
+    async listAccounts() {
+      reader.calls += 1;
+      return accounts;
+    },
+  };
+  return reader;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isReady = true;
+  mocks.redisGet.mockResolvedValue(null);
+  mocks.redisSetEx.mockResolvedValue('OK');
+});
+
+describe('fixture shape (vacuity floor)', () => {
+  it('exercises every distinction the rules draw', () => {
+    const accounts = forest();
+    const channels = accounts.filter((a) => a.kind === 'channel');
+    const activeChannels = channels.filter((a) => a.callerMembership?.status === 'active');
+
+    // Rule 1 needs more than one channel to be distinguishable from "the first".
+    expect(activeChannels.length).toBeGreaterThanOrEqual(2);
+    // Rule 2 needs an act-as-eligible account the caller genuinely may act for —
+    // the only shape where the kind filter changes the answer.
+    expect(
+      accounts.some(
+        (a) =>
+          a.kind !== 'channel' &&
+          a.callerMembership?.status === 'active' &&
+          a.callerMembership.permissions.includes('account:act_as'),
+      ),
+    ).toBe(true);
+    // A channel membership WITHOUT act_as, or the channel branch reads as
+    // "everything needs act_as" and still passes.
+    expect(
+      activeChannels.some((a) => !a.callerMembership?.permissions.includes('account:act_as')),
+    ).toBe(true);
+    // A truthy, non-`active` status, or `=== 'active'` and `Boolean(status)` agree.
+    expect(channels.some((a) => a.callerMembership?.status === 'invited')).toBe(true);
+  });
+});
+
+describe('membershipAuthorizesActingFor', () => {
+  it('accepts any ACTIVE member of a channel, with or without act_as', () => {
+    expect(membershipAuthorizesActingFor('channel', membership())).toBe(true);
+    expect(
+      membershipAuthorizesActingFor('channel', membership({ permissions: OWNER_PERMISSIONS })),
+    ).toBe(true);
+  });
+
+  it('demands act_as for an account that CAN be acted as', () => {
+    expect(membershipAuthorizesActingFor('organization', membership())).toBe(false);
+    expect(
+      membershipAuthorizesActingFor('organization', membership({ permissions: OWNER_PERMISSIONS })),
+    ).toBe(true);
+    expect(membershipAuthorizesActingFor('bot', membership({ permissions: OWNER_PERMISSIONS }))).toBe(true);
+  });
+
+  it('refuses a membership that is not active, whatever the kind', () => {
+    expect(membershipAuthorizesActingFor('channel', membership({ status: 'invited' }))).toBe(false);
+    expect(membershipAuthorizesActingFor('channel', membership({ status: 'removed' }))).toBe(false);
+    expect(
+      membershipAuthorizesActingFor('organization', membership({ status: 'invited', permissions: OWNER_PERMISSIONS })),
+    ).toBe(false);
+  });
+
+  it('refuses a missing membership and a kind neither family covers', () => {
+    expect(membershipAuthorizesActingFor('channel', null)).toBe(false);
+    expect(membershipAuthorizesActingFor('channel', undefined)).toBe(false);
+    expect(membershipAuthorizesActingFor('personal', membership({ permissions: OWNER_PERMISSIONS }))).toBe(false);
+    expect(membershipAuthorizesActingFor(null, membership({ permissions: OWNER_PERMISSIONS }))).toBe(false);
+  });
+});
+
+describe('listOperatedChannelIds', () => {
+  it('returns EVERY channel the caller actively operates, and nothing else', async () => {
+    const ids = await listOperatedChannelIds(readerReturning(forest()));
+
+    // As a set AND by length: an implementation that returns only the first, or
+    // that also returns the organization, fails on one of the two.
+    expect([...ids].sort()).toEqual([CHANNEL_ONE, CHANNEL_TWO].sort());
+    expect(ids).toHaveLength(2);
+  });
+
+  it('excludes an organization the caller may act as', async () => {
+    const ids = await listOperatedChannelIds(readerReturning(forest()));
+    expect(ids).not.toContain(ORGANIZATION);
+  });
+
+  it('excludes invited, removed and unmembered channels', async () => {
+    const ids = await listOperatedChannelIds(readerReturning(forest()));
+    expect(ids).not.toContain(CHANNEL_INVITED);
+    expect(ids).not.toContain(CHANNEL_REMOVED);
+    expect(ids).not.toContain(CHANNEL_UNMEMBERED);
+  });
+
+  it("never returns the caller's own personal account", async () => {
+    const ids = await listOperatedChannelIds(readerReturning(forest()));
+    expect(ids).not.toContain(VIEWER);
+  });
+
+  it('gives the SAME answer to a second operator of the same channel', async () => {
+    // Rule 1, from the other side: the set is a property of the channel, so two
+    // people who both operate it resolve it identically. Nothing distinguishes
+    // them — no post, no writer, no order.
+    const forOther = [
+      node(OTHER_OPERATOR, 'personal', null),
+      node(CHANNEL_ONE, 'channel', membership({ accountId: CHANNEL_ONE, memberUserId: OTHER_OPERATOR })),
+      node(CHANNEL_TWO, 'channel', membership({ accountId: CHANNEL_TWO, memberUserId: OTHER_OPERATOR })),
+    ];
+
+    const mine = await listOperatedChannelIds(readerReturning(forest()));
+    const theirs = await listOperatedChannelIds(readerReturning(forOther));
+
+    expect([...theirs].sort()).toEqual([...mine].sort());
+  });
+
+  it('fails soft to nothing when there is no reader (a service-credential caller)', async () => {
+    await expect(listOperatedChannelIds(undefined)).resolves.toEqual([]);
+  });
+
+  it('fails soft to nothing when Oxy cannot answer', async () => {
+    const reader: OperatedAccountReader = {
+      async listAccounts() {
+        throw new Error('oxy unavailable');
+      },
+    };
+    // Never throws: this sits under every notification read, and the direction
+    // that matters is that an outage can only ever REMOVE access.
+    await expect(listOperatedChannelIds(reader)).resolves.toEqual([]);
+  });
+});
+
+describe('resolveNotificationInboxIds', () => {
+  it('always leads with the viewer, then the channels they operate', async () => {
+    const ids = await resolveNotificationInboxIds(VIEWER, readerReturning(forest()));
+
+    expect(ids[0]).toBe(VIEWER);
+    expect([...ids].sort()).toEqual([VIEWER, CHANNEL_ONE, CHANNEL_TWO].sort());
+  });
+
+  it("still returns the viewer's own inbox when Oxy is unavailable", async () => {
+    const reader: OperatedAccountReader = {
+      async listAccounts() {
+        throw new Error('oxy unavailable');
+      },
+    };
+    await expect(resolveNotificationInboxIds(VIEWER, reader)).resolves.toEqual([VIEWER]);
+  });
+
+  it("still returns the viewer's own inbox when Redis is down", async () => {
+    mocks.isReady = false;
+    await expect(resolveNotificationInboxIds(VIEWER, undefined)).resolves.toEqual([VIEWER]);
+  });
+
+  it('serves a warm cache without asking Oxy again', async () => {
+    mocks.redisGet.mockResolvedValue(JSON.stringify([CHANNEL_ONE, CHANNEL_TWO]));
+    const reader = readerReturning(forest());
+
+    const ids = await resolveNotificationInboxIds(VIEWER, reader);
+
+    expect([...ids].sort()).toEqual([VIEWER, CHANNEL_ONE, CHANNEL_TWO].sort());
+    expect(reader.calls).toBe(0);
+  });
+
+  it('writes the resolved set back with the configured TTL', async () => {
+    await resolveNotificationInboxIds(VIEWER, readerReturning(forest()));
+
+    expect(mocks.redisSetEx).toHaveBeenCalledWith(
+      `notifinbox:v1:${VIEWER}`,
+      expect.any(Number),
+      JSON.stringify([CHANNEL_ONE, CHANNEL_TWO]),
+    );
+  });
+
+  it('re-resolves rather than trusting a corrupt cache entry', async () => {
+    mocks.redisGet.mockResolvedValue('{not json');
+    const reader = readerReturning(forest());
+
+    const ids = await resolveNotificationInboxIds(VIEWER, reader);
+
+    expect(reader.calls).toBe(1);
+    expect([...ids].sort()).toEqual([VIEWER, CHANNEL_ONE, CHANNEL_TWO].sort());
+  });
+
+  it('re-resolves rather than trusting a cache entry of the wrong shape', async () => {
+    // A stale entry from a different value schema must not become a recipient id.
+    mocks.redisGet.mockResolvedValue(JSON.stringify([{ accountId: CHANNEL_ONE }]));
+    const reader = readerReturning(forest());
+
+    const ids = await resolveNotificationInboxIds(VIEWER, reader);
+
+    expect(reader.calls).toBe(1);
+    expect(ids.every((id) => typeof id === 'string')).toBe(true);
+  });
+});

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -255,6 +255,11 @@ const environmentSchema = z
     FEDIVERSE_SHARING_CACHE_TTL_SECONDS: integerFromEnv(600, { minimum: 1 }),
     VIEWER_RECENT_TOPICS_TTL_SECONDS: integerFromEnv(6 * 60 * 60, { minimum: 1 }),
     USER_SUMMARY_CACHE_TTL_SECONDS: integerFromEnv(10 * 60, { minimum: 1 }),
+    // Deliberately the shortest cache TTL here: it holds an AUTHORIZATION answer
+    // (which channels' inboxes a person may read), and its staleness window is
+    // exactly how long a removed operator keeps reading. See
+    // `services/notificationInbox.ts`.
+    NOTIFICATION_INBOX_CACHE_TTL_SECONDS: integerFromEnv(60, { minimum: 1 }),
     DWELL_AGGREGATE_TTL_SECONDS: integerFromEnv(7 * 24 * 60 * 60, { minimum: 1 }),
     SYRA_PODCAST_CACHE_TTL_SECONDS: integerFromEnv(300, { minimum: 1 }),
 
@@ -753,6 +758,7 @@ export const config = {
     fediverseSharingTtlSeconds: environment.FEDIVERSE_SHARING_CACHE_TTL_SECONDS,
     viewerRecentTopicsTtlSeconds: environment.VIEWER_RECENT_TOPICS_TTL_SECONDS,
     userSummaryTtlSeconds: environment.USER_SUMMARY_CACHE_TTL_SECONDS,
+    notificationInboxTtlSeconds: environment.NOTIFICATION_INBOX_CACHE_TTL_SECONDS,
     dwellAggregateTtlSeconds: environment.DWELL_AGGREGATE_TTL_SECONDS,
     syraPodcastTtlSeconds: environment.SYRA_PODCAST_CACHE_TTL_SECONDS,
     l1MaxEntries: 1_000,

--- a/packages/backend/src/routes/notifications.ts
+++ b/packages/backend/src/routes/notifications.ts
@@ -8,7 +8,12 @@ import PushToken from '../models/PushToken';
 import { sendPushToUser } from '../utils/push';
 import { logger } from '../utils/logger';
 import { postHydrationService } from '../services/PostHydrationService';
-import { createScopedOxyClient, getServiceOxyClient } from '../utils/oxyHelpers';
+import {
+  createScopedOxyClient,
+  createUserScopedOxyServices,
+  getServiceOxyClient,
+} from '../utils/oxyHelpers';
+import { resolveNotificationInboxIds } from '../services/notificationInbox';
 import { queryInt, queryString } from '../utils/queryParams';
 import { apiRateLimiter } from '../middleware/rateLimiter';
 import type { HydratedPost } from '@mention/shared-types';
@@ -52,6 +57,20 @@ const SYSTEM_ACTOR: ActorProfile = {
 };
 
 /**
+ * Every `recipientId` this request's viewer may read — themselves, plus any
+ * CHANNEL they operate (a channel has no session of its own, so its inbox is
+ * only reachable this way). See `services/notificationInbox`.
+ *
+ * EVERY recipient-scoped query in this file goes through here. A handler that
+ * filters on `recipientId: userId` directly is not a smaller version of this —
+ * it is a channel notification the operator can see in the list and then cannot
+ * mark read, delete, or have counted in the badge.
+ */
+async function inboxRecipientIds(req: AuthRequest, userId: string): Promise<string[]> {
+  return resolveNotificationInboxIds(userId, createUserScopedOxyServices(req));
+}
+
+/**
  * Lean shape of a Notification as read in the GET handler. `entityId` is the raw
  * reference id (never populated — the post rows are batch-fetched by `$in`
  * below); `string` covers legacy/defensive reads.
@@ -77,7 +96,13 @@ router.get("/", async (req: AuthRequest, res: Response) => {
     const limit = Math.min(Math.max(queryInt(req.query.limit) || DEFAULT_NOTIFICATIONS_PAGE_SIZE, 1), MAX_NOTIFICATIONS_PAGE_SIZE);
 
     // Build query with cursor support
-    const query: { recipientId: string; _id?: { $lt: mongoose.Types.ObjectId } } = { recipientId: userId };
+    const recipientIds = await inboxRecipientIds(req, userId);
+    /** The channels among them — everything in the scope that is not the viewer. */
+    const operatedChannelIds = new Set(recipientIds.filter((id) => id !== userId));
+    const query: {
+      recipientId: { $in: string[] };
+      _id?: { $lt: mongoose.Types.ObjectId };
+    } = { recipientId: { $in: recipientIds } };
     if (cursor) {
       // Validate cursor is a valid ObjectId
       if (!mongoose.Types.ObjectId.isValid(cursor)) {
@@ -104,7 +129,7 @@ router.get("/", async (req: AuthRequest, res: Response) => {
         .limit(limit + 1)
         .lean<LeanNotification[]>(),
       Notification.countDocuments({
-        recipientId: userId,
+        recipientId: { $in: recipientIds },
         read: false
       }),
       loadShowSensitiveContent(userId),
@@ -126,16 +151,28 @@ router.get("/", async (req: AuthRequest, res: Response) => {
       notificationsRaw.map((n) => n.actorId).filter(Boolean)
     ));
 
+    // Channels named as the RECIPIENT of a row on this page. A notification the
+    // viewer received because they operate a channel says "liked your post" about
+    // a post the viewer very likely did not write, so the row has to name whose
+    // inbox it arrived in or it is simply wrong on its face. Resolving the
+    // channel's public profile costs nothing extra — it joins the actor batch
+    // below, and a channel is usually also the actor's target anyway.
+    const channelRecipientIds = Array.from(new Set(
+      notificationsRaw.map((n) => n.recipientId).filter((id) => Boolean(id) && id !== userId),
+    ));
+
     const profilesMap = new Map<string, ActorProfile>();
     if (uniqueActorIds.includes('system')) {
       profilesMap.set('system', SYSTEM_ACTOR);
     }
     // Single bulk fetch for all real actors (chunked/deduped by the SDK) instead
     // of one getUserById HTTP request per actor.
-    const realActorIds = uniqueActorIds.filter((id) => id !== 'system');
-    if (realActorIds.length > 0) {
+    const profileIdsToResolve = Array.from(new Set(
+      [...uniqueActorIds, ...channelRecipientIds].filter((id) => id !== 'system'),
+    ));
+    if (profileIdsToResolve.length > 0) {
       try {
-        const profiles = await getServiceOxyClient().getUsersByIds(realActorIds);
+        const profiles = await getServiceOxyClient().getUsersByIds(profileIdsToResolve);
         for (const profile of profiles) {
           if (profile?.id) profilesMap.set(profile.id, profile);
         }
@@ -202,7 +239,16 @@ router.get("/", async (req: AuthRequest, res: Response) => {
         // to a post the viewer wrote: a sensitive post is no surprise to its own author,
         // and hiding "someone liked your post" because the post uses a word THEY muted
         // would silently drop real engagement on their own work.
-        const isOwnPost = post.viewerState?.isOwner === true || post.viewerState?.isCollaborator === true;
+        //
+        // A post authored by a channel the viewer OPERATES is their own work by the
+        // same argument — `viewerState.isOwner` cannot see it, because the owner of
+        // that post is the channel account and the viewer is a person. Without this
+        // an operator's own muted word silently deletes their channel's engagement,
+        // which is the exact failure the paragraph above exists to prevent.
+        const isOwnPost =
+          post.viewerState?.isOwner === true ||
+          post.viewerState?.isCollaborator === true ||
+          (post.user?.id !== undefined && operatedChannelIds.has(post.user.id));
 
         if (!isOwnPost && compiledMuteWords && isMutedSubject(
           compiledMuteWords,
@@ -257,6 +303,17 @@ router.get("/", async (req: AuthRequest, res: Response) => {
           preview,
           post: embeddedPost,
           actorId_populated: toPopulatedActor(actor, n.actorId),
+          // Present ONLY when the row was addressed somewhere other than the
+          // viewer — i.e. to a channel they operate. Its absence is what the
+          // client reads as "this one is mine", so it must never be populated
+          // for the viewer's own rows. It carries the channel's PUBLIC profile
+          // and nothing else: who WROTE the post behind it stays server-side
+          // (`UserSettings.channel.signPosts` is the only thing that discloses a
+          // writer, and it does so on the post, not here).
+          recipientId_populated:
+            n.recipientId === userId
+              ? undefined
+              : toPopulatedActor(profilesMap.get(n.recipientId), n.recipientId),
         };
       });
 
@@ -329,7 +386,7 @@ const markAsReadHandler = async (req: AuthRequest, res: Response) => {
     }
 
     const notification = await Notification.findOneAndUpdate(
-      { _id: req.params.id, recipientId: userId },
+      { _id: req.params.id, recipientId: { $in: await inboxRecipientIds(req, userId) } },
       { read: true },
       { new: true }
     );
@@ -361,8 +418,12 @@ const markAllAsReadHandler = async (req: AuthRequest, res: Response) => {
       return res.status(401).json({ message: "Unauthorized" });
     }
 
+    // Clears the CHANNEL rows too. A channel's inbox is shared by its operators
+    // (one row per event, not one per operator), so this is deliberately a shared
+    // action: leaving them out would leave the badge permanently non-zero with no
+    // control that clears it.
     await Notification.updateMany(
-      { recipientId: userId },
+      { recipientId: { $in: await inboxRecipientIds(req, userId) } },
       { read: true }
     );
 
@@ -383,7 +444,10 @@ router.get('/unread-count', async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ message: 'Unauthorized' });
-    const count = await Notification.countDocuments({ recipientId: userId, read: false });
+    const count = await Notification.countDocuments({
+      recipientId: { $in: await inboxRecipientIds(req, userId) },
+      read: false,
+    });
     res.json({ count });
   } catch (error) {
     res.status(500).json({ message: 'Error fetching unread count' });
@@ -398,7 +462,7 @@ router.patch('/:id/archive', async (req: AuthRequest, res: Response) => {
 
     // If we had an archived flag, we'd set it here. For now, mark as read.
     const notification = await Notification.findOneAndUpdate(
-      { _id: req.params.id, recipientId: userId },
+      { _id: req.params.id, recipientId: { $in: await inboxRecipientIds(req, userId) } },
       { read: true },
       { new: true }
     );
@@ -426,7 +490,7 @@ router.delete("/:id", async (req: AuthRequest, res: Response) => {
 
     const notification = await Notification.findOneAndDelete({
       _id: req.params.id,
-      recipientId: userId
+      recipientId: { $in: await inboxRecipientIds(req, userId) }
     });
 
     if (!notification) {

--- a/packages/backend/src/services/notificationInbox.ts
+++ b/packages/backend/src/services/notificationInbox.ts
@@ -1,0 +1,161 @@
+/**
+ * Which `Notification.recipientId` values a signed-in person may read.
+ *
+ * For almost everybody the answer is "just their own id" and this module costs
+ * one Redis GET. It exists for the one case where the answer is bigger: a
+ * CHANNEL.
+ *
+ * THE PROBLEM IT SOLVES. A channel is an Oxy account (`kind: 'channel'`) that
+ * authors its own posts, so every engagement notification for a channel post is
+ * addressed to the channel — `createPostAuthorNotifications` derives the
+ * recipient from `post.authorship`, whose owner IS the channel. But
+ * `isActAsEligibleKind` refuses `channel`, so no session can ever be minted whose
+ * subject is a channel, and `GET /notifications` filters on `req.user.id`. Those
+ * rows were therefore written, indexed, TTL-reaped 90 days later, and read by
+ * nobody. This module is the read-side expansion that makes them reachable.
+ *
+ * WHY THE EXPANSION HAPPENS AT READ TIME, AND NOT AS A WRITE-TIME FAN-OUT. Four
+ * properties fall out of it, and each one is a bug avoided rather than a
+ * preference:
+ *
+ *  1. **Authorization is never stale by more than this cache's TTL.** The
+ *     recipient set is recomputed from the READER's own bearer at the moment
+ *     they read. A fan-out would have to pick recipients when the event
+ *     happened, from a roster captured earlier still — and a person removed from
+ *     the channel in between would keep receiving its inbox with no mechanism
+ *     that ever notices.
+ *  2. **The write path is untouched, so it cannot be broken.** No new stage runs
+ *     while a post/like/boost is being committed; there is nothing new to fail,
+ *     and nothing to make fail softly.
+ *  3. **No double-notify race.** `Notification` is unique on
+ *     `{recipientId, actorId, type, entityId}` and `createNotification` is
+ *     check-then-act, so two concurrent stages writing the same tuple is a real
+ *     collision. Adding no stage adds no racer.
+ *  4. **One row per event, not one per operator.** A channel with ten operators
+ *     writes exactly what a person does.
+ *
+ * WHO RECEIVES, AND WHY IT IS NEVER THE WRITER. Every operator of the channel
+ * receives every one of its notifications — the recipient set is a function of
+ * the CHANNEL alone and never of the post. That is not a convenience: routing by
+ * `Post.writtenByOxyUserId` would make the set of notifications each operator
+ * receives a per-post partition that ENCODES authorship. On a two-operator
+ * channel it is total — every post you were not notified about was written by
+ * the other person — and `UserSettings.channel.signPosts` exists precisely to
+ * make that disclosure a deliberate server-side decision. Nothing here reads
+ * `writtenByOxyUserId`, and nothing here should.
+ *
+ * WHY MEMBERSHIP IS THE WHOLE RIGHT. A channel cannot be acted as, so there is
+ * no stronger permission to ask for — `services/publishAsAccount` says the same
+ * thing about publishing, and answers both questions through one shared
+ * predicate so they cannot drift apart. The people who may speak as the channel
+ * are the people who hear what is said back to it.
+ */
+
+import { config } from '../config';
+import { getRedisClient } from '../utils/redis';
+import { withRedisFallback } from '../utils/redisHelpers';
+import { logger } from '../utils/logger';
+import { listOperatedChannelIds, type OperatedAccountReader } from './publishAsAccount';
+
+/**
+ * Redis key prefix for a viewer's operated-channel set. Versioned so a change to
+ * the stored VALUE shape can never be read back through the old assumptions.
+ */
+const INBOX_PREFIX = 'notifinbox:v1:';
+
+/**
+ * How long a resolved operated-channel set is trusted.
+ *
+ * This is an AUTHORIZATION answer, so the TTL is not a performance knob — it is
+ * the exact window during which somebody removed from a channel in Oxy keeps
+ * reading its notifications. Sixty seconds is the shortest value that still
+ * collapses the burst of calls a single screen makes (the list and the badge are
+ * separate endpoints, and both refetch on reconnect), and it is deliberately the
+ * shortest TTL in `config.cache`.
+ */
+const INBOX_TTL_SECONDS = config.cache.notificationInboxTtlSeconds;
+
+function keyFor(viewerId: string): string {
+  return `${INBOX_PREFIX}${viewerId}`;
+}
+
+/**
+ * The channel ids this viewer operates, cached.
+ *
+ * The cache stores ONLY the channel ids, never the finished recipient list — the
+ * viewer's own id is re-prepended by {@link resolveNotificationInboxIds} on every
+ * call, so no cache miss, corrupt entry, or Redis outage can cost somebody the
+ * notifications addressed to them personally.
+ *
+ * A cache MISS resolves from Oxy; a resolve failure yields `[]` (see
+ * {@link listOperatedChannelIds} on why fail-soft is the safe direction) and is
+ * NOT written to the cache — an outage must not be pinned in for a TTL.
+ */
+async function loadOperatedChannelIds(
+  viewerId: string,
+  reader: OperatedAccountReader | undefined,
+): Promise<string[]> {
+  const redis = getRedisClient();
+  const cached = await withRedisFallback(
+    redis,
+    async () => redis.get(keyFor(viewerId)),
+    null,
+    'notificationInboxGet',
+  );
+
+  if (typeof cached === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(cached);
+      if (Array.isArray(parsed) && parsed.every((id): id is string => typeof id === 'string')) {
+        return parsed;
+      }
+    } catch {
+      // A corrupt entry is a miss: fall through and re-resolve. Never throw —
+      // this sits under every notification read.
+    }
+  }
+
+  const resolved = await listOperatedChannelIds(reader);
+
+  // `listOperatedChannelIds` fails soft to `[]`, which is indistinguishable here
+  // from "operates no channels". Caching it either way is correct: an empty set
+  // is the common truth, and a transient outage costs at most one TTL of the
+  // channel rows — never access the reader should not have.
+  await withRedisFallback(
+    redis,
+    async () => {
+      await redis.setEx(keyFor(viewerId), INBOX_TTL_SECONDS, JSON.stringify(resolved));
+    },
+    undefined,
+    'notificationInboxSet',
+  ).catch((error: unknown) => {
+    logger.debug('[NotificationInbox] cache store failed', {
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+  });
+
+  return resolved;
+}
+
+/**
+ * Every `recipientId` this viewer's notification inbox covers: themselves, plus
+ * each channel they operate.
+ *
+ * The viewer's own id is ALWAYS first and always present — an Oxy outage, a cold
+ * Redis, or a caller with no bearer degrades a channel operator to exactly the
+ * inbox they had before any of this existed, and degrades nobody else at all.
+ *
+ * Use the returned array with `recipientId: { $in: ... }`. Callers must not
+ * re-derive it or add ids of their own: this is the only place that decides what
+ * a person may read.
+ */
+export async function resolveNotificationInboxIds(
+  viewerId: string,
+  reader: OperatedAccountReader | undefined,
+): Promise<string[]> {
+  const channelIds = await loadOperatedChannelIds(viewerId, reader);
+  // De-duplicated against the viewer defensively: an id can never be both a
+  // person's own account and a channel they operate, but `$in` with a repeat
+  // would be a silently odd query to debug.
+  return [viewerId, ...channelIds.filter((id) => id !== viewerId)];
+}

--- a/packages/backend/src/services/publishAsAccount.ts
+++ b/packages/backend/src/services/publishAsAccount.ts
@@ -47,7 +47,7 @@
 
 import type { AccountKind } from '@oxyhq/contracts';
 import { isActAsEligibleKind } from '@oxyhq/contracts';
-import type { AccountMember } from '@oxyhq/core';
+import type { AccountMember, AccountNode } from '@oxyhq/core';
 import { resolveUserSummaries } from './PostHydrationService';
 import { logger } from '../utils/logger';
 
@@ -82,6 +82,107 @@ export class PublishAsAccessError extends Error {
  */
 export interface AccountMemberReader {
   listAccountMembers(accountId: string): Promise<AccountMember[]>;
+}
+
+/**
+ * The INVERSE read: every account this caller can reach, rather than one named
+ * account's members. Separate interface for the same reason as
+ * {@link AccountMemberReader} — a caller hands over a client that can enumerate
+ * its own forest and nothing more is implied.
+ *
+ * Also authorized against the caller's OWN bearer: `GET /accounts` is anchored on
+ * the authenticated operator, so a service credential cannot ask it "which
+ * accounts does person X operate" at all. That is the whole reason the notifying
+ * side of a channel is resolved at READ time (see {@link listOperatedChannelIds}).
+ */
+export interface OperatedAccountReader {
+  listAccounts(): Promise<AccountNode[]>;
+}
+
+/**
+ * Whether an ACTIVE membership row authorises its holder to act FOR an account of
+ * this kind — the one predicate behind both questions this module answers
+ * ("may this person publish as that account", "which accounts does this person
+ * operate"), so the two can never drift into disagreeing about the same person.
+ *
+ * The two families are graded differently, and the module docstring says why:
+ * membership alone is the whole right over a `channel` (nothing stronger exists,
+ * since a channel can never be acted as), while an act-as-eligible account
+ * additionally demands `account:act_as` — the same permission
+ * `POST /accounts/:id/switch` gates on.
+ *
+ * Every "no" is a refusal rather than an assumption: a missing row, a membership
+ * that is `invited`/`removed` rather than `active`, a kind that is neither family,
+ * and an absent or malformed `permissions` array all answer `false`.
+ */
+export function membershipAuthorizesActingFor(
+  kind: AccountKind | null | undefined,
+  membership: AccountMember | null | undefined,
+): boolean {
+  if (!membership || membership.status !== 'active') return false;
+  if (kind === 'channel') return true;
+  if (!isActAsEligibleKind(kind)) return false;
+  return (
+    Array.isArray(membership.permissions) &&
+    membership.permissions.includes(ACCOUNT_ACT_AS_PERMISSION)
+  );
+}
+
+/**
+ * The CHANNEL accounts this caller operates — the recipient set for a channel's
+ * notifications (`services/notificationInbox`).
+ *
+ * WHY THIS EXISTS AS THE INVERSE OF THE GATE ABOVE. A channel has no session
+ * (`isActAsEligibleKind` refuses it), so a notification addressed to one is
+ * addressed to a mailbox nobody can open. The humans who can act on it are its
+ * members — but nothing server-side can ask Oxy "who are the members of channel
+ * C": `GET /accounts/:id/members` is authorized against the CALLER, and the
+ * notification fan-out has no caller. `GET /accounts` inverts exactly that
+ * limitation: asked with a reader's own bearer it returns the accounts THEY
+ * reach, each carrying `callerMembership` — the authorization answer and the
+ * account list in one call, with no second membership read.
+ *
+ * **Filtered to `channel` deliberately, not to "every account I operate".** An
+ * organization / project / bot CAN be acted as, so its members reach its
+ * notifications by switching into it — and that switch is gated on
+ * `account:act_as`, which a `viewer` or `billing` member does not hold. Widening
+ * this to those kinds would hand exactly that refused view to exactly those
+ * members, through a door the switch keeps shut.
+ *
+ * Where this set can differ from what {@link assertCanPublishAsAccount} would
+ * allow: that gate reads `GET /accounts/:id/members`, which returns DIRECT rows
+ * only, so a membership CASCADING from an ancestor account is invisible to it
+ * (a known gap, documented in AGENTS.md). `callerMembership` here is Oxy's
+ * resolved EFFECTIVE access and includes an inherited row. The divergence is
+ * deliberate: an inherited member is a member by Oxy's own resolution, and
+ * copying the gate's gap into a second place would leave this resolver behind on
+ * the day the gap closes.
+ *
+ * Fail-soft to `[]`. The caller ({@link resolveNotificationInboxIds}) still reads
+ * its own notifications, so an Oxy outage degrades a channel operator to the
+ * inbox they had before this existed rather than 500-ing the notifications
+ * screen — and it can never ADD a recipient, which is the direction that would
+ * matter.
+ */
+export async function listOperatedChannelIds(
+  reader: OperatedAccountReader | undefined,
+): Promise<string[]> {
+  if (!reader) return [];
+  let accounts: AccountNode[];
+  try {
+    accounts = await reader.listAccounts();
+  } catch (error) {
+    logger.warn('[publishAsAccount] Failed to list operated accounts', error);
+    return [];
+  }
+  return accounts
+    .filter(
+      (node) =>
+        node.kind === 'channel' &&
+        membershipAuthorizesActingFor(node.kind, node.callerMembership),
+    )
+    .map((node) => node.accountId)
+    .filter((accountId): accountId is string => Boolean(accountId));
 }
 
 /**
@@ -275,10 +376,11 @@ export async function assertCanPublishAsAccount(params: {
   // `membership.role` — a role list here would be a second copy of Oxy's
   // role→permission map, and the copy is what goes stale. An absent or malformed
   // `permissions` array is therefore a refusal, not an assumption.
-  if (
-    requiresActAs &&
-    !(Array.isArray(membership.permissions) && membership.permissions.includes(ACCOUNT_ACT_AS_PERMISSION))
-  ) {
+  //
+  // Answered by the SHARED predicate rather than inline, so this gate and
+  // `listOperatedChannelIds` cannot come to different conclusions about the same
+  // person and the same account.
+  if (!membershipAuthorizesActingFor(authorKind, membership)) {
     throw new PublishAsAccessError(403, 'You cannot publish as that account');
   }
 

--- a/packages/frontend/components/notifications/NotificationItem.tsx
+++ b/packages/frontend/components/notifications/NotificationItem.tsx
@@ -418,6 +418,27 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
   const timeLabel = formatRelativeTimeLocalized(item.createdAt, t);
   const actionText = descriptor.actionPhrase(t);
 
+  // The CHANNEL whose inbox this arrived in, when it is not the viewer's own.
+  // A channel has no session, so its operators read it through theirs — and the
+  // action phrases are written in the first person ("liked your post"), which is
+  // only true of a channel row once the row says whose it is.
+  //
+  // It names the channel and nothing more. Which operator WROTE the post behind
+  // it is not on this payload by design, so no arrangement of this line can
+  // disclose it.
+  const channelLabel = useMemo(() => {
+    const recipient = item.leadNotification.recipientId_populated;
+    if (!recipient) return undefined;
+    const id = recipient.id ?? recipient._id;
+    const displayName = ghostGuardedName(recipient.name?.displayName, id);
+    if (displayName) return displayName;
+    return recipient.username ? `@${recipient.username}` : undefined;
+  }, [item.leadNotification.recipientId_populated]);
+
+  const channelText = channelLabel
+    ? t('notification.forChannel', { defaultValue: 'For {{channel}}', channel: channelLabel })
+    : undefined;
+
   // The bold byline name: grouped -> "María and 3 others"; welcome -> the welcome
   // title; single -> the resolved display name (or @handle floor).
   const bylineName = useMemo(() => {
@@ -432,7 +453,12 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
   const hasDisplayName = isSingleActor && !!resolvedPrimary.displayName;
   const showHandleLine = hasDisplayName && !!resolvedPrimary.handle;
 
-  const accessibilityLabel = isWelcome ? `${bylineName}. ${actionText}` : `${bylineName} ${actionText}`;
+  const accessibilityLabel = [
+    isWelcome ? `${bylineName}. ${actionText}` : `${bylineName} ${actionText}`,
+    channelText,
+  ]
+    .filter(Boolean)
+    .join('. ');
 
   const previewText = useMemo(() => {
     if (!descriptor.hasPreview) return undefined;
@@ -668,6 +694,12 @@ const NotificationItemComponent: React.FC<NotificationItemProps> = ({ item, onMa
                 </Text>
               ) : null}
             </View>
+
+            {channelText ? (
+              <Text className="text-muted-foreground text-[13px] leading-4" numberOfLines={1}>
+                {channelText}
+              </Text>
+            ) : null}
 
             {actionText ? (
               <Text className="text-muted-foreground text-[15px] leading-5" numberOfLines={2}>

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -104,6 +104,7 @@
   "notification.action.post": "posted a new update",
   "notification.action.poke": "poked you",
   "notification.action.default": "interacted with your content",
+  "notification.forChannel": "For {{channel}}",
   "notification.like_reply": "{{actorName}} liked your reply",
   "notification.reply_reply": "{{actorName}} replied to your reply",
   "notification.mention_reply": "{{actorName}} mentioned you in a reply",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -143,6 +143,7 @@
   "notification.action.post": "publicó una nueva actualización",
   "notification.action.poke": "te hizo un poke",
   "notification.action.default": "interactuó con tu contenido",
+  "notification.forChannel": "Para {{channel}}",
   "notification.like_reply": "{{actorName}} le dio me gusta a tu respuesta",
   "notification.reply_reply": "{{actorName}} respondió a tu respuesta",
   "notification.mention_reply": "{{actorName}} te mencionó en una respuesta",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -137,6 +137,7 @@
   "notification.action.post": "ha pubblicato un nuovo aggiornamento",
   "notification.action.poke": "ti ha fatto un poke",
   "notification.action.default": "ha interagito con i tuoi contenuti",
+  "notification.forChannel": "Per {{channel}}",
   "notification.like_reply": "{{actorName}} ha messo mi piace alla tua risposta",
   "notification.reply_reply": "{{actorName}} ha risposto alla tua risposta",
   "notification.mention_reply": "{{actorName}} ti ha menzionato in una risposta",

--- a/packages/frontend/types/validation.ts
+++ b/packages/frontend/types/validation.ts
@@ -139,6 +139,17 @@ export const ZRawNotification = z.looseObject({
   preview: z.string().optional(),
   post: ZEmbeddedPost.optional(),
   actorId_populated: ZActor.optional(),
+  /**
+   * The account this notification was addressed to, present ONLY when that is not
+   * the viewer — i.e. a CHANNEL they operate, whose inbox has no session of its
+   * own and is read through theirs. Its absence means "addressed to me", so the
+   * row can be rendered without it.
+   *
+   * It names the channel, never the person who wrote the channel's post — that
+   * disclosure is `UserSettings.channel.signPosts` and is decided server-side on
+   * the post itself.
+   */
+  recipientId_populated: ZActor.optional(),
 });
 
 export type TEmbeddedPost = z.infer<typeof ZEmbeddedPost>;

--- a/packages/frontend/utils/__tests__/groupNotifications.test.ts
+++ b/packages/frontend/utils/__tests__/groupNotifications.test.ts
@@ -23,10 +23,12 @@ function notification(fields: {
   actorId: string;
   createdAt: string;
   read?: boolean;
+  /** Defaults to the viewer; a channel id models a row from an inbox they operate. */
+  recipientId?: string;
 }): TRawNotification {
   return {
     _id: fields.id,
-    recipientId: 'viewer',
+    recipientId: fields.recipientId ?? 'viewer',
     actorId: fields.actorId,
     type: fields.type,
     entityId: fields.entityId,
@@ -138,5 +140,43 @@ describe('groupNotifications', () => {
 
   it('returns nothing for an empty list', () => {
     expect(groupNotifications([])).toEqual([]);
+  });
+
+  describe('inboxes do not merge into one another', () => {
+    // The list carries rows addressed to the viewer alongside rows addressed to a
+    // CHANNEL they operate (a channel has no session of its own). `type:'follow'`
+    // stores the FOLLOWER in `entityId`, so one person following both the viewer
+    // and their channel produces two rows identical in type and entityId — keyed
+    // on those alone they collapse into one and the channel's follow disappears.
+    it('keeps the same actor following the viewer and their channel apart', () => {
+      const rows = groupNotifications([
+        notification({
+          id: 'follow-me', type: 'follow', entityId: 'actor-a', actorId: 'actor-a', createdAt: at(0),
+        }),
+        notification({
+          id: 'follow-channel', type: 'follow', entityId: 'actor-a', actorId: 'actor-a',
+          createdAt: at(HOUR_MS), recipientId: 'channel-1',
+        }),
+      ]);
+
+      expect(idsPerRow(rows)).toEqual([['follow-me'], ['follow-channel']]);
+    });
+
+    it('still groups within ONE inbox (control)', () => {
+      // Without this, the case above would also pass if grouping had simply been
+      // switched off altogether.
+      const rows = groupNotifications([
+        notification({
+          id: 'a', type: 'like', entityId: 'post-1', actorId: 'actor-a',
+          createdAt: at(0), recipientId: 'channel-1',
+        }),
+        notification({
+          id: 'b', type: 'like', entityId: 'post-1', actorId: 'actor-b',
+          createdAt: at(HOUR_MS), recipientId: 'channel-1',
+        }),
+      ]);
+
+      expect(idsPerRow(rows)).toEqual([['a', 'b']]);
+    });
   });
 });

--- a/packages/frontend/utils/groupNotifications.ts
+++ b/packages/frontend/utils/groupNotifications.ts
@@ -103,9 +103,17 @@ export function groupNotifications(
       continue;
     }
 
-    // Build a group key from type + entityId
+    // Build a group key from recipient + type + entityId.
+    //
+    // The RECIPIENT is part of the key because the list now carries rows
+    // addressed to a channel the viewer operates alongside their own. Those two
+    // inboxes collide on the pair that matters most: `type:'follow'` stores the
+    // FOLLOWER in `entityId`, so one person following both you and your channel
+    // produces two rows identical in type and entityId. Keyed on those alone they
+    // merge into one row, and the channel's follow disappears behind the personal
+    // one with nothing to reveal it.
     const entityId = objectId(n.entityId) || String(n.entityId || '');
-    const groupKey = `${n.type}:${entityId}`;
+    const groupKey = `${n.recipientId}:${n.type}:${entityId}`;
 
     const open = openGroups.get(groupKey);
 


### PR DESCRIPTION
## Summary

**A channel's notifications were written and readable by nobody.** Measured against a real mongod: five paths (quote, boost, like, mention, federated follow) each write a row addressed to the channel, because `createPostAuthorNotifications` derives recipients from `post.authorship` and a channel post's authorship owner IS the channel. All six recipient-filtered queries in `routes/notifications.ts` filtered `recipientId: req.user.id`, and `isActAsEligibleKind('channel') === false` means no session can ever have a channel as its subject. So: 5 rows addressed to the channel, **0 readable by any session**. Written, indexed, TTL-reaped at 90 days, read by nobody.

**Fixed by read-time expansion, not write-time fan-out.** `GET /notifications` now resolves which recipient ids the viewer may read (`services/notificationInbox.ts`). The write path is untouched, so it gains no stage that can fail; authorization is recomputed from the reader's own bearer rather than cached at write time; and because there is no second write stage, the `{recipientId, actorId, type, entityId}` check-then-act race has no racer. One row per event regardless of operator count.

**Recipients are the channel's active members — a function of the channel, never of the post.** Routing by `writtenByOxyUserId` was rejected because each operator's received rows would then be a partition encoding authorship: on a two-operator channel that is total disclosure of exactly what `signPosts` exists to gate.

- `membershipAuthorizesActingFor` extracted as the ONE predicate shared by the publish gate (`assertCanPublishAsAccount`) and the new inbox resolver (`listOperatedChannelIds`), so they cannot disagree about the same person.
- Single Redis cache authority (`notifinbox:v1:<viewerId>`, 60s TTL — deliberately the shortest in `config.cache`, because it *is* the window a removed operator keeps reading).
- The notifications socket now joins `user:<channelId>` rooms from the handshake bearer, since the client never polls and the socket is its only live path.
- Frontend grouping-key fix: a `follow` stores the follower in `entityId`, so one person following both you and your channel collided into one row and the channel's vanished (`groupNotifications.ts`).

### Known gaps (listed, not hidden)

- Push notifications still do not reach operators — `sendPushToUser(<channelId>)` runs and matches zero `PushToken` rows. Fixing it needs the member roster at WRITE time, which requires a service-auth member read oxy-api does not expose yet.
- The socket room join typechecks and builds but has not been exercised against a live socket.
- Live delivery to a just-removed operator persists until their socket reconnects, while every durable surface cuts off within the 60s `notificationInbox` cache TTL.

## Test plan

Gates already run by the implementing agent (not re-run here):
- [x] Backend: 432 files / 4701 tests green, coverage gate passing
- [x] Frontend: 142 suites / 1289 tests green
- [x] Both tsc clean, build clean
- [x] `validate:i18n` / `validate:workflows` / `validate:lockfile` / `validate:logger` / `audit:security` all pass
- [x] 15/15 mutations killed against a positive control

Re-verified after rebasing onto `origin/main` (moved through #593 while this branch was open — no file overlap with the new commits):
- [x] `packages/shared-types` rebuilt, backend `tsc --noEmit` clean

Note: `bun run check` exits 1 on `doctor` for a Node version mismatch (22.23.1 vs 22.17.0) and SIGINTs its siblings — environmental and pre-existing; the four survivors were re-run individually and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)