### PR TITLE
chore(deps): Oxy SDK — core 19, services 27, contracts 0.23, federation 0.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@oxyhq/crowdsource": "0.3.0",
         "@oxyhq/crowdsource-contracts": "0.3.0",
         "@oxyhq/crowdsource-express": "0.3.0",
-        "@oxyhq/federation": "^0.11.0",
+        "@oxyhq/federation": "^0.12.0",
         "@oxyhq/protocol": "^0.1.6",
         "@socket.io/redis-adapter": "^8.3.0",
         "@syra.fm/sdk": "catalog:",
@@ -241,9 +241,9 @@
   },
   "catalog": {
     "@oxyhq/bloom": "^0.73.0",
-    "@oxyhq/contracts": "^0.22.0",
-    "@oxyhq/core": "^18.0.0",
-    "@oxyhq/services": "^26.2.0",
+    "@oxyhq/contracts": "^0.23.0",
+    "@oxyhq/core": "^19.0.0",
+    "@oxyhq/services": "^27.0.0",
     "@syra.fm/sdk": "^0.7.0",
     "@types/bun": "1.3.14",
     "@types/jsonwebtoken": "^9.0.10",
@@ -773,9 +773,9 @@
 
     "@oxyhq/bloom": ["@oxyhq/bloom@0.73.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-kOWcMfNZWPPYtwru8MrFes5nte31ChH+72PpKdMYB2QGVFQAdgqxNfAILITrIaBAfgU3Ib/acy0gPAItp9pVkA=="],
 
-    "@oxyhq/contracts": ["@oxyhq/contracts@0.22.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-eVXTTjc8V8HinP8f4jKCULzFW2NzwplJadtTKvTPlr2mXaDyl0qFX6l9OasxM0E0ArIcj98vL20U0+CRsJvrDA=="],
+    "@oxyhq/contracts": ["@oxyhq/contracts@0.23.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-2vNM5wRBIDXO1XJ+K3xORGCQr3aWnGLvPswURGvG6PFSuVevLCd2L0NuzzqCcVAOT1/9imfBLq51WKwQ4VdO8w=="],
 
-    "@oxyhq/core": ["@oxyhq/core@18.0.0", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.22.0", "@oxyhq/protocol": "^0.1.6", "@scure/bip39": "^1.6.0", "@types/elliptic": "^6.4.18", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^8.0.0", "helmet": "^8.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express", "helmet"] }, "sha512-RhWFbQDFbWjWRDiREeFTn7sg5VZd8CqdCTmhneLEAAAQgmPjTf9DED6okZTNYrEiby2+S/JLz1QKpyRzZgcG7w=="],
+    "@oxyhq/core": ["@oxyhq/core@19.0.0", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.23.0", "@oxyhq/protocol": "^0.1.6", "@scure/bip39": "^1.6.0", "@types/elliptic": "^6.4.18", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^8.0.0", "helmet": "^8.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express", "helmet"] }, "sha512-ZZRvUJX8KEzUGMk/9hHQzv8uJPtqBSLSTHzDOOjJytDciXwCbISsMi/pWD3Bi7OY5DjeZ4D6kE1LiKUtjXpMtg=="],
 
     "@oxyhq/crowdsource": ["@oxyhq/crowdsource@0.3.0", "", { "dependencies": { "zod": "^4.4.3" }, "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0" } }, "sha512-YwLDyeIsXrU9qC8H51DW8KQI571HhdLXS3DjaPlJZ3n9W/Eeb/Xu+bqIHqLdFjViu/3Cvjw+dSYLPz2Zh/VAGg=="],
 
@@ -785,11 +785,11 @@
 
     "@oxyhq/crowdsource-testing": ["@oxyhq/crowdsource-testing@0.3.0", "", { "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0" } }, "sha512-Yd/cStpexe+Pl7rrSKJFkBJ8SAuid9uLBCj6VmQ30YvEB4WY2ravJUzpoTI/UTQy11gwXBuMAImzoaYxIlO4cA=="],
 
