### PR TITLE
feat(channels): deleting a channel takes its posts with it

### DIFF
--- a/packages/backend/src/__tests__/agentsMdReferences.test.ts
+++ b/packages/backend/src/__tests__/agentsMdReferences.test.ts
@@ -43,6 +43,12 @@ const UNRESOLVABLE_BY_DESIGN: ReadonlyMap<string, string> = new Map([
     '.expo/types/router.d.ts',
     "expo-router's generated route types — written into a gitignored .expo/ by the dev server, absent on a clean checkout",
   ],
+  [
+    'packages/api/src/routes/privacy.ts',
+    'a CROSS-REPO pointer: oxy-api lives in OxyHQServices, so this resolves for a reader and never against ' +
+      "this repo's `git ls-files`. The reference is correct and load-bearing — it names where the block " +
+      'refusal has to live, precisely because Mention has no block route of its own to guard',
+  ],
 ]);
 
 /**

--- a/packages/backend/src/__tests__/services/channelCascadeCoverage.test.ts
+++ b/packages/backend/src/__tests__/services/channelCascadeCoverage.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  CHANNEL_CASCADE,
+  EMBEDDED_CHANNEL_REFERENCES,
+  NOT_A_CHANNEL_REFERENCE,
+  OWNED_BY_OXY,
+} from '../../services/channelDeletion/channelCascadeManifest';
+
+/**
+ * Deleting a channel has to remove EVERYTHING that points at it. A cascade
+ * written by hand satisfies that on the day it is written and then decays
+ * silently: somebody adds a model with a `postId`, nothing references it from
+ * the cascade, and rows keep pointing at a channel that no longer exists. There
+ * is no error, no failing request and no log line — the first symptom is a
+ * hydration miss months later.
+ *
+ * So the cascade is enumerated as data (`channelCascadeManifest.ts`) and this
+ * test compares that data against the REAL model tree. A new model carrying an
+ * id-shaped field fails this test on the commit that adds it, and the failure
+ * names the field and says which list to put it in.
+ *
+ * WHY THE SCANNER KEYS ON ID SHAPE AND NOT ON A LIST OF KNOWN NAMES
+ *
+ * The first version of this matched a hand-written set of names (`postId`,
+ * `oxyUserId`, `authorId`, …). Run against the tree it missed
+ * `ModerationEnforcement.subjectId` — a real reference to a post, under a name
+ * nobody would have thought to list — and `Trending.actorIds`. A name list can
+ * only find references somebody already knew about, which is precisely the class
+ * of bug this test exists to prevent. Matching the SHAPE (`…Id`, `…Ids`, `…Uri`,
+ * and a few explicit extras) over-collects instead, and every over-collection is
+ * dismissed once, in writing, in `NOT_A_CHANNEL_REFERENCE`.
+ *
+ * Modelled on `__tests__/agentsMdReferences.test.ts`, which is this repo's
+ * reference implementation of a source-scanning gate with a vacuity floor.
+ */
+
+const MODELS_DIR = resolve(__dirname, '../../models');
+
+/**
+ * A schema field declaration: two or more leading spaces, an identifier, a
+ * colon. Deliberately loose — it also picks up nested option objects and index
+ * definitions, and over-collecting is the safe direction here. Anything it
+ * catches that is not a reference gets dismissed in `NOT_A_CHANNEL_REFERENCE`,
+ * which costs one line and buys the guarantee that nothing is missed.
+ */
+const FIELD_DECLARATION = /^\s{2,}([a-zA-Z_][a-zA-Z0-9_]*)\s*:/gm;
+
+/**
+ * Which of those field names could carry a reference to an account or a post.
+ * `Of$` catches `boostOf`/`quoteOf`; the named extras are the reference fields
+ * that carry no id-ish suffix at all.
+ */
+const ID_SHAPED = /Id$|Ids$|Uri$|Uris$|Of$|Authors$|^createdBy$|^reporter$|^mentions$|^edges$/;
+
+function modelFiles(): string[] {
+  return readdirSync(MODELS_DIR)
+    .filter((name) => name.endsWith('.ts'))
+    .sort();
+}
+
+/** Every `Model.field` key declared in every model, optionally narrowed to id-shaped ones. */
+function declaredKeys(onlyIdShaped: boolean): string[] {
+  const keys: string[] = [];
+  for (const file of modelFiles()) {
+    const model = file.replace(/\.ts$/, '');
+    const source = readFileSync(resolve(MODELS_DIR, file), 'utf8');
+    const fields = new Set(
+      Array.from(source.matchAll(FIELD_DECLARATION), (match) => match[1]).filter(
+        (field) => !onlyIdShaped || ID_SHAPED.test(field),
+      ),
+    );
+    for (const field of [...fields].sort()) keys.push(`${model}.${field}`);
+  }
+  return keys;
+}
+
+const cascadeKeys = new Set(CHANNEL_CASCADE.map((step) => `${step.model}.${step.field}`));
+const declared = declaredKeys(true);
+/**
+ * The staleness check below runs against EVERY declared field, not just the
+ * id-shaped ones, because the cascade legitimately covers a few references whose
+ * names carry no id suffix (`UserSettings.restrictedUsers`). Narrowing both
+ * directions to the same regex would report those as stale.
+ */
+const allDeclared = new Set(declaredKeys(false));
+const files = modelFiles();
+
+describe('channel deletion cascade covers the real model tree', () => {
+  it('scans a plausible number of models and reference fields', () => {
+    // The vacuity floor. A traversal that silently found nothing — a moved
+    // directory, a regex that stopped matching — would make every assertion
+    // below pass by checking nothing, which is the exact failure this file
+    // exists to prevent elsewhere.
+    expect(files.length).toBeGreaterThanOrEqual(55);
+    expect(declared.length).toBeGreaterThanOrEqual(120);
+    expect(cascadeKeys.size).toBeGreaterThanOrEqual(60);
+  });
+
+  it('classifies every id-shaped field in every model', () => {
+    const unclassified = declared.filter(
+      (key) => !cascadeKeys.has(key) && !NOT_A_CHANNEL_REFERENCE.has(key),
+    );
+
+    expect(
+      unclassified,
+      'These model fields are not covered by the channel-deletion cascade:\n  ' +
+        `${unclassified.join('\n  ')}\n` +
+        'Every id-shaped field must be classified exactly once. Either add a step to CHANNEL_CASCADE ' +
+        '(it references a channel account or a channel post, and here is what the cascade does about it), ' +
+        'or add it to NOT_A_CHANNEL_REFERENCE with what the id actually names. Leaving it out means a row ' +
+        'pointing at a deleted channel survives, silently.',
+    ).toEqual([]);
+  });
+
+  it('never classifies one field both ways', () => {
+    const both = declared.filter(
+      (key) => cascadeKeys.has(key) && NOT_A_CHANNEL_REFERENCE.has(key),
+    );
+
+    expect(
+      both,
+      `These fields are in BOTH CHANNEL_CASCADE and NOT_A_CHANNEL_REFERENCE:\n  ${both.join('\n  ')}\n` +
+        'A field is either a reference the cascade handles or not a reference at all. Two answers means ' +
+        'the cascade acts on something the manifest also claims is irrelevant.',
+    ).toEqual([]);
+  });
+
+  it('keeps the manifest from naming fields that no longer exist', () => {
+    // The other direction, so the manifest can only ever describe the real tree.
+    // Without this a renamed field leaves a cascade step that quietly matches
+    // nothing, and the coverage assertion above still passes.
+    const stale = [...cascadeKeys, ...NOT_A_CHANNEL_REFERENCE.keys()]
+      .filter((key) => !allDeclared.has(key))
+      .sort();
+
+    expect(
+      stale,
+      `The manifest names fields that no models declare:\n  ${stale.join('\n  ')}\n` +
+        'The field was renamed or removed. Update the manifest — a step that matches nothing is a cascade ' +
+        'that has stopped running while still reading as covered.',
+    ).toEqual([]);
+  });
+
+  it('writes down the references this scanner structurally cannot see', () => {
+    // The blind spot, stated rather than hidden. This test reads DECLARED schema
+    // fields, so a reference embedded in a string (`author|<oxyUserId>` inside a
+    // feed descriptor) or buried in a `Schema.Types.Mixed` blob
+    // (`params.authorIds`) is invisible to it — no schema path names either.
+    //
+    // A gate whose limits are undocumented gets mistaken for a complete one.
+    // These are enumerated by hand instead, each saying whether the cascade
+    // reaches it and, when it does not, why that is harmless.
+    expect(EMBEDDED_CHANNEL_REFERENCES.size).toBeGreaterThanOrEqual(5);
+    for (const [reference, disposition] of EMBEDDED_CHANNEL_REFERENCES) {
+      expect(
+        /REACHED|SCRUBBED|NOT REACHED/.test(disposition),
+        `${reference} must say whether the cascade reaches it — "probably fine" is how a real orphan gets shipped`,
+      ).toBe(true);
+    }
+  });
+
+  it('states what Oxy owns rather than leaving it out', () => {
+    // A reference Mention cannot delete is still a reference. The rule the user
+    // set is "nothing orphaned", and an orphan on the far side of the Oxy
+    // boundary is still an orphan — it just needs a different operator to close
+    // it. Silence here would read as "there is nothing else", which is false.
+    expect(OWNED_BY_OXY.size).toBeGreaterThanOrEqual(4);
+    for (const [boundary, reason] of OWNED_BY_OXY) {
+      expect(boundary.length, 'every cross-boundary entry needs a name').toBeGreaterThan(0);
+      expect(
+        reason.length,
+        `${boundary} needs a written reason — an unexplained exemption is how a real gap gets normalised`,
+      ).toBeGreaterThan(40);
+    }
+  });
+
+  it('gives every cascade step a written reason', () => {
+    const unexplained = CHANNEL_CASCADE.filter((step) => step.why.trim().length < 20).map(
+      (step) => `${step.model}.${step.field}`,
+    );
+
+    expect(
+      unexplained,
+      `These cascade steps have no real justification:\n  ${unexplained.join('\n  ')}\n` +
+        'Deleting a row and scrubbing a field are different decisions about somebody else\'s data. ' +
+        'The reason is what lets the next person tell a deliberate choice from a copy-paste.',
+    ).toEqual([]);
+  });
+
+  it('deletes rows that exist only for the channel, and scrubs rows that do not', () => {
+    // The distinction the whole design rests on: a row that exists BECAUSE of the
+    // channel dies with it; a row that belongs to somebody else keeps its
+    // content and loses only the pointer. Getting this backwards either strands
+    // an orphan or destroys a third party's post, so the two array-shaped
+    // actions may never be used on a row the channel owns outright.
+    const scrubbed = CHANNEL_CASCADE.filter(
+      (step) => step.action === 'pull-from-array' || step.action === 'unset-field',
+    );
+    expect(scrubbed.length).toBeGreaterThanOrEqual(10);
+
+    const quoteStep = CHANNEL_CASCADE.find(
+      (step) => step.model === 'Post' && step.field === 'quoteOf',
+    );
+    expect(
+      quoteStep?.action,
+      'A quote of a destroyed post keeps its author\'s words. Deleting it would destroy a third party\'s ' +
+        'writing to remove the channel\'s.',
+    ).toBe('unset-field');
+
+    const boostStep = CHANNEL_CASCADE.find(
+      (step) => step.model === 'Post' && step.field === 'boostOf',
+    );
+    expect(
+      boostStep?.action,
+      'A boost has an intentionally empty body and renders entirely from its original, so a surviving one ' +
+        'is a placeholder card with nothing behind it.',
+    ).toBe('delete-row');
+  });
+
+  it('never reattributes a channel post to the person who wrote it', () => {
+    // The one rule that is not about referential integrity at all. With
+    // `signPosts` off, reattributing a post to `writtenByOxyUserId` would
+    // retroactively publish who wrote what — the single promise a channel makes,
+    // broken at the moment the channel is no longer there to answer for it.
+    const writerStep = CHANNEL_CASCADE.find(
+      (step) => step.model === 'Post' && step.field === 'writtenByOxyUserId',
+    );
+
+    expect(writerStep, 'writtenByOxyUserId must be classified, not ignored').toBeDefined();
+    expect(
+      writerStep?.action,
+      'The post is destroyed, never handed to its writer.',
+    ).toBe('delete-row');
+  });
+});

