### PR TITLE
fix(feed): stop the ranked path silently dropping deferred slices

### DIFF
--- a/packages/backend/src/__tests__/feedEngine.test.ts
+++ b/packages/backend/src/__tests__/feedEngine.test.ts
@@ -54,6 +54,7 @@ vi.mock('../services/FeedSeenPostsService', () => ({
   },
 }));
 
+import { MtnConfig } from '@mention/shared-types';
 import { FeedEngine } from '../mtn/feed/engine/FeedEngine';
 import { FeedModuleRegistry } from '../mtn/feed/engine/FeedModuleRegistry';
 import { ScoreCursor } from '../mtn/feed/CursorBuilder';
@@ -232,6 +233,119 @@ describe('FeedEngine — ranked mode', () => {
       ...first.items.map((item) => item.id),
       ...second.items.map((item) => item.id),
     ])).toEqual(new Set([oid(10).toString(), oid(9).toString(), oid(8).toString()]));
+  });
+});
+
+describe('FeedEngine — ranked pagination coverage', () => {
+  const PAGE_LIMIT = 6;
+  const PROLIFIC_POSTS = 12;
+  const SOLO_AUTHORS = 12;
+
+  /**
+   * A thin follow graph: ONE prolific author interleaved with a long tail of
+   * one-post authors, strictly score-descending. This is the shape
+   * `maxPerAuthorPerPage` exists for — the prolific author supplies far more
+   * page-eligible candidates than the cap admits, so the reranker has to defer
+   * some of them.
+   */
+  function thinGraphPool(): CandidatePost[] {
+    const posts: CandidatePost[] = [];
+    let score = PROLIFIC_POSTS + SOLO_AUTHORS;
+    for (let i = 0; i < Math.max(PROLIFIC_POSTS, SOLO_AUTHORS); i += 1) {
+      if (i < PROLIFIC_POSTS) {
+        posts.push(makePost(posts.length + 1, { oxyUserId: 'prolific', _testScore: score }));
+        score -= 1;
+      }
+      if (i < SOLO_AUTHORS) {
+        posts.push(makePost(posts.length + 1, { oxyUserId: `solo-${i}`, _testScore: score }));
+        score -= 1;
+      }
+    }
+    return posts;
+  }
+
+  function rankedDef(sourceId: string): FeedDefinition {
+    return {
+      id: 'test-ranked-pagination',
+      title: 'Test ranked pagination',
+      mode: 'ranked',
+      sources: [{ module: sourceId, enabled: true }],
+      signals: [],
+      filters: [],
+    };
+  }
+
+  /**
+   * Drain a ranked pagination session to exhaustion and report what each page
+   * served.
+   *
+   * A SINGLE page cannot observe this class of bug: page one looks complete and
+   * correctly ordered, and the loss only appears as the union of every page
+   * falling short of the pool. That is why the check has to paginate.
+   */
+  async function drainRanked(
+    def: FeedDefinition,
+    limit: number,
+    poolSize: number,
+  ): Promise<{ pages: string[][]; served: string[] }> {
+    const pages: string[][] = [];
+    let cursor: string | undefined;
+    // A page that reports `hasMore` must serve at least one item, so a pool of
+    // N posts can never need more than N pages. Exceeding that is a loop, not a
+    // long session, and must fail loudly rather than spin.
+    for (let page = 0; page <= poolSize; page += 1) {
+      const result = await engine.run(def, { currentUserId: 'viewer' }, { limit, cursor });
+      pages.push(result.items.map((item) => item.id));
+      if (!result.hasMore || !result.nextCursor) {
+        return { pages, served: pages.flat() };
+      }
+      cursor = result.nextCursor;
+    }
+    throw new Error(`Ranked session did not terminate within ${poolSize} pages`);
+  }
+
+  it('serves every candidate across the session — per-author-cap overflow rolls forward, never strands', async () => {
+    // Vacuity floor: the fixture only exercises the cap if the prolific author
+    // brings more page-eligible posts than one page may admit from them.
+    expect(PROLIFIC_POSTS).toBeGreaterThan(MtnConfig.ranking.diversity.maxPerAuthorPerPage);
+
+    const pool = thinGraphPool();
+    registry.register(sourceReturning('thin-graph', pool));
+
+    const { served } = await drainRanked(rankedDef('thin-graph'), PAGE_LIMIT, pool.length);
+
+    const poolIds = pool.map((post) => String(post._id));
+    const servedSet = new Set(served);
+    const stranded = poolIds.filter((id) => !servedSet.has(id));
+
+    // The reranker's documented contract: it DEFERS, it never drops. A deferred
+    // slice scores ABOVE the page tail, so the score cursor minted from that
+    // tail excludes it from every subsequent page — it is lost, not deferred.
+    expect({ strandedCount: stranded.length, strandedIds: stranded }).toEqual({
+      strandedCount: 0,
+      strandedIds: [],
+    });
+    expect(servedSet.size).toBe(poolIds.length);
+    // A session must not repeat either: coverage bought with duplicates is not
+    // coverage.
+    expect(served.length).toBe(servedSet.size);
+  });
+
+  it('control: a pool with one post per author strands nothing (the cap never binds)', async () => {
+    const pool = Array.from({ length: PROLIFIC_POSTS + SOLO_AUTHORS }, (_, i) =>
+      makePost(i + 1, { oxyUserId: `solo-${i}`, _testScore: PROLIFIC_POSTS + SOLO_AUTHORS - i }));
+    registry.register(sourceReturning('one-each', pool));
+
+    const { served } = await drainRanked(rankedDef('one-each'), PAGE_LIMIT, pool.length);
+
+    const servedSet = new Set(served);
+    const stranded = pool.map((post) => String(post._id)).filter((id) => !servedSet.has(id));
+
+    expect({ strandedCount: stranded.length, strandedIds: stranded }).toEqual({
+      strandedCount: 0,
+      strandedIds: [],
+    });
+    expect(served.length).toBe(servedSet.size);
   });
 });
 

