### PR TITLE
fix(moderation): you cannot block, report or mute an account you operate

### DIFF
--- a/packages/backend/src/__tests__/routes/muteOperatedAccount.test.ts
+++ b/packages/backend/src/__tests__/routes/muteOperatedAccount.test.ts
@@ -1,0 +1,160 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * You cannot MUTE an account you operate.
+ *
+ * This route already refused `userId === mutedId`, so the interesting cases are
+ * the ones that comparison could never see: a channel, organization, project or
+ * bot the caller publishes as is never the caller's own id. The old rule survives
+ * as one case of the new one, and there is a test below that would catch it being
+ * lost.
+ *
+ * Same shape as the report guard's file, for the same reason: the assertions go
+ * through the route with supertest, and the guard runs for real — only the Oxy
+ * reads beneath it are stubbed. Each refusal is paired with a near-miss that must
+ * still succeed, so a guard that refused everybody could not pass.
+ */
+
+const { resolveUserSummaries, listAccountMembers, muteSave, muteFindOne } = vi.hoisted(() => ({
+  resolveUserSummaries: vi.fn(),
+  listAccountMembers: vi.fn(),
+  muteSave: vi.fn(),
+  muteFindOne: vi.fn(),
+}));
+
+vi.mock('../../models/Mute', () => {
+  class MockMute {
+    constructor(public readonly doc: unknown) {}
+    save = muteSave;
+    static findOne = muteFindOne;
+  }
+  return { default: MockMute };
+});
+
+vi.mock('../../services/PostHydrationService', () => ({ resolveUserSummaries }));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createUserScopedOxyServices: () => ({ listAccountMembers }),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import muteRoutes from '../../routes/mute.routes';
+
+const VIEWER = 'oxy-viewer';
+const OPERATED_CHANNEL = 'oxy-channel-operated';
+const OPERATED_BOT = 'oxy-bot-operated';
+const UNOPERATED_ORG = 'oxy-org-billing-only';
+const STRANGER = 'oxy-stranger';
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    Object.defineProperty(req, 'user', { value: { id: VIEWER }, writable: true });
+    next();
+  });
+  app.use('/mute', muteRoutes);
+  return app;
+}
+
+function mute(mutedId: string) {
+  return request(buildApp()).post('/mute').send({ mutedId });
+}
+
+function accountsAre(kinds: Record<string, string>): void {
+  resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+    const map = new Map();
+    for (const id of ids) {
+      if (kinds[id]) map.set(id, { user: { id, kind: kinds[id] } });
+    }
+    return map;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  muteFindOne.mockResolvedValue(null);
+  muteSave.mockResolvedValue(undefined);
+
+  accountsAre({
+    [VIEWER]: 'personal',
+    [STRANGER]: 'personal',
+    [OPERATED_CHANNEL]: 'channel',
+    [OPERATED_BOT]: 'bot',
+    [UNOPERATED_ORG]: 'organization',
+  });
+
+  listAccountMembers.mockImplementation(async (accountId: string) => {
+    if (accountId === OPERATED_CHANNEL) {
+      return [{ memberUserId: VIEWER, status: 'active', permissions: [] }];
+    }
+    if (accountId === OPERATED_BOT) {
+      return [{ memberUserId: VIEWER, status: 'active', permissions: ['account:act_as'] }];
+    }
+    if (accountId === UNOPERATED_ORG) {
+      return [{ memberUserId: VIEWER, status: 'active', permissions: ['billing:read'] }];
+    }
+    return [];
+  });
+});
+
+describe('POST /mute — an account you operate cannot be muted', () => {
+  it('refuses muting a CHANNEL the caller operates', async () => {
+    const response = await mute(OPERATED_CHANNEL);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('You cannot mute an account you operate');
+    // Refused before the write, not cleaned up after it.
+    expect(muteSave).not.toHaveBeenCalled();
+  });
+
+  it('refuses muting a BOT the caller may act as', async () => {
+    const response = await mute(OPERATED_BOT);
+
+    expect(response.status).toBe(400);
+    expect(muteSave).not.toHaveBeenCalled();
+  });
+
+  it('still refuses muting YOURSELF', async () => {
+    // The rule this replaced. It has to keep holding, and it has to keep holding
+    // for free — the self case resolves before any Oxy read.
+    const response = await mute(VIEWER);
+
+    expect(response.status).toBe(400);
+    expect(muteSave).not.toHaveBeenCalled();
+    expect(listAccountMembers).not.toHaveBeenCalled();
+    expect(resolveUserSummaries).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /mute — everybody else can still be muted (the vacuity floor)', () => {
+  it('mutes an ordinary person', async () => {
+    const response = await mute(STRANGER);
+
+    expect(response.status).toBe(201);
+    expect(muteSave).toHaveBeenCalledTimes(1);
+    expect(listAccountMembers).not.toHaveBeenCalled();
+  });
+
+  it('mutes an organization the caller may not act as', async () => {
+    const response = await mute(UNOPERATED_ORG);
+
+    expect(response.status).toBe(201);
+    expect(muteSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('mutes a managed account when Oxy cannot say who its members are', async () => {
+    // Unknown must not cost a reader the ability to quieten an account.
+    listAccountMembers.mockRejectedValue(new Error('oxy unreachable'));
+
+    const response = await mute(OPERATED_CHANNEL);
+
+    expect(response.status).toBe(201);
+    expect(muteSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/__tests__/routes/reportsAcceptedTypes.test.ts
+++ b/packages/backend/src/__tests__/routes/reportsAcceptedTypes.test.ts
@@ -34,6 +34,22 @@ vi.mock('../../services/moderation/ReportIntakeService', async () => {
   return { ...actual, createReport: (...args: unknown[]) => createReport(...args) };
 });
 
+/**
+ * A `user` report now asks whether the reporter OPERATES the account named
+ * (`services/operatedAccountAccess.ts`), which reaches Oxy for identity and the
+ * account graph. Stubbed to "an account nobody here operates" so this file keeps
+ * testing what it is about — which reported TYPES the route accepts — rather than
+ * silently becoming a test of the operator gate, which
+ * `reportsOperatedAccount.test.ts` owns.
+ */
+vi.mock('../../services/PostHydrationService', () => ({
+  resolveUserSummaries: vi.fn(async () => new Map()),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createUserScopedOxyServices: () => ({ listAccountMembers: vi.fn(async () => []) }),
+}));
+
 import reportsRoutes from '../../routes/reports.routes';
 import { ReportedType } from '../../models/Report.model';
 import { deliverableTypes } from '../../services/moderation/subjects/registry';

--- a/packages/backend/src/__tests__/routes/reportsOperatedAccount.test.ts
+++ b/packages/backend/src/__tests__/routes/reportsOperatedAccount.test.ts
@@ -1,0 +1,233 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * You cannot REPORT an account you operate, and the proof has to be the route
+ * refusing — not the menu declining to draw a button.
+ *
+ * Every assertion here goes through `POST /reports` with supertest, because the
+ * property under test is "this is not possible", and a client that never opened
+ * Mention can send this request. A UI test can only ever show that one client
+ * does not offer it.
+ *
+ * The guard itself runs FOR REAL. What is stubbed is strictly below it: the
+ * identity read that says what kind each account is, and the account-graph read
+ * that says who its members are — the two things a unit test has no Oxy to ask.
+ * `viewerOperatesAccount` and `assertCanPublishAsAccount` both execute.
+ *
+ * ## Every case here is paired, so "refuses operators" cannot pass as "refuses
+ * ## everyone"
+ *
+ * A file where the reporter always operates the target proves nothing: a guard
+ * that refused unconditionally would be just as green. So each refusal has a
+ * near-miss beside it that must still be ACCEPTED — a stranger, and an
+ * organization member who is a member but may not act as it.
+ */
+
+// `vi.hoisted`, because `vi.mock` is lifted above every `const` in the file and a
+// plain declaration is still in its temporal dead zone when the factory runs.
+const { createReport, resolveUserSummaries, listAccountMembers } = vi.hoisted(() => ({
+  createReport: vi.fn(),
+  resolveUserSummaries: vi.fn(),
+  listAccountMembers: vi.fn(),
+}));
+
+vi.mock('../../services/moderation/ReportIntakeService', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../services/moderation/ReportIntakeService')
+  >('../../services/moderation/ReportIntakeService');
+  return { ...actual, createReport: (...args: unknown[]) => createReport(...args) };
+});
+
+vi.mock('../../services/PostHydrationService', () => ({ resolveUserSummaries }));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createUserScopedOxyServices: () => ({ listAccountMembers }),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import reportsRoutes from '../../routes/reports.routes';
+
+const REPORTER = 'oxy-reporter';
+/** A channel the reporter is an active member of. Membership is the whole right. */
+const OPERATED_CHANNEL = 'oxy-channel-operated';
+/** An organization the reporter may act as. */
+const OPERATED_ORG = 'oxy-org-operated';
+/** An organization the reporter belongs to but may NOT act as (e.g. billing). */
+const UNOPERATED_ORG = 'oxy-org-billing-only';
+/** A channel somebody else runs. */
+const STRANGER_CHANNEL = 'oxy-channel-stranger';
+/** An ordinary person. The overwhelming majority of reports. */
+const STRANGER = 'oxy-stranger';
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    Object.defineProperty(req, 'user', { value: { id: REPORTER }, writable: true });
+    next();
+  });
+  app.use('/reports', reportsRoutes);
+  return app;
+}
+
+function reportUser(reportedId: string) {
+  return request(buildApp())
+    .post('/reports')
+    .send({ reportedType: 'user', reportedId, categories: ['harassment'] });
+}
+
+/** Teaches the identity read what kind each account is. */
+function accountsAre(kinds: Record<string, string>): void {
+  resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+    const map = new Map();
+    for (const id of ids) {
+      if (kinds[id]) map.set(id, { user: { id, kind: kinds[id] } });
+    }
+    return map;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createReport.mockResolvedValue({
+    report: {
+      _id: 'report_1',
+      reportedType: 'user',
+      reportedId: 'whoever',
+      categories: ['harassment'],
+      status: 'pending',
+      localStatus: 'queued',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    outboxEventId: 'event_1',
+  });
+
+  accountsAre({
+    [REPORTER]: 'personal',
+    [STRANGER]: 'personal',
+    [OPERATED_CHANNEL]: 'channel',
+    [STRANGER_CHANNEL]: 'channel',
+    [OPERATED_ORG]: 'organization',
+    [UNOPERATED_ORG]: 'organization',
+  });
+
+  listAccountMembers.mockImplementation(async (accountId: string) => {
+    if (accountId === OPERATED_CHANNEL) {
+      return [{ memberUserId: REPORTER, status: 'active', permissions: [] }];
+    }
+    if (accountId === OPERATED_ORG) {
+      return [{ memberUserId: REPORTER, status: 'active', permissions: ['account:act_as'] }];
+    }
+    if (accountId === UNOPERATED_ORG) {
+      // A real member — `members:read` succeeded — who deliberately may not speak
+      // as the account. Membership alone must not read as operating it.
+      return [{ memberUserId: REPORTER, status: 'active', permissions: ['billing:read'] }];
+    }
+    return [{ memberUserId: 'somebody-else', status: 'active', permissions: ['account:act_as'] }];
+  });
+});
+
+describe('POST /reports — an account you operate cannot be reported', () => {
+  it('refuses a report against a CHANNEL the reporter operates', async () => {
+    const response = await reportUser(OPERATED_CHANNEL);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('You cannot report an account you operate');
+    // Refused BEFORE intake: no row, no CrowdSource delivery event, no jury.
+    expect(createReport).not.toHaveBeenCalled();
+  });
+
+  it('refuses a report against an ORGANIZATION the reporter may act as', async () => {
+    // The reason this is not a channel special case: the same wrongness applies
+    // to every managed kind, and an organization renders on the PERSON screen.
+    const response = await reportUser(OPERATED_ORG);
+
+    expect(response.status).toBe(400);
+    expect(createReport).not.toHaveBeenCalled();
+  });
+
+  it('refuses a report the reporter files against THEMSELVES', async () => {
+    // Not a separate rule — "is it me" is one case of "do I operate it", and it
+    // resolves before anything is looked up. Worth pinning because this route had
+    // no self-check of any kind: reporting yourself used to open a real case.
+    const response = await reportUser(REPORTER);
+
+    expect(response.status).toBe(400);
+    expect(createReport).not.toHaveBeenCalled();
+    expect(listAccountMembers).not.toHaveBeenCalled();
+    expect(resolveUserSummaries).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /reports — everybody else can still report (the vacuity floor)', () => {
+  it('accepts a report against an ordinary person', async () => {
+    const response = await reportUser(STRANGER);
+
+    expect(response.status).toBe(201);
+    expect(createReport).toHaveBeenCalledTimes(1);
+    // The cost claim: a personal target is settled off the cached identity read,
+    // without touching the account graph.
+    expect(listAccountMembers).not.toHaveBeenCalled();
+  });
+
+  it('accepts a report against a channel somebody ELSE operates', async () => {
+    const response = await reportUser(STRANGER_CHANNEL);
+
+    expect(response.status).toBe(201);
+    expect(createReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a report against an organization the reporter may not act as', async () => {
+    // The distinction the two-family rule exists for. A `billing` member is a
+    // member; they do not speak as the account, so reporting it is a real report
+    // by somebody who is not its voice.
+    const response = await reportUser(UNOPERATED_ORG);
+
+    expect(response.status).toBe(201);
+    expect(createReport).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('POST /reports — an unknown answer must not cost anybody a report', () => {
+  it('accepts the report when Oxy cannot say who the members are', async () => {
+    // The direction that matters. Refusing here would mean that for the duration
+    // of an Oxy outage nobody can report a managed account at all — removing the
+    // tool at the moment somebody reaches for it. Wrongly allowing costs an
+    // operator a pointless report against their own channel.
+    listAccountMembers.mockRejectedValue(new Error('oxy unreachable'));
+
+    const response = await reportUser(OPERATED_CHANNEL);
+
+    expect(response.status).toBe(201);
+    expect(createReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the report when the target account resolves to no kind at all', async () => {
+    accountsAre({});
+
+    const response = await reportUser(OPERATED_CHANNEL);
+
+    expect(response.status).toBe(201);
+    expect(createReport).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('POST /reports — the guard is scoped to accounts', () => {
+  it('does not ask the account graph about a POST report', async () => {
+    // `reportedId` is a post id here; asking whether the reporter "operates" it
+    // would resolve a kind for an id that names no account.
+    const response = await request(buildApp())
+      .post('/reports')
+      .send({ reportedType: 'post', reportedId: OPERATED_CHANNEL, categories: ['spam'] });
+
+    expect(response.status).toBe(201);
+    expect(resolveUserSummaries).not.toHaveBeenCalled();
+    expect(listAccountMembers).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/services/operatedAccountAccess.test.ts
+++ b/packages/backend/src/__tests__/services/operatedAccountAccess.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { resolveUserSummaries } = vi.hoisted(() => ({ resolveUserSummaries: vi.fn() }));
+
+vi.mock('../../services/PostHydrationService', () => ({ resolveUserSummaries }));
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { viewerOperatesAccount } from '../../services/operatedAccountAccess';
+
+/**
+ * The unit-level cases the route files cannot reach through an HTTP request,
+ * because the routes validate them away first. They are here rather than nowhere
+ * because this function's contract differs from the one it delegates to in
+ * exactly these places, and a difference nothing pins is a difference that gets
+ * refactored out.
+ */
+
+const CALLER = 'oxy-caller';
+const CHANNEL = 'oxy-channel';
+
+function accountsAre(kinds: Record<string, string>): void {
+  resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+    const map = new Map();
+    for (const id of ids) {
+      if (kinds[id]) map.set(id, { user: { id, kind: kinds[id] } });
+    }
+    return map;
+  });
+}
+
+function memberReaderReturning(members: unknown[]) {
+  return { listAccountMembers: vi.fn(async () => members as never) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  accountsAre({ [CHANNEL]: 'channel', [CALLER]: 'personal' });
+});
+
+describe('viewerOperatesAccount — an absent target is not an operated account', () => {
+  it('answers false for an empty, blank or missing target id', async () => {
+    // The guard this pins is NOT redundant, and that is the whole point of the
+    // case. `assertCanPublishAsAccount` reads an absent target as "publish as
+    // yourself" and returns SUCCESS — the right answer to its question, and the
+    // exact inversion of the right answer to this one. Without the guard, a
+    // caller who reaches here with no target is reported as operating it, and
+    // whatever action was being gated is refused for everybody.
+    const reader = memberReaderReturning([]);
+
+    for (const target of ['', '   ', null, undefined]) {
+      expect(
+        await viewerOperatesAccount({ targetOxyUserId: target, callerId: CALLER, memberReader: reader }),
+      ).toBe(false);
+    }
+  });
+
+  it('answers false when there is no caller', async () => {
+    expect(
+      await viewerOperatesAccount({
+        targetOxyUserId: CHANNEL,
+        callerId: undefined,
+        memberReader: memberReaderReturning([]),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('viewerOperatesAccount — "is it me" is one case of it', () => {
+  it('answers true for the caller themselves, with no lookup at all', async () => {
+    const reader = memberReaderReturning([]);
+
+    expect(
+      await viewerOperatesAccount({
+        targetOxyUserId: CALLER,
+        callerId: CALLER,
+        memberReader: reader,
+      }),
+    ).toBe(true);
+    expect(reader.listAccountMembers).not.toHaveBeenCalled();
+    expect(resolveUserSummaries).not.toHaveBeenCalled();
+  });
+
+  it('tolerates surrounding whitespace on either id', async () => {
+    expect(
+      await viewerOperatesAccount({
+        targetOxyUserId: ` ${CALLER} `,
+        callerId: CALLER,
+        memberReader: memberReaderReturning([]),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('viewerOperatesAccount — no member reader', () => {
+  it('answers false rather than throwing, so the action goes ahead', async () => {
+    // An MCP caller has no user-scoped Oxy client. The publish-as gate refuses on
+    // that grounds; here the same fact simply means we cannot confirm anything.
+    expect(
+      await viewerOperatesAccount({
+        targetOxyUserId: CHANNEL,
+        callerId: CALLER,
+        memberReader: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/backend/src/routes/mute.routes.ts
+++ b/packages/backend/src/routes/mute.routes.ts
@@ -1,6 +1,8 @@
 import { Router, Response } from 'express';
 import Mute from '../models/Mute';
 import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
+import { viewerOperatesAccount } from '../services/operatedAccountAccess';
+import { createUserScopedOxyServices } from '../utils/oxyHelpers';
 import { logger } from '../utils/logger';
 
 const router = Router();
@@ -22,9 +24,29 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'mutedId is required' });
     }
 
-    // Prevent self-muting
-    if (userId === mutedId) {
-      return res.status(400).json({ message: 'Cannot mute yourself' });
+    /**
+     * You cannot mute an account you OPERATE.
+     *
+     * This used to read `userId === mutedId`, which is the same rule stated
+     * narrowly enough to be wrong: a channel / organization / project / bot you
+     * publish as is never your own id, so muting one passed. Muting hides your own
+     * account's posts from your own feeds, which is not a preference anybody
+     * holds — and for a channel with several members it also hides work written by
+     * the others, from an operator who has no obvious way to connect the empty
+     * feed to a row they tapped once.
+     *
+     * `viewerOperatesAccount` still answers `true` for `userId === mutedId`, so
+     * self-muting stays refused; it is now one case of the general rule rather than
+     * the only case anybody remembered to write down. 400 for the same reason the
+     * report route gives.
+     */
+    const operatesTarget = await viewerOperatesAccount({
+      targetOxyUserId: mutedId,
+      callerId: userId,
+      memberReader: createUserScopedOxyServices(req),
+    });
+    if (operatesTarget) {
+      return res.status(400).json({ message: 'You cannot mute an account you operate' });
     }
 
     // Check if already muted

--- a/packages/backend/src/routes/reports.routes.ts
+++ b/packages/backend/src/routes/reports.routes.ts
@@ -13,6 +13,8 @@ import {
   DuplicateReportError,
   createReport,
 } from '../services/moderation/ReportIntakeService';
+import { viewerOperatesAccount } from '../services/operatedAccountAccess';
+import { createUserScopedOxyServices } from '../utils/oxyHelpers';
 import { logger } from '../utils/logger';
 import { queryInt } from '../utils/queryParams';
 
@@ -117,6 +119,44 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       return res.status(400).json({
         message: 'details must be 500 characters or less'
       });
+    }
+
+    /**
+     * You cannot report an account you OPERATE — yourself, or a channel /
+     * organization / project / bot you speak as.
+     *
+     * A report is an accusation laid before a jury by somebody who was not party
+     * to the material. Filed against your own account it is not a moderation
+     * request at all: it opens a CrowdSource case, draws real reviewers onto it,
+     * and asks them to rule on whether you should be enforced against for what
+     * you published. There is no state of the world in which that is the thing the
+     * reporter meant, so it is refused rather than filed — the affordance is also
+     * absent from the UI, but that is a consequence of it being meaningless, not
+     * the thing that prevents it.
+     *
+     * **400, not 403.** An operator has MORE authority over this account than a
+     * stranger does, so "forbidden" states the opposite of what is true: nothing
+     * is being withheld from them. The target is simply not a valid target for
+     * this verb. It also matches what the two neighbouring self-refusals already
+     * answer — `POST /mute` for muting yourself, and Oxy's own
+     * `POST /privacy/blocked/:id` for blocking yourself — so the same mistake gets
+     * the same status wherever a client makes it.
+     *
+     * Only `user` reports ask this. The other reported types name objects, not
+     * accounts, and the analogous rule for a POST is a different question with a
+     * different answer already (`postManagementAccess`).
+     */
+    if (reportedType === ReportedType.USER) {
+      const operatesTarget = await viewerOperatesAccount({
+        targetOxyUserId: reportedId,
+        callerId: reporter,
+        memberReader: createUserScopedOxyServices(req),
+      });
+      if (operatesTarget) {
+        return res.status(400).json({
+          message: 'You cannot report an account you operate',
+        });
+      }
     }
 
     const { report, outboxEventId } = await createReport({

--- a/packages/backend/src/services/operatedAccountAccess.ts
+++ b/packages/backend/src/services/operatedAccountAccess.ts
@@ -1,0 +1,109 @@
+import {
+  PublishAsAccessError,
+  assertCanPublishAsAccount,
+  type AccountMemberReader,
+} from './publishAsAccount';
+import { logger } from '../utils/logger';
+
+/**
+ * Whether `callerId` OPERATES the account `targetOxyUserId` — the question every
+ * self-directed moderation refusal actually wants to ask.
+ *
+ * The one the code used to ask was "is this account me?", which is the whole
+ * truth only for a personal login. A channel, organization, project or bot is
+ * never the viewer's own id, and yet the viewer may speak with its voice; the id
+ * comparison answers "no" for all four and lets somebody block or report an
+ * account they publish as. "Is it me" is ONE CASE of "do I operate it", not a
+ * synonym for it, and this function is the general form — `assertCanPublishAsAccount`
+ * returns success for `target === callerId` before it looks anything up, so the
+ * self case falls out of the same authority rather than needing a second branch.
+ *
+ * ONE AUTHORITY, DELIBERATELY. It reuses {@link assertCanPublishAsAccount}
+ * verbatim rather than reading the account graph again, for the same reason
+ * `postManagementAccess` does: a second membership reader is a second answer, and
+ * whichever of the two is wrong, one of them is wrong in the permissive
+ * direction. That inheritance also settles the question this module would
+ * otherwise have to invent an answer to — WHICH members count — with the answer
+ * the server already enforces everywhere else:
+ *
+ *  - a **channel**: any ACTIVE member, because a channel can never be acted as,
+ *    so membership is the strongest right there is over it;
+ *  - an **act-as-eligible** account (organization / project / bot): an active
+ *    member holding `account:act_as`, because speaking as it is the same claim of
+ *    identity as being it;
+ *  - a **personal** account that is not the caller: never, whoever asks.
+ *
+ * COST. Nothing is asked of Oxy for the two cases that dominate: the target is
+ * the caller (returns before any lookup), or the target is an ordinary personal
+ * account (refused off the cached identity read, before the member list). Only a
+ * managed account reaches the account-graph call, and only on an action a person
+ * initiated.
+ *
+ * ## It fails toward ALLOWING the action, which inverts the module it calls
+ *
+ * `assertCanPublishAsAccount` fails CLOSED — an unresolvable membership refuses
+ * the publish — and that is right there, because publishing as an account is a
+ * CAPABILITY: granting one you cannot verify puts words in somebody else's mouth.
+ *
+ * Block, report and mute are the opposite kind of decision. They are PROTECTIVE,
+ * and the caller is usually the person needing protection. So the two errors are
+ * not comparable here either, but they land the other way round:
+ *
+ *  - Wrongly deciding "operates" refuses somebody the only tool they have for
+ *    getting away from an account that is abusing them, for as long as Oxy is
+ *    unreachable. There is no workaround and no way for them to tell why.
+ *  - Wrongly deciding "does not operate" lets an operator do something pointless
+ *    to their own account, which the UI did not offer them and which they can
+ *    undo.
+ *
+ * So every refusal, every outage and every unexpected failure reads as `false`
+ * (not an operator, action allowed). The guarantee this buys is deliberately the
+ * honest one: you cannot act against an account we can POSITIVELY CONFIRM you
+ * operate. The frontend fails in the same direction for the same reason, so the
+ * button and the route agree about what an unknown answer means.
+ */
+export async function viewerOperatesAccount(params: {
+  targetOxyUserId: string | null | undefined;
+  callerId: string | null | undefined;
+  memberReader: AccountMemberReader | undefined;
+}): Promise<boolean> {
+  const target = params.targetOxyUserId?.trim();
+  const callerId = params.callerId?.trim();
+  // An absent target is NOT an operated account. Spelled out because the module
+  // this delegates to reads an absent target as "publish as yourself" and answers
+  // SUCCESS — the right answer to its question and the wrong one to this one.
+  if (!target || !callerId) return false;
+
+  try {
+    await assertCanPublishAsAccount({
+      publishAsOxyUserId: target,
+      callerId,
+      memberReader: params.memberReader,
+    });
+    return true;
+  } catch (error) {
+    // Every refusal it can raise — not a member, no `account:act_as`, an account
+    // nothing can be published as, and the 503 that means Oxy could not answer —
+    // means the same thing here: we cannot confirm this caller operates the
+    // account, so the protective action goes ahead. Logged rather than swallowed,
+    // since a 503 is an outage somebody should see.
+    if (error instanceof PublishAsAccessError) {
+      if (error.status === 503) {
+        logger.warn('[operatedAccountAccess] Could not verify operator status; allowing', {
+          status: error.status,
+        });
+      }
+      return false;
+    }
+    // Nothing else is expected: the module converts its own member-read failures
+    // into a 503 and its kind lookup is fail-soft. Allowing rather than throwing
+    // keeps an unexpected fault from turning into "nobody can file a report".
+    // `{ error }`, not a bare `error`: on the backend logger `warn` merges its
+    // second argument as pino CONTEXT, so an unwrapped Error lands where a context
+    // object was expected.
+    logger.warn('[operatedAccountAccess] Unexpected failure verifying operator status', {
+      error,
+    });
+    return false;
+  }
+}

--- a/packages/frontend/components/ChannelScreen.tsx
+++ b/packages/frontend/components/ChannelScreen.tsx
@@ -5,7 +5,6 @@ import { useQuery } from '@tanstack/react-query';
 import { BloomColorScope } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
 import { FollowButton as OxyFollowButton, useAuth, useFollow } from '@oxyhq/services/ui/client';
-import type { AccountNode } from '@oxyhq/core';
 import { lanesService } from '@/services/lanesService';
 import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
 import { logger } from '@oxyhq/core/logger';
@@ -33,6 +32,7 @@ import {
     useProfileAccount,
     useProfileChrome,
     useProfileMoreMenu,
+    useOperatesAccount,
     useJustFollowed,
     useChannelWriters,
     buildProfileTabDescriptors,
@@ -91,7 +91,7 @@ const ChannelProfile: React.FC<ChannelProfileProps> = ({
     profileData,
     loading,
 }) => {
-    const { user: currentUser, oxyServices } = useAuth();
+    const { user: currentUser } = useAuth();
     const { t } = useTranslation();
 
     const [activeTabKey, setActiveTabKey] = useState<string>('posts');
@@ -164,21 +164,18 @@ const ChannelProfile: React.FC<ChannelProfileProps> = ({
         false,
     );
 
-    // Whether the viewer OPERATES this channel, which is what puts its settings
-    // in reach. A channel account has no login of its own, so there is no other
-    // signal on the profile itself. This query is the reason the check lives on
-    // the channel screen and not in the shared lookup: the account graph is a
-    // real request, and a person's profile would pay for it to answer a question
-    // that can only ever be no.
-    const operatedAccountsQuery = useQuery<AccountNode[]>({
-        queryKey: viewerQueryKeys.operatedAccounts(currentUser?.id),
-        queryFn: () => oxyServices.listAccounts(),
-        enabled: Boolean(currentUser?.id) && Boolean(profileData?.id),
+    // Whether the viewer OPERATES this channel — what puts its settings in reach,
+    // and what keeps mute / block / report out of a menu where they would be
+    // addressed at an account the viewer publishes as. A channel account has no
+    // login of its own, so there is no other signal on the profile itself.
+    //
+    // The check is shared with the person screen rather than local to this one:
+    // only `channel` routes to `/c/<handle>`, so an organization, project or bot
+    // renders over there and needs the identical answer.
+    const operatesThisChannel = useOperatesAccount({
+        accountId: profileData?.id,
+        accountKind: profileData?.kind,
     });
-    const operatesThisChannel = Boolean(
-        profileData?.id &&
-        operatedAccountsQuery.data?.some((account) => account.accountId === profileData.id),
-    );
 
     // The chrome's compact-header offsets and the scrolled-name overlay both need
     // to know how wide the icon cluster is: subscribe + share + more.
@@ -256,9 +253,14 @@ const ChannelProfile: React.FC<ChannelProfileProps> = ({
         [operatesThisChannel, handle, t],
     );
 
+    // `viewerOperatesAccount`, never `isOwnProfile: false` as this read before.
+    // That literal was true of the LOGIN identity — a channel can never be signed
+    // in as, so it is never "your own profile" — and it silently answered a
+    // different question from the one the menu asks, which is how an operator came
+    // to be offered Block and Report against their own channel.
     const handleMoreOptions = useProfileMoreMenu({
         profileData,
-        isOwnProfile: false,
+        viewerOperatesAccount: operatesThisChannel,
         leadingActions,
     });
 

--- a/packages/frontend/components/Profile/hooks/useOperatesAccount.ts
+++ b/packages/frontend/components/Profile/hooks/useOperatesAccount.ts
@@ -1,0 +1,66 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@oxyhq/services/ui/client';
+import type { AccountKind, AccountNode } from '@oxyhq/core';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import { operatesAccount } from '@/lib/operatedAccounts';
+
+/**
+ * Whether the viewer OPERATES the profile being looked at — the question every
+ * viewer-hostile affordance on a profile actually wants answered.
+ *
+ * The question it replaces is "is this profile me?", which is the whole truth
+ * only for a personal login. A channel, organization, project or bot is never the
+ * viewer's own id, and yet the viewer may publish as it, so an id comparison says
+ * "no" for all four and offers Block / Report / Mute against an account you speak
+ * with. Both profile screens ask this, because both serve managed accounts: only
+ * `channel` routes to `/c/<handle>`, so an organization, project or bot renders on
+ * the PERSON screen at `/@<handle>` and has always had the same defect.
+ *
+ * ## What it costs, and when
+ *
+ * The account graph is a real request, so it is only made when the answer can be
+ * anything other than no. A `personal` account cannot be operated by anybody but
+ * its own login — the backend refuses to publish as one on exactly that grounds —
+ * so an ordinary profile skips the query entirely and this is free, which is the
+ * overwhelming majority of profiles anybody opens. An unresolved profile (no kind
+ * yet) skips it too rather than firing a request per cold load.
+ *
+ * It shares `viewerQueryKeys.operatedAccounts` with the composer's publish-as
+ * picker and the channel-settings screen, so a viewer who has already opened
+ * either pays nothing here.
+ *
+ * ## It fails toward SHOWING the action, deliberately
+ *
+ * While the list is loading, and if it fails, this answers `false` — not an
+ * operator. The two mistakes are not comparable:
+ *
+ *  - Hiding Block and Report on a STRANGER's profile withholds the tools somebody
+ *    reaches for when an account is harassing them, at the moment they reach for
+ *    them, with nothing on screen to explain why they are missing.
+ *  - Showing them on an account you operate offers something pointless, which the
+ *    server refuses (`services/operatedAccountAccess.ts`) and which is undoable
+ *    where it is not refused.
+ *
+ * So the affordance is hidden only on a POSITIVE confirmation, and the backend
+ * fails in the same direction for the same reason — the button and the route
+ * agree on what an unknown answer means, rather than one of them guessing.
+ */
+export function useOperatesAccount(params: {
+  accountId: string | null | undefined;
+  accountKind: AccountKind | undefined;
+}): boolean {
+  const { user: currentUser, oxyServices } = useAuth();
+
+  // `personal` is not merely unlikely to be operated by somebody else — it cannot
+  // be, and the backend gate says so in the same words. Anything else, including
+  // a kind Oxy adds later, is worth asking about rather than assumed safe.
+  const couldBeOperated = Boolean(params.accountKind) && params.accountKind !== 'personal';
+
+  const { data } = useQuery<AccountNode[]>({
+    queryKey: viewerQueryKeys.operatedAccounts(currentUser?.id),
+    queryFn: () => oxyServices.listAccounts(),
+    enabled: Boolean(currentUser?.id) && Boolean(params.accountId) && couldBeOperated,
+  });
+
+  return couldBeOperated && operatesAccount(data, params.accountId);
+}

--- a/packages/frontend/components/Profile/hooks/useProfileMoreMenu.tsx
+++ b/packages/frontend/components/Profile/hooks/useProfileMoreMenu.tsx
@@ -21,7 +21,13 @@ import type { ProfileData } from '@/hooks/useProfileData';
 
 export interface ProfileMoreMenuOptions {
   profileData: ProfileData | null;
-  isOwnProfile: boolean;
+  /**
+   * Whether the viewer OPERATES this account — may speak with its voice. Being
+   * the account is one case of it; running a channel, organization, project or
+   * bot is the rest. Callers compute it as
+   * `isOwnProfile || useOperatesAccount(...)`, never as an id comparison alone.
+   */
+  viewerOperatesAccount: boolean;
   /**
    * Rows shown ABOVE the shared ones, for actions that are about RUNNING this
    * account rather than about the viewer's relationship to it. A channel's
@@ -34,16 +40,40 @@ export interface ProfileMoreMenuOptions {
 /**
  * The "…" menu on a profile: add to lists / starter packs, mute, block, report.
  *
- * Shared by both profile screens because it is entirely about the VIEWER's
- * relationship to an account, and that relationship does not change shape when
- * the account is a channel — a channel can be listed, muted, blocked and
- * reported exactly like anybody else. What differs is what an OPERATOR may
- * additionally do, which arrives as {@link ProfileMoreMenuOptions.leadingActions}
- * rather than as a branch in here.
+ * Shared by both profile screens because it is about the VIEWER's relationship to
+ * an account, and that relationship has the same shape whichever kind of account
+ * it is. What differs is what an OPERATOR may additionally do, which arrives as
+ * {@link ProfileMoreMenuOptions.leadingActions} rather than as a branch in here.
+ *
+ * ## Mute, block and report are withheld from an operator
+ *
+ * Not because they would fail, but because they mean nothing: all three are ways
+ * of putting distance between a reader and an account, and there is no distance
+ * to put between somebody and an account they publish as. Muting hides your own
+ * posts from your own feeds; blocking severs you from something you are; a report
+ * asks a jury to rule on whether you should be enforced against for what you
+ * wrote.
+ *
+ * The check is "do I operate this account?", not "is this account me?". The
+ * second is the same question asked narrowly enough to be wrong — a channel,
+ * organization, project or bot is never the viewer's own id — and asking it is
+ * what put Block and Report in a channel operator's menu. Note the whole menu is
+ * NOT suppressed for an operator the way it used to be for your own profile: a
+ * channel's operator opens it to reach the channel's settings.
+ *
+ * Nothing replaces the withheld rows. An operator's own actions are the caller's
+ * to supply through `leadingActions` — the channel screen supplies "Channel
+ * settings" — and the kinds with no operator surface in Mention get a shorter
+ * menu rather than a row that goes nowhere.
+ *
+ * What is deliberately KEPT for an operator: add/remove from lists and starter
+ * packs. Both are curation of the viewer's own collections, and putting an
+ * account you run into a starter pack you assembled is the ordinary use of one,
+ * not an accident.
  */
 export function useProfileMoreMenu({
   profileData,
-  isOwnProfile,
+  viewerOperatesAccount,
   leadingActions,
 }: ProfileMoreMenuOptions): () => void {
   const theme = useTheme();
@@ -52,7 +82,7 @@ export function useProfileMoreMenu({
   const bottomSheet = useContext(BottomSheetContext);
 
   return useCallback(() => {
-    if (!profileData || isOwnProfile) return;
+    if (!profileData) return;
 
     const displayUsername = profileData.username;
 
@@ -164,33 +194,39 @@ export function useProfileMoreMenu({
         }),
         onPress: handleAddToStarterPack,
       },
-      {
-        icon: <MuteIcon size={22} className="text-foreground" />,
-        label: t('profile.muteUser', {
-          username: displayUsername,
-          defaultValue: `Mute @${displayUsername}`,
-        }),
-        onPress: handleMute,
-      },
+      ...(viewerOperatesAccount
+        ? []
+        : [
+          {
+            icon: <MuteIcon size={22} className="text-foreground" />,
+            label: t('profile.muteUser', {
+              username: displayUsername,
+              defaultValue: `Mute @${displayUsername}`,
+            }),
+            onPress: handleMute,
+          },
+        ]),
     ];
 
-    const destructiveActions: ActionMenuAction[] = [
-      {
-        icon: <BlockIcon size={22} color={theme.colors.error} />,
-        label: t('profile.blockUser', {
-          username: displayUsername,
-          defaultValue: `Block @${displayUsername}`,
-        }),
-        onPress: handleBlock,
-        color: theme.colors.error,
-      },
-      {
-        icon: <ReportIcon size={22} color={theme.colors.error} />,
-        label: t('profile.reportUser', { defaultValue: 'Report' }),
-        onPress: handleReport,
-        color: theme.colors.error,
-      },
-    ];
+    const destructiveActions: ActionMenuAction[] = viewerOperatesAccount
+      ? []
+      : [
+        {
+          icon: <BlockIcon size={22} color={theme.colors.error} />,
+          label: t('profile.blockUser', {
+            username: displayUsername,
+            defaultValue: `Block @${displayUsername}`,
+          }),
+          onPress: handleBlock,
+          color: theme.colors.error,
+        },
+        {
+          icon: <ReportIcon size={22} color={theme.colors.error} />,
+          label: t('profile.reportUser', { defaultValue: 'Report' }),
+          onPress: handleReport,
+          color: theme.colors.error,
+        },
+      ];
 
     // Named so the block flow can reopen the exact same menu after a cancelled
     // confirm.
@@ -205,5 +241,5 @@ export function useProfileMoreMenu({
     }
 
     openMenu();
-  }, [profileData, isOwnProfile, leadingActions, theme, t, bottomSheet, oxyServices]);
+  }, [profileData, viewerOperatesAccount, leadingActions, theme, t, bottomSheet, oxyServices]);
 }

--- a/packages/frontend/components/Profile/index.ts
+++ b/packages/frontend/components/Profile/index.ts
@@ -8,6 +8,7 @@ export { useProfileScroll } from './hooks/useProfileScroll';
 export { useProfileAccount } from './hooks/useProfileAccount';
 export { useProfileChrome } from './hooks/useProfileChrome';
 export { useProfileMoreMenu } from './hooks/useProfileMoreMenu';
+export { useOperatesAccount } from './hooks/useOperatesAccount';
 export { useJustFollowed } from './hooks/useJustFollowed';
 export { useChannelWriters } from './hooks/useChannelWriters';
 

--- a/packages/frontend/components/ProfileScreen.tsx
+++ b/packages/frontend/components/ProfileScreen.tsx
@@ -39,6 +39,7 @@ import {
     useProfileAccount,
     useProfileChrome,
     useProfileMoreMenu,
+    useOperatesAccount,
     useJustFollowed,
     buildProfileTabDescriptors,
     laneTabKey,
@@ -276,7 +277,26 @@ const PersonProfile: React.FC<PersonProfileProps> = ({
         }
     }, [profileData, handle, t]);
 
-    const handleMoreOptions = useProfileMoreMenu({ profileData, isOwnProfile });
+    /**
+     * This screen serves more than people. Only a `channel` routes to
+     * `/c/<handle>`, so an ORGANIZATION, PROJECT or BOT renders here at
+     * `/@<handle>` — and the viewer may operate one of those without it ever being
+     * their own id, which is precisely the case `isOwnProfile` cannot see.
+     *
+     * `isOwnProfile` still governs everything else on this screen, and correctly:
+     * edit-profile, analytics, settings and the lanes button all act on the
+     * VIEWER'S OWN account, so operating an organization must not put them within
+     * reach. Only the hostile menu asks the wider question.
+     */
+    const operatesThisAccount = useOperatesAccount({
+        accountId: profileData?.id,
+        accountKind: profileData?.kind,
+    });
+
+    const handleMoreOptions = useProfileMoreMenu({
+        profileData,
+        viewerOperatesAccount: isOwnProfile || operatesThisAccount,
+    });
 
     const handleDM = useCallback(() => {
         if (!profileData?.id) return;

--- a/packages/frontend/components/common/__tests__/actionMenu.test.ts
+++ b/packages/frontend/components/common/__tests__/actionMenu.test.ts
@@ -96,8 +96,9 @@ describe('action menu wiring', () => {
       join('components', 'Feed', 'PostItem.tsx'),
       // The profile overflow menu. It lives in a hook rather than on a screen
       // because BOTH profile screens open the same menu — a person's and a
-      // channel's — and the rows are identical apart from the operator's
-      // channel-settings entry, which arrives as a prop.
+      // channel's — and what differs between them is data rather than structure:
+      // the operator's channel-settings entry arrives as a prop, and mute /
+      // block / report drop out for a viewer who operates the account.
       join('components', 'Profile', 'hooks', 'useProfileMoreMenu.tsx'),
     ]);
   });

--- a/packages/frontend/lib/__tests__/operatedAccounts.test.ts
+++ b/packages/frontend/lib/__tests__/operatedAccounts.test.ts
@@ -1,0 +1,171 @@
+import type { AccountNode } from '@oxyhq/core';
+import { operatesAccount, operatesAccountNode } from '../operatedAccounts';
+
+/**
+ * "Do I operate this account?" — the predicate the profile menu hides mute, block
+ * and report on.
+ *
+ * It has to give the SAME answer the backend gives, because the backend refuses
+ * the action and this only declines to offer it: if the two disagree, one of them
+ * is drawing a button the other 400s. So the cases below are the two families
+ * `services/publishAsAccount.ts` distinguishes, and each admission is paired with
+ * the near-miss that must be refused — a member without `account:act_as` is the
+ * one that tells "reads the permission" apart from "reads membership".
+ */
+
+const VIEWER_ORG = 'account-org';
+
+function node(overrides: Partial<AccountNode> & Pick<AccountNode, 'accountId' | 'kind'>): AccountNode {
+  return {
+    parentAccountId: null,
+    account: { id: overrides.accountId } as AccountNode['account'],
+    relationship: 'member' as AccountNode['relationship'],
+    callerMembership: null,
+    ...overrides,
+  } as AccountNode;
+}
+
+function membership(
+  status: string,
+  permissions: unknown,
+): AccountNode['callerMembership'] {
+  return {
+    memberUserId: 'viewer',
+    status,
+    permissions,
+  } as unknown as AccountNode['callerMembership'];
+}
+
+describe('operatesAccountNode — a channel', () => {
+  it('is operated by any ACTIVE member, with no permission required', () => {
+    // A channel can never be acted as, so membership is the strongest right
+    // there is over it — matching what the backend admits.
+    expect(
+      operatesAccountNode(
+        node({ accountId: 'c1', kind: 'channel', callerMembership: membership('active', []) }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is NOT operated by a member whose membership is not active', () => {
+    expect(
+      operatesAccountNode(
+        node({ accountId: 'c1', kind: 'channel', callerMembership: membership('invited', []) }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('operatesAccountNode — an act-as-eligible account', () => {
+  it('is operated by an active member holding account:act_as', () => {
+    expect(
+      operatesAccountNode(
+        node({
+          accountId: VIEWER_ORG,
+          kind: 'organization',
+          callerMembership: membership('active', ['account:act_as']),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is NOT operated by an active member WITHOUT account:act_as', () => {
+    // The case the whole two-family rule exists for. A `billing` or `viewer`
+    // member is a member who deliberately may not speak as the account, so they
+    // keep every affordance a stranger has — reporting it included.
+    expect(
+      operatesAccountNode(
+        node({
+          accountId: VIEWER_ORG,
+          kind: 'organization',
+          callerMembership: membership('active', ['billing:read']),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('applies the same rule to a project and a bot, not just an organization', () => {
+    for (const kind of ['project', 'bot'] as const) {
+      expect(
+        operatesAccountNode(
+          node({ accountId: 'x', kind, callerMembership: membership('active', []) }),
+        ),
+      ).toBe(false);
+      expect(
+        operatesAccountNode(
+          node({
+            accountId: 'x',
+            kind,
+            callerMembership: membership('active', ['account:act_as']),
+          }),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('refuses a permissions field that is not an array', () => {
+    // `permissions` arrives over the wire. A malformed value is a refusal, never
+    // an assumption — the same reading the backend gate takes.
+    for (const permissions of ['account:act_as', { 'account:act_as': true }, null, undefined]) {
+      expect(
+        operatesAccountNode(
+          node({
+            accountId: VIEWER_ORG,
+            kind: 'organization',
+            callerMembership: membership('active', permissions),
+          }),
+        ),
+      ).toBe(false);
+    }
+  });
+});
+
+describe('operatesAccountNode — an absent membership', () => {
+  it('reads as NOT operated', () => {
+    // `AccountNode` documents `null` as covering both "ownership is implicit" and
+    // "no membership at all". The ambiguous value takes the direction that keeps
+    // block and report available; a personal root is answered by comparing ids.
+    expect(operatesAccountNode(node({ accountId: 'c1', kind: 'channel' }))).toBe(false);
+    expect(operatesAccountNode(node({ accountId: 'p1', kind: 'personal' }))).toBe(false);
+  });
+});
+
+describe('operatesAccount — looking one account up in the list', () => {
+  const list: AccountNode[] = [
+    node({ accountId: 'operated', kind: 'channel', callerMembership: membership('active', []) }),
+    node({
+      accountId: 'member-only',
+      kind: 'organization',
+      callerMembership: membership('active', ['billing:read']),
+    }),
+  ];
+
+  it('finds an account the viewer operates', () => {
+    expect(operatesAccount(list, 'operated')).toBe(true);
+  });
+
+  it('does NOT claim an account that is merely in the list', () => {
+    // Presence in the account graph is not operating it. A predicate that only
+    // matched `accountId` would pass every other case in this file and fail here.
+    expect(operatesAccount(list, 'member-only')).toBe(false);
+  });
+
+  it('does not claim an account that is absent from the list', () => {
+    expect(operatesAccount(list, 'a-stranger')).toBe(false);
+  });
+
+  it('answers NOT operated while the list is still loading, and if it failed', () => {
+    // The load-bearing failure direction, as its own case. `undefined` is both
+    // "loading" and "the request failed", and both must leave block and report on
+    // screen — withholding a safety affordance from somebody who needs it is a
+    // worse outcome than offering a pointless one to an operator, which the server
+    // refuses anyway.
+    expect(operatesAccount(undefined, 'operated')).toBe(false);
+  });
+
+  it('answers NOT operated for an empty list and a missing account id', () => {
+    expect(operatesAccount([], 'operated')).toBe(false);
+    expect(operatesAccount(list, undefined)).toBe(false);
+    expect(operatesAccount(list, '')).toBe(false);
+  });
+});

--- a/packages/frontend/lib/operatedAccounts.ts
+++ b/packages/frontend/lib/operatedAccounts.ts
@@ -1,0 +1,73 @@
+import { isActAsEligibleKind } from '@oxyhq/contracts';
+import type { AccountNode } from '@oxyhq/core';
+
+/**
+ * The Oxy account permission that authorises assuming an account's identity, and
+ * therefore speaking as it.
+ *
+ * A wire value: Oxy derives each member's `permissions` from their role
+ * server-side and ships the resulting strings. The Mention backend names the same
+ * constant in `services/publishAsAccount.ts` for the same reason — neither
+ * `@oxyhq/contracts` nor `@oxyhq/core` exports the permission vocabulary yet.
+ * When one of them does, both call sites read it from there.
+ */
+const ACCOUNT_ACT_AS_PERMISSION = 'account:act_as';
+
+/**
+ * Whether the caller OPERATES this account — may speak with its voice — read off
+ * the membership Oxy already resolved onto the node.
+ *
+ * This is the frontend half of the rule the backend enforces in
+ * `services/publishAsAccount.ts`, and it is deliberately the SAME rule rather
+ * than a convenient approximation of it. Two families, two authorities:
+ *
+ *  - A **channel** can never be acted as, so there is no stronger right to ask
+ *    for than membership: an active member operates it.
+ *  - An **act-as-eligible** account (organization / project / bot) CAN be
+ *    switched into, so publishing under its name is gated on the same permission
+ *    as becoming it. An account's `viewer`, `billing` and `developer` members are
+ *    members who deliberately may NOT act as it.
+ *
+ * The permission is READ off `callerMembership.permissions`, which Oxy resolves
+ * from the role at write time — never inferred from `callerMembership.role`, which
+ * would be a second copy of Oxy's role→permission map and free to drift the moment
+ * a role is added.
+ *
+ * `isActAsEligibleKind` rather than `kind !== 'personal'`: it is the predicate Oxy
+ * itself gates the session switch on, so a kind Oxy adds later is handled by it
+ * instead of silently inheriting whichever branch a local list happened to put it
+ * in.
+ *
+ * **An absent `callerMembership` reads as NOT operated**, even though the node
+ * appearing in the caller's own account list implies some access. `AccountNode`
+ * documents `null` as covering both "ownership is implicit" (their own personal
+ * root) and "the caller has no membership", and those want opposite answers — so
+ * the ambiguous value takes the direction that keeps a safety affordance
+ * available. The one case it gives up, a personal root, is answered exactly and
+ * for free by comparing ids, which is what {@link useOperatesAccount}'s callers
+ * already do.
+ */
+export function operatesAccountNode(node: AccountNode): boolean {
+  const membership = node.callerMembership;
+  if (!membership || membership.status !== 'active') return false;
+  if (!isActAsEligibleKind(node.kind)) return true;
+  return (
+    Array.isArray(membership.permissions) &&
+    membership.permissions.includes(ACCOUNT_ACT_AS_PERMISSION)
+  );
+}
+
+/**
+ * Whether `accountId` is one of the accounts in `nodes` that the caller operates.
+ *
+ * `nodes` being `undefined` — the list has not loaded, or the request failed — is
+ * answered `false`: NOT an operator. See {@link useOperatesAccount} for why that
+ * direction, and not the other one.
+ */
+export function operatesAccount(
+  nodes: readonly AccountNode[] | undefined,
+  accountId: string | null | undefined,
+): boolean {
+  if (!nodes || !accountId) return false;
+  return nodes.some((node) => node.accountId === accountId && operatesAccountNode(node));
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -33,7 +33,8 @@
     ],
     "moduleNameMapper": {
       "^@oxyhq/services/ui/client$": "<rootDir>/../../node_modules/@oxyhq/services/lib/commonjs/ui/client.js",
-      "^@oxyhq/core/logger$": "<rootDir>/../../node_modules/@oxyhq/core/dist/cjs/logger/index.js"
+      "^@oxyhq/core/logger$": "<rootDir>/../../node_modules/@oxyhq/core/dist/cjs/logger/index.js",
+      "^@oxyhq/contracts$": "<rootDir>/../../node_modules/@oxyhq/contracts/dist/cjs/index.js"
     },
     "collectCoverageFrom": [
       "**/*.{ts,tsx}",


### PR DESCRIPTION
## The bug

On `/c/<handle>` the overflow menu offered **Block** and **Report** to the channel's own operator.

The menu was asking *"is this profile me?"* For a personal login that is the whole truth. For a **managed** account it is not: a channel, organization, project or bot is never the viewer's own id, and yet the viewer may publish as it. So the answer came back "no" for all four managed kinds and the rows were drawn.

The right question is **"do I operate this account?"**, of which "is it me" is one case.

## The refusal is on the server; the menu is the consequence

Hiding a row does not make an action impossible, so the fix is the route.

`services/operatedAccountAccess.ts` answers the question by reusing `assertCanPublishAsAccount` **verbatim** rather than reading the account graph again. That inheritance is what settles *which* members count, with the answer the server already enforces everywhere else:

| target | operates it |
|---|---|
| the caller themselves | yes, before any lookup |
| **channel** | any ACTIVE member — it can never be acted as, so membership is the strongest right there is |
| **organization / project / bot** | an active member holding `account:act_as` — speaking as it is the same claim as being it |
| **personal**, not the caller | never |

A second membership reader would be a second answer, and one of the two would be wrong in the permissive direction.

Wired into the two routes Mention owns:

- **`POST /reports`** — refuses a `user` report against an operated account. It had **no self-check at all**, so reporting yourself used to open a real CrowdSource case with a real jury on it.
- **`POST /mute`** — had `userId === mutedId`, the same rule stated narrowly enough to be wrong. That case still refuses, now as one case of the general rule.

**400, not 403.** An operator has *more* authority over the account than a stranger, so "forbidden" states the opposite of what is true — nothing is being withheld from them, the target is simply not a valid target for the verb. It also matches the two neighbouring self-refusals: this route's own, and Oxy's for self-block.

**Cost:** nothing is asked of Oxy for the two cases that dominate — the target is the caller (returns before any lookup), or an ordinary personal account (refused off the cached identity read, before the member list). Asserted in the tests, not just described.

## Block is NOT fixed here, and cannot be

`oxyServices.blockUser` calls **oxy-api directly** (`POST /privacy/blocked/:targetId`). Mention's backend has no block route at all, so a guard added in this repo would be bypassed by the request the app already makes — the exact failure this PR exists to stop, one floor down.

Measured on `OxyHQServices@6ff7cb3c`: `createUserActionHandler` in `packages/api/src/routes/privacy.ts` refuses **self**-block (`authUser.id === targetId` → 400) and has **no operated-account check**. That half belongs there and is left for an oxy-api change. This PR hides the row and stops the two actions Mention actually serves.

## Both layers fail toward ALLOWING the action

Deliberately inverting `assertCanPublishAsAccount`'s own direction. Publishing as an account is a **capability**, so an unverifiable one is refused. Block, report and mute are **protective**, and the caller is usually the person needing protection:

- Refusing on an unknown answer removes somebody's only way out of an account harassing them, for the length of an Oxy outage, with nothing on screen to say why.
- Wrongly allowing costs an operator one pointless action against their own account.

So the guarantee is the honest one — **you cannot act against an account we can positively confirm you operate** — and the button and the route agree about what an unknown answer means instead of one of them guessing. The UI hides a row only on a positive confirmation; loading and failure both read as "not an operator".

## Not a channel special case

`profileRouteFamilyForKind` sends only `channel` to `/c/<handle>`, so an **organization, project or bot renders on the PERSON screen** at `/@<handle>` and had the identical defect. Both screens now ask the same shared question via `useOperatesAccount`.

`isOwnProfile` still governs everything else on the person screen, and correctly: edit-profile, analytics, settings and the lanes button all act on the *viewer's own* account, so operating an organization must not put them in reach. Only the hostile menu asks the wider question.

**What replaces the withheld rows: nothing.** The channel screen's own "Channel settings" already arrives through `leadingActions`; a kind with no operator surface in Mention gets a shorter menu rather than a row that goes nowhere. Add/remove from lists and starter packs are **kept** — putting an account you run into a starter pack you assembled is the ordinary use of one.

## Verification

Mutation-tested, each against a green baseline, each failing a **named** test:

| mutation | result |
|---|---|
| delete the report guard | 3 named tests fail, 6 pass |
| narrow the report guard to `reportedId === reporter` (the actual bug) | 2 named tests fail, 7 pass |
| revert mute to its old `userId === mutedId` | 2 named tests fail, 4 pass |
| fail **closed** on a 503 instead of open | 2 named tests fail |
| drop the empty-target guard | 1 named test fails |
| ignore `account:act_as` (membership alone) | 4 named tests fail |
| match on `accountId` only | 1 named test fails |
| loosen the `Array.isArray` permissions read | 4 named tests fail |
| treat an absent membership as operated | 1 named test fails |

**Vacuity floor:** every refusal is paired with a near-miss that must still succeed — a stranger, a channel somebody else runs, an organization member *without* `account:act_as`, and an Oxy outage. "Refuses operators" therefore cannot pass as "refuses everyone".

Gates run on this branch after rebasing onto `c23934ab`:

- `bunx tsc --noEmit` — clean, backend and frontend (both were also clean at baseline)
- `bun run test:coverage` backend — 438 suites / 4805 tests, 68.83% st / 61.41% br vs 60.68 / 53.92 thresholds
- `bun run test:coverage` frontend — 151 suites / 1407 tests, 27.59% st vs 14.86 threshold
- `bun run lint:frontend` — exit 0, 0 errors (new files linted explicitly by path as well, since a lint run does not see an untracked file)
- `bun run validate:i18n` — exit 0, no new keys

One existing test needed a fix rather than a workaround: `reportsAcceptedTypes.test.ts` iterates every `ReportedType`, and the `user` case now reaches the operator gate, which was making a real network call. It gets stubs for the two Oxy reads so it keeps testing which *types* the route accepts, with the gate's own behaviour owned by `reportsOperatedAccount.test.ts`.

## Not verified

- No browser run — the frontend change is a menu row-set behind a boolean, and the load-bearing proof is the route test.
- The menu wiring itself (`useProfileMoreMenu`'s branch) is covered by tsc and the pure predicate test, not by a render test: the frontend has no `@testing-library/react-native` and adding one for this would be its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