--- a/packages/backend/src/__tests__/services/channelDeletionService.test.ts
+++ b/packages/backend/src/__tests__/services/channelDeletionService.test.ts
@@ -1,0 +1,1305 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `ChannelDeletionService` destroys user data, so these tests are written against
+ * a tiny in-memory Mongo rather than against call assertions alone: "the boost row
+ * is deleted and the quote row survives with its pointer cleared" is a statement
+ * about the END STATE, and a test that only checks which filters were passed
+ * cannot tell a correct filter from one that matches nothing.
+ *
+ * Every model is mocked per-file, never from `setup.ts` — importing a real
+ * Mongoose model here registers a schema that hangs unrelated suites.
+ *
+ * The fake collection throws on any operator it does not implement, which is the
+ * vacuity floor: a filter shape nobody anticipated fails loudly instead of
+ * silently matching nothing and making every assertion below pass.
+ */
+
+const { db, oid, moduleFor, FakeId } = vi.hoisted(() => {
+  /**
+   * Stands in for `mongoose.Types.ObjectId`, so a filter built in the ObjectId
+   * spelling (`Like.postId`) and one built in the string spelling
+   * (`Article.postId`) are genuinely different values that must both still match
+   * the stored document — exactly what `idForm` in the binding table decides.
+   */
+  class FakeId {
+    constructor(private readonly value: string) {}
+    toString(): string {
+      return this.value;
+    }
+    toJSON(): string {
+      return this.value;
+    }
+  }
+
+  type Doc = Record<string, unknown>;
+
+  const normalize = (value: unknown): unknown =>
+    value instanceof FakeId ? value.toString() : value;
+
+  const isOperatorObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && !(value instanceof FakeId)
+    && Object.keys(value).length > 0
+    && Object.keys(value).every((key) => key.startsWith('$'));
+
+  /** Dotted read, descending into an array of subdocuments (`repliers.oxyUserId`). */
+  function valueAtPath(doc: unknown, path: string): unknown {
+    return path.split('.').reduce<unknown>((current, key) => {
+      if (current === undefined || current === null) return undefined;
+      if (Array.isArray(current)) {
+        const collected = current
+          .map((element) =>
+            typeof element === 'object' && element !== null
+              ? (element as Doc)[key]
+              : undefined,
+          )
+          .filter((value) => value !== undefined);
+        return collected.length > 0 ? collected : undefined;
+      }
+      return (current as Doc)[key];
+    }, doc);
+  }
+
+  /** Mongo equality: an array field matches when any element equals the operand. */
+  function containsOrEquals(actual: unknown, expected: unknown): boolean {
+    if (Array.isArray(actual)) {
+      return actual.some((element) => normalize(element) === normalize(expected));
+    }
+    return normalize(actual) === normalize(expected);
+  }
+
+  function matchField(actual: unknown, condition: unknown): boolean {
+    if (!isOperatorObject(condition)) return containsOrEquals(actual, condition);
+
+    return Object.entries(condition).every(([operator, operand]) => {
+      switch (operator) {
+        case '$in':
+          return (operand as unknown[]).some((value) => containsOrEquals(actual, value));
+        case '$nin':
+          return !(operand as unknown[]).some((value) => containsOrEquals(actual, value));
+        case '$ne':
+          return !containsOrEquals(actual, operand);
+        case '$gt':
+          return typeof actual === 'number' && actual > (operand as number);
+        case '$exists':
+          return (actual !== undefined) === operand;
+        case '$elemMatch':
+          return (
+            Array.isArray(actual)
+            && actual.some((element) => matchesFilter(element as Doc, operand as Doc))
+          );
+        default:
+          throw new Error(`fake collection: unsupported query operator "${operator}"`);
+      }
+    });
+  }
+
+  function matchesFilter(doc: Doc, filter: Doc): boolean {
+    return Object.entries(filter).every(([key, condition]) => {
+      if (key === '$or') return (condition as Doc[]).some((sub) => matchesFilter(doc, sub));
+      if (key === '$and') return (condition as Doc[]).every((sub) => matchesFilter(doc, sub));
+      if (key.startsWith('$')) {
+        throw new Error(`fake collection: unsupported top-level operator "${key}"`);
+      }
+      return matchField(valueAtPath(doc, key), condition);
+    });
+  }
+
+  /** Walk to the parent object of a dotted path, without creating anything. */
+  function parentOf(doc: Doc, path: string): { parent: Doc | undefined; key: string } {
+    const segments = path.split('.');
+    const key = segments[segments.length - 1];
+    let current: unknown = doc;
+    for (const segment of segments.slice(0, -1)) {
+      if (typeof current !== 'object' || current === null) return { parent: undefined, key };
+      current = (current as Doc)[segment];
+    }
+    if (typeof current !== 'object' || current === null) return { parent: undefined, key };
+    return { parent: current as Doc, key };
+  }
+
+  function applyUpdate(doc: Doc, update: Doc): boolean {
+    let modified = false;
+    for (const [operator, spec] of Object.entries(update)) {
+      for (const [path, operand] of Object.entries(spec as Doc)) {
+        const { parent, key } = parentOf(doc, path);
+        if (!parent) continue;
+        switch (operator) {
+          case '$unset':
+            if (parent[key] !== undefined) {
+              delete parent[key];
+              modified = true;
+            }
+            break;
+          case '$pull': {
+            const array = parent[key];
+            if (!Array.isArray(array)) break;
+            const kept = array.filter((element) =>
+              isOperatorObject(operand)
+                ? !matchField(element, operand)
+                : typeof operand === 'object' && operand !== null && !(operand instanceof FakeId)
+                  ? !matchesFilter(element as Doc, operand as Doc)
+                  : !containsOrEquals(element, operand),
+            );
+            if (kept.length !== array.length) {
+              parent[key] = kept;
+              modified = true;
+            }
+            break;
+          }
+          case '$inc':
+            if (typeof parent[key] === 'number') {
+              parent[key] = (parent[key] as number) + (operand as number);
+              modified = true;
+            }
+            break;
+          default:
+            throw new Error(`fake collection: unsupported update operator "${operator}"`);
+        }
+      }
+    }
+    return modified;
+  }
+
+  /**
+   * A Mongoose call site may `await` the query or call `.exec()` on it, and both
+   * spellings are live here: this service awaits, while the delegated legs in
+   * `PostDeletionCascade` call `.exec()`. A thenable that is missing `exec` fails
+   * with `deleteMany(...).exec is not a function` rather than with anything about
+   * the assertion, so the fake answers to both.
+   */
+  type Queryable<T> = Promise<T> & { exec: () => Promise<T> };
+  function asQuery<T>(value: T): Queryable<T> {
+    const settled = Promise.resolve(value);
+    return Object.assign(settled, { exec: () => settled });
+  }
+
+  class FakeCollection {
+    docs: Doc[] = [];
+
+    readonly countDocuments = vi.fn((filter: Doc = {}): Queryable<number> =>
+      asQuery(this.docs.filter((doc) => matchesFilter(doc, filter)).length),
+    );
+
+    readonly deleteMany = vi.fn((filter: Doc = {}): Queryable<{ deletedCount: number }> => {
+      const remaining = this.docs.filter((doc) => !matchesFilter(doc, filter));
+      const deletedCount = this.docs.length - remaining.length;
+      this.docs = remaining;
+      return asQuery({ deletedCount });
+    });
+
+    readonly updateMany = vi.fn((filter: Doc, update: Doc): Queryable<{ modifiedCount: number }> => {
+      let modifiedCount = 0;
+      for (const doc of this.docs) {
+        if (matchesFilter(doc, filter) && applyUpdate(doc, update)) modifiedCount += 1;
+      }
+      return asQuery({ modifiedCount });
+    });
+
+    readonly updateOne = vi.fn((filter: Doc, update: Doc): Queryable<{ modifiedCount: number }> => {
+      const target = this.docs.find((doc) => matchesFilter(doc, filter));
+      if (!target) return asQuery({ modifiedCount: 0 });
+      return asQuery({ modifiedCount: applyUpdate(target, update) ? 1 : 0 });
+    });
+
+    readonly find = vi.fn((filter: Doc = {}) => ({
+      lean: async (): Promise<Doc[]> => this.docs.filter((doc) => matchesFilter(doc, filter)),
+    }));
+  }
+
+  const collections = new Map<string, FakeCollection>();
+  const collection = (name: string): FakeCollection => {
+    const existing = collections.get(name);
+    if (existing) return existing;
+    const created = new FakeCollection();
+    collections.set(name, created);
+    return created;
+  };
+
+  const db = {
+    collection,
+    /** Every write method on every collection, for order and read-only assertions. */
+    writeMocks(): ReturnType<typeof vi.fn>[] {
+      return [...collections.values()].flatMap((c) => [c.deleteMany, c.updateMany, c.updateOne]);
+    },
+    reset(): void {
+      for (const c of collections.values()) {
+        c.docs = [];
+        c.countDocuments.mockClear();
+        c.deleteMany.mockClear();
+        c.updateMany.mockClear();
+        c.updateOne.mockClear();
+        c.find.mockClear();
+      }
+    },
+    seed(name: string, docs: Doc[]): void {
+      collection(name).docs = docs;
+    },
+    docs(name: string): Doc[] {
+      return collection(name).docs;
+    },
+    snapshot(): string {
+      return JSON.stringify(
+        Object.fromEntries([...collections.entries()].map(([name, c]) => [name, c.docs])),
+      );
+    },
+  };
+
+  /** The export shape a mocked model module needs: both the named and default binding. */
+  const moduleFor = (name: string, extra: Record<string, unknown> = {}) => ({
+    [name]: collection(name),
+    default: collection(name),
+    ...extra,
+  });
+
+  return { db, oid: (value: string) => new FakeId(value), moduleFor, FakeId };
+});
+
+/**
+ * `PostDeletionCascade` — the delegate the post-dependent phase now runs through —
+ * builds its ObjectId-spelled filters with the real `mongoose`, which rejects
+ * these readable fixture ids (`p1`, `b1`) as invalid and would silently produce an
+ * EMPTY id list. That is not the code under test failing; it is the fixture's id
+ * shape, and swapping every id for a 24-hex string to satisfy it would make every
+ * assertion in this file unreadable. So `Types.ObjectId` becomes the same FakeId
+ * the fixtures use, and validity is the one thing the stub decides differently.
+ */
+vi.mock('mongoose', () => {
+  const stub = {
+    Types: { ObjectId: FakeId },
+    isValidObjectId: (value: unknown) => String(value ?? '').length > 0,
+  };
+  return { ...stub, default: stub };
+});
+
+vi.mock('../../models/Post', () => moduleFor('Post'));
+vi.mock('../../models/Like', () => moduleFor('Like'));
+vi.mock('../../models/Bookmark', () => moduleFor('Bookmark'));
+vi.mock('../../models/PostRecentReplier', () => moduleFor('PostRecentReplier'));
+vi.mock('../../models/Poll', () => moduleFor('Poll'));
+vi.mock('../../models/Article', () => moduleFor('Article'));
+vi.mock('../../models/Postgate', () => moduleFor('Postgate'));
+vi.mock('../../models/Threadgate', () => moduleFor('Threadgate'));
+vi.mock('../../models/Notification', () => moduleFor('Notification'));
+vi.mock('../../models/EngagementOutbox', () => moduleFor('EngagementOutbox'));
+vi.mock('../../models/FeedInteraction', () => moduleFor('FeedInteraction'));
+vi.mock('../../models/RepairFetchFailure', () => moduleFor('RepairFetchFailure'));
+vi.mock('../../models/ContentLabel', () => moduleFor('ContentLabel'));
+vi.mock('../../models/ModerationEnforcement', () => moduleFor('ModerationEnforcement'));
+vi.mock('../../models/Report.model', () =>
+  moduleFor('Report', {
+    ReportedType: {
+      POST: 'post',
+      USER: 'user',
+      COMMENT: 'comment',
+      MESSAGE: 'message',
+      ROOM: 'room',
+    },
+  }),
+);
+vi.mock('../../models/ModerationOutbox', () => moduleFor('ModerationOutbox'));
+vi.mock('../../models/FederationDeliveryQueue', () => moduleFor('FederationDeliveryQueue'));
+vi.mock('../../models/Lane', () => moduleFor('Lane'));
+vi.mock('../../models/LaneMute', () => moduleFor('LaneMute'));
+vi.mock('../../models/UserSettings', () => moduleFor('UserSettings'));
+vi.mock('../../models/ActorKeyPair', () => moduleFor('ActorKeyPair'));
+vi.mock('../../models/FederatedFollow', () => moduleFor('FederatedFollow'));
+vi.mock('../../models/AuthorFollowerSnapshot', () => moduleFor('AuthorFollowerSnapshot'));
+vi.mock('../../models/MentionSignedRecord', () => moduleFor('MentionSignedRecord'));
+vi.mock('../../models/MentionRepoHead', () => moduleFor('MentionRepoHead'));
+vi.mock('../../models/MentionUserNode', () => moduleFor('MentionUserNode'));
+vi.mock('../../models/MentionNodeIngestWitness', () => moduleFor('MentionNodeIngestWitness'));
+vi.mock('../../models/UserBehavior', () => moduleFor('UserBehavior'));
+vi.mock('../../models/UserFeedPreference', () => moduleFor('UserFeedPreference'));
+vi.mock('../../models/Mute', () => moduleFor('Mute'));
+vi.mock('../../models/MuteWord', () => moduleFor('MuteWord'));
+vi.mock('../../models/PostSubscription', () => moduleFor('PostSubscription'));
+vi.mock('../../models/EntityFollow', () => moduleFor('EntityFollow'));
+vi.mock('../../models/FeedLike', () => moduleFor('FeedLike'));
+vi.mock('../../models/FeedReview', () => moduleFor('FeedReview'));
+vi.mock('../../models/FeedGenerator', () => moduleFor('FeedGenerator'));
+vi.mock('../../models/Labeler', () => moduleFor('Labeler'));
+vi.mock('../../models/Poke', () => moduleFor('Poke'));
+vi.mock('../../models/PushToken', () => moduleFor('PushToken'));
+vi.mock('../../models/AccountList', () => moduleFor('AccountList'));
+vi.mock('../../models/CustomFeed', () => moduleFor('CustomFeed'));
+vi.mock('../../models/StarterPack', () => moduleFor('StarterPack'));
+vi.mock('../../models/EndorsementOutbox', () => moduleFor('EndorsementOutbox'));
+vi.mock('../../models/Trending', () => moduleFor('Trending'));
+vi.mock('../../models/FederatedActor', () => moduleFor('FederatedActor'));
+
+const { assertPostsSafeToDelete, collectPostCascadeResidue } = vi.hoisted(() => ({
+  assertPostsSafeToDelete: vi.fn(async (..._args: unknown[]): Promise<void> => undefined),
+  collectPostCascadeResidue: vi.fn(async (): Promise<string[]> => []),
+}));
+vi.mock('../../scripts/lib/adminDeletionPreflight', () => ({
+  assertPostsSafeToDelete,
+  collectPostCascadeResidue,
+}));
+
+const { federateDelete, deliverToFollowers, getUserById } = vi.hoisted(() => ({
+  federateDelete: vi.fn(async () => undefined),
+  deliverToFollowers: vi.fn(async () => undefined),
+  getUserById: vi.fn(async () => ({ username: 'thechannel' })),
+}));
+vi.mock('../../connectors/activitypub/follow.service', () => ({
+  followService: { federateDelete },
+}));
+vi.mock('../../connectors/activitypub/delivery.service', () => ({
+  deliveryService: { deliverToFollowers },
+}));
+vi.mock('../../connectors/activitypub/constants', () => ({
+  actorUrl: (username: string) => `https://mention.earth/ap/users/${username}`,
+}));
+vi.mock('@oxyhq/federation', () => ({
+  AP_CONTEXT: ['https://www.w3.org/ns/activitystreams'],
+}));
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({ getUserById }),
+}));
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+/**
+ * The gate that decides whether this may run at all. Mocked rather than stubbed
+ * through the identity cache, because the whole point of the assertions below is
+ * which ANSWER the gate refuses, and routing that through
+ * `resolveUserSummaries` would test the identity path instead.
+ */
+const { resolveAccountKind } = vi.hoisted(() => ({
+  resolveAccountKind: vi.fn(async (): Promise<string | null> => 'channel'),
+}));
+vi.mock('../../services/publishAsAccount', () => ({ resolveAccountKind }));
+
+/**
+ * The delegate is SPIED, not replaced: these tests assert both that it is handed
+ * the whole doomed set and that its real deletions land, and a stub would only
+ * ever prove the first. Individual tests override the implementation where the
+ * point is what happens WITHOUT it.
+ */
+vi.mock('../../services/PostDeletionCascade', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/PostDeletionCascade')>();
+  return { ...actual, cascadePostReferences: vi.fn(actual.cascadePostReferences) };
+});
+
+import { CHANNEL_CASCADE } from '../../services/channelDeletion/channelCascadeManifest';
+import { cascadePostReferences } from '../../services/PostDeletionCascade';
+import {
+  NotAChannelAccountError,
+  deleteChannelContent,
+  previewChannelDeletion,
+} from '../../services/channelDeletion/ChannelDeletionService';
+
+const cascadePostReferencesMock = vi.mocked(cascadePostReferences);
+
+const CHANNEL = 'chan-1';
+const WRITER = 'writer-1';
+const SECOND_WRITER = 'writer-2';
+
+/** Every key the executor must report, collapsed the way `steps` collapses them. */
+const MANIFEST_KEYS = new Set(CHANNEL_CASCADE.map((step) => `${step.model}.${step.field}`));
+
+function seedFixture(): void {
+  db.reset();
+
+  db.seed('Post', [
+    // The channel's own posts.
+    {
+      _id: oid('p1'),
+      oxyUserId: CHANNEL,
+      authorship: [{ oxyUserId: CHANNEL, role: 'owner' }],
+      type: 'text',
+      visibility: 'public',
+      status: 'published',
+      // Never reattributed: the whole promise a channel makes.
+      writtenByOxyUserId: WRITER,
+      laneId: 'lane-1',
+      stats: { likesCount: 1, boostsCount: 1 },
+    },
+    {
+      // No writer id, so it separates the two doomed-post deletes: the
+      // writer-carrying rows go in one step, this one in the next. A fixture
+      // where every channel post looked alike could not tell those apart.
+      _id: oid('p2'),
+      oxyUserId: CHANNEL,
+      authorship: [{ oxyUserId: CHANNEL, role: 'owner' }],
+      type: 'boost',
+      boostOf: 'ext-1',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+    {
+      // Private, so it must NOT get a Delete(Tombstone) — only public+published
+      // posts were ever advertised to a remote server.
+      _id: oid('p3'),
+      oxyUserId: CHANNEL,
+      authorship: [{ oxyUserId: CHANNEL, role: 'owner' }],
+      type: 'text',
+      visibility: 'private',
+      status: 'published',
+      writtenByOxyUserId: SECOND_WRITER,
+      // Quotes another DOOMED post. The scrub counts third-party rows only, so
+      // this must not be swept up in it — it is deleted outright a phase later.
+      quoteOf: 'p1',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+
+    {
+      // The denormalized `oxyUserId` cache is missing: only the authorship owner
+      // entry names the channel. The pre-save hook keeps the two in sync, but a
+      // cascade is the wrong place to depend on that having held for every row
+      // ever written.
+      _id: oid('p4'),
+      authorship: [{ oxyUserId: CHANNEL, role: 'owner' }],
+      type: 'text',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+
+    // The load-bearing pair: another person's BOOST of a channel post, and
+    // another person's QUOTE of the same post. A fixture carrying only one of
+    // them cannot tell the two policies apart.
+    {
+      _id: oid('b1'),
+      oxyUserId: 'other-1',
+      authorship: [{ oxyUserId: 'other-1', role: 'owner' }],
+      type: 'boost',
+      boostOf: 'p1',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+    {
+      // A boost OF that boost. `handleAnnounce` records an inbound Announce
+      // against whatever local post the announced uri resolved to, and that post
+      // can itself be a boost — so the doomed set has to be a closure, not one
+      // hop. Left behind, this renders a placeholder with nothing behind it AND
+      // makes the preflight refuse the run forever.
+      _id: oid('b2'),
+      oxyUserId: 'other-11',
+      authorship: [{ oxyUserId: 'other-11', role: 'owner' }],
+      type: 'boost',
+      boostOf: 'b1',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+    {
+      _id: oid('q1'),
+      oxyUserId: 'other-2',
+      type: 'text',
+      quoteOf: 'p1',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+
+    // A reply into the set. A channel cannot be replied to, so this should not
+    // exist — the cascade sweeps it anyway rather than holding the assumption.
+    {
+      _id: oid('r1'),
+      oxyUserId: 'other-7',
+      type: 'text',
+      parentPostId: 'p1',
+      threadId: 'p1',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+
+    // Surviving third-party rows the cascade scrubs rather than deletes.
+    {
+      _id: oid('m1'),
+      oxyUserId: 'other-3',
+      type: 'text',
+      mentions: [CHANNEL, 'other-9'],
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+    {
+      _id: oid('stray-1'),
+      oxyUserId: 'other-6',
+      type: 'text',
+      laneId: 'lane-1',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+
+    // Surviving posts whose denormalized counters must be repaired.
+    {
+      _id: oid('ext-1'),
+      oxyUserId: 'other-4',
+      type: 'text',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 3 },
+    },
+    {
+      _id: oid('liked-1'),
+      oxyUserId: 'other-5',
+      type: 'text',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 5, boostsCount: 0 },
+    },
+    {
+      // Its counter already lags at zero — a denormalized count that predates the
+      // like, or one an earlier repair already took. An unguarded decrement drives
+      // it NEGATIVE and every reader downstream renders that.
+      _id: oid('liked-2'),
+      oxyUserId: 'other-12',
+      type: 'text',
+      visibility: 'public',
+      status: 'published',
+      stats: { likesCount: 0, boostsCount: 0 },
+    },
+  ]);
+
+  db.seed('Like', [
+    { _id: oid('like-1'), userId: CHANNEL, postId: oid('liked-1') },
+    { _id: oid('like-2'), userId: 'other-8', postId: oid('p1') },
+    { _id: oid('like-3'), userId: CHANNEL, postId: oid('liked-2') },
+  ]);
+  db.seed('Bookmark', [{ _id: oid('bm-1'), userId: 'other-8', postId: oid('p1') }]);
+  db.seed('Poll', [
+    // `Poll.postId` is `Schema.Types.Mixed`, so Mongo does no casting for it and
+    // BOTH spellings really are stored in the wild.
+    { _id: oid('poll-1'), postId: 'p1', createdBy: CHANNEL, question: 'a' },
+    { _id: oid('poll-2'), postId: oid('p2'), createdBy: CHANNEL, question: 'b' },
+  ]);
+  db.seed('Notification', [
+    { _id: oid('n-1'), recipientId: 'other-8', actorId: CHANNEL, entityType: 'post', entityId: oid('p1') },
+    { _id: oid('n-2'), recipientId: 'other-9', actorId: 'other-9', entityType: 'profile', entityId: CHANNEL },
+    { _id: oid('n-3'), recipientId: CHANNEL, actorId: 'other-9', entityType: 'profile', entityId: 'other-9' },
+    {
+      // Named by NOTHING except the doomed post — no channel id anywhere on it — so
+      // only the delegated post-reference leg reaches it. That is what makes it a
+      // discriminator: with the delegate stubbed out, it survives.
+      _id: oid('n-4'),
+      recipientId: 'other-8',
+      actorId: 'other-8',
+      entityType: 'reply',
+      entityId: oid('p1'),
+    },
+  ]);
+  db.seed('Threadgate', [
+    // Somebody else's reply policy ON a doomed post. `Threadgate.createdBy` cannot
+    // reach it, so the delegate is its only route out.
+    { _id: oid('tg-1'), postId: 'p1', postUri: 'p1', createdBy: 'other-9' },
+  ]);
+  db.seed('Postgate', [
+    { _id: oid('pg-1'), postId: 'p1', postUri: 'p1', createdBy: CHANNEL, detachedQuoteUris: [] },
+    {
+      _id: oid('pg-2'),
+      postId: 'other',
+      postUri: 'urn:other',
+      createdBy: 'other-9',
+      detachedQuoteUris: ['p1', 'keep-me'],
+    },
+  ]);
+  db.seed('EngagementOutbox', [
+    {
+      _id: 'eo-1',
+      status: 'pending',
+      payload: { postId: 'p1', actorOxyUserId: 'other-8', postOwnerOxyUserId: CHANNEL },
+    },
+    {
+      // Reachable ONLY through `payload.postId`: no field on it names the channel,
+      // so a step keyed on the bare `postId` finds nothing and leaves it queued
+      // against a post that will not exist when it drains.
+      _id: 'eo-2',
+      status: 'pending',
+      payload: { postId: 'p1', actorOxyUserId: 'other-8' },
+    },
+    {
+      // Already PROCESSED, and reachable only through `payload.postId`. The
+      // delegate's disposition for this queue is cancel-pending, so this one must
+      // SURVIVE: it can no longer act on anything, and the scan that would find it
+      // is unindexed. A fixture with only pending rows cannot tell "cancels the
+      // backlog" from "deletes the collection".
+      _id: 'eo-3',
+      status: 'processed',
+      payload: { postId: 'p1', actorOxyUserId: 'other-8' },
+    },
+  ]);
+  db.seed('Report', [
+    { _id: oid('rep-1'), reportedType: 'post', reportedId: 'p1', reporter: 'other-9' },
+    { _id: oid('rep-2'), reportedType: 'user', reportedId: 'other-9', reporter: CHANNEL },
+    {
+      // A Mention comment IS a post with a parent, so a POST-only filter would
+      // leave every report about a reply behind.
+      _id: oid('rep-3'),
+      reportedType: 'comment',
+      reportedId: 'p1',
+      reporter: 'other-10',
+    },
+  ]);
+  db.seed('ModerationOutbox', [
+    { _id: 'mo-1', payload: { reportId: 'rep-1' } },
+    { _id: 'mo-2', payload: { reportId: 'rep-2' } },
+    { _id: 'mo-3', payload: { reportId: 'rep-3' } },
+  ]);
+  db.seed('FederationDeliveryQueue', [
+    { _id: oid('dq-1'), senderOxyUserId: CHANNEL, targetInbox: 'https://remote/inbox' },
+  ]);
+  db.seed('Lane', [{ _id: oid('lane-1'), ownerId: CHANNEL }]);
+  db.seed('LaneMute', [
+    { _id: oid('lm-1'), viewerOxyUserId: 'other-9', laneId: 'lane-1', laneOwnerOxyUserId: CHANNEL },
+  ]);
+  db.seed('UserSettings', [
+    { _id: oid('us-1'), oxyUserId: CHANNEL, channel: { signPosts: false } },
+    { _id: oid('us-2'), oxyUserId: 'other-9', privacy: { restrictedUsers: [CHANNEL, 'keep-me'] } },
+  ]);
+  db.seed('UserBehavior', [
+    {
+      _id: oid('ub-1'),
+      oxyUserId: 'other-9',
+      preferredAuthors: [{ authorId: CHANNEL }, { authorId: 'keep-me' }],
+      hiddenAuthors: [CHANNEL],
+      mutedAuthors: [],
+      blockedAuthors: [],
+    },
+  ]);
+  db.seed('FederatedFollow', [
+    {
+      _id: oid('ff-1'),
+      localUserId: CHANNEL,
+      remoteActorUri: 'https://remote.example/users/a',
+      direction: 'inbound',
+      status: 'accepted',
+    },
+  ]);
+  db.seed('Trending', [{ _id: oid('tr-1'), actorIds: [CHANNEL, 'other-9'] }]);
+  db.seed('AccountList', [
+    { _id: oid('al-1'), ownerOxyUserId: 'other-9', memberOxyUserIds: [CHANNEL, 'keep-me'] },
+  ]);
+  db.seed('MuteWord', [{ _id: oid('mw-1'), userId: CHANNEL, value: 'x' }]);
+  db.seed('ContentLabel', [
+    { _id: oid('cl-1'), targetType: 'post', targetId: 'p1', createdBy: 'other-9', labelSlug: 'x' },
+    { _id: oid('cl-2'), targetType: 'user', targetId: CHANNEL, createdBy: 'other-9', labelSlug: 'x' },
+    { _id: oid('cl-3'), targetType: 'user', targetId: 'other-9', createdBy: 'other-9', labelSlug: 'x' },
+  ]);
+  db.seed('PostRecentReplier', [
+    {
+      _id: oid('prr-1'),
+      postId: 'someone-elses-post',
+      repliers: [
+        { oxyUserId: CHANNEL, repliedAt: 1 },
+        { oxyUserId: 'keep-me', repliedAt: 2 },
+      ],
+    },
+    {
+      // The projection FOR a doomed post, naming nobody the account sweep knows —
+      // another row only the delegate can reach.
+      _id: oid('prr-2'),
+      postId: 'p1',
+      repliers: [{ oxyUserId: 'other-9', repliedAt: 1 }],
+    },
+  ]);
+}
+
+/** Every row a doomed post is reachable from ONLY through the delegated legs. */
+const DELEGATE_ONLY_ROWS: ReadonlyArray<{ collection: string; id: string }> = [
+  { collection: 'Like', id: 'like-2' },
+  { collection: 'Bookmark', id: 'bm-1' },
+  { collection: 'ContentLabel', id: 'cl-1' },
+  { collection: 'Threadgate', id: 'tg-1' },
+  { collection: 'PostRecentReplier', id: 'prr-2' },
+  { collection: 'Notification', id: 'n-4' },
+  { collection: 'EngagementOutbox', id: 'eo-2' },
+];
+
+/** The lowest recorded invocation order across a set of mocks, or Infinity. */
+function firstCall(...mocks: Array<{ mock: { invocationCallOrder: number[] } }>): number {
+  return Math.min(
+    ...mocks.flatMap((mock) =>
+      mock.mock.invocationCallOrder.length > 0 ? mock.mock.invocationCallOrder : [Number.POSITIVE_INFINITY],
+    ),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seedFixture();
+  getUserById.mockResolvedValue({ username: 'thechannel' });
+  assertPostsSafeToDelete.mockResolvedValue(undefined);
+  collectPostCascadeResidue.mockResolvedValue([]);
+  resolveAccountKind.mockResolvedValue('channel');
+});
+
+describe('ChannelDeletionService', () => {
+  it('accounts for every manifest entry exactly once, in exactly one of three ways', async () => {
+    // The binding that stops the manifest and the executor drifting apart. A step
+    // that stops being executed, delegated or retained loses its key from all three
+    // sets, which is why `steps` is never pre-seeded from the manifest — doing that
+    // would satisfy this assertion while deleting nothing.
+    //
+    // Delegated and retained steps are listed WITHOUT a count on purpose. A
+    // fabricated `0` is indistinguishable from a step that silently stopped
+    // running, which is the exact failure this assertion exists to catch, so
+    // reporting one would defeat it from inside.
+    expect(MANIFEST_KEYS.size, 'vacuity floor: the manifest must be substantial').toBeGreaterThanOrEqual(
+      80,
+    );
+
+    const result = await deleteChannelContent(CHANNEL, { dryRun: false });
+    const local = new Set(Object.keys(result.steps));
+    const delegated = new Set(result.delegated);
+    const retained = new Set(result.retained);
+
+    // Disjointness first: without it the union can be satisfied by a key that is
+    // reported twice, and a key dropped from one set would hide behind the other.
+    const overlapping = [...MANIFEST_KEYS]
+      .filter(
+        (key) =>
+          [local.has(key), delegated.has(key), retained.has(key)].filter(Boolean).length > 1,
+      )
+      .sort();
+    expect(
+      overlapping,
+      `These keys are reported in more than one account:\n  ${overlapping.join('\n  ')}\n` +
+        'Executed, delegated and retained are three different statements about one step; reporting a ' +
+        'key twice makes a dropped account invisible.',
+    ).toEqual([]);
+
+    const reported = new Set([...local, ...delegated, ...retained]);
+    const missing = [...MANIFEST_KEYS].filter((key) => !reported.has(key)).sort();
+    const extra = [...reported].filter((key) => !MANIFEST_KEYS.has(key)).sort();
+
+    expect(
+      missing,
+      `The cascade never accounted for these manifest steps:\n  ${missing.join('\n  ')}\n` +
+        'Every entry in CHANNEL_CASCADE must be executed here, delegated to PostDeletionCascade, or ' +
+        'retained on purpose — or rows pointing at a deleted channel survive with nothing to notice it.',
+    ).toEqual([]);
+    expect(
+      extra,
+      `The cascade reported steps the manifest does not name:\n  ${extra.join('\n  ')}\n` +
+        'A write that no manifest entry describes is a deletion nobody reviewed.',
+    ).toEqual([]);
+
+    // Vacuity floors on the two new accounts: an empty `delegated` would satisfy
+    // the union by leaving every key in `steps`, which is the duplication this
+    // change removed.
+    expect(result.delegated.length).toBeGreaterThanOrEqual(10);
+    expect(result.retained).toEqual(['ModerationOutbox.reportId', 'Report.model.reportedId']);
+  });
+
+  it('reports a column classified under two scopes as locally executed, with the local count', async () => {
+    // `Notification.entityId` and `ContentLabel.targetId` are each two references in
+    // one column: a post id under one discriminator, a channel id under another. The
+    // post half is the delegate's, the account half runs here, and the reported
+    // count is the LOCAL work only — pinned so the precedence cannot drift silently
+    // into reporting the delegate's rows as if this service had deleted them.
+    const result = await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    expect(result.delegated).not.toContain('Notification.entityId');
+    expect(result.delegated).not.toContain('ContentLabel.targetId');
+    expect(result.steps['Notification.entityId'], 'the profile notification only').toBe(1);
+    expect(result.steps['ContentLabel.targetId'], 'the label ON the channel only').toBe(1);
+    // …and the post-scoped rows in the same collections are gone all the same.
+    expect(db.docs('ContentLabel').map((doc) => String(doc._id))).toEqual(['cl-3']);
+  });
+
+  it('federates the deletion before deleting anything delivery reads', async () => {
+    await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    // One Tombstone per PUBLIC + PUBLISHED channel post (p1, p2, p4) and none for
+    // the private one, which no remote server was ever told about.
+    expect(federateDelete).toHaveBeenCalledTimes(3);
+    expect(deliverToFollowers).toHaveBeenCalledTimes(1);
+
+    // The outbound queue drain is the ONE write the manifest requires BEFORE the
+    // broadcast — a queued Create would otherwise race the Delete and republish a
+    // post on the receiving instance. Every other write must come after.
+    const queue = db.collection('FederationDeliveryQueue');
+    const otherWrites = db.writeMocks().filter((mock) => mock !== queue.deleteMany);
+
+    expect(firstCall(queue.deleteMany)).toBeLessThan(firstCall(deliverToFollowers));
+    expect(firstCall(deliverToFollowers)).toBeLessThan(firstCall(...otherWrites));
+
+    // The preflight is the gate, and it runs BEFORE the broadcast: a refusal is
+    // permanent until an operator acts, so broadcasting first would leave remote
+    // servers holding a Tombstone for posts that are still live here, on every
+    // retry. It declares exactly what this cascade removes itself.
+    expect(firstCall(assertPostsSafeToDelete)).toBeLessThan(firstCall(deliverToFollowers));
+    const [, targets, acknowledgements] = assertPostsSafeToDelete.mock.calls[0];
+    expect((targets as unknown[]).length, 'the whole doomed set is offered to the gate').toBe(6);
+    expect(acknowledgements).toMatchObject({ allowDanglingReplyReferences: true });
+    const { removedByCascade, keptByPolicy } = acknowledgements as {
+      removedByCascade: string[];
+      keptByPolicy: string[];
+    };
+    expect(removedByCascade).toContain('Like.postId');
+    // The two claims are DIFFERENT claims and are made separately: one says the
+    // rows are gone and is re-checked afterwards, the other says they stay on
+    // purpose. Declaring a retained reference as removed would make the residue
+    // check report it as a cascade leg that had stopped working, every run.
+    expect(keptByPolicy).toContain('Report.reportedId(post)');
+    expect(removedByCascade).not.toContain('Report.reportedId(post)');
+
+    // …and the post rows go only after everything that pointed at them.
+    const post = db.collection('Post');
+    expect(firstCall(db.collection('Like').deleteMany)).toBeLessThan(firstCall(post.deleteMany));
+    expect(firstCall(db.collection('Postgate').deleteMany)).toBeLessThan(firstCall(post.deleteMany));
+    expect(firstCall(post.updateMany)).toBeLessThan(firstCall(post.deleteMany));
+  });
+
+  it('destroys a boost of a channel post and keeps a quote of it', async () => {
+    const result = await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    const surviving = db.docs('Post').map((doc) => String(doc._id));
+    expect(surviving, 'the boost renders entirely from an original that is gone').not.toContain('b1');
+    expect(surviving, 'and so does a boost OF that boost — the set is a closure').not.toContain('b2');
+    expect(surviving, "the quoter's own words are not the channel's to destroy").toContain('q1');
+
+    const quote = db.docs('Post').find((doc) => String(doc._id) === 'q1');
+    expect(quote?.quoteOf, 'the pointer is unset, not left dangling').toBeUndefined();
+
+    expect(result.steps['Post.boostOf']).toBe(2);
+    expect(result.steps['Post.quoteOf']).toBe(1);
+    expect(result.preview.boostsByOthers).toBe(2);
+    expect(result.preview.quotesByOthersKept).toBe(1);
+
+    // The same distinction one level down: a reply keeps its text and loses its
+    // "replying to" line; a third party's mention of the channel is pulled out of
+    // a post that stays.
+    const reply = db.docs('Post').find((doc) => String(doc._id) === 'r1');
+    expect(reply?.parentPostId).toBeUndefined();
+    expect(reply?.threadId).toBeUndefined();
+    expect(db.docs('Post').find((doc) => String(doc._id) === 'm1')?.mentions).toEqual(['other-9']);
+    expect(db.docs('Postgate').find((doc) => String(doc._id) === 'pg-2')?.detachedQuoteUris).toEqual([
+      'keep-me',
+    ]);
+
+    // Counters on the posts that survive but lost an engagement record.
+    expect(db.docs('Post').find((doc) => String(doc._id) === 'ext-1')?.stats).toEqual({
+      likesCount: 0,
+      boostsCount: 2,
+    });
+    expect(db.docs('Post').find((doc) => String(doc._id) === 'liked-1')?.stats).toEqual({
+      likesCount: 4,
+      boostsCount: 0,
+    });
+    expect(
+      db.docs('Post').find((doc) => String(doc._id) === 'liked-2')?.stats,
+      'a counter that already lags must not be driven negative',
+    ).toEqual({ likesCount: 0, boostsCount: 0 });
+
+    // The scrub counts THIRD-PARTY rows: a doomed post quoting another doomed post
+    // is deleted outright, never counted as somebody else's writing being kept.
+    expect(result.steps['Post.quoteOf']).toBe(1);
+  });
+
+  it('a dry run reads and reports without writing or federating', async () => {
+    const before = db.snapshot();
+    const result = await deleteChannelContent(CHANNEL, { dryRun: true });
+
+    for (const write of db.writeMocks()) {
+      expect(write, 'a dry run must not reach a single write').not.toHaveBeenCalled();
+    }
+    expect(federateDelete).not.toHaveBeenCalled();
+    expect(deliverToFollowers).not.toHaveBeenCalled();
+    expect(getUserById).not.toHaveBeenCalled();
+    expect(db.snapshot()).toBe(before);
+
+    expect(result.dryRun).toBe(true);
+    expect(result.steps['Post.boostOf']).toBe(2);
+    expect(result.steps['FederationDeliveryQueue.senderOxyUserId']).toBe(1);
+    expect(
+      Object.values(result.steps).filter((count) => count > 0).length,
+      'a dry run that counts nothing is indistinguishable from a broken one',
+    ).toBeGreaterThan(10);
+
+    // The delegate DELETES, so a dry run cannot call it — and counting its rows
+    // here instead would mean writing its queries a second time, which is the
+    // duplication the delegation removed. The steps are still accounted for, by
+    // name and without a fabricated count.
+    expect(cascadePostReferencesMock).not.toHaveBeenCalled();
+    expect(result.delegated).toContain('Like.postId');
+    expect(result.steps).not.toHaveProperty('Like.postId');
+  });
+
+  it('is idempotent: a second run finds nothing and does not throw', async () => {
+    const first = await deleteChannelContent(CHANNEL, { dryRun: false });
+    expect(Object.values(first.steps).some((count) => count > 0)).toBe(true);
+
+    const second = await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    const leftovers = Object.entries(second.steps).filter(([, count]) => count !== 0);
+    expect(
+      leftovers,
+      `A re-run still affected rows:\n  ${leftovers.map(([key, count]) => `${key}=${count}`).join('\n  ')}\n` +
+        'A retryable cascade must converge, or a BullMQ retry keeps mutating.',
+    ).toEqual([]);
+    expect(second.preview).toEqual({
+      channelOxyUserId: CHANNEL,
+      posts: 0,
+      boostsByOthers: 0,
+      replies: 0,
+      quotesByOthersKept: 0,
+      federatedFollowers: 0,
+    });
+    // Nothing left to address a Delete to, so no second broadcast.
+    expect(deliverToFollowers).toHaveBeenCalledTimes(1);
+  });
+
+  it('never reattributes a channel post to the person who wrote it', async () => {
+    const before = db.snapshot();
+    expect(before, 'positive control: the writer ids are present before the run').toContain(WRITER);
+    expect(before).toContain(SECOND_WRITER);
+
+    const result = await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    // Both writer-carrying posts were DESTROYED, not handed to their writers…
+    expect(result.steps['Post.writtenByOxyUserId']).toBe(2);
+    expect(result.steps['Post.oxyUserId'], 'p2 and the authorship-only p4').toBe(2);
+
+    for (const writer of [WRITER, SECOND_WRITER]) {
+      expect(
+        db.snapshot(),
+        'With signPosts off, surfacing writtenByOxyUserId anywhere would retroactively publish who ' +
+          'wrote what — the single promise a channel makes.',
+      ).not.toContain(writer);
+    }
+
+    for (const call of db.collection('Post').updateMany.mock.calls) {
+      expect(JSON.stringify(call[1]), 'no post is ever re-owned').not.toContain('oxyUserId');
+    }
+    for (const call of db.collection('Post').updateOne.mock.calls) {
+      expect(JSON.stringify(call[1]), 'no post is ever re-owned').not.toContain('oxyUserId');
+    }
+  });
+
+  it('runs every remaining step and then throws when one fails', async () => {
+    const muteWords = db.collection('MuteWord');
+    muteWords.deleteMany.mockRejectedValueOnce(new Error('mongo is having a day'));
+
+    await expect(deleteChannelContent(CHANNEL, { dryRun: false })).rejects.toThrow(
+      /MuteWord\.userId/,
+    );
+
+    // Steps before AND after the failure still ran, so a retry has as little left
+    // to do as possible.
+    expect(db.collection('Like').deleteMany).toHaveBeenCalled();
+    expect(db.collection('FederatedActor').deleteMany).toHaveBeenCalled();
+    expect(db.docs('Trending')[0].actorIds).toEqual(['other-9']);
+  });
+
+  it('scrubs a third-party row at its real nested path, never at the field name', async () => {
+    // Four references whose Mongo path is not the name the manifest gives them.
+    // A wrong path here does not error — it matches nothing, the step reports 0,
+    // and the reference survives, which is the exact failure this cascade exists
+    // to prevent. Each row belongs to somebody else and must SURVIVE, minus the
+    // one entry naming the channel.
+    const result = await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    expect(db.docs('UserSettings').find((doc) => doc.oxyUserId === 'other-9')).toMatchObject({
+      privacy: { restrictedUsers: ['keep-me'] },
+    });
+    expect(db.docs('UserBehavior')[0]).toMatchObject({
+      preferredAuthors: [{ authorId: 'keep-me' }],
+      hiddenAuthors: [],
+    });
+    expect(db.docs('PostRecentReplier')[0]).toMatchObject({
+      repliers: [{ oxyUserId: 'keep-me' }],
+    });
+    expect(db.docs('Trending')[0]).toMatchObject({ actorIds: ['other-9'] });
+    expect(db.docs('AccountList')[0]).toMatchObject({ memberOxyUserIds: ['keep-me'] });
+
+    expect(result.steps['UserSettings.restrictedUsers']).toBe(1);
+    expect(result.steps['UserBehavior.authorId']).toBe(1);
+    expect(result.steps['PostRecentReplier.oxyUserId']).toBe(1);
+
+    // `payload`-nested outbox references, same hazard — including the row that
+    // names the channel nowhere except inside `payload.postId`. The disposition is
+    // the delegate's and it is cancel-pending, so the PROCESSED row stays: it can
+    // no longer act on anything, and the query that would find the rest is a scan.
+    expect(db.docs('EngagementOutbox').map((doc) => String(doc._id))).toEqual(['eo-3']);
+
+    // A `Mixed` column stores a post id in either spelling and Mongo casts
+    // neither, so a filter that builds only one of them leaves the other behind.
+    expect(db.docs('Poll')).toHaveLength(0);
+    const pollFilter = db
+      .collection('Poll')
+      .deleteMany.mock.calls.map(([filter]) => filter)
+      .find((filter) => Array.isArray(filter.$or));
+    const pollOperands = (
+      ((pollFilter ?? {}).$or as Array<{ postId?: { $in: unknown[] } }>)[0].postId ?? { $in: [] }
+    ).$in;
+    expect(
+      pollOperands.some((value) => typeof value === 'string'),
+      'the string spelling must be in the filter Mongo receives',
+    ).toBe(true);
+    expect(
+      pollOperands.some((value) => typeof value === 'object'),
+      'and the ObjectId spelling too — a Mixed column casts neither',
+    ).toBe(true);
+  });
+
+  it('sweeps the channel-scoped rows a step name does not mention', async () => {
+    // `ContentLabel.targetId` is polymorphic on `targetType`. The post rows are the
+    // delegate's; a label applied TO the channel has no delegate leg and no other
+    // step to fall to, so a post-only reading leaves it pointing at an account that
+    // no longer resolves. A stranger's unrelated label is untouched either way.
+    const result = await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    expect(db.docs('ContentLabel').map((doc) => String(doc._id))).toEqual(['cl-3']);
+    expect(result.steps['ContentLabel.targetId']).toBe(1);
+  });
+
+  it('keeps a report about a destroyed post, and its delivery job with it', async () => {
+    // The end state, not a filter: a report and its `ModerationOutbox` job are
+    // RETAINED. Deleting the report would strand an inbound CrowdSource decision —
+    // `ModerationDecisionWorker` treats "case resolves to no local report" as
+    // RETRYABLE, so the decision backs off and retries until it expires. That
+    // reason does not depend on who deleted the post, so it cannot have one answer
+    // on the live delete route and another here.
+    await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    const surviving = db.docs('Report').map((doc) => String(doc._id));
+    expect(
+      surviving,
+      'a report ABOUT a destroyed channel post survives the post',
+    ).toContain('rep-1');
+    expect(
+      surviving,
+      'and so does one filed as a COMMENT — a Mention comment is a post with a parent',
+    ).toContain('rep-3');
+    // The one report that does go is the one the channel FILED, which is a channel
+    // reference rather than a post one and has its own manifest step.
+    expect(surviving).not.toContain('rep-2');
+
+    expect(
+      db.docs('ModerationOutbox').map((doc) => String(doc._id)),
+      'the delivery jobs are kept with the reports they name; nothing is orphaned',
+    ).toEqual(['mo-1', 'mo-2', 'mo-3']);
+    expect(db.collection('ModerationOutbox').deleteMany).not.toHaveBeenCalled();
+
+    // No query for a retained reference may exist at all — `Report` is still
+    // written to, but only by the step that removes reports the channel filed.
+    for (const [filter] of db.collection('Report').deleteMany.mock.calls) {
+      expect(
+        Object.keys(filter),
+        'the only Report delete is keyed on the reporter, never on the reported post',
+      ).toEqual(['reporter']);
+    }
+  });
+
+  it('a preflight refusal aborts before anything is federated or destroyed', async () => {
+    assertPostsSafeToDelete.mockRejectedValueOnce(
+      new Error('deletion preflight found references that are not covered by a cascade'),
+    );
+
+    await expect(deleteChannelContent(CHANNEL, { dryRun: false })).rejects.toThrow(
+      /deletion preflight/,
+    );
+
+    expect(federateDelete).not.toHaveBeenCalled();
+    expect(deliverToFollowers).not.toHaveBeenCalled();
+    // The channel's own undelivered queue is the one thing already drained, which
+    // is what makes the common blocker disappear before the gate is asked.
+    expect(db.docs('FederationDeliveryQueue')).toHaveLength(0);
+    // Nothing else was touched: every post is still here.
+    expect(db.docs('Post')).toHaveLength(13);
+    expect(db.docs('Like')).toHaveLength(3);
+  });
+
+  it('aborts before deleting anything when the channel username will not resolve', async () => {
+    // The canonical Note ids a remote server matches a Tombstone against are minted
+    // from the username, and it is read SERVER-SIDE from the authoritative
+    // oxyUserId — never from a request. Without it the fediverse can never be told,
+    // and once the posts are gone there is nothing left to address a later Delete
+    // from, so the run stops here and is retried instead.
+    getUserById.mockResolvedValueOnce({ username: '   ' });
+
+    await expect(deleteChannelContent(CHANNEL, { dryRun: false })).rejects.toThrow(
+      /no resolvable username/,
+    );
+
+    expect(federateDelete).not.toHaveBeenCalled();
+    expect(deliverToFollowers).not.toHaveBeenCalled();
+    expect(db.docs('Post')).toHaveLength(13);
+    expect(db.docs('Like')).toHaveLength(3);
+  });
+
+  it('a counter repair that fails is logged, and does not lose the deletion', async () => {
+    // The ids being repaired came from rows this run has already deleted, so a
+    // retry computes an EMPTY repair set and can never make good on it. Failing
+    // the job would lose the deletion's success without saving the counter.
+    db.collection('Post').updateOne.mockRejectedValue(new Error('mongo is having a day'));
+
+    const result = await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    expect(result.steps['Post.oxyUserId']).toBe(2);
+    expect(db.docs('Post').find((doc) => String(doc._id) === 'ext-1')?.stats).toEqual({
+      likesCount: 0,
+      boostsCount: 3,
+    });
+  });
+
+  it('hands the whole doomed set to PostDeletionCascade, once', async () => {
+    await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    expect(cascadePostReferencesMock).toHaveBeenCalledTimes(1);
+    const [handed] = cascadePostReferencesMock.mock.calls[0];
+    expect(
+      handed.map((row) => String(row._id)).sort(),
+      'the channel\'s own posts AND the boosts of them — a partial set leaves references behind',
+    ).toEqual(['b1', 'b2', 'p1', 'p2', 'p3', 'p4']);
+
+    // Rows, not ids: the delegate also reaches a post's owned Poll and Article
+    // through `content.pollId` / `content.article.articleId`, which an id list
+    // cannot carry.
+    expect(handed.every((row) => typeof row === 'object' && '_id' in row)).toBe(true);
+  });
+
+  it('issues none of the delegated queries itself', async () => {
+    // The mutation-resistant half of the delegation: with the delegate stubbed to a
+    // no-op, every row reachable ONLY through a delegated leg must SURVIVE. A
+    // leftover local copy of any of those queries — the duplication this change
+    // removed — shows up here as a row that disappeared anyway.
+    cascadePostReferencesMock.mockResolvedValueOnce({ failedLegs: [] });
+
+    await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    for (const { collection, id } of DELEGATE_ONLY_ROWS) {
+      expect(
+        db.docs(collection).map((doc) => String(doc._id)),
+        `${collection}/${id} is reachable only through the delegate, so nothing here may delete it`,
+      ).toContain(id);
+    }
+
+    // Positive control: the run really did happen, and the steps this service still
+    // owns did their work.
+    expect(db.docs('Post').map((doc) => String(doc._id))).not.toContain('p1');
+    expect(db.docs('Lane')).toHaveLength(0);
+  });
+
+  it('a failed delegate leg makes the run throw, so a retry re-runs it', async () => {
+    // The whole reason `cascadePostReferences` exists beside the never-throwing
+    // entry point the live delete route calls: an administrative cascade runs inside
+    // a job that CAN be retried, so a leg that failed has to reach the caller.
+    cascadePostReferencesMock.mockResolvedValueOnce({ failedLegs: ['Like.postId'] });
+
+    await expect(deleteChannelContent(CHANNEL, { dryRun: false })).rejects.toThrow(
+      /PostDeletionCascade:Like\.postId/,
+    );
+  });
+
+  it('previews without touching anything', async () => {
+    const before = db.snapshot();
+    const preview = await previewChannelDeletion(CHANNEL);
+
+    expect(preview).toEqual({
+      channelOxyUserId: CHANNEL,
+      posts: 4,
+      boostsByOthers: 2,
+      // A channel cannot be replied to, so this is a finding rather than a number
+      // to accept — the fixture carries one on purpose.
+      replies: 1,
+      quotesByOthersKept: 1,
+      federatedFollowers: 1,
+    });
+    for (const write of db.writeMocks()) {
+      expect(write).not.toHaveBeenCalled();
+    }
+    expect(db.snapshot()).toBe(before);
+  });
+});
+
+/**
+ * The gate that decides whether any of the above may run at all.
+ *
+ * TWO-SIDED ON PURPOSE. A suite that only ever feeds this a `channel` cannot tell
+ * "refuses everything else" from "refuses nothing" — both pass — so the refusing
+ * fixtures are the load-bearing ones and the accepting fixture is what stops the
+ * gate being satisfied by a function that always throws.
+ */
+describe('ChannelDeletionService — the account-kind gate', () => {
+  /** Both entry points, because the refusal has to hold for the read-only one too. */
+  const entryPoints: ReadonlyArray<{ name: string; run: () => Promise<unknown> }> = [
+    { name: 'deleteChannelContent', run: () => deleteChannelContent(CHANNEL, { dryRun: false }) },
+    { name: 'previewChannelDeletion', run: () => previewChannelDeletion(CHANNEL) },
+  ];
+
+  /** Nothing was read, nothing was written, nothing was told to the fediverse. */
+  function expectUntouched(before: string): void {
+    expect(
+      db.collection('Post').find,
+      'the gate must run BEFORE any read of the post set, not after it',
+    ).not.toHaveBeenCalled();
+    for (const write of db.writeMocks()) {
+      expect(write, 'a refusal must not reach a single write').not.toHaveBeenCalled();
+    }
+    expect(federateDelete).not.toHaveBeenCalled();
+    expect(deliverToFollowers).not.toHaveBeenCalled();
+    expect(getUserById).not.toHaveBeenCalled();
+    expect(cascadePostReferencesMock).not.toHaveBeenCalled();
+    expect(assertPostsSafeToDelete).not.toHaveBeenCalled();
+    expect(db.snapshot()).toBe(before);
+  }
+
+  for (const { name, run } of entryPoints) {
+    it(`${name} refuses a personal account, and destroys nothing`, async () => {
+      // The case the gate exists for. `deleteChannelContent` took an oxyUserId on
+      // trust; pointed at a human's account it destroys their posts irreversibly,
+      // and "no route calls it yet" is the absence of an accident rather than a
+      // defence against one.
+      resolveAccountKind.mockResolvedValue('personal');
+      const before = db.snapshot();
+
+      await expect(run()).rejects.toThrow(NotAChannelAccountError);
+      await expect(run()).rejects.toThrow(/resolved as personal, not a channel/);
+
+      expectUntouched(before);
+    });
+
+    it(`${name} refuses an account whose kind will not resolve`, async () => {
+      // `resolveAccountKind` is fail-soft to `null` BY DESIGN — the reply gate needs
+      // an identity outage not to refuse every reply on the site — so the decision
+      // belongs to each caller, and here it is no. Accepting `null` would make an
+      // Oxy outage the condition under which this deletes anything it is pointed at.
+      resolveAccountKind.mockResolvedValue(null);
+      const before = db.snapshot();
+
+      await expect(run()).rejects.toThrow(NotAChannelAccountError);
+      // The message distinguishes the two causes because the operator response
+      // differs: a wrong id must never be retried as-is, an outage should be.
+      await expect(run()).rejects.toThrow(/could not be resolved/);
+
+      expectUntouched(before);
+    });
+
+    it(`${name} refuses when the kind lookup itself fails`, async () => {
+      // Belt and braces: the fail-soft contract lives in another module and could be
+      // tightened there without anybody looking at this call site.
+      resolveAccountKind.mockRejectedValue(new Error('oxy is having a day'));
+      const before = db.snapshot();
+
+      await expect(run()).rejects.toThrow(NotAChannelAccountError);
+      await expect(run()).rejects.toThrow(/could not be resolved/);
+
+      expectUntouched(before);
+    });
+  }
+
+  it('proceeds for a channel — without this the gate could be refusing everything', async () => {
+    resolveAccountKind.mockResolvedValue('channel');
+
+    const result = await deleteChannelContent(CHANNEL, { dryRun: false });
+
+    expect(resolveAccountKind).toHaveBeenCalledWith(CHANNEL);
+    expect(result.preview.posts).toBe(4);
+    expect(db.docs('Post').map((doc) => String(doc._id))).not.toContain('p1');
+    expect(deliverToFollowers).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/__tests__/services/mtn/mentionNodeScheduler.test.ts
+++ b/packages/backend/src/__tests__/services/mtn/mentionNodeScheduler.test.ts
@@ -173,8 +173,24 @@ describe('Read-path invariant — feeds/hydration never touch a node', () => {
   // Hot read-path modules: anything a feed/hydration request executes. None may
   // reference the node model, node endpoints, or the node services.
   const HOT_PATH_DIRS = ['src/mtn/feed', 'src/controllers', 'src/services'];
-  // The node layer itself is the ONLY place node I/O is allowed — exclude it.
-  const NODE_LAYER = path.normalize('src/services/mtn');
+  /**
+   * The two directories under a scanned root that are not read paths at all.
+   *
+   *  - `src/services/mtn` is the node layer itself: the only place node I/O is
+   *    allowed to live.
+   *  - `src/services/channelDeletion` is an administrative cascade. It has to
+   *    ENUMERATE the node models in order to delete their rows when a channel is
+   *    destroyed — leaving a chain and a node registration behind would be exactly
+   *    the orphan that cascade exists to prevent — and nothing in it is reachable
+   *    from a feed or hydration request.
+   *
+   * Neither exemption widens what a hot path may do; both name a directory that is
+   * not one.
+   */
+  const NOT_A_READ_PATH = [
+    path.normalize('src/services/mtn'),
+    path.normalize('src/services/channelDeletion'),
+  ];
   const FORBIDDEN = [
     'MentionUserNode',
     'MentionNodeSyncService',
@@ -197,8 +213,7 @@ describe('Read-path invariant — feeds/hydration never touch a node', () => {
     for (const entry of entries) {
       const full = path.join(abs, entry);
       const rel = path.relative(path.resolve(__dirname, '../../../../'), full);
-      // The node layer (src/services/mtn) is the allowed home of node I/O.
-      if (path.normalize(rel).startsWith(NODE_LAYER)) continue;
+      if (NOT_A_READ_PATH.some((excluded) => path.normalize(rel).startsWith(excluded))) continue;
       if (statSync(full).isDirectory()) {
         files.push(...walk(rel));
       } else if (full.endsWith('.ts') && !full.endsWith('.test.ts')) {

--- a/packages/backend/src/scripts/lib/adminDeletionPreflight.ts
+++ b/packages/backend/src/scripts/lib/adminDeletionPreflight.ts
@@ -146,6 +146,26 @@ export interface PostDeletionAcknowledgements {
    */
   removedByCascade?: readonly PostReferenceProbeName[];
   /**
+   * Probes whose rows the caller deliberately LEAVES IN PLACE, because a written
+   * policy says they must outlive the post — `Report.reportedId(post)`, whose
+   * removal strands an inbound CrowdSource decision on a retry loop, and the two
+   * durable queues whose live backlog is cancelled while their completed rows
+   * stay as a log.
+   *
+   * Kept SEPARATE from {@link removedByCascade} on purpose, even though the gate
+   * treats both the same way. That one is a CLAIM that the rows are gone, and
+   * {@link collectPostCascadeResidue} re-runs exactly those probes afterwards to
+   * check it; this one is a decision that they stay, which the same check would
+   * report as a failure. Collapsing them would make a deliberately retained
+   * reference indistinguishable from a cascade leg that had silently stopped
+   * working — the one confusion this module exists to remove.
+   *
+   * Compiler-checked against {@link POST_REFERENCE_PROBE_NAMES} like its sibling,
+   * so a probe added upstream cannot be inherited into an existing caller's
+   * policy without somebody deciding.
+   */
+  keptByPolicy?: readonly PostReferenceProbeName[];
+  /**
    * The caller deliberately LEAVES `parentPostId` / `quoteOf` / `threadId`
    * pointing at a removed post, because the referencing posts belong to OTHER
    * users and deleting them would destroy their content to remove someone
@@ -244,7 +264,10 @@ export async function assertPostsSafeToDelete(
 
   const ids = targets.map((target) => target.id);
   const idStrings = unique(ids.map(String));
-  const acknowledged = new Set<PostReferenceProbeName>(options.removedByCascade ?? []);
+  const acknowledged = new Set<PostReferenceProbeName>([
+    ...(options.removedByCascade ?? []),
+    ...(options.keptByPolicy ?? []),
+  ]);
   const referenceProbes = buildPostReferenceProbes(targets);
 
   const danglingReferenceFields = options.allowDanglingReplyReferences

--- a/packages/backend/src/services/PostDeletionCascade.ts
+++ b/packages/backend/src/services/PostDeletionCascade.ts
@@ -103,9 +103,24 @@ const POST_REFERENCE_DISPOSITION: Record<PostReferenceProbeName, ReferenceDispos
 };
 
 /** The claim this cascade makes, in the shape the residue check verifies. */
-const CASCADED_POST_REFERENCES: readonly PostReferenceProbeName[] = (
+export const CASCADED_POST_REFERENCES: readonly PostReferenceProbeName[] = (
   Object.keys(POST_REFERENCE_DISPOSITION) as PostReferenceProbeName[]
 ).filter((name) => POST_REFERENCE_DISPOSITION[name] === 'cascade');
+
+/**
+ * The references this module deliberately does NOT remove — the `retain` and
+ * `cancel-pending` halves of the table above.
+ *
+ * Derived from the same `Record` rather than written out a second time, so a
+ * disposition that changes moves both lists at once. Exported for a caller that
+ * has to declare its position to `assertPostsSafeToDelete`
+ * (`keptByPolicy`): a reference this module keeps on purpose must not read to
+ * that gate as one nobody thought about, and the only honest way to say so is
+ * to name the decision's owner rather than to claim the rows are gone.
+ */
+export const POST_REFERENCES_KEPT_BY_POLICY: readonly PostReferenceProbeName[] = (
+  Object.keys(POST_REFERENCE_DISPOSITION) as PostReferenceProbeName[]
+).filter((name) => POST_REFERENCE_DISPOSITION[name] !== 'cascade');
 
 /**
  * The fields the cascade reads off a post. Deliberately the same set the
@@ -409,6 +424,39 @@ function referenceLegs(targets: readonly CascadedPostRow[]): CascadeLeg[] {
       run: () => Bookmark.deleteMany({ postId: { $in: objectIds } }).exec(),
     },
   ];
+}
+
+/**
+ * The reference legs alone, over MANY posts, for an ADMINISTRATIVE caller.
+ *
+ * WHY A SECOND ENTRY POINT EXISTS, RATHER THAN A FLAG ON THE FIRST.
+ *
+ * {@link cascadeDeletedPost} serves the LIVE delete route: one post, already
+ * removed by the request that authorized it, and the user has been told the
+ * delete succeeded. It must therefore never throw — a derived row that could not
+ * be removed is not a reason to report a completed deletion as a failure — so it
+ * swallows everything and states the residue in a log.
+ *
+ * An administrative cascade is the opposite case in both respects. It deletes
+ * MANY posts, and it runs inside a job that can be re-run, so a leg that failed
+ * MUST reach the caller: a BullMQ retry re-running the whole cascade is exactly
+ * the recovery the live path does not have. Returning the failed leg NAMES is
+ * what makes that possible without either caller inheriting the other's error
+ * posture — a shared flag would put both postures in one function and let the
+ * wrong one be selected by a default.
+ *
+ * Scope is deliberately narrow: the reference legs and nothing else. It does not
+ * delete the `Post` rows (the caller owns which posts die and in what order), it
+ * does not expand the boost closure (use {@link collectBoostClosure}), and it
+ * does not repair counters (the surviving-row set depends on which posts the
+ * caller is destroying, which only the caller knows). Duplicating any of those
+ * here would put a second implementation beside the caller's.
+ */
+export async function cascadePostReferences(
+  targets: readonly CascadedPostRow[],
+): Promise<{ failedLegs: string[] }> {
+  if (targets.length === 0) return { failedLegs: [] };
+  return { failedLegs: await runLegs(referenceLegs(targets)) };
 }
 
 export interface PostDeletionCascadeInput {

--- a/packages/backend/src/services/channelDeletion/ChannelDeletionService.ts
+++ b/packages/backend/src/services/channelDeletion/ChannelDeletionService.ts
@@ -1,0 +1,1334 @@
+/**
+ * Executes {@link CHANNEL_CASCADE} — the destruction of one channel account's
+ * content, and of every row in Mention's own database that points at it.
+ *
+ * WHAT THIS IS NOT
+ *
+ * It does not delete the Oxy account, its membership rows, its follow edges or
+ * its uploaded bytes; those live on the far side of the Oxy boundary and are
+ * enumerated in `OWNED_BY_OXY` rather than silently omitted.
+ *
+ * IT REFUSES ANYTHING THAT IS NOT A CHANNEL
+ *
+ * The account `kind` is resolved here, at the top of both entry points, before a
+ * single post is read — see {@link NotAChannelAccountError}. It used to be the
+ * caller's job, on the reasoning that no route calls this yet; the absence of a
+ * route is the absence of an accident, not a defence, and pointing this at a
+ * personal account destroys a person's writing irreversibly. An unresolvable kind
+ * is a refusal too: `resolveAccountKind` is fail-soft to `null` by design and
+ * leaves the decision to its caller, and the two directions here are not
+ * comparable — refusing delays an administrative action, allowing may destroy the
+ * wrong account's posts.
+ *
+ * THE MANIFEST IS THE PROGRAM
+ *
+ * Every write below is driven by an entry in `CHANNEL_CASCADE`. Nothing is
+ * deleted that the manifest does not name, and every manifest entry is accounted
+ * for in the result — under `steps` with a count when this service performs the
+ * write, under `delegated` when `services/PostDeletionCascade.ts` owns the
+ * disposition, and under `retained` when the row is deliberately kept.
+ * `__tests__/services/channelDeletionService.test.ts` asserts that the three key
+ * sets are disjoint and that their union is EXACTLY the manifest's, so a step
+ * that stops executing disappears from all three and fails the build rather than
+ * silently leaving rows behind. Delegated and retained steps carry no count on
+ * purpose: a fabricated `0` is indistinguishable from a step that never ran,
+ * which is the failure this binding exists to catch. Do not pre-seed `steps` from
+ * the manifest either — that satisfies the assertion while executing nothing.
+ *
+ * RETRY CONTRACT
+ *
+ * Per-step failures are collected, every remaining step still runs, and the call
+ * THROWS at the end — the `sharingCleanup.service.ts` throw-on-partial shape, so
+ * a BullMQ worker retries against whatever survived. Every step is idempotent, so
+ * a re-run converges: a second pass over an already-deleted channel returns
+ * all-zero counts and does not throw.
+ */
+
+import type { Types } from 'mongoose';
+import type { AccountKind } from '@oxyhq/contracts';
+import { PostVisibility } from '@mention/shared-types';
+import { CHANNEL_CASCADE, type CascadeStep } from './channelCascadeManifest';
+
+import { Post } from '../../models/Post';
+import Like from '../../models/Like';
+import Bookmark from '../../models/Bookmark';
+import PostRecentReplier from '../../models/PostRecentReplier';
+import Poll from '../../models/Poll';
+import Article from '../../models/Article';
+import { Postgate } from '../../models/Postgate';
+import { Threadgate } from '../../models/Threadgate';
+import Notification from '../../models/Notification';
+import EngagementOutbox from '../../models/EngagementOutbox';
+import { FeedInteraction } from '../../models/FeedInteraction';
+import { RepairFetchFailure } from '../../models/RepairFetchFailure';
+import ContentLabel from '../../models/ContentLabel';
+import ModerationEnforcement from '../../models/ModerationEnforcement';
+import Report from '../../models/Report.model';
+import FederationDeliveryQueue from '../../models/FederationDeliveryQueue';
+import Lane from '../../models/Lane';
+import LaneMute from '../../models/LaneMute';
+import UserSettings from '../../models/UserSettings';
+import ActorKeyPair from '../../models/ActorKeyPair';
+import FederatedFollow from '../../models/FederatedFollow';
+import { AuthorFollowerSnapshot } from '../../models/AuthorFollowerSnapshot';
+import MentionSignedRecord from '../../models/MentionSignedRecord';
+import MentionRepoHead from '../../models/MentionRepoHead';
+import MentionUserNode from '../../models/MentionUserNode';
+import MentionNodeIngestWitness from '../../models/MentionNodeIngestWitness';
+import UserBehavior from '../../models/UserBehavior';
+import UserFeedPreference from '../../models/UserFeedPreference';
+import Mute from '../../models/Mute';
+import { MuteWord } from '../../models/MuteWord';
+import PostSubscription from '../../models/PostSubscription';
+import { EntityFollow } from '../../models/EntityFollow';
+import FeedLike from '../../models/FeedLike';
+import FeedReview from '../../models/FeedReview';
+import { FeedGenerator } from '../../models/FeedGenerator';
+import Labeler from '../../models/Labeler';
+import Poke from '../../models/Poke';
+import PushToken from '../../models/PushToken';
+import AccountList from '../../models/AccountList';
+import CustomFeed from '../../models/CustomFeed';
+import StarterPack from '../../models/StarterPack';
+import EndorsementOutbox from '../../models/EndorsementOutbox';
+import Trending from '../../models/Trending';
+import FederatedActor from '../../models/FederatedActor';
+
+import {
+  assertPostsSafeToDelete,
+  collectPostCascadeResidue,
+  type PostDeletionTarget,
+  type PostReferenceProbeName,
+} from '../../scripts/lib/adminDeletionPreflight';
+import {
+  CASCADED_POST_REFERENCES,
+  POST_REFERENCES_KEPT_BY_POLICY,
+  cascadePostReferences,
+  collectBoostClosure,
+  type CascadedPostRow,
+} from '../PostDeletionCascade';
+import { resolveAccountKind } from '../publishAsAccount';
+import { followService } from '../../connectors/activitypub/follow.service';
+import { deliveryService } from '../../connectors/activitypub/delivery.service';
+import { actorUrl } from '../../connectors/activitypub/constants';
+import { AP_CONTEXT } from '@oxyhq/federation';
+import { getServiceOxyClient } from '../../utils/oxyHelpers';
+import { logger } from '../../utils/logger';
+
+const LOG_PREFIX = '[ChannelDeletion]';
+
+/**
+ * What this cascade tells the preflight about the post references it does not
+ * have to prove absent, in the two shapes the gate distinguishes.
+ *
+ * Both lists are DERIVED from `POST_REFERENCE_DISPOSITION` rather than restated,
+ * because the disposition of a post reference is that table's decision and a copy
+ * here would be free to disagree with the code that actually runs. They are typed
+ * `PostReferenceProbeName[]`, so a probe renamed or added upstream breaks this
+ * build instead of being silently acknowledged.
+ *
+ *  - {@link CASCADED_POST_REFERENCES} is a CLAIM that the rows are gone, and it is
+ *    verified after the fact by `collectPostCascadeResidue`.
+ *  - {@link POST_REFERENCES_KEPT_BY_POLICY} is a decision that they STAY — the
+ *    retained `Report.reportedId(post)` and the two durable queues whose live
+ *    backlog is cancelled while their completed rows remain as a log. Declaring it
+ *    as a claim instead would make the residue check report every one of them as a
+ *    cascade leg that had stopped working.
+ */
+const REMOVED_BY_CASCADE: readonly PostReferenceProbeName[] = CASCADED_POST_REFERENCES;
+const KEPT_BY_POLICY: readonly PostReferenceProbeName[] = POST_REFERENCES_KEPT_BY_POLICY;
+
+// ---------------------------------------------------------------------------
+// Target resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * The channel's OWN posts, projected as {@link CascadedPostRow} — the shape the
+ * delegate reads — plus the two fields only this cascade needs.
+ *
+ * Reusing the delegate's row type is what lets the doomed set be handed over
+ * whole; `visibility` and `status` are read here alone, to decide which posts a
+ * remote server was ever told about and therefore needs a Tombstone for.
+ */
+interface ChannelPostRow extends CascadedPostRow {
+  visibility?: string;
+  status?: string;
+}
+
+/** Either spelling of a post id: a `Mixed` column stores both and Mongo casts neither. */
+type PostIdValue = Types.ObjectId | string;
+
+/**
+ * Everything the cascade needs, resolved ONCE before any row is touched.
+ *
+ * Resolving up front is what makes the ordering safe: every step below filters on
+ * an id set captured here, so deleting the posts cannot destroy the ids the
+ * dependent sweeps are enumerated from, and a crash mid-cascade leaves a set a
+ * re-run can rebuild from the surviving rows.
+ */
+interface DeletionTargets {
+  readonly channelOxyUserId: string;
+  /** The channel's own posts. */
+  readonly channelPostIds: readonly PostIdValue[];
+  readonly channelPostIdStrings: readonly string[];
+  /** Public + published channel posts — the ones a `Delete(Tombstone)` is emitted for. */
+  readonly federatablePostIds: readonly string[];
+  /** Other people's boosts of them, transitively (see {@link collectBoostClosure}). */
+  readonly boostPostIds: readonly PostIdValue[];
+  /** The channel's posts UNION those boosts — every row this run destroys. */
+  readonly doomedPostIds: readonly PostIdValue[];
+  readonly doomedPostIdStrings: readonly string[];
+  /**
+   * The same rows, in the shape {@link cascadePostReferences} reads. Handed over
+   * WHOLE rather than as ids: the delegate also reaches a post's owned `Poll` and
+   * `Article` rows through `content.pollId` / `content.article.articleId`, which an
+   * id list cannot carry.
+   */
+  readonly doomedRows: readonly CascadedPostRow[];
+  /** The doomed ids PLUS the AP ids/urls those rows advertise (`channel-post-uris` scope). */
+  readonly postKeys: readonly string[];
+  /** The preflight's view of the same set. */
+  readonly deletionTargets: readonly PostDeletionTarget[];
+  readonly laneIds: readonly string[];
+  /**
+   * Originals that SURVIVE this run and lose a boost to it: one entry per channel
+   * post that boosted somebody else's post.
+   */
+  readonly boostedOriginalIds: readonly string[];
+  /** Surviving posts the channel liked: one entry per `Like` row being deleted. */
+  readonly likedPostIds: readonly string[];
+  /** Remote inboxes a `Delete(actor)` would reach. */
+  readonly federatedFollowers: number;
+  /** Other people's replies into the doomed set — expected to be 0. */
+  readonly repliesByOthers: number;
+  /** Other people's quotes of a doomed post; kept, pointer cleared. */
+  readonly quotesByOthersKept: number;
+}
+
+/**
+ * Deliberately the same fields the delegate's own boost-closure projection reads,
+ * so the two halves of the doomed set are the same shape and the whole of it can
+ * be handed to `cascadePostReferences` — plus `visibility`/`status`, which decide
+ * which posts were ever advertised to a remote server.
+ */
+const POST_PROJECTION = {
+  _id: 1,
+  oxyUserId: 1,
+  visibility: 1,
+  status: 1,
+  boostOf: 1,
+  parentPostId: 1,
+  federation: 1,
+  'content.pollId': 1,
+  'content.article.articleId': 1,
+} as const;
+
+function uriKeysOf(rows: readonly CascadedPostRow[]): string[] {
+  return rows.flatMap((row) =>
+    [row.federation?.activityId, row.federation?.url].filter(
+      (value): value is string => typeof value === 'string' && value.length > 0,
+    ),
+  );
+}
+
+/**
+ * Read every id set the cascade filters on. Strictly read-only, so both
+ * {@link previewChannelDeletion} and the dry run share it unchanged.
+ */
+async function resolveDeletionTargets(channelOxyUserId: string): Promise<DeletionTargets> {
+  // A channel post is reachable by the denormalized owner cache OR by its
+  // authorship owner entry; the two are kept in sync by the `Post` pre-save hook,
+  // but a cascade is the wrong place to depend on that having held for every row.
+  const channelPosts = await Post.find(
+    {
+      $or: [
+        { oxyUserId: channelOxyUserId },
+        { authorship: { $elemMatch: { oxyUserId: channelOxyUserId, role: 'owner' } } },
+      ],
+    },
+    POST_PROJECTION,
+  ).lean<ChannelPostRow[]>();
+
+  const channelPostIds = channelPosts.map((post) => post._id);
+  const channelPostIdStrings = channelPostIds.map(String);
+
+  // The delegate's closure, not a second one. It is transitive (a boost of a boost
+  // is still a card with nothing behind it) and it REFUSES past its own cap rather
+  // than truncating — a partially deboosted post leaves exactly the blank cards the
+  // expansion prevents, and an operator needs to hear about it.
+  const boostRows = await collectBoostClosure(channelPostIdStrings);
+  if (boostRows === null) {
+    throw new Error(
+      `${LOG_PREFIX} refused to expand the boost closure for ${channelOxyUserId}: it exceeds the ` +
+        'bound in PostDeletionCascade. Deleting a prefix of it would leave blank boost cards behind, ' +
+        'so this needs an operator rather than a retry.',
+    );
+  }
+  const boostPostIds = boostRows.map((post) => post._id);
+
+  const doomedRows: CascadedPostRow[] = [...channelPosts, ...boostRows];
+  const doomedPostIds = [...channelPostIds, ...boostPostIds];
+  const doomedPostIdStrings = doomedPostIds.map(String);
+  const doomedIdSet = new Set(doomedPostIdStrings);
+
+  const [laneRows, likeRows, federatedFollowers, repliesByOthers, quotesByOthersKept] =
+    await Promise.all([
+      Lane.find({ ownerId: channelOxyUserId }, { _id: 1 }).lean<Array<{ _id: Types.ObjectId }>>(),
+      Like.find({ userId: channelOxyUserId }, { postId: 1 }).lean<
+        Array<{ postId: Types.ObjectId }>
+      >(),
+      FederatedFollow.countDocuments({
+        localUserId: channelOxyUserId,
+        direction: 'inbound',
+        status: 'accepted',
+      }),
+      Post.countDocuments({
+        parentPostId: { $in: channelPostIdStrings },
+        _id: { $nin: doomedPostIds },
+      }),
+      Post.countDocuments({
+        quoteOf: { $in: doomedPostIdStrings },
+        _id: { $nin: doomedPostIds },
+      }),
+    ]);
+
+  return {
+    channelOxyUserId,
+    channelPostIds,
+    channelPostIdStrings,
+    federatablePostIds: channelPosts
+      .filter((post) => post.visibility === PostVisibility.PUBLIC && post.status === 'published')
+      .map((post) => String(post._id)),
+    boostPostIds,
+    doomedPostIds,
+    doomedPostIdStrings,
+    doomedRows,
+    postKeys: [...new Set([...doomedPostIdStrings, ...uriKeysOf(doomedRows)])],
+    deletionTargets: doomedRows.map((post) => ({
+      id: post._id,
+      uris: uriKeysOf([post]),
+    })),
+    laneIds: laneRows.map((lane) => String(lane._id)),
+    // A channel post that boosted somebody else's post: the original survives and
+    // must lose the boost from its denormalized counter. A boost of another post
+    // in the doomed set needs no repair — that post is going away too.
+    boostedOriginalIds: channelPosts
+      .map((post) => post.boostOf)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0 && !doomedIdSet.has(id)),
+    likedPostIds: likeRows
+      .map((like) => String(like.postId))
+      .filter((id) => !doomedIdSet.has(id)),
+    federatedFollowers,
+    repliesByOthers,
+    quotesByOthersKept,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The step → Mongo binding table
+// ---------------------------------------------------------------------------
+
+/**
+ * The order the phases run in, and what a crash inside each one leaves behind.
+ * Each name is what the executor groups manifest steps by.
+ */
+type CascadePhase =
+  /** Undelivered outbound activities from the channel. */
+  | 'federation-drain'
+  /** Rows that exist only as an attachment to a doomed post. */
+  | 'post-dependents'
+  /** Other people's posts that point INTO the doomed set. */
+  | 'scrub-foreign-posts'
+  /** The doomed `Post` rows themselves. */
+  | 'doomed-posts'
+  /** Rows keyed on the channel's lanes. */
+  | 'lanes'
+  /** Rows keyed on the channel account. */
+  | 'account';
+
+/** How a schema stores a post id, so a `$in` is built in the type it can match. */
+type PostIdForm = 'objectId' | 'string' | 'both';
+
+/**
+ * The three operations the cascade performs, typed structurally so ONE table can
+ * hold models of different document shapes without an `any` in sight.
+ */
+interface CascadeCollection {
+  countDocuments(filter: Record<string, unknown>): PromiseLike<number>;
+  deleteMany(filter: Record<string, unknown>): PromiseLike<{ deletedCount: number }>;
+  updateMany(
+    filter: Record<string, unknown>,
+    update: Record<string, unknown>,
+  ): PromiseLike<{ modifiedCount: number }>;
+}
+
+/**
+ * A manifest step whose disposition belongs to `services/PostDeletionCascade.ts`.
+ *
+ * `leg` names the reference the delegate covers, and it is typed
+ * `PostReferenceProbeName` so the COMPILER holds the two files together: a probe
+ * renamed upstream breaks this build rather than leaving a step delegated to a leg
+ * that no longer exists. It is documentation with a gate on it, not a lookup key —
+ * the delegate is handed the whole doomed set once and decides its own legs.
+ */
+interface DelegatedBinding {
+  readonly delegated: true;
+  readonly leg: PostReferenceProbeName;
+}
+
+interface LocalStepBinding {
+  readonly collection: CascadeCollection;
+  readonly phase: CascadePhase;
+  /**
+   * Tiebreaker WITHIN a phase; steps otherwise run in manifest order. Only one
+   * step needs it, and the reason is on that entry — a step whose count can only
+   * ever be zero is a step nobody can verify.
+   */
+  readonly order?: number;
+  /** The Mongo path carrying the reference, when it is not the manifest's `field`. */
+  readonly path?: string;
+  /** Extra terms ANDed into the scope-derived filter. */
+  readonly match?: Readonly<Record<string, unknown>>;
+  /** Only read for `channel-posts` scope. Defaults to `'string'`. */
+  readonly idForm?: PostIdForm;
+  /**
+   * `pull-from-array` over an array of SUBDOCUMENTS: the array to `$pull` from and
+   * the key inside each element that carries the reference. Without it the array
+   * is assumed to hold the referenced ids directly.
+   */
+  readonly pullSubdocument?: { readonly arrayPath: string; readonly elementKey: string };
+  /** Replaces the scope-derived filter for the references a plain `$in` cannot express. */
+  readonly filter?: (targets: DeletionTargets) => Record<string, unknown>;
+}
+
+type StepBinding = LocalStepBinding | DelegatedBinding;
+
+function isDelegated(binding: StepBinding): binding is DelegatedBinding {
+  return 'delegated' in binding;
+}
+
+/** A manifest entry's identity. `Notification.entityId` appears under two scopes. */
+function bindingKey(step: CascadeStep): string {
+  return `${step.model}.${step.field}|${step.scope}`;
+}
+
+/** The key a step reports its count under. The two `Notification.entityId` steps share one. */
+function stepKey(step: CascadeStep): string {
+  return `${step.model}.${step.field}`;
+}
+
+/**
+ * The ONE place a manifest step's Mongo shape is written down: which collection,
+ * which phase, and — where the schema path differs from the manifest's field name
+ * or the filter needs a term the scope cannot supply — exactly how.
+ *
+ * Kept in manifest order so the two files diff against each other, and because
+ * within a phase the executor runs steps in that order.
+ */
+const STEP_BINDINGS: Readonly<Record<string, StepBinding>> = {
+  // --- Engagement and derived rows ON the destroyed posts --------------------
+  // DELEGATED to `PostDeletionCascade.cascadePostReferences` — the live delete
+  // route's own implementation of "what happens to a reference on a post that is
+  // gone", whose `POST_REFERENCE_DISPOSITION` is a `Record` over the preflight's
+  // probe list and therefore breaks its own build when a reference type is added.
+  // A second copy here would destroy that property. See the manifest's block
+  // comment for the full argument.
+  'Like.postId|channel-posts': { delegated: true, leg: 'Like.postId' },
+  'Bookmark.postId|channel-posts': { delegated: true, leg: 'Bookmark.postId' },
+  'PostRecentReplier.postId|channel-posts': {
+    delegated: true,
+    leg: 'PostRecentReplier.postId',
+  },
+  'Poll.postId|channel-posts': { delegated: true, leg: 'Poll.postId' },
+  'Article.postId|channel-posts': { delegated: true, leg: 'Article.postId' },
+  'Postgate.postId|channel-posts': { delegated: true, leg: 'Postgate.postId/postUri' },
+  'Postgate.postUri|channel-post-uris': { delegated: true, leg: 'Postgate.postId/postUri' },
+  'Threadgate.postId|channel-posts': { delegated: true, leg: 'Threadgate.postId/postUri' },
+  'Threadgate.postUri|channel-post-uris': {
+    delegated: true,
+    leg: 'Threadgate.postId/postUri',
+  },
+  // Someone else's postgate listing a doomed post among its detached quotes: the
+  // row is theirs and stays, only the entry goes. NOT delegated — the delegate
+  // deletes the postgate rows that BELONG to a doomed post, which is a different
+  // question from an entry naming one inside a stranger's row.
+  'Postgate.detachedQuoteUris|channel-post-uris': {
+    collection: Postgate,
+    phase: 'scrub-foreign-posts',
+  },
+  // `entityId` holds a POST id only when `entityType` is post/reply — that half is
+  // the delegate's. The SAME column holds an oxyUserId for a profile notification,
+  // which is a channel reference and has no delegate leg, so it runs here.
+  'Notification.entityId|channel-posts': { delegated: true, leg: 'Notification.entityId' },
+  'Notification.entityId|channel-account': {
+    collection: Notification,
+    phase: 'account',
+    match: { entityType: 'profile' },
+  },
+  'EngagementOutbox.postId|channel-posts': {
+    delegated: true,
+    leg: 'EngagementOutbox.payload.postId',
+  },
+  'FeedInteraction.postUri|channel-post-uris': {
+    delegated: true,
+    leg: 'FeedInteraction.postUri',
+  },
+  'RepairFetchFailure.postId|channel-posts': {
+    collection: RepairFetchFailure,
+    phase: 'post-dependents',
+  },
+  // `targetId` is polymorphic on `targetType`, so the column is two references and
+  // the manifest gives it two steps. The post rows are the delegate's; the
+  // user-scoped rows are a label applied TO the channel, which nothing else
+  // sweeps.
+  'ContentLabel.targetId|channel-posts': {
+    delegated: true,
+    leg: 'ContentLabel.targetId(post)',
+  },
+  'ContentLabel.targetId|channel-account': {
+    collection: ContentLabel,
+    phase: 'account',
+    match: { targetType: 'user' },
+  },
+  'ModerationEnforcement.subjectId|channel-posts': {
+    collection: ModerationEnforcement,
+    phase: 'post-dependents',
+  },
+  // `Report.model.reportedId` and `ModerationOutbox.reportId` have NO binding: the
+  // manifest gives them the `retain` action, so there is nothing to execute and a
+  // binding for them would be a query nobody may run. The reasons are on those
+  // entries; the short version is that removing a report leaves an inbound
+  // CrowdSource decision retrying until it expires.
+  //
+  // Hoisted OUT of the account phase and into the drain: the manifest requires
+  // these to go before the actor Delete is broadcast, or a queued Create races it
+  // and republishes a post on the receiving instance.
+  'FederationDeliveryQueue.senderOxyUserId|channel-account': {
+    collection: FederationDeliveryQueue,
+    phase: 'federation-drain',
+  },
+
+  // --- Other people's POSTS that point INTO the destroyed set ----------------
+  // The boost ROWS themselves; they are already in the doomed set, so this deletes
+  // by id rather than by `boostOf` and cannot reach a post outside it.
+  'Post.boostOf|channel-posts': {
+    collection: Post,
+    phase: 'doomed-posts',
+    order: 1,
+    filter: (targets) => ({ _id: { $in: targets.boostPostIds } }),
+  },
+  // `$nin` the doomed set so the count means "somebody else's post scrubbed" —
+  // the doomed rows carrying the same pointer are deleted outright below.
+  'Post.quoteOf|channel-posts': {
+    collection: Post,
+    phase: 'scrub-foreign-posts',
+    filter: (targets) => ({
+      quoteOf: { $in: targets.doomedPostIdStrings },
+      _id: { $nin: targets.doomedPostIds },
+    }),
+  },
+  'Post.parentPostId|channel-posts': {
+    collection: Post,
+    phase: 'scrub-foreign-posts',
+    filter: (targets) => ({
+      parentPostId: { $in: targets.doomedPostIdStrings },
+      _id: { $nin: targets.doomedPostIds },
+    }),
+  },
+  'Post.threadId|channel-posts': {
+    collection: Post,
+    phase: 'scrub-foreign-posts',
+    filter: (targets) => ({
+      threadId: { $in: targets.doomedPostIdStrings },
+      _id: { $nin: targets.doomedPostIds },
+    }),
+  },
+  'Post.mentions|channel-account': { collection: Post, phase: 'account' },
+
+  // --- The channel's own posts ----------------------------------------------
+  // Deleted by the resolved id set, not by owner: that set is what the preflight
+  // cleared and what every dependent sweep above was enumerated from, so a row
+  // created since resolution is left for the next run rather than deleted with
+  // its dependents unswept.
+  'Post.oxyUserId|channel-account': {
+    collection: Post,
+    phase: 'doomed-posts',
+    order: 3,
+    filter: (targets) => ({ _id: { $in: targets.doomedPostIds } }),
+  },
+  // The doomed rows that name a writer, destroyed FIRST among the authored posts
+  // (`order`) so the count means something: how many of the channel's posts had a
+  // human behind them. Left in manifest order it would run after the owner-keyed
+  // delete had already taken every doomed row, and a step that can only ever
+  // report zero is a step no test can tell from a broken one.
+  //
+  // The row is DELETED. It is never handed to the person named in
+  // `writtenByOxyUserId` — with `signPosts` off that would retroactively publish
+  // who wrote what, the single promise a channel makes, broken at the moment the
+  // channel is no longer there to answer for it.
+  'Post.writtenByOxyUserId|channel-posts': {
+    collection: Post,
+    phase: 'doomed-posts',
+    order: 2,
+    filter: (targets) => ({
+      _id: { $in: targets.doomedPostIds },
+      writtenByOxyUserId: { $exists: true },
+    }),
+  },
+  'Post.laneId|channel-lanes': { collection: Post, phase: 'lanes' },
+
+  // --- Rows keyed on the channel ACCOUNT -------------------------------------
+  'Lane.ownerId|channel-account': { collection: Lane, phase: 'account' },
+  'LaneMute.laneId|channel-lanes': { collection: LaneMute, phase: 'lanes' },
+  'LaneMute.laneOwnerOxyUserId|channel-account': { collection: LaneMute, phase: 'account' },
+  'LaneMute.viewerOxyUserId|channel-account': { collection: LaneMute, phase: 'account' },
+  'UserSettings.oxyUserId|channel-account': { collection: UserSettings, phase: 'account' },
+  // Another person's privacy settings naming the channel; the array is nested
+  // under `privacy`, and the row is theirs so only the entry goes.
+  'UserSettings.restrictedUsers|channel-account': {
+    collection: UserSettings,
+    phase: 'account',
+    path: 'privacy.restrictedUsers',
+  },
+  'ActorKeyPair.oxyUserId|channel-account': { collection: ActorKeyPair, phase: 'account' },
+  'FederatedFollow.localUserId|channel-account': { collection: FederatedFollow, phase: 'account' },
+  'AuthorFollowerSnapshot.oxyUserId|channel-account': {
+    collection: AuthorFollowerSnapshot,
+    phase: 'account',
+  },
+  'MentionSignedRecord.oxyUserId|channel-account': {
+    collection: MentionSignedRecord,
+    phase: 'account',
+  },
+  'MentionRepoHead.oxyUserId|channel-account': { collection: MentionRepoHead, phase: 'account' },
+  'MentionUserNode.oxyUserId|channel-account': { collection: MentionUserNode, phase: 'account' },
+  'MentionNodeIngestWitness.oxyUserId|channel-account': {
+    collection: MentionNodeIngestWitness,
+    phase: 'account',
+  },
+  'Notification.recipientId|channel-account': { collection: Notification, phase: 'account' },
+  'Notification.actorId|channel-account': { collection: Notification, phase: 'account' },
+  'EngagementOutbox.actorOxyUserId|channel-account': {
+    collection: EngagementOutbox,
+    phase: 'account',
+    path: 'payload.actorOxyUserId',
+  },
+  'EngagementOutbox.postOwnerOxyUserId|channel-account': {
+    collection: EngagementOutbox,
+    phase: 'account',
+    path: 'payload.postOwnerOxyUserId',
+  },
+  'UserBehavior.oxyUserId|channel-account': { collection: UserBehavior, phase: 'account' },
+  // `preferredAuthors` is an array of SUBDOCUMENTS keyed on `authorId`. The
+  // manifest classifies it under both names, so both steps run: the first pulls
+  // the entries, the second re-runs the identical pull and legitimately reports 0
+  // in a live run (in a dry run both report the same rows, which are the same
+  // rows).
+  'UserBehavior.authorId|channel-account': {
+    collection: UserBehavior,
+    phase: 'account',
+    path: 'preferredAuthors.authorId',
+    pullSubdocument: { arrayPath: 'preferredAuthors', elementKey: 'authorId' },
+  },
+  'UserBehavior.preferredAuthors|channel-account': {
+    collection: UserBehavior,
+    phase: 'account',
+    path: 'preferredAuthors.authorId',
+    pullSubdocument: { arrayPath: 'preferredAuthors', elementKey: 'authorId' },
+  },
+  'UserBehavior.hiddenAuthors|channel-account': { collection: UserBehavior, phase: 'account' },
+  'UserBehavior.mutedAuthors|channel-account': { collection: UserBehavior, phase: 'account' },
+  'UserBehavior.blockedAuthors|channel-account': { collection: UserBehavior, phase: 'account' },
+  'UserFeedPreference.oxyUserId|channel-account': {
+    collection: UserFeedPreference,
+    phase: 'account',
+  },
+  'Mute.mutedId|channel-account': { collection: Mute, phase: 'account' },
+  'Mute.userId|channel-account': { collection: Mute, phase: 'account' },
+  'MuteWord.userId|channel-account': { collection: MuteWord, phase: 'account' },
+  'Like.userId|channel-account': { collection: Like, phase: 'account' },
+  'Bookmark.userId|channel-account': { collection: Bookmark, phase: 'account' },
+  'PostSubscription.subscriberId|channel-account': {
+    collection: PostSubscription,
+    phase: 'account',
+  },
+  'PostSubscription.authorId|channel-account': { collection: PostSubscription, phase: 'account' },
+  // The channel inside another post's replier projection: an array of
+  // subdocuments, and that post belongs to someone else.
+  'PostRecentReplier.oxyUserId|channel-account': {
+    collection: PostRecentReplier,
+    phase: 'account',
+    path: 'repliers.oxyUserId',
+    pullSubdocument: { arrayPath: 'repliers', elementKey: 'oxyUserId' },
+  },
+  'EntityFollow.userId|channel-account': { collection: EntityFollow, phase: 'account' },
+  'FeedInteraction.userId|channel-account': { collection: FeedInteraction, phase: 'account' },
+  'FeedLike.userId|channel-account': { collection: FeedLike, phase: 'account' },
+  'FeedReview.reviewerId|channel-account': { collection: FeedReview, phase: 'account' },
+  'FeedGenerator.createdBy|channel-account': { collection: FeedGenerator, phase: 'account' },
+  'Labeler.creatorId|channel-account': { collection: Labeler, phase: 'account' },
+  'Poke.pokerId|channel-account': { collection: Poke, phase: 'account' },
+  'Poke.pokedId|channel-account': { collection: Poke, phase: 'account' },
+  'PushToken.userId|channel-account': { collection: PushToken, phase: 'account' },
+  'Poll.createdBy|channel-account': { collection: Poll, phase: 'account' },
+  'Article.createdBy|channel-account': { collection: Article, phase: 'account' },
+  'Postgate.createdBy|channel-account': { collection: Postgate, phase: 'account' },
+  'Threadgate.createdBy|channel-account': { collection: Threadgate, phase: 'account' },
+  'ContentLabel.createdBy|channel-account': { collection: ContentLabel, phase: 'account' },
+  'Report.model.reporter|channel-account': {
+    collection: Report,
+    phase: 'account',
+    path: 'reporter',
+  },
+  'AccountList.ownerOxyUserId|channel-account': { collection: AccountList, phase: 'account' },
+  'AccountList.memberOxyUserIds|channel-account': { collection: AccountList, phase: 'account' },
+  'CustomFeed.ownerOxyUserId|channel-account': { collection: CustomFeed, phase: 'account' },
+  'CustomFeed.memberOxyUserIds|channel-account': { collection: CustomFeed, phase: 'account' },
+  'StarterPack.ownerOxyUserId|channel-account': { collection: StarterPack, phase: 'account' },
+  'StarterPack.memberOxyUserIds|channel-account': { collection: StarterPack, phase: 'account' },
+  'StarterPack.usedByOxyUserIds|channel-account': { collection: StarterPack, phase: 'account' },
+  'EndorsementOutbox.pendingRemoveOwnerId|channel-account': {
+    collection: EndorsementOutbox,
+    phase: 'account',
+  },
+  'EndorsementOutbox.pendingRemoveMemberIds|channel-account': {
+    collection: EndorsementOutbox,
+    phase: 'account',
+  },
+  'Trending.actorIds|channel-account': { collection: Trending, phase: 'account' },
+  'FederatedActor.oxyUserId|channel-account': { collection: FederatedActor, phase: 'account' },
+};
+
+// ---------------------------------------------------------------------------
+// Step execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Count (dry run) or delete (live), returning the affected-row count either way.
+ * With {@link countOrUpdate} this is the single chokepoint that keeps a dry run
+ * strictly read-only — mirrors `scripts/purgeGoneFederatedActors.ts`.
+ */
+async function countOrDelete(
+  collection: CascadeCollection,
+  filter: Record<string, unknown>,
+  dryRun: boolean,
+): Promise<number> {
+  if (dryRun) return collection.countDocuments(filter);
+  const result = await collection.deleteMany(filter);
+  return result.deletedCount;
+}
+
+/** Count (dry run) or apply an `$unset`/`$pull` (live). */
+async function countOrUpdate(
+  collection: CascadeCollection,
+  filter: Record<string, unknown>,
+  update: Record<string, unknown>,
+  dryRun: boolean,
+): Promise<number> {
+  if (dryRun) return collection.countDocuments(filter);
+  const result = await collection.updateMany(filter, update);
+  return result.modifiedCount;
+}
+
+/** The ids a `channel-posts` step filters on, in the spelling its schema stores. */
+function postIdsFor(binding: LocalStepBinding, targets: DeletionTargets): unknown[] {
+  switch (binding.idForm ?? 'string') {
+    case 'objectId':
+      return [...targets.doomedPostIds];
+    case 'both':
+      return [...targets.doomedPostIds, ...targets.doomedPostIdStrings];
+    case 'string':
+      return [...targets.doomedPostIdStrings];
+  }
+}
+
+/** The single value (account scope) or value set (every other scope) a step matches. */
+function scopeOperand(
+  step: CascadeStep,
+  binding: LocalStepBinding,
+  targets: DeletionTargets,
+): unknown {
+  switch (step.scope) {
+    case 'channel-account':
+      return targets.channelOxyUserId;
+    case 'channel-lanes':
+      return { $in: [...targets.laneIds] };
+    case 'channel-post-uris':
+      return { $in: [...targets.postKeys] };
+    case 'channel-posts':
+      return { $in: postIdsFor(binding, targets) };
+  }
+}
+
+function buildFilter(
+  step: CascadeStep,
+  binding: LocalStepBinding,
+  targets: DeletionTargets,
+): Record<string, unknown> {
+  if (binding.filter) return binding.filter(targets);
+  return {
+    [binding.path ?? step.field]: scopeOperand(step, binding, targets),
+    ...binding.match,
+  };
+}
+
+function buildPullUpdate(
+  step: CascadeStep,
+  binding: LocalStepBinding,
+  targets: DeletionTargets,
+): Record<string, unknown> {
+  const operand = scopeOperand(step, binding, targets);
+  if (binding.pullSubdocument) {
+    const { arrayPath, elementKey } = binding.pullSubdocument;
+    return { $pull: { [arrayPath]: { [elementKey]: operand } } };
+  }
+  return { $pull: { [binding.path ?? step.field]: operand } };
+}
+
+async function executeStep(
+  step: CascadeStep,
+  binding: LocalStepBinding,
+  targets: DeletionTargets,
+  dryRun: boolean,
+): Promise<number> {
+  const filter = buildFilter(step, binding, targets);
+  switch (step.action) {
+    case 'delete-row':
+      return countOrDelete(binding.collection, filter, dryRun);
+    case 'unset-field':
+      return countOrUpdate(
+        binding.collection,
+        filter,
+        { $unset: { [binding.path ?? step.field]: '' } },
+        dryRun,
+      );
+    case 'pull-from-array':
+      return countOrUpdate(
+        binding.collection,
+        filter,
+        buildPullUpdate(step, binding, targets),
+        dryRun,
+      );
+    case 'retain':
+      // Unreachable: `buildSchedule` never schedules a retained step, precisely so
+      // no query for one can exist. Kept as a real throw rather than a silent
+      // fall-through so a future binding that contradicts the manifest is loud.
+      throw new Error(
+        `${LOG_PREFIX} ${bindingKey(step)} is retained by the manifest and must not be executed`,
+      );
+  }
+}
+
+/**
+ * Accumulates what happened to every manifest step, and the failures that make
+ * the call throw at the end.
+ *
+ * Three disjoint accounts, because "this ran and affected N rows", "somebody else
+ * owns this" and "this is deliberately kept" are three different statements and
+ * collapsing them loses the only one that matters. Counting a delegated or
+ * retained step as `0` would be the worst of the three options: indistinguishable
+ * from a step that silently stopped running, which is the exact failure the
+ * manifest binding exists to catch.
+ */
+class CascadeRun {
+  readonly steps: Record<string, number> = {};
+  readonly failures: string[] = [];
+  private readonly delegatedKeys = new Set<string>();
+  private readonly retainedKeys = new Set<string>();
+
+  record(key: string, count: number): void {
+    this.steps[key] = (this.steps[key] ?? 0) + count;
+  }
+
+  delegate(key: string): void {
+    this.delegatedKeys.add(key);
+  }
+
+  retain(key: string): void {
+    this.retainedKeys.add(key);
+  }
+
+  fail(key: string, error: unknown): void {
+    this.failures.push(key);
+    logger.error(`${LOG_PREFIX} cascade step failed`, error);
+  }
+
+  /**
+   * A failure the delegate has ALREADY logged with its own leg name; recorded so
+   * the run still throws and a BullMQ retry re-runs it. Not logged a second time —
+   * two entries for one failure read as two failures.
+   */
+  failDelegated(reference: string): void {
+    this.failures.push(`PostDeletionCascade:${reference}`);
+  }
+
+  /**
+   * The delegated and retained key lists, made DISJOINT from `steps`.
+   *
+   * Two columns are classified twice by scope — `Notification.entityId` and
+   * `ContentLabel.targetId` each hold a post id under one `entityType`/`targetType`
+   * and an account id under another — so one step key can have both a delegated
+   * entry and a locally executed one. Local wins, because a real count is more
+   * informative than a label and because the count would otherwise be silently
+   * dropped from the result. The manifest entry for the delegated half says so in
+   * its `why`, which is where a reader looks for the disposition anyway.
+   */
+  classify(): { delegated: string[]; retained: string[] } {
+    const local = new Set(Object.keys(this.steps));
+    return {
+      delegated: [...this.delegatedKeys].filter((key) => !local.has(key)).sort(),
+      retained: [...this.retainedKeys]
+        .filter((key) => !local.has(key) && !this.delegatedKeys.has(key))
+        .sort(),
+    };
+  }
+}
+
+interface ScheduledStep {
+  readonly step: CascadeStep;
+  /** Only a LOCAL binding is ever scheduled — a delegated one has no query here. */
+  readonly binding: LocalStepBinding;
+}
+type CascadeSchedule = ReadonlyMap<CascadePhase, readonly ScheduledStep[]>;
+
+/**
+ * Account for every manifest step exactly once, and group the ones this service
+ * executes under the phase that runs them.
+ *
+ * Done in ONE pass over the manifest rather than per phase, so a step with no
+ * binding is reported once rather than once per phase — and so the delegated and
+ * retained accounts are complete even in a dry run, where the delegate is never
+ * called.
+ */
+function buildSchedule(run: CascadeRun): CascadeSchedule {
+  const schedule = new Map<CascadePhase, ScheduledStep[]>();
+
+  for (const step of CHANNEL_CASCADE) {
+    // The manifest's own action decides this, ahead of any binding lookup: a
+    // retained row has no query, and a binding for one would be a query nobody may
+    // run.
+    if (step.action === 'retain') {
+      run.retain(stepKey(step));
+      continue;
+    }
+    const binding = STEP_BINDINGS[bindingKey(step)];
+    if (!binding) {
+      run.fail(bindingKey(step), new Error(`no Mongo binding for cascade step ${bindingKey(step)}`));
+      continue;
+    }
+    if (isDelegated(binding)) {
+      run.delegate(stepKey(step));
+      continue;
+    }
+    const bucket = schedule.get(binding.phase);
+    if (bucket) bucket.push({ step, binding });
+    else schedule.set(binding.phase, [{ step, binding }]);
+  }
+
+  // A stable sort, so an entry without an `order` keeps its manifest position.
+  for (const bucket of schedule.values()) {
+    bucket.sort((left, right) => (left.binding.order ?? 0) - (right.binding.order ?? 0));
+  }
+  return schedule;
+}
+
+/**
+ * Run every manifest step assigned to one phase.
+ *
+ * A step that throws still records its key (as 0) so the result stays a complete
+ * description of the manifest, and the failure is collected for the throw at the
+ * end. A step with NO binding records nothing — the missing key is what the
+ * manifest-binding test reports.
+ */
+async function runPhase(
+  phase: CascadePhase,
+  schedule: CascadeSchedule,
+  targets: DeletionTargets,
+  dryRun: boolean,
+  run: CascadeRun,
+): Promise<void> {
+  for (const { step, binding } of schedule.get(phase) ?? []) {
+    try {
+      run.record(stepKey(step), await executeStep(step, binding, targets, dryRun));
+    } catch (error) {
+      run.record(stepKey(step), 0);
+      run.fail(stepKey(step), error);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Federation
+// ---------------------------------------------------------------------------
+
+/**
+ * Tell the fediverse the posts and then the actor are gone, BEFORE anything they
+ * are addressed from is deleted: `deliverToFollowers` resolves its inboxes from
+ * the `FederatedFollow` rows, which the account phase removes.
+ *
+ * The username is resolved SERVER-SIDE from the authoritative `oxyUserId` — the
+ * canonical Note ids a remote server matches against are minted from it, and no
+ * request-scoped value is trusted for it. A resolve miss THROWS before any row is
+ * deleted, so the run is retried rather than leaving remote copies with no local
+ * post left to address a later Delete from.
+ *
+ * Skipped entirely when the channel has no accepted inbound followers: there is
+ * nobody to deliver to, so it would be a round trip to Oxy for no delivery.
+ */
+async function broadcastFederatedDelete(targets: DeletionTargets): Promise<void> {
+  if (targets.federatedFollowers === 0) return;
+
+  const user = await getServiceOxyClient().getUserById(targets.channelOxyUserId);
+  const username = user.username?.trim();
+  if (!username) {
+    throw new Error(
+      `${LOG_PREFIX} cannot federate the deletion of ${targets.channelOxyUserId}: no resolvable username`,
+    );
+  }
+
+  // Per-post Tombstones first: once the actor is deleted a remote server may drop
+  // the account wholesale, and an instance that does not still needs each status
+  // named. `federateDelete` is best-effort by design and never throws.
+  for (const postId of targets.federatablePostIds) {
+    await followService.federateDelete({ _id: postId }, targets.channelOxyUserId, username);
+  }
+
+  const actor = actorUrl(username);
+  await deliveryService.deliverToFollowers(
+    {
+      '@context': AP_CONTEXT,
+      id: `${actor}#delete-${Date.now()}`,
+      type: 'Delete',
+      actor,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      object: actor,
+    },
+    targets.channelOxyUserId,
+    username,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Counter repair
+// ---------------------------------------------------------------------------
+
+/**
+ * Repair the denormalized counters on posts that SURVIVE this run but lose an
+ * engagement record to it: a channel post that boosted somebody else's post, and
+ * a `Like` the channel left on somebody else's post.
+ *
+ * Each decrement is independently guarded on `$gt: 0`, mirroring the live
+ * `Undo(Announce)` / unlike teardown, so a counter that already lags cannot
+ * underflow. `stats.federatedBoostsCount` is deliberately untouched: it counts
+ * inbound Announces, and a channel is a local author.
+ */
+async function repairSurvivingCounters(
+  targets: DeletionTargets,
+  dryRun: boolean,
+): Promise<{ boostCounters: number; likeCounters: number }> {
+  let boostCounters = 0;
+  let likeCounters = 0;
+
+  for (const originalId of targets.boostedOriginalIds) {
+    boostCounters += await decrementStat(originalId, 'stats.boostsCount', dryRun);
+  }
+  for (const postId of targets.likedPostIds) {
+    likeCounters += await decrementStat(postId, 'stats.likesCount', dryRun);
+  }
+
+  return { boostCounters, likeCounters };
+}
+
+/**
+ * One guarded decrement. A failure is LOGGED and swallowed rather than thrown,
+ * which is the opposite of every other step here and deliberate: the ids being
+ * repaired were derived from rows this run has already deleted, so a retry
+ * computes an EMPTY repair set and can never make good on it. Failing the job
+ * would therefore lose the deletion's success without saving the counter. A stale
+ * denormalized count is reconcilable on its own
+ * (`scripts/recomputeFederatedEngagement.ts`); a half-reported cascade is not.
+ */
+async function decrementStat(postId: string, path: string, dryRun: boolean): Promise<number> {
+  const filter = { _id: postId, [path]: { $gt: 0 } };
+  try {
+    if (dryRun) {
+      // Count the SAME predicate the live write uses, so the dry-run figure is not
+      // an optimistic guess about a post that may no longer exist.
+      return (await Post.countDocuments(filter)) > 0 ? 1 : 0;
+    }
+    const result = await Post.updateOne(filter, { $inc: { [path]: -1 } });
+    return result.modifiedCount;
+  } catch (error) {
+    logger.error(`${LOG_PREFIX} could not repair ${path} on a surviving post`, error);
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * The account this was pointed at is not a channel, so nothing was read and
+ * nothing was written.
+ *
+ * The message distinguishes the two causes ON PURPOSE, because the operator
+ * response is not the same one: "resolved as personal" means the id is wrong and
+ * the run must never be repeated as-is, while "could not be resolved" means Oxy
+ * could not answer and the same command is worth retrying once identity is back.
+ * A single "not a channel" message would make the second look like the first, and
+ * the natural reaction to the first — go and find the right id — is exactly the
+ * wrong reaction to the second.
+ */
+export class NotAChannelAccountError extends Error {
+  /** The kind Oxy answered with, or `null` when the read produced no answer. */
+  readonly resolvedKind: AccountKind | null;
+
+  constructor(oxyUserId: string, resolvedKind: AccountKind | null) {
+    super(
+      resolvedKind === null
+        ? `${LOG_PREFIX} refused: the Oxy account kind of ${oxyUserId} could not be resolved, and ` +
+            'deleting an account whose kind is unknown is not a risk this takes'
+        : `${LOG_PREFIX} refused: ${oxyUserId} resolved as ${resolvedKind}, not a channel`,
+    );
+    this.name = 'NotAChannelAccountError';
+    this.resolvedKind = resolvedKind;
+  }
+}
+
+/**
+ * Refuse anything that is not a channel, before a single row is read.
+ *
+ * `resolveAccountKind` is fail-soft to `null` by design — the reply gate needs an
+ * identity outage not to refuse every reply on the site — so the DECISION is the
+ * caller's, and here it is no. The two directions are not comparable: refusing
+ * delays an administrative action that can be re-run, while allowing destroys a
+ * person's posts irreversibly if the id turns out to name a personal account.
+ *
+ * The `catch` is deliberate belt-and-braces rather than dead code: the fail-soft
+ * contract lives in another module and could be tightened there without anybody
+ * looking at this call site, and a rejection that propagated would abort the run
+ * with an error that says nothing about why.
+ */
+async function assertChannelAccount(oxyUserId: string): Promise<void> {
+  let kind: AccountKind | null;
+  try {
+    kind = await resolveAccountKind(oxyUserId);
+  } catch (error) {
+    logger.error(`${LOG_PREFIX} could not resolve the account kind`, error);
+    throw new NotAChannelAccountError(oxyUserId, null);
+  }
+  if (kind !== 'channel') {
+    logger.warn(`${LOG_PREFIX} refused a deletion for a non-channel account`, {
+      oxyUserId,
+      resolvedKind: kind,
+    });
+    throw new NotAChannelAccountError(oxyUserId, kind);
+  }
+}
+
+export interface ChannelDeletionPreview {
+  channelOxyUserId: string;
+  /** The channel's own posts. */
+  posts: number;
+  /** Other people's boosts of them, which are destroyed alongside. */
+  boostsByOthers: number;
+  /** Other people's replies into the set. A channel cannot be replied to, so 0. */
+  replies: number;
+  /** Other people's quotes of a doomed post: kept, pointer cleared. */
+  quotesByOthersKept: number;
+  /** Remote inboxes the `Delete(actor)` will reach. */
+  federatedFollowers: number;
+}
+
+function buildPreview(targets: DeletionTargets): ChannelDeletionPreview {
+  return {
+    channelOxyUserId: targets.channelOxyUserId,
+    posts: targets.channelPostIds.length,
+    boostsByOthers: targets.boostPostIds.length,
+    replies: targets.repliesByOthers,
+    quotesByOthersKept: targets.quotesByOthersKept,
+    federatedFollowers: targets.federatedFollowers,
+  };
+}
+
+/**
+ * What deleting this channel would cost, without touching anything.
+ *
+ * Gated on the account kind exactly like the deletion itself: a preview of "every
+ * post this person has ever written" is not a harmless read to hand back for an
+ * account nobody established is a channel.
+ *
+ * `replies` should always be 0 — the reply gate refuses a `channel` author at
+ * five sites — and a non-zero value is a finding, not a number to accept.
+ */
+export async function previewChannelDeletion(
+  channelOxyUserId: string,
+): Promise<ChannelDeletionPreview> {
+  await assertChannelAccount(channelOxyUserId);
+  return buildPreview(await resolveDeletionTargets(channelOxyUserId));
+}
+
+export interface ChannelDeletionResult {
+  /**
+   * Affected-row counts for the steps THIS service executed, keyed EXACTLY
+   * `${step.model}.${step.field}`.
+   *
+   * A key whose column is classified under two scopes (`Notification.entityId`,
+   * `ContentLabel.targetId`) appears here when EITHER scope runs locally, and the
+   * count is that local work only — the other scope's disposition is on its
+   * manifest entry.
+   */
+  steps: Record<string, number>;
+  /**
+   * Manifest keys whose disposition belongs to
+   * `PostDeletionCascade.cascadePostReferences`. Listed without a count on
+   * purpose: the delegate reports failed legs, not per-reference totals, and
+   * inventing a `0` here would be indistinguishable from a step that never ran.
+   */
+  delegated: string[];
+  /** Manifest keys deliberately KEPT — see each entry's `why` for the reason. */
+  retained: string[];
+  preview: ChannelDeletionPreview;
+  dryRun: boolean;
+}
+
+/**
+ * Destroy one channel's content and every Mention row pointing at it.
+ *
+ * The order below is the whole design; each phase says what a crash inside it
+ * leaves behind, and none of those states is unrecoverable by a re-run.
+ */
+export async function deleteChannelContent(
+  channelOxyUserId: string,
+  options: { dryRun: boolean },
+): Promise<ChannelDeletionResult> {
+  const { dryRun } = options;
+
+  // 0. Refuse anything that is not a channel, before any read of the post set and
+  //    long before any write or federation call. Pointed at a personal account
+  //    this destroys a person's writing, and no route existing today is the
+  //    absence of an accident rather than a defence against one.
+  await assertChannelAccount(channelOxyUserId);
+
+  const run = new CascadeRun();
+  const schedule = buildSchedule(run);
+
+  // 1. Resolve every id set ONCE, read-only. A crash here has changed nothing.
+  const targets = await resolveDeletionTargets(channelOxyUserId);
+  const preview = buildPreview(targets);
+  logger.info(`${LOG_PREFIX} resolved deletion targets`, {
+    dryRun,
+    posts: preview.posts,
+    boostsByOthers: preview.boostsByOthers,
+    replies: preview.replies,
+    quotesByOthersKept: preview.quotesByOthersKept,
+    federatedFollowers: preview.federatedFollowers,
+  });
+
+  // 2. Drain the channel's undelivered outbound activities. The manifest requires
+  //    this BEFORE the actor Delete, or a queued Create races it and republishes a
+  //    post on the receiving instance. A crash here leaves some queued activities
+  //    that a re-run drains; nothing has been told the channel is gone yet.
+  await runPhase('federation-drain', schedule, targets, dryRun, run);
+
+  // 3. Prove the deletion cannot strand a reference nobody cleans. Read-only, and
+  //    deliberately BEFORE the broadcast rather than after it: a refusal here is
+  //    permanent until an operator acts, and broadcasting first would leave remote
+  //    servers holding a Tombstone for posts that are still live locally, on every
+  //    retry. It runs in a dry run too, so a blocker surfaces before a live run.
+  await assertPostsSafeToDelete(`channelDeletion:${channelOxyUserId}`, targets.deletionTargets, {
+    removedByCascade: REMOVED_BY_CASCADE,
+    // Stated separately from the claim above because it is the opposite kind of
+    // statement: these rows are kept on purpose, so the residue check must not
+    // demand their absence. See the constants at the top of this file.
+    keptByPolicy: KEPT_BY_POLICY,
+    // The graph probe would otherwise refuse the run for the quotes and replies
+    // this cascade UNSETS in phase 6 — a strictly stronger disposition than the
+    // dangling pointer the allowance describes. `boostOf` stays covered, and the
+    // boost closure resolved in phase 1 is what keeps it satisfied.
+    allowDanglingReplyReferences: true,
+  });
+
+  // 4. Tell the fediverse. Nothing delivery reads has been deleted yet. A crash
+  //    here leaves an actor that remote servers may already have dropped while its
+  //    local rows survive — a re-run re-sends (Delete is idempotent remotely) and
+  //    completes the cascade.
+  if (!dryRun) {
+    await broadcastFederatedDelete(targets);
+  }
+
+  // 5. Rows that exist only as an attachment to a doomed post. A crash here leaves
+  //    posts alive with some of their engagement gone: visible as under-counted
+  //    rows, converged by a re-run.
+  //
+  //    Most of this phase is the DELEGATE's: `cascadePostReferences` is the live
+  //    delete route's own implementation of these dispositions, handed the whole
+  //    doomed set at once. A failed leg is recorded so the run still throws and a
+  //    BullMQ retry re-runs it — the reason that entry point exists separately from
+  //    the never-throwing one the delete route calls. Skipped in a dry run: it
+  //    deletes, and counting it instead would mean writing the queries again here,
+  //    which is the duplication the delegation removes.
+  if (!dryRun) {
+    const { failedLegs } = await cascadePostReferences(targets.doomedRows);
+    for (const leg of failedLegs) run.failDelegated(leg);
+  }
+  //    The rest is local: the references the preflight has no probe for, so the
+  //    delegate has no leg for them either.
+  await runPhase('post-dependents', schedule, targets, dryRun, run);
+
+  // 6. Other people's posts that point INTO the doomed set. Their content is kept;
+  //    only the pointer goes. A crash here leaves a mix of scrubbed and dangling
+  //    pointers, which hydration already tolerates until the re-run.
+  await runPhase('scrub-foreign-posts', schedule, targets, dryRun, run);
+
+  // 7. The doomed rows: the boosts first (they render entirely from an original
+  //    that is about to disappear), then the channel's own posts. A crash here is
+  //    the first point at which content is actually gone, and everything that
+  //    pointed at it has already been swept.
+  await runPhase('doomed-posts', schedule, targets, dryRun, run);
+
+  // 8. Lane rows, then the account-keyed rows. The lane ids were captured in phase
+  //    1, so deleting the lanes after the mutes cannot orphan either.
+  await runPhase('lanes', schedule, targets, dryRun, run);
+  await runPhase('account', schedule, targets, dryRun, run);
+
+  // 9. Counters on posts that SURVIVE but lost an engagement record. Deliberately
+  //    not part of `steps`: no manifest entry describes a counter, and inventing a
+  //    key would break the set equality that binds this file to the manifest.
+  //
+  //    NOT duplicated with the delegate: `cascadePostReferences` runs the reference
+  //    legs only — `PostDeletionCascade`'s own counter repair belongs to
+  //    `cascadeDeletedPost`, which this never calls — because which rows survive
+  //    depends on which posts the caller is destroying, and only the caller knows
+  //    that.
+  const counters = await repairSurvivingCounters(targets, dryRun);
+  logger.info(`${LOG_PREFIX} repaired counters on surviving posts`, {
+    dryRun,
+    boostCounters: counters.boostCounters,
+    likeCounters: counters.likeCounters,
+  });
+
+  // 10. Verify what the cascade CLAIMED to remove actually went — the `cascade`
+  //     half only, never the retained half, whose absence would be the bug.
+  //     Skipped in a dry run, where every claim is trivially unmet because nothing
+  //     was deleted.
+  if (!dryRun) {
+    const residue = await collectPostCascadeResidue(targets.deletionTargets, REMOVED_BY_CASCADE);
+    if (residue.length > 0) {
+      logger.error(
+        `${LOG_PREFIX} cascade claimed references it did not remove: ${residue.join(', ')}`,
+      );
+    }
+  }
+
+  if (run.failures.length > 0) {
+    throw new Error(
+      `${LOG_PREFIX} ${run.failures.length} cascade step(s) failed for ${channelOxyUserId} ` +
+        `(${run.failures.join(', ')}) — the run will be retried against whatever survived`,
+    );
+  }
+
+  const { delegated, retained } = run.classify();
+  return { steps: run.steps, delegated, retained, preview, dryRun };
+}

--- a/packages/backend/src/services/channelDeletion/channelCascadeManifest.ts
+++ b/packages/backend/src/services/channelDeletion/channelCascadeManifest.ts
@@ -1,0 +1,969 @@
+/**
+ * The complete, enumerated inventory of everything in Mention's own database
+ * that points at a channel account or at a post a channel authored.
+ *
+ * WHY THIS IS A DATA STRUCTURE AND NOT A FUNCTION
+ *
+ * A hand-written cascade goes stale the day somebody adds a model, and it fails
+ * SILENTLY: the new collection keeps rows pointing at a channel that no longer
+ * exists, nothing throws, and nobody finds out for months. So the cascade is
+ * expressed as data that a test can compare against the real model tree —
+ * `src/__tests__/services/channelCascadeCoverage.test.ts` walks
+ * `src/models/*.ts`, extracts every id-shaped field, and fails when one is not
+ * classified here. A new model with a `postId` breaks that test on the commit
+ * that adds it, which is the only mechanism that keeps this honest.
+ *
+ * Every id-shaped field in every model is in EXACTLY ONE of three places:
+ *   - {@link CHANNEL_CASCADE} — it references a channel or a channel's post, and
+ *     this is what the cascade does about it.
+ *   - {@link NOT_A_CHANNEL_REFERENCE} — the id names something that is neither an
+ *     Oxy account nor a Mention post (a topic, a feed, a run, a file, a
+ *     CrowdSource case), with the reason.
+ *   - {@link OWNED_BY_OXY} — it is a real reference that Mention CANNOT delete,
+ *     because the row on the other side of it belongs to Oxy. Enumerated rather
+ *     than omitted: an orphan across the boundary is still an orphan, and the
+ *     only way an operator can close it is by knowing it is there.
+ *
+ * The cascade EXECUTES this list (see `ChannelDeletionService`), rather than
+ * describing something implemented separately. That is deliberate — a manifest
+ * that merely documents a hand-written cascade is a second thing to keep in
+ * sync, and the two would drift in exactly the direction nobody notices.
+ */
+
+/** What the cascade does to a row that carries the reference. */
+export type CascadeAction =
+  /** The row exists only because of the channel or its post; it dies with it. */
+  | 'delete-row'
+  /**
+   * The row belongs to SOMEBODY ELSE and carries its own content. The pointer is
+   * removed and the row is kept — deleting it would destroy a third party's work
+   * in order to remove the channel's.
+   */
+  | 'pull-from-array'
+  | 'unset-field'
+  /**
+   * The row is deliberately KEPT, pointing at content that no longer exists.
+   *
+   * Expressible as an action rather than left out of the manifest, because a
+   * reference nobody removes and a reference nobody thought about look identical
+   * from the outside — and the whole premise of this file is that they must not.
+   * An entry here is a decision with a written reason and a name attached; an
+   * absent entry is an oversight the coverage test will eventually find. Only the
+   * first of those is safe to leave alone.
+   */
+  | 'retain';
+
+/** Which set of ids the step's filter is built from. */
+export type CascadeScope =
+  /** The channel account's own `oxyUserId`. */
+  | 'channel-account'
+  /**
+   * Every post being destroyed: the channel's own posts PLUS other people's
+   * boosts of them, which are resolved into the set before any row is deleted.
+   */
+  | 'channel-posts'
+  /** The same posts, keyed by their ActivityPub ids/urls instead of `_id`. */
+  | 'channel-post-uris'
+  /** The `_id`s of the lanes the channel owns. */
+  | 'channel-lanes';
+
+export interface CascadeStep {
+  /** Model FILE basename under `src/models`, which is what the scanner sees. */
+  readonly model: string;
+  /** The schema field carrying the reference. */
+  readonly field: string;
+  readonly scope: CascadeScope;
+  readonly action: CascadeAction;
+  /** Why this disposition and not the other one. Read by humans, not by code. */
+  readonly why: string;
+}
+
+/**
+ * BOOSTS AND QUOTES — the one genuinely contested pair, decided here once.
+ *
+ * The question is what happens to OTHER people's posts that point at a post
+ * being destroyed. The repo already answered it, twice, in prose that predates
+ * channels (`scripts/lib/adminDeletionPreflight.ts` and
+ * `scripts/purgeBlockedDomainContent.ts`), and this follows that answer rather
+ * than inventing a channel-specific one:
+ *
+ *  - A BOOST is deleted. Its body is deliberately empty and it renders entirely
+ *    from `boostOf`, so once the original is gone it is not degraded content —
+ *    it is a placeholder card with nothing behind it. Deleting it removes an
+ *    amplification, never an authored thought.
+ *  - A QUOTE is KEPT, because the quoter wrote their own words and those words
+ *    are not the channel's to destroy.
+ *
+ * This differs from the prose in exactly one respect, and deliberately. The
+ * written policy leaves `quoteOf` DANGLING and relies on hydration soft-failing
+ * the lookup forever. Here the field is UNSET instead. The rendered result is
+ * identical — `attachNestedContext` resolves a missing quote to null and drops
+ * the card either way — but a row that points at nothing is an orphan by the
+ * invariant this cascade exists to uphold, while a row that simply is not a
+ * quote any more is not. Unsetting is also idempotent, which a dangling pointer
+ * is not: a retry cannot tell "already cleaned" from "never cleaned".
+ *
+ * `parentPostId` / `threadId` get the same treatment for the same reason, with
+ * one caveat recorded in their steps below: a channel post cannot be replied to
+ * (the reply gate refuses a `channel` author at five sites), so cross-author
+ * rows in that shape should not exist at all. They are swept anyway, because
+ * "should not exist" is an assumption and a cascade is the wrong place to hold
+ * one.
+ */
+export const CHANNEL_CASCADE: readonly CascadeStep[] = [
+  // ---------------------------------------------------------------------------
+  // Engagement and derived rows ON the destroyed posts. Each exists only as an
+  // attachment to a post, and none carries content of its own.
+  //
+  // MOST OF THIS BLOCK IS NOT EXECUTED HERE. `services/PostDeletionCascade.ts`
+  // already owns "what happens to a reference ON a post that is gone", for the
+  // live delete route every user hits, and its `POST_REFERENCE_DISPOSITION` is a
+  // `Record` over the preflight's probe list — so a reference type added upstream
+  // breaks THAT file's build until somebody decides what to do about it. A second
+  // implementation of the same decisions destroys exactly that property, because
+  // one of the two will be the one nobody remembers to update. So these steps are
+  // DELEGATED: `ChannelDeletionService` hands the whole doomed set to
+  // `cascadePostReferences` and reports them under `delegated` rather than with a
+  // count of its own. The manifest still names them, because the inventory has to
+  // stay complete whoever performs the write.
+  // ---------------------------------------------------------------------------
+  {
+    model: 'Like',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why: 'A like is an edge to a post; with the post gone it has no subject.',
+  },
+  {
+    model: 'Bookmark',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why: 'A bookmark points at a post; a saved-list entry for a destroyed post renders as a hole.',
+  },
+  {
+    model: 'PostRecentReplier',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why: 'A denormalized replier projection for a destroyed post.',
+  },
+  {
+    model: 'Poll',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why: 'The poll and its votes live inside the row; the post owned it.',
+  },
+  {
+    model: 'Article',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why: 'Long-form body owned by the post.',
+  },
+  {
+    model: 'Postgate',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why: 'A per-post quote/embed policy has no meaning once the post is gone.',
+  },
+  {
+    model: 'Postgate',
+    field: 'postUri',
+    scope: 'channel-post-uris',
+    action: 'delete-row',
+    why: 'Same row, reachable by AP uri as well as by id; both are swept so a uri-only row cannot survive.',
+  },
+  {
+    model: 'Threadgate',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why: 'A per-thread reply policy owned by the root post.',
+  },
+  {
+    model: 'Threadgate',
+    field: 'postUri',
+    scope: 'channel-post-uris',
+    action: 'delete-row',
+    why: 'The same row reachable by AP uri instead of id; both keys are swept so a uri-only row cannot survive.',
+  },
+  {
+    model: 'Postgate',
+    field: 'detachedQuoteUris',
+    scope: 'channel-post-uris',
+    action: 'pull-from-array',
+    why:
+      'A channel post that quoted somebody and was detached is listed by uri inside THEIR postgate. The row ' +
+      'is theirs and stays; only the entry naming a destroyed post goes.',
+  },
+  {
+    model: 'Notification',
+    field: 'entityId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why: 'A notification whose subject post is destroyed opens onto nothing when tapped (entityType post/reply).',
+  },
+  {
+    model: 'Notification',
+    field: 'entityId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why:
+      'The SAME column holds an oxyUserId when entityType is "profile" (a follow or a poke). A sweep that ' +
+      'only ever read it as a post id leaves those rows pointing at a deleted channel.',
+  },
+  {
+    model: 'EngagementOutbox',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why:
+      'A queued engagement projection for a post that will not exist when it drains. DELEGATED, and the ' +
+      'delegate owns the disposition: `PostDeletionCascade` cancels the PENDING rows and keeps the processed ' +
+      'ones, because only a pending row can still act on a post that is gone — a processed one is a log entry, ' +
+      'and the unindexed scan that would find the rest belongs in a batch job, not on this collection.',
+  },
+  {
+    model: 'FeedInteraction',
+    field: 'postUri',
+    scope: 'channel-post-uris',
+    action: 'delete-row',
+    why: 'Ranking telemetry keyed by post uri; it would train affinity on removed content.',
+  },
+  {
+    model: 'RepairFetchFailure',
+    field: 'postId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why:
+      'An admin repair-log row naming a post that no longer exists. Absent from the existing preflight probes, ' +
+      'and therefore from `PostDeletionCascade` too — so this one is executed HERE. A reference the delegate ' +
+      'has never heard of cannot be delegated to it.',
+  },
+  {
+    model: 'ContentLabel',
+    field: 'targetId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why:
+      'A label on a destroyed post — rows filtered to targetType "post". DELEGATED, since a label on a post ' +
+      'that is gone is the same reference whoever deleted the post; the channel-scoped rows in the SAME column ' +
+      'are a different question and get their own step below.',
+  },
+  {
+    model: 'ContentLabel',
+    field: 'targetId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why:
+      'The same polymorphic column holds an oxyUserId when targetType is "user": a label applied TO the channel. ' +
+      'Nothing else sweeps it — the post-scoped delegate reads the column only as a post id — so a label ON a ' +
+      'deleted channel would survive as the last row pointing at it.',
+  },
+  {
+    model: 'ModerationEnforcement',
+    field: 'subjectId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why:
+      'An enforcement record whose subject post is gone. Named `subjectId`, so a scanner keyed on ' +
+      '"postId" misses it — which is exactly why the coverage test keys on id SHAPE and not on a name list. ' +
+      'Executed HERE: it is not one of the preflight\'s probes, so the delegate has no leg for it.',
+  },
+  {
+    model: 'Report.model',
+    field: 'reportedId',
+    scope: 'channel-posts',
+    action: 'retain',
+    why:
+      'A report about a destroyed post is KEPT, and deleting it would break something rather than merely lose ' +
+      'an audit trail. An inbound CrowdSource decision is matched to local rows by `Report.crowdSourceCaseId`, ' +
+      'and `ModerationDecisionWorker` throws a RETRYABLE `ModerationDecisionDeferredError` when a case resolves ' +
+      'to no report — so a decision arriving after the reported post was destroyed would back off and retry ' +
+      'until it expired. That reason does not depend on WHO deleted the post, so it cannot have two answers ' +
+      'depending on the cause: this follows the live delete path (`POST_REFERENCE_DISPOSITION` in ' +
+      '`PostDeletionCascade`), which retains it for exactly this reason. `purgeBlockedDomainContent` DOES delete ' +
+      'these, deliberately and differently — it removes a blocked instance\'s content wholesale and its cascade ' +
+      'owns that call; the divergence is noted here so a reader does not take this for an oversight. The other ' +
+      'side is already designed for a vanished subject: `ModerationDeliveryWorker` closes the report as ' +
+      'undeliverable rather than retrying, so the row is stranded by being removed, never by being kept.',
+  },
+  {
+    model: 'ModerationOutbox',
+    field: 'reportId',
+    scope: 'channel-posts',
+    action: 'retain',
+    why:
+      'The delivery job for a Report, kept because its report is now kept: with the report surviving there is ' +
+      'nothing orphaned, and deleting the job would strand a report at `queued` that nothing will ever deliver. ' +
+      'The one report this cascade still removes is one the channel FILED (`Report.reporter`, which cannot ' +
+      'exist — a channel can never be acted as), and even that leaves no stuck job: ' +
+      '`deliverReportOutboxEvent` completes an event whose report is gone instead of retrying it. Same ' +
+      'deliberate divergence from `purgeBlockedDomainContent` as the step above.',
+  },
+  {
+    model: 'FederationDeliveryQueue',
+    field: 'senderOxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why:
+      'Undelivered outbound activities from the channel. They must go BEFORE the actor delete is broadcast, ' +
+      'or a queued Create races the Delete and republishes a post on the receiving instance.',
+  },
+
+  // ---------------------------------------------------------------------------
+  // Other people's POSTS that point INTO the destroyed set.
+  // ---------------------------------------------------------------------------
+  {
+    model: 'Post',
+    field: 'boostOf',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why:
+      'A boost has an intentionally empty body and renders entirely from its original. Dangling, it is a ' +
+      'permanent "unavailable" placeholder, so it is destroyed with the original — see the header note.',
+  },
+  {
+    model: 'Post',
+    field: 'quoteOf',
+    scope: 'channel-posts',
+    action: 'unset-field',
+    why:
+      'The quoter wrote their own words and keeps them; only the pointer goes. Unset rather than left ' +
+      'dangling so no row references a destroyed post — see the header note.',
+  },
+  {
+    model: 'Post',
+    field: 'parentPostId',
+    scope: 'channel-posts',
+    action: 'unset-field',
+    why:
+      'A channel post cannot be replied to, so this set should be EMPTY; swept anyway because a cascade is ' +
+      'the wrong place to hold an assumption. A reply that survives keeps its text and loses its "replying to" line.',
+  },
+  {
+    model: 'Post',
+    field: 'threadId',
+    scope: 'channel-posts',
+    action: 'unset-field',
+    why: 'Same shape as parentPostId: the thread root is gone, the post keeps its own content.',
+  },
+  {
+    model: 'Post',
+    field: 'mentions',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why:
+      'Other people\'s posts that @-mention the channel. The post is theirs and stays; the mention would ' +
+      'otherwise render a link to an account that no longer resolves.',
+  },
+
+  // ---------------------------------------------------------------------------
+  // The channel's own posts. Deleted AFTER everything above, so that a crash
+  // never destroys the ids the steps above are enumerated from.
+  // ---------------------------------------------------------------------------
+  {
+    model: 'Post',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'The channel\'s posts. The whole point: with the channel gone their only public author is gone.',
+  },
+  {
+    model: 'Post',
+    field: 'writtenByOxyUserId',
+    scope: 'channel-posts',
+    action: 'delete-row',
+    why:
+      'Carried by the same rows being deleted. It is NEVER used to reattribute a post to its writer: for a ' +
+      'channel that did not opt into naming its writers, that would retroactively publish who wrote what — ' +
+      'the one promise a channel makes, broken at the moment it is no longer there to answer for it.',
+  },
+  {
+    model: 'Post',
+    field: 'laneId',
+    scope: 'channel-lanes',
+    action: 'unset-field',
+    why:
+      'Defence in depth. A lane belongs to one publisher and only that publisher\'s posts carry its id, so ' +
+      'these rows are inside the deleted set already; the sweep catches a mis-assigned row rather than trusting that.',
+  },
+
+  // ---------------------------------------------------------------------------
+  // Rows keyed on the channel ACCOUNT.
+  // ---------------------------------------------------------------------------
+  {
+    model: 'Lane',
+    field: 'ownerId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Lanes the channel owns. Absent from the existing preflight probes entirely.',
+  },
+  {
+    model: 'LaneMute',
+    field: 'laneId',
+    scope: 'channel-lanes',
+    action: 'delete-row',
+    why: 'A reader\'s mute of a lane that no longer exists. Absent from the existing preflight probes.',
+  },
+  {
+    model: 'LaneMute',
+    field: 'laneOwnerOxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Same rows reachable by publisher; swept so a mute cannot outlive its lane by either key.',
+  },
+  {
+    model: 'LaneMute',
+    field: 'viewerOxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'A channel can never be acted as, so it cannot be a viewer; swept defensively like the other actor-side rows.',
+  },
+  {
+    model: 'UserSettings',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why:
+      'The channel\'s settings row, which carries the writer-disclosure decision. Named in prose rather than ' +
+      'by its flag: `channelWriterDisclosure.ts` is that flag\'s one reader, and a gate enforces it.',
+  },
+  {
+    model: 'UserSettings',
+    field: 'restrictedUsers',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why:
+      'Another person\'s privacy settings naming the channel as restricted. Their row is theirs and stays; ' +
+      'only the entry goes. Carries no id-shaped suffix, so the scanner cannot flag it — listed in ' +
+      'EMBEDDED_CHANNEL_REFERENCES too, which is what keeps that blind spot written down.',
+  },
+  {
+    model: 'ActorKeyPair',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'The channel\'s ActivityPub signing key. Deleted LAST among account rows: outbound deletes are signed with it.',
+  },
+  {
+    model: 'FederatedFollow',
+    field: 'localUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Remote accounts following the channel. Read BEFORE deletion to address the Delete(actor) broadcast.',
+  },
+  {
+    model: 'AuthorFollowerSnapshot',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Denormalized follower counts used by feed ranking.',
+  },
+  {
+    model: 'MentionSignedRecord',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'The channel\'s MTN hash chain. A channel post does emit a signed record, under the channel\'s own identity.',
+  },
+  {
+    model: 'MentionRepoHead',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'The head of that chain; orphaned the moment the records go.',
+  },
+  {
+    model: 'MentionUserNode',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Self-hosted node registration for the channel.',
+  },
+  {
+    model: 'MentionNodeIngestWitness',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Ingest witnesses for that node.',
+  },
+  {
+    model: 'Notification',
+    field: 'recipientId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Notifications addressed to the channel. It has no session to read them, but rows can exist.',
+  },
+  {
+    model: 'Notification',
+    field: 'actorId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Notifications naming the channel as the actor; the "X posted" row would name an account that will not resolve.',
+  },
+  {
+    model: 'EngagementOutbox',
+    field: 'actorOxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Queued projections whose actor is the channel.',
+  },
+  {
+    model: 'EngagementOutbox',
+    field: 'postOwnerOxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Queued projections whose post owner is the channel.',
+  },
+  {
+    model: 'UserBehavior',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'A viewer-behaviour row for the channel. It cannot be acted as, so this should be empty; swept defensively.',
+  },
+  {
+    model: 'UserBehavior',
+    field: 'authorId',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'The channel inside another viewer\'s `preferredAuthors` affinity entries; the viewer\'s row is theirs and stays.',
+  },
+  {
+    model: 'UserBehavior',
+    field: 'preferredAuthors',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'Same array, named as the array rather than the nested id.',
+  },
+  {
+    model: 'UserBehavior',
+    field: 'hiddenAuthors',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'Another viewer\'s hidden-author list; scrubbed, never deleted.',
+  },
+  {
+    model: 'UserBehavior',
+    field: 'mutedAuthors',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'Another viewer\'s muted-author list.',
+  },
+  {
+    model: 'UserBehavior',
+    field: 'blockedAuthors',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'Another viewer\'s blocked-author list.',
+  },
+  {
+    model: 'UserFeedPreference',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Feed preferences for the channel; defensive, same reason as UserBehavior.',
+  },
+  {
+    model: 'Mute',
+    field: 'mutedId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Somebody\'s mute OF the channel. The row exists only to name that pair, so it dies with the channel.',
+  },
+  {
+    model: 'Mute',
+    field: 'userId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Mutes BY the channel; defensive, it cannot act.',
+  },
+  {
+    model: 'MuteWord',
+    field: 'userId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Muted words owned by the channel; defensive.',
+  },
+  {
+    model: 'Like',
+    field: 'userId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why:
+      'Likes BY the channel on other people\'s posts. Their `stats.likesCount` is decremented in the same step — ' +
+      'a surviving post must not keep a count that includes a deleted record.',
+  },
+  {
+    model: 'Bookmark',
+    field: 'userId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Bookmarks owned by the channel.',
+  },
+  {
+    model: 'PostSubscription',
+    field: 'subscriberId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Subscriptions the channel holds.',
+  },
+  {
+    model: 'PostSubscription',
+    field: 'authorId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Other people\'s subscriptions to the channel\'s output; the author they name is gone.',
+  },
+  {
+    model: 'PostRecentReplier',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'The channel inside another post\'s replier projection; that post belongs to someone else.',
+  },
+  {
+    model: 'EntityFollow',
+    field: 'userId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Hashtag/list follows owned by the channel; defensive.',
+  },
+  {
+    model: 'FeedInteraction',
+    field: 'userId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Ranking telemetry attributed to the channel as a viewer; defensive.',
+  },
+  {
+    model: 'FeedLike',
+    field: 'userId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Custom-feed subscriptions held by the channel; defensive.',
+  },
+  {
+    model: 'FeedReview',
+    field: 'reviewerId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Feed reviews written by the channel; defensive.',
+  },
+  {
+    model: 'FeedGenerator',
+    field: 'createdBy',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Feed generators the channel registered.',
+  },
+  {
+    model: 'Labeler',
+    field: 'creatorId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Labeler services the channel created.',
+  },
+  {
+    model: 'Poke',
+    field: 'pokerId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Pokes sent by the channel; defensive.',
+  },
+  {
+    model: 'Poke',
+    field: 'pokedId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Pokes aimed at the channel.',
+  },
+  {
+    model: 'PushToken',
+    field: 'userId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'A channel has no device and no session, so this must be empty; swept so "must be" is enforced, not assumed.',
+  },
+  {
+    model: 'Poll',
+    field: 'createdBy',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Polls authored by the channel outside its own posts.',
+  },
+  {
+    model: 'Article',
+    field: 'createdBy',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Articles authored by the channel.',
+  },
+  {
+    model: 'Postgate',
+    field: 'createdBy',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Quote policies the channel set.',
+  },
+  {
+    model: 'Threadgate',
+    field: 'createdBy',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Reply policies the channel set.',
+  },
+  {
+    model: 'ContentLabel',
+    field: 'createdBy',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Labels the channel applied.',
+  },
+  {
+    model: 'Report.model',
+    field: 'reporter',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Reports filed by the channel; defensive, it cannot act.',
+  },
+  {
+    model: 'AccountList',
+    field: 'ownerOxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Lists the channel owns; an ownerless list is unreachable and unmanageable.',
+  },
+  {
+    model: 'AccountList',
+    field: 'memberOxyUserIds',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'The channel as a MEMBER of somebody else\'s list; the list is theirs and survives one fewer member.',
+  },
+  {
+    model: 'CustomFeed',
+    field: 'ownerOxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Custom feeds the channel owns.',
+  },
+  {
+    model: 'CustomFeed',
+    field: 'memberOxyUserIds',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'The channel as a member of somebody else\'s feed definition.',
+  },
+  {
+    model: 'StarterPack',
+    field: 'ownerOxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'Starter packs the channel owns.',
+  },
+  {
+    model: 'StarterPack',
+    field: 'memberOxyUserIds',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'The channel as a member of somebody else\'s pack.',
+  },
+  {
+    model: 'StarterPack',
+    field: 'usedByOxyUserIds',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'The channel recorded as having used a pack.',
+  },
+  {
+    model: 'EndorsementOutbox',
+    field: 'pendingRemoveOwnerId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why: 'A queued endorsement retraction naming the channel as owner.',
+  },
+  {
+    model: 'EndorsementOutbox',
+    field: 'pendingRemoveMemberIds',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why: 'The channel inside another scope\'s pending-removal list; the row belongs to that scope.',
+  },
+  {
+    model: 'Trending',
+    field: 'actorIds',
+    scope: 'channel-account',
+    action: 'pull-from-array',
+    why:
+      'A trend row naming the channel among its actors. The trend belongs to the term, not the account, so the ' +
+      'row survives with one fewer actor. Absent from the existing preflight probes.',
+  },
+  {
+    model: 'FederatedActor',
+    field: 'oxyUserId',
+    scope: 'channel-account',
+    action: 'delete-row',
+    why:
+      'A channel is a LOCAL account, so no anchor row should ever name it — these are written only for remote ' +
+      'actors. Swept so that a mislabelled row cannot survive as the last thing pointing at the channel.',
+  },
+];
+
+/**
+ * Id-shaped fields that do NOT reference an Oxy account or a Mention post, with
+ * what each one actually names.
+ *
+ * This list exists so the coverage test can be exhaustive without being useless:
+ * the scanner flags every field whose name looks like an id, which is the only
+ * way a NEW reference cannot slip past it, and that necessarily catches topic
+ * ids, file ids and run ids too. Each is dismissed once, here, in writing.
+ */
+export const NOT_A_CHANNEL_REFERENCE: ReadonlyMap<string, string> = new Map([
+  ['ActorKeyPair.keyId', 'the key pair\'s own AP key identifier, not an account'],
+  ['BlockedDomainPurge.runId', 'an admin purge run, not an account'],
+  ['BlockedDomainPurgeRun.runId', 'an admin purge run'],
+  ['BlocklistProposalRun.runId', 'a blocklist proposal run'],
+  ['ContentLabel.labelerId', 'the Labeler service that emitted the label'],
+  ['CustomFeed.sourceListIds', 'AccountList ids the feed draws from'],
+  ['CustomFeed.topicIds', 'topic ids'],
+  ['EndorsementOutbox.sourceId', 'the starter-pack or list id the scope belongs to'],
+  ['EngagementOutbox.federationActivityId', 'an ActivityPub activity id'],
+  ['EngagementOutbox.relationshipId', 'an Oxy relationship edge id, owned by Oxy'],
+  ['FederatedActor.publicKeyId', 'a remote actor\'s AP key id'],
+  ['FederatedFollow.activityId', 'the AP activity that created the follow'],
+  ['FederatedMediaCache.oxyFileId', 'an Oxy S3 file id; the cache is keyed on a remote URL, never on an account'],
+  ['FederatedMediaCache.posterFileId', 'an Oxy S3 file id for an extracted video poster'],
+  ['FeedLike.feedId', 'the CustomFeed being subscribed to'],
+  ['FeedReview.feedId', 'the CustomFeed being reviewed'],
+  ['Gif.klipyId', 'an upstream GIF provider id'],
+  ['Gif.mp4FileId', 'an Oxy file id'],
+  ['Gif.previewFileId', 'an Oxy file id'],
+  ['MentionNodeIngestWitness.recordId', 'a signed-record id within a chain'],
+  ['MentionRepoHead.headRecordId', 'the signed record at the head of a chain'],
+  ['MentionSignedRecord.recordId', 'the record\'s own id'],
+  ['ModerationEnforcement.caseId', 'a CrowdSource case id; CrowdSource owns cases'],
+  ['ModerationEnforcement.decisionId', 'a CrowdSource decision id'],
+  ['ModerationEvent.caseId', 'a CrowdSource case id'],
+  ['ModerationOutbox.caseId', 'a CrowdSource case id'],
+  ['ModerationOutbox.eventId', 'a CrowdSource event id'],
+  ['Post.activityId', 'the AP activity id of a federated post; a channel post is local'],
+  ['Post.actorUri', 'the remote actor uri of a federated post; never set for a local channel'],
+  ['Post.articleId', 'the Article row the post owns, deleted via Article.postId'],
+  ['Post.eventId', 'an event attachment id'],
+  ['Post.pollId', 'the Poll row the post owns, deleted via Poll.postId'],
+  ['Post.roomId', 'a Syra live-room id, owned by Syra'],
+  ['Post.syraPodcastId', 'a Syra podcast id, owned by Syra'],
+  ['Post.topicId', 'a topic id'],
+  ['PushToken.deviceId', 'a device identifier'],
+  ['Report.model.crowdSourceCaseId', 'a CrowdSource case id'],
+  ['Report.model.crowdSourceReportId', 'a CrowdSource report id'],
+  ['Report.model.decisionId', 'a CrowdSource decision id'],
+  ['TopicStats.topicId', 'a topic id'],
+  ['TrendGraph.edges', 'term-to-term co-occurrence edges, not accounts'],
+  ['Trending.topicId', 'a topic id'],
+  ['UserBehavior.topicId', 'a topic id'],
+  ['UserSettings.labelerId', 'a subscribed Labeler service'],
+  ['UserSettings.mentions', 'the "who may mention me" privacy setting — an enum, not a list of accounts'],
+  ['UserSettings.syraPodcastId', 'a Syra podcast id'],
+  ['UserSettings.syraTrackId', 'a Syra track id'],
+  ['EntityFollow.entityId', 'a hashtag or list id; entityType is never "user"'],
+  [
+    'FederatedFollow.remoteActorUri',
+    'the REMOTE side of a follow edge. A channel is a local account and can never appear here; the channel\'s ' +
+      'own rows are deleted by `localUserId`',
+  ],
+]);
+
+/**
+ * References that live INSIDE a string or a `Mixed` blob, where no schema path
+ * names them.
+ *
+ * This list exists because the coverage test is structurally blind to them: it
+ * reads declared schema fields, and `author|<oxyUserId>` inside a feed
+ * descriptor, or `params.authorIds` inside a `Schema.Types.Mixed`, is not a
+ * declared field. Saying so out loud is the point — a gate whose blind spot is
+ * undocumented gets mistaken for a complete one, and the next person to add an
+ * embedded reference has no way to know this file wanted to hear about it.
+ *
+ * Each entry names how the cascade reaches it, or states that it deliberately
+ * does not and why that is harmless.
+ */
+export const EMBEDDED_CHANNEL_REFERENCES: ReadonlyMap<string, string> = new Map([
+  [
+    'MentionSignedRecord.rkey / .subjectDid / .envelope',
+    'A post record\'s `rkey` IS the `Post._id`, and the DID embeds the oxyUserId. REACHED: the whole chain is ' +
+      'deleted by `oxyUserId`, so no per-field sweep is needed.',
+  ],
+  [
+    'MentionRepoHead.subjectDid',
+    'Embeds the channel\'s oxyUserId. REACHED: the row is deleted by `oxyUserId`.',
+  ],
+  [
+    'UserSettings.privacy.restrictedUsers',
+    'Another person\'s settings naming the channel as restricted. SCRUBBED by the cascade as an explicit ' +
+      '$pull, because their settings row is theirs and only the entry goes.',
+  ],
+  [
+    'FederationDeliveryQueue.activityJson.actor / .object',
+    'The sender actor uri and the post uri inside a queued activity. REACHED twice, from both ends: every row ' +
+      'the CHANNEL queued is deleted by `senderOxyUserId` before the actor Delete is broadcast, and a row ' +
+      'anybody else queued that NAMES a doomed post is cancelled by the delegate (`PostDeletionCascade`), which ' +
+      'owns that disposition — pending rows only, since a delivered row is a log entry and the three ' +
+      '`activityJson` paths are unindexed.',
+  ],
+  [
+    'CustomFeed.definition.sources[].params.authorIds',
+    'A legacy account-source feed can pin the channel by id inside a Mixed blob. NOT REACHED — a Mixed ' +
+      'sub-path cannot be indexed or filtered reliably, so the cascade leaves it. Harmless: the source ' +
+      'resolves the id through the ordinary author path, which returns nothing once the account is archived, ' +
+      'so the feed loses a contributor rather than breaking.',
+  ],
+  [
+    'Like.source / FeedInteraction.feedDescriptor / UserFeedPreference.savedFeeds[].descriptor',
+    'Ranking telemetry and saved feeds can embed `author|<oxyUserId>` or `lane|<laneId>`. NOT REACHED for ' +
+      'third-party rows: these are provenance labels, not pointers — nothing dereferences them to render, and ' +
+      'a descriptor naming a gone author simply ranks nothing. The channel\'s OWN rows are deleted outright.',
+  ],
+]);
+
+/**
+ * Real references to a deleted channel that Mention CANNOT remove, because the
+ * row lives on the other side of the Oxy boundary.
+ *
+ * Enumerated rather than silently omitted. An orphan in Oxy is still an orphan,
+ * and the operator closing one needs to know it exists — the blocked-domain
+ * purge is the precedent: Mention purges its own half and calls oxy-api's
+ * `POST /federation/domain-purge` for Oxy's, because neither side can do the
+ * other's work.
+ */
+export const OWNED_BY_OXY: ReadonlyMap<string, string> = new Map([
+  [
+    'Account graph membership (`account_members`)',
+    'The rows naming who may publish as the channel. Only Oxy can remove them, and only Oxy can enforce ' +
+      'the "a channel cannot have zero members" invariant — Mention never sees a member join or leave.',
+  ],
+  [
+    'The channel account itself (`users`, kind: channel)',
+    'Deleted via the SDK\'s `archiveAccount` (a soft archive, not a row removal). Mention has no way to hard-delete it.',
+  ],
+  [
+    'Follow edges to the channel (the Oxy graph)',
+    'Following a channel is an ordinary Oxy follow. Mention reads them and never owns them; archiving the ' +
+      'account is what stops them resolving.',
+  ],
+  [
+    'Media uploaded by the channel (Oxy S3 assets)',
+    'Post media are bare Oxy file ids. Mention deletes the posts that referenced them; the bytes are Oxy\'s ' +
+      'to collect and there is no Mention-side call that removes them.',
+  ],
+  [
+    'Blocks involving the channel',
+    'Oxy owns block rows and deletes them with the identity — the actor purge makes the same exemption for ' +
+      'the same reason, and duplicating it here would be a second authority for one fact.',
+  ],
+]);


### PR DESCRIPTION
## Half of this belongs to Oxy, and I did not build it

**"A channel cannot have zero members; the last one leaving deletes it" cannot be enforced from Mention.** Measured against the SDK this repo actually consumes (`@oxyhq/core` 19.0.0, `@oxyhq/contracts` 0.23.0), not inferred:

- Membership lives only in Oxy's `account_members`. Mention has no membership table on purpose — `services/publishAsAccount.ts` says a local copy "would go stale exactly when it matters".
- Removal is Oxy-side: `DELETE /accounts/:id/members/:memberId` (`members:remove`) and the service-token `revokeChannelMember`. **There is no "leave" route at all** — nobody can self-remove today.
- **No Oxy→Mention membership signal exists.** The only push contract is `OXY_USER_INVALIDATION_CHANNEL`, whose on-the-wire reason enum is `['profile']` and whose own docstring says delivery is at-most-once and "never authoritative for anything except 're-read this user from Oxy'". Membership writes publish nothing.
- Account deletion is `archiveAccount` — a soft archive, Oxy-side.

So any Mention-side "leave" endpoint is bypassed by a direct Oxy call. Building one would be an approximation that looks like a guarantee. **What Oxy needs to add**, in `packages/api`'s member-removal path: refuse the last removal unless the caller passes an explicit destroy confirmation; on that path call Mention for the count first and the cascade after. This PR is Mention's half, the same two-sided shape as the blocked-domain purge.

## The cascade is data, and a test keeps it honest

A hand-written cascade satisfies its own commit and then decays **silently**: somebody adds a model with a `postId`, nothing references it, rows keep pointing at a channel that no longer exists, and there is no error anywhere.

`channelCascadeManifest.ts` classifies **133 id-shaped fields across 57 models**; `channelCascadeCoverage.test.ts` compares it against the real model tree, so a new reference fails the build that introduces it.

- **Keys on id SHAPE, not a list of known names.** A name list missed `ModerationEnforcement.subjectId` and `Trending.actorIds` — both real references, under names nobody would have thought to list. That is exactly the class of bug the gate exists to catch, so it over-collects and dismisses each non-reference once, in writing.
- **Nine models nothing had ever probed:** `Lane`, `LaneMute`, `FederatedActor`, `ModerationOutbox`, `ModerationEvent`, `ModerationEnforcement`, `Trending`, `RepairFetchFailure`, `AdminScriptCursor`.
- **The blind spot is declared, not tacit.** The scanner reads declared schema fields, so `author|<id>` inside a descriptor string or `params.authorIds` in a `Mixed` blob is invisible to it. `EMBEDDED_CHANNEL_REFERENCES` enumerates those by hand, each stating whether the cascade reaches it. A declared blind spot is a defence; an undeclared one is a trap.

Mutation-tested: dropping a collection, dropping a delegated step, breaking the scanner regex, removing the kind gate, accepting an unresolvable kind, and re-deleting Reports each fail **naming the problem**, with a green control either side.

## Decisions

**Ordering.** Dependents die before the posts, because the post ids are what every later step is enumerated from — delete the posts first and a crash strands rows you can no longer *find*. Every earlier crash point leaves rows whose referent still exists; the run is re-runnable to zero counts.

**Boosts and quotes** follow the policy already written in this repo rather than a channel-specific rule: a boost is deleted (empty body, renders entirely from `boostOf`, so a survivor is a blank card); a quote is kept (the quoter's writing is not the channel's to destroy). One deliberate difference — the pointer is **unset** rather than left dangling, since a row pointing at nothing is an orphan, and unsetting is idempotent where a dangling pointer is not.

**No reattribution to writers, ever.** For a channel that did not opt into naming its writers, reattribution would retroactively publish who wrote what — the one promise a channel makes, broken at the moment it is no longer there to answer for it. The posts go instead.

**The post-dependent phase is delegated to `PostDeletionCascade`,** whose disposition table is a `Record<PostReferenceProbeName, …>` — a second implementation would destroy that fail-closed property, because one of the two would be forgotten. That delegation also settles **`Report.reportedId(post)`, which is RETAINED**: `ModerationDecisionWorker` treats "no local report" as retryable, so deleting it leaves an inbound decision retrying until it expires — and that reason does not depend on who deleted the post, so it cannot have two answers depending on the cause. The divergence from `purgeBlockedDomainContent`, which does delete them, is documented where it is resolved.

**`deleteChannelContent` refuses anything that is not `kind: 'channel'`,** failing closed on an unresolvable kind or a failed lookup, before any read and long before any write or federation call. It has no caller yet — that is the absence of an accident, not a defence.

## Second commit: a pre-existing `main` failure

`agentsMdReferences` has been red on `main` since `29d6d656`, which documented that the block refusal belongs in oxy-api's `packages/api/src/routes/privacy.ts` — correct and load-bearing, but oxy-api is in OxyHQServices, so it can never resolve against this repo's `git ls-files`. Added to `UNRESOLVABLE_BY_DESIGN` as a new category (cross-repo pointer, not a generated artifact and not history). Not caused by this PR; included because it blocks every PR.

## Verification

441 test files / 4864 tests green; `tsc --noEmit` clean; coverage **69.13% statements against the 60.68% threshold** — all after reinstalling for main's Oxy SDK major bump (core 19, services 27, contracts 0.23, federation 0.12) and rebuilding `shared-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