-    "@oxyhq/federation": ["@oxyhq/federation@0.11.0", "", { "dependencies": { "@oxyhq/core": "^18.0.0" }, "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-xIe2Muemqid3O5K60V/e3rQk1UAO5Wi3v8yxRgRNcWJvfHyChSsdAiQLunPGsaV1nrdmaqP080TRFtqoEJg88Q=="],
+    "@oxyhq/federation": ["@oxyhq/federation@0.12.0", "", { "dependencies": { "@oxyhq/contracts": "^0.23.0", "@oxyhq/core": "^19.0.0" }, "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-aKOGq7xlA6fZpsqFKH+ufYeaCCF44MaT0OI2NKH4QKuP/FR70PU7018jj7/fP9x6Ds/a5BTQSFGU6viVRjwuYg=="],
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.6", "", { "dependencies": { "@oxyhq/contracts": "^0.18.0", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-modules-core": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-/27AFpvOwxt19XWdZYJy0W4TnIQbK+IhPOfQVlod4s/kEuzIzMXo0zi9MSystegFu1RhZHKGjaxOTo+83Sx3Sw=="],
 
-    "@oxyhq/services": ["@oxyhq/services@26.2.0", "", { "dependencies": { "@oxyhq/contracts": "0.22.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@oxyhq/core": "^17.0.3 || ^18.0.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "expo-web-browser": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-css": "^3.0.6", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "expo-web-browser", "nativewind", "react-native-css", "react-native-keyboard-controller"] }, "sha512-hiLYHuIMVVAARsFQUdlOti56KdJxokS9HIttmS0kgBz8yFZA3dOG/kiM/7WybVSrqIkoWqdMrRENbUd0hccpJg=="],
+    "@oxyhq/services": ["@oxyhq/services@27.0.0", "", { "dependencies": { "@oxyhq/contracts": "0.23.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@oxyhq/core": "^19.0.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "expo-web-browser": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-css": "^3.0.6", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "expo-web-browser", "nativewind", "react-native-css", "react-native-keyboard-controller"] }, "sha512-DVxNjOAWkyS/pRInyMAJ3/AFd75L+/3S1BfPeto8kEn/sMTN8P1qbECKzvIsbsgWa/Rrn5LNlCKl+7lO4z2hYg=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     ],
     "catalog": {
       "@oxyhq/bloom": "^0.73.0",
-      "@oxyhq/contracts": "^0.22.0",
-      "@oxyhq/core": "^18.0.0",
-      "@oxyhq/services": "^26.2.0",
+      "@oxyhq/contracts": "^0.23.0",
+      "@oxyhq/core": "^19.0.0",
+      "@oxyhq/services": "^27.0.0",
       "@syra.fm/sdk": "^0.7.0",
       "@types/bun": "1.3.14",
       "@types/jsonwebtoken": "^9.0.10",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -25,7 +25,7 @@
     "@oxyhq/crowdsource": "0.3.0",
     "@oxyhq/crowdsource-contracts": "0.3.0",
     "@oxyhq/crowdsource-express": "0.3.0",
-    "@oxyhq/federation": "^0.11.0",
+    "@oxyhq/federation": "^0.12.0",
     "@oxyhq/protocol": "^0.1.6",
     "@socket.io/redis-adapter": "^8.3.0",
     "@syra.fm/sdk": "catalog:",


### PR DESCRIPTION
Bumps the four Oxy SDK packages published from OxyHQServices `58e5c41e`.

| package | from | to |
|---|---|---|
| `@oxyhq/contracts` | 0.22.0 | **0.23.0** |
| `@oxyhq/core` | 18.0.0 | **19.0.0** |
| `@oxyhq/services` | 26.2.0 | **27.0.0** |
| `@oxyhq/federation` | 0.11.0 | **0.12.0** |

## What the versions carry

**The identity-cache sweep.** `updateAccount`, `updateProfile`, `updatePrivacySettings` and the `@oxyhq/core/server` invalidation subscriber now share ONE key enumeration (`utils/identityCacheSweep.ts`) instead of two hand-written lists that had drifted apart — `updateAccount` never busted `GET:/profiles/username/<handle>`, so the refetch after an edit overwrote the freshly-merged entry with the pre-edit profile. `@oxyhq/services` gains `upsertCachedUser(qc, user, viewerId, { cleared: [...] })`: oxy-api omits a cleared scalar rather than sending `null`, so a cleared avatar is byte-identical on the wire to a sparse projection and the caller has to say which fields it emptied.

**Why core and services are MAJORS.** Not the cache work — an unrelated change landed between the two commits: the single-valued `organizationCategory` became the ordered `accountCategories` list, so `OrganizationCategory` / `ORGANIZATION_CATEGORIES` are gone from contracts and core. **Nothing in this repo referenced either symbol** (grepped across `packages/` before bumping), so the majors are inert here. The new 46-id `accountCategories` vocabulary is what unblocks the channel category picker and the profile chips.

**federation 0.12** stops announcing every Oxy account to the fediverse as a `Person` — the type is derived from `AccountKind` (`personal`→`Person`, `organization`/`project`/`channel`→`Organization`, `bot`→`Service`). It also widens the inbound profile-`Update` condition, which accepted only `Person|Service|Application` and so discarded every Lemmy community's profile edits in silence.

## Two things worth knowing about the ranges

- **`@oxyhq/federation` is not catalogued** (single consumer, `packages/backend/package.json`). In a `0.x` version a caret pins the MINOR, so `^0.11.0` would never have reached 0.12.0 — the range had to be raised explicitly or the backend would have kept the old engine with a green install.
- **No new nested copies.** `@alia.onl/sdk` and `@syra.fm/sdk` each bring their own `@oxyhq/services@26.0.0` → `@oxyhq/core@17.0.2`. Those are byte-identical to what `main` already records — verified by running the same grep against `origin/main`'s committed lockfile, not by reasoning about ranges.

## Verification

Every published package was checked from a **clean external install outside the monorepo** plus a real `import()`, not from the publish CLI's output — including that `ACCOUNT_CATEGORY_IDS` has exactly **46** entries (47 would have meant a stale tree; `entertainment` was dropped in the final revision) and that `isApActorType('Group')` is `true`, which is the Lemmy fix.

Local gates, all under the pinned Node 22.17.0:

- `check:workspace` — green, doctor reports the workspace reproducible
- `build` + `check:types` — **0 type errors**
- backend **439 files / 4828 tests**, frontend **151 suites / 1407 tests**, shared-types 145, mcp 32 — all pass
- `.github/scripts/verify-lockfile.sh origin/main` — the committed lockfile is exactly the incremental resolution, 16 lines

The 8 `import/first` lint warnings are pre-existing in test files this diff does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)