--- a/packages/backend/src/mtn/feed/capDiscoveryShare.ts
+++ b/packages/backend/src/mtn/feed/capDiscoveryShare.ts
@@ -14,8 +14,11 @@
  *
  * Contract — IDENTICAL to `diversifyByAuthor`:
  *  - NEVER drops an item. Discovery slices beyond the cap are DEFERRED to the page
- *    tail (in their original rank order), so they still emit (after the trusted
- *    content, or roll forward via pagination) rather than being lost.
+ *    tail (in their original rank order), so they still emit after the trusted
+ *    content rather than being lost. As with `diversifyByAuthor`, that only holds
+ *    because the caller passes the slices it is about to SERVE: deferring past a
+ *    page window would put the slice above the keyset cursor minted from that
+ *    page's tail, which no later page can reach.
  *  - On a THIN follow graph the cap is simply unmet: there isn't enough trusted
  *    content to fill the trusted floor, so the deferred discovery slices backfill
  *    the tail and the page still fills to `limit`. The never-blank + popular

--- a/packages/backend/src/mtn/feed/diversifyByAuthor.ts
+++ b/packages/backend/src/mtn/feed/diversifyByAuthor.ts
@@ -18,8 +18,20 @@
  *
  * Properties:
  *  - Never DROPS an item. Overflow / still-conflicting items are appended at the
- *    tail in their original (rank) order, so they still emit (and roll forward
- *    via pagination) rather than being lost.
+ *    tail in their original (rank) order, so they still emit rather than being
+ *    lost. Output length always equals input length.
+ *  - That deferral is only worth anything if the caller reranks the items it is
+ *    about to SERVE. It does NOT survive a caller that reranks a deeper pool and
+ *    truncates afterwards: a ranked page is continued by a score-descending
+ *    keyset cursor minted from the page's own LOWEST anchor, so an item deferred
+ *    past the page window scores ABOVE that cursor and is filtered out of every
+ *    subsequent page — deferred here, dropped there, silently and permanently.
+ *    `FeedEngine.finalizeRanked` therefore selects the page window BEFORE
+ *    calling this; any future caller paginating on a keyset must do the same.
+ *  - Consequence of the above: when one author owns MORE of the page window than
+ *    `maxPerAuthor` admits, the cap is arithmetically unsatisfiable — the page
+ *    cannot hold fewer of that author's items without losing them. The cap then
+ *    degrades to ORDERING, and their surplus lands as a run at the page tail.
  *  - Preserves overall rank order as closely as the constraints allow: items are
  *    emitted greedily in rank order, an item is only deferred when emitting it
  *    now would violate the gap or the per-author cap.

--- a/packages/backend/src/mtn/feed/engine/FeedEngine.ts
+++ b/packages/backend/src/mtn/feed/engine/FeedEngine.ts
@@ -565,32 +565,38 @@ export class FeedEngine {
       viewerId: ctx.currentUserId,
     });
 
