### PR TITLE
fix(ci): stop cancelling CI on main, where it is the release trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,33 @@ on:
 permissions:
   contents: read
 
+# On a pull request a new push genuinely supersedes the old one, so cancelling
+# is right. On main it is backwards: three deploy workflows (deploy-aws,
+# deploy-frontends, deploy-mcp-aws) trigger on `workflow_run` of this workflow
+# and every one of them requires `conclusion == 'success'`, so CI here is not a
+# check — it is the release trigger, and a cancelled run is a release that never
+# happens. Merges land faster than CI completes, so `cancel-in-progress: true`
+# made the repo deploy LESS the busier it got: six of the last eight runs on
+# main were cancelled, one after 54 seconds, leaving production 40+ minutes
+# behind main.
+#
+# Gated on the event rather than on `github.ref != 'refs/heads/main'`. Both are
+# correct for the two triggers this workflow declares, but they differ on
+# triggers it does not have yet: a merge_group run's ref is
+# `refs/heads/gh-readonly-queue/...`, so the ref test would resume cancelling
+# the runs that gate a merge, reintroducing exactly this bug. The event test
+# fails toward NOT cancelling, which costs runner minutes and never a release.
+#
+# The group deliberately still collapses every main push into one lane. That is
+# what bounds the cost: GitHub cancels a previously *pending* run when a new one
+# queues, so main holds at most one running plus one pending run rather than a
+# thundering herd, and the pending one that survives is always the newest
+# commit. Superseded commits are not stranded — deployment-scope.sh diffs
+# against the `deployed/<target>` marker tag, not against the previous commit,
+# so the next successful release carries the whole backlog.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BUN_VERSION: '1.3.14'


### PR DESCRIPTION
## The bug

`ci.yml` had `cancel-in-progress: true` on a group keyed by `github.ref`. On a PR that is right. On `main` it is backwards: **three** deploy workflows trigger on `workflow_run` of CI and every one requires `conclusion == 'success'` —

| workflow | concurrency group | requires |
|---|---|---|
| `deploy-aws.yml` (backend) | `deploy-mention-backend` | `workflow_run.conclusion == 'success'` |
| `deploy-frontends.yml` | `deploy-mention-frontend` | `workflow_run.conclusion == 'success'` |
| `deploy-mcp-aws.yml` | `deploy-mention-mcp` | `workflow_run.conclusion == 'success'` |

So on `main`, CI is not a check — it is the release trigger, and each merge cancelled the previous merge's release. Merges land every 2–3 min; CI takes longer. **The repo deployed less the busier it got.**

Measured on `main` before this change (`gh run list --workflow=ci.yml --branch=main`): the six runs preceding the current one were `cancelled`, `cancelled`, `cancelled`, `cancelled`, `cancelled`, `success`. Last successful `Deploy Frontends` was 13:34 UTC for `c23934ab`; at 14:18 production was still on it, 40+ min behind `main`.

## The change

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why the event and not the ref

`on:` declares exactly two triggers (verified by parsing the file, not by reading it — `on` has exactly the keys `push` and `pull_request`, both `branches: [main]`):

| trigger | `github.event_name` | `github.ref` | this expression | `github.ref != 'refs/heads/main'` |
|---|---|---|---|---|
| push → main | `push` | `refs/heads/main` | **false** ✅ | false ✅ |
| pull_request → main | `pull_request` | `refs/pull/N/merge` | **true** ✅ | true ✅ |
| *(hypothetical)* merge_group | `merge_group` | `refs/heads/gh-readonly-queue/main/...` | **false** ✅ | **true** ❌ reintroduces the bug |
| *(hypothetical)* workflow_dispatch on a branch | `workflow_dispatch` | `refs/heads/foo` | false (wasteful, safe) | true |
| *(hypothetical)* schedule | `schedule` | `refs/heads/main` | false ✅ | false ✅ |

Both forms are correct for the two triggers that exist today. They diverge on triggers that do not exist yet, and the event test is the one that **fails toward not cancelling** — the failure mode is wasted runner minutes, never a dropped release.

## What this costs, stated plainly

**The queue is bounded at two, and nothing here is a thundering herd.** The group still collapses every `main` push into one lane. GitHub cancels a previously *pending* run when a new one queues, so `main` holds at most **1 running + 1 pending**, and the pending survivor is always the newest commit.

**Superseded commits are not stranded.** `deployment-scope.sh` diffs the candidate against the `deployed/<target>` marker tag, not against the previous commit ("a commit that only repairs CI still releases whatever an earlier failed run left undeployed"). The next successful release carries the backlog.

**A stale tree cannot ship.** `require-current-main.sh` fails the deploy when `DEPLOY_SHA` is no longer the exact head of `origin/main`, and it is invoked three times in `deploy-frontends.yml` (before build, before production changes, before promotion). This is not theory — run `30819551409` today did exactly that: built `25b07955`, then refused at *Re-verify current main before production promotion* because `main` had moved.

**The real cost:** during a busy stretch more runs now complete, so more deploys start and some are refused at that guard, producing red `Deploy Frontends` runs. That is the guard doing its job, and it is already today's behaviour. I did not widen the guard's scope in this PR.

## Sibling-workflow audit

Asked for either way, so: **`ci.yml` was the only `cancel-in-progress: true` in the repo.** All six others are already `false` — the three deploys above plus `run-blocked-domain-content-purge`, `run-blocked-domain-purge` and `run-federated-text-backfill`. No other workflow cancels something whose completion another workflow depends on.

## Verification

- `bun run validate:workflows` → `Validated 7 GitHub Actions workflow file(s).`, exit 0.
- **Positive control**, so that pass is not vacuous: appending a duplicate top-level `permissions:` key made it exit 1 (`uniqueKeys: true` caught it); restoring made it exit 0 again.
- Parsed `ci.yml` with the same `strict` + `uniqueKeys` options: 0 errors, and `concurrency['cancel-in-progress']` is the expected expression string.
- `actionlint` **is not installed on this machine and was not run.**
- GitHub expression evaluation cannot be executed locally, hence the explicit per-trigger table above rather than a claim that it was tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)