### PR TITLE
feat(channels): give a channel's owner a way to end it, counted before it goes

### DIFF
--- a/packages/backend/src/__tests__/routes/channelDeletionRoutes.test.ts
+++ b/packages/backend/src/__tests__/routes/channelDeletionRoutes.test.ts
@@ -1,0 +1,241 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `GET /channels/:id/deletion-preview` and `DELETE /channels/:id/content` — the
+ * trigger `ChannelDeletionService` was deliberately shipped without.
+ *
+ * The REAL gate runs here. Mocking `assertCanDeleteAccount` would leave the one
+ * property these routes exist to hold — that the destructive call is unreachable
+ * without `account:delete` — asserted against a stand-in that answers however the
+ * test says. So only the identity read and the cascade itself are mocked, and the
+ * permission decision is made by the code that makes it in production.
+ *
+ * Three properties:
+ *
+ *   * **The cascade is not called for anybody the gate refuses.** Asserted as an
+ *     absence on the cascade spy, not merely as a status code: a route that
+ *     answered 403 after already deleting would satisfy a status assertion.
+ *   * **The PREVIEW is behind the same gate as the deletion.** It is the number a
+ *     confirmation states, so a preview readable by somebody the deletion refuses
+ *     is a button that appears and then fails. Affordance is a subset of
+ *     permission, and this is where that is enforced rather than hoped for.
+ *   * **A partially failed cascade is a 500, never a 200.** The client archives
+ *     the Oxy account on a 2xx, and that archive is what makes an incomplete
+ *     deletion permanent: Oxy's account reads exclude an archived account, so the
+ *     cascade could never resolve the kind or the username again.
+ */
+
+const CALLER = 'caller-1';
+const CHANNEL = 'channel-1';
+const ORGANIZATION = 'org-1';
+
+/** The permission sets Oxy derives from its roles, as they arrive on the wire. */
+const OWNER_PERMISSIONS = ['account:read', 'account:update', 'account:delete', 'account:act_as'];
+/** `editor` — may publish as the channel, may not end it. */
+const EDITOR_PERMISSIONS = ['account:read', 'account:act_as'];
+
+const state = vi.hoisted(() => ({
+  /** What Oxy answers for each account id, or nothing to make it unresolvable. */
+  kindOf: new Map<string, string>(),
+  /** The permissions the caller's own membership row carries, or null for none. */
+  callerPermissions: null as string[] | null,
+}));
+
+const resolveUserSummaries = vi.hoisted(() => vi.fn());
+const previewChannelDeletion = vi.hoisted(() => vi.fn());
+const deleteChannelContent = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/PostHydrationService', () => ({ resolveUserSummaries }));
+
+vi.mock('../../services/channelDeletion/ChannelDeletionService', () => {
+  class NotAChannelAccountError extends Error {
+    readonly resolvedKind: string | null;
+    constructor(oxyUserId: string, resolvedKind: string | null) {
+      super(`refused: ${oxyUserId} is ${resolvedKind ?? 'unresolvable'}`);
+      this.name = 'NotAChannelAccountError';
+      this.resolvedKind = resolvedKind;
+    }
+  }
+  return { NotAChannelAccountError, previewChannelDeletion, deleteChannelContent };
+});
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  createUserScopedOxyServices: () => ({
+    async listAccountMembers(accountId: string) {
+      if (state.callerPermissions === null) return [];
+      return [
+        {
+          _id: 'member-row-1',
+          accountId,
+          memberUserId: CALLER,
+          role: 'owner',
+          permissions: state.callerPermissions,
+          inherit: true,
+          status: 'active',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ];
+    },
+  }),
+}));
+
+vi.mock('@oxyhq/core/server', () => ({
+  getRequiredOxyUserId: (req: express.Request & { user?: { id: string } }) => req.user?.id ?? '',
+}));
+
+// Real Redis stores are not reachable from a unit run, and the limiters are
+// production-gated out of the handler chain anyway.
+vi.mock('../../middleware/security', () => ({
+  channelDeletionRateLimiter: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { default: channelDeletionRoutes } = await import('../../routes/channelDeletion.routes');
+
+function buildApp() {
+  const app = express();
+  app.use((req, _res, next) => {
+    (req as express.Request & { user?: { id: string } }).user = { id: CALLER };
+    next();
+  });
+  app.use('/channels', channelDeletionRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  state.kindOf = new Map([
+    [CHANNEL, 'channel'],
+    [ORGANIZATION, 'organization'],
+  ]);
+  state.callerPermissions = OWNER_PERMISSIONS;
+  resolveUserSummaries.mockReset();
+  resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+    const map = new Map<string, { user: { id: string; kind?: string; name: object } }>();
+    for (const id of ids) {
+      const kind = state.kindOf.get(id);
+      if (kind) map.set(id, { user: { id, kind, name: {} } });
+    }
+    return map;
+  });
+  previewChannelDeletion.mockReset();
+  previewChannelDeletion.mockResolvedValue({
+    channelOxyUserId: CHANNEL,
+    posts: 42,
+    boostsByOthers: 7,
+    replies: 0,
+    quotesByOthersKept: 3,
+    federatedFollowers: 12,
+  });
+  deleteChannelContent.mockReset();
+  deleteChannelContent.mockResolvedValue({
+    steps: {},
+    delegated: [],
+    retained: [],
+    preview: {
+      channelOxyUserId: CHANNEL,
+      posts: 42,
+      boostsByOthers: 7,
+      replies: 0,
+      quotesByOthersKept: 3,
+      federatedFollowers: 12,
+    },
+    dryRun: false,
+  });
+});
+
+describe('an owner', () => {
+  it('reads the counts a confirmation states, and nothing operational', async () => {
+    const res = await request(buildApp())
+      .get(`/channels/${CHANNEL}/deletion-preview`)
+      .expect(200);
+
+    // Exactly the two numbers, and no `channelOxyUserId`, `replies`,
+    // `quotesByOthersKept` or `federatedFollowers`: those are facts for a log,
+    // not numbers to put in front of somebody about to destroy an archive.
+    expect(res.body.data).toEqual({ posts: 42, boostsByOthers: 7 });
+    expect(previewChannelDeletion).toHaveBeenCalledWith(CHANNEL);
+  });
+
+  it('deletes, and reports what went', async () => {
+    const res = await request(buildApp()).delete(`/channels/${CHANNEL}/content`).expect(200);
+
+    expect(res.body.data).toEqual({ posts: 42, boostsByOthers: 7 });
+    expect(deleteChannelContent).toHaveBeenCalledWith(CHANNEL, { dryRun: false });
+  });
+});
+
+describe('somebody the account graph does not authorise', () => {
+  it('refuses an EDITOR, who may publish as the channel', async () => {
+    // The fixture the route turns on. Bare membership, or a check on
+    // `account:act_as`, admits this caller — and Oxy would then refuse them the
+    // account archive, leaving a channel with no posts and an account standing.
+    state.callerPermissions = EDITOR_PERMISSIONS;
+    const app = buildApp();
+
+    await request(app).delete(`/channels/${CHANNEL}/content`).expect(403);
+
+    expect(deleteChannelContent).not.toHaveBeenCalled();
+  });
+
+  it('refuses an EDITOR the PREVIEW too, so no confirmation can be built', async () => {
+    state.callerPermissions = EDITOR_PERMISSIONS;
+
+    await request(buildApp()).get(`/channels/${CHANNEL}/deletion-preview`).expect(403);
+
+    expect(previewChannelDeletion).not.toHaveBeenCalled();
+  });
+
+  it('refuses somebody with no membership at all', async () => {
+    state.callerPermissions = null;
+
+    await request(buildApp()).delete(`/channels/${CHANNEL}/content`).expect(403);
+
+    expect(deleteChannelContent).not.toHaveBeenCalled();
+  });
+});
+
+describe('a target that is not a deletable channel', () => {
+  it('refuses an ORGANIZATION the caller genuinely owns', async () => {
+    // The gate ALLOWS this caller — they hold `account:delete` over it — and the
+    // route still refuses, because `CHANNEL_CASCADE` describes a channel and
+    // nothing else. Two different questions, answered in two places.
+    await request(buildApp()).delete(`/channels/${ORGANIZATION}/content`).expect(400);
+
+    expect(deleteChannelContent).not.toHaveBeenCalled();
+  });
+
+  it('refuses an account Oxy cannot resolve at all', async () => {
+    await request(buildApp()).delete('/channels/nobody-1/content').expect(400);
+
+    expect(deleteChannelContent).not.toHaveBeenCalled();
+  });
+});
+
+describe('a cascade that did not finish', () => {
+  it('answers 500, because the client archives the Oxy account on a 2xx', async () => {
+    deleteChannelContent.mockRejectedValue(new Error('2 cascade step(s) failed'));
+
+    await request(buildApp()).delete(`/channels/${CHANNEL}/content`).expect(500);
+  });
+
+  it('answers 400 when the service itself refuses the account as not a channel', async () => {
+    // Its own guard, one layer below this route's. Reported as a refusal rather
+    // than as a fault, so a client sees the same answer either place it is made.
+    const { NotAChannelAccountError } = await import(
+      '../../services/channelDeletion/ChannelDeletionService'
+    );
+    deleteChannelContent.mockRejectedValue(new NotAChannelAccountError(CHANNEL, 'personal'));
+
+    await request(buildApp()).delete(`/channels/${CHANNEL}/content`).expect(400);
+  });
+});

--- a/packages/backend/src/__tests__/services/assertCanDeleteAccount.test.ts
+++ b/packages/backend/src/__tests__/services/assertCanDeleteAccount.test.ts
@@ -1,0 +1,344 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AccountMember } from '@oxyhq/core';
+
+/**
+ * `assertCanDeleteAccount` — "may this person END that account".
+ *
+ * The distinction this suite exists for is the one that reads as pedantic and is
+ * not: **deleting a channel asks for strictly more than publishing as one.**
+ *
+ * `assertCanPublishAsAccount` grades a `channel` at bare ACTIVE MEMBERSHIP, and
+ * correctly — a channel can never be acted as, so over a channel there is no
+ * capability stronger than membership to ask for. Deletion is the exception,
+ * because the stronger right exists and lives at Oxy: `DELETE /accounts/:id`
+ * gates on `account:delete`, which oxy-api's `ROLE_PERMISSIONS` grants to `owner`
+ * ALONE. `admin` and `editor` hold `account:act_as` without it.
+ *
+ * If Mention accepted a mere member here, an `editor` could destroy every post a
+ * channel has published and then be refused the account archive by Oxy: a channel
+ * with no content, an account still standing, and no undo. So the fixtures below
+ * are chosen so that the strict check and every looser one DISAGREE:
+ *
+ *  - a channel member with `account:act_as` and no `account:delete` — the shape
+ *    "membership is enough" and "act_as is enough" both get wrong;
+ *  - a member with an EMPTY permission array, and one with no array at all, which
+ *    a `permissions?.includes` written without the array guard would throw on;
+ *  - an owner-shaped set that DOES carry `account:delete`, so the suite cannot
+ *    pass by refusing everybody.
+ *
+ * `resolveUserSummaries` is mocked because it is the Redis/Oxy identity path. The
+ * KIND still matters: the gate refuses an account whose kind Oxy cannot resolve
+ * at all, and hands the resolved kind back for the caller to judge.
+ */
+
+const resolveUserSummaries = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/PostHydrationService', () => ({
+  resolveUserSummaries,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  assertCanDeleteAccount,
+  PublishAsAccessError,
+  type AccountMemberReader,
+} from '../../services/publishAsAccount';
+
+const CALLER = 'caller-1';
+const CHANNEL = 'channel-1';
+const ORGANIZATION = 'org-1';
+const UNKNOWN = 'unknown-1';
+
+/** The permission sets Oxy derives from its roles, as they arrive on the wire. */
+const OWNER_PERMISSIONS = [
+  'account:read',
+  'account:update',
+  'account:delete',
+  'account:act_as',
+  'members:read',
+];
+/** `admin` — everything an owner has except the one permission that matters here. */
+const ADMIN_PERMISSIONS = ['account:read', 'account:update', 'account:act_as', 'members:read'];
+/** `editor` — may publish as the channel, may not end it. */
+const EDITOR_PERMISSIONS = ['account:read', 'account:act_as', 'members:read'];
+/** `viewer` — a real, active member with neither right. */
+const VIEWER_PERMISSIONS = ['account:read', 'members:read'];
+
+function member(overrides: Partial<AccountMember> = {}): AccountMember {
+  return {
+    _id: 'member-row-1',
+    accountId: 'account-1',
+    memberUserId: CALLER,
+    role: 'owner',
+    permissions: OWNER_PERMISSIONS,
+    inherit: true,
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function readerReturning(members: AccountMember[]): AccountMemberReader & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    async listAccountMembers(accountId: string) {
+      calls.push(accountId);
+      return members;
+    },
+  };
+}
+
+function readerThatFails(): AccountMemberReader {
+  return {
+    async listAccountMembers() {
+      throw new Error('oxy is unreachable');
+    },
+  };
+}
+
+function kindsAre(byId: Record<string, string>): void {
+  resolveUserSummaries.mockImplementation(async (ids: string[]) => {
+    const map = new Map<string, { user: { id: string; kind?: string; name: object } }>();
+    for (const id of ids) {
+      const kind = byId[id];
+      if (kind) map.set(id, { user: { id, kind, name: {} } });
+    }
+    return map;
+  });
+}
+
+/** The status a refusal carried, or a failure if it did not refuse at all. */
+async function refusalStatus(promise: Promise<unknown>): Promise<number> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof PublishAsAccessError) return error.status;
+    throw error;
+  }
+  throw new Error('the gate allowed the deletion');
+}
+
+beforeEach(() => {
+  resolveUserSummaries.mockReset();
+  kindsAre({ [CHANNEL]: 'channel', [ORGANIZATION]: 'organization' });
+});
+
+describe('assertCanDeleteAccount — what it allows', () => {
+  it('allows a member holding account:delete, and answers with the kind', async () => {
+    const reader = readerReturning([member()]);
+
+    await expect(
+      assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+    ).resolves.toBe('channel');
+
+    expect(reader.calls).toEqual([CHANNEL]);
+  });
+
+  it('does not care what KIND the account is — that is the caller’s question', async () => {
+    // The gate answers "may this person", never "is this a channel". Returning
+    // the kind rather than judging it is what lets one route refuse a
+    // non-channel with its own status while the service keeps its own guard.
+    const reader = readerReturning([member({ accountId: ORGANIZATION })]);
+
+    await expect(
+      assertCanDeleteAccount({
+        targetOxyUserId: ORGANIZATION,
+        callerId: CALLER,
+        memberReader: reader,
+      }),
+    ).resolves.toBe('organization');
+  });
+
+  it('trims the target before asking about it', async () => {
+    const reader = readerReturning([member()]);
+
+    await expect(
+      assertCanDeleteAccount({
+        targetOxyUserId: `  ${CHANNEL} `,
+        callerId: CALLER,
+        memberReader: reader,
+      }),
+    ).resolves.toBe('channel');
+
+    expect(reader.calls).toEqual([CHANNEL]);
+  });
+});
+
+describe('assertCanDeleteAccount — the permission, not the membership', () => {
+  it('refuses an ADMIN of the channel', async () => {
+    const reader = readerReturning([member({ role: 'admin', permissions: ADMIN_PERMISSIONS })]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses an EDITOR of the channel, who may publish as it', async () => {
+    // The fixture the whole suite turns on: publishing as this channel is
+    // theirs, ending it is not, and only a check on `account:delete` tells the
+    // two apart.
+    const reader = readerReturning([member({ role: 'editor', permissions: EDITOR_PERMISSIONS })]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses a VIEWER of the channel', async () => {
+    const reader = readerReturning([member({ role: 'viewer', permissions: VIEWER_PERMISSIONS })]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses an EMPTY permission array rather than reading it as unrestricted', async () => {
+    const reader = readerReturning([member({ permissions: [] })]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses a row with NO permissions array, and does not throw doing it', async () => {
+    // A row that arrived without the field at all — a serializer change, an
+    // older API. `permissions.includes(...)` written without the array guard
+    // raises a TypeError here, which a route turns into a 500 rather than a
+    // refusal, and a 500 is not a "no" anybody can act on.
+    const reader = readerReturning([
+      member({ permissions: undefined as unknown as string[] }),
+    ]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses a permissions value that is not an array at all', async () => {
+    const reader = readerReturning([
+      member({ permissions: 'account:delete' as unknown as string[] }),
+    ]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+});
+
+describe('assertCanDeleteAccount — who is asking', () => {
+  it('refuses an INVITED member who has not accepted', async () => {
+    const reader = readerReturning([member({ status: 'invited' })]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses a REMOVED member, whatever permissions the stale row carries', async () => {
+    const reader = readerReturning([member({ status: 'removed' })]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses somebody who is not on the member list', async () => {
+    const reader = readerReturning([member({ memberUserId: 'somebody-else' })]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses an anonymous caller before asking Oxy anything', async () => {
+    const reader = readerReturning([member()]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: CHANNEL, callerId: null, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+
+    expect(reader.calls).toEqual([]);
+    expect(resolveUserSummaries).not.toHaveBeenCalled();
+  });
+
+  it('refuses when there is no client to ask Oxy with (an MCP caller)', async () => {
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({
+          targetOxyUserId: CHANNEL,
+          callerId: CALLER,
+          memberReader: undefined,
+        }),
+      ),
+    ).resolves.toBe(403);
+  });
+
+  it('refuses an ABSENT target rather than reading it as "delete yourself"', async () => {
+    // The sibling gate reads an absent target as "publish as yourself" and
+    // answers SUCCESS. That is the right answer to its question and a hole in
+    // this one.
+    const reader = readerReturning([member()]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: '   ', callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(403);
+
+    expect(reader.calls).toEqual([]);
+  });
+});
+
+describe('assertCanDeleteAccount — it fails closed', () => {
+  it('refuses an account whose kind Oxy cannot resolve, before reading members', async () => {
+    const reader = readerReturning([member()]);
+
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({ targetOxyUserId: UNKNOWN, callerId: CALLER, memberReader: reader }),
+      ),
+    ).resolves.toBe(400);
+
+    expect(reader.calls).toEqual([]);
+  });
+
+  it('answers 503 when the member list cannot be read, never a silent allow', async () => {
+    // An Oxy outage is indistinguishable here from "you have no members:read",
+    // and both must refuse. 503 because the outage is the case a client can act
+    // on by trying again.
+    await expect(
+      refusalStatus(
+        assertCanDeleteAccount({
+          targetOxyUserId: CHANNEL,
+          callerId: CALLER,
+          memberReader: readerThatFails(),
+        }),
+      ),
+    ).resolves.toBe(503);
+  });
+});

--- a/packages/backend/src/appRoutes.ts
+++ b/packages/backend/src/appRoutes.ts
@@ -28,6 +28,7 @@ import profileLinkMentionsRoutes, {
 } from './routes/profileLinkMentions.routes';
 import lanesRoutes, { publicLanesRouter } from './routes/lanes.routes';
 import channelWritersRoutes from './routes/channelWriters.routes';
+import channelDeletionRoutes from './routes/channelDeletion.routes';
 import reportsRoutes from './routes/reports.routes';
 import { createCrowdSourceWebhookRoutes } from './routes/crowdSourceWebhook.routes';
 import trendingRoutes from './routes/trending.routes';
@@ -140,6 +141,12 @@ export function createAppRoutes({
   // the mount is the gate, so the handler needs no auth check of its own.
   authenticatedApi.use('/mentions', profileLinkMentionsRateLimiter, profileLinkMentionsRoutes);
   authenticatedApi.use('/lanes', lanesRoutes);
+  // The SAME `/channels` prefix the public writers router carries, one mount
+  // later: that router hands an unmatched path straight on, so a `/channels`
+  // route that needs a caller lands here behind `requireAuth` rather than needing
+  // a second prefix for the same noun (`/posts` and `/statistics` are split the
+  // same way).
+  authenticatedApi.use('/channels', channelDeletionRoutes);
   authenticatedApi.use('/reports', reportsRoutes);
   authenticatedApi.use('/pokes', pokesRoutes);
   authenticatedApi.use('/entity-follows', entityFollowRoutes);

--- a/packages/backend/src/middleware/security.ts
+++ b/packages/backend/src/middleware/security.ts
@@ -376,6 +376,26 @@ export const channelWritersRateLimiter = rateLimit({
 });
 
 /**
+ * The channel-deletion router — the preview and the deletion itself.
+ *
+ * The most expensive pair of routes an authenticated caller can reach. Both walk
+ * a channel's ENTIRE publishing history plus the transitive boost closure over
+ * it, and both cost an Oxy membership read before they get that far, so a caller
+ * who is a member of nothing still spends an upstream round trip per request.
+ *
+ * 10/minute, far below every other limiter here, because there is no legitimate
+ * use above it: an operator previews once and deletes once, and a second delete
+ * is a retry after a failure rather than a rhythm. Its OWN store prefix, written
+ * as a LITERAL for the reason spelled out above `lanesStore` —
+ * `rateLimitPrefixUniqueness.test.ts` resolves prefixes by reading SOURCE, so a
+ * prefix built through a factory reads as the default and fails the guard.
+ */
+export const channelDeletionRateLimiter = rateLimit({
+  store: new RedisStore({ prefix: 'rate-limit:channel-deletion:', windowMs: 60 * 1000 }),
+  ...complianceOptions(10, 'Too many channel deletion requests. Please slow down.'),
+});
+
+/**
  * Rate limiter for `POST /statistics/post/:postId/view`.
  *
  * The only WRITE on the statistics router, and the only route there that reaches

--- a/packages/backend/src/routes/channelDeletion.routes.ts
+++ b/packages/backend/src/routes/channelDeletion.routes.ts
@@ -1,0 +1,233 @@
+/**
+ * DELETING A CHANNEL — Mention's half, and the trigger `ChannelDeletionService`
+ * was deliberately shipped without.
+ *
+ * ── TWO HALVES, TWO OWNERS, ONE ORDER ─────────────────────────────────────────
+ *
+ * Deleting a channel destroys things on both sides of the Oxy boundary. Mention
+ * owns the posts and every row pointing at them (`CHANNEL_CASCADE`); Oxy owns the
+ * account itself, its membership rows, its follow edges and its uploaded bytes
+ * (`OWNED_BY_OXY`). Mention cannot archive the account — `DELETE /accounts/:id`
+ * is authorized against the CALLER, not against a service credential — so the
+ * client performs that half with the SDK once this one has answered.
+ *
+ * The order is not a preference. Oxy's account reads EXCLUDE an archived account:
+ * `GET /users/:id` answers 404 for one and `POST /users/by-ids` filters
+ * `accountStatus: { $ne: 'archived' }`. So after the archive:
+ *
+ *  - `resolveAccountKind` answers `null`, and `deleteChannelContent` refuses
+ *    permanently with `NotAChannelAccountError` — by design, since deleting an
+ *    account whose kind is unknown is not a risk it takes; and
+ *  - `broadcastFederatedDelete` cannot resolve the username the canonical Note
+ *    ids are minted from, and throws before a single Tombstone goes out.
+ *
+ * Archive-first therefore strands every post the channel ever published, forever,
+ * with no route able to re-target them and no retry that helps. Mention-first
+ * fails the other way: the posts are gone, the fediverse has been told, and an
+ * account survives that the operator can archive on a retry. The cascade is
+ * idempotent, so a second run over an already-emptied channel reports all-zero
+ * counts and does not throw, which is what makes that retry safe.
+ *
+ * ── WHY THIS IS SYNCHRONOUS AND NOT A BULLMQ JOB ──────────────────────────────
+ *
+ * The `sharing-cleanup` shape (202, enqueue, inline fallback) is the obvious
+ * model and it is the wrong one HERE, for the reason above: a 202 tells the
+ * client nothing about whether Mention's half finished, so a client that archived
+ * on a 202 would be racing the worker into exactly the unrecoverable state. The
+ * client must not archive until this route has answered, so this route answers
+ * when the work is done.
+ *
+ * A client timeout is therefore not a failure of the cascade — the run continues
+ * server-side, and a retry converges on a 200 the client can then act on. What
+ * must never happen is an archive on anything other than a 2xx from here.
+ *
+ * ── AUTHORIZATION ─────────────────────────────────────────────────────────────
+ *
+ * `account:delete`, via `assertCanDeleteAccount` — the SAME permission Oxy gates
+ * the account archive on, held by the `owner` role alone. Membership is not
+ * enough even though it is enough to PUBLISH as the channel: see that function on
+ * why the two halves have to be permitted or refused together.
+ */
+
+import { Router, type Response } from 'express';
+import type { AccountKind } from '@oxyhq/contracts';
+import type { ChannelDeletionCounts } from '@mention/shared-types';
+import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
+import { getRequiredOxyUserId } from '@oxyhq/core/server';
+import {
+  assertCanDeleteAccount,
+  PublishAsAccessError,
+} from '../services/publishAsAccount';
+import {
+  deleteChannelContent,
+  previewChannelDeletion,
+  NotAChannelAccountError,
+  type ChannelDeletionPreview,
+} from '../services/channelDeletion/ChannelDeletionService';
+import { createUserScopedOxyServices } from '../utils/oxyHelpers';
+import { channelDeletionRateLimiter } from '../middleware/security';
+import { config } from '../config';
+import { sendErrorResponse, sendSuccessResponse } from '../utils/apiHelpers';
+import { logger } from '../utils/logger';
+
+const router = Router();
+
+/** Longest account id we will look up — an Oxy user id is a 24-char hex ObjectId. */
+const MAX_OXY_USER_ID_LENGTH = 64;
+
+/**
+ * The server's preview, narrowed to what a person deciding is owed.
+ *
+ * `replies` is structurally always 0 (a channel takes no replies at five enforced
+ * sites) and `quotesByOthersKept` counts rows that SURVIVE — both are operational
+ * facts for a log rather than numbers to put in front of somebody about to
+ * destroy an archive, and `channelOxyUserId` is something the client already
+ * knows. Narrowing here rather than at the client keeps the decision in one
+ * place.
+ */
+function toCounts(preview: ChannelDeletionPreview): ChannelDeletionCounts {
+  return { posts: preview.posts, boostsByOthers: preview.boostsByOthers };
+}
+
+/**
+ * Resolve the target account and authorize the caller over it, or answer and
+ * return `null`.
+ *
+ * Shared by both routes ON PURPOSE: an affordance the server refuses is worse
+ * than no affordance, so the preview a confirmation is built from has to be
+ * behind exactly the gate the deletion is behind. A preview readable by somebody
+ * the deletion would refuse is a button that appears and then fails.
+ *
+ * The kind check is separate from the permission check and stays here rather than
+ * inside the gate: `assertCanDeleteAccount` answers "may this person", the
+ * service answers "is this a channel", and this route is where the two meet. The
+ * service re-checks the kind at its own door regardless — that guard is its
+ * defence and not this route's to satisfy.
+ */
+async function resolveDeletableChannel(
+  req: AuthRequest,
+  res: Response,
+): Promise<string | null> {
+  const channelOxyUserId =
+    typeof req.params.oxyUserId === 'string' ? req.params.oxyUserId.trim() : '';
+  if (!channelOxyUserId || channelOxyUserId.length > MAX_OXY_USER_ID_LENGTH) {
+    sendErrorResponse(res, 400, 'Bad Request', 'oxyUserId is required');
+    return null;
+  }
+
+  const callerId = getRequiredOxyUserId(req);
+
+  let kind: AccountKind;
+  try {
+    kind = await assertCanDeleteAccount({
+      targetOxyUserId: channelOxyUserId,
+      callerId,
+      memberReader: createUserScopedOxyServices(req),
+    });
+  } catch (error) {
+    if (error instanceof PublishAsAccessError) {
+      sendErrorResponse(
+        res,
+        error.status,
+        error.status === 400 ? 'Bad Request' : 'Forbidden',
+        error.message,
+      );
+      return null;
+    }
+    throw error;
+  }
+
+  if (kind !== 'channel') {
+    sendErrorResponse(res, 400, 'Bad Request', 'That account is not a channel');
+    return null;
+  }
+
+  return channelOxyUserId;
+}
+
+/**
+ * GET /channels/:oxyUserId/deletion-preview
+ *
+ * What deleting this channel would destroy, counted, touching nothing. The count
+ * is what the client's confirmation STATES — a channel is a publication, and a
+ * bare "are you sure" is not informed consent for destroying an archive.
+ */
+router.get(
+  '/:oxyUserId/deletion-preview',
+  // Production-gated in the PER-ROUTE position. `router.use(...limiters)` with an
+  // empty array throws `argument handler is required` at import outside
+  // production, and this is also the only position CodeQL inspects.
+  ...(config.runtime.isProduction ? [channelDeletionRateLimiter] : []),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const channelOxyUserId = await resolveDeletableChannel(req, res);
+      if (!channelOxyUserId) return;
+
+      return sendSuccessResponse(res, 200, toCounts(await previewChannelDeletion(channelOxyUserId)));
+    } catch (error) {
+      if (error instanceof NotAChannelAccountError) {
+        return sendErrorResponse(res, 400, 'Bad Request', 'That account is not a channel');
+      }
+      logger.error('[ChannelDeletion] Failed to preview a channel deletion', {
+        channelOxyUserId: req.params.oxyUserId,
+        userId: req.user?.id,
+        error,
+      });
+      return sendErrorResponse(
+        res,
+        500,
+        'Internal Server Error',
+        'Failed to read what deleting this channel would remove',
+      );
+    }
+  },
+);
+
+/**
+ * DELETE /channels/:oxyUserId/content
+ *
+ * Destroy the channel's posts and every Mention row pointing at them, and tell
+ * the fediverse. Named `/content` because that is honestly all it does: the
+ * account is Oxy's, and the client archives it with the SDK once this answers
+ * 200.
+ *
+ * A 500 here means Mention's half did NOT complete, and the client must not
+ * archive — `deleteChannelContent` collects per-step failures, runs every
+ * remaining step, and throws at the end precisely so a caller learns that some of
+ * it survived.
+ */
+router.delete(
+  '/:oxyUserId/content',
+  ...(config.runtime.isProduction ? [channelDeletionRateLimiter] : []),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const channelOxyUserId = await resolveDeletableChannel(req, res);
+      if (!channelOxyUserId) return;
+
+      logger.warn('[ChannelDeletion] Destroying the content of a channel', {
+        channelOxyUserId,
+        userId: req.user?.id,
+      });
+      const result = await deleteChannelContent(channelOxyUserId, { dryRun: false });
+
+      return sendSuccessResponse(res, 200, toCounts(result.preview));
+    } catch (error) {
+      if (error instanceof NotAChannelAccountError) {
+        return sendErrorResponse(res, 400, 'Bad Request', 'That account is not a channel');
+      }
+      logger.error('[ChannelDeletion] Failed to delete the content of a channel', {
+        channelOxyUserId: req.params.oxyUserId,
+        userId: req.user?.id,
+        error,
+      });
+      return sendErrorResponse(
+        res,
+        500,
+        'Internal Server Error',
+        'Some of the channel could not be deleted. Nothing else was changed; try again.',
+      );
+    }
+  },
+);
+
+export default router;

--- a/packages/backend/src/services/publishAsAccount.ts
+++ b/packages/backend/src/services/publishAsAccount.ts
@@ -1,6 +1,13 @@
 /**
- * The ONE definition of "may this person publish as that account", and of "is
- * that account a channel".
+ * The ONE definition of "may this person publish as that account", of "may this
+ * person DELETE that account", and of "is that account a channel".
+ *
+ * The first two live together because they share the membership READ, not
+ * because they share an answer — they deliberately do not. Publishing as a
+ * channel asks for membership; deleting one asks for `account:delete`, the
+ * permission Oxy itself gates the account archive on. A second reader for the
+ * second question would be a second answer, and whichever of the two were wrong,
+ * one of them would be wrong in the permissive direction.
  *
  * A channel is an Oxy ACCOUNT (`kind: 'channel'`), not a Mention row, so both
  * questions are answered by Oxy and Mention stores neither. There is deliberately
@@ -63,6 +70,25 @@ import { logger } from '../utils/logger';
  * is one named constant rather than a string scattered through the checks.
  */
 const ACCOUNT_ACT_AS_PERMISSION = 'account:act_as';
+
+/**
+ * The Oxy account permission that authorises DESTROYING an account — what
+ * `DELETE /accounts/:id` gates on (`requireAccountPermission('account:delete')`
+ * in oxy-api's `routes/accounts.ts`), and therefore what destroying that
+ * account's content in Mention gates on too.
+ *
+ * Oxy grants it to the `owner` role ALONE: its `ROLE_PERMISSIONS` map gives
+ * `admin` and `editor` `account:act_as` without it, so the people who may publish
+ * as a channel are strictly wider than the people who may end it. Matching that
+ * here is not a preference — a member who could destroy every post while being
+ * refused the account archive would produce exactly the half-deleted channel the
+ * ordering elsewhere exists to prevent.
+ *
+ * A literal for the same reason as {@link ACCOUNT_ACT_AS_PERMISSION}: Oxy derives
+ * each member's `permissions` from their role server-side and ships the strings,
+ * and neither `@oxyhq/contracts` nor `@oxyhq/core` exports the vocabulary today.
+ */
+const ACCOUNT_DELETE_PERMISSION = 'account:delete';
 
 /** A refusal carrying the status the HTTP layer should answer with. */
 export class PublishAsAccessError extends Error {
@@ -279,6 +305,42 @@ export async function isChannelAccount(
   return (await resolveAccountKind(oxyUserId)) === 'channel';
 }
 
+/**
+ * The caller's ACTIVE membership row on an account, or a refusal.
+ *
+ * The ONE membership read behind every question this module answers, factored so
+ * the publish gate and {@link assertCanDeleteAccount} cannot come to different
+ * conclusions about who a caller is on an account — a second read is a second
+ * answer, and whichever of the two is wrong, one of them is wrong in the
+ * permissive direction. What each caller then DEMANDS of the row is their own
+ * decision; this only establishes which row is theirs.
+ */
+async function readActiveMembership(
+  target: string,
+  callerId: string,
+  memberReader: AccountMemberReader,
+): Promise<AccountMember> {
+  let members: AccountMember[];
+  try {
+    members = await memberReader.listAccountMembers(target);
+  } catch (error) {
+    // Includes Oxy's own 403 for a caller with no `members:read`, which is the
+    // same answer as "not a member" — but it is not distinguishable here from a
+    // genuine outage, and both must refuse. The status says "try again" because
+    // the outage case is the one a client can act on.
+    logger.warn('[publishAsAccount] Failed to read account members', error);
+    throw new PublishAsAccessError(503, 'Could not verify your access to that account');
+  }
+
+  const membership = members.find(
+    (member) => member.memberUserId === callerId && member.status === 'active',
+  );
+  if (!membership) {
+    throw new PublishAsAccessError(403, 'You are not a member of that account');
+  }
+  return membership;
+}
+
 /** What {@link assertCanPublishAsAccount} answers with. */
 export interface PublishAsAuthor {
   /**
@@ -353,24 +415,7 @@ export async function assertCanPublishAsAccount(params: {
     throw new PublishAsAccessError(403, 'You cannot publish as another account');
   }
 
-  let members: AccountMember[];
-  try {
-    members = await params.memberReader.listAccountMembers(target);
-  } catch (error) {
-    // Includes Oxy's own 403 for a caller with no `members:read`, which is the
-    // same answer as "not a member" — but it is not distinguishable here from a
-    // genuine outage, and both must refuse. The status says "try again" because
-    // the outage case is the one a client can act on.
-    logger.warn('[publishAsAccount] Failed to read account members', error);
-    throw new PublishAsAccessError(503, 'Could not verify your access to that account');
-  }
-
-  const membership = members.find(
-    (member) => member.memberUserId === callerId && member.status === 'active',
-  );
-  if (!membership) {
-    throw new PublishAsAccessError(403, 'You are not a member of that account');
-  }
+  const membership = await readActiveMembership(target, callerId, params.memberReader);
 
   // The permission is READ off the membership Oxy resolved, never inferred from
   // `membership.role` — a role list here would be a second copy of Oxy's
@@ -385,4 +430,85 @@ export async function assertCanPublishAsAccount(params: {
   }
 
   return { authorId: target, authorKind };
+}
+
+/**
+ * Refuse unless `callerId` may DELETE the account `targetOxyUserId`, and answer
+ * with the kind Oxy resolved for it.
+ *
+ * ## Why this is not {@link assertCanPublishAsAccount} with a different message
+ *
+ * That gate grades a `channel` at bare ACTIVE MEMBERSHIP, and correctly: a
+ * channel can never be acted as, so over a channel there is no capability
+ * stronger than membership to ask for. Deletion is the exception, because the
+ * stronger right exists and lives at Oxy. `DELETE /accounts/:id` gates on
+ * `account:delete`, which oxy-api's `ROLE_PERMISSIONS` grants to `owner` alone —
+ * `admin` and `editor` hold `account:act_as` and not this. So the set of people
+ * who may publish as a channel is strictly WIDER than the set who may end it.
+ *
+ * Deleting a channel is two halves that answer to two authorities: Mention
+ * destroys its own rows, Oxy archives the account. If Mention accepted a mere
+ * member here, an `editor` could destroy every post the channel has published and
+ * then be refused the archive by Oxy — a channel with no content, no way to undo
+ * it, and an account still standing. Asking for the SAME permission Oxy asks for
+ * is what makes the two halves either both permitted or both refused.
+ *
+ * ## The refusals
+ *
+ *  - **400** — the account's kind could not be resolved at all. Deleting an
+ *    account whose kind is unknown is the risk `ChannelDeletionService` already
+ *    refuses to take at its own door, and this is the same judgement made one
+ *    layer earlier, before a member list is even read.
+ *  - **403** — no caller, no client to ask Oxy with (an unauthenticated or MCP
+ *    caller), the caller is not an ACTIVE member, or they are a member WITHOUT
+ *    `account:delete`.
+ *  - **503** — Oxy could not answer. It fails closed for the reason in the module
+ *    docstring, and here the argument is at its strongest: the action is
+ *    irreversible, so a refusal costs a retry and a wrong allow costs an archive.
+ *
+ * The kind is RETURNED rather than checked here, because "may this person delete
+ * that account" and "is that account a thing Mention knows how to delete" are two
+ * questions. The caller answers the second — `ChannelDeletionService` refuses
+ * anything that is not a channel at its own entry points, and a route wanting a
+ * different status code for that can say so without this gate growing a second
+ * opinion.
+ */
+export async function assertCanDeleteAccount(params: {
+  targetOxyUserId: string | null | undefined;
+  callerId: string | null | undefined;
+  memberReader: AccountMemberReader | undefined;
+}): Promise<AccountKind> {
+  const target = params.targetOxyUserId?.trim();
+  const callerId = params.callerId?.trim();
+  // No self case, deliberately: the accounts this gate governs have no login, so
+  // a caller can never BE one. Were a personal account ever routed here, its owner
+  // holds `account:delete` through their own membership like anybody else, and a
+  // shortcut that skipped the read would be a hole rather than an optimisation.
+  if (!target || !callerId) {
+    throw new PublishAsAccessError(403, 'You cannot delete that account');
+  }
+
+  const kind = await resolveAccountKind(target);
+  if (!kind) {
+    throw new PublishAsAccessError(400, 'That account cannot be deleted');
+  }
+
+  if (!params.memberReader) {
+    throw new PublishAsAccessError(403, 'You cannot delete that account');
+  }
+
+  const membership = await readActiveMembership(target, callerId, params.memberReader);
+
+  // READ off the row Oxy resolved, never inferred from `membership.role` — a role
+  // list here would be a second copy of Oxy's role→permission map, and the copy
+  // is what goes stale on the day a role's grants change. An absent or malformed
+  // `permissions` array is a refusal, not an assumption.
+  if (
+    !Array.isArray(membership.permissions) ||
+    !membership.permissions.includes(ACCOUNT_DELETE_PERMISSION)
+  ) {
+    throw new PublishAsAccessError(403, 'Only an owner of this account can delete it');
+  }
+
+  return kind;
 }

--- a/packages/frontend/app/(app)/c/[username]/__tests__/channelDeleteChannel.test.tsx
+++ b/packages/frontend/app/(app)/c/[username]/__tests__/channelDeleteChannel.test.tsx
@@ -1,0 +1,445 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * Deleting a channel: who is offered it, what they are told, and what runs in
+ * which order once they say yes.
+ *
+ * Four properties, and a screen test is the only place any of them is
+ * observable, because all four live in the wiring between a permission array,
+ * a dialog and two calls to two different systems.
+ *
+ *   * **The affordance is a subset of the permission.** Oxy grants
+ *     `account:delete` to the `owner` role alone, so an `admin` or `editor` who
+ *     reaches this screen, edits the profile and flips the byline must not be
+ *     offered a control the server would refuse. Both fixtures are here: a
+ *     membership that holds the permission and one that holds `account:act_as`
+ *     without it, which is exactly the shape a role-derived check would get
+ *     wrong.
+ *   * **The destructive call cannot fire without the confirmation.** A suite
+ *     where the dialog always resolves `true` cannot tell "asks first" from
+ *     "never asks", so the declining fixture is the load-bearing one.
+ *   * **The confirmation is counted.** The count comes from the server preview,
+ *     not from anything the screen already had, so the question can only be
+ *     asked after that read.
+ *   * **The account is archived only after Mention's half RESOLVES.** Oxy's
+ *     reads exclude an archived account, and Mention's cascade resolves the
+ *     account kind and username through them, so archiving first strands every
+ *     post permanently. The failing-half fixture pins that the archive never
+ *     happens when the content delete rejects.
+ *
+ * The mocks stop at module boundaries, matching `channelSettingsIdentityWrite`:
+ * the SDK barrel and Bloom cannot be required under jest, and React Query is
+ * real because the mutation's own sequencing is the thing under test.
+ */
+
+const mockPreview = jest.fn();
+const mockDeleteContent = jest.fn();
+const mockConfirmDialog = jest.fn();
+const mockArchiveAccount = jest.fn();
+const mockListAccounts = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock('@/services/channelDeletionService', () => ({
+  channelDeletionService: {
+    preview: (...args: unknown[]) => mockPreview(...args),
+    deleteContent: (...args: unknown[]) => mockDeleteContent(...args),
+  },
+}));
+jest.mock('@/utils/alerts', () => ({
+  confirmDialog: (...args: unknown[]) => mockConfirmDialog(...args),
+}));
+jest.mock('@/lib/actorCache', () => ({ noteIdentityChanged: jest.fn() }));
+jest.mock('@oxyhq/services', () => ({ clearedFieldsFromAccountUpdate: () => [] }));
+
+jest.mock('@oxyhq/services/ui/client', () => ({
+  OxyAuthPrompt: () => null,
+  useAuth: () => ({
+    user: { id: 'viewer-1', username: 'operator' },
+    oxyServices: {
+      listAccounts: (...args: unknown[]) => mockListAccounts(...args),
+      updateAccount: jest.fn(),
+      archiveAccount: (...args: unknown[]) => mockArchiveAccount(...args),
+    },
+    canUsePrivateApi: true,
+    isAuthenticated: true,
+    isAuthResolved: true,
+    isPrivateApiPending: false,
+    showBottomSheet: jest.fn(),
+  }),
+}));
+
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user: { username?: string } | null | undefined) =>
+    user?.username ?? null,
+}));
+jest.mock('@oxyhq/core/logger', () => ({
+  createLogger: () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }),
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ username: 'daily' }),
+  router: { replace: (...args: unknown[]) => mockReplace(...args) },
+}));
+
+/**
+ * Renders the real English source of each key, with i18next's own plural
+ * selection and `{{...}}` substitution reproduced for the shapes this screen
+ * uses. A stand-in that echoed the key would make every assertion about WHAT
+ * the operator is told vacuous, which is the half of this test that matters
+ * most: the count has to reach the words, not merely the call.
+ */
+jest.mock('react-i18next', () => {
+  const catalog = jest.requireActual<{ channels: { settings: Record<string, string> } }>(
+    '../../../../../locales/en.json',
+  );
+  return {
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) => {
+        const bare = key.replace(/^channels\.settings\./, '');
+        const count = typeof options?.count === 'number' ? options.count : undefined;
+        const entry =
+          (count === undefined
+            ? undefined
+            : catalog.channels.settings[`${bare}_${count === 1 ? 'one' : 'other'}`]) ??
+          catalog.channels.settings[bare] ??
+          (typeof options?.defaultValue === 'string' ? options.defaultValue : key);
+        return entry.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+          String(options?.[name] ?? ''),
+        );
+      },
+    }),
+  };
+});
+
+jest.mock('@expo/vector-icons/Ionicons', () => () => null);
+jest.mock('@oxyhq/bloom/avatar', () => ({ Avatar: () => null }));
+jest.mock('@oxyhq/bloom/loading', () => ({ SpinnerIcon: () => null }));
+jest.mock('@oxyhq/bloom/switch', () => ({ Switch: () => null }));
+jest.mock('@oxyhq/bloom/toast', () => {
+  const toast = Object.assign(jest.fn(), { success: jest.fn(), error: jest.fn() });
+  return { toast };
+});
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({ colors: { textSecondary: '#888', primary: '#00f', error: '#f00' } }),
+}));
+jest.mock('@oxyhq/bloom/settings-list', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { Text, View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    SettingsListGroup: (props: { children?: React.ReactNode }) =>
+      ReactActual.createElement(View, null, props.children),
+    // Rendered as a pressable Text carrying its own title, so the delete row can
+    // be found BY that title — a stub returning null would make "the row is
+    // absent" true whether the screen renders it or not.
+    SettingsListItem: (props: { title: string; onPress?: () => void; disabled?: boolean }) =>
+      ReactActual.createElement(
+        Text,
+        { testID: `settings-item:${props.title}`, onPress: props.onPress, disabled: props.disabled },
+        props.title,
+      ),
+  };
+});
+jest.mock('@oxyhq/bloom/item', () => ({ Item: () => null }));
+
+jest.mock('@/components/ThemedView', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    ThemedView: (props: { children?: React.ReactNode }) =>
+      ReactActual.createElement(View, null, props.children),
+  };
+});
+jest.mock('@/components/Header', () => ({ Header: () => null }));
+jest.mock('@/components/ui/Button', () => ({ IconButton: () => null }));
+jest.mock('@/assets/icons/back-arrow-icon', () => ({ BackArrowIcon: () => null }));
+jest.mock('@/components/common/EmptyState', () => ({ EmptyState: () => null }));
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }));
+jest.mock('@/services/channelAccountService', () => ({
+  channelAccountService: {
+    getSettings: jest.fn().mockResolvedValue({ signPosts: false }),
+    setSignPosts: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import ChannelAccountSettingsScreen from '../settings';
+
+const CHANNEL_ID = 'channel-1';
+
+/** The row's own title, and the only handle the test has on the affordance. */
+const DELETE_ROW = 'settings-item:Delete this channel';
+
+/** How the profile form is known to have mounted (see the sibling suite). */
+const BIO_PLACEHOLDER = 'What this channel is about';
+
+/**
+ * A membership row as Oxy resolves it. `permissions` is the WIRE value: Oxy
+ * derives it from the role server-side, so a fixture that carried a role and let
+ * the test derive the permissions would be testing the test.
+ */
+function membership(permissions: string[]) {
+  return {
+    _id: 'member-1',
+    accountId: CHANNEL_ID,
+    memberUserId: 'viewer-1',
+    role: 'owner',
+    permissions,
+    inherit: true,
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function accountNode(callerMembership: ReturnType<typeof membership> | null) {
+  return {
+    accountId: CHANNEL_ID,
+    kind: 'channel',
+    parentAccountId: null,
+    account: {
+      id: CHANNEL_ID,
+      username: 'daily',
+      name: { displayName: 'Daily Digest' },
+      avatar: 'avatar-1',
+      bio: 'bio-before',
+    },
+    relationship: 'owner',
+    callerMembership,
+  };
+}
+
+let mounted: TestRenderer.ReactTestRenderer | null = null;
+
+async function renderScreen() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  await act(async () => {
+    mounted = TestRenderer.create(
+      <QueryClientProvider client={client}>
+        <ChannelAccountSettingsScreen />
+      </QueryClientProvider>,
+    );
+  });
+  const renderer = mounted;
+  if (!renderer) throw new Error('the screen did not render');
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (renderer.root.findAllByProps({ placeholder: BIO_PLACEHOLDER }).length > 0) {
+      return renderer;
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error('the channel profile form never mounted');
+}
+
+/** Press the delete row and let the whole async flow settle. */
+async function pressDelete(renderer: TestRenderer.ReactTestRenderer) {
+  const row = renderer.root.findByProps({ testID: DELETE_ROW });
+  await act(async () => {
+    row.props.onPress();
+  });
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+/** The single options object the screen handed to the confirmation. */
+function confirmOptions(): {
+  title: string;
+  message: string;
+  okText: string;
+  destructive?: boolean;
+} {
+  const [options] = mockConfirmDialog.mock.calls[0] ?? [];
+  if (!options) throw new Error('the confirmation was never opened');
+  return options;
+}
+
+beforeEach(() => {
+  mockPreview.mockReset();
+  mockDeleteContent.mockReset();
+  mockConfirmDialog.mockReset();
+  mockArchiveAccount.mockReset();
+  mockListAccounts.mockReset();
+  mockReplace.mockReset();
+  mockPreview.mockResolvedValue({ posts: 42, boostsByOthers: 7 });
+  mockDeleteContent.mockResolvedValue({ posts: 42, boostsByOthers: 7 });
+  mockArchiveAccount.mockResolvedValue({ success: true });
+  mockListAccounts.mockResolvedValue([accountNode(membership(['account:delete']))]);
+});
+
+afterEach(() => {
+  const renderer = mounted;
+  if (renderer) act(() => renderer.unmount());
+  mounted = null;
+});
+
+describe('who is offered the delete', () => {
+  it('offers it to a member holding account:delete', async () => {
+    const renderer = await renderScreen();
+
+    // `findAllByProps` returns the composite AND its host element, so the count
+    // is 2 for one row. The property is presence against the absence the next
+    // three cases assert, so it is written as such rather than pinned to a
+    // number the renderer decides.
+    expect(renderer.root.findAllByProps({ testID: DELETE_ROW }).length).toBeGreaterThan(0);
+  });
+
+  it('withholds it from a member who may publish as the channel but not end it', async () => {
+    // The exact shape a role-derived check gets wrong: an editor holds
+    // `account:act_as`, so every OTHER control on this screen is rightly theirs.
+    mockListAccounts.mockResolvedValue([accountNode(membership(['account:act_as']))]);
+    const renderer = await renderScreen();
+
+    expect(renderer.root.findAllByProps({ testID: DELETE_ROW })).toHaveLength(0);
+    // The screen itself still rendered, so the absence above is a decision and
+    // not a screen that failed to mount.
+    expect(renderer.root.findByProps({ placeholder: BIO_PLACEHOLDER })).toBeTruthy();
+  });
+
+  it('withholds it when the membership carries no permissions at all', async () => {
+    mockListAccounts.mockResolvedValue([accountNode(membership([]))]);
+    const renderer = await renderScreen();
+
+    expect(renderer.root.findAllByProps({ testID: DELETE_ROW })).toHaveLength(0);
+  });
+
+  it('withholds it when there is no membership row to read', async () => {
+    mockListAccounts.mockResolvedValue([accountNode(null)]);
+    const renderer = await renderScreen();
+
+    expect(renderer.root.findAllByProps({ testID: DELETE_ROW })).toHaveLength(0);
+  });
+});
+
+describe('the confirmation', () => {
+  it('states how many posts are being destroyed, in the body and on the button', async () => {
+    mockConfirmDialog.mockResolvedValue(false);
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    const options = confirmOptions();
+    expect(options.message).toContain('42 posts');
+    expect(options.okText).toBe('Delete 42 posts');
+    expect(options.title).toBe('Delete Daily Digest?');
+    expect(options.destructive).toBe(true);
+  });
+
+  it('names the count the SERVER gave it, not one it already had', async () => {
+    // The screen holds no post count of its own, so a preview that answers
+    // differently is the only way to tell a real read from a hardcoded number.
+    mockPreview.mockResolvedValue({ posts: 1, boostsByOthers: 0 });
+    mockConfirmDialog.mockResolvedValue(false);
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    expect(mockPreview).toHaveBeenCalledWith(CHANNEL_ID);
+    const options = confirmOptions();
+    expect(options.message).toContain('1 post published by this channel');
+    expect(options.okText).toBe('Delete 1 post');
+  });
+
+  it('says other people’s boosts go too, and only when some do', async () => {
+    mockConfirmDialog.mockResolvedValue(false);
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    expect(confirmOptions().message).toContain('7 boosts of them by other people go as well');
+  });
+
+  it('omits the boost sentence when nobody boosted the channel', async () => {
+    mockPreview.mockResolvedValue({ posts: 3, boostsByOthers: 0 });
+    mockConfirmDialog.mockResolvedValue(false);
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    expect(confirmOptions().message).not.toContain('boost');
+  });
+
+  it('promises to ASK remote servers and admits it cannot make them', async () => {
+    mockConfirmDialog.mockResolvedValue(false);
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    const { message } = confirmOptions();
+    expect(message).toContain('asked to remove it');
+    expect(message).toContain('cannot make them');
+    expect(message).toContain('archived');
+  });
+});
+
+describe('what happens once the operator answers', () => {
+  it('destroys NOTHING when the confirmation is declined', async () => {
+    // The load-bearing fixture. With the dialog always resolving true, a screen
+    // that never asked at all would pass every other test in this file.
+    mockConfirmDialog.mockResolvedValue(false);
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    expect(mockConfirmDialog).toHaveBeenCalledTimes(1);
+    expect(mockDeleteContent).not.toHaveBeenCalled();
+    expect(mockArchiveAccount).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('deletes Mention’s half and only then archives the Oxy account', async () => {
+    const order: string[] = [];
+    mockDeleteContent.mockImplementation(async () => {
+      order.push('mention');
+      return { posts: 42, boostsByOthers: 7 };
+    });
+    mockArchiveAccount.mockImplementation(async () => {
+      order.push('oxy');
+      return { success: true };
+    });
+    mockConfirmDialog.mockResolvedValue(true);
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    expect(mockDeleteContent).toHaveBeenCalledWith(CHANNEL_ID);
+    expect(mockArchiveAccount).toHaveBeenCalledWith(CHANNEL_ID);
+    // Archive-first strands every post permanently: Oxy's reads exclude an
+    // archived account, and the cascade resolves the account kind and username
+    // through them. The order is the whole design.
+    expect(order).toEqual(['mention', 'oxy']);
+    expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+
+  it('leaves the account ALONE when Mention’s half fails', async () => {
+    // The survivable failure is "posts gone, account still standing, retry
+    // archives it". Archiving anyway would make it the unrecoverable one.
+    mockDeleteContent.mockRejectedValue(new Error('a cascade step failed'));
+    mockConfirmDialog.mockResolvedValue(true);
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    expect(mockDeleteContent).toHaveBeenCalledTimes(1);
+    expect(mockArchiveAccount).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('stays put when the preview fails, so nothing is asked or destroyed', async () => {
+    mockPreview.mockRejectedValue(new Error('nope'));
+    const renderer = await renderScreen();
+
+    await pressDelete(renderer);
+
+    expect(mockConfirmDialog).not.toHaveBeenCalled();
+    expect(mockDeleteContent).not.toHaveBeenCalled();
+    expect(mockArchiveAccount).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/app/(app)/c/[username]/__tests__/channelSettingsIdentityWrite.test.tsx
+++ b/packages/frontend/app/(app)/c/[username]/__tests__/channelSettingsIdentityWrite.test.tsx
@@ -84,6 +84,7 @@ jest.mock('@oxyhq/core/logger', () => ({
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: () => ({ username: 'daily' }),
+  router: { replace: jest.fn() },
 }));
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -138,6 +139,17 @@ jest.mock('@/services/channelAccountService', () => ({
     getSettings: jest.fn().mockResolvedValue({ signPosts: false }),
     setSignPosts: jest.fn(),
   },
+}));
+/**
+ * The delete flow, stubbed at its two module boundaries. Neither is exercised
+ * here — the fixture's `callerMembership` is `null`, so the row is not even
+ * rendered — but both are imported by the screen, and the real `@/utils/alerts`
+ * reaches `@oxyhq/bloom/dialog`, which cannot be required under jest.
+ * `__tests__/channelDeleteChannel.test.tsx` is where the flow itself is pinned.
+ */
+jest.mock('@/utils/alerts', () => ({ confirmDialog: jest.fn().mockResolvedValue(false) }));
+jest.mock('@/services/channelDeletionService', () => ({
+  channelDeletionService: { preview: jest.fn(), deleteContent: jest.fn() },
 }));
 
 // eslint-disable-next-line import/first

--- a/packages/frontend/app/(app)/c/[username]/settings.tsx
+++ b/packages/frontend/app/(app)/c/[username]/settings.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Pressable, ScrollView, Text, TextInput, View } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -31,7 +31,9 @@ import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { useSafeBack } from '@/hooks/useSafeBack';
 import { EmptyState } from '@/components/common/EmptyState';
+import { confirmDialog } from '@/utils/alerts';
 import { channelAccountService, type ChannelAccountSettings } from '@/services/channelAccountService';
+import { channelDeletionService } from '@/services/channelDeletionService';
 import { noteIdentityChanged } from '@/lib/actorCache';
 import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
 import { getErrorMessage } from '@/utils/apiError';
@@ -48,6 +50,35 @@ const channelSettingsLogger = createLogger('ChannelAccountSettings');
 
 /** Same cap the create form applies to a new channel's title. */
 const MAX_TITLE_LENGTH = 100;
+
+/**
+ * The Oxy account permission that authorises ending an account, and therefore
+ * the one thing that decides whether this screen offers to.
+ *
+ * Oxy grants it to the `owner` role ALONE, so it is strictly narrower than being
+ * able to operate the channel: an `admin` or `editor` reaches this screen, edits
+ * the profile and flips the byline, and may not delete. Read off the membership
+ * Oxy resolved rather than inferred from `callerMembership.role`, because a role
+ * list here would be a second copy of Oxy's role to permission map and the copy
+ * is what goes stale.
+ *
+ * The affordance is a SUBSET of the permission, never a guess at it: both Mention
+ * routes behind the row gate on this same permission, and Oxy gates the account
+ * archive on it, so a row that appears is a deletion all three will allow.
+ *
+ * A literal because it is a WIRE value — Oxy derives each member's `permissions`
+ * server-side and ships the strings, and neither `@oxyhq/contracts` nor
+ * `@oxyhq/core` exports the vocabulary today. The backend keeps the same constant
+ * for the same reason (`services/publishAsAccount.ts`).
+ */
+const ACCOUNT_DELETE_PERMISSION = 'account:delete';
+
+/**
+ * What a delete attempt ended as. Backing out at the confirmation is a normal
+ * outcome and not an error, so it is expressed as one — a rejection would put a
+ * "failed to delete" toast in front of somebody who just decided not to.
+ */
+type ChannelDeletionOutcome = { deleted: boolean };
 
 /**
  * What an OPERATOR can change about a channel from inside Mention.
@@ -264,6 +295,94 @@ function ChannelAccountSettingsForm({ channel }: { channel: AccountNode }) {
     },
   });
 
+  /**
+   * Deleting the channel: Mention's rows, then Oxy's account, in that order and
+   * only ever behind a counted confirmation.
+   *
+   * ## The order is forced, not chosen
+   *
+   * Oxy's account reads exclude an archived account, and Mention's cascade
+   * resolves both the account's KIND (which it refuses to proceed without) and
+   * its USERNAME (which the canonical ids in each `Delete(Tombstone)` are minted
+   * from) through exactly those reads. Archive first and every post the channel
+   * published is stranded permanently, with nothing left that can address a
+   * deletion for it.
+   *
+   * So `archiveAccount` runs only after `deleteContent` has RESOLVED. A failure
+   * between the two halves leaves the survivable state: no posts, the fediverse
+   * told, and an account still standing that a retry archives. The server's
+   * cascade is idempotent, so that retry converges rather than double-deleting.
+   *
+   * ## Why the whole flow is one mutation
+   *
+   * The preview, the question and both halves are one decision, and splitting
+   * them across handlers is how a destructive call ends up reachable without the
+   * question. `deleteContent` is written on the line after the `confirmed` guard
+   * and can be read as unreachable without it.
+   *
+   * The preview is fetched HERE rather than by a query on mount: it walks the
+   * channel's entire publishing history, and its only consumer is a dialog that
+   * does not exist until the operator asks for it.
+   */
+  const deleteMutation = useMutation<ChannelDeletionOutcome, unknown, void>({
+    mutationFn: async () => {
+      const counts = await channelDeletionService.preview(accountId);
+
+      // The count is the point. A channel is a publication, and "are you sure?"
+      // is not informed consent for destroying an archive — so the body says how
+      // many posts go, the button repeats it, and the sentences after it are the
+      // two things a person could otherwise be surprised by: other people's
+      // boosts die with the posts, and remote servers are ASKED rather than made.
+      const confirmed = await confirmDialog({
+        title: t('channels.settings.deleteConfirmTitle', {
+          name: account.name?.displayName ?? '',
+        }),
+        message: [
+          counts.posts > 0
+            ? t('channels.settings.deleteConfirmPosts', { count: counts.posts })
+            : t('channels.settings.deleteConfirmEmpty'),
+          counts.boostsByOthers > 0
+            ? t('channels.settings.deleteConfirmBoosts', { count: counts.boostsByOthers })
+            : null,
+          t('channels.settings.deleteConfirmFediverse'),
+          t('channels.settings.deleteConfirmAccount'),
+        ]
+          .filter((sentence): sentence is string => sentence !== null)
+          .join(' '),
+        okText:
+          counts.posts > 0
+            ? t('channels.settings.deleteConfirmAction', { count: counts.posts })
+            : t('channels.settings.deleteConfirmActionEmpty'),
+        cancelText: t('common.cancel'),
+        destructive: true,
+      });
+      if (!confirmed) return { deleted: false };
+
+      await channelDeletionService.deleteContent(accountId);
+      // Oxy's half, and ONLY now: see the order argument above.
+      await oxyServices.archiveAccount(accountId);
+      return { deleted: true };
+    },
+    onSuccess: (outcome) => {
+      if (!outcome.deleted) return;
+      // The account is archived, so every list that enumerates the caller's
+      // accounts — this screen's own gate, and the composer's publish-as picker
+      // behind the same key — is now wrong.
+      queryClient.invalidateQueries({ queryKey: viewerQueryKeys.operatedAccounts(viewerId) });
+      toast.success(t('channels.settings.deleted', { defaultValue: 'Channel deleted' }));
+      // Home rather than back: back is the channel's own page, which no longer
+      // resolves.
+      router.replace('/');
+    },
+    onError: (error) => {
+      const fallback = t('channels.settings.deleteFailed', {
+        defaultValue: 'Failed to delete the channel',
+      });
+      channelSettingsLogger.error(fallback, error, { accountId });
+      toast(getErrorMessage(error, fallback), { type: 'error' });
+    },
+  });
+
   const openAvatarPicker = useCallback(() => {
     showBottomSheet?.({
       screen: 'FileManagement',
@@ -321,6 +440,17 @@ function ChannelAccountSettingsForm({ channel }: { channel: AccountNode }) {
       setCategories((current) => promoteAccountCategoryToPrimary(current, id)),
     [],
   );
+
+  const handleDelete = useCallback(() => deleteMutation.mutate(), [deleteMutation]);
+
+  /**
+   * Whether this operator may end the channel, read off the permission array Oxy
+   * resolved for them. `=== true` rather than a truthiness test, and an absent or
+   * malformed array answers no: this decides whether a destructive control
+   * appears, so anything short of an explicit grant is a refusal.
+   */
+  const canDelete =
+    channel.callerMembership?.permissions?.includes(ACCOUNT_DELETE_PERMISSION) === true;
 
   if (isPending) {
     return (
@@ -532,6 +662,33 @@ function ChannelAccountSettingsForm({ channel }: { channel: AccountNode }) {
           }
         />
       </SettingsListGroup>
+
+      {/* Its own group at the very bottom, and shown only to a member Oxy has
+          granted `account:delete`. Two operators can both reach this screen and
+          only one of them see this row, which is correct: publishing as a
+          channel and ending it are different rights, and offering a row the
+          server would refuse is worse than not offering it. */}
+      {canDelete && (
+        <SettingsListGroup
+          title={t('channels.settings.dangerZone', { defaultValue: 'Delete' })}
+          footer={t('channels.settings.deleteFooter', {
+            defaultValue:
+              'Deleting a channel destroys everything it has published. There is no undo, and nothing brings a post back once it is gone.',
+          })}>
+          <SettingsListItem
+            icon={<Ionicons name="trash-outline" size={20} color={colors.error} />}
+            title={
+              deleteMutation.isPending
+                ? t('channels.settings.deleting', { defaultValue: 'Deleting…' })
+                : t('channels.settings.delete', { defaultValue: 'Delete this channel' })
+            }
+            destructive
+            showChevron={false}
+            disabled={deleteMutation.isPending}
+            onPress={deleteMutation.isPending ? undefined : handleDelete}
+          />
+        </SettingsListGroup>
+      )}
 
       {/* Not a settings group: there is no row here to tap. It names the two
           things this screen deliberately does NOT own, so their absence reads as

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -1887,7 +1887,24 @@
       "categoriesAtCap": "Remove one to choose a different category.",
       "makePrimary": "Make primary",
       "removeCategory": "Remove {{category}}",
-      "categoryUnavailable": "Not available in this version"
+      "categoryUnavailable": "Not available in this version",
+      "dangerZone": "Delete",
+      "delete": "Delete this channel",
+      "deleting": "Deleting…",
+      "deleteFooter": "Deleting a channel destroys everything it has published. There is no undo, and nothing brings a post back once it is gone.",
+      "deleteConfirmTitle": "Delete {{name}}?",
+      "deleteConfirmPosts_one": "This destroys {{count}} post published by this channel, along with every like and save on it.",
+      "deleteConfirmPosts_other": "This destroys {{count}} posts published by this channel, along with every like and save on them.",
+      "deleteConfirmEmpty": "This channel has published nothing, so there are no posts to destroy.",
+      "deleteConfirmBoosts_one": "{{count}} boost of them by somebody else goes as well.",
+      "deleteConfirmBoosts_other": "{{count}} boosts of them by other people go as well.",
+      "deleteConfirmFediverse": "Every server that received a copy is asked to remove it. We send that request; we cannot make them honour it.",
+      "deleteConfirmAccount": "The channel account is archived at the end, so nobody can follow it or publish as it again.",
+      "deleteConfirmAction_one": "Delete {{count}} post",
+      "deleteConfirmAction_other": "Delete {{count}} posts",
+      "deleteConfirmActionEmpty": "Delete this channel",
+      "deleted": "Channel deleted",
+      "deleteFailed": "Failed to delete the channel"
     },
     "insights": {
       "operatorOnly": "Only an operator can see this channel’s insights"

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -1858,7 +1858,24 @@
       "categoriesAtCap": "Quita una para elegir otra categoría.",
       "makePrimary": "Hacer principal",
       "removeCategory": "Quitar {{category}}",
-      "categoryUnavailable": "No disponible en esta versión"
+      "categoryUnavailable": "No disponible en esta versión",
+      "dangerZone": "Eliminar",
+      "delete": "Eliminar este canal",
+      "deleting": "Eliminando…",
+      "deleteFooter": "Eliminar un canal destruye todo lo que ha publicado. No se puede deshacer, y nada recupera una publicación una vez que desaparece.",
+      "deleteConfirmTitle": "¿Eliminar {{name}}?",
+      "deleteConfirmPosts_one": "Esto destruye {{count}} publicación de este canal, junto con cada me gusta y cada guardado que tenga.",
+      "deleteConfirmPosts_other": "Esto destruye {{count}} publicaciones de este canal, junto con cada me gusta y cada guardado que tengan.",
+      "deleteConfirmEmpty": "Este canal no ha publicado nada, así que no hay publicaciones que destruir.",
+      "deleteConfirmBoosts_one": "{{count}} impulso de otra persona desaparece también.",
+      "deleteConfirmBoosts_other": "{{count}} impulsos de otras personas desaparecen también.",
+      "deleteConfirmFediverse": "A cada servidor que recibió una copia se le pide que la elimine. Enviamos esa petición; no podemos obligarlos a cumplirla.",
+      "deleteConfirmAccount": "La cuenta del canal se archiva al final, así que nadie podrá seguirla ni publicar como ella de nuevo.",
+      "deleteConfirmAction_one": "Eliminar {{count}} publicación",
+      "deleteConfirmAction_other": "Eliminar {{count}} publicaciones",
+      "deleteConfirmActionEmpty": "Eliminar este canal",
+      "deleted": "Canal eliminado",
+      "deleteFailed": "No se pudo eliminar el canal"
     },
     "insights": {
       "operatorOnly": "Solo un operador puede ver las estadísticas de este canal"

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -1638,7 +1638,24 @@
       "categoriesAtCap": "Rimuovine una per sceglierne un’altra.",
       "makePrimary": "Rendi principale",
       "removeCategory": "Rimuovi {{category}}",
-      "categoryUnavailable": "Non disponibile in questa versione"
+      "categoryUnavailable": "Non disponibile in questa versione",
+      "dangerZone": "Elimina",
+      "delete": "Elimina questo canale",
+      "deleting": "Eliminazione…",
+      "deleteFooter": "Eliminare un canale distrugge tutto ciò che ha pubblicato. Non si può annullare, e nulla riporta indietro un post una volta sparito.",
+      "deleteConfirmTitle": "Eliminare {{name}}?",
+      "deleteConfirmPosts_one": "Questo distrugge {{count}} post pubblicato da questo canale, insieme a ogni mi piace e ogni salvataggio che ha ricevuto.",
+      "deleteConfirmPosts_other": "Questo distrugge {{count}} post pubblicati da questo canale, insieme a ogni mi piace e ogni salvataggio che hanno ricevuto.",
+      "deleteConfirmEmpty": "Questo canale non ha pubblicato nulla, quindi non ci sono post da distruggere.",
+      "deleteConfirmBoosts_one": "Anche {{count}} boost di un'altra persona sparisce.",
+      "deleteConfirmBoosts_other": "Spariscono anche {{count}} boost di altre persone.",
+      "deleteConfirmFediverse": "A ogni server che ne ha ricevuto una copia viene chiesto di rimuoverla. Noi inviamo la richiesta; non possiamo costringerli a rispettarla.",
+      "deleteConfirmAccount": "L'account del canale viene archiviato alla fine, così nessuno potrà più seguirlo né pubblicare a suo nome.",
+      "deleteConfirmAction_one": "Elimina {{count}} post",
+      "deleteConfirmAction_other": "Elimina {{count}} post",
+      "deleteConfirmActionEmpty": "Elimina questo canale",
+      "deleted": "Canale eliminato",
+      "deleteFailed": "Impossibile eliminare il canale"
     },
     "insights": {
       "operatorOnly": "Solo un operatore può vedere le statistiche di questo canale"

--- a/packages/frontend/services/channelDeletionService.ts
+++ b/packages/frontend/services/channelDeletionService.ts
@@ -1,0 +1,71 @@
+import type { ChannelDeletionCounts } from '@mention/shared-types';
+import { authenticatedClient } from '@/utils/api';
+
+const CHANNELS_PATH = '/channels';
+
+/**
+ * MENTION'S HALF of deleting a channel: its posts, and every Mention row that
+ * points at them.
+ *
+ * The OTHER half — archiving the account itself — is Oxy's, and is performed by
+ * the caller with `oxyServices.archiveAccount`. It is deliberately not wrapped
+ * here: this module would then read as "delete a channel" while owning neither
+ * the account nor the order the two halves have to run in, and the one thing a
+ * caller must get right is that order.
+ *
+ * ## The order, and why it is this way round
+ *
+ * Mention first, and only on SUCCESS may the account be archived. Oxy's account
+ * reads exclude an archived account (`GET /users/:id` answers 404, and
+ * `POST /users/by-ids` filters them out), and Mention's cascade resolves the
+ * account's kind and its username through exactly those reads: it refuses to
+ * delete an account whose kind it cannot establish, and it cannot address a
+ * `Delete(Tombstone)` for a post whose canonical id is minted from a username it
+ * can no longer resolve. Archive first and the posts are stranded permanently,
+ * with nothing left that can re-target them.
+ *
+ * The failure between the halves is therefore the survivable one: the posts are
+ * gone, the fediverse has been told, and the account still stands. The operator
+ * retries, the cascade converges (a second run over an emptied channel reports
+ * zero and does not throw), and the archive lands.
+ *
+ * Nothing here catches. A deletion that failed must say so — one that quietly
+ * reported success would send the caller on to archive the account, which is the
+ * one step that makes the failure permanent.
+ */
+class ChannelDeletionService {
+  /**
+   * What deleting this channel would destroy, counted. Reads only.
+   *
+   * Fetched when the operator asks to delete, never on mount: it walks the
+   * channel's whole publishing history plus the boost closure over it, and its
+   * only consumer is the confirmation, which does not exist until then.
+   *
+   * Behind the SAME `account:delete` gate as the deletion itself, so a preview
+   * that answers is a deletion that will be permitted.
+   */
+  async preview(oxyUserId: string): Promise<ChannelDeletionCounts> {
+    const res = await authenticatedClient.get<ChannelDeletionCounts>(
+      `${CHANNELS_PATH}/${encodeURIComponent(oxyUserId)}/deletion-preview`,
+    );
+    return res.data;
+  }
+
+  /**
+   * Destroy the channel's posts and every Mention row pointing at them, and tell
+   * every server that received a copy to remove it.
+   *
+   * Resolves with what was destroyed. It rejects rather than reporting a partial
+   * result: the server runs every remaining step after one fails and throws at
+   * the end, so a rejection means some of the channel survived and the account
+   * must NOT be archived yet.
+   */
+  async deleteContent(oxyUserId: string): Promise<ChannelDeletionCounts> {
+    const res = await authenticatedClient.delete<ChannelDeletionCounts>(
+      `${CHANNELS_PATH}/${encodeURIComponent(oxyUserId)}/content`,
+    );
+    return res.data;
+  }
+}
+
+export const channelDeletionService = new ChannelDeletionService();

--- a/packages/shared-types/src/channel.ts
+++ b/packages/shared-types/src/channel.ts
@@ -48,3 +48,32 @@ export interface ChannelWritersResponse {
   writers: ChannelWriter[];
   nextCursor?: string;
 }
+
+/**
+ * What deleting a channel destroys, counted.
+ *
+ * Shipped so a confirmation can SAY what it is about to take. A channel is a
+ * publication rather than a profile, and "are you sure?" is not informed consent
+ * for destroying an archive — the operator is told how many posts go before they
+ * are asked, and told it again by the same shape once the deletion has run.
+ *
+ * Deliberately NARROWER than the server's own preview, which also carries the
+ * channel id, the replies count (structurally always 0, since a channel takes no
+ * replies) and the number of foreign quotes that are KEPT with their pointer
+ * cleared. Those are operational facts for a log; a person deciding whether to
+ * delete their channel is owed the two numbers below and nothing they would have
+ * to interpret.
+ */
+export interface ChannelDeletionCounts {
+  /** The channel's own posts. Every one of them is destroyed. */
+  posts: number;
+  /**
+   * Other people's boosts of those posts, destroyed alongside them.
+   *
+   * A boost renders entirely from the post it points at, so once that post is
+   * gone it is a card with nothing behind it rather than something somebody
+   * wrote. Stated separately because the rows belong to other people, and an
+   * operator should know their action reaches beyond their own account.
+   */
+  boostsByOthers: number;
+}


### PR DESCRIPTION
`ChannelDeletionService` landed in #604 with no trigger: `deleteChannelContent` had no route and `previewChannelDeletion` had no caller. This is the trigger, and the count is why the preview existed.

## What the operator is told

The confirmation states how many posts are being destroyed, in the body and again on the button ("Delete 42 posts"). A channel is a publication rather than a profile, and a bare "are you sure" is not informed consent for destroying an archive. It also names what somebody could otherwise be surprised by: other people's boosts die with the posts, remote servers are ASKED to remove their copies and cannot be made to, and the account is archived at the end. Copy is in en, es and it, with no dashes.

It uses `ConfirmPromptProvider` via `confirmDialog`, never a browser `alert`/`confirm`.

## Authorisation

Deleting asks for strictly more than publishing as the channel. Oxy gates `DELETE /accounts/:id` on **`account:delete`**, which its `ROLE_PERMISSIONS` grants to the `owner` role alone, while `admin` and `editor` hold `account:act_as` without it.

- `assertCanDeleteAccount` (`services/publishAsAccount.ts`) asks for that permission off the SAME membership read the publish gate uses, factored so a second reader cannot become a second answer.
- Both new routes gate on it, the preview included: a preview readable by somebody the deletion refuses is a button that appears and then fails.
- The settings row is shown only to a membership carrying it, read off the `permissions` array Oxy resolved rather than inferred from `callerMembership.role`.

If Mention accepted a mere member, an editor could destroy every post the channel has published and then be refused the archive by Oxy.

## Order, and what a failure between the halves leaves

Mention's rows first, then Oxy's account, and the client archives only after the delete RESOLVES. Oxy's account reads exclude an archived account (`GET /users/:id` 404s, `POST /users/by-ids` filters `accountStatus: { $ne: 'archived' }`), and the cascade resolves both the account kind it refuses to proceed without and the username the Tombstone ids are minted from through exactly those reads. Archive first and every post is stranded permanently, with nothing able to re-target it.

That is why the route is synchronous rather than a BullMQ job: a 202 tells the client nothing about whether it may archive yet.

A failure between the halves therefore leaves the survivable state: **no posts, the fediverse told, and an account still standing that a retry archives.** The cascade is idempotent, so the retry converges rather than double-deleting.

## Verification

- **Real mongod, scratch database, dropped after**: the previewed count is exactly the number of posts removed, a stranger's quote survives with its pointer cleared, the boosted original's boost and like counters are repaired, and a second run reports zero. Positive control: an off-by-one in the preview turns the probe red.
- **Mutation-tested on both sides.** Backend: `account:act_as` in place of `account:delete`, the permission check removed, the `Array.isArray` guard removed, an unresolvable kind allowed, the route's gate removed, the preview skipped past it, a cascade failure read as success. Frontend: the permission gate weakened to bare membership, the destructive call moved ahead of the confirmation, the two halves swapped, the count hardcoded, the boost sentence made unconditional, the honesty sentence dropped. Every one goes red.
- Fixtures sit on both sides of each distinction: a member who may delete and one who may not, a confirmation that is declined as well as accepted, and a `permissions` value that is a string rather than an array (the shape that tells `Array.isArray(...) && includes` from a bare `includes`).
- Frontend 159 suites / 1521 tests (from 158 / 1508), backend 444 files / 4902 tests, `tsc --noEmit` clean in all four packages, `expo lint` 0 errors (the new files verified reachable by eslint with a positive control), `validate:i18n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)