### PR TITLE
feat(channels): the marker beside a channel's name answers what a channel is

### DIFF
--- a/packages/frontend/components/AccountBadge.tsx
+++ b/packages/frontend/components/AccountBadge.tsx
@@ -19,14 +19,21 @@ import { HIT_SLOP_MD } from '@/styles/hitSlop';
  * remote (fediverse / Bluesky) or a channel.
  *
  * INERT BY DEFAULT. A marker is a statement, not a control: it renders as a
- * plain labelled icon everywhere unless a caller explicitly hands it
- * `onExplainNetwork`. The default matters more than it looks — this component
- * appears on ~15 surfaces (every post header, every who-to-follow row, search,
- * suggestions, notifications, hover cards, member lists) and only ONE of them,
- * the profile, is a place where a reader asking "what is this?" has room for an
- * answer. A prop defaulting to interactive that each surface had to switch off
- * would be the same bug with more places to forget it, and every surface added
- * later would inherit the wrong behaviour silently.
+ * plain labelled icon everywhere unless a caller explicitly hands it the
+ * handler for the marker it is drawing — `onExplainNetwork` for the federated
+ * one, `onExplainChannel` for the channel one. The default matters more than it
+ * looks — this component appears on ~15 surfaces (every post header, every
+ * who-to-follow row, search, suggestions, notifications, hover cards, member
+ * lists) and only the account's OWN page is a place where a reader asking "what
+ * is this?" has room for an answer. A prop defaulting to interactive that each
+ * surface had to switch off would be the same bug with more places to forget
+ * it, and every surface added later would inherit the wrong behaviour silently.
+ *
+ * The two handlers are separate props rather than one, and that is the point
+ * rather than an accident of naming: each is read by exactly one branch below,
+ * so no call site can wire the fediverse explainer to a channel icon or the
+ * channel explainer to a remote account. One prop covering both would put that
+ * mistake back within reach of every surface that draws a marker.
  *
  * Being inert is also what keeps the marker from stealing the row's tap: on a
  * post row or a who-to-follow card the whole row navigates, and a nested
@@ -53,8 +60,12 @@ interface IdentityMarkerProps extends IdentityBadgeVisualProps {
   /**
    * Opt IN to interactivity. Absent → a plain icon that cannot be tapped and
    * cannot swallow an enclosing row's press.
+   *
+   * Deliberately named for what it DOES here rather than for which explainer it
+   * opens: each branch of {@link AccountBadge} hands it that branch's own
+   * handler, and this component is the shared mechanism, not the choice.
    */
-  onExplainNetwork?: () => void;
+  onExplain?: () => void;
 }
 
 /**
@@ -64,7 +75,7 @@ interface IdentityMarkerProps extends IdentityBadgeVisualProps {
 function IdentityMarker({
   Icon,
   a11yLabel,
-  onExplainNetwork,
+  onExplain,
   size = 15,
   className,
   color,
@@ -77,15 +88,15 @@ function IdentityMarker({
       // identity line that a parent may make pressable, so an opted-in marker
       // keeps its tap to itself rather than also firing the row's navigation.
       event?.stopPropagation?.();
-      onExplainNetwork?.();
+      onExplain?.();
     },
-    [onExplainNetwork],
+    [onExplain],
   );
 
   const iconClassName = className ?? (color ? undefined : 'text-muted-foreground');
   const icon = <Icon size={size} color={color} className={iconClassName} />;
 
-  if (!onExplainNetwork) {
+  if (!onExplain) {
     // `image` rather than no role: the marker carries meaning a sighted reader
     // gets from the glyph, so it stays in the accessibility tree — it simply
     // stops being announced as something that can be activated.
@@ -127,12 +138,18 @@ export interface AccountBadgeProps extends IdentityBadgeVisualProps {
    */
   network?: ExternalNetwork;
   /**
-   * Opt IN to the fediverse explainer. Honoured ONLY by the federated marker:
-   * the channel marker has no explainer to open, so it is inert on every
-   * surface including a channel's own page. Wiring the fediverse dialog to a
-   * channel icon is therefore not something a call site can do by mistake.
+   * Opt IN to the fediverse explainer. Honoured ONLY by the federated marker.
+   * Passing it alongside a `channel` kind does nothing, so wiring the fediverse
+   * dialog to a channel icon is not something a call site can do by mistake.
    */
   onExplainNetwork?: () => void;
