### PR TITLE
design(channels): compose the channel header for a page with no banner

### DIFF
--- a/packages/frontend/components/ChannelScreen.tsx
+++ b/packages/frontend/components/ChannelScreen.tsx
@@ -286,7 +286,11 @@ const ChannelProfile: React.FC<ChannelProfileProps> = ({
                     privacySettings={profileData.privacy}
                     UserNameComponent={UserName}
                 />
-                <View className="mt-3 mb-2">
+                {/* The last element of the centred masthead, and the boundary
+                    the left-aligned body starts after — so it gets an equal
+                    gap on both sides rather than the tighter `mb` a control
+                    tucked under a left-aligned name row wanted. */}
+                <View className="mt-4 mb-4">
                     <ChannelActions
                         profileId={profileData.id}
                         isFollowing={profileData.isFollowing}

--- a/packages/frontend/components/Profile/ChannelHeader.tsx
+++ b/packages/frontend/components/Profile/ChannelHeader.tsx
@@ -1,22 +1,61 @@
 import React, { memo } from 'react';
 import { View } from 'react-native';
-import Ionicons from '@expo/vector-icons/Ionicons';
-import { useTheme } from '@oxyhq/bloom/theme';
 import { ZoomableAvatar } from '@/components/ZoomableAvatar';
 import { PrivateBadge } from './PrivateBadge';
 import type { ChannelActionsProps, ChannelHeaderProps } from './types';
 
 /**
- * A CHANNEL's profile header: name on the left, a 70px avatar on the right.
+ * The avatar's edge-to-edge footprint.
  *
- * The compact shape is not a style preference — it is what a channel IS. There
- * is no banner because `UpdateAccountInput` has no banner field to set, so the
- * layout has no band for one rather than an empty band; and the avatar does not
- * collapse on scroll because there is no banner for it to overlap in the first
- * place. This used to be `ProfileHeaderMinimalist`, selected by a
- * `design.minimalistMode` flag that was itself defined as `kind === 'channel'` —
- * a layout name for an account fact, which is exactly the confusion this split
- * removes.
+ * Exported because `ProfileSkeleton` draws the placeholder that this avatar
+ * replaces, and a skeleton exists to hold the EXACT box the real content lands
+ * in. Two copies of this number is a layout shift at the moment the data
+ * arrives — the one thing the skeleton is there to prevent — so the two read the
+ * same constant rather than agreeing by convention.
+ */
+export const CHANNEL_AVATAR_SIZE = 96;
+
+/**
+ * A CHANNEL's profile header: a CENTRED masthead — the avatar on top, then the
+ * name, then the handle, then the follow control, each centred under the last.
+ *
+ * The centring is composed for what a channel page IS rather than inherited
+ * from the person page. A person's header is asymmetric because it has a banner
+ * to hang off: the avatar is pinned left and pulled up to overlap the band, and
+ * the controls fill the space beside it. `UpdateAccountInput` has no banner
+ * field, so a channel has no band, and the person layout with the band deleted
+ * leaves an avatar pushed to one side of a row that no longer has anything on
+ * the other — an alignment that was a consequence of the banner, kept after the
+ * banner was gone. With nothing to overlap, the avatar is the top of the page,
+ * and the top of a page with no other anchor is its centre. (This is why the
+ * header is its own component at all: it used to be `ProfileHeaderMinimalist`,
+ * chosen by a `design.minimalistMode` flag that was itself defined as
+ * `kind === 'channel'` — a layout name for an account fact. Nothing here should
+ * become a flag on the person header again.)
+ *
+ * WHAT IS CENTRED STOPS AT THE FOLLOW BUTTON, and the boundary is deliberate.
+ * Below it `ProfileContent` renders the bio, the joined/location row, the stats,
+ * the links and the communities, all left-aligned, sharing one gutter with the
+ * tab strip and the feed rows beneath them. Two reasons that body does not
+ * follow the masthead:
+ *
+ *  - The bio is PROSE, and centred ragged prose gives the eye no fixed left edge
+ *    to return to. It also carries inline links and a "Read more" toggle, which
+ *    centring would park at a different x on every channel.
+ *  - The stats row is a denser rendering of the TAB STRIP — its cells are jump
+ *    links that scroll to the posts and boosts tabs, or navigate to the follower
+ *    lists. Keeping it on the same left gutter as the strip it points into keeps
+ *    that relationship legible; centred, it would float free of the thing it
+ *    controls.
+ *
+ * The column needs no `max-width` of its own, and that is measured rather than
+ * assumed. The shell caps the center panel long before the viewport does, and
+ * the panel is WIDEST in the middle of the range rather than at the end:
+ * measured in a browser, a 1600px viewport gives a 592px panel while a 900px
+ * one gives 817px (the RightBar is gone by then, so the center takes the room).
+ * 817px is the worst case a centred masthead ever sees, and it reads fine.
+ * A `max-width` would not move anything anyway — every item in the stack is
+ * intrinsically sized and centred — it would only shift the axis they centre on.
  */
 export const ChannelHeader = memo(function ChannelHeader({
   displayName,
@@ -28,58 +67,66 @@ export const ChannelHeader = memo(function ChannelHeader({
   UserNameComponent,
   trailingBadge,
 }: ChannelHeaderProps) {
-  const theme = useTheme();
   return (
-    <View className="flex-row justify-between items-start mb-4 relative w-full gap-4">
-      <View className="flex-1">
-        <UserNameComponent
-          name={displayName}
-          handle={username}
-          verified={false}
-          // Not a guess and not a conditional: this component only ever draws a
-          // channel (the route canonicalizes anything else away before it
-          // renders), so the marker states what the page is. It stays INERT —
-          // `AccountBadge` has no explainer for a channel to open, and the page
-          // itself is the explanation.
-          kind="channel"
-          variant="default"
-          trailingBadge={trailingBadge}
-          style={{
-            name: { fontSize: 24, fontWeight: 'bold' as const, marginTop: 10, marginBottom: 4 },
-            handle: { fontSize: 15, marginBottom: 12 },
-            container: undefined,
-          }}
-        />
-        {isPrivate && <PrivateBadge privacySettings={privacySettings} />}
-      </View>
+    <View className="items-center w-full">
       {/* No live badge and no presence dot, and neither is an omission: both
           report on a SESSION, and `isActAsEligibleKind` refuses `channel`, so no
           session can ever have one as its subject. A channel cannot be online
           and cannot host a live room — the states could not occur, rather than
           being hidden. */}
-      <View className="relative">
-        <ZoomableAvatar
-          source={avatarUri}
-          size={70}
-          className="border-[3px] border-background bg-secondary"
-          style={{ width: 70, height: 70, borderRadius: 35 }}
-          imageStyle={{}}
-        />
-        {verified && (
-          <View
-            className="absolute rounded-[10px] p-0.5 bg-background"
-            style={{ left: -6, bottom: -2 }}
-          >
-            <Ionicons name="checkmark-circle" size={18} color={theme.colors.primary} />
-          </View>
-        )}
-      </View>
+      <ZoomableAvatar
+        source={avatarUri}
+        size={CHANNEL_AVATAR_SIZE}
+        className="border-[3px] border-background bg-secondary"
+        style={{
+          width: CHANNEL_AVATAR_SIZE,
+          height: CHANNEL_AVATAR_SIZE,
+          borderRadius: CHANNEL_AVATAR_SIZE / 2,
+        }}
+        imageStyle={{}}
+      />
+      <UserNameComponent
+        name={displayName}
+        handle={username}
+        // Inline, next to the name, rather than the corner badge this header
+        // used to pin to the avatar. That badge was positioned against the
+        // avatar's left edge — coherent only while the avatar sat at the right
+        // end of a row — and it drew `checkmark-circle` from Ionicons where
+        // every other identity surface in the app draws the shared
+        // `VerifiedIcon` through `UserName`. Inline also puts it beside the
+        // channel marker below, so the two facts about this identity read as
+        // one cluster instead of two conventions.
+        verified={verified}
+        // Not a guess and not a conditional: this component only ever draws a
+        // channel (the route canonicalizes anything else away before it
+        // renders), so the marker states what the page is. It stays INERT —
+        // `AccountBadge` has no explainer for a channel to open, and the page
+        // itself is the explanation.
+        kind="channel"
+        align="center"
+        variant="default"
+        trailingBadge={trailingBadge}
+        style={{
+          name: { fontSize: 24, fontWeight: 'bold' as const, marginTop: 12, marginBottom: 4 },
+          handle: { fontSize: 15 },
+          container: undefined,
+        }}
+      />
+      {/* `PrivateBadge` is `self-start`, which would pull it to the left edge of
+          this centred column. The wrapper shrinks to the badge's own width, so
+          starting inside it and being centred are the same position. */}
+      {isPrivate && (
+        <View className="mt-1">
+          <PrivateBadge privacySettings={privacySettings} />
+        </View>
+      )}
     </View>
   );
 });
 
 /**
- * The follow control under a channel's header.
+ * The follow control under a channel's header — centred, as the last element of
+ * the masthead above it.
  *
  * There is no poke here, and its absence is structural rather than suppressed: a
  * poke is addressed to a person, and a channel account can never be signed in as
@@ -99,7 +146,7 @@ export const ChannelActions = memo(function ChannelActions({
 }: ChannelActionsProps) {
   if (!profileId) return null;
   return (
-    <View className="flex-row items-center gap-3">
+    <View className="flex-row items-center justify-center gap-3">
       <FollowButtonComponent userId={profileId} initiallyFollowing={isFollowing} />
     </View>
   );

--- a/packages/frontend/components/Profile/ProfileSkeleton.tsx
+++ b/packages/frontend/components/Profile/ProfileSkeleton.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { POST_ITEM_SPACING } from '@/styles/shared';
+import { CHANNEL_AVATAR_SIZE } from './ChannelHeader';
 import { LAYOUT } from './types';
 
 /**
@@ -44,10 +45,14 @@ const TAB_CHIP_WIDTHS = [42, 54, 50, 58, 44, 56];
 const FEED_ROW_COUNT = 4;
 
 // A CHANNEL's anatomy, which is a different shape rather than a smaller one: no
-// banner to overlap, a 70px avatar on the RIGHT with the name beside it, four
-// stats (no replies — a channel can author none) and four tabs. Mirrors
-// `ChannelHeader` + `useProfileChrome({ hasBannerBand: false })`.
-const CHANNEL_AVATAR_SIZE = 70;
+// banner to overlap, a CENTRED masthead (avatar, then name, then handle, then
+// the follow control), four stats (no replies — a channel can author none) and
+// four tabs. Mirrors `ChannelHeader` + `useProfileChrome({ hasBannerBand:
+// false })`.
+//
+// The avatar size is IMPORTED rather than restated: it is the one measurement
+// where a disagreement between this file and the header is a visible jump at
+// the moment the data lands.
 const CHANNEL_CONTENT_OFFSET = 60;
 const CHANNEL_STAT_CHIP_WIDTHS = [96, 104, 78, 84];
 const CHANNEL_TAB_CHIP_WIDTHS = [42, 50, 58, 56];
@@ -97,23 +102,35 @@ export const ProfileSkeleton = memo(function ProfileSkeleton({
       <View className="flex-1 bg-background" accessibilityRole="progressbar">
         <View style={{ paddingTop: insets.top + CHANNEL_CONTENT_OFFSET }}>
           <View className="bg-background px-4 pb-4">
-            {/* Name/handle on the left, avatar on the right — `ChannelHeader`. */}
-            <View className="flex-row justify-between items-start mb-4 gap-4">
-              <View className="flex-1">
-                <View className="mt-2.5 mb-1">
-                  <Skeleton.Box width="70%" height={22} borderRadius={6} />
-                </View>
-                <Skeleton.Box width="45%" height={14} borderRadius={6} />
-              </View>
+            {/* Centred masthead — avatar, then name, then handle. The margins
+                are `ChannelHeader`'s own: the name Text carries `marginTop: 12,
+                marginBottom: 4` and the handle sits straight under it, so the
+                placeholders repeat those as `mt-3` / `mb-1` rather than a
+                rhythm of their own.
+                Each bar is drawn SHORTER than the line it stands in — a
+                full-height slab reads as a block, not a line — so it is centred
+                inside a wrapper of the line's TRUE height: `h-7` (28px) for the
+                24px display name, `h-5` (20px) for the 15px/20 handle. Measured
+                in a browser: without the wrappers the masthead came out 12px
+                short and everything below it, the follow control and the tab
+                strip included, sat 12px high and jumped when the data landed —
+                which is the exact defect a skeleton exists to prevent. */}
+            <View className="items-center w-full">
               <Skeleton.Circle
                 size={CHANNEL_AVATAR_SIZE}
                 style={{ borderWidth: AVATAR_RING, borderColor: theme.colors.background }}
               />
+              <View className="mt-3 mb-1 h-7 justify-center">
+                <Skeleton.Box width={180} height={22} borderRadius={6} />
+              </View>
+              <View className="h-5 justify-center">
+                <Skeleton.Box width={110} height={14} borderRadius={6} />
+              </View>
             </View>
 
-            {/* Follow button — the whole action row; a channel has no poke and
-                no self view. */}
-            <View className="mt-3 mb-2 flex-row">
+            {/* Follow button — the whole action row, and the last element of the
+                centred masthead; a channel has no poke and no self view. */}
+            <View className="mt-4 mb-4 flex-row justify-center">
               <Skeleton.Box width={92} height={36} borderRadius={999} />
             </View>
 


### PR DESCRIPTION
A channel has no banner — `UpdateAccountInput` has no field to set one — and its header was the person layout with the band deleted: the avatar still pinned to one side of a row that no longer had anything on the other, an alignment that was a consequence of the banner and outlived it.

## What it looks like now

A centred masthead: **avatar → name → handle → follow control**, each centred under the last.

**What is centred stops at the follow button**, and the boundary is the decision, not an oversight:

- The **bio** is prose. Centred ragged prose gives the eye no fixed left edge to return to, and it carries inline links plus a "Read more" toggle that centring would park at a different x on every channel.
- The **stats row** is a denser rendering of the tab strip — its cells jump to the posts and boosts tabs, or navigate to the follower lists. It keeps the strip's left gutter so that relationship stays legible, rather than floating free of the thing it controls.
- The **tab strip** is unchanged: full width, with its scroll and active-underline intact.

The **verified mark moves inline** beside the name. Its old position was anchored to the avatar's left edge — coherent only while the avatar sat at the right end of a row — and it drew Ionicons' `checkmark-circle` where every other identity surface in the app draws the shared `VerifiedIcon` through `UserName`. Inline also groups it with the channel marker already on that line.

**No `max-width`**, and that is measured rather than assumed: the shell caps the center panel long before the viewport does, and the panel is widest in the *middle* of the range — 592px at a 1600px viewport, 817px at 900px (the RightBar is gone by then). 817px is the worst case a centred masthead ever sees. A `max-width` would not move anything anyway, since every item in the stack is intrinsically sized and centred.

The live badge and presence dot stay absent (a channel can hold no session, so neither state can occur), and nothing became a flag on the person header — `ProfileScreen` and `ProfileHeader` are untouched.

## The skeleton moved with it

A skeleton that holds the wrong space *is* the layout shift it exists to prevent, so `ProfileSkeleton`'s channel variant was recomposed in the same commit. Two fixes there, both found by measuring boxes in a browser rather than by eye:

- the avatar size is now **imported** from `ChannelHeader` instead of restated, so the two cannot disagree;
- the name and handle bars are drawn shorter than their lines on purpose, but now sit inside wrappers of the **true** line heights (28px / 20px). Without them the masthead came out 12px short and the follow control, stats and tab strip all sat high — jumping the moment the data landed.

## Verification

Measured in a real, foregrounded browser (headful Chrome on a private Xvfb), comparing `getBoundingClientRect()` of the loaded avatar against the skeleton avatar, each relative to its own block root:

| viewport | panel | loaded avatar | skeleton avatar | follow slot |
|---|---|---|---|---|
| 1600 | 592 | 248, 60, 96×96 | 248, 60, 96×96 | 236 / 236 |
| 900 | 817 | 360.5, 60, 96×96 | 360.5, 60, 96×96 | 236 / 236 |
| 520 | 437 | 170.5, 60, 96×96 | 170.5, 60, 96×96 | 236 / 236 |
| 500 | 485 | 194.5, 60, 96×96 | 194.5, 60, 96×96 | 236 / 236 |
| 499 | 484 | 194, 60, 96×96 | 194, 60, 96×96 | 236 / 236 |
| 400 | 385 | 144.5, 60, 96×96 | 144.5, 60, 96×96 | 236 / 236 |
| 360 | 345 | 124.5, 60, 96×96 | 124.5, 60, 96×96 | 236 / 236 |

Identical at every width, and the avatar's centre offset from the panel centre is 0 in both. The same box (`left 248, top 60, 96×96`, root width 592) was then re-observed on the **real** `/c/<handle>` route rather than only in the measuring harness.

**Mutation-tested** — removing one of the two line-height wrappers makes the check report `DRIFT -6` while the avatar check correctly stays green, so it can tell success from failure and the two assertions are independent.

Gates, all run on the rebased tree and matching the pre-change baseline I took myself: `tsc --noEmit` 0 errors · `test:coverage` 151 suites / 1407 tests pass (27.59% statements vs a 14.86% threshold) · `lint:frontend` 0 errors, 8 warnings (all pre-existing, in test files) · `validate:i18n` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)