### PR TITLE
fix(identity): let a channel's description follow the edit that changed it

### DIFF
--- a/packages/frontend/app/(app)/c/[username]/__tests__/channelSettingsIdentityWrite.test.tsx
+++ b/packages/frontend/app/(app)/c/[username]/__tests__/channelSettingsIdentityWrite.test.tsx
@@ -1,0 +1,321 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * What a channel's profile save tells the identity door.
+ *
+ * This screen is the ONLY door a channel's profile has — `/edit-profile` edits
+ * the signed-in user and a channel can never be signed in as — so whatever it
+ * forgets to mention here is not merely late anywhere else, it is unreachable
+ * until a reload. It forgot the description for as long as it has been able to
+ * edit one: the save landed, `noteIdentityChanged` was called with a payload
+ * that named the handle, the name and the picture, and the channel page went on
+ * rendering the previous text from a React Query entry that
+ * `upsertCachedUser` deliberately leaves fresh.
+ *
+ * Two properties, and a screen test is the only place either can be observed:
+ *
+ *   * The identity handed over is the ACCOUNT the server returned, not a
+ *     payload assembled here. An object literal type-checks identically while
+ *     omitting a field, which is exactly how this happened; handing the whole
+ *     account over moves the decision to `meaningfulFields`, where it is made
+ *     once.
+ *   * `cleared` is derived from the write INPUT. It cannot come from the
+ *     response — Oxy omits an emptied scalar exactly as it omits an untouched
+ *     one — so the input is the only witness that the operator emptied
+ *     something, and it exists only inside this screen.
+ *
+ * `noteIdentityChanged` itself is a spy: what it does with the payload belongs
+ * to `lib/__tests__/actorCache.test.ts`. The mocks below stop at module
+ * boundaries — the SDK barrel cannot be required under jest (untranspiled ESM),
+ * and Bloom ships the same way. React Query is real, because the mutation's own
+ * `onSuccess` wiring is the thing under test.
+ */
+
+const mockNoteIdentityChanged = jest.fn();
+jest.mock('@/lib/actorCache', () => ({
+  noteIdentityChanged: (...args: unknown[]) => mockNoteIdentityChanged(...args),
+}));
+
+/**
+ * The SDK's own derivation, reproduced only for the fields this screen writes.
+ * The real one lives behind the unrequirable barrel; what matters here is that
+ * the screen feeds it the INPUT and forwards the answer, so a stand-in that
+ * answers differently for a set and a cleared bio is enough to tell the two
+ * apart — and `lib/__tests__/actorCache.test.ts` pins the forwarding contract
+ * against the shape the real helper returns.
+ */
+jest.mock('@oxyhq/services', () => ({
+  clearedFieldsFromAccountUpdate: (input: { bio?: string | null; avatar?: string | null }) => {
+    const cleared: string[] = [];
+    if ('bio' in input && !input.bio) cleared.push('bio');
+    if ('avatar' in input && !input.avatar) cleared.push('avatar');
+    return cleared;
+  },
+}));
+
+const mockUpdateAccount = jest.fn();
+const mockListAccounts = jest.fn();
+
+jest.mock('@oxyhq/services/ui/client', () => ({
+  OxyAuthPrompt: () => null,
+  useAuth: () => ({
+    user: { id: 'viewer-1', username: 'operator' },
+    oxyServices: {
+      listAccounts: (...args: unknown[]) => mockListAccounts(...args),
+      updateAccount: (...args: unknown[]) => mockUpdateAccount(...args),
+    },
+    canUsePrivateApi: true,
+    isAuthenticated: true,
+    isAuthResolved: true,
+    isPrivateApiPending: false,
+    showBottomSheet: jest.fn(),
+  }),
+}));
+
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user: { username?: string } | null | undefined) =>
+    user?.username ?? null,
+}));
+jest.mock('@oxyhq/core/logger', () => ({
+  createLogger: () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }),
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ username: 'daily' }),
+}));
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+jest.mock('@expo/vector-icons/Ionicons', () => () => null);
+jest.mock('@oxyhq/bloom/avatar', () => ({ Avatar: () => null }));
+jest.mock('@oxyhq/bloom/loading', () => ({ SpinnerIcon: () => null }));
+jest.mock('@oxyhq/bloom/switch', () => ({ Switch: () => null }));
+jest.mock('@oxyhq/bloom/toast', () => {
+  const toast = Object.assign(jest.fn(), { success: jest.fn(), error: jest.fn() });
+  return { toast };
+});
+jest.mock('@oxyhq/bloom/theme', () => ({ useTheme: () => ({ colors: { textSecondary: '#888' } }) }));
+jest.mock('@oxyhq/bloom/settings-list', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    SettingsListGroup: (props: { children?: React.ReactNode }) =>
+      ReactActual.createElement(View, null, props.children),
+    SettingsListItem: () => null,
+  };
+});
+jest.mock('@oxyhq/bloom/item', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    Item: (props: { onPress?: () => void; disabled?: boolean; title?: string }) =>
+      ReactActual.createElement(
+        Text,
+        { testID: 'save-profile', onPress: props.onPress, disabled: props.disabled },
+        props.title ?? '',
+      ),
+  };
+});
+
+jest.mock('@/components/ThemedView', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return { ThemedView: (props: { children?: React.ReactNode }) =>
+    ReactActual.createElement(View, null, props.children) };
+});
+jest.mock('@/components/Header', () => ({ Header: () => null }));
+jest.mock('@/components/ui/Button', () => ({ IconButton: () => null }));
+jest.mock('@/assets/icons/back-arrow-icon', () => ({ BackArrowIcon: () => null }));
+jest.mock('@/components/common/EmptyState', () => ({ EmptyState: () => null }));
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }));
+jest.mock('@/services/channelAccountService', () => ({
+  channelAccountService: {
+    getSettings: jest.fn().mockResolvedValue({ signPosts: false }),
+    setSignPosts: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import ChannelAccountSettingsScreen from '../settings';
+
+const CHANNEL_ID = 'channel-1';
+
+/**
+ * How the description field is located. Its `accessibilityLabel` would read
+ * better, but react-native does not surface that prop on the rendered
+ * `TextInput` under this renderer, so a selector written against it finds
+ * nothing whether the field is there or not.
+ */
+const BIO_PLACEHOLDER = 'What this channel is about';
+
+/** The channel as the account graph holds it before any edit. */
+function storedAccount() {
+  return {
+    id: CHANNEL_ID,
+    username: 'daily',
+    name: { displayName: 'Daily Digest' },
+    avatar: 'avatar-1',
+    bio: 'bio-before',
+  };
+}
+
+/** The account node `listAccounts` returns for it. */
+function accountNode() {
+  return {
+    accountId: CHANNEL_ID,
+    kind: 'channel',
+    parentAccountId: null,
+    account: storedAccount(),
+    relationship: {},
+    callerMembership: null,
+  };
+}
+
+let mounted: TestRenderer.ReactTestRenderer | null = null;
+
+async function renderScreen() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  await act(async () => {
+    mounted = TestRenderer.create(
+      <QueryClientProvider client={client}>
+        <ChannelAccountSettingsScreen />
+      </QueryClientProvider>,
+    );
+  });
+  const renderer = mounted;
+  if (!renderer) throw new Error('the screen did not render');
+  // Two queries resolve in series — the operated-accounts list decides whether
+  // the form mounts at all, and only then does the form ask for its byline
+  // settings — so the screen sits on a spinner for more than one flush. Polling
+  // for the field rather than flushing a fixed number of times keeps the wait
+  // tied to what the test needs instead of to React Query's scheduling.
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (renderer.root.findAllByProps({ placeholder: BIO_PLACEHOLDER }).length > 0) {
+      return renderer;
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error('the channel profile form never mounted');
+}
+
+/** Type into the description field and press save. */
+async function saveWithBio(renderer: TestRenderer.ReactTestRenderer, bio: string) {
+  const field = renderer.root.findByProps({ placeholder: BIO_PLACEHOLDER });
+  await act(async () => {
+    field.props.onChangeText(bio);
+  });
+  const save = renderer.root.findByProps({ testID: 'save-profile' });
+  await act(async () => {
+    save.props.onPress();
+  });
+}
+
+beforeEach(() => {
+  mockNoteIdentityChanged.mockReset();
+  mockUpdateAccount.mockReset();
+  mockListAccounts.mockReset();
+  mockListAccounts.mockResolvedValue([accountNode()]);
+});
+
+afterEach(() => {
+  const renderer = mounted;
+  if (renderer) act(() => renderer.unmount());
+  mounted = null;
+});
+
+describe('saving a channel profile', () => {
+  it('found the form it is about to drive', async () => {
+    // The assertions below all run through one text field and one button, so a
+    // screen that fell back to its operator-only or loading branch would make
+    // every one of them vacuous.
+    const renderer = await renderScreen();
+
+    expect(renderer.root.findByProps({ placeholder: BIO_PLACEHOLDER })).toBeTruthy();
+    expect(renderer.root.findByProps({ testID: 'save-profile' })).toBeTruthy();
+  });
+
+  it('tells the identity door about a NEW description', async () => {
+    const updated = { ...accountNode(), account: { ...storedAccount(), bio: 'bio-after' } };
+    mockUpdateAccount.mockResolvedValue(updated);
+    const renderer = await renderScreen();
+
+    await saveWithBio(renderer, 'bio-after');
+
+    expect(mockUpdateAccount).toHaveBeenCalledWith(
+      CHANNEL_ID,
+      expect.objectContaining({ bio: 'bio-after' }),
+    );
+    expect(mockNoteIdentityChanged).toHaveBeenCalledWith(
+      updated.account,
+      'viewer-1',
+      { cleared: [] },
+    );
+  });
+
+  it('hands over the whole account, so a field it never names still travels', async () => {
+    // The regression this replaces was an object literal that listed four
+    // fields and not the fifth. Anything the account carries has to arrive at
+    // the door for the door to be the one place the set is decided — the
+    // category list is the live proof, added to this form by a later change
+    // that never had to touch the identity write at all.
+    const updated = {
+      ...accountNode(),
+      account: {
+        ...storedAccount(),
+        bio: 'bio-after',
+        accountCategories: ['news', 'sports'],
+      },
+    };
+    mockUpdateAccount.mockResolvedValue(updated);
+    const renderer = await renderScreen();
+
+    await saveWithBio(renderer, 'bio-after');
+
+    const [identity] = mockNoteIdentityChanged.mock.calls[0];
+    expect(identity).toBe(updated.account);
+    expect(identity).toMatchObject({ accountCategories: ['news', 'sports'] });
+  });
+
+  it('declares the clear when the operator EMPTIES the description', async () => {
+    // The other direction, and a different mechanism: nothing in the response
+    // distinguishes an emptied field from an untouched one, so only the input
+    // this screen sent can say so.
+    //
+    // The fixture has to OMIT `bio`, not carry it as `undefined`, or it cannot
+    // tell the two apart: oxy-api's serializer drops a cleared scalar from the
+    // payload entirely, and a key that is merely `undefined` still answers
+    // `'bio' in response` — which is enough to make a `cleared` wrongly derived
+    // from the RESPONSE produce the right answer here and the wrong one in
+    // production. Verified by mutation: with `bio: undefined` that swap passes
+    // every test in this file.
+    const { bio: _cleared, ...withoutBio } = storedAccount();
+    const updated = { ...accountNode(), account: withoutBio };
+    mockUpdateAccount.mockResolvedValue(updated);
+    const renderer = await renderScreen();
+
+    await saveWithBio(renderer, '   ');
+
+    expect(mockUpdateAccount).toHaveBeenCalledWith(CHANNEL_ID, expect.objectContaining({ bio: null }));
+    expect(mockNoteIdentityChanged).toHaveBeenCalledWith(updated.account, 'viewer-1', {
+      cleared: ['bio'],
+    });
+  });
+
+  it('tells no cache anything when the save fails', async () => {
+    mockUpdateAccount.mockRejectedValue(new Error('nope'));
+    const renderer = await renderScreen();
+
+    await saveWithBio(renderer, 'bio-after');
+
+    expect(mockNoteIdentityChanged).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/app/(app)/c/[username]/settings.tsx
+++ b/packages/frontend/app/(app)/c/[username]/settings.tsx
@@ -12,8 +12,13 @@ import { toast } from '@oxyhq/bloom/toast';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { SettingsListGroup, SettingsListItem } from '@oxyhq/bloom/settings-list';
 import { OxyAuthPrompt, useAuth } from '@oxyhq/services/ui/client';
+import { clearedFieldsFromAccountUpdate } from '@oxyhq/services';
 import { createLogger } from '@oxyhq/core/logger';
-import { getNormalizedUserHandle, type AccountNode } from '@oxyhq/core';
+import {
+  getNormalizedUserHandle,
+  type AccountNode,
+  type UpdateAccountInput,
+} from '@oxyhq/core';
 import {
   MAX_ACCOUNT_CATEGORIES,
   SELECTABLE_ACCOUNT_CATEGORY_IDS,
@@ -223,37 +228,29 @@ function ChannelAccountSettingsForm({ channel }: { channel: AccountNode }) {
     [signPostsMutation],
   );
 
-  const profileMutation = useMutation<AccountNode, unknown, void>({
-    mutationFn: () =>
-      oxyServices.updateAccount(accountId, {
-        name: { displayName: trimmedName },
-        // `null` is Oxy's documented clear for both; an empty string would store
-        // one rather than remove it.
-        bio: trimmedBio.length > 0 ? trimmedBio : null,
-        avatar: avatar.length > 0 ? avatar : null,
-        // Sent whole and IN ORDER, because that is the only shape Oxy accepts:
-        // there is no add/remove verb, and element 0 is what records the
-        // primary. `[]` is the documented clear — unlike `bio` and `avatar`,
-        // this field is not nullable, since the empty case already has one
-        // spelling and a second could only ever disagree with it.
-        accountCategories: categories,
-      }),
-    onSuccess: (updated) => {
-      // A channel's name and picture are held by more caches than this screen
-      // can see — the SDK's user cache behind its page, the operated-accounts
-      // list behind the composer's publish-as picker, and a copy embedded in
-      // every post the channel has ever published. `noteIdentityChanged` is the
-      // single authority that reaches all of them; writing any one of them from
-      // here is how the others get forgotten.
-      noteIdentityChanged(
-        {
-          id: updated.account.id,
-          username: updated.account.username,
-          name: updated.account.name,
-          avatar: updated.account.avatar,
-        },
-        viewerId,
-      );
+  // The mutation takes the write INPUT as its variable rather than closing over
+  // the form state, because `onSuccess` needs it: which fields the operator
+  // EMPTIED is not recoverable from the response (Oxy omits a cleared scalar
+  // exactly as it omits an untouched one), so the input is the only witness.
+  const profileMutation = useMutation<AccountNode, unknown, UpdateAccountInput>({
+    mutationFn: (input) => oxyServices.updateAccount(accountId, input),
+    onSuccess: (updated, input) => {
+      // A channel's name, picture and description are held by more caches than
+      // this screen can see — the SDK's user cache behind its page, the
+      // operated-accounts list behind the composer's publish-as picker, and a
+      // copy embedded in every post the channel has ever published.
+      // `noteIdentityChanged` is the single authority that reaches all of them;
+      // writing any one of them from here is how the others get forgotten.
+      //
+      // The whole ACCOUNT goes over, not a hand-picked payload of its fields.
+      // The door picks the ones it carries, so it is the one place the set is
+      // decided and a field added there arrives here already supplied — whereas
+      // an object literal type-checks identically while silently omitting one,
+      // which is exactly how the description came to be missing for as long as
+      // this screen has been able to edit it.
+      noteIdentityChanged(updated.account, viewerId, {
+        cleared: clearedFieldsFromAccountUpdate(input),
+      });
       toast.success(
         t('channels.settings.profileSaved', { defaultValue: 'Channel updated' }),
       );
@@ -288,7 +285,23 @@ function ChannelAccountSettingsForm({ channel }: { channel: AccountNode }) {
     });
   }, [showBottomSheet]);
 
-  const handleSaveProfile = useCallback(() => profileMutation.mutate(), [profileMutation]);
+  const handleSaveProfile = useCallback(
+    () =>
+      profileMutation.mutate({
+        name: { displayName: trimmedName },
+        // `null` is Oxy's documented clear for both; an empty string would store
+        // one rather than remove it.
+        bio: trimmedBio.length > 0 ? trimmedBio : null,
+        avatar: avatar.length > 0 ? avatar : null,
+        // Sent whole and IN ORDER, because that is the only shape Oxy accepts:
+        // there is no add/remove verb, and element 0 is what records the
+        // primary. `[]` is the documented clear — unlike `bio` and `avatar`,
+        // this field is not nullable, since the empty case already has one
+        // spelling and a second could only ever disagree with it.
+        accountCategories: categories,
+      }),
+    [profileMutation, trimmedName, trimmedBio, avatar, categories],
+  );
 
   // Both take the previous list rather than closing over `categories`, so the
   // handlers stay identity-stable and can never apply an edit to a stale one.

--- a/packages/frontend/lib/__tests__/actorCache.test.ts
+++ b/packages/frontend/lib/__tests__/actorCache.test.ts
@@ -61,6 +61,7 @@ describe('noteIdentityChanged', () => {
         username: 'daily',
         name: { displayName: 'Daily Digest' },
         avatar: 'avatar-after',
+        bio: 'bio-after',
       },
       'viewer-1',
     );
@@ -73,14 +74,69 @@ describe('noteIdentityChanged', () => {
         username: 'daily',
         name: { displayName: 'Daily Digest' },
         avatar: 'avatar-after',
+        bio: 'bio-after',
       },
       'viewer-1',
+      undefined,
     );
     expect(getKnownIdentity('channel-1')).toEqual({
       id: 'channel-1',
       username: 'daily',
       name: { displayName: 'Daily Digest' },
       avatar: 'avatar-after',
+      bio: 'bio-after',
+    });
+  });
+
+  /**
+   * The description, both directions.
+   *
+   * The React Query user entry behind a channel's page is what renders it, and
+   * `upsertCachedUser` leaves an EXISTING entry's freshness alone — so an edit
+   * that never reaches this call is not merely late, it is invisible until the
+   * five-minute `staleTime` lapses or the page is reloaded. Setting it and
+   * emptying it are different mechanisms (a value that wins the merge versus a
+   * declared clear that lowers the SDK's anti-degradation guard), so one passing
+   * says nothing about the other.
+   */
+  describe('a description', () => {
+    it('reaches the cache when it is set', () => {
+      noteIdentityChanged({ id: 'channel-1', username: 'daily', bio: 'bio-after' }, 'viewer-1');
+
+      const [, user] = mockUpsertCachedUser.mock.calls[0];
+      expect(user).toMatchObject({ bio: 'bio-after' });
+    });
+
+    it('reaches the cache as a DECLARED clear when it is emptied', () => {
+      // Oxy omits a cleared scalar exactly as it omits an untouched one, so the
+      // payload cannot carry the intent — only the declaration can. Without it
+      // the SDK's guard (rightly) preserves the stale text.
+      noteIdentityChanged({ id: 'channel-1', username: 'daily' }, 'viewer-1', {
+        cleared: ['bio'],
+      });
+
+      expect(mockUpsertCachedUser).toHaveBeenCalledWith(
+        mockQueryClient,
+        { id: 'channel-1', username: 'daily' },
+        'viewer-1',
+        { cleared: ['bio'] },
+      );
+    });
+
+    it('declares no clear for an edit that emptied nothing', () => {
+      // The guard this lowers is what stops sparse hydration blanking real
+      // identity across every Oxy app, so it must be lowered only for a field
+      // the writer actually observed being emptied.
+      noteIdentityChanged({ id: 'channel-1', username: 'daily', bio: 'bio-after' }, 'viewer-1', {
+        cleared: [],
+      });
+
+      expect(mockUpsertCachedUser).toHaveBeenCalledWith(
+        mockQueryClient,
+        expect.objectContaining({ bio: 'bio-after' }),
+        'viewer-1',
+        { cleared: [] },
+      );
     });
   });
 
@@ -147,6 +203,23 @@ describe('cacheActors / cacheActor', () => {
     expect(lastBatch()).toEqual([
       { id: 'channel-1', username: 'daily', avatar: 'avatar-after' },
       { id: 'someone-else', username: 'else', avatar: 'their-avatar' },
+    ]);
+  });
+
+  it('corrects a stale description on a surface that carries one', () => {
+    // Recommendations, similar accounts and the followers/following lists all
+    // carry a bio, and the SDK merge overrides a real value with a real value —
+    // so any of them can put the pre-edit text straight back over the edit.
+    noteIdentityChanged({ id: 'channel-1', username: 'daily', bio: 'bio-after' });
+
+    cacheActors([
+      { id: 'channel-1', username: 'daily', bio: 'bio-before' },
+      { id: 'someone-else', username: 'else', bio: 'their-bio' },
+    ]);
+
+    expect(lastBatch()).toEqual([
+      { id: 'channel-1', username: 'daily', bio: 'bio-after' },
+      { id: 'someone-else', username: 'else', bio: 'their-bio' },
     ]);
   });
 

--- a/packages/frontend/lib/__tests__/precacheActorsFromPosts.test.ts
+++ b/packages/frontend/lib/__tests__/precacheActorsFromPosts.test.ts
@@ -18,7 +18,7 @@
 
 import { queryClient as mockQueryClient } from '@/lib/queryClient';
 import { noteIdentityChanged } from '@/lib/actorCache';
-import { resetIdentityUpdates } from '@/stores/identityUpdates';
+import { getKnownIdentity, resetIdentityUpdates } from '@/stores/identityUpdates';
 import { precacheActorsFromPosts } from '../precacheActorsFromPosts';
 
 const mockUpsertCachedUsers = jest.fn();
@@ -205,6 +205,33 @@ describe('precacheActorsFromPosts — an identity the viewer just edited', () =>
     expect(lastUpsertedUsers()).toEqual([
       { id: EDITED, username: 'daily', avatar: 'avatar-changed-elsewhere' },
     ]);
+  });
+
+  it('keeps correcting a description no post can speak for', () => {
+    // The reported symptom's other half. A feed page carries the handle, the
+    // name and the picture and NEVER a description, so it can retire those and
+    // must leave this one recorded — otherwise the first page after the save
+    // discards the correction that the bio-carrying surfaces still need.
+    noteIdentityChanged({
+      id: EDITED,
+      username: 'daily',
+      name: { displayName: 'Daily Digest' },
+      avatar: 'avatar-after',
+      bio: 'bio-after',
+    });
+
+    precacheActorsFromPosts([
+      {
+        user: {
+          id: EDITED,
+          username: 'daily',
+          name: { displayName: 'Daily Digest' },
+          avatar: 'avatar-after',
+        },
+      },
+    ]);
+
+    expect(getKnownIdentity(EDITED)).toEqual({ id: EDITED, bio: 'bio-after' });
   });
 
   it('does not retire on a batch that agrees about only SOME of the edit', () => {

--- a/packages/frontend/lib/actorCache.ts
+++ b/packages/frontend/lib/actorCache.ts
@@ -1,4 +1,9 @@
-import { upsertCachedUser, upsertCachedUsers, type CacheableUser } from '@oxyhq/services';
+import {
+  upsertCachedUser,
+  upsertCachedUsers,
+  type CacheableUser,
+  type UpsertCachedUserOptions,
+} from '@oxyhq/services';
 import { queryClient } from '@/lib/queryClient';
 import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
 import {
@@ -62,8 +67,22 @@ export function cacheActor(actor: CacheableUser | null | undefined): void {
  * Record that a profile edit landed, and tell every cache holding a copy of that
  * identity. Call this only after the server has accepted the write: a failed
  * edit leaves every surface exactly as the caches already have it.
+ *
+ * `options.cleared` names the fields the write deliberately EMPTIED, and it is
+ * the only way a clear can propagate at all: the response omits a cleared scalar
+ * exactly as it omits one the write never touched, so nothing downstream can
+ * tell them apart from the payload. The SDK owns both the semantics and the
+ * closed list of fields this may name (`CLEARABLE_USER_FIELDS`) — derive the
+ * list at the call site with the helper matching the write that was performed
+ * (`clearedFieldsFromAccountUpdate` for `updateAccount`,
+ * `clearedFieldsFromProfileUpdate` for `updateProfile`), because the write INPUT
+ * is the only place the intent exists.
  */
-export function noteIdentityChanged(update: IdentityUpdate, viewerId?: string): void {
+export function noteIdentityChanged(
+  update: IdentityUpdate,
+  viewerId?: string,
+  options?: UpsertCachedUserOptions,
+): void {
   const stored = recordIdentityChange(update);
   if (!stored) return;
 
@@ -73,7 +92,7 @@ export function noteIdentityChanged(update: IdentityUpdate, viewerId?: string): 
   // without losing the counts and viewer relationship an authoritative profile
   // fetch had already stored. Not routed through `cacheActor`: this is the
   // authority for that identity, so it must not be reconciled against itself.
-  upsertCachedUser(queryClient, stored, viewerId);
+  upsertCachedUser(queryClient, stored, viewerId, options);
 
   // The operated-accounts list embeds each account's profile and feeds the
   // channels screen, the composer's publish-as picker and the channel settings

--- a/packages/frontend/stores/__tests__/identityUpdates.test.ts
+++ b/packages/frontend/stores/__tests__/identityUpdates.test.ts
@@ -1,3 +1,4 @@
+import type { AccountCategoryId } from '@oxyhq/contracts';
 import {
   applyKnownIdentity,
   getKnownIdentity,
@@ -34,13 +35,58 @@ describe('recordIdentityChange', () => {
     expect(getKnownIdentity('channel-1')).toBe(stored);
   });
 
-  it.each<[string, { username?: string; avatar?: string | null; name?: { displayName?: string } }]>([
+  it('stores the description an edit carried', () => {
+    // The field the channel header reads. It was absent from the recorded shape
+    // for as long as this module existed, so a description edit reached the
+    // server and every client-side copy kept serving the old text.
+    const stored = recordIdentityChange({ id: 'channel-1', bio: 'What this is about' });
+
+    expect(stored).toEqual({ id: 'channel-1', bio: 'What this is about' });
+    expect(getKnownIdentity('channel-1')).toBe(stored);
+  });
+
+  it('stores the categories an edit carried, in the order it carried them', () => {
+    // Ordered because element 0 is the primary — the one thing a reader sees
+    // under the channel's name — so a list that survives as a set has lost the
+    // edit that promoted one.
+    const stored = recordIdentityChange({
+      id: 'channel-1',
+      accountCategories: ['news', 'sports'],
+    });
+
+    expect(stored).toEqual({ id: 'channel-1', accountCategories: ['news', 'sports'] });
+  });
+
+  it.each<
+    [
+      string,
+      {
+        username?: string;
+        avatar?: string | null;
+        bio?: string;
+        name?: { displayName?: string };
+        accountCategories?: AccountCategoryId[];
+      },
+    ]
+  >([
     ['an empty username', { username: '   ' }],
     ['a cleared picture', { avatar: null }],
     ['an emptied picture', { avatar: '' }],
+    ['an emptied description', { bio: '   ' }],
+    ['an emptied category list', { accountCategories: [] }],
     ['an emptied display name', { name: { displayName: '  ' } }],
   ])('never records %s, so no cache can be degraded by one', (_label, fields) => {
     expect(recordIdentityChange({ id: 'channel-1', ...fields })).toEqual({ id: 'channel-1' });
+  });
+
+  it('returns a write that emptied everything without recording it', () => {
+    // The caller still needs it — a declared clear reaches the caches through
+    // `noteIdentityChanged` — but an entry with no fields corrects nothing, and
+    // nothing could ever retire it: retirement needs a field to agree ABOUT.
+    // Every recorded entry holding at least one field is what makes the sweep
+    // below terminate.
+    expect(recordIdentityChange({ id: 'channel-1', bio: '' })).toEqual({ id: 'channel-1' });
+    expect(getKnownIdentity('channel-1')).toBeUndefined();
   });
 
   it('refuses a write with no id — there is nothing to key it on', () => {
@@ -150,5 +196,116 @@ describe('reconciling against the server', () => {
 
     reconcileKnownIdentities([{ avatar: 'avatar-after' }]);
     expect(getKnownIdentity('channel-1')).toEqual({ id: 'channel-1', avatar: 'avatar-after' });
+  });
+
+  /**
+   * The two sides of answerability, and neither is optional.
+   *
+   * A post author carries no description at all — not an empty one, none — so
+   * an entry holding one meets actors that can answer for some of what it holds
+   * and nothing about the rest. Read that silence as disagreement and the
+   * picture beside it is pinned for the session; read it as agreement and a
+   * description edit is retired before anything ever confirmed it.
+   */
+  describe('a field the actor cannot answer for', () => {
+    function editedEverything() {
+      recordIdentityChange({
+        id: 'channel-1',
+        username: 'daily',
+        name: { displayName: 'Daily Digest' },
+        avatar: 'avatar-after',
+        bio: 'bio-after',
+      });
+    }
+
+    it('retires what a bio-less actor DOES confirm, and keeps the rest', () => {
+      editedEverything();
+
+      // A post author: handle, name and picture, never a description.
+      reconcileKnownIdentities([
+        { id: 'channel-1', username: 'daily', name: { displayName: 'Daily Digest' }, avatar: 'avatar-after' },
+      ]);
+
+      expect(getKnownIdentity('channel-1')).toEqual({ id: 'channel-1', bio: 'bio-after' });
+    });
+
+    it('retires the entry once an actor that CAN answer agrees', () => {
+      editedEverything();
+
+      reconcileKnownIdentities([
+        { id: 'channel-1', username: 'daily', name: { displayName: 'Daily Digest' }, avatar: 'avatar-after' },
+      ]);
+      // A recommendation / followers row does carry one.
+      reconcileKnownIdentities([{ id: 'channel-1', bio: 'bio-after' }]);
+
+      expect(getKnownIdentity('channel-1')).toBeUndefined();
+    });
+
+    it('keeps correcting a description the server has not caught up with', () => {
+      editedEverything();
+
+      reconcileKnownIdentities([{ id: 'channel-1', bio: 'bio-before' }]);
+
+      expect(getKnownIdentity('channel-1')).toEqual({
+        id: 'channel-1',
+        username: 'daily',
+        name: { displayName: 'Daily Digest' },
+        avatar: 'avatar-after',
+        bio: 'bio-after',
+      });
+    });
+
+    it('retires nothing at all while ANY field it can answer for differs', () => {
+      editedEverything();
+
+      // The picture caught up, the name did not. One lagging field is proof the
+      // server copy is behind, so the picture's agreement proves nothing either.
+      reconcileKnownIdentities([
+        { id: 'channel-1', username: 'daily', name: { displayName: 'Daily' }, avatar: 'avatar-after' },
+      ]);
+
+      expect(getKnownIdentity('channel-1')).toEqual({
+        id: 'channel-1',
+        username: 'daily',
+        name: { displayName: 'Daily Digest' },
+        avatar: 'avatar-after',
+        bio: 'bio-after',
+      });
+    });
+
+    it('treats a REORDERED category list as a disagreement', () => {
+      // The promotion IS the edit. A set-wise comparison calls this agreement
+      // and retires the correction that carries it.
+      recordIdentityChange({ id: 'channel-1', accountCategories: ['news', 'sports'] });
+
+      reconcileKnownIdentities([{ id: 'channel-1', accountCategories: ['sports', 'news'] }]);
+
+      expect(getKnownIdentity('channel-1')).toEqual({
+        id: 'channel-1',
+        accountCategories: ['news', 'sports'],
+      });
+    });
+
+    it('retires the category list once an actor carries it in the same order', () => {
+      recordIdentityChange({ id: 'channel-1', accountCategories: ['news', 'sports'] });
+
+      reconcileKnownIdentities([{ id: 'channel-1', accountCategories: ['news', 'sports'] }]);
+
+      expect(getKnownIdentity('channel-1')).toBeUndefined();
+    });
+
+    it('does not notify when every field is unanswerable', () => {
+      recordIdentityChange({ id: 'channel-1', bio: 'bio-after' });
+      const listener = jest.fn();
+      const unsubscribe = subscribeToIdentityUpdates(listener);
+
+      // Waking every mounted post row for a batch that said nothing is the cost
+      // this guard avoids; it runs on every page of every feed.
+      reconcileKnownIdentities([{ id: 'channel-1', username: 'daily', avatar: 'avatar-after' }]);
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(getKnownIdentity('channel-1')).toEqual({ id: 'channel-1', bio: 'bio-after' });
+      unsubscribe();
+    });
   });
 });

--- a/packages/frontend/stores/identityUpdates.ts
+++ b/packages/frontend/stores/identityUpdates.ts
@@ -1,14 +1,19 @@
 import { useSyncExternalStore } from 'react';
 import type { PostUser } from '@mention/shared-types';
+// Type-only, and it has to stay that way: this module is in `PostItem`'s graph
+// (see below), so a runtime edge from here reaches every screen that renders a
+// post. An erased import costs nothing and keeps the id union the one Oxy owns.
+import type { AccountCategoryId } from '@oxyhq/contracts';
 
 /**
  * The single authority for "a profile edit changed an identity that other
  * surfaces are holding their own copy of".
  *
  * The write class this owns is a person's or a channel's IDENTITY — the display
- * name, the handle and the picture. Today one screen performs it
- * (`app/(app)/c/[username]/settings.tsx`, the only door a channel's profile
- * has), but nothing here is channel-specific: an identity is an identity.
+ * name, the handle, the picture, the bio and the categories. Today one screen
+ * performs it (`app/(app)/c/[username]/settings.tsx`, the only door a channel's
+ * profile has), but nothing here is channel-specific: an identity is an
+ * identity.
  *
  * It sits beside `stores/engagementInvalidation` and `stores/laneInvalidation`,
  * which own the other two write classes, and it exists for the same reason they
@@ -91,6 +96,13 @@ type IdentityName = PostUser['name'];
  * ever writes. Everything else about a user — counts, viewer relationship,
  * joined date — is owned by whichever cache holds it and is never touched here.
  *
+ * THE one place the set is decided, which is what lets a caller hand over the
+ * whole account the server returned rather than a payload it assembled: an Oxy
+ * `User` is a superset of this, and {@link recordIdentityChange} PICKS, so a
+ * field added here is already being supplied by every existing call site. The
+ * opposite arrangement — each site listing the fields it thinks matter — is how
+ * the description came to be missing while type-checking clean.
+ *
  * A type alias rather than an interface on purpose: only an alias gets
  * TypeScript's implicit index signature, and without it this is not assignable
  * to the SDK's `CacheableUser` — which is where every recorded edit is handed
@@ -101,6 +113,24 @@ export type IdentityUpdate = {
   username?: string;
   name?: IdentityName;
   avatar?: string | null;
+  /**
+   * The account's description. It rides only SOME of the surfaces below — a
+   * recommendation, a similar-accounts card and a followers list all carry one,
+   * while a post author never does (`PostUser` has no bio, because no post
+   * renders one). That asymmetry is what {@link reconcileKnownIdentities} is
+   * built around, and it is the whole reason retirement is per-field.
+   */
+  bio?: string;
+  /**
+   * What the account IS, as an ORDERED list of ids whose element 0 is the
+   * primary. Ordered, so agreement below is positional — a reordering IS the
+   * edit that makes a different category primary, and a set-wise comparison
+   * would call it no change at all.
+   *
+   * Unanswerable on every surface that exists today, exactly like the bio and
+   * for the same reason: nothing embedded in a post carries one.
+   */
+  accountCategories?: readonly AccountCategoryId[];
 };
 
 /**
@@ -115,6 +145,8 @@ type IdentityHolder = {
   username?: string;
   name?: IdentityName | string;
   avatar?: string | null;
+  bio?: string | null;
+  accountCategories?: readonly string[];
 };
 
 /**
@@ -154,9 +186,19 @@ function notify(): void {
  * Empty and cleared values are dropped rather than recorded, which mirrors the
  * SDK's own merge (`upsertCachedUser` never lets a degraded value overwrite a
  * good one) so identity resolves under ONE rule everywhere instead of two that
- * disagree at the edges. The cost is that CLEARING a picture does not appear
- * instantly — it takes the same path it takes today — and that limit belongs to
- * the SDK's merge contract rather than to this file.
+ * disagree at the edges.
+ *
+ * The cost is that a CLEAR is invisible here: an emptied bio or picture reads
+ * exactly like a field this write did not carry, and telling them apart needs
+ * the one thing the payload does not hold — what the writer intended. The SDK
+ * takes that as a DECLARATION from the call site instead
+ * (`upsertCachedUser(…, { cleared })`, bounded to its own closed
+ * `CLEARABLE_USER_FIELDS`), which `noteIdentityChanged` passes straight through,
+ * so a clear does reach the React Query user entry. What it does not reach is
+ * the overlay: an actor cannot express "this field is empty" distinguishably
+ * from "I do not carry it", so a recorded clear could never be retired against
+ * one and would pin an emptied field for the whole session. A clear therefore
+ * still takes the ordinary path through the post rows.
  */
 function meaningfulFields(update: IdentityUpdate): Omit<IdentityUpdate, 'id'> {
   const fields: Omit<IdentityUpdate, 'id'> = {};
@@ -169,32 +211,101 @@ function meaningfulFields(update: IdentityUpdate): Omit<IdentityUpdate, 'id'> {
   if (update.avatar && update.avatar.trim() !== '') {
     fields.avatar = update.avatar;
   }
+  if (update.bio && update.bio.trim() !== '') {
+    fields.bio = update.bio;
+  }
+  if (update.accountCategories && update.accountCategories.length > 0) {
+    fields.accountCategories = update.accountCategories;
+  }
   return fields;
 }
 
-/** Whether an incoming actor already carries everything a recorded entry holds. */
-function serverAgrees(entry: IdentityUpdate, actor: IdentityHolder): boolean {
-  if (entry.username !== undefined && actor.username !== entry.username) return false;
-  if (entry.avatar !== undefined && actor.avatar !== entry.avatar) return false;
-  if (entry.name !== undefined) {
-    const incoming = typeof actor.name === 'string' ? actor.name : actor.name?.displayName;
-    if (incoming !== entry.name.displayName) return false;
-  }
-  return true;
+/**
+ * What one incoming actor says about ONE recorded field.
+ *
+ * `unanswerable` is the case the whole rule turns on, and it is not the same as
+ * disagreement: an actor that does not carry the field at all has said nothing
+ * about it. A post author carries no bio — not an empty one, none — so treating
+ * its silence as a mismatch would pin every OTHER field of that entry forever,
+ * and treating it as agreement would retire a correction nothing has confirmed.
+ */
+type FieldVerdict = 'unrecorded' | 'agrees' | 'differs' | 'unanswerable';
+
+function fieldVerdict(
+  recorded: string | null | undefined,
+  carried: string | null | undefined,
+): FieldVerdict {
+  if (recorded === undefined) return 'unrecorded';
+  if (carried === undefined) return 'unanswerable';
+  return carried === recorded ? 'agrees' : 'differs';
+}
+
+/**
+ * {@link fieldVerdict} for the ordered category list. Positional, because the
+ * order carries the primary; a set comparison would read a promotion as no
+ * change. Written here rather than through `utils/accountCategories`'
+ * `accountCategoriesEqual` because that module imports `@oxyhq/contracts` at
+ * RUNTIME, which is the one thing this file may not pull into `PostItem`'s
+ * graph.
+ */
+function listVerdict(
+  recorded: readonly string[] | undefined,
+  carried: readonly string[] | undefined,
+): FieldVerdict {
+  if (recorded === undefined) return 'unrecorded';
+  if (carried === undefined) return 'unanswerable';
+  const same =
+    recorded.length === carried.length && recorded.every((id, index) => carried[index] === id);
+  return same ? 'agrees' : 'differs';
+}
+
+/**
+ * The recorded fields still outstanding after an incoming actor has spoken, or
+ * `null` when it changes nothing — the overwhelming majority of actors, and the
+ * cheap way to leave the map alone.
+ *
+ * A field retires only on POSITIVE agreement, and only when every OTHER field
+ * the same actor could answer for agrees too. That second condition is what
+ * keeps a lagging field protecting the rest: an actor carrying the new picture
+ * beside a stale display name has not caught up, whatever the picture says, so
+ * neither is retired and both keep correcting. Fields it could not answer for
+ * are simply carried forward.
+ */
+function unconfirmedFields(
+  entry: IdentityUpdate,
+  actor: IdentityHolder,
+): Omit<IdentityUpdate, 'id'> | null {
+  const carriedName = typeof actor.name === 'string' ? actor.name : actor.name?.displayName;
+  const username = fieldVerdict(entry.username, actor.username);
+  const avatar = fieldVerdict(entry.avatar, actor.avatar);
+  const bio = fieldVerdict(entry.bio, actor.bio);
+  const name = fieldVerdict(entry.name?.displayName, carriedName);
+  const categories = listVerdict(entry.accountCategories, actor.accountCategories);
+
+  const verdicts = [username, avatar, bio, name, categories];
+  if (verdicts.includes('differs') || !verdicts.includes('agrees')) return null;
+
+  const remaining: Omit<IdentityUpdate, 'id'> = {};
+  if (username === 'unanswerable') remaining.username = entry.username;
+  if (avatar === 'unanswerable') remaining.avatar = entry.avatar;
+  if (bio === 'unanswerable') remaining.bio = entry.bio;
+  if (name === 'unanswerable') remaining.name = entry.name;
+  if (categories === 'unanswerable') remaining.accountCategories = entry.accountCategories;
+  return remaining;
 }
 
 /**
  * The identity recorded for a user, or `undefined` when nothing has been.
  *
- * The returned object is stable by reference until the next write for that user,
- * which is what lets {@link useKnownIdentities} hand the map to `useSyncExternalStore`
- * directly.
+ * The returned object is stable by reference until the next write for that user
+ * or until one of its fields retires, which is what lets {@link useKnownIdentities}
+ * hand the map to `useSyncExternalStore` directly.
  */
 export function getKnownIdentity(userId: string | undefined): IdentityUpdate | undefined {
   return userId ? knownIdentities.get(userId) : undefined;
 }
 
-/** Every recorded identity. Stable by reference until one is written or retired. */
+/** Every recorded identity. Stable by reference until one is written or a field of one retires. */
 export function getKnownIdentities(): ReadonlyMap<string, IdentityUpdate> {
   return knownIdentities;
 }
@@ -250,24 +361,47 @@ export function useKnownIdentities(): ReadonlyMap<string, IdentityUpdate> {
 }
 
 /**
- * Drop every recorded identity that the incoming actors now agree with.
+ * Drop every recorded FIELD that the incoming actors now agree with, and the
+ * entry itself once nothing is left outstanding.
  *
- * Called with each batch of server-hydrated authors, which is exactly the moment
+ * Called with each batch of server-hydrated actors, which is exactly the moment
  * the question can be answered: the overlay exists to cover the window in which
- * post hydration still carries the old value, so it has done its job as soon as
- * hydration carries the new one. One Oxy account is one Redis entry, so
- * agreement is all-or-nothing per user rather than per field.
+ * hydration still carries the old value, so it has done its job as soon as
+ * hydration carries the new one.
+ *
+ * **Per FIELD, and only over the fields the actor can ANSWER for.** Retirement
+ * used to be all-or-nothing across the whole entry, on the reasoning that one
+ * Oxy account is one server cache entry — so an actor agreeing about everything
+ * recorded proved that entry had been refreshed. That reasoning survives here
+ * unchanged (a single `differs` still retires nothing at all); what it cannot
+ * survive is a recorded field NO post carries. `bio` is one: `PostUser` has
+ * none, because no post renders one.
+ *
+ * Both simpler rules fail, in opposite directions. Demand agreement about every
+ * recorded field and an entry holding a bio can never be retired by a feed — so
+ * the picture and the name it also holds stay pinned for the whole session.
+ * Retire each field on its own agreement and an UNCHANGED field, which agrees
+ * with anything, retires instantly: an edit that touched only the bio would drop
+ * its handle/name/picture guard on the first page, and — worse — a stale name
+ * beside a fresh picture would no longer be the proof that the server is behind.
+ * Answerability separates the two: silence is not evidence, so it neither
+ * retires a field nor blocks anything else from retiring.
  */
 export function reconcileKnownIdentities(actors: readonly IdentityHolder[]): void {
   if (knownIdentities.size === 0) return;
-  const retiring: string[] = [];
+  let next: Map<string, IdentityUpdate> | null = null;
   for (const actor of actors) {
-    const entry = getKnownIdentity(actor.id);
-    if (entry && serverAgrees(entry, actor)) retiring.push(entry.id);
+    const id = actor.id;
+    if (!id) continue;
+    const entry = (next ?? knownIdentities).get(id);
+    if (!entry) continue;
+    const remaining = unconfirmedFields(entry, actor);
+    if (!remaining) continue;
+    next ??= new Map(knownIdentities);
+    if (Object.keys(remaining).length === 0) next.delete(id);
+    else next.set(id, { id, ...remaining });
   }
-  if (retiring.length === 0) return;
-  const next = new Map(knownIdentities);
-  for (const id of retiring) next.delete(id);
+  if (!next) return;
   knownIdentities = next.size === 0 ? EMPTY : next;
   notify();
 }
@@ -295,10 +429,19 @@ export function subscribeToIdentityUpdates(listener: IdentityListener): () => vo
  * (see the note at the top), which is why it is the only caller.
  *
  * Returns `null` for an id-less write — there is nothing to key it on.
+ *
+ * A write carrying no meaningful field at all (everything it touched was
+ * cleared) is still RETURNED, so the caller can hand it to the caches, but it is
+ * not recorded: an entry with no fields corrects nothing, and — since a field is
+ * what {@link reconcileKnownIdentities} retires against — nothing would ever
+ * retire it. Every recorded entry holding at least one field is the invariant
+ * that makes per-field retirement terminate.
  */
 export function recordIdentityChange(update: IdentityUpdate): IdentityUpdate | null {
   if (!update.id) return null;
-  const stored: IdentityUpdate = { id: update.id, ...meaningfulFields(update) };
+  const fields = meaningfulFields(update);
+  const stored: IdentityUpdate = { id: update.id, ...fields };
+  if (Object.keys(fields).length === 0) return stored;
   const next = new Map(knownIdentities);
   next.set(update.id, stored);
   knownIdentities = next;


### PR DESCRIPTION
Editing a channel's bio reached the server and nothing else. Going back to the channel page showed the old text until the React Query entry went stale (five minutes) or the page was reloaded.

## The trace, confirmed

`IdentityUpdate` (`stores/identityUpdates.ts`) — the one definition of what a profile edit can change — carried `id`, `username`, `name` and `avatar`. No `bio`. So `noteIdentityChanged` merged four fields into the SDK's user cache and left the fifth at its pre-edit value. `upsertCachedUser` deliberately does not touch an existing entry's freshness, and `useUserByUsername` pairs `staleTime: 5min` with `refetchOnMount: true`, which does not refetch an entry that is still fresh — so nothing re-asked. `ChannelScreen` → `ProfileContent` renders `profileData.bio` straight off that entry.

## What changed

**Widened at the definition, not the call site.** `IdentityUpdate` gains `bio`, and the screen now hands `noteIdentityChanged` the whole account the server returned instead of a payload it assembles. An object literal type-checks identically while omitting a field, which is exactly how this happened; an Oxy `User` is a superset of `IdentityUpdate` and `recordIdentityChange` picks, so a field added to `meaningfulFields` later arrives already supplied. The one-door property (`lib/actorCache.ts`, enforced by its own scan test) is untouched.

**`accountCategories` was the same bug, and is fixed here too.** It landed on this form in #611 while this was in flight and is read by `ChannelHeader` from the same query entry. It is also the proof the new shape works: the door had to name it, the screen did not.

**Retirement is now per field, over the fields an actor can ANSWER for.** It was all-or-nothing across the entry, on the reasoning that one Oxy account is one server cache entry. That holds only while every recorded field rides every surface, and neither `bio` nor `accountCategories` does — `PostUser` carries neither, because no post renders either. Both simpler rules fail, in opposite directions:

* Demand agreement about every recorded field, and an entry holding a bio can never be retired by a feed — the picture and name it also holds stay pinned for the whole session.
* Retire each field on its own agreement, and an UNCHANGED field (which agrees with anything) retires instantly: a bio-only edit drops its handle/name/picture guard on the first page, and a stale name beside a fresh picture stops being the proof that the server is behind.

So a field retires only on positive agreement AND only when every other field the same actor can answer for agrees too. Silence is neither evidence nor a blocker. The category list compares positionally — element 0 is the primary, so a promotion IS the edit and a set-wise comparison would call it no change.

**Clearing works too.** `@oxyhq/services@27` (installed) ships `upsertCachedUser(qc, user, viewerId, { cleared })` with a closed `CLEARABLE_USER_FIELDS`; `bio`, `avatar`, `name.displayName` and `accountCategories` are all on it. `noteIdentityChanged` forwards the declaration and the screen derives it from the write INPUT with the SDK's own `clearedFieldsFromAccountUpdate` — the only place that intent exists, since Oxy omits an emptied scalar exactly as it omits an untouched one. The overlay still cannot record a clear (an actor cannot say "this is empty" distinguishably from "I do not carry it", so a recorded clear could never retire); that boundary is documented where it lives.

No SDK changes. The person's own name/bio/avatar go through the SDK's `ManageAccount` screens, which already wire `cleared` upstream.

## Verified

Against this branch rebased on `main`, all matching the pre-change baseline:

* `bunx tsc --noEmit` (via `bun run typecheck`) — 0 errors
* `bun run test:coverage` — **158 suites**, 1508 tests, all passing (baseline 155/1444); thresholds met
* `bun run lint:frontend` — 0 errors, 8 warnings (all pre-existing, none in touched files); every touched file also linted explicitly, since `expo lint` skips untracked ones
* `bun run validate:i18n` — clean

Mutation-tested, both directions, each caught by a named test:

| mutation | caught |
|---|---|
| `meaningfulFields` drops `bio` (the original bug) | 10 tests, 3 suites |
| `meaningfulFields` drops `accountCategories` | 2 tests |
| unanswerable read as agreement | 3 tests |
| unanswerable read as disagreement | 3 tests |
| a single `differs` no longer blocks the rest | 5 tests |
| category comparison becomes set-wise | 1 test |
| an emptied category list is recorded | 1 test |
| the door drops the `cleared` declaration | 3 tests |
| the call site hand-picks the payload again | 2 tests |
| `cleared` derived from the RESPONSE, not the input | 1 test |
| the overlay corrects EVERY actor, not just the edited one | 3 tests |
| the write invalidates every query family | 1 test |

The response-derived-`cleared` mutation initially SURVIVED: the fixture spelled a cleared bio `bio: undefined`, which still answers `'bio' in response`, so both derivations agreed. Oxy's serializer omits the key entirely — the fixture now does too, and the mutation is caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)