### PR TITLE
test(agents-md): catch the exemption that stops exempting anything

### DIFF
--- a/packages/backend/src/__tests__/agentsMdReferences.test.ts
+++ b/packages/backend/src/__tests__/agentsMdReferences.test.ts
@@ -39,16 +39,6 @@ const UNRESOLVABLE_BY_DESIGN: ReadonlyMap<string, string> = new Map([
   ['_worker.js', 'the deleted Cloudflare Pages Advanced-Mode worker; cited as history, must not come back'],
   ['_routes.json', 'deleted alongside that worker; cited as history'],
   ['services/FederationService.ts', 'the removed facade the connectors module replaced; cited as history'],
-  [
-    '.expo/types/router.d.ts',
-    "expo-router's generated route types — written into a gitignored .expo/ by the dev server, absent on a clean checkout",
-  ],
-  [
-    'packages/api/src/routes/privacy.ts',
-    'a CROSS-REPO pointer: oxy-api lives in OxyHQServices, so this resolves for a reader and never against ' +
-      "this repo's `git ls-files`. The reference is correct and load-bearing — it names where the block " +
-      'refusal has to live, precisely because Mention has no block route of its own to guard',
-  ],
 ]);
 
 /**
@@ -107,5 +97,27 @@ describe('AGENTS.md file references', () => {
 
     expect(nowResolving, 'these are listed in UNRESOLVABLE_BY_DESIGN but now resolve — '
       + `delete the entry:\n  ${nowResolving.join('\n  ')}\n`).toEqual([]);
+  });
+
+  it('drops an exemption once AGENTS.md stops making the reference', () => {
+    // The OTHER way an exemption rots, and the one the check above cannot see:
+    // the document stops naming the path at all. The entry then exempts nothing,
+    // and because an unmade reference can never resolve, it sits there passing
+    // forever while reading as a live decision about a real reference.
+    //
+    // This is not hypothetical. Two changes landed within minutes of each other
+    // for one cross-repo path — `packages/api/src/routes/privacy.ts`, which lives
+    // in OxyHQServices — one adding the exemption and one rewriting the sentence
+    // so the path was no longer written as a reference. The exemption survived as
+    // dead weight, and nothing failed.
+    const unreferenced = [...UNRESOLVABLE_BY_DESIGN.keys()]
+      .filter((reference) => !references.includes(reference))
+      .sort();
+
+    expect(
+      unreferenced,
+      'these are listed in UNRESOLVABLE_BY_DESIGN but AGENTS.md no longer references them, so the entry '
+        + `exempts nothing — delete it:\n  ${unreferenced.join('\n  ')}\n`,
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
`UNRESOLVABLE_BY_DESIGN` in `agentsMdReferences.test.ts` says it "must only ever shrink". One direction was enforced — an entry that **starts resolving** is a lie and fails. The other was not: when AGENTS.md stops naming a path at all, the entry exempts nothing, and because an unmade reference can never resolve, it passes forever while reading as a live decision about a real reference.

Both entries currently in the list got there that way, which is why this is a check and not a tidy-up:

- **`packages/api/src/routes/privacy.ts`** — #604 added the exemption and #606 rewrote the sentence so the path was no longer written as a reference, within minutes of each other. Two correct fixes for one problem; the residue was invisible to the suite. (#604 is mine, so this is my own litter.)
- **`.expo/types/router.d.ts`** — the `typedRoutes` finding moved up to `~/Oxy/AGENTS.md` under the layering rule, and this gate only reads the repo's own `AGENTS.md`. The exemption has been dead for as long as that text has lived in the parent file.

Both removed. **The new check found the second one on its first run**, which is the argument for it existing.

Mutation-tested in both directions, green control either side: re-adding a dead exemption fails the new check naming it; exempting something that *does* resolve still fails the original check independently.

441 files / 4864 tests green, coverage 69.13% against the 60.68% threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
