### PR TITLE
fix(channels): a byline change reaches the posts already on screen

### DIFF
--- a/packages/frontend/hooks/__tests__/channelBylineRevalidation.test.tsx
+++ b/packages/frontend/hooks/__tests__/channelBylineRevalidation.test.tsx
@@ -1,0 +1,346 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import type { HydratedPost, SlicedFeedResponse } from '@mention/shared-types';
+import { feedService } from '@/services/feedService';
+import { usePostsStore } from '@/stores/postsStore';
+import { clearAllFeedMemoryCaches } from '@/stores/feedScrollStore';
+import { resetEngagementInvalidation } from '@/stores/engagementInvalidation';
+import { resetSafetyInvalidation } from '@/stores/safetyInvalidation';
+import {
+    noteChannelBylineChanged,
+    resetBylineInvalidation,
+} from '@/stores/bylineInvalidation';
+import { useFeedState, type UseFeedStateReturn } from '../useFeedState';
+
+/**
+ * Turning "Name the writer" on must make the channel's posts name their writer,
+ * and turning it off must take the name back off them — on the feed the operator
+ * is looking at, without a reload.
+ *
+ * The disclosure is decided ENTIRELY on the server, so this file models the server
+ * honestly: `serverPosts` records who actually wrote each post, and the fake
+ * transport puts the writer in `authors` only while the channel discloses. That is
+ * what makes the OFF → ON direction a real assertion — while the byline is off the
+ * writer's id is never sent to this device at all, so nothing held here could
+ * reconstruct the byline and only a refetch can produce it. A local transform
+ * would pass the ON → OFF case (the writer is in the cached DTO to strip) and fail
+ * this one, which is precisely the wrong fix this exists to rule out.
+ *
+ * The write side is `channelAccountService.setSignPosts`, which calls
+ * `noteChannelBylineChanged` after the server accepts — pinned separately in
+ * `services/__tests__/channelAccountService.test.ts`, since a screen that stops
+ * reporting is invisible from here. The read side is `useFeedState`, in two
+ * halves: a live subscription for the channel page still mounted under the
+ * settings screen, and a warm-start staleness check for feeds that were unmounted
+ * when the toggle was flipped. Both halves are exercised here, on both paths
+ * (memory-mode web and SQLite native).
+ */
+
+(globalThis as { __DEV__?: boolean }).__DEV__ = false;
+
+jest.mock('@/stores/postsStore', () => {
+    const state = {
+        fetchFeed: jest.fn(() => Promise.resolve()),
+        fetchUserFeed: jest.fn(() => Promise.resolve({ pending: false })),
+        refreshFeed: jest.fn(() => Promise.resolve()),
+        loadMoreFeed: jest.fn(() => Promise.resolve()),
+        cachePosts: jest.fn(),
+        clearFeed: jest.fn(),
+        clearUserFeed: jest.fn(),
+        clearError: jest.fn(),
+        feedUI: {},
+    };
+    const usePostsStore = (selector: (value: typeof state) => unknown) => selector(state);
+    usePostsStore.getState = () => state;
+    return {
+        usePostsStore,
+        useFeedSelector: () => undefined,
+        useUserFeedSelector: () => undefined,
+    };
+});
+
+jest.mock('@/services/feedService', () => ({
+    feedService: { getFeed: jest.fn(), getUserFeed: jest.fn() },
+}));
+
+// Web has no SQLite and runs the memory path; native has it and reads through the
+// store instead. Both branches carry the fix, so both are switched on here.
+let mockDbAvailable = false;
+
+jest.mock('@/db', () => ({
+    buildFeedKey: jest.fn(() => FEED_KEY),
+    hasFeedData: jest.fn(() => mockDbAvailable),
+    isDbAvailable: jest.fn(() => mockDbAvailable),
+}));
+
+jest.mock('@oxyhq/core/logger', () => ({
+    ...jest.requireActual('@oxyhq/core/logger'),
+    createLogger: () => ({ debug: jest.fn(), error: jest.fn(), warn: jest.fn() }),
+}));
+
+jest.mock('@/lib/precacheActorsFromPosts', () => ({
+    precacheActorsFromPosts: jest.fn(),
+}));
+
+const VIEWER_ID = 'operator-a';
+const CHANNEL_ID = 'channel-1';
+const WRITER_ID = 'writer-1';
+const FEED_KEY = 'feed-key';
+
+/** One post as the server holds it, including who wrote it for the channel. */
+interface ServerPost {
+    id: string;
+    authorId: string;
+    /** The human behind a channel post. Never sent while the channel is anonymous. */
+    writerId?: string;
+}
+
+let serverPosts: ServerPost[] = [];
+
+/** Whether the channel currently names the people who write for it. */
+let channelDiscloses = false;
+
+/**
+ * The server's half of the rule: `PostHydrationService` appends the writer to
+ * `authors` as `role: 'writer'` when the channel discloses, and omits them
+ * entirely when it does not — so with the byline off, the writer's id never
+ * crosses the wire.
+ */
+function page(): SlicedFeedResponse {
+    return {
+        items: serverPosts.map((post) => {
+            const authors = [{ id: post.authorId, role: 'owner' }];
+            if (post.writerId && channelDiscloses) {
+                authors.push({ id: post.writerId, role: 'writer' });
+            }
+            return {
+                id: post.id,
+                user: { id: post.authorId },
+                authors,
+            } as unknown as HydratedPost;
+        }),
+        slices: [],
+        interstitials: [],
+        hasMore: false,
+        totalCount: serverPosts.length,
+    };
+}
+
+let latest: UseFeedStateReturn | undefined;
+
+/**
+ * Every feed opened by this file and not yet closed. A mounted feed holds a live
+ * subscription, so one leaked by a failing assertion would answer the NEXT test's
+ * signal and report a second, unrelated failure there — which is exactly what a
+ * mutation test must not do if its output is to name the code it broke.
+ */
+const openFeeds = new Set<TestRenderer.ReactTestRenderer>();
+
+/** The channel's own page: the author feed the operator returns to on Back. */
+function ChannelFeed() {
+    latest = useFeedState({
+        type: 'posts',
+        userId: CHANNEL_ID,
+        useScoped: false,
+        isAuthenticated: true,
+        currentUserId: VIEWER_ID,
+    });
+    return null;
+}
+
+const getUserFeedMock = feedService.getUserFeed as jest.Mock;
+
+async function flush(): Promise<void> {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+}
+
+/** Open the feed, as a navigation would: a fresh mount. */
+async function openFeed(): Promise<TestRenderer.ReactTestRenderer> {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+        renderer = TestRenderer.create(<ChannelFeed />);
+    });
+    await flush();
+    openFeeds.add(renderer);
+    return renderer;
+}
+
+/** Navigate away from the feed: it unmounts and unsubscribes. */
+function closeFeed(renderer: TestRenderer.ReactTestRenderer): void {
+    act(() => renderer.unmount());
+    openFeeds.delete(renderer);
+}
+
+/**
+ * Flip the toggle the way the settings screen does: the server accepts the write
+ * first, then the one authority tells the caches. Never unmounts anything — the
+ * settings screen is pushed OVER the channel page, which stays mounted underneath.
+ */
+async function setSignPosts(discloses: boolean): Promise<void> {
+    await act(async () => {
+        channelDiscloses = discloses;
+        noteChannelBylineChanged(CHANNEL_ID);
+    });
+    await flush();
+}
+
+/** Who the rendered rows currently name, post by post. */
+function renderedBylines(): string[][] {
+    return (latest?.items ?? []).map((item) => (item.authors ?? []).map((author) => author.id));
+}
+
+describe('a channel byline converges on the feeds the operator is looking at', () => {
+    beforeAll(() => {
+        (
+            globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = true;
+    });
+
+    beforeEach(() => {
+        latest = undefined;
+        jest.clearAllMocks();
+        clearAllFeedMemoryCaches();
+        resetEngagementInvalidation();
+        resetSafetyInvalidation();
+        resetBylineInvalidation();
+        serverPosts = [
+            { id: 'post-1', authorId: CHANNEL_ID, writerId: WRITER_ID },
+            { id: 'post-2', authorId: CHANNEL_ID, writerId: WRITER_ID },
+        ];
+        channelDiscloses = false;
+        mockDbAvailable = false;
+        usePostsStore.getState().feedUI = {};
+        getUserFeedMock.mockImplementation(() => Promise.resolve(page()));
+    });
+
+    afterEach(() => {
+        for (const renderer of openFeeds) {
+            act(() => renderer.unmount());
+        }
+        openFeeds.clear();
+    });
+
+    it('names the writer on the page already open when the operator turns the byline on', async () => {
+        const feed = await openFeed();
+        expect(renderedBylines()).toEqual([[CHANNEL_ID], [CHANNEL_ID]]);
+
+        // The direction no client-side transform could serve: while the byline was
+        // off the writer's id was never sent here, so it is not held anywhere on
+        // this device to reveal.
+        await setSignPosts(true);
+        expect(renderedBylines()).toEqual([
+            [CHANNEL_ID, WRITER_ID],
+            [CHANNEL_ID, WRITER_ID],
+        ]);
+
+        closeFeed(feed);
+    });
+
+    it('takes the writer back off the page already open when the operator turns the byline off', async () => {
+        channelDiscloses = true;
+
+        const feed = await openFeed();
+        expect(renderedBylines()).toEqual([
+            [CHANNEL_ID, WRITER_ID],
+            [CHANNEL_ID, WRITER_ID],
+        ]);
+
+        // The other direction, and the one where being late has a person's name in
+        // it: a row that keeps naming a writer whose channel has stopped disclosing.
+        await setSignPosts(false);
+        expect(renderedBylines()).toEqual([[CHANNEL_ID], [CHANNEL_ID]]);
+
+        closeFeed(feed);
+    });
+
+    it('applies a byline changed while the feed was unmounted on its next mount', async () => {
+        const firstVisit = await openFeed();
+        expect(renderedBylines()).toEqual([[CHANNEL_ID], [CHANNEL_ID]]);
+        closeFeed(firstVisit);
+
+        // Nothing is subscribed now, so only the retained slice's age can carry the
+        // change to the next mount.
+        channelDiscloses = true;
+        noteChannelBylineChanged(CHANNEL_ID);
+
+        const secondVisit = await openFeed();
+        expect(renderedBylines()).toEqual([
+            [CHANNEL_ID, WRITER_ID],
+            [CHANNEL_ID, WRITER_ID],
+        ]);
+        closeFeed(secondVisit);
+    });
+
+    it('still warm-starts without a request when no byline changed', async () => {
+        const firstVisit = await openFeed();
+        expect(getUserFeedMock).toHaveBeenCalledTimes(1);
+        closeFeed(firstVisit);
+
+        // The control. Without it, "refetches when the byline changes" and "always
+        // refetches" are the same test — and the second would destroy the warm
+        // start that keeps a deep-scrolled feed from resetting on every Back.
+        const secondVisit = await openFeed();
+        expect(getUserFeedMock).toHaveBeenCalledTimes(1);
+        expect(renderedBylines()).toEqual([[CHANNEL_ID], [CHANNEL_ID]]);
+        closeFeed(secondVisit);
+    });
+
+    it('leaves an unmounted feed alone until it is opened again', async () => {
+        const firstVisit = await openFeed();
+        expect(getUserFeedMock).toHaveBeenCalledTimes(1);
+        closeFeed(firstVisit);
+
+        // An unsubscribed feed must not be woken — the whole point of the staleness
+        // half is that it costs nothing until the feed is needed.
+        act(() => {
+            noteChannelBylineChanged(CHANNEL_ID);
+        });
+        expect(getUserFeedMock).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * Native reads its feed out of SQLite rather than local state, so the same
+     * question is asked in a different place: `fetchInitial` skips the fetch
+     * entirely when the store says this feed was already loaded. That skip has to
+     * notice a byline changed since, or the rows SQLite is holding — which survive
+     * an app restart — keep naming (or not naming) the writer forever.
+     */
+    describe('on the SQLite path', () => {
+        /** Put the store in the state a previously-loaded native feed leaves behind. */
+        function seedLoadedSqliteFeed(): void {
+            mockDbAvailable = true;
+            usePostsStore.getState().feedUI = {
+                [FEED_KEY]: { isLoading: false, error: null, lastUpdated: Date.now() },
+            };
+        }
+
+        it('refetches on the next mount when the byline changed since the cache was written', async () => {
+            seedLoadedSqliteFeed();
+            const fetchUserFeed = usePostsStore.getState().fetchUserFeed as jest.Mock;
+
+            const firstVisit = await openFeed();
+            expect(fetchUserFeed).not.toHaveBeenCalled();
+            closeFeed(firstVisit);
+
+            noteChannelBylineChanged(CHANNEL_ID);
+
+            const secondVisit = await openFeed();
+            expect(fetchUserFeed).toHaveBeenCalledTimes(1);
+            closeFeed(secondVisit);
+        });
+
+        it('still serves the SQLite cache without a request when no byline changed', async () => {
+            seedLoadedSqliteFeed();
+            const fetchUserFeed = usePostsStore.getState().fetchUserFeed as jest.Mock;
+
+            const firstVisit = await openFeed();
+            closeFeed(firstVisit);
+
+            const secondVisit = await openFeed();
+            expect(fetchUserFeed).not.toHaveBeenCalled();
+            closeFeed(secondVisit);
+        });
+    });
+});

--- a/packages/frontend/hooks/useFeedState.ts
+++ b/packages/frontend/hooks/useFeedState.ts
@@ -33,6 +33,10 @@ import {
     isFeedCacheStaleForSafety,
     subscribeToSafetyFilterChanges,
 } from '@/stores/safetyInvalidation';
+import {
+    isFeedCacheStaleForByline,
+    subscribeToBylineChanges,
+} from '@/stores/bylineInvalidation';
 
 // Re-export so callers that already imported from here keep working.
 export { resolveUseMemoryFeed } from '@/utils/feedMemoryMode';
@@ -499,19 +503,24 @@ export function useFeedState({
 
             const feedTypeToCheck = showOnlySaved ? 'saved' : type;
 
-            // A retained slice is only good if it postdates ALL THREE classes of
-            // change that decide what a list contains: an engagement (like/boost/
-            // save), a lane write (a post moved between lanes, a lane's displayMode
-            // changed, a lane muted), and a safety-rule change (muted words, the
-            // sensitive-content toggle — these decide what the server is willing to
-            // send at all). Each lives in its own authority module and none can see
-            // another's writes, so all three are asked. Ask them HERE rather than at
-            // each call site: a caller that consults two of the three still returns
-            // a plausible feed, which is why that mistake survives review.
+            // A retained slice is only good if it postdates ALL FOUR classes of
+            // change that decide what a feed shows. Three decide what a list
+            // CONTAINS: an engagement (like/boost/save), a lane write (a post moved
+            // between lanes, a lane's displayMode changed, a lane muted), and a
+            // safety-rule change (muted words, the sensitive-content toggle — these
+            // decide what the server is willing to send at all). The fourth decides
+            // what a row already in the list SAYS: a channel turning its byline on
+            // or off adds or removes the writer from every one of its posts, and the
+            // client was never sent the writer's id while it was off. Each lives in
+            // its own authority module and none can see another's writes, so all
+            // four are asked. Ask them HERE rather than at each call site: a caller
+            // that consults three of the four still returns a plausible feed, which
+            // is why that mistake survives review.
             const cacheIsStale = (retainedAt: number): boolean =>
                 isFeedCacheStale(feedTypeToCheck, userId, currentUserId, retainedAt)
                 || isLaneFeedCacheStale(userId, currentUserId, filters?.laneId, retainedAt)
-                || isFeedCacheStaleForSafety(retainedAt);
+                || isFeedCacheStaleForSafety(retainedAt)
+                || isFeedCacheStaleForByline(retainedAt);
 
             // Check SQLite for cached data (cold-start optimization).
             // Only relevant when using the SQLite path (useMemoryFeed === false).
@@ -577,6 +586,11 @@ export function useFeedState({
             // what the server is willing to send at all, so a slice retained under
             // the old rules holds content the viewer asked not to see (or is
             // missing content they just asked for). See `stores/safetyInvalidation`.
+            //
+            // FOURTH EXCEPTION — a slice that predates a channel changing its
+            // byline. The posts are the same posts; their AUTHOR LIST is not, and
+            // the writer's id was never sent while the channel kept them anonymous,
+            // so nothing held here can reconstruct it. See `stores/bylineInvalidation`.
             const seeded = seededCacheRef.current;
             if (useMemoryFeed && !forceRefresh && seeded && type !== 'replies') {
                 seededCacheRef.current = undefined;
@@ -585,7 +599,7 @@ export function useFeedState({
                     isFetchingRef.current = false;
                     return;
                 }
-                logger.debug('Warm cache predates an engagement, lane write or safety change — revalidating');
+                logger.debug('Warm cache predates an engagement, lane write, safety change or byline change — revalidating');
             }
 
             try {
@@ -731,6 +745,24 @@ export function useFeedState({
     // `fetchInitial` off the ref, so it never needs re-subscribing.
     useEffect(
         () => subscribeToSafetyFilterChanges(() => {
+            void fetchInitialRef.current?.(true);
+        }),
+        [],
+    );
+
+    // A channel turning its byline on or off rewrites the author list of every
+    // post it has published, and the client cannot derive the new one: with the
+    // byline off the writer's id is never sent here at all. So, as above, the
+    // posts have to be asked for again — and the same two halves apply, for a
+    // sharper version of the same reason. The settings screen is pushed over the
+    // CHANNEL'S OWN PAGE, so the surface most in need of converging is the one
+    // still mounted underneath, and Back lands the operator straight on it.
+    //
+    // A separate subscription rather than a shared one: these are two different
+    // write classes with two different authorities, and one listener serving both
+    // would make either module's signal impossible to test without the other.
+    useEffect(
+        () => subscribeToBylineChanges(() => {
             void fetchInitialRef.current?.(true);
         }),
         [],

--- a/packages/frontend/lib/__tests__/viewerQueryKeys.test.ts
+++ b/packages/frontend/lib/__tests__/viewerQueryKeys.test.ts
@@ -192,6 +192,29 @@ describe('viewer-scoped private cache', () => {
     ).toBe(false);
   });
 
+  it('matches ONE channel\'s writers list, not the whole family', () => {
+    // A byline write names one channel. A reader holding several channels' writer
+    // lists must not have the others refetched — on a channel that does not
+    // disclose, that request spends itself re-deriving a 404.
+    const changed = viewerQueryKeys.channelWriters('viewer-a', 'channel-1');
+    expect(viewerQueryKeys.isChannelWriters(changed, 'channel-1')).toBe(true);
+    expect(viewerQueryKeys.isChannelWriters(changed, 'channel-2')).toBe(false);
+    expect(
+      viewerQueryKeys.isChannelWriters(
+        viewerQueryKeys.channelAccountSettings('viewer-a', 'channel-1'),
+        'channel-1',
+      ),
+    ).toBe(false);
+    // A channel id the caller does not have resolves to the empty slot the key
+    // factory writes, so it must not be matched by a real id.
+    expect(
+      viewerQueryKeys.isChannelWriters(
+        viewerQueryKeys.channelWriters('viewer-a', undefined),
+        'channel-1',
+      ),
+    ).toBe(false);
+  });
+
   it('removes only A when the active account switches A to B', async () => {
     const queryClient = new QueryClient();
     const aSearch = viewerQueryKeys.search('viewer-a', 'saved', 'oxy', true);

--- a/packages/frontend/lib/viewerQueryKeys.ts
+++ b/packages/frontend/lib/viewerQueryKeys.ts
@@ -494,6 +494,17 @@ export const viewerQueryKeys = {
    */
   isOperatedAccounts: (queryKey: readonly unknown[]): boolean =>
     viewerQueryKeys.isFamily(queryKey, 'accounts') && queryKey[3] === 'operated',
+  /**
+   * ONE channel's writers list, whichever viewer's copy it is.
+   *
+   * Scoped rather than family-wide because the event that invalidates it names a
+   * channel: its operator turned the byline on or off. A reader who has visited
+   * several channels holds an entry for each, and the others did not change —
+   * refetching them would spend a request to arrive back at the same answer, and
+   * on a channel that does not disclose, that answer is a 404.
+   */
+  isChannelWriters: (queryKey: readonly unknown[], channelId: string): boolean =>
+    viewerQueryKeys.isFamily(queryKey, 'channel-writers') && queryKey[3] === channelId,
 };
 
 /** The single factory for every Mention-owned React Query key. */

--- a/packages/frontend/services/__tests__/channelAccountService.test.ts
+++ b/packages/frontend/services/__tests__/channelAccountService.test.ts
@@ -14,6 +14,16 @@
  * Without this test the frontend half of that fix is unpinned: pointing the read
  * back at the bare settings path would restore the bug with every backend test
  * still green.
+ *
+ * The write also has to REPORT itself, and that is the second thing pinned here.
+ * Flipping the toggle rewrites the byline of every post the channel has published,
+ * and the caches holding those posts have no way to learn it: a byline is not a
+ * field a client can correct (with disclosure off the writer's id is never sent
+ * here at all), so the only answer is to ask the server again. This is the join
+ * between the two halves of that fix and the one place a regression would be
+ * completely silent — `useFeedState` keeps honouring the signal perfectly, the
+ * service simply stops sending it, and every surface goes back to needing a
+ * reload.
  */
 
 import { authenticatedClient } from '@/utils/api';
@@ -25,6 +35,12 @@ import { channelAccountService } from '../channelAccountService';
 // imports stay first and keeps `import/first` satisfied.
 jest.mock('@/utils/api', () => ({
   authenticatedClient: { get: jest.fn(), put: jest.fn() },
+}));
+
+const mockNoteBylineChanged = jest.fn();
+
+jest.mock('@/stores/bylineInvalidation', () => ({
+  noteChannelBylineChanged: (...args: unknown[]) => mockNoteBylineChanged(...args),
 }));
 
 const mockGet = jest.mocked(authenticatedClient.get);
@@ -104,5 +120,37 @@ describe('channelAccountService.setSignPosts', () => {
     await expect(channelAccountService.setSignPosts(CHANNEL, true)).resolves.toEqual({
       signPosts: true,
     });
+  });
+
+  /**
+   * BOTH directions, because they are not the same fix. Turning the byline OFF
+   * could in principle be served by stripping the writer out of the cached posts;
+   * turning it ON cannot, because the writer's id was never sent while the channel
+   * kept them anonymous. A report that fired on only one of them would leave the
+   * other needing a reload — and would still look like a working feature to
+   * whoever tested the direction that happened to be covered.
+   */
+  it.each([[true], [false]])(
+    'reports the change once the server has accepted it (signPosts: %s)',
+    async (value) => {
+      mockPut.mockResolvedValue({ data: { channel: { signPosts: value } } });
+
+      await channelAccountService.setSignPosts(CHANNEL, value);
+
+      // Named by the CHANNEL, never by the operator: the writers list this scopes
+      // is keyed on the account whose setting moved.
+      expect(mockNoteBylineChanged).toHaveBeenCalledTimes(1);
+      expect(mockNoteBylineChanged).toHaveBeenCalledWith(CHANNEL);
+    },
+  );
+
+  it('reports nothing when the server refuses the write', async () => {
+    mockPut.mockRejectedValue(new Error('network'));
+
+    await expect(channelAccountService.setSignPosts(CHANNEL, true)).rejects.toThrow();
+
+    // A refused toggle leaves every surface exactly as the caches already have it,
+    // and throwing away a feed for a change that did not land is pure cost.
+    expect(mockNoteBylineChanged).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/services/channelAccountService.ts
+++ b/packages/frontend/services/channelAccountService.ts
@@ -1,4 +1,5 @@
 import { authenticatedClient } from '@/utils/api';
+import { noteChannelBylineChanged } from '@/stores/bylineInvalidation';
 
 const SETTINGS_PATH = '/profile/settings';
 
@@ -51,11 +52,31 @@ class ChannelAccountService {
     return { signPosts: res.data?.channel?.signPosts === true };
   }
 
+  /**
+   * Flip whether this channel's posts name their writer — and REPORT it, because
+   * the toggle rewrites the byline of every post the channel has ever published
+   * and every cache holding one is now wrong.
+   *
+   * The report is made here, not in the screen's mutation handler, on the rule
+   * this repo has already paid to learn: a signal sent from a caller is a signal
+   * the next caller forgets. `postsStore` reports every engagement write for
+   * exactly that reason, after two call sites that wrote through it without
+   * touching the engagement hooks were found to be silent. This method is the ONE
+   * place this fact is written, so it is the one place that can speak for it —
+   * anything reaching for the toggle later (an onboarding step, a channel-creation
+   * flow, a bulk operator tool) inherits the convergence rather than having to
+   * remember it.
+   *
+   * After the await and only on success: a refused write leaves every surface
+   * exactly as the caches already have it, and a throw here would never reach the
+   * report at all.
+   */
   async setSignPosts(oxyUserId: string, signPosts: boolean): Promise<ChannelAccountSettings> {
     const res = await authenticatedClient.put<{ channel?: Partial<ChannelAccountSettings> }>(
       `${SETTINGS_PATH}/${encodeURIComponent(oxyUserId)}`,
       { channel: { signPosts } },
     );
+    noteChannelBylineChanged(oxyUserId);
     // The server's own answer wins when it sends one; the requested value is the
     // fallback so a terse 200 does not flip the switch back under the operator.
     return { signPosts: res.data?.channel?.signPosts ?? signPosts };

--- a/packages/frontend/stores/__tests__/bylineInvalidation.test.ts
+++ b/packages/frontend/stores/__tests__/bylineInvalidation.test.ts
@@ -1,0 +1,140 @@
+import { queryClient } from '@/lib/queryClient';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import {
+  isFeedCacheStaleForByline,
+  noteChannelBylineChanged,
+  resetBylineInvalidation,
+  subscribeToBylineChanges,
+} from '../bylineInvalidation';
+
+/**
+ * The authority has to reach BOTH read caches, and the React Query half is the
+ * one no feed test can see: a channel's post is embedded in a notification row, a
+ * search result, the saved screen and a profile's pinned post, all of which live
+ * under query keys rather than in the feed store.
+ *
+ * The family tokens are the whole risk — `isFamily` matches ONE position of a
+ * key, so a token that reads plausibly but does not match ('postsRoot', 'saved',
+ * 'notificationsRoot') silently invalidates nothing and every assertion about the
+ * feed half still passes. Hence a real `QueryClient` with real keys, plus an
+ * unrelated family asserted to be left alone so a predicate that matched
+ * everything could not pass either.
+ */
+
+const VIEWER_ID = 'viewer-a';
+const CHANNEL_ID = 'channel-1';
+const OTHER_CHANNEL_ID = 'channel-2';
+
+function wasInvalidated(key: readonly unknown[]): boolean {
+  return queryClient.getQueryState(key)?.isInvalidated === true;
+}
+
+describe('the channel-byline authority', () => {
+  beforeEach(() => {
+    resetBylineInvalidation();
+    queryClient.clear();
+  });
+
+  afterAll(() => {
+    queryClient.clear();
+  });
+
+  it('invalidates every query family that embeds a post the byline rewrote', () => {
+    const postDetail = viewerQueryKeys.post(VIEWER_ID, 'post-1');
+    const pinned = viewerQueryKeys.pinnedPost(VIEWER_ID, CHANNEL_ID);
+    const scheduled = viewerQueryKeys.scheduledPosts(VIEWER_ID);
+    const saved = viewerQueryKeys.savedPosts(VIEWER_ID, '', null);
+    const search = viewerQueryKeys.search(VIEWER_ID, 'posts', 'oxy', true);
+    const notifications = viewerQueryKeys.notifications(VIEWER_ID);
+    const unrelated = viewerQueryKeys.bookmarkFolders(VIEWER_ID);
+
+    for (const key of [postDetail, pinned, scheduled, saved, search, notifications, unrelated]) {
+      queryClient.setQueryData(key, []);
+    }
+
+    noteChannelBylineChanged(CHANNEL_ID);
+
+    expect(wasInvalidated(postDetail)).toBe(true);
+    expect(wasInvalidated(pinned)).toBe(true);
+    // Collateral, and pinned as such: `scheduledPosts` shares the `posts` family
+    // but cannot itself hold a channel's post — `GET /posts/scheduled` matches
+    // the CALLER's `oxyUserId`, and a post published as a channel carries the
+    // channel's. The family is the granularity `isFamily` offers; one refetch of
+    // a scheduled list is the price, and naming it here stops the next reader
+    // from mistaking it for a claim.
+    expect(wasInvalidated(scheduled)).toBe(true);
+    expect(wasInvalidated(saved)).toBe(true);
+    expect(wasInvalidated(search)).toBe(true);
+    expect(wasInvalidated(notifications)).toBe(true);
+    // A byline names a person on a post; it cannot rename a bookmark folder.
+    expect(wasInvalidated(unrelated)).toBe(false);
+  });
+
+  it('refetches only the writers list of the channel that changed', () => {
+    const changed = viewerQueryKeys.channelWriters(VIEWER_ID, CHANNEL_ID);
+    const untouched = viewerQueryKeys.channelWriters(VIEWER_ID, OTHER_CHANNEL_ID);
+
+    for (const key of [changed, untouched]) {
+      queryClient.setQueryData(key, { writers: [], nextCursor: undefined });
+    }
+
+    noteChannelBylineChanged(CHANNEL_ID);
+
+    // The tab's existence IS this setting — the endpoint 404s for a channel that
+    // does not disclose — so the list of the channel that changed has to be asked
+    // again. Another channel the reader visited did not change, and on one that
+    // does not disclose the refetch would spend a request to re-derive a 404.
+    expect(wasInvalidated(changed)).toBe(true);
+    expect(wasInvalidated(untouched)).toBe(false);
+  });
+
+  it('marks a feed cache retained before the change as stale, and one retained after as current', () => {
+    const beforeChange = Date.now() - 1;
+    expect(isFeedCacheStaleForByline(beforeChange)).toBe(false);
+
+    noteChannelBylineChanged(CHANNEL_ID);
+
+    expect(isFeedCacheStaleForByline(beforeChange)).toBe(true);
+    expect(isFeedCacheStaleForByline(Date.now() + 1)).toBe(false);
+  });
+
+  it('condemns a slice retained in the same millisecond as the change', () => {
+    // Both stamps are `Date.now()`, so a slice retained and a byline changed close
+    // enough together carry the SAME number. A slice retained no later than the
+    // change cannot be known to reflect it, and the error the strict `<` makes is
+    // leaving a writer's name on screen after their channel stopped disclosing it.
+    const now = Date.now();
+    const realNow = Date.now;
+    Date.now = () => now;
+    try {
+      noteChannelBylineChanged(CHANNEL_ID);
+      expect(isFeedCacheStaleForByline(now)).toBe(true);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('stops notifying a subscriber that has unsubscribed', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToBylineChanges(listener);
+
+    noteChannelBylineChanged(CHANNEL_ID);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // An unmounted feed must not be woken, or a screen the viewer left would
+    // issue a request nothing is waiting for.
+    unsubscribe();
+    noteChannelBylineChanged(CHANNEL_ID);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgets the change once reset', () => {
+    const beforeChange = Date.now() - 1;
+    noteChannelBylineChanged(CHANNEL_ID);
+    expect(isFeedCacheStaleForByline(beforeChange)).toBe(true);
+
+    resetBylineInvalidation();
+
+    expect(isFeedCacheStaleForByline(beforeChange)).toBe(false);
+  });
+});

--- a/packages/frontend/stores/bylineInvalidation.ts
+++ b/packages/frontend/stores/bylineInvalidation.ts
@@ -1,0 +1,160 @@
+import { queryClient } from '@/lib/queryClient';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+
+/**
+ * The single authority for "a channel changed whether its posts name the person
+ * who wrote them".
+ *
+ * The write is one boolean — `UserSettings.channel.signPosts`, flipped from
+ * `app/(app)/c/[username]/settings.tsx` — and what it changes is who appears on
+ * the byline of EVERY post that channel has ever published. `PostHydrationService`
+ * appends the writer to `authors[]` as `role: 'writer'` when the channel
+ * discloses and omits them when it does not, so the same post comes back with a
+ * different author list either side of the toggle.
+ *
+ * **Why this is a refetch signal rather than a correction applied locally**, which
+ * is the question to settle first because Mention now has machinery for the other
+ * answer. `stores/identityUpdates` + `lib/actorCache` correct an identity FIELD of
+ * an actor a cached post already carries — a changed picture or display name — and
+ * they are the right tool for that. They cannot serve this one, in both
+ * directions and for two different reasons:
+ *
+ *   * OFF → ON. The writer is not in the cached DTO to correct, and their id was
+ *     never sent to this device: withholding it is the entire point of
+ *     `signPosts: false`, and the server decides the disclosure so that no
+ *     renderer can get it wrong. There is nothing local to reconstruct the byline
+ *     from, so the posts have to be asked for again.
+ *   * ON → OFF. The writer IS in the cached DTO and could be stripped out here —
+ *     which is exactly the trap. That would be a second implementation of a
+ *     server-side disclosure rule, live on one of the two directions only, and it
+ *     would disagree with the server the moment that rule gains a case (a
+ *     restricted channel, a writer who left). One rule, decided in one place.
+ *
+ * **Why a sibling module and not a line in `stores/engagementInvalidation`.** That
+ * module records that a write changed WHICH POSTS A LIST CONTAINS — a like moves a
+ * post into the likes tab, a save into the saved screen — and everything it
+ * exposes is shaped around list membership (`engagementKindForFeed` asks whose
+ * list it is, because only that viewer's own writes can change it). A byline
+ * changes no membership at all: no post enters or leaves any list, and every list
+ * that showed the channel yesterday shows exactly the same posts today. It is the
+ * CONTENT of rows already held that moved. Folding the two together would make
+ * `isFeedCacheStale` answer two different questions under one name, and the next
+ * reader would have to know which one their call site meant.
+ *
+ * The near neighbour is `stores/safetyInvalidation`, and deliberately so — the
+ * shape is borrowed from it wholesale, because the situation is the same one:
+ * a setting written on a screen pushed OVER the surface that has to converge, and
+ * an answer only the server can give. Hence both halves, for the same reasons that
+ * file gives at length:
+ *
+ *   * {@link subscribeToBylineChanges} converges the feeds still mounted
+ *     underneath — on this flow, the channel's own page, which is where the
+ *     operator came from and where they will land on Back.
+ *   * {@link isFeedCacheStaleForByline} converges the rest on their next mount,
+ *     because the feed store warm-starts from a retained slice instead of
+ *     refetching page 1 and has no staleness notion of its own.
+ *
+ * **The feed half is global, though the write names one channel.** A channel's
+ * posts are not confined to its page: they reach For You, Following, a list feed,
+ * a hashtag feed, search — and they ride inside OTHER people's posts as a quote
+ * card or a boosted original, so even a feed whose subject is somebody else can be
+ * holding one. Answering "could this slice contain that channel?" would mean
+ * walking every item of every retained slice on every mount, to save a single
+ * refetch of a rare, operator-initiated write. The React Query half below is
+ * scoped where scoping is free — the writers list is keyed by channel — and global
+ * where it is not.
+ */
+
+/** When a channel last changed its byline disclosure, in `Date.now()` terms. */
+let changedAt = 0;
+
+/** Notified when a byline changes, so a mounted feed can refetch. */
+type BylineListener = () => void;
+
+const listeners = new Set<BylineListener>();
+
+/**
+ * Whether a feed cache retained at `retainedAt` predates a byline change, in
+ * which case the posts it holds may name a writer the channel has since taken
+ * back — or stay anonymous when the channel has since decided to name them.
+ *
+ * Inclusive for the reason `isFeedCacheStale` in `engagementInvalidation`
+ * documents at length: two `Date.now()` stamps can share a millisecond, and a
+ * slice retained no later than the change cannot be known to reflect it. The
+ * wrong answer here has a name attached to it, which is the direction to be
+ * careful in: a row that keeps naming a writer whose channel has just stopped
+ * disclosing is a person's identity left on screen after the setting that
+ * published it was withdrawn.
+ */
+export function isFeedCacheStaleForByline(retainedAt: number): boolean {
+  return retainedAt <= changedAt;
+}
+
+/**
+ * Subscribe a mounted feed to byline changes so it refetches without waiting for
+ * a remount. Returns an unsubscribe function.
+ */
+export function subscribeToBylineChanges(listener: BylineListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Record that a channel changed whether its posts name their writer, and tell
+ * both caches. Call this only after the server has accepted the write: a toggle
+ * that failed leaves every surface exactly as the caches already have it, and
+ * throwing away a feed for a change that did not land is pure cost.
+ *
+ * `channelOxyUserId` is the channel whose setting moved. It scopes the one query
+ * family that can be scoped — everything else is global, see the note above.
+ */
+export function noteChannelBylineChanged(channelOxyUserId: string): void {
+  changedAt = Date.now();
+
+  void queryClient.invalidateQueries({
+    predicate: (query) =>
+      // Every family whose cached response embeds a post DTO, and therefore a
+      // byline the server has just rewritten:
+      //   `posts`       — the post detail behind a notification, and a profile's
+      //                   pinned post, which on a channel's page is the channel's
+      //                   own. `scheduledPosts` rides in the same family and is
+      //                   collateral rather than a target: `GET /posts/scheduled`
+      //                   matches `oxyUserId: <caller>`, and a post published as a
+      //                   channel carries the CHANNEL's id, so an operator's
+      //                   scheduled list cannot hold one.
+      //   `saved-posts` — the saved screen, React Query's own post list.
+      //   `search`      — the posts tab.
+      //   `notifications` — rows embed the post they are about, and the server
+      //                   applies the same disclosure decision to them.
+      viewerQueryKeys.isFamily(query.queryKey, 'posts')
+      || viewerQueryKeys.isFamily(query.queryKey, 'saved-posts')
+      || viewerQueryKeys.isFamily(query.queryKey, 'search')
+      || viewerQueryKeys.isFamily(query.queryKey, 'notifications')
+      // And the writers list itself, which this setting does not merely change
+      // but decides the EXISTENCE of: the endpoint 404s for a channel that does
+      // not disclose, and `useChannelWriters` reads that refusal as "no tab".
+      // Keyed by channel, so only this one is asked to fetch again.
+      || viewerQueryKeys.isChannelWriters(query.queryKey, channelOxyUserId),
+  });
+
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/**
+ * Drop the recorded change. For tests.
+ *
+ * Deliberately NOT wired into the account switch, unlike `resetEngagementInvalidation`
+ * and `resetSafetyInvalidation` beside it, and for the reason `resetIdentityUpdates`
+ * gives: those two record something about the VIEWER — their own engagements, their
+ * own safety rules — which says nothing about the next viewer. A channel's byline is
+ * the channel's fact and is the same fact whoever is signed in. It would also be
+ * inert either way: the switch drops every retained slice, so every slice the next
+ * viewer holds is retained after this stamp and none of them is condemned by it.
+ */
+export function resetBylineInvalidation(): void {
+  changedAt = 0;
+}


### PR DESCRIPTION
## The bug

Toggle **"Name the writer"** in a channel's settings, go back, and the channel's posts still show the old byline. Only a full reload fixes it.

## Why the identity overlay is the wrong tool for it

`stores/identityUpdates` + `lib/actorCache` (landed today) correct an identity **field** of an actor a cached post already carries — a changed avatar or display name. `signPosts` changes something else: **whether the writer is in `authors[]` at all.** `PostHydrationService` appends them as `role: 'writer'` only when the channel discloses.

So a cached post is not stale in a field — it is missing, or wrongly carrying, a whole author. And there is no local information to rebuild it from:

* **OFF → ON.** The writer's id was never sent to this device. Withholding it *is* `signPosts: false`. Nothing here can reconstruct the byline.
* **ON → OFF.** The writer *is* in the cached DTO and could be stripped — which is the trap. That would be a second implementation of a server-side disclosure rule, live in one direction only, and it would disagree with the server the moment that rule gains a case.

Therefore: refetch.

## Why a sibling module, not a line in `engagementInvalidation`

That module records that a write changed **which posts a list contains** — everything it exposes is shaped around membership (`engagementKindForFeed` asks *whose* list it is, because only that viewer's writes can change it). A byline changes no membership at all: no post enters or leaves any list. It is the **content of rows already held** that moved. Folding them together would make `isFeedCacheStale` answer two questions under one name.

The near neighbour is `stores/safetyInvalidation`, and the shape is borrowed from it wholesale because the situation is identical — a setting written on a screen pushed **over** the surface that must converge, and an answer only the server can give. Hence both halves:

* `subscribeToBylineChanges` — converges the channel page still mounted underneath, which is where Back lands the operator.
* `isFeedCacheStaleForByline` — converges the rest on their next mount, since the feed store warm-starts from a retained slice and has no staleness notion of its own. Honoured on **both** the memory-mode (web) and SQLite (native) paths in `useFeedState.fetchInitial`.

The feed half is global though the write names one channel: a channel's posts reach For You, Following, lists, hashtags — and ride inside other people's posts as a quote card or boosted original, so even a feed about somebody else can hold one. The React Query half is scoped where scoping is free.

## Where the signal is sent from

`channelAccountService.setSignPosts`, after the server accepts — **not** the screen's mutation handler. Same rule that put engagement reporting in `postsStore` after two call sites were found writing through it silently: a signal sent from a caller is a signal the next caller forgets.

## Surfaces

**Covered by the feed store's two halves** — every `<Feed>` surface, because `useFeedState` is the single data owner behind both `Feed.web.tsx` and `Feed.native.tsx`: the channel page and all its tabs, For You, Following, Explore, a person's profile feed, list feeds, hashtag feeds, custom feeds, the videos viewer, lane tabs, the replies feed on a post detail, and the saved feed.

**Covered by the React Query invalidation** (5): the saved screen (`saved-posts`), search results (`search`), the notifications list and the post each row embeds (`notifications`), the post detail behind a notification and a profile's pinned post (`posts`), and the channel's **Writers tab including whether it exists at all** (`channel-writers`, scoped by channel through a new `viewerQueryKeys.isChannelWriters` — the endpoint 404s for a channel that does not disclose).

**Covered already, no signal needed** (3): `/p/<id>` revalidates on every mount and `PostItem`'s memo comparator already compares `authors` by id (#595); quote cards and boosted originals are embedded in the parent's DTO and arrive with whatever refetch delivered it; thread ancestors and continuations are fetched per mount.

**Deliberately excluded** (2): `insights` — the operator's own analytics can never contain a channel post (`authorship` names the channel, and `writtenByOxyUserId` is never in it). `scheduledPosts` — rides in the `posts` family as collateral, not a target: `GET /posts/scheduled` matches the caller's own `oxyUserId`, so it cannot hold a channel post. Both stated in the code so they read as decisions.

**Not covered** (1): a `/p/<id>` already mounted at the moment the toggle lands keeps its byline until remount. Unreachable on this flow (settings is reached from the channel page) and the next mount fixes it.

## Verification

All run in this worktree, rebased onto `7d190f18`.

| gate | `origin/main` @ 7d190f18 | this branch |
|---|---|---|
| `bunx tsc --noEmit` | 0 errors | 0 errors |
| `bun run test:coverage` | 151 files on disk / **151 suites** / 1407 tests, all pass | 153 / **153 suites** / 1424 tests, all pass |
| coverage (stmt/br/fn/ln) | 27.59 / 23.08 / 23.90 / 28.19 | 27.66 / 23.13 / 24.02 / 28.26 |
| `bun run lint:frontend` | — | 0 errors, 8 pre-existing warnings, none in touched files |
| `bun run validate:i18n` | — | pass (no new keys) |

Suite count matches the file count on disk on both sides, so nothing failed to load. The three new/changed test files were linted **explicitly** by path (3 files, 0/0) and that gate was mutation-tested — a `var` + `==` inserted into the new module is reported.

**Mutation testing: 11 mutations, 11 killed.** Each names the assertion it broke.

| mutation | killed by |
|---|---|
| drop the byline term from `cacheIsStale` | both warm-start tests (memory + SQLite) |
| drop the live subscription from `useFeedState` | both mounted-page tests |
| service stops calling `noteChannelBylineChanged` | both direction tests |
| `<` instead of `<=` in the staleness bound | the same-millisecond test |
| `isChannelWriters` loses its channel scope | the scoped-key test |
| drop `posts` / `saved-posts` / `search` / `notifications` from the predicate (4 runs) | the family test, each time |
| drop `isChannelWriters` from the predicate | the writers-list test |
| **control:** make every feed cache always stale | the two "no request when nothing changed" tests |
| **control:** fake server always discloses | 4 tests |
| **control:** fake server never discloses | 3 tests |

The last three are the vacuity guards: without them "refetches on the toggle" and "always refetches" would be the same test, and a fixture that did not actually exercise the server's decision would pass either way. Both directions are asserted separately, on the mounted page and across an unmount, because OFF→ON and ON→OFF are different code paths and only one of them could ever be faked locally.

**Not verified in a browser.** No local backend was running, and prod CORS refuses a localhost origin, so a real end-to-end pass would have meant standing up Mongo + Redis + Oxy service credentials + a channel with posts and an operator session. The change is pure JS in shared modules — no DOM, no CSS, no animation, no layout — so none of the three browser-only failure classes this repo keeps hitting (Reanimated mappers, NativeWind className layout, transitions in a backgrounded tab) applies; and the web path (memory mode, no SQLite) is the **default** in the feed test, with the native SQLite path exercised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
