### PR TITLE
chore(deps): @oxyhq/bloom 0.73.1 — className lays the native button out

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -241,7 +241,7 @@
     "react-native-svg": "15.15.4",
   },
   "catalog": {
-    "@oxyhq/bloom": "^0.73.0",
+    "@oxyhq/bloom": "^0.73.1",
     "@oxyhq/contracts": "^0.23.0",
     "@oxyhq/core": "^19.0.0",
     "@oxyhq/services": "^27.0.0",
@@ -772,7 +772,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.73.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-kOWcMfNZWPPYtwru8MrFes5nte31ChH+72PpKdMYB2QGVFQAdgqxNfAILITrIaBAfgU3Ib/acy0gPAItp9pVkA=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.73.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-1ea+SdL8eoE5Flv7EAqz62cVchmHhqGLi7Nyu1mFNEOtIJTtxVfBcRsEvkrTh5QiwqdfHT2MuJPvy+Su2omY8Q=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.23.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-2vNM5wRBIDXO1XJ+K3xORGCQr3aWnGLvPswURGvG6PFSuVevLCd2L0NuzzqCcVAOT1/9imfBLq51WKwQ4VdO8w=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@oxyhq/bloom": "^0.73.0",
+      "@oxyhq/bloom": "^0.73.1",
       "@oxyhq/contracts": "^0.23.0",
       "@oxyhq/core": "^19.0.0",
       "@oxyhq/services": "^27.0.0",


### PR DESCRIPTION
`className` on a Bloom `Button` was inert for **layout** on native. It rendered two nodes — an unstyled `Animated.View` holding the press-scale transform, wrapping the `Pressable` that carried `className`, `style` and every visual. The wrapper was the flex child the parent laid out, and it hugged its content, so visual classes worked and layout classes silently did not, with no error on either platform. The web fork renders a single `<button>` and was correct all along, which is why the same call site behaved on web and did nothing on native.

[Bloom 0.73.1](https://github.com/OxyHQ/Bloom/pull/27) collapses it to one node, matching the DOM fork's shape. A second bug in the same line is fixed too: the icon variant's chrome was `className ?? 'bg-background border border-border'`, so a caller passing any class lost the background and border entirely.

## What changes in Mention

`components/notifications/NotificationItem.tsx` passes `flex-1`, and five `@oxyhq/services` screens pass `w-full` / `flex-1` / `mt-space-24`. Every one of those was inert on native and now applies as written — **a visual difference at those call sites is the fix landing, not a regression.** Nothing was relying on the inertness.

## The diff

One edit, per the catalog rule: `workspaces.catalog` owns the version, and the root `overrides` entry plus `packages/frontend`'s manifest both keep reading `catalog:`. `@oxyhq/services` carries Bloom as a **peerDependency** at `>=0.59.0`, which already admits 0.73.1, so it needs no change.

## Verification

Baseline measured on this same tree at 0.73.0, then re-measured after the bump — identical on all three:

| gate | baseline (0.73.0) | after (0.73.1) |
|---|---|---|
| frontend typecheck | 0 errors | 0 errors |
| `test:coverage` | 159 suites / 1521 tests, 28.2% stmts | 159 suites / 1521 tests, 28.2% stmts |
| `lint:frontend` | 0 errors, 8 warnings | 0 errors, 8 warnings |

The 8 warnings are pre-existing `import/first` in three test files.

- `validate:lockfile` green across 2005 resolutions and 304 override edges.
- `verify-lockfile.sh origin/main` green — the committed lockfile is exactly what bun resolves incrementally, not a from-scratch regen.
- Exactly **one** `@oxyhq/bloom` resolution in `bun.lock`; no nested stale copy.
- Its integrity `sha512-1ea+SdL8eoE5F…` matches the published registry document, verified end to end from the packed tarball.
- `doctor` clean apart from a pre-existing local Node-version mismatch that fails identically on unmodified `main`; its Bloom pin assertion was mutation-tested to confirm it is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)