-    // A pre-scored source owns a strict score-descending keyset. Select that
-    // page's score window BEFORE visual author diversification: otherwise a
-    // lower-score slice can be pulled into the page, move the cursor below a
-    // deferred higher-score slice, and skip that slice forever.
-    // Pagination units are slices, not raw candidates: thread grouping can
-    // collapse several candidates into one slice, so candidate count would
+    // EVERY ranked page — pre-scored or ranked right here — continues under a
+    // score-descending keyset minted from the page's own LOWEST anchor, so the
+    // set a page serves has to be a PREFIX of the score order. A slice the page
+    // skips while serving something below it scores above the cursor, and the
+    // next page's `score < cursor` filter excludes it: it is never served, on
+    // any page.
+    //
+    // Both reorderers below DEFER rather than drop — that is the contract each
+    // one documents — but a deferral only survives if the deferred slice is
+    // still inside the page window. So select the window FIRST and let them
+    // permute within it. Reranking the whole pool and truncating afterwards is
+    // what silently turns "deferred to the tail" into "dropped for good", since
+    // deferred slices are exactly the ones scoring above the tail the cursor is
+    // taken from.
+    //
+    // Pagination units are SLICES, not raw candidates: thread grouping can
+    // collapse several candidates into one slice, so a candidate count would
     // advertise a phantom next page.
-    const preScoredHasMore = exec.preScored && rawSlices.length > limit;
-    const slicesToDiversify = exec.preScored ? rawSlices.slice(0, limit) : rawSlices;
-    const diversifiedSlices = diversifyByAuthor(slicesToDiversify, sliceAuthorKey);
+    const hasMore = rawSlices.length > limit;
+    const windowedSlices = rawSlices.slice(0, limit);
+    const diversifiedSlices = diversifyByAuthor(windowedSlices, sliceAuthorKey);
 
     // Phase 5: cap the discovery share of the page (For You sets
     // `maxDiscoveryShare`; every other feed leaves it unset → no-op). Runs AFTER