+  /**
+   * Opt IN to the channel explainer. Honoured ONLY by the channel marker, and
+   * only the channel's own page passes it — a channel marker beside a name in a
+   * post header, a who-to-follow row or a search result stays a statement,
+   * because those rows are already a tap that goes somewhere.
+   */
+  onExplainChannel?: () => void;
 }
 
 /**
@@ -168,6 +185,7 @@ export function AccountBadge({
   isFederated,
   network = 'activitypub',
   onExplainNetwork,
+  onExplainChannel,
   ...visual
 }: AccountBadgeProps) {
   const { t } = useTranslation();
@@ -191,13 +209,20 @@ export function AccountBadge({
         {...visual}
         Icon={FediverseIcon}
         a11yLabel={t('fediverse.remoteBadge.a11yLabel')}
-        onExplainNetwork={onExplainNetwork}
+        onExplain={onExplainNetwork}
       />
     );
   }
 
   if (kind === 'channel') {
-    return <IdentityMarker {...visual} Icon={ChannelIcon} a11yLabel={t('channels.badge.a11yLabel')} />;
+    return (
+      <IdentityMarker
+        {...visual}
+        Icon={ChannelIcon}
+        a11yLabel={t('channels.badge.a11yLabel')}
+        onExplain={onExplainChannel}
+      />
+    );
   }
 
   return null;
@@ -221,7 +246,7 @@ export function FediverseSharingBadge({
       {...visual}
       Icon={FediverseIcon}
       a11yLabel={t('fediverse.badge.a11yLabel')}
-      onExplainNetwork={onExplainNetwork}
+      onExplain={onExplainNetwork}
     />
   );
 }

--- a/packages/frontend/components/Channels/ChannelInfoDialog.tsx
+++ b/packages/frontend/components/Channels/ChannelInfoDialog.tsx
@@ -1,0 +1,155 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Dialog, useDialogControl } from '@oxyhq/bloom/dialog';
+import { Button } from '@oxyhq/bloom/button';
+import { ChannelIcon } from '@/assets/icons/channel-icon';
+
+type ExplainerStep = 0 | 1 | 2;
+
+/**
+ * The three facts a reader actually needs, in the order the questions arrive:
+ * what following one commits you to, why there is no reply box, and whose words
+ * these are. Deliberately not a feature list — every step names something the
+ * reader can observe on the page behind the dialog.
+ */
+const STEP_KEYS: readonly { title: string; body: string }[] = [
+  { title: 'channels.explainer.step1.title', body: 'channels.explainer.step1.body' },
+  { title: 'channels.explainer.step2.title', body: 'channels.explainer.step2.body' },
+  { title: 'channels.explainer.step3.title', body: 'channels.explainer.step3.body' },
+];
+
+let globalShowChannelInfo: (() => void) | null = null;
+
+/**
+ * Open the channel explainer. Routed to the single `ChannelInfoDialogProvider`
+ * host in the providers tree rather than mounted beside the marker that asks for
+ * it, so the dialog outlives the header's own render and there is one instance
+ * however many markers a screen draws. No-ops if the host isn't mounted yet.
+ */
+export function showChannelInfo() {
+  globalShowChannelInfo?.();
+}
+
+/**
+ * Single global host for the channel explainer. Mount once near the app root
+ * (see `AppProviders`).
+ *
+ * BOOT-SAFETY (critical, and the reason this host looks emptier than it should):
+ * it is mounted eagerly at app boot — before the async i18n init effect in
+ * `RootLayout` has run — so it must NOT call any suspenseful hook. `useTranslation`
+ * is one: under react-i18next's default `useSuspense: true` it throws a promise
+ * while i18n is still initializing, which would discard the root render, so the
+ * init effect never commits, its promise never resolves, and the app deadlocks on
+ * a blank screen with no error at all. This host therefore owns ONLY the open
+ * flag and renders NOTHING until `showChannelInfo` is called — which also keeps
+ * the Dialog's reanimated bottom-sheet out of the boot path. Every translated or
+ * dialog-dependent piece lives in `ChannelInfoDialogContent`, mounted on demand,
+ * by which point i18n is long ready.
+ */
+export function ChannelInfoDialogProvider() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    globalShowChannelInfo = () => {
+      setIsOpen(true);
+    };
+    return () => {
+      globalShowChannelInfo = null;
+    };
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  // Nothing requested → render nothing. Crucially this returns BEFORE any
+  // suspenseful hook exists in this component, keeping app boot safe.
+  if (!isOpen) return null;
+
+  return <ChannelInfoDialogContent onClose={handleClose} />;
+}
+
+/**
+ * The explainer's actual UI: Bloom's adaptive `Dialog` — a bottom sheet on narrow
+ * viewports, a centered card on desktop — stepping through the three cards.
+ * Mounted ONLY once a request exists, so `useTranslation` here is always safe.
+ *
+ * It owns its own `control` and OPENS ITSELF on mount: the Dialog's imperative
+ * handle binds `control` during the commit's layout phase, before this passive
+ * mount effect runs, so `control.open()` always reaches a bound handle — no
+ * `setTimeout` and no dependency on how the request was triggered.
+ */
+function ChannelInfoDialogContent({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  const control = useDialogControl();
+  const [step, setStep] = useState<ExplainerStep>(0);
+
+  useEffect(() => {
+    control.open();
+  }, [control]);
+
+  const isFirstStep = step === 0;
+  const isLastStep = step === 2;
+
+  const onPrimary = useCallback(() => {
+    if (isLastStep) {
+      control.close();
+      return;
+    }
+    setStep((current) => (current + 1) as ExplainerStep);
+  }, [control, isLastStep]);
+
+  const onSecondary = useCallback(() => {
+    if (isFirstStep) {
+      control.close();
+      return;
+    }
+    setStep((current) => (current - 1) as ExplainerStep);
+  }, [control, isFirstStep]);
+
+  const dots = useMemo(
+    () =>
+      STEP_KEYS.map((keys, index) => (
+        <View
+          key={keys.title}
+          className={
+            index === step ? 'w-2 h-2 rounded-full bg-primary' : 'w-2 h-2 rounded-full bg-border'
+          }
+        />
+      )),
+    [step],
+  );
+
+  return (
+    <Dialog
+      control={control}
+      onClose={onClose}
+      placement={{ base: 'bottom', md: 'center' }}
+      label={t('channels.explainer.title')}
+    >
+      <View className="items-center gap-4 py-4">
+        <View className="w-20 h-20 rounded-full bg-primary/10 items-center justify-center">
+          <ChannelIcon size={40} className="text-primary" />
+        </View>
+        <Text className="text-foreground text-xl font-bold text-center">
+          {t(STEP_KEYS[step].title)}
+        </Text>
+        <Text className="text-muted-foreground text-base leading-6 text-center">
+          {t(STEP_KEYS[step].body)}
+        </Text>
+      </View>
+
+      <View className="flex-row items-center justify-center gap-2 py-4">{dots}</View>
+
+      <View className="gap-3">
+        <Button variant="primary" size="large" onPress={onPrimary}>
+          {isLastStep ? t('channels.explainer.done') : t('channels.explainer.next')}
+        </Button>
+        <Button variant="ghost" size="large" onPress={onSecondary}>
+          {isFirstStep ? t('channels.explainer.cancel') : t('channels.explainer.back')}
+        </Button>
+      </View>
+    </Dialog>
+  );
+}

--- a/packages/frontend/components/Channels/__tests__/ChannelInfoDialog.test.tsx
+++ b/packages/frontend/components/Channels/__tests__/ChannelInfoDialog.test.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import TestRenderer, { type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
+
+/**
+ * The channel explainer, and the one property that fails catastrophically and
+ * silently: the host is mounted at app BOOT, so it must render nothing — and in
+ * particular must not reach `useTranslation` — until something asks for it.
+ * Under react-i18next's default `useSuspense: true` that hook throws a promise
+ * while i18n is initializing, which discards the root render, so the init effect
+ * never commits and the app deadlocks on a blank screen with no console output.
+ * This app has shipped that exact white screen before.
+ *
+ * A test cannot see a deadlock, so it is pinned from the observable side: the
+ * translator is a spy, and mounting the host must not call it. Mutating the host
+ * to render its content unconditionally turns that assertion red.
+ */
+
+const mockTranslate = jest.fn((key: string) => {
+  const catalog: Record<string, unknown> = require('@/locales/en.json');
+  const resolved = key
+    .split('.')
+    .reduce<unknown>(
+      (node, part) =>
+        node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined,
+      catalog,
+    );
+  return typeof resolved === 'string' ? resolved : `MISSING_I18N_KEY:${key}`;
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => mockTranslate(key) }),
+}));
+
+jest.mock('@/assets/icons/channel-icon', () => ({ ChannelIcon: 'ChannelIcon' }));
+
+/**
+ * Both aliases carry a `Mock` prefix because a `jest.mock` factory may not
+ * reference an out-of-scope name — and babel's hoist guard applies that to a
+ * TYPE annotation too, so a plainly-named `Control` fails the suite at load with
+ * "Invalid variable access", not at a line anyone would suspect. The prefix is
+ * the documented escape hatch and is case-insensitive.
+ */
+type MockDialogControl = { open: () => void; close: () => void };
+type MockNode = React.ReactNode;
+
+/**
+ * Bloom's `Dialog` reduced to the contract this component actually uses: it
+ * renders its children, and `control.close()` reaches the `onClose` the caller
+ * passed. Registration happens in an effect, which is also what makes the
+ * component's own "open on mount" assumption meaningful here.
+ */
+jest.mock('@oxyhq/bloom/dialog', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const closers = new Map<MockDialogControl, () => void>();
+
+  return {
+    __esModule: true,
+    useDialogControl: (): MockDialogControl =>
+      ReactActual.useMemo<MockDialogControl>(() => {
+        const control: MockDialogControl = {
+          open: () => {},
+          close: () => closers.get(control)?.(),
+        };
+        return control;
+      }, []),
+    Dialog: ({
+      control,
+      onClose,
+      children,
+    }: {
+      control: MockDialogControl;
+      onClose: () => void;
+      children: MockNode;
+    }) => {
+      ReactActual.useEffect(() => {
+        closers.set(control, onClose);
+        return () => {
+          closers.delete(control);
+        };
+      }, [control, onClose]);
+      return children;
+    },
+  };
+});
+
+jest.mock('@oxyhq/bloom/button', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { Pressable, Text } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    Button: ({ children, onPress }: { children: MockNode; onPress: () => void }) =>
+      ReactActual.createElement(
+        Pressable,
+        { onPress, accessibilityRole: 'button' },
+        ReactActual.createElement(Text, null, children),
+      ),
+  };
+});
+
+// eslint-disable-next-line import/first
+import { ChannelInfoDialogProvider, showChannelInfo } from '../ChannelInfoDialog';
+// eslint-disable-next-line import/first
+import enStrings from '@/locales/en.json';
+
+const COPY = enStrings.channels.explainer;
+
+function mount(): ReactTestRenderer {
+  let renderer!: ReactTestRenderer;
+  TestRenderer.act(() => {
+    renderer = TestRenderer.create(<ChannelInfoDialogProvider />);
+  });
+  return renderer;
+}
+
+/** Every string the render put on screen. */
+function textOf(renderer: ReactTestRenderer): string {
+  return JSON.stringify(renderer.toJSON() ?? null);
+}
+
+/**
+ * The rendered text of a subtree. Reading `props.children` instead would work
+ * for a button whose child is a bare string and throw "circular structure" for
+ * one whose child is an element — which is the same button one render later.
+ */
+function textIn(node: ReactTestInstance | string): string {
+  return typeof node === 'string' ? node : node.children.map(textIn).join('');
+}
+
+/**
+ * Presses the button showing `label`.
+ *
+ * `Pressable` drives its host through the responder props, so the host View
+ * carries no `onPress` — the handler lives on the composite, which is why this
+ * looks for a press handler anywhere rather than for the button host.
+ */
+function press(renderer: ReactTestRenderer, label: string): void {
+  const button = renderer.root
+    .findAll((node) => typeof node.props?.onPress === 'function', { deep: true })
+    .find((node) => textIn(node).includes(label));
+  if (!button) throw new Error(`no button labelled "${label}" on screen`);
+  TestRenderer.act(() => {
+    button.props.onPress();
+  });
+}
+
+/** Unmounting commits the host's cleanup, so it belongs inside `act` like any update. */
+function unmount(renderer: ReactTestRenderer): void {
+  TestRenderer.act(() => {
+    renderer.unmount();
+  });
+}
+
+beforeEach(() => {
+  mockTranslate.mockClear();
+});
+
+describe('the host is inert until something asks for the explainer', () => {
+  it('renders nothing and translates nothing when mounted at boot', () => {
+    const renderer = mount();
+
+    expect(renderer.toJSON()).toBeNull();
+    expect(mockTranslate).not.toHaveBeenCalled();
+
+    unmount(renderer);
+  });
+
+  it('does nothing at all when nothing has mounted the host', () => {
+    // The imperative entry point is a module-level slot. Calling it with no host
+    // must be a no-op rather than a throw, because a deep link can land on a
+    // screen before the providers tree has finished mounting.
+    expect(() => showChannelInfo()).not.toThrow();
+  });
+});
+
+describe('the explainer opens, steps and closes', () => {
+  it('walks all three cards forward and back, then dismisses', () => {
+    const renderer = mount();
+
+    TestRenderer.act(() => {
+      showChannelInfo();
+    });
+
+    expect(textOf(renderer)).toContain(COPY.step1.title);
+    expect(textOf(renderer)).toContain(COPY.step1.body);
+
+    press(renderer, COPY.next);
+    expect(textOf(renderer)).toContain(COPY.step2.title);
+    press(renderer, COPY.next);
+    expect(textOf(renderer)).toContain(COPY.step3.title);
+
+    // Last card swaps the primary label rather than offering a fourth step.
+    expect(textOf(renderer)).toContain(COPY.done);
+    expect(textOf(renderer)).not.toContain(COPY.next);
+
+    press(renderer, COPY.back);
+    expect(textOf(renderer)).toContain(COPY.step2.title);
+    press(renderer, COPY.back);
+    expect(textOf(renderer)).toContain(COPY.step1.title);
+
+    // First card offers a dismissal, not a fourth direction.
+    expect(textOf(renderer)).toContain(COPY.cancel);
+    expect(textOf(renderer)).not.toContain(COPY.back);
+
+    press(renderer, COPY.cancel);
+    expect(renderer.toJSON()).toBeNull();
+
+    unmount(renderer);
+  });
+
+  it('closes from the last card and can be opened again from the start', () => {
+    const renderer = mount();
+
+    TestRenderer.act(() => {
+      showChannelInfo();
+    });
+    press(renderer, COPY.next);
+    press(renderer, COPY.next);
+    press(renderer, COPY.done);
+    expect(renderer.toJSON()).toBeNull();
+
+    TestRenderer.act(() => {
+      showChannelInfo();
+    });
+    // Reopening on card three would be the state surviving the unmount.
+    expect(textOf(renderer)).toContain(COPY.step1.title);
+
+    unmount(renderer);
+  });
+
+  it('renders real copy rather than missing keys', () => {
+    const renderer = mount();
+    TestRenderer.act(() => {
+      showChannelInfo();
+    });
+
+    expect(textOf(renderer)).not.toContain('MISSING_I18N_KEY');
+
+    unmount(renderer);
+  });
+});

