### PR TITLE
fix(fediverse): let the explainer sheet morph between its steps

### DIFF
--- a/packages/frontend/components/Fediverse/FediverseInfoDialog.tsx
+++ b/packages/frontend/components/Fediverse/FediverseInfoDialog.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Image, type ImageProps } from 'expo-image';
-import { Dialog, useDialogControl } from '@oxyhq/bloom/dialog';
+import { Dialog, useDialogControl, useDialogFrame } from '@oxyhq/bloom/dialog';
 import { Button } from '@oxyhq/bloom/button';
 
 type SheetStep = 0 | 1 | 2;
@@ -143,26 +143,6 @@ function FediverseInfoDialogContent({
     setStep((current) => (current - 1) as SheetStep);
   }, [control, isFirstStep]);
 
-  const primaryLabel = isLastStep
-    ? showEnableCta
-      ? t('fediverse.sheet.enable')
-      : t('fediverse.sheet.done')
-    : t('fediverse.sheet.next');
-  const secondaryLabel = isFirstStep ? t('fediverse.sheet.cancel') : t('fediverse.sheet.back');
-
-  const dots = useMemo(
-    () =>
-      STEP_KEYS.map((_, index) => (
-        <View
-          key={index}
-          className={
-            index === step ? 'w-2 h-2 rounded-full bg-primary' : 'w-2 h-2 rounded-full bg-border'
-          }
-        />
-      )),
-    [step],
-  );
-
   return (
     <Dialog
       control={control}
@@ -170,6 +150,57 @@ function FediverseInfoDialogContent({
       placement={{ base: 'bottom', md: 'center' }}
       label={t('fediverse.badge.a11yLabel')}
     >
+      <FediverseInfoSteps
+        step={step}
+        showEnableCta={showEnableCta}
+        onPrimary={onPrimary}
+        onSecondary={onSecondary}
+      />
+    </Dialog>
+  );
+}
+
+/**
+ * The stepped content, and the declaration of WHICH step is on screen.
+ *
+ * `useDialogFrame` is why this is its own component rather than JSX inlined
+ * above: the frame channel is published by Bloom's `DialogMorphContent`, which
+ * wraps the surface's CHILDREN, so a caller that declares the frame from the
+ * component rendering `<Dialog>` itself sits outside the provider and the hook
+ * quietly no-ops. Advancing a step changes the key while the surface stays
+ * open, which is exactly the in-place swap the morph exists for: Bloom animates
+ * the panel from the outgoing step's height to the incoming one's (260ms) and
+ * fades the incoming content in over a deliberately shorter 150ms, so the new
+ * step has landed by the time the panel finishes settling. We declare identity
+ * and nothing else — no local height measurement, no opacity shared value, no
+ * `entering` animation. Reimplementing any of that here would fight the morph
+ * for the same two properties.
+ */
+function FediverseInfoSteps({
+  step,
+  showEnableCta,
+  onPrimary,
+  onSecondary,
+}: {
+  step: SheetStep;
+  showEnableCta: boolean;
+  onPrimary: () => void;
+  onSecondary: () => void;
+}) {
+  const { t } = useTranslation();
+  useDialogFrame({ key: `fediverse-info#${step}` });
+
+  const isFirstStep = step === 0;
+  const isLastStep = step === 2;
+  const primaryLabel = isLastStep
+    ? showEnableCta
+      ? t('fediverse.sheet.enable')
+      : t('fediverse.sheet.done')
+    : t('fediverse.sheet.next');
+  const secondaryLabel = isFirstStep ? t('fediverse.sheet.cancel') : t('fediverse.sheet.back');
+
+  return (
+    <>
       <View className="items-center gap-4 py-4">
         {/* The artwork is transparent line art and sits DIRECTLY on the sheet's
             own surface — no card, plate or fill behind it, in either theme. Each
@@ -181,13 +212,20 @@ function FediverseInfoDialogContent({
             `accessibilityElementsHidden` and `importantForAccessibility`,
             react-native-web emits the DOM attribute): the art restates the step's
             title and body and adds nothing a screen reader should hear. Every
-            step still reads completely with images off. */}
+            step still reads completely with images off.
+
+            No `transition`: the step change is ONE animation and Bloom's dialog
+            morph owns it. expo-image's own cross-fade is a second animation over
+            the same swap, and it does not run in step with the first — measured
+            in a browser, it pushed the new art's first paint from 64ms to 300ms
+            after the tap, i.e. past the end of the panel's 260ms reshape, so the
+            picture arrived visibly after the words and the panel had already
+            finished resizing around it. */}
         <Image
           aria-hidden
           source={STEP_KEYS[step].art}
           className="w-full h-[168px]"
           contentFit="contain"
-          transition={180}
           alt=""
         />
         <Text className="text-foreground text-xl font-bold text-center">
@@ -198,7 +236,16 @@ function FediverseInfoDialogContent({
         </Text>
       </View>
 
-      <View className="flex-row items-center justify-center gap-2 py-4">{dots}</View>
+      <View className="flex-row items-center justify-center gap-2 py-4">
+        {STEP_KEYS.map((entry, index) => (
+          <View
+            key={entry.title}
+            className={
+              index === step ? 'w-2 h-2 rounded-full bg-primary' : 'w-2 h-2 rounded-full bg-border'
+            }
+          />
+        ))}
+      </View>
 
       {/* One navigation row: the way back on the left, the way forward on the
           right, matching both the reading order and the direction the progress
@@ -211,23 +258,16 @@ function FediverseInfoDialogContent({
           which puts the free pixels exactly where the overflow risk is. `shrink`
           lets the secondary give way first if even that is not enough.
 
-          Both are wrapped in a plain View because Bloom's native Button renders
-          its Pressable inside an unstyled `Animated.View`: `className`/`style` on
-          the Button reach the Pressable, so neither can make the outer element
-          grow or shrink. (Bloom's web fork renders a real `<button>`, where it
-          would work — the wrappers are what make the two platforms agree.) */}
+          These are Bloom Buttons as they come — a variant and a layout class,
+          no wrapper element. */}
       <View className="flex-row items-center gap-3">
-        <View className="shrink">
-          <Button variant="ghost" size="large" onPress={onSecondary}>
-            {secondaryLabel}
-          </Button>
-        </View>
-        <View className="flex-1">
-          <Button variant="primary" size="large" onPress={onPrimary}>
-            {primaryLabel}
-          </Button>
-        </View>
+        <Button variant="ghost" size="large" className="shrink" onPress={onSecondary}>
+          {secondaryLabel}
+        </Button>
+        <Button variant="primary" size="large" className="flex-1" onPress={onPrimary}>
+          {primaryLabel}
+        </Button>
       </View>
-    </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
Advancing a step swapped the panel in one frame — new height, new picture, new words, no transition. Bloom's `Dialog` already animates exactly this; the content only has to say which step it is.

## What changed

`useDialogFrame({ key })`. A key change while the surface stays open is the in-place swap the morph exists for: the panel eases from the outgoing step's height to the incoming one's over 260ms while the incoming content fades in over a deliberately shorter 150ms.

Nothing here reimplements it — no height measurement, no opacity shared value, no `entering` animation. All three would fight the morph for the same two properties, and each would have to rediscover what Bloom already handles (a frame that measures identically never reports a second layout, hence its timeout; `onLayout` never fires on web for a className'd component). It needs its own component because the frame channel is published by `DialogMorphContent`, which wraps the surface's **children** — declared one level up, the hook sits outside the provider and quietly no-ops.

**Buttons are Bloom's, unwrapped.** The two `View` wrappers are gone; `className` goes on the `Button`. Bloom's web fork puts the caller's className on the real `<button>`, so on web the wrappers were never load-bearing. Native still needs Bloom's own fix (its Button renders the Pressable inside an unstyled `Animated.View`, so the class cannot reach the outer element) — being fixed in Bloom, not papered over here.

**The illustration drops `transition={180}`** — expo-image's cross-fade is a second animation over the same swap and does not run in step with the first.

## Measured in a real foregrounded browser, sampling every frame

| | result |
|---|---|
| height, 390px, step 2→3 | row below eases `880 → 860 → 870 → 876 → 879 → 880` over ~246ms, **12 distinct values** (a snap shows 2) |
| step 3→2 | same, shrink direction, 12 values |
| fade | `1.00 → 0.09 → 0.58 → 0.85 → 0.97 → 1.00` over ~165ms, 10 values, finishing inside the reshape |
| frozen-layout check | stable at 2.4s, past the 5× window (1300ms) where a pinned `position: absolute` shows up |
| art first paint | **300ms → 64ms** after dropping `transition` — it was landing after the reshape had finished |

Step 1→2 at 390px does not resize at all: those two steps measure the same height there. That is the case Bloom's measure timeout covers, not a missed animation.

**108 combinations** (2 themes × 3 languages × 6 widths 320–1280 × 3 steps), **0 failures**: no wrapper, no overflow, no overlap, art slot 168px. Both themes confirmed through the **painted sheet colour** (light `rgb(247 249 255)`, dark `rgb(13 20 27)`) rather than a class name. Italian's longest label (`Attiva la condivisione`) holds at 320px. The wrapper assertion is mutation-tested — reintroducing one wrapper turns all 3 checks red and names the cause; the language axis carries a vacuity guard, which caught it being inert (wrong locale codes) before these numbers were trusted.

---

## The artwork is deliberately unchanged — and there is a finding

I was asked to re-encode the three re-sent PNGs smaller. **They are already done, and re-encoding would only lose quality.**

- The committed WebPs carry real alpha: VP8X alpha bit set, real `ALPH` chunk, alpha 0 at all four corners **and** all four edge midpoints. 512×448, 34,824 / 54,222 / 45,376 B = **131.3 KiB**, under the 150 KB target.
- The encode is not damaged. Pure encode error at the shipped settings is **meanAbs 1.41 / p99 17.7** on a 0–255 scale, with block-boundary energy at or below my own control encode. q90/aq100 buys meanAbs 1.41 → 1.00 for **+54% bytes**.
- The fit is exactly reproducible: contain into 486×422 centred in 512×448, so all three subjects land at the same 422px height. Coherent, nothing cropped.
- The re-sent PNGs are the **same artwork**, already trimmed (740×685 / 721×661 / 694×687, vs the 1024×1024 #613 consumed). Indistinguishable at 3× zoom; edge sharpness within noise. The 1024 master is the better source, so re-encoding from the smaller re-exports would be a downgrade.

### The real problem is DARK mode, and it is the opposite of what we assumed

The premise I was given — light strokes drawn for a dark ground, so transparent-on-light would be near-invisible — is **inverted**. That reading came from an area-weighted luminance stat (mean 172–185, most pixels above 170), which describes the **fills**: 75–77% of the ink by pixel count, carrying no structure. The **outlines** are 23–25% of pixels and are what the eye reads.

Splitting the ink into those two populations (WCAG 1.4.11, 3:1 for non-text graphics):

| | outlines, median | outlines below 3:1 |
|---|---|---|
| **light sheet** `rgb(247 249 255)` | **6.0 – 8.5 : 1** | **0%** |
| **dark sheet** `rgb(13 20 27)` | **2.0 – 2.8 : 1** | **69 – 98%** |

So the art reads correctly on light — that half is fine and needs nothing. On **dark**, the lines that define each drawing wash out: step 1's orbit rings go dim, step 3's saucer rim merges into the ground. Recognisable, but visibly muddier. Both sheet colours were read off the deployed app, not assumed.

### Options for dark mode — your call, not mine

1. **Leave it.** Degraded but readable. 0 bytes, 0 risk.
2. **A dark-theme variant** that lifts only the desaturated dark strokes (accents and fills untouched). Prototyped and measured: ink below 3:1 on dark drops from 17.8–23.6% to **1.4–2.4%**. Cost is a second asset set — roughly **+120 KiB**, taking the total past the 150 KB budget to ~250 KiB. Shrinking both sets to 384×336 (exactly 2× the 192×168 CSS render) gets to ~168 KiB but under-samples at dpr 3.
3. **A scrim behind the art in dark mode only.** Cheapest fix, but it is a container, and you have asked twice for none — so I am not proposing it as the default.

I have not picked one. Nothing in this PR touches the assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)