-    // author diversification and BEFORE truncation; it DEFERS discovery overflow to
-    // the tail (never drops), so `hasMore` / cursor semantics are unchanged.
-    const cappedSlices = capDiscoveryShare(
+    // author diversification and INSIDE the page window, so the discovery
+    // overflow it defers to the tail still lands on the page it was computed for.
+    const pageSlices = capDiscoveryShare(
       diversifiedSlices,
       sliceIsDiscovery,
       exec.maxDiscoveryShare,
       limit,
     );
-
-    const hasMore = exec.preScored ? preScoredHasMore : cappedSlices.length > limit;
-    const pageSlices = exec.preScored
-      ? cappedSlices
-      : (hasMore ? cappedSlices.slice(0, limit) : cappedSlices);
 
     const hydratedSlices = await postHydrationService.hydrateSlices(pageSlices, {
       viewerId: ctx.currentUserId,

--- a/packages/backend/src/mtn/feed/engine/types.ts
+++ b/packages/backend/src/mtn/feed/engine/types.ts
@@ -246,11 +246,13 @@ export interface FeedExecution {
   /**
    * DISCOVERY-SHARE CAP (Phase 5) — the maximum SHARE (0..1) of a rendered ranked
    * page that may come from DISCOVERY lanes (slices whose anchor post carries the
-   * opaque `_discovery` marker). After author diversification and BEFORE page
-   * truncation, `capDiscoveryShare` DEFERS — never drops (same contract as
-   * `diversifyByAuthor`) — discovery slices beyond `floor(maxDiscoveryShare ·
-   * limit)` to the page tail, guaranteeing a floor for trusted (following /
-   * affinity / lists) content. Unset (every feed except For You) = no cap. On a
+   * opaque `_discovery` marker). After author diversification, and INSIDE the
+   * already-selected page window, `capDiscoveryShare` DEFERS — never drops (same
+   * contract as `diversifyByAuthor`) — discovery slices beyond
+   * `floor(maxDiscoveryShare · limit)` to the page tail, guaranteeing a floor for
+   * trusted (following / affinity / lists) content. Running it on a deeper pool
+   * and truncating afterwards would make that deferral a silent drop; see
+   * `FeedEngine.finalizeRanked`. Unset (every feed except For You) = no cap. On a
    * thin follow graph the cap is simply unmet and discovery backfills the page.
    */
   maxDiscoveryShare?: number;

--- a/packages/shared-types/src/mtn/config.ts
+++ b/packages/shared-types/src/mtn/config.ts
@@ -166,8 +166,17 @@ export const MtnConfig = {
        * Hard cap on how many items a single author may contribute to one rendered
        * page. Prevents a prolific author from filling the page even with spacing.
        * The reranker never DROPS items — it defers an author's overflow items to
-       * the tail of the page (so they appear after everyone else, or roll to the
-       * next page via pagination) rather than removing them.
+       * the tail of the page (so they appear after everyone else) rather than
+       * removing them.
+       *
+       * It cannot defer them to the NEXT page. The reranker runs on the page
+       * window a ranked feed has already selected, because a ranked page is
+       * continued by a score-descending keyset cursor taken from that page's own
+       * lowest item — anything held back past the window scores above the cursor
+       * and no later page can reach it. So when an author owns more of the window
+       * than this admits, the cap is unsatisfiable and degrades to ordering: their
+       * surplus is served, as a run at the page tail. Raising this value does not
+       * change that; it only lets the run start earlier.
        */
       maxPerAuthorPerPage: 3,
     },


### PR DESCRIPTION
## Summary

**The ranked feed path silently dropped slices instead of deferring them, permanently.** `diversifyByAuthor` documents that it never drops an item — "they still emit and roll forward via pagination". On the ranked path it did drop them. Mechanism, four lines: cap overflow (`maxPerAuthorPerPage`, production value 3) is appended at the TAIL, so its score sits above the page tail's; the page is truncated to `limit`; the cursor is taken from the page MINIMUM; and the next page filters `postScore < cursor.score` — excluding exactly those higher-scoring deferred slices. They are never served, on any page.

**Measured on the real `FeedEngine` through a full paginated session** (24 candidates, one prolific author among 12 one-post authors, `limit: 6`): **18 of 24 served, 6 stranded, every one of them the prolific author's**. Page 1 loses P20 and P18, page 2 loses P12 and P10, page 3 loses P4 and P2.

**The team had already fixed this for the pre-scored path only** — `FeedEngine.ts:576` read `exec.preScored ? rawSlices.slice(0, limit) : rawSlices`, with a comment naming this exact hazard. For You, Videos, Media, Trending and stored `mode:'ranked'` still passed all `rawSlices`.

**Remedy: select the page window before reranking.** The `exec.preScored` fork collapses entirely — the two branches were provably identical once the ranked path adopted the remedy, so this is one code path with one contract rather than a second special case. `hasMore` and the cursor are unchanged: both reorderers preserve length, so the old `cappedSlices.length > limit` was already exactly `rawSlices.length > limit`, and it stays stated in SLICES so thread grouping cannot advertise a phantom page.

**Why the alternative was rejected, argued not dismissed:** making the cursor account for deferred items requires a threshold above them, which re-admits everything already served in between, so those must be excluded by id — an unbounded set (a dominant author defers again every page) against `MAX_SCORE_CURSOR_EXCLUDE_IDS = 100`. Raising that turns a keyset into a seen-set carried in the URL, and on overflow the failure flips from silent gaps to silent duplicates, which is worse. The general fact: with a score-threshold cursor, the set a page serves must be a PREFIX of the score order. Reordering within a prefix is free; leaving it is not. Raising `maxPerAuthorPerPage` is rejected for the same reason — it does not make the served set a prefix, so it reduces stranding only by coincidence while restoring the clustering the cap exists to prevent.

**The honest cost, measured.** Interleaved pool: 18/24 → **24/24 served, 6 → 0 stranded**, the prolific author going from 2 to 3 posts per page at spaced positions. In a BURST pool where one author owns 5 of the top 6 slices, page 1 goes from a clean, well-spaced page that loses three posts forever, to a 4-run of one author at the tail that loses none. A smaller pool means the cap can no longer REPLACE a dominant author's surplus with someone else's post, only reposition it — when one author owns more of the window than the cap admits, the cap is arithmetically unsatisfiable and degrades to ordering. Today's cleaner page buys its diversity by deleting content, which is not the trade the code claimed to make. Note this is not a new class of behaviour: the pre-scored path (Explore) has had exactly it since its remedy landed.

**Every comment that promised deferral was corrected**, in `diversifyByAuthor.ts`, `capDiscoveryShare.ts` (comment only, behaviour untouched — its "roll forward" clause became false under the fix), `engine/types.ts`, and `shared-types/src/mtn/config.ts`, which also now records that raising the cap does not change the degradation, only lets the run start earlier.

**Follow-up flagged, not done:** block-appending is the worst arrangement of an unsatisfiable cap (maximum run length). Spacing re-admitted overflow instead would be a genuine improvement, but it changes `diversifyByAuthor` for Explore too and is a design decision about what the cap means when the pool IS the page.

## Test plan

- [x] `bun run --cwd packages/shared-types build` (rebuilt before typecheck)
- [x] `tsc --noEmit` clean in `packages/backend`
- [x] `packages/backend/src/__tests__/feedEngine.test.ts` — 431 files / 4704 tests green
- [x] Coverage gate passes; golden master needed no changes
- [x] Mutation test: reintroducing the deep-pool rerank fails exactly one named test reporting `strandedCount: 6`, run twice (full-file revert and a surgical two-line revert)
- [x] Control non-vacuous: a pool with one post per author strands nothing in both states

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>