### PR TITLE
fix(posts): close the delete cascade before a config line closes it wrong

### DIFF
--- a/packages/backend/src/__tests__/adminDeletionPreflight.test.ts
+++ b/packages/backend/src/__tests__/adminDeletionPreflight.test.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   DeletionPreflightError,
+  POST_REFERENCE_PROBE_NAMES,
+  actorReferenceProbes,
   assertNoDeletionBlockers,
   collectReferenceBlockers,
 } from '../scripts/lib/adminDeletionPreflight';
@@ -67,6 +69,60 @@ describe('administrative deletion preflight', () => {
       expect(source.indexOf('assertPostsSafeToDelete(')).toBeLessThan(
         source.indexOf('Post.deleteOne('),
       );
+    }
+  });
+
+  it('probes every user-referencing field a cascade would otherwise strand', () => {
+    const names = actorReferenceProbes(
+      { oxyUserId: 'actor-1', actorUri: 'https://remote.example/users/a' },
+      // The gone-actor bucket: probes its own cascade does NOT remove. Each of
+      // these names a row that survives that cascade holding the actor's id, so
+      // this is the bucket they have to be in to be checked at all.
+      true,
+    ).map((probe) => probe.name);
+
+    // Vacuity floor: a broken traversal returning nothing would satisfy every
+    // `toContain` below by satisfying none of them.
+    expect(names.length).toBeGreaterThanOrEqual(25);
+    expect(new Set(names).size).toBe(names.length);
+
+    for (const name of [
+      // The writer behind a channel post — deliberately outside `authorship[]`
+      // to protect their anonymity, which put it outside every matcher too.
+      'Post.writtenByOxyUserId',
+      'Lane.ownerId',
+      'LaneMute.viewer/laneOwner',
+      'McpConnection.oxyUserId/activeOxyUserId',
+      'ModerationEnforcement.subjectId',
+      'UserSettings privacy references from another viewer',
+    ]) {
+      expect(names).toContain(name);
+    }
+  });
+
+  it('probes author subscriptions by their real fields, and nothing probes them by post', () => {
+    const names = actorReferenceProbes(
+      { oxyUserId: 'actor-1', actorUri: 'https://remote.example/users/a' },
+      true,
+    ).map((probe) => probe.name);
+    // `PostSubscription` is `{ subscriberId, authorId }` — a subscription to an
+    // AUTHOR, with no post reference at all. It belongs to the ACTOR probes and
+    // must never appear among the post ones.
+    expect(names).toContain('PostSubscription.subscriberId/authorId');
+    expect(POST_REFERENCE_PROBE_NAMES).not.toContain('PostSubscription');
+
+    // The regression this guards: a cascade step filtering that collection by a
+    // post id. It matched nothing and reported its guaranteed zero as work
+    // done, and under `strictQuery` the unknown path is STRIPPED — turning the
+    // same call into `deleteMany({})`. Measured on mongod 8.0.28 with this
+    // repo's mongoose: 0 deleted as shipped, 3 of 3 deleted with the flag on.
+    for (const file of [
+      '../controllers/posts.controller.ts',
+      '../scripts/purgeBlockedDomainContent.ts',
+      '../services/PostDeletionCascade.ts',
+    ]) {
+      const source = readFileSync(path.resolve(__dirname, file), 'utf8');
+      expect(source).not.toMatch(/PostSubscription\s*[,)]?[\s\S]{0,80}postId/);
     }
   });
 

