### PR TITLE
feat(channels): a channel that names its writers shows them

### DIFF
--- a/packages/backend/src/__tests__/routes/channelWriters.test.ts
+++ b/packages/backend/src/__tests__/routes/channelWriters.test.ts
@@ -1,0 +1,665 @@
+import express, { type NextFunction, type Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OxyAuthRequest } from '@oxyhq/core/server';
+
+/**
+ * `GET /channels/:oxyUserId/writers` — the list behind a channel's writers tab.
+ *
+ * The gate IS the feature, so most of this file is about refusing. Three
+ * conditions have to hold and each fails closed: the account resolves as a
+ * CHANNEL, its settings say `signPosts === true`, and this reader may see the
+ * channel at all. Every refusal is the same 404, so a caller cannot use the
+ * status code to learn which condition failed.
+ *
+ * Two properties get asserted on the refusal path that a status-code check alone
+ * would miss:
+ *
+ *  - the aggregation is NEVER RUN when the gate refuses, so the set is not merely
+ *    withheld from the response — it is never computed. A leak cannot come from
+ *    somewhere the ids were never loaded.
+ *  - the real `channelWriterDisclosure` is used (only the `UserSettings` model is
+ *    mocked), so these are tests of the actual gate rather than of a stub that
+ *    agrees with it.
+ *
+ * The `Post.aggregate` mock EXECUTES the pipeline against fixture documents
+ * instead of returning canned rows. Without that, every assertion about which
+ * posts count — public, published, owned by this channel, carrying a writer —
+ * would be an assertion about the mock, and deleting any of those `$match` terms
+ * would leave this suite green.
+ */
+
+const CHANNEL_ID = 'oxy-channel';
+const OTHER_ACCOUNT_ID = 'oxy-other-account';
+const VIEWER_ID = 'oxy-viewer';
+const WRITER_A = 'oxy-writer-aaa';
+const WRITER_B = 'oxy-writer-bbb';
+const WRITER_C = 'oxy-writer-ccc';
+const GHOST_WRITER = 'oxy-writer-ghost';
+
+const {
+  userSettingsFind,
+  userSettingsFindOne,
+  postAggregate,
+  resolveUserSummaries,
+  checkFollowAccess,
+} = vi.hoisted(() => ({
+  userSettingsFind: vi.fn(),
+  userSettingsFindOne: vi.fn(),
+  postAggregate: vi.fn(),
+  resolveUserSummaries: vi.fn(),
+  checkFollowAccess: vi.fn(),
+}));
+
+vi.mock('../../models/UserSettings', () => {
+  const model = {
+    find: (...args: unknown[]) => {
+      const rows = userSettingsFind(...args);
+      const chain = { select: () => chain, lean: async () => rows };
+      return chain;
+    },
+    findOne: (...args: unknown[]) => {
+      const row = userSettingsFindOne(...args);
+      const chain = { select: () => chain, lean: async () => row };
+      return chain;
+    },
+  };
+  return { UserSettings: model, default: model };
+});
+
+vi.mock('../../models/Post', () => {
+  const model = {
+    aggregate: (...args: unknown[]) => {
+      const rows = postAggregate(...args);
+      const chain = { option: () => chain, exec: async () => rows };
+      return chain;
+    },
+  };
+  return { Post: model, default: model };
+});
+
+// Only the identity RESOLVER is stubbed. `degradedActorSummary` is left REAL
+// (the route imports it from its owning module), so a change to the degraded
+// shape breaks the ghost-handle test rather than being masked by a stub.
+vi.mock('../../services/PostHydrationService', () => ({
+  resolveUserSummaries: (...args: unknown[]) => resolveUserSummaries(...args),
+}));
+
+vi.mock('../../utils/privacyHelpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/privacyHelpers')>();
+  return {
+    // `requiresAccessCheck` stays REAL — it is the pure half of the visibility
+    // rule, and stubbing it would make the private-channel cases test nothing.
+    requiresAccessCheck: actual.requiresAccessCheck,
+    checkFollowAccess: (...args: unknown[]) => checkFollowAccess(...args),
+  };
+});
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createUserScopedOxyServices: vi.fn(() => ({})),
+}));
+
+import channelWritersRouter from '../../routes/channelWriters.routes';
+
+/* ------------------------------------------------------------------------- */
+/* A minimal aggregation engine, covering exactly the stages the route builds. */
+/* ------------------------------------------------------------------------- */
+
+/**
+ * `type`, not `interface`, on purpose: a type alias carries an implicit index
+ * signature, so a fixture is assignable to the `Record<string, unknown>` the
+ * evaluator reads without a cast anywhere in this file.
+ */
+type PostFixture = {
+  oxyUserId: string;
+  visibility: string;
+  status: string;
+  writtenByOxyUserId?: string | null;
+  createdAt: Date;
+};
+
+/**
+ * `_id` is `string | null` because that is what Mongo produces: a `$group` keyed
+ * on a field some documents lack yields a `null` group rather than dropping them.
+ * Modelling that faithfully is what makes the `{ $type: 'string' }` term in the
+ * route's `$match` testable — an evaluator that quietly skipped non-string
+ * writers would agree with the route whether or not that term were there.
+ */
+type GroupedRow = {
+  _id: string | null;
+  lastPostAt: Date;
+};
+
+/** Both sides are always the same kind here — Date against Date, string against string. */
+function compare(a: unknown, b: unknown): number {
+  const x = a instanceof Date ? a.getTime() : a;
+  const y = b instanceof Date ? b.getTime() : b;
+  if (x === y) return 0;
+  if (typeof x === 'number' && typeof y === 'number') return x < y ? -1 : 1;
+  return String(x) < String(y) ? -1 : 1;
+}
+
+/** Equality, `{ $type: 'string' }`, `{ $lt: v }`, and a top-level `$or`. */
+function matches(doc: Record<string, unknown>, query: Record<string, unknown>): boolean {
+  return Object.entries(query).every(([key, condition]) => {
+    if (key === '$or') {
+      if (!Array.isArray(condition)) throw new Error('$or expects an array');
+      return condition.some((clause) => matches(doc, clause));
+    }
+    const value = doc[key];
+    if (condition !== null && typeof condition === 'object' && !(condition instanceof Date)) {
+      return Object.entries(condition).every(([op, operand]) => {
+        if (op === '$type') return operand === 'string' && typeof value === 'string';
+        if (op === '$lt') return value !== undefined && compare(value, operand) < 0;
+        throw new Error(`unsupported operator ${op}`);
+      });
+    }
+    return compare(value, condition) === 0;
+  });
+}
+
+/** Run the route's pipeline over `docs`. Throws on any stage it does not know. */
+function runPipeline(docs: PostFixture[], pipeline: Array<Record<string, unknown>>): GroupedRow[] {
+  let matched: PostFixture[] = docs;
+  let grouped: GroupedRow[] | null = null;
+
+  for (const stage of pipeline) {
+    const entry = Object.entries(stage)[0];
+    if (!entry) throw new Error('empty pipeline stage');
+    const [name, spec] = entry;
+
+    if (name === '$limit') {
+      if (typeof spec !== 'number') throw new Error('$limit expects a number');
+      if (!grouped) throw new Error('$limit before $group');
+      grouped = grouped.slice(0, spec);
+      continue;
+    }
+    if (typeof spec !== 'object' || spec === null) throw new Error(`bad spec for ${name}`);
+    const fields: Record<string, unknown> = { ...spec };
+
+    switch (name) {
+      case '$match': {
+        if (grouped) {
+          grouped = grouped.filter((row) => matches({ ...row }, fields));
+        } else {
+          matched = matched.filter((doc) => matches({ ...doc }, fields));
+        }
+        break;
+      }
+      case '$group': {
+        expect(fields._id).toBe('$writtenByOxyUserId');
+        expect(fields.lastPostAt).toEqual({ $max: '$createdAt' });
+        const byWriter = new Map<string | null, Date>();
+        for (const doc of matched) {
+          // Mongo's own semantics: a missing field groups under `null`, and so
+          // does an explicit `null`. Neither is dropped.
+          const writer = typeof doc.writtenByOxyUserId === 'string' ? doc.writtenByOxyUserId : null;
+          const current = byWriter.get(writer);
+          if (!current || doc.createdAt > current) byWriter.set(writer, doc.createdAt);
+        }
+        grouped = [...byWriter].map(([_id, lastPostAt]) => ({ _id, lastPostAt }));
+        break;
+      }
+      case '$sort': {
+        if (!grouped) throw new Error('$sort before $group');
+        const keys = Object.entries(fields);
+        grouped = [...grouped].sort((a, b) => {
+          for (const [key, direction] of keys) {
+            if (typeof direction !== 'number') throw new Error('$sort expects 1 or -1');
+            const result = compare({ ...a }[key], { ...b }[key]);
+            if (result !== 0) return result * direction;
+          }
+          return 0;
+        });
+        break;
+      }
+      default:
+        throw new Error(`unsupported stage ${name}`);
+    }
+  }
+
+  if (!grouped) throw new Error('pipeline produced no group stage');
+  return grouped;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Fixtures                                                                    */
+/* ------------------------------------------------------------------------- */
+
+function post(overrides: Partial<PostFixture> & { createdAt: Date }): PostFixture {
+  return {
+    oxyUserId: CHANNEL_ID,
+    visibility: 'public',
+    status: 'published',
+    ...overrides,
+  };
+}
+
+const at = (iso: string) => new Date(iso);
+
+/**
+ * One post per rule the `$match` enforces, so removing ANY of its terms changes
+ * the answer. Each excluded fixture names a writer nobody else names, so its
+ * appearance in the response is unambiguous evidence of which clause broke.
+ */
+const CORPUS: PostFixture[] = [
+  // Counts: three public, published posts by two writers.
+  post({ writtenByOxyUserId: WRITER_A, createdAt: at('2026-01-01T00:00:00.000Z') }),
+  post({ writtenByOxyUserId: WRITER_A, createdAt: at('2026-03-01T00:00:00.000Z') }),
+  post({ writtenByOxyUserId: WRITER_B, createdAt: at('2026-02-01T00:00:00.000Z') }),
+  // Does NOT count — one excluded fixture per clause.
+  post({ writtenByOxyUserId: 'writer-draft', status: 'draft', createdAt: at('2026-06-01T00:00:00.000Z') }),
+  post({ writtenByOxyUserId: 'writer-scheduled', status: 'scheduled', createdAt: at('2026-06-02T00:00:00.000Z') }),
+  post({ writtenByOxyUserId: 'writer-restricted', status: 'restricted', createdAt: at('2026-06-03T00:00:00.000Z') }),
+  post({ writtenByOxyUserId: 'writer-followers', visibility: 'followers_only', createdAt: at('2026-06-04T00:00:00.000Z') }),
+  post({ writtenByOxyUserId: 'writer-private', visibility: 'private', createdAt: at('2026-06-05T00:00:00.000Z') }),
+  post({ writtenByOxyUserId: 'writer-elsewhere', oxyUserId: OTHER_ACCOUNT_ID, createdAt: at('2026-06-06T00:00:00.000Z') }),
+  // No writer at all: an ordinary post by a person signed in as themselves. The
+  // `null` shape is the one `$exists: true` would wrongly admit — it is stored by
+  // clearing the field with an assignment rather than an `$unset`.
+  post({ createdAt: at('2026-06-07T00:00:00.000Z') }),
+  post({ writtenByOxyUserId: null, createdAt: at('2026-06-08T00:00:00.000Z') }),
+];
+
+const ACCOUNTS: Record<string, { id: string; username: string; name: { displayName: string }; kind: string }> = {
+  [CHANNEL_ID]: { id: CHANNEL_ID, username: 'thechannel', name: { displayName: 'The Channel' }, kind: 'channel' },
+  [WRITER_A]: { id: WRITER_A, username: 'writera', name: { displayName: 'Writer A' }, kind: 'personal' },
+  [WRITER_B]: { id: WRITER_B, username: 'writerb', name: { displayName: 'Writer B' }, kind: 'personal' },
+  [WRITER_C]: { id: WRITER_C, username: 'writerc', name: { displayName: 'Writer C' }, kind: 'personal' },
+};
+
+/**
+ * `null` is an ANONYMOUS reader — deliberately not `undefined`, which a default
+ * parameter would silently turn back into a signed-in one.
+ */
+function buildApp(viewerId: string | null = VIEWER_ID): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req: OxyAuthRequest, _res: Response, next: NextFunction) => {
+    if (viewerId) req.user = { id: viewerId };
+    next();
+  });
+  app.use('/channels', channelWritersRouter);
+  return app;
+}
+
+/** `signPosts` for the channel, as the settings collection would answer it. */
+function signing(value: unknown): void {
+  userSettingsFind.mockReturnValue([{ oxyUserId: CHANNEL_ID, channel: { signPosts: value } }]);
+}
+
+describe('GET /channels/:oxyUserId/writers', () => {
+  beforeEach(() => {
+    userSettingsFind.mockReset();
+    userSettingsFindOne.mockReset();
+    postAggregate.mockReset();
+    resolveUserSummaries.mockReset();
+    checkFollowAccess.mockReset();
+
+    signing(true);
+    userSettingsFindOne.mockReturnValue(null);
+    checkFollowAccess.mockResolvedValue(false);
+    postAggregate.mockImplementation((pipeline: Array<Record<string, unknown>>) =>
+      runPipeline(CORPUS, pipeline),
+    );
+    resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+      const map = new Map<string, { user: unknown }>();
+      for (const id of ids) {
+        const account = ACCOUNTS[id];
+        if (account) map.set(id, { user: account });
+      }
+      return map;
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /* The list itself                                                        */
+  /* --------------------------------------------------------------------- */
+
+  it('lists the distinct writers of the channel, most recent post first', async () => {
+    const res = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(200);
+
+    expect(res.body.data.writers.map((row: { writer: { id: string } }) => row.writer.id)).toEqual([
+      // Writer A posted in March, Writer B in February — and A is first even
+      // though both have written, which is what "most recent post" means.
+      WRITER_A,
+      WRITER_B,
+    ]);
+    expect(res.body.data.writers[0].lastPostAt).toBe('2026-03-01T00:00:00.000Z');
+    expect(res.body.data.nextCursor).toBeUndefined();
+  });
+
+  /**
+   * The ordering decision, isolated.
+   *
+   * Writer A has TWO posts to Writer B's one, so a "most posts first" ordering
+   * puts A first for a different reason than recency does — this fixture makes B
+   * the more recent, so the two orderings disagree and only one of them passes.
+   */
+  it('orders by most recent post, NOT by most posts', async () => {
+    postAggregate.mockImplementation((pipeline: Array<Record<string, unknown>>) =>
+      runPipeline(
+        [
+          post({ writtenByOxyUserId: WRITER_A, createdAt: at('2026-01-01T00:00:00.000Z') }),
+          post({ writtenByOxyUserId: WRITER_A, createdAt: at('2026-01-02T00:00:00.000Z') }),
+          post({ writtenByOxyUserId: WRITER_A, createdAt: at('2026-01-03T00:00:00.000Z') }),
+          post({ writtenByOxyUserId: WRITER_B, createdAt: at('2026-05-01T00:00:00.000Z') }),
+        ],
+        pipeline,
+      ),
+    );
+
+    const res = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(200);
+
+    expect(res.body.data.writers.map((row: { writer: { id: string } }) => row.writer.id)).toEqual([
+      WRITER_B,
+      WRITER_A,
+    ]);
+  });
+
+  /**
+   * Every clause of the `$match`, in one assertion.
+   *
+   * The corpus carries one post per exclusion — a draft, a scheduled post, a
+   * moderation-restricted post, a followers-only post, a private post, a post
+   * owned by another account, a post with no writer, and a post whose writer
+   * field is an explicit `null`. Each names a writer nobody else names, so
+   * dropping any single term from the query puts a NAMED stranger in this list.
+   */
+  it('counts only public, published posts this channel owns that carry a writer', async () => {
+    const res = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(200);
+
+    const ids = res.body.data.writers.map((row: { writer: { id: string } }) => row.writer.id);
+    expect(ids).toEqual([WRITER_A, WRITER_B]);
+    for (const excluded of [
+      'writer-draft',
+      'writer-scheduled',
+      'writer-restricted',
+      'writer-followers',
+      'writer-private',
+      'writer-elsewhere',
+    ]) {
+      expect(ids).not.toContain(excluded);
+    }
+    // Vacuity floor: the corpus really did contain every excluded shape, so the
+    // assertions above are about the query and not about an empty fixture set.
+    expect(CORPUS).toHaveLength(11);
+  });
+
+  it('returns an empty list for a disclosing channel that has published nothing signed', async () => {
+    postAggregate.mockImplementation((pipeline: Array<Record<string, unknown>>) => runPipeline([], pipeline));
+
+    const res = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(200);
+
+    // The list EXISTS and is empty — a different fact from "there is no list",
+    // which is the 404 below.
+    expect(res.body.data).toEqual({ writers: [] });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /* The gate                                                               */
+  /* --------------------------------------------------------------------- */
+
+  it('404s when the channel has not opted in', async () => {
+    signing(false);
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+
+    // Not merely withheld: the writers were never even loaded.
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  it('404s when the channel has no settings row at all', async () => {
+    userSettingsFind.mockReturnValue([]);
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The fixture that tells `signPosts === true` from `Boolean(signPosts)`. Every
+   * other gate case here is `true`, `false` or absent, and a loose read agrees
+   * with a strict one on all three.
+   */
+  it('404s on a truthy non-boolean signPosts', async () => {
+    signing('false');
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  it('404s when the settings lookup fails — it fails CLOSED', async () => {
+    userSettingsFind.mockImplementation(() => {
+      throw new Error('mongo is down');
+    });
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The `kind` clause. A settings row saying `signPosts: true` under a PERSONAL
+   * account is a row that should not exist, and it must not become consent to
+   * publish the ids of everybody who has ever posted through that account.
+   */
+  it('404s when the account is not a channel, whatever its settings row says', async () => {
+    resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+      const map = new Map<string, { user: unknown }>();
+      for (const id of ids) {
+        map.set(id, { user: { ...ACCOUNTS[CHANNEL_ID], id, kind: 'personal' } });
+      }
+      return map;
+    });
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  it('404s when the account cannot be resolved at all', async () => {
+    resolveUserSummaries.mockResolvedValue(new Map());
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A failed identity lookup is a 500, not a 404, and that is deliberate: the
+   * settings read has a safe default to fall back on (no consent), while "we do
+   * not know what kind of account this is" has none that is not a lie. Both are
+   * non-disclosing, which is the property that matters — the writers are never
+   * loaded either way.
+   */
+  it('does not disclose when the identity lookup throws', async () => {
+    resolveUserSummaries.mockRejectedValue(new Error('oxy is down'));
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(500);
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Every refusal answers the SAME body, so the status code and the message
+   * together cannot tell a caller which condition failed — a channel that does
+   * not sign, an account that is not a channel and an id that names nothing are
+   * one answer.
+   */
+  it('answers every refusal identically', async () => {
+    signing(false);
+    const notSigning = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+
+    resolveUserSummaries.mockResolvedValue(new Map());
+    const unknown = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+
+    expect(notSigning.body).toEqual(unknown.body);
+  });
+
+  it('400s on a missing or oversized account id', async () => {
+    await request(buildApp()).get(`/channels/${'x'.repeat(65)}/writers`).expect(400);
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  /* --------------------------------------------------------------------- */
+  /* Profile visibility                                                     */
+  /* --------------------------------------------------------------------- */
+
+  it('404s a restricted channel for a reader who does not follow it', async () => {
+    userSettingsFindOne.mockReturnValue({ privacy: { profileVisibility: 'followers_only' } });
+    checkFollowAccess.mockResolvedValue(false);
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  it('404s a restricted channel for an ANONYMOUS reader, without an upstream call', async () => {
+    userSettingsFindOne.mockReturnValue({ privacy: { profileVisibility: 'private' } });
+
+    await request(buildApp(null)).get(`/channels/${CHANNEL_ID}/writers`).expect(404);
+
+    expect(checkFollowAccess).not.toHaveBeenCalled();
+    expect(postAggregate).not.toHaveBeenCalled();
+  });
+
+  it('serves a restricted channel to a reader who follows it', async () => {
+    userSettingsFindOne.mockReturnValue({ privacy: { profileVisibility: 'followers_only' } });
+    checkFollowAccess.mockResolvedValue(true);
+
+    const res = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(200);
+
+    expect(res.body.data.writers).toHaveLength(2);
+    expect(checkFollowAccess).toHaveBeenCalledWith(VIEWER_ID, CHANNEL_ID, expect.anything());
+  });
+
+  it('does not pay for a follow check on an ordinary public channel', async () => {
+    userSettingsFindOne.mockReturnValue({ privacy: { profileVisibility: 'public' } });
+
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(200);
+
+    expect(checkFollowAccess).not.toHaveBeenCalled();
+  });
+
+  /* --------------------------------------------------------------------- */
+  /* Identity                                                               */
+  /* --------------------------------------------------------------------- */
+
+  /**
+   * The ghost-handle rule. A writer Oxy cannot resolve arrives DEGRADED — empty
+   * username, `'Unknown user'` — never as a raw `oxyUserId` in a handle position,
+   * because `/@<id>` is not a profile.
+   */
+  it('degrades a writer Oxy cannot resolve, never emitting a raw id as a handle', async () => {
+    postAggregate.mockImplementation((pipeline: Array<Record<string, unknown>>) =>
+      runPipeline(
+        [post({ writtenByOxyUserId: GHOST_WRITER, createdAt: at('2026-04-01T00:00:00.000Z') })],
+        pipeline,
+      ),
+    );
+
+    const res = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(200);
+
+    const [row] = res.body.data.writers;
+    expect(row.writer.id).toBe(GHOST_WRITER);
+    expect(row.writer.username).toBe('');
+    expect(row.writer.name.displayName).toBe('Unknown user');
+  });
+
+  it('still renders the page when the whole identity batch fails', async () => {
+    // The channel resolves (the gate needs it); the writers batch does not.
+    resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+      if (ids.length === 1 && ids[0] === CHANNEL_ID) {
+        return new Map([[CHANNEL_ID, { user: ACCOUNTS[CHANNEL_ID] }]]);
+      }
+      throw new Error('oxy is down');
+    });
+
+    const res = await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers`).expect(200);
+
+    expect(res.body.data.writers.map((row: { writer: { username: string } }) => row.writer.username)).toEqual([
+      '',
+      '',
+    ]);
+  });
+
+  /* --------------------------------------------------------------------- */
+  /* Paging                                                                 */
+  /* --------------------------------------------------------------------- */
+
+  it('emits a cursor and resumes from it without skipping or repeating', async () => {
+    const corpus = [
+      post({ writtenByOxyUserId: WRITER_A, createdAt: at('2026-03-01T00:00:00.000Z') }),
+      post({ writtenByOxyUserId: WRITER_B, createdAt: at('2026-02-01T00:00:00.000Z') }),
+      post({ writtenByOxyUserId: WRITER_C, createdAt: at('2026-01-01T00:00:00.000Z') }),
+    ];
+    postAggregate.mockImplementation((pipeline: Array<Record<string, unknown>>) =>
+      runPipeline(corpus, pipeline),
+    );
+    const app = buildApp();
+
+    const first = await request(app).get(`/channels/${CHANNEL_ID}/writers?limit=2`).expect(200);
+    expect(first.body.data.writers.map((row: { writer: { id: string } }) => row.writer.id)).toEqual([
+      WRITER_A,
+      WRITER_B,
+    ]);
+    expect(typeof first.body.data.nextCursor).toBe('string');
+
+    const second = await request(app)
+      .get(`/channels/${CHANNEL_ID}/writers?limit=2&cursor=${encodeURIComponent(first.body.data.nextCursor)}`)
+      .expect(200);
+    expect(second.body.data.writers.map((row: { writer: { id: string } }) => row.writer.id)).toEqual([
+      WRITER_C,
+    ]);
+    expect(second.body.data.nextCursor).toBeUndefined();
+  });
+
+  /**
+   * The tie-break the cursor exists for.
+   *
+   * Two writers whose most recent posts landed in the SAME millisecond straddle
+   * the page boundary. On `lastPostAt` alone the second page's filter would drop
+   * both or return both — the writer id in the keyset is what makes the boundary
+   * exact.
+   */
+  it('does not lose a writer whose last post shares a millisecond with another', async () => {
+    const sameInstant = at('2026-03-01T00:00:00.000Z');
+    const corpus = [
+      post({ writtenByOxyUserId: WRITER_A, createdAt: sameInstant }),
+      post({ writtenByOxyUserId: WRITER_B, createdAt: sameInstant }),
+      post({ writtenByOxyUserId: WRITER_C, createdAt: at('2026-01-01T00:00:00.000Z') }),
+    ];
+    postAggregate.mockImplementation((pipeline: Array<Record<string, unknown>>) =>
+      runPipeline(corpus, pipeline),
+    );
+    const app = buildApp();
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < 3; page += 1) {
+      const query = `limit=1${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`;
+      const res = await request(app).get(`/channels/${CHANNEL_ID}/writers?${query}`).expect(200);
+      seen.push(...res.body.data.writers.map((row: { writer: { id: string } }) => row.writer.id));
+      cursor = res.body.data.nextCursor;
+      if (!cursor) break;
+    }
+
+    expect(seen).toHaveLength(3);
+    expect(new Set(seen)).toEqual(new Set([WRITER_A, WRITER_B, WRITER_C]));
+  });
+
+  it('treats a malformed cursor as the first page rather than an error', async () => {
+    const res = await request(buildApp())
+      .get(`/channels/${CHANNEL_ID}/writers?cursor=not-a-cursor`)
+      .expect(200);
+
+    expect(res.body.data.writers.map((row: { writer: { id: string } }) => row.writer.id)).toEqual([
+      WRITER_A,
+      WRITER_B,
+    ]);
+  });
+
+  it('clamps the page size', async () => {
+    await request(buildApp()).get(`/channels/${CHANNEL_ID}/writers?limit=99999`).expect(200);
+
+    const pipeline = postAggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const limitStage = pipeline.find((stage) => '$limit' in stage);
+    // 100 is the cap; the route asks for one extra row to decide `nextCursor`.
+    expect(limitStage).toEqual({ $limit: 101 });
+  });
+});

--- a/packages/backend/src/__tests__/services/channelWriterDisclosure.test.ts
+++ b/packages/backend/src/__tests__/services/channelWriterDisclosure.test.ts
@@ -1,0 +1,244 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * THE ONE AUTHORITY ON WHETHER A CHANNEL NAMES ITS WRITERS.
+ *
+ * Two surfaces ask this question — the post byline ("name the writer of THIS
+ * post") and the channel's writers list ("name everyone who has written for this
+ * channel") — and the whole reason this module exists is that two answers is one
+ * answer too many. A disagreement here is not a rendering inconsistency: one of
+ * the two would be publishing a name the channel never consented to publish, and
+ * that is not recoverable by a later request that gets it right.
+ *
+ * So this file pins two different things:
+ *
+ *  1. the DECISION — fail-closed at every step, including the `=== true` read
+ *     that no `true` / `false` / absent fixture can distinguish from a loose one;
+ *  2. the SINGLENESS of it — a source scan that fails if any other module starts
+ *     reading `signPosts` for itself.
+ */
+
+const CHANNEL_ID = 'oxy-channel';
+const OTHER_CHANNEL_ID = 'oxy-channel-2';
+
+const { userSettingsFind } = vi.hoisted(() => ({ userSettingsFind: vi.fn() }));
+
+vi.mock('../../models/UserSettings', () => {
+  const model = {
+    find: (...args: unknown[]) => {
+      const rows = userSettingsFind(...args);
+      const chain = {
+        select: () => chain,
+        lean: async () => rows,
+      };
+      return chain;
+    },
+  };
+  return { UserSettings: model, default: model };
+});
+
+import { disclosesWriters, loadSigningChannelIds } from '../../services/channelWriterDisclosure';
+
+describe('loadSigningChannelIds', () => {
+  beforeEach(() => {
+    userSettingsFind.mockReset();
+    userSettingsFind.mockReturnValue([]);
+  });
+
+  it('holds an account whose settings row says signPosts is true', async () => {
+    userSettingsFind.mockReturnValue([{ oxyUserId: CHANNEL_ID, channel: { signPosts: true } }]);
+
+    const signing = await loadSigningChannelIds([CHANNEL_ID]);
+
+    expect([...signing]).toEqual([CHANNEL_ID]);
+  });
+
+  it('omits an account that has not opted in', async () => {
+    userSettingsFind.mockReturnValue([{ oxyUserId: CHANNEL_ID, channel: { signPosts: false } }]);
+
+    expect((await loadSigningChannelIds([CHANNEL_ID])).has(CHANNEL_ID)).toBe(false);
+  });
+
+  it('omits an account with no settings row at all', async () => {
+    userSettingsFind.mockReturnValue([]);
+
+    expect((await loadSigningChannelIds([CHANNEL_ID])).has(CHANNEL_ID)).toBe(false);
+  });
+
+  it('omits an account whose settings row has no channel subdocument', async () => {
+    userSettingsFind.mockReturnValue([{ oxyUserId: CHANNEL_ID }]);
+
+    expect((await loadSigningChannelIds([CHANNEL_ID])).has(CHANNEL_ID)).toBe(false);
+  });
+
+  /**
+   * The fixture that tells `signPosts === true` from `Boolean(signPosts)`.
+   *
+   * Every other case in this file is `true`, `false` or absent, and a loose read
+   * agrees with a strict one on all three — so without a truthy NON-boolean,
+   * dropping the `=== true` leaves the whole suite green. `"false"` is the shape a
+   * form post, a hand-edited document or a migration that stringified a column
+   * produces, and it must NOT disclose. Mutation-verified: relaxing the read to
+   * `Boolean(...)` reddens exactly this case and nothing else.
+   */
+  it.each([{ value: 'false' }, { value: 'true' }, { value: 1 }, { value: {} }])(
+    'refuses a truthy non-boolean signPosts ($value)',
+    async ({ value }: { value: unknown }) => {
+      userSettingsFind.mockReturnValue([{ oxyUserId: CHANNEL_ID, channel: { signPosts: value } }]);
+
+      expect((await loadSigningChannelIds([CHANNEL_ID])).has(CHANNEL_ID)).toBe(false);
+    },
+  );
+
+  it('fails CLOSED when the settings lookup throws', async () => {
+    userSettingsFind.mockImplementation(() => {
+      throw new Error('mongo is down');
+    });
+
+    expect([...(await loadSigningChannelIds([CHANNEL_ID]))]).toEqual([]);
+  });
+
+  it('asks nothing when there are no candidates', async () => {
+    expect([...(await loadSigningChannelIds([]))]).toEqual([]);
+    expect(userSettingsFind).not.toHaveBeenCalled();
+  });
+
+  it('drops empty and duplicate candidates before querying', async () => {
+    userSettingsFind.mockReturnValue([]);
+
+    await loadSigningChannelIds([CHANNEL_ID, CHANNEL_ID, '']);
+
+    expect(userSettingsFind).toHaveBeenCalledTimes(1);
+    expect(userSettingsFind).toHaveBeenCalledWith({ oxyUserId: { $in: [CHANNEL_ID] } });
+  });
+
+  it('answers a whole page of channels in ONE query, per channel', async () => {
+    userSettingsFind.mockReturnValue([
+      { oxyUserId: CHANNEL_ID, channel: { signPosts: true } },
+      { oxyUserId: OTHER_CHANNEL_ID, channel: { signPosts: false } },
+    ]);
+
+    const signing = await loadSigningChannelIds([CHANNEL_ID, OTHER_CHANNEL_ID]);
+
+    expect(signing.has(CHANNEL_ID)).toBe(true);
+    expect(signing.has(OTHER_CHANNEL_ID)).toBe(false);
+    expect(userSettingsFind).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('disclosesWriters', () => {
+  const signing: ReadonlySet<string> = new Set([CHANNEL_ID]);
+
+  it('discloses a channel account that signs', () => {
+    expect(disclosesWriters(CHANNEL_ID, { kind: 'channel' }, signing)).toBe(true);
+  });
+
+  /**
+   * The `kind` clause on its own. A settings row saying `signPosts: true` under a
+   * PERSONAL account is not a channel disclosing its writer — it is a row that
+   * should not exist — and reading it as consent would name somebody on a person's
+   * own post.
+   */
+  it.each([['personal'], ['organization'], ['project'], ['bot']] as const)(
+    'refuses a signing account of kind %s',
+    (kind) => {
+      expect(disclosesWriters(CHANNEL_ID, { kind }, signing)).toBe(false);
+    },
+  );
+
+  it('refuses an account whose kind is unknown', () => {
+    expect(disclosesWriters(CHANNEL_ID, {}, signing)).toBe(false);
+  });
+
+  /**
+   * An account Oxy could not resolve. The identity path answers `undefined` here,
+   * and an unresolved account must never be treated as a channel — the whole
+   * disclosure rests on knowing what kind of account this is.
+   */
+  it('refuses an unresolvable account', () => {
+    expect(disclosesWriters(CHANNEL_ID, undefined, signing)).toBe(false);
+  });
+
+  it('refuses a channel that does not sign', () => {
+    expect(disclosesWriters(OTHER_CHANNEL_ID, { kind: 'channel' }, signing)).toBe(false);
+  });
+
+  it('refuses an empty id even against a set that somehow contains one', () => {
+    expect(disclosesWriters('', { kind: 'channel' }, new Set(['']))).toBe(false);
+  });
+});
+
+/**
+ * ONE reader of the flag, enforced by scanning the tree.
+ *
+ * `PostHydrationService` used to run this query itself. When the writers list
+ * needed the same answer, the tempting move was to write a second `UserSettings`
+ * read beside it — which is how the byline and the list would end up disagreeing
+ * about a consent decision, silently, in whichever direction the drift happened
+ * to go. This scan is what makes that a test failure instead.
+ *
+ * The allow-list is deliberately short and each entry is a DIFFERENT job:
+ * declaring the field, writing it, and reading it. Anything else that starts
+ * mentioning `signPosts` in code has to justify itself here first.
+ */
+describe('signPosts has exactly one reader', () => {
+  const BACKEND_SRC = path.resolve(__dirname, '../..');
+
+  /**
+   * Files that may mention the flag in CODE. Comments are stripped before the
+   * scan, so a docstring explaining the rule (there are several, including in
+   * `PostHydrationService`) does not count as reading it.
+   */
+  const ALLOWED = new Set([
+    // The declaration: the interface field and the schema path.
+    'models/UserSettings.ts',
+    // The write: `PUT /profile/settings/:userId`, the operator's toggle.
+    'routes/profileSettings.ts',
+    // The read: the one authority this file is about.
+    'services/channelWriterDisclosure.ts',
+  ]);
+
+  /** Strip block and line comments so a docstring is not read as a usage. */
+  function stripComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+  }
+
+  function collect(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry === '__tests__' || entry === 'node_modules' || entry === 'dist') continue;
+        collect(full, out);
+        continue;
+      }
+      if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) out.push(full);
+    }
+    return out;
+  }
+
+  it('mentions the flag in code only where it is declared, written and read', () => {
+    const files = collect(BACKEND_SRC);
+    // Vacuity floor: a broken walk must not read as a clean result.
+    expect(files.length).toBeGreaterThan(200);
+
+    const mentions = files
+      .filter((file) => stripComments(readFileSync(file, 'utf8')).includes('signPosts'))
+      .map((file) => path.relative(BACKEND_SRC, file))
+      .sort();
+
+    // Vacuity floor for the comment stripper: every allowed file really was found,
+    // so a stripper that ate the whole source could not pass this.
+    expect(mentions).toEqual([...ALLOWED].sort());
+  });
+
+  it('does not let PostHydrationService read the flag for itself', () => {
+    const source = readFileSync(path.join(BACKEND_SRC, 'services/PostHydrationService.ts'), 'utf8');
+    // Vacuity floor: the file really was read.
+    expect(source.length).toBeGreaterThan(1000);
+
+    expect(source).toContain("from './channelWriterDisclosure'");
+    expect(stripComments(source)).not.toContain('signPosts');
+  });
+});

--- a/packages/backend/src/appRoutes.ts
+++ b/packages/backend/src/appRoutes.ts
@@ -27,6 +27,7 @@ import profileLinkMentionsRoutes, {
   profileLinkMentionsRateLimiter,
 } from './routes/profileLinkMentions.routes';
 import lanesRoutes, { publicLanesRouter } from './routes/lanes.routes';
+import channelWritersRoutes from './routes/channelWriters.routes';
 import reportsRoutes from './routes/reports.routes';
 import { createCrowdSourceWebhookRoutes } from './routes/crowdSourceWebhook.routes';
 import trendingRoutes from './routes/trending.routes';
@@ -113,6 +114,10 @@ export function createAppRoutes({
   publicApi.use('/starter-packs', optionalAuth, starterPacksRoutes);
   // Reader-agnostic: the lanes a visitor needs to draw a publisher's tabs.
   publicApi.use('/lanes', optionalAuth, publicLanesRouter);
+  // A channel's page is public, so its writers list is readable anonymously —
+  // the reader's identity only decides whether a RESTRICTED channel is visible
+  // at all. The disclosure gate itself is inside the route.
+  publicApi.use('/channels', optionalAuth, channelWritersRoutes);
   publicApi.use('/mtn/nodes', optionalAuth, mtnNodesRoutes);
   publicApi.use('/statistics', optionalAuth, publicStatisticsRouter);
 

--- a/packages/backend/src/middleware/security.ts
+++ b/packages/backend/src/middleware/security.ts
@@ -360,6 +360,22 @@ export const laneWriteRateLimiter = rateLimit({
 });
 
 /**
+ * `GET /channels/:oxyUserId/writers` — anonymously reachable, and the one route
+ * here whose cost scales with a channel's whole publishing history: the writers
+ * list is an aggregation over every public post that channel has published.
+ * Cheap per call (the scan is index-covered) but unbounded in call rate, and an
+ * unauthenticated caller keys to a hashed IP.
+ *
+ * Its OWN store prefix, for the reason spelled out above `lanesStore`: two
+ * limiters sharing a prefix share a counter. The prefix is a LITERAL because
+ * `rateLimitPrefixUniqueness.test.ts` resolves prefixes by reading SOURCE.
+ */
+export const channelWritersRateLimiter = rateLimit({
+  store: new RedisStore({ prefix: 'rate-limit:channel-writers:', windowMs: 60 * 1000 }),
+  ...complianceOptions(120, 'Too many channel writer requests. Please slow down.'),
+});
+
+/**
  * Rate limiter for `POST /statistics/post/:postId/view`.
  *
  * The only WRITE on the statistics router, and the only route there that reaches

--- a/packages/backend/src/migrations/0027-post-channel-writer-index.ts
+++ b/packages/backend/src/migrations/0027-post-channel-writer-index.ts
@@ -1,0 +1,67 @@
+/**
+ * Migration 0027: `post_channel_writer_v1` on `posts`.
+ *
+ * A channel that names the people who write for it gains a list of them on its
+ * page, and that list is derived from posts rather than from the account's member
+ * roll: the distinct `writtenByOxyUserId` values on the channel's public,
+ * published posts. Without an index, answering it means walking every post that
+ * channel has ever published and fetching each document to read a field the
+ * existing author indexes do not carry.
+ *
+ * `{ oxyUserId: 1, visibility: 1, status: 1, writtenByOxyUserId: 1, createdAt: -1 }`
+ * serves it end to end: the three equality terms make the channel's signed posts
+ * one contiguous range, `writtenByOxyUserId` is the aggregation's group key, and
+ * `createdAt` is the value it takes the max of — so both values the `$group`
+ * reads live in the index and no post document is fetched.
+ *
+ * `partialFilterExpression`, NOT `sparse`, for the reason `0023-post-lane-index`
+ * documents: Mongo indexes a document in a SPARSE compound index when ANY indexed
+ * key is present, and every post has `visibility`, `status` and `createdAt`, so
+ * `sparse` would index the whole collection and buy nothing.
+ *
+ * And `{ $type: 'string' }` rather than `{ $exists: true }`, which is the sharper
+ * end of the same rule: a stored `null` SATISFIES `$exists`, so an `$exists`
+ * filter would quietly admit any post whose writer field was cleared by assignment
+ * rather than unset. `$type` excludes both shapes and does not depend on every
+ * future writer of that field getting the clearing idiom right. The route's query
+ * carries the same `{ $type: 'string' }` term so the planner can prove its
+ * predicate is a subset of the filter — an `$exists: true` query term would NOT
+ * make this index eligible.
+ *
+ * The schema declares it, but `autoIndex`/`autoCreate` are OFF in production (see
+ * `utils/database.ts`), so this migration is the only thing that creates it. It is
+ * deliberately NOT an entry in `POST_HOT_PATH_INDEXES`: that array is migration
+ * `0010`'s payload, `0010` is already applied, and the runner skips an applied
+ * migration — so an entry there would be a silent no-op in production.
+ *
+ * Idempotent and data-free: `createIndex` with an identical spec is a no-op, and
+ * nothing is backfilled — a post published by a person signed in as themselves
+ * carries no `writtenByOxyUserId`, which is exactly what the partial filter
+ * excludes.
+ */
+
+import mongoose from 'mongoose';
+import { logger } from '../utils/logger';
+import { MIGRATION_POST_CHANNEL_WRITER_INDEX } from './constants';
+import { Post } from '../models/Post';
+import type { Migration } from './runner';
+
+export const migrationPostChannelWriterIndex: Migration = {
+  id: MIGRATION_POST_CHANNEL_WRITER_INDEX,
+
+  async run(db: mongoose.mongo.Db): Promise<void> {
+    const posts = db.collection(Post.collection.collectionName);
+    await posts.createIndex(
+      { oxyUserId: 1, visibility: 1, status: 1, writtenByOxyUserId: 1, createdAt: -1 },
+      {
+        name: 'post_channel_writer_v1',
+        partialFilterExpression: { writtenByOxyUserId: { $type: 'string' } },
+      },
+    );
+    logger.info(
+      `[migration] ensured index post_channel_writer_v1 on ${posts.collectionName} ` +
+        '{ oxyUserId: 1, visibility: 1, status: 1, writtenByOxyUserId: 1, createdAt: -1 } ' +
+        "partial on { writtenByOxyUserId: { $type: 'string' } }",
+    );
+  },
+};

--- a/packages/backend/src/migrations/constants.ts
+++ b/packages/backend/src/migrations/constants.ts
@@ -236,3 +236,12 @@ export const MIGRATION_CHANNEL_FOLLOW_USER_INDEX = '0025-channel-follow-user-ind
  * indexes. See {@link ./0026-channel-accounts}.
  */
 export const MIGRATION_CHANNEL_ACCOUNTS = '0026-channel-accounts';
+
+/**
+ * Create the PARTIAL `post_channel_writer_v1` index on `posts` so a channel's
+ * writers tab — the distinct people who have published under it — is served from
+ * the index rather than by walking every post that channel has published.
+ * Production disables Mongoose auto-indexing, so this migration is the schema
+ * authority. See {@link ./0027-post-channel-writer-index}.
+ */
+export const MIGRATION_POST_CHANNEL_WRITER_INDEX = '0027-post-channel-writer-index';

--- a/packages/backend/src/migrations/runner.ts
+++ b/packages/backend/src/migrations/runner.ts
@@ -37,6 +37,7 @@ import { migrationPostLaneIndex } from './0023-post-lane-index';
 import { migrationChannelIndexes } from './0024-channel-indexes';
 import { migrationChannelFollowUserIndex } from './0025-channel-follow-user-index';
 import { migrationChannelAccounts } from './0026-channel-accounts';
+import { migrationPostChannelWriterIndex } from './0027-post-channel-writer-index';
 import { MIGRATIONS_COLLECTION } from './constants';
 
 export interface Migration {
@@ -99,6 +100,7 @@ const MIGRATIONS: readonly Migration[] = [
   migrationChannelIndexes,
   migrationChannelFollowUserIndex,
   migrationChannelAccounts,
+  migrationPostChannelWriterIndex,
 ];
 
 /**

--- a/packages/backend/src/models/Post.ts
+++ b/packages/backend/src/models/Post.ts
@@ -892,6 +892,31 @@ PostSchema.index(
   { name: 'post_lane_chrono_v1', partialFilterExpression: { laneId: { $exists: true } } },
 );
 
+// A channel's writers tab: the distinct people who have published under one
+// channel, and when each of them last did.
+//
+// The three equality terms lead, so the channel's signed posts are ONE
+// contiguous range; `writtenByOxyUserId` is the aggregation's group key and
+// `createdAt` the value it takes the max of, so both live in the index and the
+// `$group` never fetches a post document.
+//
+// `partialFilterExpression` on `{ $type: 'string' }`, NOT `sparse` and NOT
+// `$exists`. Sparse would cover every post (they all have `visibility`), and
+// `$exists` admits a stored `null` — while only a `$type` filter narrows the
+// index to the posts that actually carry a writer, which is a vanishing fraction
+// of the collection. The query in `routes/channelWriters.routes.ts` carries the
+// SAME `{ $type: 'string' }` term so the planner can prove eligibility.
+//
+// NOTE: `autoIndex`/`autoCreate` are OFF in production — created by migration
+// `0027-post-channel-writer-index`, not on model load.
+PostSchema.index(
+  { oxyUserId: 1, visibility: 1, status: 1, writtenByOxyUserId: 1, createdAt: -1 },
+  {
+    name: 'post_channel_writer_v1',
+    partialFilterExpression: { writtenByOxyUserId: { $type: 'string' } },
+  },
+);
+
 // Saved posts with text search: optimizes saved posts queries with a regex over
 // the post's bodies. Compound index helps when filtering by _id (from
 // savedPostIds) and searching the (multikey) variant bodies.

--- a/packages/backend/src/routes/channelWriters.routes.ts
+++ b/packages/backend/src/routes/channelWriters.routes.ts
@@ -1,0 +1,322 @@
+/**
+ * A CHANNEL'S WRITERS — the people it has already named on its posts.
+ *
+ * A channel is an Oxy ACCOUNT, not a Mention row (the Mention-local channel was
+ * retired in migration `0026`), so `:oxyUserId` below is that account's Oxy user
+ * id — the same id `/c/<handle>` resolves to and the same one every other
+ * account-scoped surface takes. This router is not a revival of the local channel
+ * model; it is one derived list about one kind of account.
+ *
+ * ── THE LIST IS WHO HAS WRITTEN, NEVER WHO MAY WRITE ──────────────────────────
+ *
+ * It is derived from the distinct `writtenByOxyUserId` values on the channel's
+ * PUBLIC, PUBLISHED posts, and never from the account's member list. Those are
+ * two different facts and only one of them is disclosable:
+ *
+ *  - `channel.signPosts` consents to naming the writer OF A PUBLISHED POST. Every
+ *    name this route returns is therefore already on a post any reader can open —
+ *    the list aggregates a disclosure that has happened, it does not make a new
+ *    one.
+ *  - The account's members are people who MAY publish as the channel. That set
+ *    includes people who never have, people who never will, and people who never
+ *    consented to being named anywhere. `listAccountMembers` would answer the
+ *    wrong question, so it is deliberately not called here.
+ *
+ * "Just list the members, it is simpler" is the change a later reader will reach
+ * for. It is simpler, and it publishes the identities of people who have written
+ * nothing.
+ *
+ * ── THE GATE ──────────────────────────────────────────────────────────────────
+ *
+ * Three conditions, ALL fail-closed, and the same three that decide whether a
+ * post's byline names its writer:
+ *
+ *  1. the account resolves through Oxy as `kind: 'channel'`,
+ *  2. `UserSettings.channel.signPosts === true`, and
+ *  3. this reader may see the channel's profile at all.
+ *
+ * (1) and (2) are `disclosesWriters` from `services/channelWriterDisclosure`,
+ * which `PostHydrationService` reads too — one authority, so the list and the
+ * byline cannot disagree about a consent decision. An unresolvable account, a
+ * missing settings row, an unset flag and a failed lookup are all "no".
+ *
+ * (3) exists because a private / followers-only profile serves an EMPTY author
+ * feed to a non-follower (`canViewAuthorFeed` in the feed engine). Without the
+ * same check, this route would be a side door onto who writes for a channel whose
+ * posts the reader cannot read. A channel has no login of its own and its only
+ * settings write accepts `channel.signPosts`, so its visibility is public in
+ * practice today — read rather than assumed, for the same reason `ChannelScreen`
+ * reads it: hardcoding "public" would silently expose a channel somebody had
+ * restricted through another surface.
+ *
+ * ── ONE SHAPE FOR "THERE IS NO LIST HERE" ─────────────────────────────────────
+ *
+ * Every refusal is a 404 with the same body: not a channel, a channel that does
+ * not sign, and a channel this reader may not see are indistinguishable from each
+ * other and from an id that names nothing. That is the idiom the fediverse-sharing
+ * consent gate already uses (its AP surfaces 404 when sharing is off), and it
+ * means no future change to what is disclosed has to revisit a status code. A
+ * disclosing channel that has published nothing with a writer is a 200 with an
+ * empty list — the list exists and is empty, which is a different fact.
+ */
+
+import { Router, type Response } from 'express';
+import type { PipelineStage } from 'mongoose';
+import { PostVisibility, type ChannelWriter, type ChannelWritersResponse } from '@mention/shared-types';
+import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
+import { Post } from '../models/Post';
+import { UserSettings } from '../models/UserSettings';
+import { resolveUserSummaries } from '../services/PostHydrationService';
+import { degradedActorSummary } from '../utils/degradedActorSummary';
+import type { CachedUserSummary } from '../services/userSummaryCache';
+import { disclosesWriters, loadSigningChannelIds } from '../services/channelWriterDisclosure';
+import { checkFollowAccess, requiresAccessCheck } from '../utils/privacyHelpers';
+import { createUserScopedOxyServices } from '../utils/oxyHelpers';
+import { channelWritersRateLimiter } from '../middleware/security';
+import { config } from '../config';
+import { sendErrorResponse, sendSuccessResponse } from '../utils/apiHelpers';
+import { queryInt, queryString } from '../utils/queryParams';
+import { logger } from '../utils/logger';
+
+const router = Router();
+
+/** Longest account id we will look up — an Oxy user id is a 24-char hex ObjectId. */
+const MAX_OXY_USER_ID_LENGTH = 64;
+
+const DEFAULT_WRITERS_PAGE_SIZE = 50;
+const MAX_WRITERS_PAGE_SIZE = 100;
+
+/** The one body every refusal answers with. See the header note. */
+const NO_LIST_MESSAGE = 'No writers list for that account';
+
+/**
+ * The keyset a writers page resumes from.
+ *
+ * `lastPostAt` alone is NOT unique — two writers whose most recent post landed in
+ * the same millisecond would straddle a page boundary and be skipped or repeated
+ * — so the cursor carries the writer's id as the tie-break, matching the
+ * `{ lastPostAt: -1, _id: -1 }` sort exactly.
+ */
+interface WritersCursor {
+  lastPostAt: Date;
+  writerOxyUserId: string;
+}
+
+/** `<epochMillis>_<oxyUserId>` — opaque to the client, cheap to parse here. */
+function encodeWritersCursor(lastPostAt: Date, writerOxyUserId: string): string {
+  return `${lastPostAt.getTime()}_${writerOxyUserId}`;
+}
+
+/**
+ * Parse a client-supplied cursor. A malformed token yields `undefined` (⇒ the
+ * first page) rather than an error, matching `GET /subscriptions`: a tampered
+ * cursor must never become a 500. The id half is only ever compared as a STRING
+ * against the group key, so it needs no cast — but it is length-bounded so a
+ * megabyte of cursor cannot ride into a query.
+ */
+function parseWritersCursor(raw: string | undefined): WritersCursor | undefined {
+  if (!raw) return undefined;
+  const separator = raw.indexOf('_');
+  if (separator <= 0) return undefined;
+
+  const millis = Number.parseInt(raw.slice(0, separator), 10);
+  if (!Number.isFinite(millis)) return undefined;
+  const lastPostAt = new Date(millis);
+  if (Number.isNaN(lastPostAt.getTime())) return undefined;
+
+  const writerOxyUserId = raw.slice(separator + 1);
+  if (!writerOxyUserId || writerOxyUserId.length > MAX_OXY_USER_ID_LENGTH) return undefined;
+
+  return { lastPostAt, writerOxyUserId };
+}
+
+/**
+ * The distinct writers of a channel's posts, most recent publication first.
+ *
+ * WHAT COUNTS. Exactly the posts whose byline already names their writer, minus
+ * the ones no visitor can reach:
+ *
+ *  - `oxyUserId: <channel>` — the channel is the post's OWNER. The denormalized
+ *    field is synced from the owner authorship entry by the `Post` pre-save hook,
+ *    so this is the owner comparison, and it is the right one rather than merely
+ *    the indexed one: a post the channel merely COLLABORATED on belongs to
+ *    somebody else, and its `writtenByOxyUserId` is that other owner's business.
+ *  - `visibility: 'public'` + `status: 'published'` — a draft, a scheduled post,
+ *    a followers-only post and a post `restricted` by moderation all drop out.
+ *    This is what keeps the list one stable answer for every reader, and it is
+ *    the fail-closed direction: a non-public post still names its writer to
+ *    whoever may read THAT post, but it does not put a name in a directory.
+ *  - `writtenByOxyUserId: { $type: 'string' }` — a post published by a person
+ *    signed in as themselves has no writer to disclose. The `$type` term is also
+ *    what makes the partial index eligible; `$exists: true` would not, and a
+ *    stored `null` satisfies `$exists` while satisfying nothing else.
+ *
+ * There is deliberately no post-TYPE filter and no lane filter, so a boost the
+ * channel published counts its publisher, a thread continuation counts its
+ * writer, and a post tucked into a `hidden` lane counts too. None of that is an
+ * oversight. Hydration names the writer on EVERY one of those posts, and a lane
+ * is curation rather than privacy — those posts still reach every feed and stay
+ * readable at their own URL. A list that quietly disagreed with the bylines
+ * beside it ("why is X not in the writers list, their name is right there") is
+ * worse than one exactly as wide as the disclosure it reports on. This is a
+ * directory OF that disclosure, not a second editorial judgment about what counts
+ * as writing.
+ *
+ * ORDER: most recent post first. The alternative, most posts first, ranks people
+ * against each other — it turns a masthead into a leaderboard on a measure the
+ * channel never chose, and volume is a poor proxy for contribution (one long
+ * investigation against fifty short notes). Recency says something the page
+ * already says everywhere else: this channel's own feed is chronological, so a
+ * reader arriving from a post they just read finds its writer at the top. It also
+ * pages honestly — a keyset on `(lastPostAt, writerId)` is stable, while a count
+ * ordering drifts under the reader between pages.
+ *
+ * COST: one aggregation, served by `post_channel_writer_v1` — the channel's
+ * signed posts are a contiguous, tiny slice of that partial index, and both
+ * values the `$group` reads live in the index, so no post document is fetched.
+ * The `$sort` that follows runs over DISTINCT WRITERS, a number bounded by how
+ * many humans have ever published as this channel.
+ */
+async function loadWriterIds(
+  channelOxyUserId: string,
+  limit: number,
+  cursor: WritersCursor | undefined,
+): Promise<Array<{ writerOxyUserId: string; lastPostAt: Date }>> {
+  const pipeline: PipelineStage[] = [
+    {
+      $match: {
+        oxyUserId: channelOxyUserId,
+        visibility: PostVisibility.PUBLIC,
+        status: 'published',
+        writtenByOxyUserId: { $type: 'string' },
+      },
+    },
+    { $group: { _id: '$writtenByOxyUserId', lastPostAt: { $max: '$createdAt' } } },
+  ];
+
+  if (cursor) {
+    pipeline.push({
+      $match: {
+        $or: [
+          { lastPostAt: { $lt: cursor.lastPostAt } },
+          { lastPostAt: cursor.lastPostAt, _id: { $lt: cursor.writerOxyUserId } },
+        ],
+      },
+    });
+  }
+
+  pipeline.push({ $sort: { lastPostAt: -1, _id: -1 } }, { $limit: limit });
+
+  const rows = await Post.aggregate<{ _id: string; lastPostAt: Date }>(pipeline)
+    .option({ maxTimeMS: 5000 })
+    .exec();
+
+  return rows.map((row) => ({ writerOxyUserId: String(row._id), lastPostAt: row.lastPostAt }));
+}
+
+/**
+ * GET /channels/:oxyUserId/writers?limit=&cursor=
+ *
+ * Mounted with `optionalAuth`: a channel's page is public, so its writers list is
+ * readable anonymously — the reader's identity matters only to condition (3) of
+ * the gate above.
+ */
+router.get(
+  '/:oxyUserId/writers',
+  // Production-gated in the PER-ROUTE position. `router.use(...limiters)` with an
+  // empty array throws `argument handler is required` at import outside
+  // production, and this is also the only position CodeQL inspects.
+  ...(config.runtime.isProduction ? [channelWritersRateLimiter] : []),
+  async (req: AuthRequest, res: Response) => {
+    const channelOxyUserId = typeof req.params.oxyUserId === 'string' ? req.params.oxyUserId.trim() : '';
+    try {
+      if (!channelOxyUserId || channelOxyUserId.length > MAX_OXY_USER_ID_LENGTH) {
+        return sendErrorResponse(res, 400, 'Bad Request', 'oxyUserId is required');
+      }
+
+      const limit = Math.min(
+        Math.max(queryInt(req.query.limit) || DEFAULT_WRITERS_PAGE_SIZE, 1),
+        MAX_WRITERS_PAGE_SIZE,
+      );
+      const cursor = parseWritersCursor(queryString(req.query.cursor));
+
+      // The identity and both settings reads, in one round trip. Nothing here
+      // depends on another's answer, and the account resolve is the same batched
+      // path a post author goes through — so a channel whose page was just
+      // rendered is already in the identity cache.
+      const [summaries, signingChannelIds, settings] = await Promise.all([
+        resolveUserSummaries([channelOxyUserId]),
+        loadSigningChannelIds([channelOxyUserId]),
+        UserSettings.findOne(
+          { oxyUserId: channelOxyUserId },
+          { 'privacy.profileVisibility': 1 },
+        ).lean<{ privacy?: { profileVisibility?: string } } | null>(),
+      ]);
+
+      const account = summaries.get(channelOxyUserId)?.user;
+      if (!disclosesWriters(channelOxyUserId, account, signingChannelIds)) {
+        return sendErrorResponse(res, 404, 'Not Found', NO_LIST_MESSAGE);
+      }
+
+      // Only a restricted profile costs the follow check, which is an Oxy round
+      // trip. The caller's OWN client is used, the same one the profile-design
+      // gate uses, so the answer is scoped to who is asking.
+      if (requiresAccessCheck(settings?.privacy?.profileVisibility)) {
+        const viewerId = req.user?.id;
+        // An anonymous reader can never satisfy a restricted profile, so the
+        // upstream call is not even made for one.
+        const canView = viewerId
+          ? await checkFollowAccess(viewerId, channelOxyUserId, createUserScopedOxyServices(req))
+          : false;
+        if (!canView) {
+          return sendErrorResponse(res, 404, 'Not Found', NO_LIST_MESSAGE);
+        }
+      }
+
+      // One extra row decides `nextCursor` without a second query.
+      const rows = await loadWriterIds(channelOxyUserId, limit + 1, cursor);
+      const hasMore = rows.length > limit;
+      const page = hasMore ? rows.slice(0, limit) : rows;
+
+      // One batched identity pass for the whole page, through the same resolver
+      // post authors go through. A whole-batch failure is not fatal: every writer
+      // falls back to its degraded summary (empty username, `'Unknown user'`) so
+      // the list still renders and self-heals on the next fetch — a raw
+      // `oxyUserId` must never surface as a handle.
+      let writerSummaries = new Map<string, CachedUserSummary>();
+      if (page.length > 0) {
+        try {
+          writerSummaries = await resolveUserSummaries(page.map((row) => row.writerOxyUserId));
+        } catch (error) {
+          logger.warn('[ChannelWriters] Failed to resolve channel writers', {
+            channelOxyUserId,
+            count: page.length,
+            reason: error instanceof Error ? error.message : 'unknown',
+          });
+        }
+      }
+
+      const writers: ChannelWriter[] = page.map((row) => ({
+        writer: writerSummaries.get(row.writerOxyUserId)?.user ?? degradedActorSummary(row.writerOxyUserId),
+        lastPostAt: row.lastPostAt.toISOString(),
+      }));
+
+      const last = page[page.length - 1];
+      const body: ChannelWritersResponse = { writers };
+      if (hasMore && last) {
+        body.nextCursor = encodeWritersCursor(last.lastPostAt, last.writerOxyUserId);
+      }
+
+      return sendSuccessResponse(res, 200, body);
+    } catch (error) {
+      logger.error('[ChannelWriters] Error listing channel writers:', {
+        channelOxyUserId,
+        userId: req.user?.id,
+        error,
+      });
+      return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to list channel writers');
+    }
+  },
+);
+
+export default router;

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -8,6 +8,7 @@ import Like from '../models/Like';
 import Bookmark from '../models/Bookmark';
 import { FederatedActor } from '../models/FederatedActor';
 import { UserSettings } from '../models/UserSettings';
+import { disclosesWriters, loadSigningChannelIds } from './channelWriterDisclosure';
 import { actorService } from '../connectors/activitypub/actor.service';
 import { ACTOR_DOMAIN, FEDERATION_DOMAIN, FEDERATION_ENABLED } from '../connectors/activitypub/constants';
 import { deriveBridgyActorUri } from '../connectors/activitypub/bridgy';
@@ -1559,23 +1560,16 @@ export class PostHydrationService {
   }
 
   /**
-   * The channel accounts in this page that DISCLOSE their writers, in ONE
-   * indexed `UserSettings` query keyed by the candidate authors' ids.
+   * The channel accounts in this page that DISCLOSE their writers.
    *
    * Only posts that actually carry a `writtenByOxyUserId` contribute a
-   * candidate, so an ordinary page of posts asks about nothing and the query is
-   * skipped entirely.
+   * candidate, so an ordinary page of posts asks about nothing and
+   * {@link loadSigningChannelIds} skips its query entirely.
    *
-   * **It fails CLOSED, three times over, and each one matters.** The set holds
-   * only ids whose settings row says `channel.signPosts === true`: a channel
-   * with no settings row is absent, a channel that never opted in is absent, and
-   * a lookup that THROWS yields an empty set — so every failure mode lands on
-   * "do not disclose". Anonymity is the safe answer here; naming a writer who
-   * did not consent cannot be undone by a later request that works.
-   *
-   * The `=== true` is deliberate rather than incidental. The value is read out
-   * of a document, so it is not the schema's word that reaches this line, and a
-   * loose read would disclose on any truthy value a stray write left behind.
+   * The decision itself — including the fail-closed reading of
+   * `channel.signPosts` — belongs to `services/channelWriterDisclosure`, which
+   * the channel's writers list reads too. Hydration collects the candidates; it
+   * does not decide.
    */
   private async buildSigningChannelIds(nodes: HydratedGraphNode[]): Promise<Set<string>> {
     const candidateAuthorIds = new Set<string>();
@@ -1587,26 +1581,7 @@ export class PostHydrationService {
       if (authorId) candidateAuthorIds.add(authorId);
     }
 
-    if (candidateAuthorIds.size === 0) {
-      return new Set();
-    }
-
-    try {
-      const rows = await UserSettings.find({ oxyUserId: { $in: [...candidateAuthorIds] } })
-        .select('oxyUserId channel.signPosts')
-        .lean<Array<{ oxyUserId?: string; channel?: { signPosts?: unknown } }>>();
-
-      const signing = new Set<string>();
-      for (const row of rows) {
-        if (row?.oxyUserId && row.channel?.signPosts === true) {
-          signing.add(String(row.oxyUserId));
-        }
-      }
-      return signing;
-    } catch (error) {
-      logger.error('[PostHydration] Failed to load channel signing settings:', error);
-      return new Set();
-    }
+    return loadSigningChannelIds(candidateAuthorIds);
   }
 
   /**
@@ -2269,12 +2244,13 @@ export class PostHydrationService {
 
     // The human behind a channel post, named only when the channel says to.
     //
-    // FAIL-CLOSED, and every clause is load-bearing: the account has to BE a
-    // channel (`user.kind`, which the identity cache carries), that channel has
-    // to be in `signingChannelIds` — which holds only accounts whose settings
-    // row says `signPosts === true`, so a missing row, a channel that never
-    // opted in, and a failed lookup are all absent from it — and the post has to
-    // carry a writer. Miss any one and nothing is disclosed.
+    // FAIL-CLOSED. {@link disclosesWriters} owns both disclosure clauses — the
+    // account has to BE a channel, and that channel has to be in
+    // `signingChannelIds`, which holds only accounts whose settings row says
+    // `signPosts === true`, so a missing row, a channel that never opted in and
+    // a failed lookup are all absent from it. The remaining conditions here are
+    // about the BYLINE rather than about consent: the post has to carry a
+    // writer, and that writer must not already be in it.
     //
     // `userMap` only holds the writer when the SAME conditions already sent the
     // id to the batch, so an undisclosed writer is not merely unrendered: they
@@ -2288,8 +2264,7 @@ export class PostHydrationService {
     if (
       writerId &&
       authors.length > 0 &&
-      user.kind === 'channel' &&
-      signingChannelIds.has(authorId) &&
+      disclosesWriters(authorId, user, signingChannelIds) &&
       !authors.some((author) => author.id === writerId)
     ) {
       const writer = userMap.get(writerId);

--- a/packages/backend/src/services/channelWriterDisclosure.ts
+++ b/packages/backend/src/services/channelWriterDisclosure.ts
@@ -1,0 +1,94 @@
+/**
+ * WHETHER A CHANNEL NAMES THE PEOPLE WHO WRITE FOR IT.
+ *
+ * A channel is an Oxy account and AUTHORS its own posts; the person who wrote one
+ * is recorded on `Post.writtenByOxyUserId`, deliberately outside `authorship`.
+ * `UserSettings.channel.signPosts` is the WHOLE disclosure decision, and this
+ * module is the one place that reads it.
+ *
+ * It lives apart from `PostHydrationService` because two surfaces now ask the
+ * same question — the post byline ("name the writer of THIS post") and the
+ * channel's writers list ("name everyone who has written for this channel") — and
+ * two implementations of a consent gate is how they end up disagreeing. One of
+ * the two answers would then be a leak, and the one that leaks is not
+ * recoverable: a name published without consent cannot be un-published by a later
+ * request that gets it right.
+ *
+ * It fails CLOSED at every step. A channel with no settings row is absent from
+ * the signing set, a channel that never opted in is absent, a lookup that THROWS
+ * yields an empty set, and an account that is not a channel is refused whatever
+ * its settings row happens to say. Anonymity is the safe answer at each of them.
+ */
+
+import type { AccountKind } from '@oxyhq/contracts';
+import { UserSettings } from '../models/UserSettings';
+import { logger } from '../utils/logger';
+
+/**
+ * Which of `candidateChannelIds` have `channel.signPosts === true`, in ONE
+ * indexed `UserSettings` query.
+ *
+ * Batched over the whole candidate set on purpose: hydration asks about every
+ * channel on a page at once, so a feed never pays a settings read per post.
+ * An empty candidate set skips the query entirely, which is what makes an
+ * ordinary page of posts cost nothing for this.
+ *
+ * The `=== true` is deliberate rather than incidental. The value is read out of a
+ * document, so it is not the schema's word that reaches this line, and a loose
+ * read (`Boolean(...)`) would disclose on any truthy value a stray write or a
+ * hand-edited document left behind — `"false"`, `1`, `{}`. Every one of those
+ * must mean anonymous.
+ */
+export async function loadSigningChannelIds(
+  candidateChannelIds: Iterable<string>,
+): Promise<Set<string>> {
+  const ids = [
+    ...new Set(
+      [...candidateChannelIds].filter((id): id is string => typeof id === 'string' && id.length > 0),
+    ),
+  ];
+  if (ids.length === 0) {
+    return new Set();
+  }
+
+  try {
+    const rows = await UserSettings.find({ oxyUserId: { $in: ids } })
+      .select('oxyUserId channel.signPosts')
+      .lean<Array<{ oxyUserId?: string; channel?: { signPosts?: unknown } }>>();
+
+    const signing = new Set<string>();
+    for (const row of rows) {
+      if (row?.oxyUserId && row.channel?.signPosts === true) {
+        signing.add(String(row.oxyUserId));
+      }
+    }
+    return signing;
+  } catch (error) {
+    logger.error('[ChannelWriterDisclosure] Failed to load channel signing settings:', error);
+    return new Set();
+  }
+}
+
+/**
+ * Whether this account discloses its writers — BOTH clauses, in one place.
+ *
+ * The settings row is not sufficient on its own: `channel.signPosts` means
+ * something on exactly one kind of account, so a row saying `true` under a
+ * PERSONAL account is not a channel disclosing its writer, it is a row that
+ * should not exist. Reading it as consent would name somebody on a person's own
+ * post.
+ *
+ * `account` is the resolved Oxy identity (a `PostUser`, or anything else
+ * carrying its `kind`) — Oxy owns the account kind, so it is read from the
+ * identity that came back, never inferred from the presence of a settings
+ * subdocument.
+ */
+export function disclosesWriters(
+  channelOxyUserId: string,
+  account: { kind?: AccountKind } | undefined,
+  signingChannelIds: ReadonlySet<string>,
+): boolean {
+  if (!channelOxyUserId) return false;
+  if (account?.kind !== 'channel') return false;
+  return signingChannelIds.has(channelOxyUserId);
+}

--- a/packages/frontend/components/ChannelScreen.tsx
+++ b/packages/frontend/components/ChannelScreen.tsx
@@ -34,6 +34,7 @@ import {
     useProfileChrome,
     useProfileMoreMenu,
     useJustFollowed,
+    useChannelWriters,
     buildProfileTabDescriptors,
     profileTabIndex,
     type LaneTabInput,
@@ -72,11 +73,17 @@ interface ChannelProfileProps {
  * - **Four tabs, not nine.** `profileTabsForAccountKind` drops the five a channel
  *   account can never fill; see its docstring for the three separate reasons.
  * - **No tab in the URL.** `/c/<handle>` is ONE route with no sub-tabs beneath
- *   it, so its tabs are local state. Writing `/@<handle>/media` here would
- *   navigate a channel out of its own URL family.
+ *   it, so its tabs are local state — the writers tab included. Writing
+ *   `/@<handle>/media` here would navigate a channel out of its own URL family,
+ *   and giving ONE channel tab a `/c/<handle>/…` route of its own while the
+ *   other four stay local state would be a worse inconsistency than either
+ *   answer applied uniformly. `about` and `settings` are separate SCREENS, not
+ *   tabs, which is why they have routes.
  *
- * What is ADDED is the operator's way in: a channel has no login, so its
- * settings are reachable only from the overflow menu of whoever operates it.
+ * What is ADDED is the operator's way in — a channel has no login, so its
+ * settings are reachable only from the overflow menu of whoever operates it —
+ * and a FIFTH tab that only a channel can have: `writers`, present when this
+ * channel names the people who write for it (see below).
  */
 const ChannelProfile: React.FC<ChannelProfileProps> = ({
     username,
@@ -100,6 +107,18 @@ const ChannelProfile: React.FC<ChannelProfileProps> = ({
         },
     });
 
+    // Whether this channel NAMES the people who write for it, which is the whole
+    // rule for the writers tab. It is not on the profile DTO — the disclosure is
+    // a Mention-owned setting on the channel account, and the writers endpoint
+    // reports it only by REFUSING (one 404 for "not a channel", "does not sign"
+    // and "you may not see this channel" alike). So the tab is keyed on the
+    // query having succeeded, never on the list being non-empty: a channel that
+    // discloses and has published nothing signed keeps its tab and says so.
+    //
+    // The tab's own content reads this same hook, so the two share one cached
+    // answer and opening the tab costs no second request.
+    const { disclosed: disclosesWriters } = useChannelWriters(profileData?.id);
+
     const tabDescriptors = useMemo(
         () =>
             buildProfileTabDescriptors(
@@ -113,11 +132,13 @@ const ChannelProfile: React.FC<ChannelProfileProps> = ({
                     feeds: t('profile.tabs.feeds', { defaultValue: 'Feeds' }),
                     starter_packs: t('profile.tabs.starter_packs', { defaultValue: 'Starter Packs' }),
                     lists: t('profile.tabs.lists', { defaultValue: 'Lists' }),
+                    writers: t('profile.tabs.writers', { defaultValue: 'Writers' }),
                 },
                 laneTabs,
                 'channel',
+                disclosesWriters,
             ),
-        [t, laneTabs],
+        [t, laneTabs, disclosesWriters],
     );
 
     const activeTab = profileTabIndex(tabDescriptors, activeTabKey);

--- a/packages/frontend/components/Profile/ProfileTabs.tsx
+++ b/packages/frontend/components/Profile/ProfileTabs.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@oxyhq/services/ui/client';
 import { Spinner } from '@/components/ui/Spinner';
 import { Feed } from '@/components/Feed/index';
+import { ProfileWriters } from './ProfileWriters';
 import MediaGrid from './MediaGrid';
 import VideosGrid from './VideosGrid';
 import { FeedCard } from '@/components/FeedCard';
@@ -137,6 +138,12 @@ export const ProfileTabs = memo(function ProfileTabs({
         viewerId={user?.id}
       />
     );
+  }
+
+  // Writers tab — a channel's masthead. The strip only carries it for a channel
+  // that names its writers, so reaching here already means the list exists.
+  if (tab === 'writers') {
+    return <ProfileWriters channelOxyUserId={profileId} />;
   }
 
   // Media grid

--- a/packages/frontend/components/Profile/ProfileWriters.tsx
+++ b/packages/frontend/components/Profile/ProfileWriters.tsx
@@ -1,0 +1,107 @@
+import React, { memo } from 'react';
+import { View, Text } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useTheme } from '@oxyhq/bloom/theme';
+import { useTranslation } from 'react-i18next';
+import { SecondaryButton } from '@/components/ui/Button';
+import { ProfileCard, ProfileCardSkeletonList } from '@/components/ProfileCard';
+import { formatRelativeTimeLocalized } from '@/utils/dateUtils';
+import { useChannelWriters } from './hooks/useChannelWriters';
+
+/**
+ * A CHANNEL's writers — the people it has already NAMED on its posts.
+ *
+ * WHAT THIS LIST IS, because the wrong reading of it is the dangerous one: it is
+ * who HAS WRITTEN, derived by the server from the channel's public, published
+ * posts. Every name here is already on a post any reader can open, so the tab
+ * aggregates a disclosure that has happened rather than making a new one. It is
+ * NOT the account's member roll, which would name people who have written
+ * nothing and consented to nothing. The caption says so on the screen, because a
+ * reader looking at a masthead will otherwise assume the other thing.
+ *
+ * An EMPTY list and NO TAB AT ALL are different facts, and they look different.
+ * The strip carries this tab only once the server has confirmed the channel
+ * discloses, so arriving here with nothing to show means the channel names its
+ * writers and has published nothing signed yet — which is what the empty state
+ * says. A channel that does NOT name its writers has no tab to arrive at.
+ *
+ * Rows are {@link ProfileCard}, the one user row, taking the canonical
+ * `PostUser` straight from the DTO with no adapter. That is what gives this list
+ * the handle normalization, the avatar resolution (a bare Oxy file id through
+ * Bloom's resolver), the live correction of a profile edited in this session,
+ * and — the one that matters most here — the ghost-handle rule: a writer Oxy
+ * could not resolve arrives with an EMPTY username and renders as "Unknown user"
+ * with no `@handle` line and no profile link, never as a raw id.
+ *
+ * Pagination is a BUTTON rather than an `onEndReached` or a scroll sentinel: a
+ * profile tab does not own its scroll (the shell or the feed's list does), so a
+ * list here cannot observe the viewport without nesting a second scroller. The
+ * page is the server's default of 50 and the set is bounded by how many humans
+ * have ever published as this channel, so a second page is rare — and every
+ * other non-feed profile tab fetches exactly one page and stops, which this at
+ * least improves on.
+ */
+export const ProfileWriters = memo(function ProfileWriters({
+  channelOxyUserId,
+}: {
+  channelOxyUserId?: string;
+}) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const { writers, loading, hasMore, loadingMore, loadMore } = useChannelWriters(channelOxyUserId);
+
+  if (loading) {
+    return <ProfileCardSkeletonList count={5} showFollowButton />;
+  }
+
+  if (writers.length === 0) {
+    return (
+      <View className="items-center justify-center p-8 gap-3" style={{ minHeight: 200 }}>
+        <Ionicons name="create-outline" size={48} color={theme.colors.textSecondary} />
+        <Text className="text-muted-foreground text-base font-medium">
+          {t('channels.writers.empty', { defaultValue: 'No writers yet' })}
+        </Text>
+        <Text className="text-muted-foreground text-sm text-center">
+          {t('channels.writers.emptyDetail', {
+            defaultValue:
+              'This channel names the person who wrote each post. None have been published yet.',
+          })}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="w-full">
+      <Text className="text-muted-foreground text-sm px-3 py-3">
+        {t('channels.writers.caption', {
+          defaultValue: 'The people this channel has named on its posts.',
+        })}
+      </Text>
+      {writers.map((entry, index) => (
+        <ProfileCard
+          key={entry.writer.id}
+          profile={entry.writer}
+          showFollowButton
+          meta={t('channels.writers.lastWrote', {
+            time: formatRelativeTimeLocalized(entry.lastPostAt, t),
+            defaultValue: 'Last wrote {{time}}',
+          })}
+          // The last row's hairline would otherwise sit under nothing — unless
+          // the load-more button follows it, which it then separates.
+          showDivider={hasMore || index < writers.length - 1}
+        />
+      ))}
+      {hasMore ? (
+        <View className="p-4">
+          {/* The label does not change while the page is in flight: `Button` has
+              no loading state, and a second string here would be a new catalog
+              entry for a moment nobody reads. `disabled` is what says it. */}
+          <SecondaryButton onPress={loadMore} disabled={loadingMore}>
+            {t('common.loadMore')}
+          </SecondaryButton>
+        </View>
+      ) : null}
+    </View>
+  );
+});

--- a/packages/frontend/components/Profile/__tests__/channelWritersTab.test.tsx
+++ b/packages/frontend/components/Profile/__tests__/channelWritersTab.test.tsx
@@ -1,0 +1,592 @@
+import React from 'react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import TestRenderer, { act } from 'react-test-renderer';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ChannelWritersResponse } from '@mention/shared-types';
+import enMessages from '@/locales/en.json';
+
+/**
+ * A CHANNEL'S WRITERS TAB — the rule, and the two facts it must tell apart.
+ *
+ * The tab exists when the channel NAMES the people who write for it. Nothing on
+ * the profile DTO says so: the disclosure is a Mention-owned setting on the
+ * channel account, and `GET /channels/:id/writers` reports it only by REFUSING —
+ * one 404 for "not a channel", for "does not sign its posts", and for "you may
+ * not see this channel". So the tab is keyed on the query having SUCCEEDED.
+ *
+ * That makes one distinction load-bearing, and it is the reason this file exists
+ * rather than a single happy-path fixture:
+ *
+ *  - **404** ⇒ there is no list ⇒ NO TAB.
+ *  - **200 with `writers: []`** ⇒ the list exists and is empty ⇒ the tab is
+ *    there, saying so.
+ *
+ * A suite whose endpoint always answers 200 cannot tell "tab when disclosing"
+ * from "tab always", and a suite that reads `writers.length` instead of the
+ * query's success cannot tell an empty masthead from an undisclosed one. Both
+ * fixtures are therefore present below, and they are asserted to produce
+ * DIFFERENT outcomes rather than each merely producing its own.
+ *
+ * Mocks stop at the module boundary: the SDK packages that ship untranspiled TS,
+ * and the HTTP client. `channelWritersService`, `useChannelWriters`,
+ * `buildProfileTabDescriptors`, `ProfileWriters` and the real `ProfileCard`
+ * beneath it are all the code under test — which is what lets the ghost-handle
+ * assertion mean anything. `t` resolves against the REAL `en.json`, so a missing
+ * catalog entry fails here instead of shipping a raw key.
+ */
+
+type MessageNode = string | number | boolean | null | MessageNode[] | { [key: string]: MessageNode };
+const messages: { [key: string]: MessageNode } = enMessages;
+
+function mockTranslate(key: string, vars?: Record<string, string> & { defaultValue?: string }): string {
+  // i18next resolves a dotted key against nested objects AND flat dotted keys.
+  const direct = messages[key];
+  const nested =
+    typeof direct === 'string'
+      ? direct
+      : key
+          .split('.')
+          .reduce<MessageNode | undefined>(
+            (node, part) =>
+              typeof node === 'object' && node !== null && !Array.isArray(node)
+                ? node[part]
+                : undefined,
+            messages,
+          );
+  const value = typeof nested === 'string' ? nested : vars?.defaultValue;
+  if (typeof value !== 'string') return key;
+  if (!vars) return value;
+  return value.replace(/\{\{(\w+)\}\}/g, (_m, name: string) => String(vars[name] ?? ''));
+}
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockTranslate }),
+}));
+
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn() },
+  useRouter: () => ({ push: jest.fn() }),
+  Link: () => null,
+}));
+
+const mockAuth = {
+  user: { id: 'viewer-1' } as { id: string } | null,
+  canUsePrivateApi: true,
+  isPrivateApiPending: false,
+};
+
+jest.mock('@oxyhq/services/ui/client', () => {
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    useAuth: () => mockAuth,
+    FollowButton: () => <View testID="follow-button" />,
+  };
+});
+
+interface HandleUser {
+  username?: string;
+  handle?: string;
+  isFederated?: boolean;
+  type?: string;
+  instance?: string;
+  federation?: { domain?: string };
+}
+
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user?: HandleUser | null): string | null => {
+    const username = (user?.username ?? user?.handle ?? '').trim().replace(/^@/, '');
+    if (username.length === 0) return null;
+    const isFederated = user?.isFederated === true || user?.type === 'federated';
+    const instance = (user?.instance ?? user?.federation?.domain ?? '').trim().replace(/^@/, '');
+    if (isFederated && instance.length > 0 && !username.includes('@')) {
+      return `${username}@${instance}`;
+    }
+    return username;
+  },
+}));
+
+jest.mock('@oxyhq/bloom/avatar', () => {
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { Avatar: () => <View testID="avatar" /> };
+});
+
+jest.mock('@oxyhq/bloom/skeleton', () => {
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  const Box = ({ children }: { children?: React.ReactNode }) => (
+    <View testID="skeleton">{children}</View>
+  );
+  return { Row: Box, Col: Box, Text: Box, Circle: Box, Pill: Box, Box };
+});
+
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      primary: '#0000ff',
+      text: '#000000',
+      textSecondary: '#666666',
+      border: '#cccccc',
+      error: '#ff0000',
+      card: '#ffffff',
+    },
+  }),
+}));
+
+// Reached through ProfileCard → UserName (its copyable handle).
+jest.mock('@oxyhq/bloom/toast', () => ({ toast: jest.fn() }));
+
+// Reached through `SecondaryButton` (components/ui/Button).
+jest.mock('@oxyhq/bloom/hooks', () => ({
+  useHaptics: () => ({ trigger: jest.fn(), impact: jest.fn(), selection: jest.fn() }),
+  useInteractionState: () => ({ pressed: false, hovered: false }),
+  useInteractionStates: () => ({ pressed: false, hovered: false }),
+}));
+
+jest.mock('@oxyhq/bloom/button', () => {
+  const { Text, TouchableOpacity } =
+    jest.requireActual<typeof import('react-native')>('react-native');
+  const Button = ({ label, onPress }: { label?: string; onPress?: () => void }) => (
+    <TouchableOpacity accessibilityRole="button" accessibilityLabel={label} onPress={onPress}>
+      <Text>{label}</Text>
+    </TouchableOpacity>
+  );
+  return { Button, ButtonText: Text };
+});
+
+// Reached through ProfileCard → RemoteActorBadge → FediverseInfoDialog.
+jest.mock('@oxyhq/bloom/dialog', () => {
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <View>{children}</View>;
+  return {
+    Dialog: Passthrough,
+    DialogContent: Passthrough,
+    DialogHeader: Passthrough,
+    DialogTitle: Passthrough,
+    DialogDescription: Passthrough,
+    DialogFooter: Passthrough,
+    DialogTrigger: Passthrough,
+    BottomSheet: Passthrough,
+    useDialogControl: () => ({ open: jest.fn(), close: jest.fn() }),
+  };
+});
+
+/**
+ * The HTTP boundary, not the service — so the request path, the cursor
+ * round-trip and the service's refusal to swallow a 404 are all under test. A
+ * mock of `channelWritersService` would assert only that the hook calls it.
+ */
+const mockGet = jest.fn();
+jest.mock('@/utils/api', () => ({
+  authenticatedClient: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+import { useChannelWriters } from '../hooks/useChannelWriters';
+import { ProfileWriters } from '../ProfileWriters';
+import { buildProfileTabDescriptors, CHANNEL_ONLY_TAB_NAMES, TAB_NAMES, type ProfileTab } from '../types';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const CHANNEL_ID = 'channel-oxy-1';
+
+function writer(id: string, username: string, displayName: string) {
+  return { id, username, name: { displayName }, avatar: `file-${id}`, verified: false };
+}
+
+/** The exact degraded shape the backend emits for a writer Oxy could not resolve. */
+function degradedWriter(id: string) {
+  return { id, username: '', name: { displayName: 'Unknown user' }, avatar: null };
+}
+
+/** What the endpoint answers for every refusal — the same body for all of them. */
+function notFound(): Error & { response: { status: number } } {
+  return Object.assign(new Error('Request failed with status code 404'), {
+    response: { status: 404, data: { message: 'No writers list for that account' } },
+  });
+}
+
+/** The linked client peels the backend's `{ data }` envelope before this layer. */
+function page(body: ChannelWritersResponse): { data: ChannelWritersResponse } {
+  return { data: body };
+}
+
+const LABELS: Record<ProfileTab, string> = Object.fromEntries(
+  [...TAB_NAMES, ...CHANNEL_ONLY_TAB_NAMES].map((tab) => [tab, `label:${tab}`]),
+) as Record<ProfileTab, string>;
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+type Hook = ReturnType<typeof useChannelWriters>;
+let latest: Hook | null = null;
+
+function Probe({ channelId }: { channelId: string | undefined }) {
+  latest = useChannelWriters(channelId);
+  return null;
+}
+
+const clients: QueryClient[] = [];
+const renderers: TestRenderer.ReactTestRenderer[] = [];
+
+/**
+ * `retry: 1` on the CLIENT, not `false`.
+ *
+ * The hook sets `retry: false` for itself, and a client that also refuses to
+ * retry would make that option unobservable — the "asks once" case below would
+ * pass with the hook's option deleted. A client that WOULD retry is what turns
+ * that assertion into a real one. `retryDelay: 0` keeps it instant, and
+ * `gcTime: 0` stops a settled query holding a five-minute timer past the run.
+ */
+function newClient(): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: 1, retryDelay: 0, gcTime: 0 },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+  clients.push(client);
+  return client;
+}
+
+function render(element: React.ReactElement, client: QueryClient): TestRenderer.ReactTestRenderer {
+  let renderer: TestRenderer.ReactTestRenderer | null = null;
+  act(() => {
+    renderer = TestRenderer.create(
+      <QueryClientProvider client={client}>{element}</QueryClientProvider>,
+    );
+  });
+  const created = renderer as unknown as TestRenderer.ReactTestRenderer;
+  renderers.push(created);
+  return created;
+}
+
+/**
+ * Advance the world until `predicate` holds.
+ *
+ * CONDITION-based, and on a value the tree has actually RENDERED — never on
+ * `client.isFetching()`. React Query notifies its subscribers on a macrotask
+ * AFTER the fetch count drops, so a wait that stops at `isFetching() === 0`
+ * reads the probe before it has re-rendered and sees the pre-settle value. That
+ * is a race, and it is one that only loses under load: every case in this file
+ * passed run on its own and one of them took the full suite red.
+ *
+ * The iteration cap is a FAILURE ceiling, not the wait — a condition that never
+ * becomes true reports itself by name instead of hanging to jest's timeout.
+ */
+async function waitUntil(predicate: () => boolean, description: string): Promise<void> {
+  const FAILURE_CEILING = 500;
+  for (let attempt = 0; attempt < FAILURE_CEILING; attempt += 1) {
+    if (predicate()) return;
+    await act(async () => {
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error(`waitUntil never saw: ${description}`);
+}
+
+/**
+ * The hook has settled EITHER WAY — `loading` is the query's own `isPending`,
+ * which clears on success and on refusal alike. Waiting on it rather than on the
+ * expected outcome is what keeps the empty and refused cases from becoming
+ * tautologies.
+ */
+async function settleHook(): Promise<void> {
+  await waitUntil(() => latest !== null && !latest.loading, 'the writers query to settle');
+}
+
+/** Whether the list is still showing its loading placeholder rows. */
+function showsSkeleton(renderer: TestRenderer.ReactTestRenderer): boolean {
+  return renderer.root.findAllByProps({ testID: 'skeleton' }).length > 0;
+}
+
+/** The rendered list has stopped loading — a signal independent of what it then shows. */
+async function settleUi(renderer: TestRenderer.ReactTestRenderer): Promise<void> {
+  await waitUntil(() => !showsSkeleton(renderer), 'the writers list to stop loading');
+}
+
+/** Nothing should be in flight — for the case where no request is made at all. */
+async function settleIdle(client: QueryClient): Promise<void> {
+  await waitUntil(() => client.isFetching() === 0, 'React Query to go idle');
+}
+
+type JsonNode = TestRenderer.ReactTestRendererJSON | string | null;
+
+function collectText(node: JsonNode | JsonNode[]): string[] {
+  if (node === null || node === undefined) return [];
+  if (typeof node === 'string') return [node];
+  if (Array.isArray(node)) return node.flatMap(collectText);
+  return (node.children ?? []).flatMap((child) => collectText(child as JsonNode));
+}
+
+function renderedText(renderer: TestRenderer.ReactTestRenderer): string {
+  return collectText(renderer.toJSON() as JsonNode | JsonNode[]).join(' | ');
+}
+
+/** The same text with no separators — `UserName` splits `@ada` across nodes. */
+function compactText(renderer: TestRenderer.ReactTestRenderer): string {
+  return collectText(renderer.toJSON() as JsonNode | JsonNode[]).join('');
+}
+
+/** The tab strip a channel gets for a given disclosure answer. */
+function channelStrip(disclosed: boolean): string[] {
+  return buildProfileTabDescriptors(LABELS, [], 'channel', disclosed).map((d) => d.key);
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockAuth.user = { id: 'viewer-1' };
+  latest = null;
+});
+
+afterEach(() => {
+  for (const renderer of renderers.splice(0)) {
+    act(() => renderer.unmount());
+  }
+  for (const client of clients.splice(0)) {
+    client.clear();
+    client.unmount();
+  }
+});
+
+// ── The refusal, and what it means for the tab ──────────────────────────────
+
+describe('a channel that does not name its writers has no tab', () => {
+  it('reports NOT disclosed when the endpoint refuses', async () => {
+    mockGet.mockRejectedValue(notFound());
+    const client = newClient();
+    render(<Probe channelId={CHANNEL_ID} />, client);
+    await settleHook();
+
+    expect(latest?.disclosed).toBe(false);
+    expect(latest?.writers).toEqual([]);
+  });
+
+  it('asks exactly once — the refusal is an answer, not an error to retry', async () => {
+    mockGet.mockRejectedValue(notFound());
+    const client = newClient();
+    render(<Probe channelId={CHANNEL_ID} />, client);
+    await settleHook();
+
+    // The client above WOULD retry; only the hook's own `retry: false` stops it.
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not ask at all before the channel has resolved', async () => {
+    const client = newClient();
+    render(<Probe channelId={undefined} />, client);
+    await settleIdle(client);
+
+    expect(mockGet).not.toHaveBeenCalled();
+    // Unresolved is not disclosed: no tab until something affirmatively says so.
+    expect(latest?.disclosed).toBe(false);
+  });
+});
+
+describe('a disclosing channel with nothing published keeps its tab', () => {
+  it('reports DISCLOSED for a 200 whose list is empty', async () => {
+    mockGet.mockResolvedValue(page({ writers: [] }));
+    const client = newClient();
+    render(<Probe channelId={CHANNEL_ID} />, client);
+    await settleHook();
+
+    expect(latest?.disclosed).toBe(true);
+    expect(latest?.writers).toEqual([]);
+  });
+
+  /**
+   * THE discriminator. Both fixtures produce an empty list, so any rule that
+   * reads `writers.length` answers them identically — and would hide the tab of
+   * a channel that has genuinely opted in. Only the query's success tells them
+   * apart, and the two strips must therefore differ.
+   */
+  it('gives the empty-200 channel a writers tab and the 404 channel none', async () => {
+    mockGet.mockResolvedValue(page({ writers: [] }));
+    const disclosingClient = newClient();
+    render(<Probe channelId={CHANNEL_ID} />, disclosingClient);
+    await settleHook();
+    const disclosedAnswer = latest?.disclosed ?? false;
+    const emptyWriters = latest?.writers ?? [];
+
+    mockGet.mockReset();
+    mockGet.mockRejectedValue(notFound());
+    const refusingClient = newClient();
+    render(<Probe channelId={CHANNEL_ID} />, refusingClient);
+    await settleHook();
+    const refusedAnswer = latest?.disclosed ?? false;
+
+    // Same rendered list on both sides…
+    expect(emptyWriters).toEqual([]);
+    expect(latest?.writers).toEqual([]);
+    // …opposite answers to the only question the tab asks…
+    expect(disclosedAnswer).toBe(true);
+    expect(refusedAnswer).toBe(false);
+    // …and therefore two different tab strips.
+    expect(channelStrip(disclosedAnswer)).toContain('writers');
+    expect(channelStrip(refusedAnswer)).not.toContain('writers');
+    expect(channelStrip(disclosedAnswer)).not.toEqual(channelStrip(refusedAnswer));
+  });
+});
+
+// ── The list itself ─────────────────────────────────────────────────────────
+
+describe('the writers list', () => {
+  it('requests the channel’s own writers path', async () => {
+    mockGet.mockResolvedValue(page({ writers: [] }));
+    const client = newClient();
+    render(<Probe channelId={CHANNEL_ID} />, client);
+    await settleHook();
+
+    // Asserted by path: a typo here type-checks and ships as a channel that
+    // never discloses, which is indistinguishable from one that opted out.
+    expect(mockGet).toHaveBeenCalledWith(`/channels/${CHANNEL_ID}/writers`, { params: {} });
+  });
+
+  it('follows nextCursor and appends the next page', async () => {
+    mockGet
+      .mockResolvedValueOnce(
+        page({
+          writers: [{ writer: writer('w1', 'ada', 'Ada'), lastPostAt: '2026-08-01T00:00:00.000Z' }],
+          nextCursor: 'cursor-1',
+        }),
+      )
+      .mockResolvedValueOnce(
+        page({
+          writers: [{ writer: writer('w2', 'bea', 'Bea'), lastPostAt: '2026-07-01T00:00:00.000Z' }],
+        }),
+      );
+
+    const client = newClient();
+    render(<Probe channelId={CHANNEL_ID} />, client);
+    await settleHook();
+
+    expect(latest?.hasMore).toBe(true);
+    expect(latest?.writers.map((entry) => entry.writer.id)).toEqual(['w1']);
+
+    act(() => latest?.loadMore());
+    await waitUntil(() => (latest?.writers.length ?? 0) === 2, 'the second page to land');
+
+    expect(mockGet).toHaveBeenLastCalledWith(`/channels/${CHANNEL_ID}/writers`, {
+      params: { cursor: 'cursor-1' },
+    });
+    expect(latest?.writers.map((entry) => entry.writer.id)).toEqual(['w1', 'w2']);
+    // No `nextCursor` on the second page is the end of the list.
+    expect(latest?.hasMore).toBe(false);
+  });
+
+  it('caches under the VIEWER’s key, so one reader’s refusal is not another’s', async () => {
+    mockGet.mockResolvedValue(page({ writers: [] }));
+    const client = newClient();
+    render(<Probe channelId={CHANNEL_ID} />, client);
+    await settleHook();
+
+    expect(client.getQueryData(viewerQueryKeys.channelWriters('viewer-1', CHANNEL_ID))).toBeDefined();
+    expect(client.getQueryData(viewerQueryKeys.channelWriters('viewer-2', CHANNEL_ID))).toBeUndefined();
+  });
+});
+
+// ── What the tab renders ────────────────────────────────────────────────────
+
+describe('the writers tab on screen', () => {
+  it('says the list is empty rather than showing nothing', async () => {
+    mockGet.mockResolvedValue(page({ writers: [] }));
+    const client = newClient();
+    const renderer = render(<ProfileWriters channelOxyUserId={CHANNEL_ID} />, client);
+    await settleUi(renderer);
+
+    expect(renderedText(renderer)).toContain('No writers yet');
+    expect(renderedText(renderer)).toContain('This channel names the person who wrote each post');
+  });
+
+  it('names each writer, when they last wrote, and what the list is', async () => {
+    mockGet.mockResolvedValue(
+      page({
+        writers: [
+          { writer: writer('w1', 'ada', 'Ada Lovelace'), lastPostAt: new Date().toISOString() },
+        ],
+      }),
+    );
+    const client = newClient();
+    const renderer = render(<ProfileWriters channelOxyUserId={CHANNEL_ID} />, client);
+    await settleUi(renderer);
+
+    const text = renderedText(renderer);
+    expect(text).toContain('Ada Lovelace');
+    expect(text).toContain('Last wrote');
+    // The caption is what stops a reader taking a masthead for a member roll.
+    expect(text).toContain('The people this channel has named on its posts.');
+  });
+
+  /**
+   * The ghost-handle rule, on this surface. A writer Oxy could not resolve must
+   * render as "Unknown user" with no `@handle` line and no `/@<id>` link — the
+   * raw id is not a profile, and a transient lookup failure must not look like a
+   * real account. It holds because the row IS `ProfileCard`; this asserts the
+   * DTO reaches it untouched, so a future hand-built row here fails.
+   */
+  it('never renders an unresolvable writer’s raw id', async () => {
+    const ghostId = 'ghost-oxy-id-000';
+    mockGet.mockResolvedValue(
+      page({
+        writers: [{ writer: degradedWriter(ghostId), lastPostAt: new Date().toISOString() }],
+      }),
+    );
+    const client = newClient();
+    const renderer = render(<ProfileWriters channelOxyUserId={CHANNEL_ID} />, client);
+    await settleUi(renderer);
+
+    expect(compactText(renderer)).toContain('Unknown user');
+    expect(compactText(renderer)).not.toContain(ghostId);
+    expect(compactText(renderer)).not.toContain(`@${ghostId}`);
+  });
+
+  it('offers a load-more control only while there is another page', async () => {
+    mockGet.mockResolvedValue(
+      page({
+        writers: [{ writer: writer('w1', 'ada', 'Ada'), lastPostAt: new Date().toISOString() }],
+        nextCursor: 'cursor-1',
+      }),
+    );
+    const client = newClient();
+    const renderer = render(<ProfileWriters channelOxyUserId={CHANNEL_ID} />, client);
+    await settleUi(renderer);
+    expect(renderedText(renderer)).toContain('Load more');
+
+    mockGet.mockReset();
+    mockGet.mockResolvedValue(
+      page({
+        writers: [{ writer: writer('w1', 'ada', 'Ada'), lastPostAt: new Date().toISOString() }],
+      }),
+    );
+    const lastPageClient = newClient();
+    const lastPageRenderer = render(<ProfileWriters channelOxyUserId={CHANNEL_ID} />, lastPageClient);
+    await settleUi(lastPageRenderer);
+    expect(renderedText(lastPageRenderer)).not.toContain('Load more');
+  });
+});
+
+// ── The wiring the screen owns ──────────────────────────────────────────────
+
+/**
+ * `ChannelProfile` is not exported and mounting the whole profile shell to reach
+ * it would test the shell, so the ONE line this file cannot otherwise reach is
+ * pinned by reading the source: the strip's writers flag must come from the
+ * hook's answer. A literal `true` there — the obvious "simplify" — gives every
+ * channel a writers tab, including ones that opted out, and every other
+ * assertion in this file still passes.
+ */
+describe('the channel screen feeds the endpoint’s answer into its tab strip', () => {
+  const CHANNEL_SCREEN = join(__dirname, '..', '..', 'ChannelScreen.tsx');
+  const source = readFileSync(CHANNEL_SCREEN, 'utf8');
+
+  it('read a plausible file, so the assertions below are not vacuous', () => {
+    expect(source.length).toBeGreaterThan(2000);
+    expect(source).toContain('buildProfileTabDescriptors');
+  });
+
+  it('takes the flag from useChannelWriters and passes it as the strip’s fourth argument', () => {
+    expect(source).toMatch(/const \{ disclosed: disclosesWriters \} = useChannelWriters\(/);
+    expect(source).toMatch(/'channel',\s*disclosesWriters,/);
+  });
+});

--- a/packages/frontend/components/Profile/__tests__/profileTabDescriptors.test.ts
+++ b/packages/frontend/components/Profile/__tests__/profileTabDescriptors.test.ts
@@ -1,4 +1,5 @@
 import {
+  CHANNEL_ONLY_TAB_NAMES,
   TAB_NAMES,
   buildProfileTabDescriptors,
   laneTabKey,
@@ -7,8 +8,8 @@ import {
   type ProfileTab,
 } from '@/components/Profile/types';
 
-const LABELS = Object.fromEntries(
-  TAB_NAMES.map((tab) => [tab, `label:${tab}`]),
+const LABELS: Record<ProfileTab, string> = Object.fromEntries(
+  [...TAB_NAMES, ...CHANNEL_ONLY_TAB_NAMES].map((tab) => [tab, `label:${tab}`]),
 ) as Record<ProfileTab, string>;
 
 /**
@@ -67,7 +68,18 @@ describe('profile tab descriptors', () => {
       'media',
       'videos',
       'boosts',
+      // Channel-only, and last: this asks the account kind whether the tab is
+      // POSSIBLE, not whether this particular channel gets it — that second
+      // question is `disclosesWriters`, and it lives in the descriptor builder.
+      'writers',
     ]);
+  });
+
+  it('offers the writers tab to a channel and to nobody else', () => {
+    expect(profileTabsForAccountKind('channel')).toContain('writers');
+    for (const kind of ['personal', 'organization', 'project', 'bot', undefined] as const) {
+      expect(profileTabsForAccountKind(kind)).not.toContain('writers');
+    }
   });
 
   /**
@@ -108,6 +120,41 @@ describe('profile tab descriptors', () => {
       'videos',
       'boosts',
     ]);
+  });
+
+  /**
+   * The writers tab is the one tab whose presence the account KIND cannot
+   * decide: every channel could have one, only a channel that NAMES its writers
+   * gets one. Both directions are asserted here — a fixture that only ever
+   * disclosed could not tell "tab when disclosing" from "tab always".
+   */
+  it('adds the writers tab to a channel that discloses, and only then', () => {
+    const disclosing = buildProfileTabDescriptors(LABELS, [], 'channel', true);
+    const notDisclosing = buildProfileTabDescriptors(LABELS, [], 'channel', false);
+
+    expect(disclosing.map((d) => d.key)).toEqual([
+      'posts',
+      'media',
+      'videos',
+      'boosts',
+      'writers',
+    ]);
+    expect(notDisclosing.map((d) => d.key)).toEqual(['posts', 'media', 'videos', 'boosts']);
+    // The two must actually differ; if they ever stop differing, the tab has
+    // become unconditional and every assertion above still passes.
+    expect(disclosing.map((d) => d.key)).not.toEqual(notDisclosing.map((d) => d.key));
+  });
+
+  it('defaults the writers tab to ABSENT, so a missing answer names nobody', () => {
+    const descriptors = buildProfileTabDescriptors(LABELS, [], 'channel');
+    expect(descriptors.map((d) => d.key)).not.toContain('writers');
+  });
+
+  it('never gives a person a writers tab, however the disclosure flag is set', () => {
+    for (const disclosed of [true, false]) {
+      const descriptors = buildProfileTabDescriptors(LABELS, [], 'personal', disclosed);
+      expect(descriptors.map((d) => d.key)).toEqual([...TAB_NAMES]);
+    }
   });
 
   it('lands a channel on posts for a tab its strip no longer has', () => {

--- a/packages/frontend/components/Profile/hooks/useChannelWriters.ts
+++ b/packages/frontend/components/Profile/hooks/useChannelWriters.ts
@@ -1,0 +1,88 @@
+import { useCallback, useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useAuth } from '@oxyhq/services/ui/client';
+import type { ChannelWriter } from '@mention/shared-types';
+import { channelWritersService } from '@/services/channelWritersService';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+
+export interface ChannelWritersState {
+  /** The people this channel has named, most recent publication first. */
+  writers: ChannelWriter[];
+  /**
+   * Whether this channel NAMES the people who write for it — the whole tab-
+   * visibility rule.
+   *
+   * It is the QUERY'S OWN SUCCESS, not anything in the body, because the server
+   * refuses with a 404 in every case where there is no list to show: the account
+   * is not a channel, the channel does not sign its posts, or this reader may
+   * not see it. One shape for all three, so nothing here has to re-derive a
+   * disclosure decision the server already made — and so a case added to that
+   * refusal later needs no change on this side.
+   *
+   * A DISCLOSING channel that has published nothing signed answers 200 with an
+   * empty list, which is a different fact and keeps the tab. Collapsing the two
+   * would either hide a real (if empty) masthead or advertise one that was never
+   * disclosed, so {@link writers}`.length` must never be read as this.
+   */
+  disclosed: boolean;
+  /** True until the first page has settled either way. */
+  loading: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
+  loadMore: () => void;
+}
+
+/**
+ * A channel's writers, as both consumers need them.
+ *
+ * TWO callers on purpose, sharing ONE React Query key: the channel screen asks
+ * only whether the tab exists, and the tab itself asks for the rows. React Query
+ * serves both from a single cache entry, so the strip and its contents can never
+ * disagree about whether this channel discloses — and opening the tab costs no
+ * second request.
+ *
+ * That the screen pays for a request it may never show is not an oversight. The
+ * disclosure is not on the profile DTO (it is a Mention-owned setting on the
+ * channel account, and the endpoint deliberately reports it only by refusing),
+ * so there is nothing cheaper to ask. The request is one index-covered
+ * aggregation, and its answer is cached for the visit.
+ */
+export function useChannelWriters(channelOxyUserId: string | undefined): ChannelWritersState {
+  const { user } = useAuth();
+
+  const query = useInfiniteQuery({
+    queryKey: viewerQueryKeys.channelWriters(user?.id, channelOxyUserId),
+    queryFn: ({ pageParam }) => channelWritersService.list(channelOxyUserId ?? '', pageParam),
+    initialPageParam: undefined as string | undefined,
+    // The absence of `nextCursor` is the end of the list.
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    enabled: Boolean(channelOxyUserId),
+    // A failure here is an ANSWER — "no writers list" — not something to recover
+    // from, so retrying it spends three requests per page view to arrive back at
+    // the same missing tab. The client-wide policy retries a 5xx twice, which is
+    // right for a query whose failure is an error; for this one, a transient
+    // outage simply means no tab for the visit, which is the fail-closed
+    // direction a disclosure surface should fail in anyway.
+    retry: false,
+  });
+
+  const writers = useMemo(
+    () => query.data?.pages.flatMap((page) => page.writers) ?? [],
+    [query.data],
+  );
+
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = query;
+  const loadMore = useCallback(() => {
+    if (isFetchingNextPage || !hasNextPage) return;
+    void fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return {
+    writers,
+    disclosed: query.isSuccess,
+    loading: query.isPending,
+    hasMore: Boolean(hasNextPage),
+    loadingMore: isFetchingNextPage,
+    loadMore,
+  };
+}

--- a/packages/frontend/components/Profile/index.ts
+++ b/packages/frontend/components/Profile/index.ts
@@ -9,6 +9,7 @@ export { useProfileAccount } from './hooks/useProfileAccount';
 export { useProfileChrome } from './hooks/useProfileChrome';
 export { useProfileMoreMenu } from './hooks/useProfileMoreMenu';
 export { useJustFollowed } from './hooks/useJustFollowed';
+export { useChannelWriters } from './hooks/useChannelWriters';
 
 // Components
 export { ProfileSkeleton } from './ProfileSkeleton';
@@ -19,6 +20,7 @@ export { ProfileStats } from './ProfileStats';
 export { ProfileMeta } from './ProfileMeta';
 export { ProfileCommunities } from './ProfileCommunities';
 export { ProfileTabs } from './ProfileTabs';
+export { ProfileWriters } from './ProfileWriters';
 export { PrivateBadge } from './PrivateBadge';
 export { ProfileContent } from './ProfileContent';
 

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -12,7 +12,28 @@ import type { useAuth } from '@oxyhq/services/ui/client';
 
 // Tab configuration
 export const TAB_NAMES = ['posts', 'replies', 'media', 'videos', 'likes', 'boosts', 'feeds', 'starter_packs', 'lists'] as const;
-export type ProfileTab = typeof TAB_NAMES[number];
+
+/**
+ * Tabs only a CHANNEL account's profile has, appended after {@link TAB_NAMES}.
+ *
+ * A separate list rather than another entry in `TAB_NAMES` filtered back out for
+ * everybody else, because the two directions are not the same statement:
+ * `CHANNEL_EXCLUDED_TABS` names tabs a channel CANNOT FILL, while this names one
+ * that only a channel HAS. Folding them together would make `TAB_NAMES` a list
+ * no account actually gets, and every reader of it would have to consult the
+ * filter to know what it means.
+ *
+ * - **`writers`** — the people this channel has already named on its posts. It
+ *   exists at all only because `UserSettings.channel.signPosts` is a channel-only
+ *   setting: a person's post has no writer distinct from its author, so the tab
+ *   has no subject anywhere else. Whether a given channel gets it is a second,
+ *   RUNTIME question — see {@link buildProfileTabDescriptors}.
+ */
+export const CHANNEL_ONLY_TAB_NAMES = ['writers'] as const;
+
+export type ProfileTab =
+  | (typeof TAB_NAMES)[number]
+  | (typeof CHANNEL_ONLY_TAB_NAMES)[number];
 
 /**
  * The static tabs a CHANNEL account's profile does NOT get.
@@ -93,7 +114,7 @@ export function profileTabsForAccountKind(
 ): readonly ProfileTab[] {
   if (kind !== 'channel') return TAB_NAMES;
   const excluded = CHANNEL_EXCLUDED_TABS as readonly ProfileTab[];
-  return TAB_NAMES.filter((tab) => !excluded.includes(tab));
+  return [...TAB_NAMES.filter((tab) => !excluded.includes(tab)), ...CHANNEL_ONLY_TAB_NAMES];
 }
 
 /**
@@ -146,14 +167,24 @@ export function laneTabKey(laneId: string): string {
  * step — see {@link profileTabsForAccountKind} for which tabs it drops and why.
  * `labels` still covers every {@link ProfileTab}: the caller has no reason to
  * know which subset survives, and an unused label costs one `t()`.
+ *
+ * `disclosesWriters` is the one input the account's KIND cannot answer. Every
+ * channel could have a writers tab; only a channel that NAMES its writers gets
+ * one, and that is a Mention-owned setting the profile DTO does not carry — the
+ * screen learns it by asking the writers endpoint, which refuses when there is
+ * no list. It defaults to `false` so the tab is absent unless something
+ * affirmatively says otherwise, which is the same direction the disclosure
+ * itself fails in: a missing answer must never name anybody.
  */
 export function buildProfileTabDescriptors(
   labels: Readonly<Record<ProfileTab, string>>,
   lanes: readonly LaneTabInput[] = [],
   accountKind?: AccountKind,
+  disclosesWriters = false,
 ): ProfileTabDescriptor[] {
   const descriptors: ProfileTabDescriptor[] = [];
   for (const tab of profileTabsForAccountKind(accountKind)) {
+    if (tab === 'writers' && !disclosesWriters) continue;
     descriptors.push({ key: tab, label: labels[tab], tab });
     if (tab === 'posts') {
       for (const lane of lanes) {

--- a/packages/frontend/components/ProfileScreen.tsx
+++ b/packages/frontend/components/ProfileScreen.tsx
@@ -132,6 +132,12 @@ const PersonProfile: React.FC<PersonProfileProps> = ({
                     feeds: t('profile.tabs.feeds', { defaultValue: 'Feeds' }),
                     starter_packs: t('profile.tabs.starter_packs', { defaultValue: 'Starter Packs' }),
                     lists: t('profile.tabs.lists', { defaultValue: 'Lists' }),
+                    // A person has no writers tab — `profileTabsForAccountKind`
+                    // drops it for every kind but `channel`. The label is still
+                    // passed because `labels` covers every `ProfileTab` by
+                    // contract: the caller has no reason to know which subset
+                    // survives, and an unused label costs one `t()`.
+                    writers: t('profile.tabs.writers', { defaultValue: 'Writers' }),
                 },
                 laneTabs,
                 profileData?.kind,

--- a/packages/frontend/lib/viewerQueryKeys.ts
+++ b/packages/frontend/lib/viewerQueryKeys.ts
@@ -230,6 +230,26 @@ export const viewerQueryKeys = {
     'channel-settings',
     accountId,
   ] as const,
+  /**
+   * The people ONE channel has already NAMED on its posts, keyed by that
+   * channel's `oxyUserId`.
+   *
+   * Deliberately not under `accounts` beside {@link channelAccountSettings},
+   * which is the operator's read of a preference. This is a public derived list
+   * about the same account, and the two are invalidated by different events.
+   *
+   * Keyed by viewer for the reason {@link lanesForOwner} gives, plus a sharper
+   * one: the server answers 404 both for a channel that does not name its
+   * writers and for a RESTRICTED channel this reader may not see. Those two are
+   * indistinguishable by design, and that refusal decides whether the tab
+   * exists at all — so one viewer's 404 must never be served to another as the
+   * absence of a tab.
+   */
+  channelWriters: (viewerId: ViewerId, channelId: string | null | undefined) => [
+    ...viewerQueryKeys.all(viewerId),
+    'channel-writers',
+    channelId ?? '',
+  ] as const,
   pokesRoot: (viewerId: ViewerId) => [
     ...viewerQueryKeys.all(viewerId),
     'pokes',

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -207,6 +207,7 @@
   "profile.tabs.videos": "Videos",
   "profile.tabs.likes": "Likes",
   "profile.tabs.boosts": "Boosts",
+  "profile.tabs.writers": "Writers",
   "profile.stats.boosts": "Boosts",
   "profile.stats.replies": "Replies",
   "profile.posts": "posts",
@@ -1876,6 +1877,12 @@
       "signPosts": "Name the writer",
       "signPostsFooter": "The channel signs its own posts. With this on, the person who wrote one is named alongside it — with it off, they never leave the server at all.",
       "identityFooter": "The channel’s name, handle, picture and the people who may publish as it belong to the account itself — change them where you manage your Oxy accounts."
+    },
+    "writers": {
+      "caption": "The people this channel has named on its posts.",
+      "lastWrote": "Last wrote {{time}}",
+      "empty": "No writers yet",
+      "emptyDetail": "This channel names the person who wrote each post. None have been published yet."
     }
   },
   "trendGraph": {

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -246,6 +246,7 @@
   "profile.tabs.videos": "Vídeos",
   "profile.tabs.likes": "Me gusta",
   "profile.tabs.boosts": "Impulsos",
+  "profile.tabs.writers": "Quién escribe",
   "profile.stats.boosts": "Impulsos",
   "profile.stats.replies": "Respuestas",
   "profile.posts": "publicaciones",
@@ -1847,6 +1848,12 @@
       "signPosts": "Nombrar a quien escribe",
       "signPostsFooter": "El canal firma sus propias publicaciones. Con esto activado, también se nombra a quien la escribió; desactivado, esa persona no sale del servidor.",
       "identityFooter": "El nombre, el identificador, la imagen del canal y quienes pueden publicar como él pertenecen a la cuenta: cámbialos donde gestionas tus cuentas de Oxy."
+    },
+    "writers": {
+      "caption": "Las personas a quienes este canal ha nombrado en sus publicaciones.",
+      "lastWrote": "Escribió por última vez {{time}}",
+      "empty": "Todavía no hay nadie nombrado",
+      "emptyDetail": "Este canal nombra a quien escribe cada publicación. Todavía no ha publicado ninguna."
     }
   },
   "trendGraph": {

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -208,6 +208,7 @@
   "profile.tabs.videos": "Video",
   "profile.tabs.likes": "Mi piace",
   "profile.tabs.boosts": "Boost",
+  "profile.tabs.writers": "Chi scrive",
   "profile.stats.boosts": "Boost",
   "profile.stats.replies": "Risposte",
   "profile.posts": "post",
@@ -1627,6 +1628,12 @@
       "signPosts": "Indica chi scrive",
       "signPostsFooter": "Il canale firma i propri post. Con questa opzione attiva viene indicata anche la persona che l’ha scritto; disattivata, non lascia mai il server.",
       "identityFooter": "Nome, identificativo, immagine del canale e chi può pubblicare come lui appartengono all’account: modificali dove gestisci i tuoi account Oxy."
+    },
+    "writers": {
+      "caption": "Le persone che questo canale ha indicato nei suoi post.",
+      "lastWrote": "Ha scritto l’ultima volta {{time}}",
+      "empty": "Ancora nessuno indicato",
+      "emptyDetail": "Questo canale indica chi scrive ogni post. Non ne ha ancora pubblicato nessuno."
     }
   },
   "trendGraph": {

--- a/packages/frontend/services/channelWritersService.ts
+++ b/packages/frontend/services/channelWritersService.ts
@@ -1,0 +1,50 @@
+import type { ChannelWritersResponse } from '@mention/shared-types';
+import { authenticatedClient } from '@/utils/api';
+
+const CHANNELS_PATH = '/channels';
+
+/**
+ * A channel's writers — the people it has already named on its posts.
+ *
+ * The list is who HAS WRITTEN, never who MAY write. The server derives it from
+ * the channel's public, published posts, so every name it returns is one the
+ * channel is already publishing on a post any reader can open. It is NOT the
+ * account's member roll, which would name people who have written nothing and
+ * consented to nothing.
+ *
+ * `authenticatedClient` rather than `publicApi`, even though a channel's page is
+ * public: the endpoint is `optionalAuth`, and the reader's identity is what lets
+ * a follower of a RESTRICTED channel see the list at all. The linked client
+ * simply sends the request unauthenticated when there is no session, which is
+ * the anonymous case — so one client covers both readers, while `publicApi`
+ * would silently hide the tab from a signed-in follower.
+ *
+ * NOTHING HERE CATCHES, and that is the whole contract with the caller. A 404 is
+ * this endpoint's answer for "there is no list here" — not a channel, a channel
+ * that does not name its writers, a channel this reader may not see — and the
+ * tab's existence is keyed on it. Swallowing it into an empty list would turn
+ * every one of those into a channel that discloses and has published nothing,
+ * which is a different fact and the one case that DOES render a tab.
+ */
+class ChannelWritersService {
+  /**
+   * One page of a channel's writers, most recent publication first.
+   *
+   * `cursor` is the opaque `nextCursor` from the previous page; its absence in
+   * the response is the end of the list. `limit` is left to the server's own
+   * default rather than restated here — a second copy of a page size is a second
+   * thing to keep in step.
+   */
+  async list(channelOxyUserId: string, cursor?: string): Promise<ChannelWritersResponse> {
+    const params: { cursor?: string } = {};
+    if (cursor) params.cursor = cursor;
+
+    const res = await authenticatedClient.get<ChannelWritersResponse>(
+      `${CHANNELS_PATH}/${encodeURIComponent(channelOxyUserId)}/writers`,
+      { params },
+    );
+    return res.data;
+  }
+}
+
+export const channelWritersService = new ChannelWritersService();

--- a/packages/shared-types/src/channel.ts
+++ b/packages/shared-types/src/channel.ts
@@ -1,0 +1,50 @@
+/**
+ * Channels — the people who write for one.
+ *
+ * A channel is an Oxy ACCOUNT that authors its own posts; the human who wrote
+ * one is recorded on the post but never shipped, and `UserSettings.channel
+ * .signPosts` decides whether that person is NAMED on the post's byline. When a
+ * channel names them, its page gains a list of everyone it has already named.
+ *
+ * The list is derived from POSTS — the distinct writers of the channel's public,
+ * published posts — and never from the account's member list. Those are two
+ * different facts: a member is somebody who MAY write, which includes people who
+ * never have and who never consented to being named anywhere. Every name in this
+ * list is one the channel is already publishing on a post any reader can open.
+ */
+
+import type { PostUser } from './post';
+
+/**
+ * One writer of a channel, with the moment they last published under it.
+ *
+ * `writer` is the canonical Oxy {@link PostUser} passed through UNCHANGED —
+ * `name.displayName` renders directly, `avatar` stays a bare Oxy file id for
+ * Bloom's `ImageResolver`, and the handle is derived with
+ * `getNormalizedUserHandle`. A writer Oxy could not resolve arrives degraded
+ * (empty `username`, `'Unknown user'`), never as a raw id.
+ */
+export interface ChannelWriter {
+  writer: PostUser;
+  /**
+   * When this writer last published under the channel, ISO 8601. Also the
+   * pagination sort key — the list is ordered by it, newest first.
+   */
+  lastPostAt: string;
+}
+
+/**
+ * One page of a channel's writers, most recently published first.
+ *
+ * `nextCursor` is an opaque keyset token echoed back as `?cursor=` to fetch the
+ * following page; its ABSENCE is the end of the list.
+ *
+ * A channel that does not name its writers has no list at all — the endpoint
+ * answers 404 there, exactly as it does for an account that is not a channel and
+ * for a channel this reader may not see, so nothing in the response shape can
+ * report on a set that was never disclosed.
+ */
+export interface ChannelWritersResponse {
+  writers: ChannelWriter[];
+  nextCursor?: string;
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -32,7 +32,8 @@ export * from './list';
 // Lanes (a publisher's own named carriageways through their output)
 export * from './lane';
 
-// Channels (a shared, multi-user destination people follow without following its authors)
+// Channels (an Oxy account people follow without following the people who write for it)
+export * from './channel';
 
 // Activity subscriptions ("notify me when this account posts")
 export * from './subscription';


### PR DESCRIPTION
A channel that names the people who write for it now shows them: `/c/<handle>` gains a **Writers** tab, backed by a new `GET /channels/:oxyUserId/writers`.

## The rule that makes this safe

**The list is who HAS WRITTEN, never who MAY write.**

It is derived from the distinct `writtenByOxyUserId` values on the channel's **public, published** posts — a set that is already public, because `channel.signPosts` put each of those names on a post any reader can open. The tab aggregates a disclosure that has already happened; it does not make a new one.

It is deliberately **not** derived from the account's member roll. `listAccountMembers` would answer a different question — who may publish as the channel — and that set includes people who have written nothing, will never write, and consented to being named nowhere. "Just list the members, it's simpler" is the change a later reader will reach for; it is simpler, and it publishes the identities of people who wrote nothing. The route's header note says so at the call site.

## The gate

Three conditions, all fail-closed, and the same three that decide whether a post's byline names its writer:

1. the account resolves through Oxy as `kind: 'channel'`,
2. `UserSettings.channel.signPosts === true`,
3. this reader may see the channel's profile at all.

(1) and (2) are `disclosesWriters` in the new `services/channelWriterDisclosure`, which `PostHydrationService` now reads too — **one consent authority**, so the list and the byline cannot disagree. A missing settings row, an unset flag and a failed lookup are all "no". (3) exists so the route is not a side door onto who writes for a channel whose posts the reader cannot read.

Every refusal is the **same 404 body** — not a channel, does not sign, not visible, id names nothing — so the status is not an oracle, and a case added to that refusal later needs no change on the client.

## 404 and empty-200 are different facts

- **404** ⇒ there is no list ⇒ **no tab**.
- **200 with `writers: []`** ⇒ the list exists and is empty ⇒ **the tab is there and says so** ("No writers yet — this channel names the person who wrote each post. None have been published yet.").

So the tab keys on the query having *succeeded*, never on `writers.length`. Both fixtures are in the suite and asserted to produce **different** tab strips — a suite that only ever answered 200 could not tell "tab when disclosing" from "tab always", and one that read the list length could not tell an empty masthead from an undisclosed one.

Mutation-tested; every one of these is RED, each caught by the test written for it:

| mutation | caught by |
|---|---|
| screen passes a literal `true` for the flag | the screen-wiring assertion |
| `disclosed = writers.length > 0` | the empty-200 case + the discriminator |
| descriptor builder ignores the flag | the discriminator + 4 strip cases |
| hook retries the refusal | "asks exactly once" |
| service swallows the 404 into an empty list | the refusal case + the discriminator |
| row hand-builds a handle from the raw id | the ghost-handle case |
| channel-only tab handed to every account kind | 7 strip cases |
| writers path typo | the path + pagination cases |

## Decisions

- **Name.** "Writers", tied to the wording of the setting that turns it on in each language: en `Name the writer` → **Writers**; es `Nombrar a quien escribe` → **Quién escribe**; it `Indica chi scrive` → **Chi scrive**.
- **No URL.** `/c/<handle>` is one route whose tabs are local state. Giving one channel tab a `/c/<handle>/…` route while the other four stayed local would be a worse inconsistency than either answer applied uniformly — so no route, and `canonicalProfileHref`'s fixed point is untouched. (`about`/`settings` have routes because they are separate *screens*, not tabs.)
- **`ProfileCard`, no adapter.** The canonical `PostUser` goes straight to the one user row, so handle normalization, avatar resolution through Bloom's resolver from a bare file id, live correction of a profile edited in this session, and the ghost-handle rule are inherited rather than reimplemented. An unresolvable writer renders "Unknown user" with no handle line and no `/@<id>` link.
- **One hook, two readers.** The screen asks whether the tab exists, the tab asks what is in it, both through `useChannelWriters` on one React Query key — so they cannot disagree, and opening the tab costs no second request. `retry: false`: the refusal is an answer, not an error to recover from, and "no tab this visit" is the direction a disclosure surface should fail in.
- **Pagination is a button.** A profile tab does not own its scroll, so it cannot observe the viewport without nesting a second scroller. Page size 50, and the set is bounded by how many humans have ever published as this channel.

## Cost

One aggregation served end to end by `post_channel_writer_v1` (migration `0027`), partial on `{ writtenByOxyUserId: { $type: 'string' } }` — `sparse` would index the whole collection (every post has `visibility`), and `$exists` would admit a stored `null`. Both `$group` values live in the index, so no post document is fetched.

## Verification

Run on the rebased tree:

- `bunx tsc --noEmit` — clean, frontend and backend
- frontend `bun run test:coverage` — **150 suites / 1395 tests**, coverage gate passed
- backend `bun run test` — **435 files / 4785 tests**
- `bun run lint:frontend` — 0 errors (8 warnings, all `import/first` on jest-mock-before-import, the same pre-existing pattern as `subscriptionsScreen.test.tsx`)
- `bun run validate:i18n` — 3 catalogs, en/es/it all populated
- `bun run validate:logger` — 9/9

One harness bug found and fixed along the way: the new suite's wait settled on `client.isFetching()`, which loses the race under full-suite contention (React Query notifies subscribers a macrotask later). It passed in isolation and took the full run red once; it now waits on a value the tree has actually rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