--- a/packages/frontend/components/Profile/ChannelHeader.tsx
+++ b/packages/frontend/components/Profile/ChannelHeader.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 import { View } from 'react-native';
 import { ZoomableAvatar } from '@/components/ZoomableAvatar';
+import { showChannelInfo } from '@/components/Channels/ChannelInfoDialog';
 import { PrivateBadge } from './PrivateBadge';
 import type { ChannelActionsProps, ChannelHeaderProps } from './types';
 
@@ -99,10 +100,15 @@ export const ChannelHeader = memo(function ChannelHeader({
         verified={verified}
         // Not a guess and not a conditional: this component only ever draws a
         // channel (the route canonicalizes anything else away before it
-        // renders), so the marker states what the page is. It stays INERT —
-        // `AccountBadge` has no explainer for a channel to open, and the page
-        // itself is the explanation.
+        // renders), so the marker states what the page is.
         kind="channel"
+        // THE opt-in, and the only one. A channel is an unfamiliar kind of
+        // account, and this is the one screen where a reader who wants to know
+        // what it is has room for the answer — everywhere else the marker sits
+        // in a row that is already a tap going somewhere, so it stays inert
+        // there (see `AccountBadge`). The handler is channel-specific on
+        // purpose: it cannot reach the fediverse explainer, nor that one this.
+        onExplainChannel={showChannelInfo}
         align="center"
         variant="default"
         trailingBadge={trailingBadge}

--- a/packages/frontend/components/Profile/__tests__/channelExplainer.test.tsx
+++ b/packages/frontend/components/Profile/__tests__/channelExplainer.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import TestRenderer, { type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
+
+/**
+ * The marker beside a channel's name opens the explainer ON THE CHANNEL PAGE.
+ *
+ * `AccountBadge.test.tsx` proves the badge honours the channel opt-in and that a
+ * source scan keeps every other surface off it. (It also owns the only mentions
+ * of the prop's NAME outside production code — that scan is an allow-list, so a
+ * second test writing it down would read as a new surface arming the marker.)
+ * Neither is the thing a reader experiences: between the opt-in and the badge
+ * sit `ChannelHeader` and
+ * `UserName`, and a prop dropped in either forwards nothing while both of those
+ * suites stay green. So this one renders the REAL chain — the header the channel
+ * route mounts, the real `UserName`, the real `AccountBadge` — and presses the
+ * marker.
+ *
+ * The control is the same chain with `kind="channel"` and no opt-in, which is
+ * exactly the call every other surface makes (a post header, a who-to-follow
+ * row, a search result). Without it, "armed on the channel page" and "armed
+ * wherever a channel is named" are the same passing run.
+ *
+ * Mocks below are leaves only — the avatar, the icon font, the theme, the
+ * clipboard — kept out because they drag untransformed ESM or native modules
+ * into the graph, not because they carry any part of the answer.
+ */
+
+const mockShowChannelInfo = jest.fn();
+
+jest.mock('@/components/Channels/ChannelInfoDialog', () => ({
+  showChannelInfo: () => mockShowChannelInfo(),
+}));
+
+jest.mock('@/components/ZoomableAvatar', () => ({ ZoomableAvatar: () => null }));
+jest.mock('@/components/Profile/PrivateBadge', () => ({ PrivateBadge: () => null }));
+jest.mock('@expo/vector-icons/Ionicons', () => 'Ionicons');
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({ colors: { text: '#000000', primary: '#0000ff' } }),
+}));
+jest.mock('@oxyhq/bloom/toast', () => ({ toast: jest.fn() }));
+jest.mock('expo-clipboard', () => ({ setStringAsync: jest.fn() }));
+
+// Host-string stand-ins so "which marker" is read off the render rather than
+// re-derived from the props the test passed in.
+jest.mock('@/assets/icons/channel-icon', () => ({ ChannelIcon: 'ChannelIcon' }));
+jest.mock('@/assets/icons/fediverse-icon', () => ({ FediverseIcon: 'FediverseIcon' }));
+jest.mock('@/assets/icons/verified-icon', () => ({ VerifiedIcon: 'VerifiedIcon' }));
+jest.mock('@/assets/icons/agent-icon', () => ({ AgentIcon: 'AgentIcon' }));
+jest.mock('@/assets/icons/automated-icon', () => ({ AutomatedIcon: 'AutomatedIcon' }));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const catalog: Record<string, unknown> = require('@/locales/en.json');
+      const resolved = key
+        .split('.')
+        .reduce<unknown>(
+          (node, part) =>
+            node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined,
+          catalog,
+        );
+      return typeof resolved === 'string' ? resolved : `MISSING_I18N_KEY:${key}`;
+    },
+  }),
+}));
+
+// eslint-disable-next-line import/first
+import { ChannelHeader } from '@/components/Profile/ChannelHeader';
+// eslint-disable-next-line import/first
+import UserName from '@/components/UserName';
+// eslint-disable-next-line import/first
+import enStrings from '@/locales/en.json';
+
+const CHANNEL_LABEL = enStrings.channels.badge.a11yLabel;
+
+function render(element: React.ReactElement): ReactTestRenderer {
+  let renderer!: ReactTestRenderer;
+  TestRenderer.act(() => {
+    renderer = TestRenderer.create(element);
+  });
+  return renderer;
+}
+
+/** The channel marker, wherever it ended up in the tree. */
+function marker(renderer: ReactTestRenderer): ReactTestInstance[] {
+  return renderer.root.findAll(
+    (node) =>
+      typeof node.type === 'string' && node.props?.accessibilityLabel === CHANNEL_LABEL,
+    { deep: true },
+  );
+}
+
+function pressHandlers(renderer: ReactTestRenderer): ((event?: unknown) => void)[] {
+  const unique = new Set<(event?: unknown) => void>();
+  renderer.root
+    .findAll((node) => typeof node.props?.onPress === 'function', { deep: true })
+    .forEach((node) => unique.add(node.props.onPress));
+  return [...unique];
+}
+
+beforeEach(() => {
+  mockShowChannelInfo.mockClear();
+});
+
+describe('the channel page arms the marker beside the name', () => {
+  it('renders it as a button and opens the explainer when it is pressed', () => {
+    const renderer = render(
+      <ChannelHeader
+        displayName="The Daily"
+        username="thedaily"
+        isPrivate={false}
+        UserNameComponent={UserName}
+      />,
+    );
+
+    const found = marker(renderer);
+    expect(found).toHaveLength(1);
+    expect(found[0].props.accessibilityRole).toBe('button');
+
+    expect(mockShowChannelInfo).not.toHaveBeenCalled();
+    TestRenderer.act(() => {
+      pressHandlers(renderer).forEach((press) => press());
+    });
+    expect(mockShowChannelInfo).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('every other surface that names a channel leaves the marker alone', () => {
+  it('renders the SAME marker as a plain image with no handler', () => {
+    // The `UserName` call a post header, a who-to-follow row and a search result
+    // all make: the account's kind, no opt-in.
+    const renderer = render(<UserName name="The Daily" handle="thedaily" kind="channel" />);
+
+    const found = marker(renderer);
+    // Positive control — inert is not "absent", and the whole point of this file
+    // is that the two are told apart.
+    expect(found).toHaveLength(1);
+    expect(found[0].props.accessibilityRole).toBe('image');
+
+    TestRenderer.act(() => {
+      pressHandlers(renderer).forEach((press) => press());
+    });
+    expect(mockShowChannelInfo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -330,6 +330,13 @@ export interface UserNameProps {
    */
   onExplainNetwork?: () => void;
   /**
+   * Opt IN to making the CHANNEL marker open the channel explainer. A separate
+   * prop from `onExplainNetwork` rather than a shared one, so the two dialogs
+   * cannot be crossed at a call site — see {@link AccountBadge}. Only a
+   * channel's own page passes it.
+   */
+  onExplainChannel?: () => void;
+  /**
    * Opt-in tap-to-copy for the `@handle`. Default off so the handle stays plain
    * text inside navigable parents (e.g. who-to-follow cards), letting the parent
    * receive the tap and navigate. Only the profile header enables it.

--- a/packages/frontend/components/UserName.tsx
+++ b/packages/frontend/components/UserName.tsx
@@ -9,7 +9,7 @@ import { AgentIcon } from '@/assets/icons/agent-icon';
 import { AutomatedIcon } from '@/assets/icons/automated-icon';
 import type { UserNameProps } from '@/components/Profile/types';
 
-const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated, kind, isAgent, isAutomated, unifiedColors, onPress, onExplainNetwork, copyableHandle, variant = 'default', align = 'start', style, trailingBadge, handleTrailing }) => {
+const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated, kind, isAgent, isAutomated, unifiedColors, onPress, onExplainNetwork, onExplainChannel, copyableHandle, variant = 'default', align = 'start', style, trailingBadge, handleTrailing }) => {
     const theme = useTheme();
     const nameStyle = [styles.name, variant === 'small' && styles.nameSmall, style?.name];
 
@@ -114,11 +114,13 @@ const UserName: React.FC<UserNameProps> = ({ name, handle, verified, isFederated
                 )}
                 {/* One marker for the account's whole identity state — remote or
                     channel, never both, and nothing at all for an ordinary local
-                    account. Inert unless the caller passed `onExplainNetwork`. */}
+                    account. Inert unless the caller passed the handler for the
+                    marker it draws; forwarded, never chosen between here. */}
                 <AccountBadge
                     isFederated={isFederated}
                     kind={kind}
                     onExplainNetwork={onExplainNetwork}
+                    onExplainChannel={onExplainChannel}
                     size={iconSize}
                     color={theme.colors.text}
                     style={{ transform: [{ translateY: baselineNudge }] }}

--- a/packages/frontend/components/__tests__/AccountBadge.test.tsx
+++ b/packages/frontend/components/__tests__/AccountBadge.test.tsx
@@ -210,8 +210,19 @@ describe('AccountBadge — which marker the account state chooses', () => {
   });
 });
 
-describe('AccountBadge — the channel marker has no explainer to open', () => {
-  it('ignores a handler for a channel while honouring the SAME handler when federated', () => {
+/**
+ * The two explainers are two PROPS, and each branch reads exactly one of them.
+ *
+ * A single shared handler would be the same component with the same call sites
+ * and one new defect available: a surface that wanted the channel explainer
+ * would arm the fediverse one on every remote account it draws, and vice versa.
+ * Neither miswiring is visible in a render — both produce a tappable marker that
+ * opens A dialog — so each direction is asserted here, and each assertion is
+ * paired with the handler that IS honoured, or "ignored the handler" would be
+ * indistinguishable from "the prop does not work at all".
+ */
+describe('AccountBadge — the two explainers cannot be crossed', () => {
+  it('gives the channel marker the fediverse handler and nothing happens', () => {
     const onExplainNetwork = jest.fn();
 
     const channel = render(<AccountBadge kind="channel" onExplainNetwork={onExplainNetwork} />);
@@ -224,6 +235,73 @@ describe('AccountBadge — the channel marker has no explainer to open', () => {
     // channel branch and not about a handler prop that never worked.
     const federated = render(<AccountBadge isFederated onExplainNetwork={onExplainNetwork} />);
     expect(buttons(federated)).toHaveLength(1);
+  });
+
+  it('gives the federated marker the channel handler and nothing happens', () => {
+    const onExplainChannel = jest.fn();
+
+    const federated = render(<AccountBadge isFederated onExplainChannel={onExplainChannel} />);
+    expect(icons(federated, 'FediverseIcon')).toHaveLength(1);
+    expect(buttons(federated)).toHaveLength(0);
+    expect(pressHandlers(federated)).toHaveLength(0);
+
+    const channel = render(<AccountBadge kind="channel" onExplainChannel={onExplainChannel} />);
+    expect(buttons(channel)).toHaveLength(1);
+  });
+});
+
+describe('AccountBadge — the channel marker opts in on its own prop', () => {
+  it('stays a plain icon with no handler', () => {
+    const renderer = render(<AccountBadge kind="channel" />);
+
+    expect(icons(renderer, 'ChannelIcon')).toHaveLength(1);
+    expect(labels(renderer)).toContain(CHANNEL_LABEL);
+    expect(buttons(renderer)).toHaveLength(0);
+    expect(pressHandlers(renderer)).toHaveLength(0);
+  });
+
+  it('becomes a control when a caller opts in, and then it calls back', () => {
+    const onExplainChannel = jest.fn();
+    const renderer = render(<AccountBadge kind="channel" onExplainChannel={onExplainChannel} />);
+
+    const armed = buttons(renderer);
+    expect(armed).toHaveLength(1);
+    expect(armed[0].props.accessibilityLabel).toBe(CHANNEL_LABEL);
+
+    const handlers = pressHandlers(renderer);
+    expect(handlers).toHaveLength(1);
+    TestRenderer.act(() => {
+      handlers[0]();
+    });
+    expect(onExplainChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps an opted-in tap to itself so an enclosing row does not also fire', () => {
+    const onExplainChannel = jest.fn();
+    const renderer = render(<AccountBadge kind="channel" onExplainChannel={onExplainChannel} />);
+    const stopPropagation = jest.fn();
+
+    TestRenderer.act(() => {
+      pressHandlers(renderer)[0]({ stopPropagation });
+    });
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(onExplainChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it('draws a channel that is also federated as the inert remote marker, armed or not', () => {
+    // The federation-wins rule and the opt-in are independent, and a reader
+    // could reasonably expect arming the channel handler to force the channel
+    // branch. It does not: which marker is drawn is decided by the account, and
+    // only then does that marker look for its own handler.
+    const onExplainChannel = jest.fn();
+    const renderer = render(
+      <AccountBadge kind="channel" isFederated onExplainChannel={onExplainChannel} />,
+    );
+
+    expect(icons(renderer, 'FediverseIcon')).toHaveLength(1);
+    expect(icons(renderer, 'ChannelIcon')).toHaveLength(0);
+    expect(buttons(renderer)).toHaveLength(0);
   });
 });
 
@@ -247,14 +325,70 @@ describe('FediverseSharingBadge — the own-profile marker obeys the same defaul
 /**
  * The rule the unit tests above cannot hold on their own: they prove the DEFAULT
  * is inert, not that every surface actually takes it. A screen added next year
- * that passes `onExplainNetwork` would leave all of them green — which is the
- * exact regression this whole change exists to prevent, so it is gated on the
- * source rather than remembered.
+ * that passes either handler would leave all of them green — which is the exact
+ * regression this whole change exists to prevent, so it is gated on the source
+ * rather than remembered.
+ *
+ * ONE walk feeds both gates. Two copies of this scan is two places for the
+ * traversal, the roots and the vacuity floor to drift, and the second copy is
+ * the one that quietly stops scanning anything.
  */
-describe('surfaces — only the profile opts the marker in', () => {
-  const FRONTEND_ROOT = path.resolve(__dirname, '../..');
-  const SCAN_ROOTS = ['app', 'components'];
+const FRONTEND_ROOT = path.resolve(__dirname, '../..');
+const SCAN_ROOTS = ['app', 'components'];
 
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      walk(full, out);
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const sources = SCAN_ROOTS.flatMap((root) => walk(path.join(FRONTEND_ROOT, root))).map((file) => ({
+  rel: path.relative(FRONTEND_ROOT, file).split(path.sep).join('/'),
+  text: fs.readFileSync(file, 'utf8'),
+}));
+
+/** Every scanned file that writes the handler's name down, for any reason. */
+function filesNaming(handler: string): string[] {
+  return sources.filter(({ text }) => text.includes(handler)).map(({ rel }) => rel);
+}
+
+describe('surfaces — the scan itself', () => {
+  it('scanned a real tree (vacuity floor)', () => {
+    // A broken traversal returns nothing and makes every assertion below pass.
+    expect(sources.length).toBeGreaterThan(300);
+    const rendering = sources.filter(({ text }) => /<AccountBadge[\s/>]/.test(text));
+    expect(rendering.length).toBeGreaterThanOrEqual(4);
+  });
+
+  /**
+   * The gates below are allow-lists, so they can only ever catch a NEW file.
+   * These two name the surfaces that draw a marker today and must keep taking
+   * the default — without them, "armed on one page" and "armed everywhere" are
+   * the same green run, since an allow-list says nothing about a file it does
+   * not contain until that file breaks the rule.
+   */
+  it.each([
+    ['components/Post/PostHeader.tsx', 'a post row is already a tap that opens the post'],
+    ['components/ProfileHoverCard/index.web.tsx', 'a hover card is already a link to the profile'],
+    ['components/notifications/NotificationItem.tsx', 'a notification row navigates on tap'],
+  ])('leaves the marker inert in %s (%s)', (rel) => {
+    const source = sources.find((entry) => entry.rel === rel);
+    // Not `?.text` — a renamed file must fail loudly rather than pass by absence.
+    expect(source).toBeDefined();
+    expect(source?.text).toMatch(/<AccountBadge[\s/>]/);
+    expect(source?.text).not.toContain('onExplainNetwork');
+    expect(source?.text).not.toContain('onExplainChannel');
+  });
+});
+
+describe('surfaces — only the profile arms the FEDIVERSE marker', () => {
   /**
    * Files permitted to mention `onExplainNetwork`, each for a stated reason.
    * Anything else naming it is a surface arming the marker.
@@ -267,45 +401,64 @@ describe('surfaces — only the profile opts the marker in', () => {
     'components/__tests__/AccountBadge.test.tsx': 'this test',
   };
 
-  function walk(dir: string, out: string[] = []): string[] {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        if (entry.name === 'node_modules') continue;
-        walk(full, out);
-      } else if (/\.tsx?$/.test(entry.name)) {
-        out.push(full);
-      }
-    }
-    return out;
-  }
-
-  const files = SCAN_ROOTS.flatMap((root) => walk(path.join(FRONTEND_ROOT, root)));
-  const sources = files.map((file) => ({
-    rel: path.relative(FRONTEND_ROOT, file).split(path.sep).join('/'),
-    text: fs.readFileSync(file, 'utf8'),
-  }));
-
-  it('scanned a real tree (vacuity floor)', () => {
-    // A broken traversal returns nothing and makes every assertion below pass.
-    expect(sources.length).toBeGreaterThan(300);
-    const rendering = sources.filter(({ text }) => /<AccountBadge[\s/>]/.test(text));
-    expect(rendering.length).toBeGreaterThanOrEqual(4);
-  });
-
-  it('no surface other than the profile arms the marker', () => {
-    const offenders = sources
-      .filter(({ text }) => text.includes('onExplainNetwork'))
-      .map(({ rel }) => rel)
-      .filter((rel) => !(rel in ALLOWED));
-
-    expect(offenders).toEqual([]);
+  it('no surface other than the profile arms it', () => {
+    expect(filesNaming('onExplainNetwork').filter((rel) => !(rel in ALLOWED))).toEqual([]);
   });
 
   it('every allow-listed file still names it, so the list cannot rot', () => {
-    const named = new Set(
-      sources.filter(({ text }) => text.includes('onExplainNetwork')).map(({ rel }) => rel),
-    );
+    const named = new Set(filesNaming('onExplainNetwork'));
     expect(Object.keys(ALLOWED).filter((rel) => !named.has(rel))).toEqual([]);
+  });
+
+  it('the opt-in reaches the badge rather than only being mentioned', () => {
+    // The rot check above is satisfied by a comment. This one is not.
+    const profile = sources.find((entry) => entry.rel === 'components/ProfileScreen.tsx');
+    expect(profile?.text).toMatch(/onExplainNetwork=\{/);
+  });
+});
+
+describe('surfaces — only a channel’s own page arms the CHANNEL marker', () => {
+  /**
+   * The same rule for the second explainer, kept as its own allow-list rather
+   * than merged with the one above: the point of two props is that the two
+   * permissions are different, and one shared list would let a file arm either
+   * explainer once it was on it for one of them.
+   */
+  const ALLOWED: Record<string, string> = {
+    'components/AccountBadge.tsx': 'defines the opt-in',
+    'components/Profile/types.ts': 'declares the prop on UserNameProps',
+    'components/UserName.tsx': 'forwards its own prop through; opts nothing in itself',
+    'components/Profile/ChannelHeader.tsx':
+      "THE opt-in — a channel's own page is where the explainer belongs",
+    'components/__tests__/AccountBadge.test.tsx': 'this test',
+  };
+
+  it('no surface other than the channel header arms it', () => {
+    expect(filesNaming('onExplainChannel').filter((rel) => !(rel in ALLOWED))).toEqual([]);
+  });
+
+  it('every allow-listed file still names it, so the list cannot rot', () => {
+    const named = new Set(filesNaming('onExplainChannel'));
+    expect(Object.keys(ALLOWED).filter((rel) => !named.has(rel))).toEqual([]);
+  });
+
+  it('the opt-in reaches the badge rather than only being mentioned', () => {
+    const header = sources.find((entry) => entry.rel === 'components/Profile/ChannelHeader.tsx');
+    expect(header?.text).toMatch(/onExplainChannel=\{/);
+  });
+
+  it('is the only file outside the badge that opens the dialog', () => {
+    // `onExplainChannel` is the prop; `showChannelInfo` is the effect. A screen
+    // could skip the prop entirely and call the dialog from an onPress of its
+    // own, which the allow-list above would never see. Tests are excluded — one
+    // has to name it to spy on it, and this file names it on the line below.
+    const callers = sources
+      .filter(({ rel }) => !rel.includes('__tests__'))
+      .filter(({ text }) => text.includes('showChannelInfo'))
+      .map(({ rel }) => rel);
+    expect(callers.sort()).toEqual([
+      'components/Channels/ChannelInfoDialog.tsx',
+      'components/Profile/ChannelHeader.tsx',
+    ]);
   });
 });

--- a/packages/frontend/components/providers/AppProviders.tsx
+++ b/packages/frontend/components/providers/AppProviders.tsx
@@ -26,6 +26,7 @@ import { ConfirmPromptProvider } from '@/components/common/ConfirmPrompt';
 import { ActionMenuHost } from '@/components/common/ActionMenu';
 import { ContentDialogHost } from '@/components/common/ContentDialog';
 import { FediverseInfoDialogProvider } from '@/components/Fediverse/FediverseInfoDialog';
+import { ChannelInfoDialogProvider } from '@/components/Channels/ChannelInfoDialog';
 import { LiveFeatureHost } from '@/components/providers/LiveFeatureProviders';
 import { LiveRoomControllerProvider } from '@/context/LiveRoomContext';
 import i18n from '@/lib/i18n';
@@ -151,6 +152,7 @@ export const AppProviders = memo(function AppProviders({
                               <ActionMenuHost />
                               <ContentDialogHost />
                               <FediverseInfoDialogProvider />
+                              <ChannelInfoDialogProvider />
                             </HomeRefreshProvider>
                             <LiveFeatureHost />
                           </LiveRoomControllerProvider>

--- a/packages/frontend/components/providers/__tests__/appShellContextReach.test.tsx
+++ b/packages/frontend/components/providers/__tests__/appShellContextReach.test.tsx
@@ -109,6 +109,9 @@ jest.mock('@/components/common/ContentDialog', () => ({ ContentDialogHost: () =>
 jest.mock('@/components/Fediverse/FediverseInfoDialog', () => ({
   FediverseInfoDialogProvider: () => null,
 }));
+jest.mock('@/components/Channels/ChannelInfoDialog', () => ({
+  ChannelInfoDialogProvider: () => null,
+}));
 jest.mock('@/components/providers/LiveFeatureProviders', () => ({ LiveFeatureHost: () => null }));
 
 jest.mock('@oxyhq/bloom/tab-bar', () => ({

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -1883,6 +1883,25 @@
       "lastWrote": "Last wrote {{time}}",
       "empty": "No writers yet",
       "emptyDetail": "This channel names the person who wrote each post. None have been published yet."
+    },
+    "explainer": {
+      "title": "About channels",
+      "step1": {
+        "title": "What is a channel?",
+        "body": "A channel is an account that publishes on its own. Following it brings its posts to your feed without you following any of the people who write for it — that separation is what a channel is for."
+      },
+      "step2": {
+        "title": "It publishes, it doesn’t reply",
+        "body": "A channel’s posts are ordinary posts: they reach feeds, search and the fediverse like anyone else’s, and you can boost one to your own profile. What’s missing is the reply box — a channel never takes replies, and that is how channels are built rather than a setting someone switched off."
+      },
+      "step3": {
+        "title": "Who wrote this?",
+        "body": "A channel signs its own posts. With “Name the writer” on, the person who wrote one is shown alongside the channel; with it off, the post is the channel’s alone. That is the channel’s own choice, not something missing."
+      },
+      "next": "Next",
+      "back": "Back",
+      "done": "Got it",
+      "cancel": "Cancel"
     }
   },
   "trendGraph": {

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -1854,6 +1854,25 @@
       "lastWrote": "Escribió por última vez {{time}}",
       "empty": "Todavía no hay nadie nombrado",
       "emptyDetail": "Este canal nombra a quien escribe cada publicación. Todavía no ha publicado ninguna."
+    },
+    "explainer": {
+      "title": "Sobre los canales",
+      "step1": {
+        "title": "¿Qué es un canal?",
+        "body": "Un canal es una cuenta que publica por sí misma. Al seguirlo, sus publicaciones llegan a tu feed sin que sigas a ninguna de las personas que escriben en él: esa separación es justo para lo que sirve un canal."
+      },
+      "step2": {
+        "title": "Publica, no responde",
+        "body": "Las publicaciones de un canal son publicaciones normales: llegan a los feeds, a la búsqueda y al fediverso como las de cualquiera, y puedes republicar una en tu propio perfil. Lo que no hay es cuadro de respuesta: un canal nunca acepta respuestas, y así es como están hechos los canales, no un ajuste que alguien haya desactivado."
+      },
+      "step3": {
+        "title": "¿Quién escribió esto?",
+        "body": "Un canal firma sus propias publicaciones. Con «Nombrar a quien escribe» activado, junto al canal aparece la persona que escribió cada una; desactivado, la publicación es solo del canal. Es una decisión del propio canal, no algo que falte."
+      },
+      "next": "Siguiente",
+      "back": "Atrás",
+      "done": "Entendido",
+      "cancel": "Cancelar"
     }
   },
   "trendGraph": {

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -1634,6 +1634,25 @@
       "lastWrote": "Ha scritto l’ultima volta {{time}}",
       "empty": "Ancora nessuno indicato",
       "emptyDetail": "Questo canale indica chi scrive ogni post. Non ne ha ancora pubblicato nessuno."
+    },
+    "explainer": {
+      "title": "Informazioni sui canali",
+      "step1": {
+        "title": "Che cos’è un canale?",
+        "body": "Un canale è un account che pubblica per conto proprio. Seguendolo, i suoi post arrivano nel tuo feed senza che tu segua nessuna delle persone che ci scrivono: è proprio a questa separazione che serve un canale."
+      },
+      "step2": {
+        "title": "Pubblica, non risponde",
+        "body": "I post di un canale sono post normali: arrivano nei feed, nella ricerca e nel fediverso come quelli di chiunque altro, e puoi ricondividerne uno sul tuo profilo. Quello che manca è il riquadro delle risposte: un canale non accetta mai risposte, ed è così che sono fatti i canali, non un’impostazione che qualcuno ha disattivato."
+      },
+      "step3": {
+        "title": "Chi ha scritto questo?",
+        "body": "Un canale firma i propri post. Con «Indica chi scrive» attivo, accanto al canale viene mostrata la persona che ha scritto il post; disattivato, il post è solo del canale. È una scelta del canale stesso, non qualcosa che manca."
+      },
+      "next": "Avanti",
+      "back": "Indietro",
+      "done": "Ho capito",
+      "cancel": "Annulla"
     }
   },
   "trendGraph": {


### PR DESCRIPTION
A channel is the least self-explanatory thing on the page. It is an account, it looks like an account, and then it behaves like nothing else on the site: following it does not follow anybody who writes for it, its posts have no reply box, and its byline is either a person or nobody depending on a setting the channel owns. A reader who wants to know what they are looking at has, until now, had nowhere to ask.

The marker was already there and already meant "channel". It now opens a three-card explainer, **on the channel's own page and nowhere else**.

## The prop is new, not widened

`onExplainChannel` is a SECOND prop rather than a widening of `onExplainNetwork`, and that is the whole design. #593 made the badge inert by default and arranged that the fediverse handler is read only by the federated branch, so no surface can wire that dialog to a channel icon by mistake. One prop covering both explainers hands that mistake back to every surface that draws a marker — in both directions — so each branch reads exactly one handler, and **each handler has its own allow-list** in `AccountBadge.test.tsx`. `IdentityMarker`'s internal prop is renamed to `onExplain` because it is the shared mechanism and never the choice.

Everywhere else stays a statement. A post header, a who-to-follow row, a search result and a hover card are already a tap that goes somewhere, and a marker that opens a dialog there takes that tap.

## The copy

Three cards, about what a channel DOES, since that is what is surprising:

1. **What is a channel?** — "A channel is an account that publishes on its own. Following it brings its posts to your feed without you following any of the people who write for it — that separation is what a channel is for."
2. **It publishes, it doesn't reply** — "A channel's posts are ordinary posts: they reach feeds, search and the fediverse like anyone else's, and you can boost one to your own profile. What's missing is the reply box — a channel never takes replies, and that is how channels are built rather than a setting someone switched off."
3. **Who wrote this?** — "A channel signs its own posts. With \"Name the writer\" on, the person who wrote one is shown alongside the channel; with it off, the post is the channel's alone. That is the channel's own choice, not something missing."

Nothing here offers to block, report or act as the channel — a channel can never be acted as, and #597 is removing the other two for people who operate one. `es` and `it` are real translations reusing the terminology already in those catalogs ("Nombrar a quien escribe", "Indica chi scrive").

## Boot safety

The dialog follows `FediverseInfoDialog` exactly, including the part that matters: the host is mounted at boot and renders NOTHING until asked, so it never reaches `useTranslation` while i18n is still initializing. That suspend discards the root render and deadlocks the app on a blank screen with no console output, which this app has shipped before — so the test spies on the translator and fails if mounting the host calls it.

## Gates

Every one mutation-tested, control green before and after, and each failure names the offending file:

| mutation | result |
|---|---|
| a post header arms the CHANNEL marker | red, names `PostHeader.tsx` |
| a post header arms the FEDIVERSE marker (#593's property) | red, names `PostHeader.tsx` |
| the channel header stops arming it | red (scan **and** render chain) |
| `UserName` stops FORWARDING it | scan **green**, render chain red |
| the two explainers crossed inside `AccountBadge` | red |
| the boot host renders its content unconditionally | red |
| the channel branch loses its handler | red (unit **and** render chain) |

Row four is why `channelExplainer.test.tsx` exists: a source scan cannot see a dropped forward. It renders the real chain — `ChannelHeader` → `UserName` → `AccountBadge` — presses the marker, and asserts the same chain with no opt-in stays `role="image"` in the same suite, so "armed on the channel page" and "armed wherever a channel is named" cannot pass identically.

## Verification

Run on this branch, rebased onto `29d6d656`, after a reinstall for the SDK bump in #601 (core 19.0.0, services 27.0.0, contracts 0.23.0, bloom 0.73.0):

- `bunx tsc --noEmit` — 0 errors (baseline 0)
- `bun run test:coverage` — **155 suites / 1444 tests**, all pass (baseline 151 / 1407); coverage up on all four axes
- `bun run lint:frontend` — 0 errors, 8 warnings (baseline identical, all pre-existing `import/first` in tests); the new files were also linted explicitly, with a control proving eslint actually reads them
- `bun run validate:i18n` — pass, untranslated counts **unchanged** (es 35, it 156)

Real foregrounded Chromium on a private Xvfb, trusted CDP input (never `element.click()`): 15/15 — the marker is `role="button"` with a real hit area, the tap opens the card, it paints (opacity 1, non-zero box), all three cards step forward and back, the last card swaps Next for Got it, dismissal removes it, and it opens again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)