--- a/packages/backend/src/__tests__/services/postDeletionCascade.test.ts
+++ b/packages/backend/src/__tests__/services/postDeletionCascade.test.ts
@@ -1,0 +1,350 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  postFind: vi.fn(),
+  postDeleteMany: vi.fn(),
+  postUpdateOne: vi.fn(),
+  deleteMany: {} as Record<string, ReturnType<typeof vi.fn>>,
+  residue: vi.fn(),
+  error: vi.fn(),
+  /** Successive `Post.find` results, one per boost-closure round. */
+  boostRounds: [] as Array<Array<Record<string, unknown>>>,
+}));
+
+function deleteManyMock(name: string) {
+  const fn = vi.fn(() => ({ exec: async () => ({ deletedCount: 1 }) }));
+  mocks.deleteMany[name] = fn;
+  return fn;
+}
+
+vi.mock('../../models/Post', () => ({
+  Post: {
+    find: (...args: unknown[]) => mocks.postFind(...args),
+    deleteMany: (...args: unknown[]) => mocks.postDeleteMany(...args),
+    updateOne: (...args: unknown[]) => mocks.postUpdateOne(...args),
+  },
+}));
+vi.mock('../../models/Like', () => ({ default: { deleteMany: deleteManyMock('Like') } }));
+vi.mock('../../models/Bookmark', () => ({ default: { deleteMany: deleteManyMock('Bookmark') } }));
+vi.mock('../../models/Notification', () => ({
+  default: { deleteMany: deleteManyMock('Notification') },
+}));
+vi.mock('../../models/Poll', () => ({ default: { deleteMany: deleteManyMock('Poll') } }));
+vi.mock('../../models/Article', () => ({ default: { deleteMany: deleteManyMock('Article') } }));
+vi.mock('../../models/Postgate', () => ({ Postgate: { deleteMany: deleteManyMock('Postgate') } }));
+vi.mock('../../models/Threadgate', () => ({
+  Threadgate: { deleteMany: deleteManyMock('Threadgate') },
+}));
+vi.mock('../../models/PostRecentReplier', () => ({
+  PostRecentReplier: { deleteMany: deleteManyMock('PostRecentReplier') },
+}));
+vi.mock('../../models/EngagementOutbox', () => ({
+  default: { deleteMany: deleteManyMock('EngagementOutbox') },
+}));
+vi.mock('../../models/ContentLabel', () => ({
+  default: { deleteMany: deleteManyMock('ContentLabel') },
+}));
+vi.mock('../../models/FeedInteraction', () => ({
+  FeedInteraction: { deleteMany: deleteManyMock('FeedInteraction') },
+}));
+vi.mock('../../models/FederationDeliveryQueue', () => ({
+  default: { deleteMany: deleteManyMock('FederationDeliveryQueue') },
+}));
+
+vi.mock('../../scripts/lib/adminDeletionPreflight', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../scripts/lib/adminDeletionPreflight')>()),
+  collectPostCascadeResidue: (...args: unknown[]) => mocks.residue(...args),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    error: (...args: unknown[]) => mocks.error(...args),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import mongoose from 'mongoose';
+import { cascadeDeletedPost, collectBoostClosure } from '../../services/PostDeletionCascade';
+import { POST_REFERENCE_PROBE_NAMES } from '../../scripts/lib/adminDeletionPreflight';
+
+const CASCADE_SOURCE = readFileSync(
+  path.resolve(__dirname, '../../services/PostDeletionCascade.ts'),
+  'utf8',
+);
+
+const POST_ID = new mongoose.Types.ObjectId();
+
+function filterOf(name: string): Record<string, unknown> {
+  const call = mocks.deleteMany[name]?.mock.calls[0];
+  if (!call) throw new Error(`${name}.deleteMany was never called`);
+  return call[0] as Record<string, unknown>;
+}
+
+describe('post deletion cascade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.boostRounds.length = 0;
+    mocks.postFind.mockImplementation(() => ({
+      lean: async () => mocks.boostRounds.shift() ?? [],
+    }));
+    mocks.postDeleteMany.mockReturnValue({ exec: async () => ({ deletedCount: 0 }) });
+    mocks.postUpdateOne.mockReturnValue({ exec: async () => ({ modifiedCount: 1 }) });
+    mocks.residue.mockResolvedValue([]);
+  });
+
+  it('decides a disposition for every reference the preflight knows about', () => {
+    // The compiler already enforces this (the table is a `Record` over the
+    // probe union), but a runtime check carries the vacuity floor: an empty or
+    // truncated probe list would satisfy the type and prove nothing.
+    expect(POST_REFERENCE_PROBE_NAMES.length).toBeGreaterThanOrEqual(13);
+    for (const name of POST_REFERENCE_PROBE_NAMES) {
+      expect(CASCADE_SOURCE).toContain(`'${name}':`);
+    }
+  });
+
+  it('deletes reply notifications, not only post ones', async () => {
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    // `entityType` has three values and two of them name a post row. Filtering
+    // on `'post'` alone left every reply notification behind — the shape the
+    // route shipped with.
+    expect(filterOf('Notification')).toEqual({
+      entityType: { $in: ['post', 'reply'] },
+      entityId: { $in: [POST_ID] },
+    });
+  });
+
+  it('matches side tables by post id AND by the ActivityPub identifiers', async () => {
+    await cascadeDeletedPost({
+      post: {
+        _id: POST_ID,
+        federation: { activityId: 'https://remote/notes/1', url: 'https://remote/@a/1' },
+      },
+    });
+
+    expect(filterOf('FeedInteraction')).toEqual({
+      postUri: {
+        $in: [String(POST_ID), 'https://remote/notes/1', 'https://remote/@a/1'],
+      },
+    });
+    const keys = [String(POST_ID), 'https://remote/notes/1', 'https://remote/@a/1'];
+    expect(filterOf('FederationDeliveryQueue')).toEqual({
+      status: 'pending',
+      $or: [
+        { 'activityJson.id': { $in: keys } },
+        { 'activityJson.object.id': { $in: keys } },
+        { 'activityJson.object': { $in: keys } },
+      ],
+    });
+  });
+
+  it('cancels only the queue rows that can still act, through an indexed prefix', async () => {
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    // Neither collection is indexed on the field the post is named by, and one
+    // of them is never pruned at all — so an unscoped delete here is a
+    // collection scan on the route every user hits. `status` is an index prefix
+    // on both, and a completed row is a log entry rather than a live pointer.
+    expect(filterOf('EngagementOutbox')).toEqual({
+      status: 'pending',
+      'payload.postId': { $in: [String(POST_ID)] },
+    });
+    expect(filterOf('FederationDeliveryQueue')).toMatchObject({ status: 'pending' });
+  });
+
+  it('never claims the queues it only partly clears', async () => {
+    // Claiming them would make the residue check verify something the cascade
+    // does not do, and report the shortfall it finds as satisfied.
+    expect(CASCADE_SOURCE).toContain("'EngagementOutbox.payload.postId': 'cancel-pending'");
+    expect(CASCADE_SOURCE).toContain("'FederationDeliveryQueue.activityJson': 'cancel-pending'");
+
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    const [, claimed] = mocks.residue.mock.calls.at(-1) ?? [];
+    expect(claimed).toEqual(
+      expect.not.arrayContaining([
+        'EngagementOutbox.payload.postId',
+        'FederationDeliveryQueue.activityJson',
+      ]),
+    );
+    expect(claimed).toEqual(expect.arrayContaining(['Like.postId', 'Bookmark.postId']));
+  });
+
+  it('cleans the references of replies the caller already deleted', async () => {
+    const replyId = new mongoose.Types.ObjectId();
+
+    await cascadeDeletedPost({
+      post: { _id: POST_ID },
+      alsoDeleted: [{ _id: replyId }],
+    });
+
+    expect(filterOf('Like')).toEqual({ postId: { $in: [POST_ID, replyId] } });
+    expect(filterOf('Bookmark')).toEqual({ postId: { $in: [POST_ID, replyId] } });
+  });
+
+  it('decrements the parent reply counter, guarded so it cannot go negative', async () => {
+    const parentId = new mongoose.Types.ObjectId();
+
+    await cascadeDeletedPost({ post: { _id: POST_ID, parentPostId: String(parentId) } });
+
+    expect(mocks.postUpdateOne).toHaveBeenCalledWith(
+      { _id: String(parentId), 'stats.commentsCount': { $gt: 0 } },
+      { $inc: { 'stats.commentsCount': -1 } },
+    );
+  });
+
+  it('leaves the boost counter alone when the boosted post is being deleted too', async () => {
+    const boostId = new mongoose.Types.ObjectId();
+    mocks.boostRounds.push([{ _id: boostId, boostOf: String(POST_ID) }]);
+
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    // The boost's target IS the deleted post, so decrementing its counter would
+    // be writing to a row that no longer exists.
+    expect(mocks.postUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('repairs the boost counters of a surviving original when a boost is deleted', async () => {
+    const originalId = new mongoose.Types.ObjectId();
+
+    await cascadeDeletedPost({
+      post: {
+        _id: POST_ID,
+        boostOf: String(originalId),
+        federation: { activityId: 'https://remote/announce/1' },
+      },
+    });
+
+    expect(mocks.postUpdateOne).toHaveBeenCalledWith(
+      { _id: String(originalId), 'stats.boostsCount': { $gt: 0 } },
+      { $inc: { 'stats.boostsCount': -1 } },
+    );
+    expect(mocks.postUpdateOne).toHaveBeenCalledWith(
+      { _id: String(originalId), 'stats.federatedBoostsCount': { $gt: 0 } },
+      { $inc: { 'stats.federatedBoostsCount': -1 } },
+    );
+  });
+
+  it('does not touch the federated boost counter for a native boost', async () => {
+    const originalId = new mongoose.Types.ObjectId();
+
+    await cascadeDeletedPost({ post: { _id: POST_ID, boostOf: String(originalId) } });
+
+    expect(mocks.postUpdateOne).toHaveBeenCalledTimes(1);
+    expect(mocks.postUpdateOne).toHaveBeenCalledWith(
+      { _id: String(originalId), 'stats.boostsCount': { $gt: 0 } },
+      { $inc: { 'stats.boostsCount': -1 } },
+    );
+  });
+
+  it('follows the boost graph transitively and deletes the rows last', async () => {
+    const boostId = new mongoose.Types.ObjectId();
+    const nestedId = new mongoose.Types.ObjectId();
+    mocks.boostRounds.push(
+      [{ _id: boostId, boostOf: String(POST_ID) }],
+      [{ _id: nestedId, boostOf: String(boostId) }],
+    );
+
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    // A boost of a boost would otherwise be left rendering the same blank card
+    // the expansion exists to prevent.
+    expect(mocks.postDeleteMany).toHaveBeenCalledWith({ _id: { $in: [boostId, nestedId] } });
+    // Their own references go first, so a run that dies midway leaves boosts
+    // pointing at nothing rather than boost references pointing at nothing.
+    expect(filterOf('Like')).toEqual({ postId: { $in: [POST_ID, boostId, nestedId] } });
+  });
+
+  it('refuses to expand an oversized boost closure instead of deleting a prefix', async () => {
+    mocks.boostRounds.push(
+      Array.from({ length: 501 }, () => ({
+        _id: new mongoose.Types.ObjectId(),
+        boostOf: String(POST_ID),
+      })),
+    );
+
+    await expect(collectBoostClosure([String(POST_ID)])).resolves.toBeNull();
+  });
+
+  it('deletes nothing at all when the boost closure is refused', async () => {
+    mocks.boostRounds.push(
+      Array.from({ length: 501 }, () => ({
+        _id: new mongoose.Types.ObjectId(),
+        boostOf: String(POST_ID),
+      })),
+    );
+
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    expect(mocks.deleteMany.Like).not.toHaveBeenCalled();
+    expect(mocks.postDeleteMany).not.toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledWith(
+      'Post deletion cascade refused to expand an oversized boost closure',
+      expect.objectContaining({ postId: String(POST_ID) }),
+    );
+  });
+
+  it('names the leg that failed instead of swallowing it', async () => {
+    mocks.deleteMany.Like.mockReturnValueOnce({
+      exec: async () => {
+        throw new Error('index build in progress');
+      },
+    });
+
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    // `Promise.allSettled` never rejects, so the previous shape could not tell a
+    // leg that threw from one that deleted nothing.
+    expect(mocks.error).toHaveBeenCalledWith(
+      'Post deletion cascade leg failed',
+      expect.objectContaining({ reference: 'Like.postId' }),
+    );
+    expect(mocks.error).toHaveBeenCalledWith(
+      'Post deletion cascade left references behind',
+      expect.objectContaining({ failedLegs: ['Like.postId'] }),
+    );
+  });
+
+  it('reports residue found by re-running the probes it claimed', async () => {
+    mocks.residue.mockResolvedValue(['Bookmark.postId']);
+
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      'Post deletion cascade left references behind',
+      expect.objectContaining({ residue: ['Bookmark.postId'] }),
+    );
+  });
+
+  it('stays silent when the cascade is clean', async () => {
+    await cascadeDeletedPost({ post: { _id: POST_ID } });
+
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it('never reports a delete the user asked for as a failure', async () => {
+    mocks.postFind.mockImplementation(() => ({
+      lean: async () => {
+        throw new Error('Mongo unavailable');
+      },
+    }));
+
+    await expect(cascadeDeletedPost({ post: { _id: POST_ID } })).resolves.toBeUndefined();
+    expect(mocks.error).toHaveBeenCalledWith(
+      'Post deletion cascade failed',
+      expect.objectContaining({ postId: String(POST_ID) }),
+    );
+  });
+
+  it('keeps moderation reports, which are not the deleting user’s to erase', () => {
+    // Deleting the row would strand an inbound CrowdSource decision:
+    // `ModerationDecisionWorker` resolves a case through
+    // `Report.crowdSourceCaseId` and treats "no local report" as retryable.
+    expect(CASCADE_SOURCE).toContain("'Report.reportedId(post)': 'retain'");
+    expect(mocks.deleteMany.Report).toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/services/postRecentReplierDeletion.test.ts
+++ b/packages/backend/src/__tests__/services/postRecentReplierDeletion.test.ts
@@ -143,8 +143,11 @@ describe('PostRecentReplierService deletion repair', () => {
   it('deletes the parent projection and projections for every child it deletes', async () => {
     mocks.childRows.push({ _id: 'child-one' }, { _id: 'child-two' });
 
-    await repairRecentRepliersAfterPostDelete({ postId: 'deleted-parent' });
+    const deleted = await repairRecentRepliersAfterPostDelete({ postId: 'deleted-parent' });
 
+    // The rows travel back to the caller so the deletion cascade can clean up
+    // what the deleted replies referenced — nothing else knows they went.
+    expect(deleted).toEqual([{ _id: 'child-one' }, { _id: 'child-two' }]);
     expect(mocks.aggregate).not.toHaveBeenCalled();
     expect(mocks.postDeleteMany).toHaveBeenCalledWith(
       { _id: { $in: ['child-one', 'child-two'] } },
@@ -207,15 +210,19 @@ describe('PostRecentReplierService deletion repair', () => {
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 
-  it('logs and resolves when repair remains unavailable after the delete', async () => {
+  it('logs and reports no deleted replies when repair remains unavailable after the delete', async () => {
     mocks.startSession.mockRejectedValue(new Error('Mongo unavailable'));
+    // A row this call did NOT delete must never be reported as deleted: the
+    // caller sends the returned rows to the deletion cascade, so a false
+    // positive here would strip the references off a reply that still exists.
+    mocks.childRows.push({ _id: 'child-that-survived' });
 
     await expect(
       repairRecentRepliersAfterPostDelete({
         postId: 'already-deleted',
         parentPostId: 'parent-post',
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual([]);
 
     expect(mocks.warn).toHaveBeenCalledWith(
       '[PostRecentReplier] Failed to repair projection after post deletion',

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -7,7 +7,6 @@ import Bookmark from '../models/Bookmark';
 import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import mongoose from 'mongoose';
 import { createMentionNotifications } from '../utils/notificationUtils';
-import PostSubscription from '../models/PostSubscription';
 import {
   PostVisibility,
   PostAttachmentDescriptor,
@@ -82,6 +81,7 @@ import {
   updateBookmarkFolderForViewer,
 } from '../services/BookmarkFolderService';
 import { repairRecentRepliersAfterPostDelete } from '../services/PostRecentReplierService';
+import { cascadeDeletedPost } from '../services/PostDeletionCascade';
 import { loadScheduledChain } from '../services/scheduledChain';
 
 // Constants from centralized config
@@ -2321,7 +2321,9 @@ export const deletePost = async (req: AuthRequest, res: Response) => {
     }
 
     const postId = post._id.toString();
-    await repairRecentRepliersAfterPostDelete({
+    // Deletes the post's direct replies as well as repairing the projection —
+    // it returns them so the cascade below can clean up what they referenced.
+    const deletedReplies = await repairRecentRepliersAfterPostDelete({
       postId,
       parentPostId: post.parentPostId,
     });
@@ -2357,29 +2359,15 @@ export const deletePost = async (req: AuthRequest, res: Response) => {
       }));
     }
 
-    // Cascading cleanup — best-effort, don't fail the request
-    try {
-      await Promise.allSettled([
-        // Delete associated article
-        post.content?.article?.articleId
-          ? ArticleModel.deleteOne({ _id: post.content.article.articleId }).exec()
-          : Promise.resolve(),
-        // Delete associated poll
-        post.content?.pollId
-          ? Poll.deleteOne({ _id: post.content.pollId }).exec()
-          : Promise.resolve(),
-        // Delete likes for this post
-        Like.deleteMany({ postId }).exec(),
-        // Delete bookmarks for this post
-        Bookmark.deleteMany({ postId }).exec(),
-        // Delete post subscriptions
-        PostSubscription.deleteMany({ postId }).exec(),
-        // Delete notifications referencing this post
-        mongoose.model('Notification').deleteMany({ entityId: postId, entityType: 'post' }).exec(),
-      ]);
-    } catch (cleanupError) {
-      logger.error('Error during cascading post cleanup', cleanupError);
-    }
+    // Cascading cleanup — best-effort (it never throws) and awaited, so the
+    // response is not sent while rows that name a post nobody can load are
+    // still readable. Every known reference is enumerated by
+    // `PostReferenceProbeName`, and the cascade re-runs those probes afterwards
+    // to state what it actually left behind rather than assuming it worked.
+    // The DOCUMENT, never a hand-picked literal: a literal type-checks against
+    // whatever the cascade reads today and silently drops a field added to it
+    // tomorrow.
+    await cascadeDeletedPost({ post, alsoDeleted: deletedReplies });
 
     await deleteScheduledContinuations(cancelledContinuations, userId);
 

--- a/packages/backend/src/scripts/lib/adminDeletionPreflight.ts
+++ b/packages/backend/src/scripts/lib/adminDeletionPreflight.ts
@@ -37,6 +37,10 @@ import MentionUserNode from '../../models/MentionUserNode';
 import MentionRepoHead from '../../models/MentionRepoHead';
 import MentionSignedRecord from '../../models/MentionSignedRecord';
 import MentionNodeIngestWitness from '../../models/MentionNodeIngestWitness';
+import { Lane } from '../../models/Lane';
+import { LaneMute } from '../../models/LaneMute';
+import ModerationEnforcement from '../../models/ModerationEnforcement';
+import McpConnection from '../../mcp/models/McpConnection';
 
 export interface ReferenceProbe {
   name: string;
@@ -298,7 +302,18 @@ export async function collectPostCascadeResidue(
   );
 }
 
-function actorReferenceProbes(
+/**
+ * Every known reference to an ACTOR, as executable probes.
+ *
+ * Exported so a test can assert which probes exist and which bucket each sits
+ * in — the two facts that decide whether a reference is checked at all. A probe
+ * that is missing here is invisible to every guard built on top of it, and
+ * nothing else in the tree would notice its absence.
+ *
+ * `includeReferencesRemovedByGoneActorCascade` returns ONLY the probes that
+ * cascade does not remove; everything appended afterwards is what it does.
+ */
+export function actorReferenceProbes(
   target: ActorDeletionTarget,
   includeReferencesRemovedByGoneActorCascade: boolean,
 ): ReferenceProbe[] {
@@ -500,6 +515,75 @@ function actorReferenceProbes(
               $or: [
                 { 'authorship.oxyUserId': oxyUserId },
                 { 'federation.actorUri': actorUri },
+              ],
+            }),
+          ),
+      },
+      {
+        /**
+         * The writer behind a channel post, which is the ONE reference to a
+         * person that is deliberately outside `authorship[]` — putting them in
+         * it would both end the channel's anonymity and put the post back on
+         * their own profile. That same choice puts the column outside every
+         * authorship matcher and, until this probe, outside every guard: the
+         * gone-actor cascade removes posts by owner and by authorship, so a
+         * channel post written by this actor survives it holding their id.
+         */
+        name: 'Post.writtenByOxyUserId',
+        hasReference: () => exists(Post.exists({ writtenByOxyUserId: oxyUserId })),
+      },
+      {
+        name: 'Lane.ownerId',
+        hasReference: () => exists(Lane.exists({ ownerId: oxyUserId })),
+      },
+      {
+        name: 'LaneMute.viewer/laneOwner',
+        hasReference: () =>
+          exists(
+            LaneMute.exists({
+              $or: [
+                { viewerOxyUserId: oxyUserId },
+                { laneOwnerOxyUserId: oxyUserId },
+              ],
+            }),
+          ),
+      },
+      {
+        name: 'McpConnection.oxyUserId/activeOxyUserId',
+        hasReference: () =>
+          exists(
+            McpConnection.exists({
+              $or: [{ oxyUserId }, { activeOxyUserId: oxyUserId }],
+            }),
+          ),
+      },
+      {
+        /**
+         * `subjectId` holds whichever id the case was about, so it names this
+         * actor for an `identity.profile` subject. Kept as a BLOCKER rather
+         * than something a cascade may remove: it is the record that an
+         * enforcement action was carried out, and its `decisionId + revision +
+         * action` uniqueness is what makes a later correction idempotent.
+         */
+        name: 'ModerationEnforcement.subjectId',
+        hasReference: () => exists(ModerationEnforcement.exists({ subjectId: oxyUserId })),
+      },
+      {
+        /**
+         * Another viewer's settings naming this actor. Scoped to OTHER rows for
+         * the same reason `UserBehavior references from another viewer` is: the
+         * actor's own settings row is covered by `UserSettings.oxyUserId`
+         * below, which the gone-actor cascade removes, while a stranger's row
+         * survives it holding the id.
+         */
+        name: 'UserSettings privacy references from another viewer',
+        hasReference: () =>
+          exists(
+            UserSettings.exists({
+              oxyUserId: { $ne: oxyUserId },
+              $or: [
+                { 'privacy.restrictedUsers': oxyUserId },
+                { 'privacy.labelPreferences.subscribedLabelers': oxyUserId },
               ],
             }),
           ),

--- a/packages/backend/src/scripts/purgeBlockedDomainContent.ts
+++ b/packages/backend/src/scripts/purgeBlockedDomainContent.ts
@@ -144,7 +144,6 @@ import Bookmark from '../models/Bookmark';
 import Notification from '../models/Notification';
 import Poll from '../models/Poll';
 import Article from '../models/Article';
-import PostSubscription from '../models/PostSubscription';
 import PostRecentReplier from '../models/PostRecentReplier';
 import FederatedActor from '../models/FederatedActor';
 import FederatedFollow from '../models/FederatedFollow';
@@ -373,7 +372,6 @@ export interface PurgeCounts {
   threadRootsKept: number;
   likesOnRemovedPosts: number;
   bookmarksOnRemovedPosts: number;
-  postSubscriptions: number;
   polls: number;
   articles: number;
   postgates: number;
@@ -428,7 +426,6 @@ const COUNT_KEYS: readonly (keyof PurgeCounts)[] = [
   'threadRootsKept',
   'likesOnRemovedPosts',
   'bookmarksOnRemovedPosts',
-  'postSubscriptions',
   'polls',
   'articles',
   'postgates',
@@ -874,14 +871,14 @@ async function purgePostBatch(
     report, domain, 'bookmarksOnRemovedPosts',
     await countOrDelete(Bookmark, { postId: { $in: removedIds } }, options.dryRun),
   );
-  record(
-    report, domain, 'postSubscriptions',
-    await countOrDelete(
-      PostSubscription,
-      { postId: { $in: [...removedIds, ...removedIdStrings] } },
-      options.dryRun,
-    ),
-  );
+  // There is deliberately no `PostSubscription` step here. That collection is
+  // `{ subscriberId, authorId }` — a subscription to an AUTHOR's future posts,
+  // with no post reference of any kind. The filter this used to run,
+  // `{ postId: … }`, matched nothing and reported its guaranteed zero as work
+  // done; with `strictQuery` enabled it would instead have been STRIPPED to
+  // `{}` and deleted every subscription in the instance. Author subscriptions
+  // belong to the ACTOR cascade, where `assertActorSafeToDelete` already probes
+  // both of their real fields.
   record(
     report, domain, 'notificationsByEntity',
     await countOrDelete(Notification, { entityId: { $in: removedIds } }, options.dryRun),

--- a/packages/backend/src/services/PostDeletionCascade.ts
+++ b/packages/backend/src/services/PostDeletionCascade.ts
@@ -1,0 +1,516 @@
+import mongoose from 'mongoose';
+import { PostType } from '@mention/shared-types';
+import { Post } from '../models/Post';
+import Like from '../models/Like';
+import Bookmark from '../models/Bookmark';
+import Notification from '../models/Notification';
+import Poll from '../models/Poll';
+import Article from '../models/Article';
+import { Postgate } from '../models/Postgate';
+import { Threadgate } from '../models/Threadgate';
+import EngagementOutbox from '../models/EngagementOutbox';
+import ContentLabel from '../models/ContentLabel';
+import { FeedInteraction } from '../models/FeedInteraction';
+import FederationDeliveryQueue from '../models/FederationDeliveryQueue';
+import { PostRecentReplier } from '../models/PostRecentReplier';
+import { logger } from '../utils/logger';
+import {
+  collectPostCascadeResidue,
+  type PostDeletionTarget,
+  type PostReferenceProbeName,
+} from '../scripts/lib/adminDeletionPreflight';
+
+/**
+ * Everything that has to happen once a `Post` row is gone, for the LIVE delete
+ * path — the route every user hits, not an administrative sweep.
+ *
+ * The reference list this works from is the one
+ * {@link PostReferenceProbeName} already enumerates, and the disposition table
+ * below is a `Record` over it ON PURPOSE: adding a reference type to the probe
+ * list breaks THIS file's build until somebody decides what the delete route
+ * should do about it. That is the property a plain array of claimed names does
+ * not have, and it is what makes the cascade fail closed on a reference nobody
+ * has thought about yet rather than silently leaving it behind.
+ */
+
+/** What the live delete path does about one known kind of post reference. */
+type ReferenceDisposition =
+  /** Deleted in this cascade — the row describes a post and cannot outlive it. */
+  | 'cascade'
+  /**
+   * A queue whose PENDING rows are cancelled and whose completed rows are kept.
+   * Deliberately NOT claimed to the residue check: the claim would be false,
+   * and a false claim reported as satisfied is the exact failure this module
+   * exists to remove.
+   */
+  | 'cancel-pending'
+  /** Deliberately kept. Every entry carries its reason in the table below. */
+  | 'retain';
+
+const POST_REFERENCE_DISPOSITION: Record<PostReferenceProbeName, ReferenceDisposition> = {
+  // Pure derivations of the post: nothing else keys on them, and left behind
+  // they name an id no surface can resolve.
+  'Notification.entityId': 'cascade',
+  'Poll.postId': 'cascade',
+  'Article.postId': 'cascade',
+  'Postgate.postId/postUri': 'cascade',
+  'Threadgate.postId/postUri': 'cascade',
+  'PostRecentReplier.postId': 'cascade',
+  'ContentLabel.targetId(post)': 'cascade',
+  'FeedInteraction.postUri': 'cascade',
+  'Like.postId': 'cascade',
+  'Bookmark.postId': 'cascade',
+
+  /**
+   * Two durable queues, cancelled but not erased, for the same two reasons.
+   *
+   * Only a PENDING row can still act — apply an engagement transition to a post
+   * that is gone, or deliver an activity about it. A processed or delivered row
+   * is a log entry, not a pointer anything dereferences.
+   *
+   * And the queries that would find the rest do not belong on a user-facing
+   * route. Neither collection is indexed on the field the reference is named
+   * by (`payload.postId`; the three `activityJson` paths), so an unscoped
+   * delete is a collection scan — over 30 days of engagement in one case, and
+   * in the other over a queue nothing prunes at all: rows are flipped to
+   * `delivered`/`failed` in place and kept forever. Filtering on `status`
+   * reaches both through an existing index prefix and touches only the live
+   * backlog. The administrative purge still removes them wholesale, which is
+   * the right trade for a batch job and the wrong one here.
+   */
+  'EngagementOutbox.payload.postId': 'cancel-pending',
+  'FederationDeliveryQueue.activityJson': 'cancel-pending',
+
+  /**
+   * RETAINED, and this is the one entry where deleting would break something
+   * rather than merely lose an audit trail.
+   *
+   * An inbound CrowdSource decision is matched to local rows by
+   * `Report.crowdSourceCaseId` — `ModerationDecisionWorker` throws a RETRYABLE
+   * `ModerationDecisionDeferredError` when a case resolves to no report, so a
+   * decision arriving after the reported post was deleted would back off and
+   * retry until it expired. The delivery side already has a designed answer for
+   * a subject that vanished (`ModerationDeliveryWorker` closes the report as
+   * undeliverable rather than retrying), so the row is not stranded by being
+   * kept — only by being removed.
+   *
+   * `purgeBlockedDomainContent` deletes these, which is a different call for a
+   * different reason: it removes a blocked instance's content wholesale, and
+   * its cascade owns that decision. A user deleting their own post does not get
+   * to erase reports filed about it.
+   */
+  'Report.reportedId(post)': 'retain',
+};
+
+/** The claim this cascade makes, in the shape the residue check verifies. */
+const CASCADED_POST_REFERENCES: readonly PostReferenceProbeName[] = (
+  Object.keys(POST_REFERENCE_DISPOSITION) as PostReferenceProbeName[]
+).filter((name) => POST_REFERENCE_DISPOSITION[name] === 'cascade');
+
+/**
+ * The fields the cascade reads off a post. Deliberately the same set the
+ * administrative purge projects, so the two cannot drift into needing different
+ * reads of the same row.
+ */
+export interface CascadedPostRow {
+  _id: mongoose.Types.ObjectId | string;
+  oxyUserId?: string;
+  boostOf?: string;
+  parentPostId?: string;
+  federation?: { activityId?: string; url?: string } | null;
+  content?: { pollId?: string; article?: { articleId?: string } } | null;
+}
+
+const BOOST_CLOSURE_PROJECTION = {
+  _id: 1,
+  oxyUserId: 1,
+  boostOf: 1,
+  parentPostId: 1,
+  federation: 1,
+  'content.pollId': 1,
+  'content.article.articleId': 1,
+} as const;
+
+/**
+ * A hard cap on how many boosts one delete may take with it.
+ *
+ * The closure is unbounded in principle — a widely boosted post has as many
+ * boosts as it has boosters — and a live HTTP request is the wrong place to
+ * discover that. Past the cap the cascade REFUSES to expand rather than
+ * deleting an arbitrary prefix: a partially deboosted post leaves exactly the
+ * blank cards the expansion exists to prevent, and the operator needs to know
+ * it happened. Reported through the residue log, which is the signal an
+ * administrative reconciliation reads.
+ */
+const MAX_BOOST_CLOSURE = 500;
+
+function idString(value: mongoose.Types.ObjectId | string): string {
+  return String(value);
+}
+
+/** The AP identifiers a post can additionally be named by. */
+function postUris(post: CascadedPostRow): string[] {
+  return [post.federation?.activityId, post.federation?.url].filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  );
+}
+
+/**
+ * Every boost of `seedIds`, transitively.
+ *
+ * Transitive because `boostOf` can name a boost: one level would leave a boost
+ * of a boost pointing at a row this cascade removed, which is the same blank
+ * card the expansion exists to prevent.
+ *
+ * Returns `null` when the closure exceeds {@link MAX_BOOST_CLOSURE} — see the
+ * constant for why that is a refusal rather than a truncation.
+ */
+export async function collectBoostClosure(
+  seedIds: readonly string[],
+): Promise<CascadedPostRow[] | null> {
+  const seen = new Set(seedIds);
+  const found: CascadedPostRow[] = [];
+  let frontier = [...seedIds];
+
+  while (frontier.length > 0) {
+    const next = await Post.find(
+      { type: PostType.BOOST, boostOf: { $in: frontier } },
+      BOOST_CLOSURE_PROJECTION,
+    ).lean<CascadedPostRow[]>();
+
+    frontier = [];
+    for (const boost of next) {
+      const id = idString(boost._id);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      found.push(boost);
+      if (found.length > MAX_BOOST_CLOSURE) return null;
+      frontier.push(id);
+    }
+  }
+
+  return found;
+}
+
+/** One reference deletion, named so a failure says which leg failed. */
+interface CascadeLeg {
+  reference: string;
+  run: () => Promise<unknown>;
+}
+
+/**
+ * Delete every reference this cascade claims, over the full target set.
+ *
+ * Runs the legs concurrently but reports each rejection with the leg's name.
+ * The previous shape — `Promise.allSettled` whose result was discarded inside a
+ * `try` that logged only if the wrapper itself threw — could not fail visibly:
+ * `allSettled` never rejects, so a leg that threw was indistinguishable from one
+ * that deleted nothing, which is how a cascade step that had never worked at all
+ * survived unnoticed.
+ */
+async function runLegs(legs: readonly CascadeLeg[]): Promise<string[]> {
+  const outcomes = await Promise.allSettled(legs.map((leg) => leg.run()));
+  const failed: string[] = [];
+  outcomes.forEach((outcome, index) => {
+    if (outcome.status !== 'rejected') return;
+    const { reference } = legs[index];
+    failed.push(reference);
+    logger.error('Post deletion cascade leg failed', {
+      reference,
+      error: outcome.reason,
+    });
+  });
+  return failed;
+}
+
+/**
+ * Restore the counters a deleted post contributed to on rows that SURVIVE it.
+ *
+ * Only two of a post's counters live somewhere else:
+ *
+ *  - a reply contributed 1 to its parent's `stats.commentsCount`. The canonical
+ *    definition of that counter is `Post.countDocuments({ parentPostId })` —
+ *    `recomputeFederatedEngagement`'s `computeRealCounts` is the reference — so a
+ *    decrement is exactly its inverse.
+ *  - a boost contributed 1 to its target's `stats.boostsCount` (and, when the
+ *    boost arrived over ActivityPub, to `stats.federatedBoostsCount`).
+ *
+ * Both writes are guarded on `$gt: 0`, the same guard the unboost path and the
+ * administrative purge use, so a counter that is already behind can never be
+ * driven negative. It CAN still be driven low: `POST /posts` creates a reply
+ * without incrementing the parent (only `POST /feed/reply` increments), so a
+ * population of replies created through both routes decrements more often than
+ * it incremented. That asymmetry is a creation-path bug and is deliberately not
+ * papered over here — the decrement matches the canonical definition, and a
+ * counter reconciliation is the thing that repairs drift in both directions.
+ */
+async function repairSurvivingCounters(
+  post: CascadedPostRow,
+  boosts: readonly CascadedPostRow[],
+  removedIds: ReadonlySet<string>,
+): Promise<CascadeLeg[]> {
+  const legs: CascadeLeg[] = [];
+
+  if (post.parentPostId && mongoose.isValidObjectId(post.parentPostId)) {
+    const parentPostId = post.parentPostId;
+    legs.push({
+      reference: 'stats.commentsCount',
+      run: () =>
+        Post.updateOne(
+          { _id: parentPostId, 'stats.commentsCount': { $gt: 0 } },
+          { $inc: { 'stats.commentsCount': -1 } },
+        ).exec(),
+    });
+  }
+
+  // Only boosts whose TARGET survives this delete need a repair; a boost of the
+  // deleted post is repairing a counter on a row that is already gone.
+  const boostsToRepair = [post, ...boosts].filter(
+    (row): row is CascadedPostRow & { boostOf: string } =>
+      typeof row.boostOf === 'string' &&
+      !removedIds.has(row.boostOf) &&
+      mongoose.isValidObjectId(row.boostOf),
+  );
+  for (const boost of boostsToRepair) {
+    const targetId = boost.boostOf;
+    const federated = Boolean(boost.federation);
+    legs.push({
+      reference: 'stats.boostsCount',
+      run: async () => {
+        await Post.updateOne(
+          { _id: targetId, 'stats.boostsCount': { $gt: 0 } },
+          { $inc: { 'stats.boostsCount': -1 } },
+        ).exec();
+        if (federated) {
+          await Post.updateOne(
+            { _id: targetId, 'stats.federatedBoostsCount': { $gt: 0 } },
+            { $inc: { 'stats.federatedBoostsCount': -1 } },
+          ).exec();
+        }
+      },
+    });
+  }
+
+  return legs;
+}
+
+/** The reference-deleting legs, over the whole target set. */
+function referenceLegs(targets: readonly CascadedPostRow[]): CascadeLeg[] {
+  const idStrings = [...new Set(targets.map((post) => idString(post._id)))];
+  // `Like.postId`, `Bookmark.postId` and `Notification.entityId` are ObjectId
+  // columns, so they are matched with real ObjectIds rather than left to
+  // per-query casting.
+  const objectIds = idStrings
+    .filter((id) => mongoose.isValidObjectId(id))
+    .map((id) => new mongoose.Types.ObjectId(id));
+  // Both keys a post can be named by: its id, and the AP identifiers a
+  // federated post also travels under. The side tables are split between the
+  // two exactly as the preflight's probes are.
+  const postKeys = [...new Set([...idStrings, ...targets.flatMap(postUris)])];
+  const pollIds = targets.flatMap((post) => (post.content?.pollId ? [post.content.pollId] : []));
+  const articleIds = targets.flatMap((post) =>
+    post.content?.article?.articleId ? [post.content.article.articleId] : [],
+  );
+
+  return [
+    {
+      // Both entity types the enum can hold for a post row. `'post'` alone
+      // missed every reply notification — `PostCreationService` and the
+      // ActivityPub inbox both write `entityType: 'reply'`.
+      reference: 'Notification.entityId',
+      run: () =>
+        Notification.deleteMany({
+          entityType: { $in: ['post', 'reply'] },
+          entityId: { $in: objectIds },
+        }).exec(),
+    },
+    {
+      reference: 'Poll.postId',
+      run: () =>
+        Poll.deleteMany({
+          $or: [
+            { postId: { $in: [...objectIds, ...idStrings] } },
+            ...(pollIds.length > 0 ? [{ _id: { $in: pollIds } }] : []),
+          ],
+        }).exec(),
+    },
+    {
+      reference: 'Article.postId',
+      run: () =>
+        Article.deleteMany({
+          $or: [
+            { postId: { $in: idStrings } },
+            ...(articleIds.length > 0 ? [{ _id: { $in: articleIds } }] : []),
+          ],
+        }).exec(),
+    },
+    {
+      reference: 'Postgate.postId/postUri',
+      run: () =>
+        Postgate.deleteMany({
+          $or: [{ postId: { $in: idStrings } }, { postUri: { $in: postKeys } }],
+        }).exec(),
+    },
+    {
+      reference: 'Threadgate.postId/postUri',
+      run: () =>
+        Threadgate.deleteMany({
+          $or: [{ postId: { $in: idStrings } }, { postUri: { $in: postKeys } }],
+        }).exec(),
+    },
+    {
+      // `repairRecentRepliersAfterPostDelete` already removes the projections
+      // for the seed post and the replies it deletes. This covers the rest of
+      // the target set — a boost can be replied to, and so can carry one.
+      reference: 'PostRecentReplier.postId',
+      run: () => PostRecentReplier.deleteMany({ postId: { $in: idStrings } }).exec(),
+    },
+    {
+      // `pending` only, never `processing`: a claimed row is being applied by a
+      // worker right now, and pulling it out from under an open lease trades a
+      // harmless no-op update for a real race.
+      reference: 'EngagementOutbox.payload.postId(pending)',
+      run: () =>
+        EngagementOutbox.deleteMany({
+          status: 'pending',
+          'payload.postId': { $in: idStrings },
+        }).exec(),
+    },
+    {
+      reference: 'ContentLabel.targetId(post)',
+      run: () =>
+        ContentLabel.deleteMany({ targetType: 'post', targetId: { $in: idStrings } }).exec(),
+    },
+    {
+      reference: 'FeedInteraction.postUri',
+      run: () => FeedInteraction.deleteMany({ postUri: { $in: postKeys } }).exec(),
+    },
+    {
+      // Cancels outbound work for a post we have just deleted — the
+      // `Delete(Tombstone)` this route sends is what remote instances should
+      // receive, not a queued `Create(Note)` for a post that no longer exists.
+      reference: 'FederationDeliveryQueue.activityJson(pending)',
+      run: () =>
+        FederationDeliveryQueue.deleteMany({
+          status: 'pending',
+          $or: [
+            { 'activityJson.id': { $in: postKeys } },
+            { 'activityJson.object.id': { $in: postKeys } },
+            { 'activityJson.object': { $in: postKeys } },
+          ],
+        }).exec(),
+    },
+    {
+      reference: 'Like.postId',
+      run: () => Like.deleteMany({ postId: { $in: objectIds } }).exec(),
+    },
+    {
+      reference: 'Bookmark.postId',
+      run: () => Bookmark.deleteMany({ postId: { $in: objectIds } }).exec(),
+    },
+  ];
+}
+
+export interface PostDeletionCascadeInput {
+  /** The post row, as returned by the delete that removed it. */
+  post: CascadedPostRow;
+  /**
+   * Rows this request's caller has ALREADY deleted and whose references are
+   * therefore this cascade's to clean — today the direct replies that
+   * `repairRecentRepliersAfterPostDelete` removes inside its own transaction.
+   * Captured BEFORE that delete, so a federated reply still carries the AP
+   * identifiers half the side tables name it by.
+   */
+  alsoDeleted?: readonly CascadedPostRow[];
+}
+
+/**
+ * Clean up after a post row that has already been removed.
+ *
+ * Ordering is deliberate. The seed post is gone before this runs — the route's
+ * `findOneAndDelete` is what AUTHORIZES the delete and claims it against a
+ * concurrent second request — so this cannot pretend to remove side tables
+ * first. What it can do is remove the boost rows LAST, after their own
+ * references are gone, so a run that dies midway leaves boosts pointing at
+ * nothing rather than boost references pointing at nothing.
+ *
+ * Never throws: a delete the user asked for and the database performed must not
+ * be reported as a failure because a derived row could not be removed. Every
+ * failure is logged with the leg that produced it, and the residue check at the
+ * end states what is actually still there.
+ *
+ * ## Dependents
+ *
+ * - **Boosts are deleted.** A `type:'boost'` post has an intentionally empty
+ *   body and renders entirely from `boostOf`, so a boost outliving its original
+ *   is not degraded content — it is a blank card. `adminDeletionPreflight`
+ *   refuses to let any caller acknowledge `boostOf` away for this reason.
+ * - **Quotes are NOT deleted.** A quote carries the quoter's own writing.
+ *   `PostHydrationService` resolves `quotedPost` to null and drops the quote
+ *   card, leaving the text its author wrote intact. Deleting it would destroy
+ *   one person's content to remove another's.
+ * - **Replies are not this function's decision.** Direct replies are already
+ *   removed by `repairRecentRepliersAfterPostDelete`, inside the transaction
+ *   that repairs the replier projection; the rows arrive here as
+ *   `alsoDeleted` so that whatever that policy removes gets cleaned up. Deeper
+ *   descendants are left standing and hydration tolerates the dangling
+ *   `parentPostId`.
+ */
+export async function cascadeDeletedPost(input: PostDeletionCascadeInput): Promise<void> {
+  const { post } = input;
+  const seedId = idString(post._id);
+
+  try {
+    const seeds = [post, ...(input.alsoDeleted ?? [])];
+    const boosts = await collectBoostClosure(seeds.map((row) => idString(row._id)));
+    if (boosts === null) {
+      logger.error('Post deletion cascade refused to expand an oversized boost closure', {
+        postId: seedId,
+        limit: MAX_BOOST_CLOSURE,
+      });
+      return;
+    }
+
+    const targets = [...seeds, ...boosts];
+    const removedIds = new Set(targets.map((row) => idString(row._id)));
+
+    const failed = await runLegs([
+      ...(await repairSurvivingCounters(post, boosts, removedIds)),
+      ...referenceLegs(targets),
+    ]);
+
+    // Boost ROWS last — see the ordering note above.
+    if (boosts.length > 0) {
+      await Post.deleteMany({
+        _id: { $in: boosts.map((boost) => boost._id) },
+      }).exec();
+    }
+
+    await reportResidue(targets, failed, seedId);
+  } catch (error) {
+    logger.error('Post deletion cascade failed', { postId: seedId, error });
+  }
+}
+
+/**
+ * Verify the claim rather than trusting it, using the same probes the
+ * administrative purge is checked with — the end state, after the deletes, with
+ * nothing acknowledged.
+ */
+async function reportResidue(
+  targets: readonly CascadedPostRow[],
+  failedLegs: readonly string[],
+  postId: string,
+): Promise<void> {
+  const probeTargets: PostDeletionTarget[] = targets.map((row) => ({
+    id: row._id,
+    uris: postUris(row),
+  }));
+  const residue = await collectPostCascadeResidue(probeTargets, CASCADED_POST_REFERENCES);
+  if (residue.length === 0 && failedLegs.length === 0) return;
+  logger.error('Post deletion cascade left references behind', {
+    postId,
+    residue,
+    failedLegs,
+  });
+}

--- a/packages/backend/src/services/PostRecentReplierService.ts
+++ b/packages/backend/src/services/PostRecentReplierService.ts
@@ -33,6 +33,21 @@ export interface DeletedPostProjectionContext {
   parentPostId?: unknown;
 }
 
+/**
+ * A direct reply removed alongside its parent, in the shape
+ * {@link import('./PostDeletionCascade').CascadedPostRow} consumes — the two are
+ * checked against each other by the compiler at the call site in
+ * `posts.controller`.
+ */
+export interface DeletedReplyRow {
+  _id: mongoose.Types.ObjectId;
+  oxyUserId?: string;
+  boostOf?: string;
+  parentPostId?: string;
+  federation?: { activityId?: string; url?: string } | null;
+  content?: { pollId?: string; article?: { articleId?: string } } | null;
+}
+
 function validDate(value: unknown): Date | null {
   const date = value instanceof Date ? value : new Date(String(value ?? ''));
   return Number.isFinite(date.getTime()) ? date : null;
@@ -246,10 +261,26 @@ async function recomputeProjection(
   );
 }
 
+/**
+ * The direct replies this transaction deletes, projected onto the fields the
+ * deletion cascade needs. Read BEFORE the delete, because afterwards nothing
+ * but the ids would be recoverable and half of a post's side tables name it by
+ * its ActivityPub identifiers rather than its id.
+ */
+const DELETED_CHILD_PROJECTION = {
+  _id: 1,
+  oxyUserId: 1,
+  boostOf: 1,
+  parentPostId: 1,
+  federation: 1,
+  'content.pollId': 1,
+  'content.article.articleId': 1,
+} as const;
+
 async function repairDeletedPostProjectionInTransaction(
   input: { postId: string; parentPostId: string },
   session: ClientSession,
-): Promise<void> {
+): Promise<DeletedReplyRow[]> {
   if (input.parentPostId) {
     // The authoritative Post query and projection replacement share one
     // snapshot transaction. A concurrent reply writer touches this same
@@ -259,9 +290,9 @@ async function repairDeletedPostProjectionInTransaction(
   }
 
   const deletedChildren = await Post.find({ parentPostId: input.postId })
-    .select({ _id: 1 })
+    .select(DELETED_CHILD_PROJECTION)
     .session(session)
-    .lean<Array<{ _id: unknown }>>();
+    .lean<DeletedReplyRow[]>();
   const deletedChildIds = deletedChildren
     .map((child) => normalizedId(child._id))
     .filter(Boolean);
@@ -281,19 +312,28 @@ async function repairDeletedPostProjectionInTransaction(
     { postId: { $in: [input.postId, ...deletedChildIds] } },
     { session },
   );
+
+  return deletedChildren;
 }
 
 /**
  * Repair the recent-replier read model after a Post row has already been
  * deleted. Fail-soft by design: projection maintenance must never turn a
  * successful authoritative delete into an API failure.
+ *
+ * Returns the direct replies this call DELETED, which is not something a
+ * projection repair would normally have to say — but it deletes them, and their
+ * own likes, bookmarks, notifications and gates are then nobody's to clean
+ * unless it reports which rows went. Empty when nothing was deleted, and empty
+ * when the repair failed outright: an unreported row is a missed cleanup, while
+ * a falsely reported one would send the cascade after a post that still exists.
  */
 export async function repairRecentRepliersAfterPostDelete(
   input: DeletedPostProjectionContext,
-): Promise<void> {
+): Promise<DeletedReplyRow[]> {
   const postId = normalizedId(input.postId);
   const parentPostId = normalizedId(input.parentPostId);
-  if (!postId) return;
+  if (!postId) return [];
 
   let lastError: unknown;
   for (let attempt = 1; attempt <= MAX_PROJECTION_REPAIR_ATTEMPTS; attempt += 1) {
@@ -304,15 +344,19 @@ export async function repairRecentRepliersAfterPostDelete(
     if (!session) break;
 
     try {
+      let deletedReplies: DeletedReplyRow[] = [];
       await session.withTransaction(
-        () =>
-          repairDeletedPostProjectionInTransaction(
+        async () => {
+          // Reassigned per attempt: a retried transaction re-reads the
+          // children, and the previous attempt's rows were rolled back.
+          deletedReplies = await repairDeletedPostProjectionInTransaction(
             { postId, parentPostId },
             session,
-          ),
+          );
+        },
         PROJECTION_REPAIR_TRANSACTION_OPTIONS,
       );
-      return;
+      return deletedReplies;
     } catch (error) {
       lastError = error;
       if (
@@ -331,6 +375,7 @@ export async function repairRecentRepliersAfterPostDelete(
     parentPostId: parentPostId || undefined,
     reason: lastError instanceof Error ? lastError.message : String(lastError),
   });
+  return [];
 }
 
 export async function recordRecentReplierForPost(reply: RecentReplyLike): Promise<void> {


### PR DESCRIPTION
## Summary

A dead cascade step was one config line from a catastrophe. `deletePost` ran `PostSubscription.deleteMany({ postId })` against a schema with no `postId` — it is an AUTHOR subscription, `{subscriberId, authorId}`. Reproduced on a live mongod 8.0.28 with the repo's mongoose 8.24.1: as shipped, `deletedCount=0, survivors=3` — a silent no-op reported as work. With `mongoose.set('strictQuery', true)` the unknown path is stripped and the identical call becomes `deleteMany({})`: `deletedCount=3, survivors=0`, every post subscription in the instance wiped on every post deletion. `strictQuery` is absent from `packages/`, so the default saves us today. Both call sites removed — the same filter was in `purgeBlockedDomainContent`, where its guaranteed zero was reported as the `postSubscriptions` count.

`deletePost` covered 5.5 of 13 known post references. Boosts were never deleted (the live mechanism behind the blank-boost class — every ordinary deletion minted new ones), `stats.commentsCount` was never decremented on the parent, the notification filter missed `entityType:'reply'`, and `Promise.allSettled` made a throwing leg indistinguishable from one that deleted nothing.

Seven user-referencing fields had no probe at all, including `Post.writtenByOxyUserId` — deliberately outside `authorship[]` to protect a channel writer's anonymity, which also put it outside every matcher and every guard. Each new probe was proven against a real mongod with a negative case first.

A correction to the audit that prompted this, worth recording: replies WERE already deleted, one level, inside `repairRecentRepliersAfterPostDelete`'s projection-repair transaction. That policy was NOT changed — three places in the tree disagree about whether a deleted post's replies should stand, so flipping it either way would be a product decision made on a false premise. What did change: the function now returns the rows it deleted, so their likes, bookmarks, notifications and gates are cleaned instead of silently dangling.

Two cascades deliberately refused, with reasons: `Report.reportedId(post)` is retained because `ModerationDecisionWorker` treats a missing local report as RETRYABLE, so deleting it strands an inbound decision on retry until it expires. `RepairFetchFailure.postId` is a real gap left unprobed on purpose — `reingestEmptyFederatedPosts` deletes exactly the federated posts that collection names, so adding it would fail-close that script against itself.

A performance regression caught before shipping: `EngagementOutbox.payload.postId` and the three `FederationDeliveryQueue.activityJson` paths are unindexed, and the delivery queue is never pruned. Unscoped deletes there are collection scans on the route every user hits. Both legs are now scoped to `status:'pending'` — the only rows that can still act, reachable through an existing index prefix — and a third disposition `'cancel-pending'` records that they are therefore NOT claimed to the residue check. Claiming them would repeat the very failure this change removes.

The self-policing property: the disposition table is a `Record<PostReferenceProbeName, …>`, so adding a probe breaks this file's build until someone decides what the delete route does about it.

One pre-existing bug documented, not fixed: `POST /posts` with `parentPostId` never increments `stats.commentsCount` — only `POST /feed/reply` does — so replies created through both routes will now drift low as well as high. The canonical definition is `Post.countDocuments({parentPostId})`.

## Test plan
- [x] Real-mongod verification, 54 assertions, vacuity floor
- [x] 28 mutations across two runs, zero survivors, each killed by its own named assertion
- [x] Full suite: 432 files / 4710 tests green
- [x] CI coverage gate exit 0
- [x] `tsc` clean
- [x] `lint:backend` and `validate:logger` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)