### PR TITLE
fix(channels): preserve anonymity after channel deletion

### DIFF
--- a/packages/backend/src/__tests__/routes/channelsRoutes.test.ts
+++ b/packages/backend/src/__tests__/routes/channelsRoutes.test.ts
@@ -11,12 +11,9 @@ import { MAX_CHANNEL_MEMBERS, MAX_CHANNELS_PER_OWNER } from '@mention/shared-typ
  * Four things here fail SILENTLY if they regress, which is why each has a test of
  * its own rather than being implied by the happy path:
  *
- *  1. **The delete order.** `$unset` `channelId` on the posts FIRST. Skip it and
- *     those posts are reachable from NOTHING — still excluded from their author's
- *     profile and their followers' timeline (the exclusion matches on the FIELD's
- *     presence, not on the channel existing), while the `channel|<id>` feed no
- *     longer resolves. They also become permanently anonymous, because hydration
- *     treats a post whose channel is missing as unsigned.
+ *  1. **The delete order and retained marker.** Clear `laneId` on the posts FIRST,
+ *     but retain `channelId`: its presence keeps the posts anonymous and excluded
+ *     from author surfaces after the channel row is deleted.
  *  2. **The 409 is the unique index, not the pre-check.** `findOne` is not a lock.
  *  3. **The owner's membership row is written at create time**, which is what
  *     makes "may publish" ONE question with ONE answer — no "or the owner" branch
@@ -524,7 +521,7 @@ describe('PUT /channels/:id', () => {
 });
 
 describe('DELETE /channels/:id', () => {
-  it('releases the posts FIRST, then the lanes, then the rows, then the channel', async () => {
+  it('clears post lanes FIRST, then deletes the lanes, rows, and channel', async () => {
     channelFindById.mockReturnValue(chain({ ownerOxyUserId: VIEWER_ID }));
     laneFind.mockReturnValue(chain([{ _id: 'lane_1' }]));
 
@@ -541,16 +538,16 @@ describe('DELETE /channels/:id', () => {
     ]);
   });
 
-  it('unsets BOTH channelId and laneId on the released posts', async () => {
-    // A post left pointing at a dead channel is reachable from nothing at all,
-    // and a post left in a lane whose publisher is gone can never be managed.
+  it('retains channelId as the anonymity marker while unsetting laneId', async () => {
+    // The dead channel marker keeps the post anonymous and off author surfaces;
+    // a lane whose publisher is gone can never be managed and must be removed.
     channelFindById.mockReturnValue(chain({ ownerOxyUserId: VIEWER_ID }));
 
     await request(buildApp()).delete(`/channels/${CHANNEL_ID}`);
 
     expect(postUpdateMany).toHaveBeenCalledWith(
       { channelId: CHANNEL_ID },
-      { $unset: { channelId: '', laneId: '' } },
+      { $unset: { laneId: '' } },
     );
   });
 

--- a/packages/backend/src/routes/channels.routes.ts
+++ b/packages/backend/src/routes/channels.routes.ts
@@ -785,19 +785,16 @@ router.put(
  * THE ORDER OF THE WRITES IS LOAD-BEARING, and the FIRST one is the whole reason
  * this handler is not a one-liner:
  *
- *  1. **`$unset` `channelId` on the channel's posts.** Skip it and those posts are
- *     reachable from NOTHING: still excluded from their author's profile and their
- *     followers' timeline (`EXCLUDE_CHANNEL_POSTS` matches on the field's
- *     presence, not on the channel existing), while the `channel|<id>` feed no
- *     longer resolves. They also become anonymous forever, because hydration
- *     treats a post whose channel is missing as unsigned.
- *  2. unset `laneId` on those same posts and delete the channel's lanes and their
+ *  1. **Keep `channelId` on the channel's posts.** Its presence permanently keeps
+ *     those posts off author surfaces and makes hydration fail closed when the
+ *     channel row is gone. Removing it would expose writers of unsigned posts.
+ *  2. unset `laneId` on those posts and delete the channel's lanes and their
  *     mutes — a lane whose publisher is gone can never be reached or managed.
  *  3. delete the membership and follow rows,
  *  4. delete the channel.
  *
- * An interruption partway through leaves posts that have already been released
- * back to their authors, which is the safe direction to fail in.
+ * An interruption partway through can leave stale channel administration rows,
+ * but it never releases channel posts to their writers' identity surfaces.
  */
 router.delete('/:id', ...writeLimiters, validateObjectId('id'), async (req: AuthRequest, res: Response) => {
   try {
@@ -814,7 +811,7 @@ router.delete('/:id', ...writeLimiters, validateObjectId('id'), async (req: Auth
       return sendErrorResponse(res, 403, 'Forbidden', 'Only the owner can delete this channel');
     }
 
-    await Post.updateMany({ channelId }, { $unset: { channelId: '', laneId: '' } });
+    await Post.updateMany({ channelId }, { $unset: { laneId: '' } });
 
     const lanes = await Lane.find({ ownerType: 'channel', ownerId: channelId })
       .select('_id')

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -2318,12 +2318,10 @@ export class PostHydrationService {
       ...(typeof post.laneId === 'string' && laneMap.has(post.laneId)
         ? { lane: laneMap.get(post.laneId) }
         : {}),
-      // The channel signature. Absent when the post has no channel, and absent
-      // when its channel row is gone (the delete cascade `$unset`s `channelId`
-      // before removing the Channel, so this is only reachable if that cascade was
-      // interrupted). Note that an ABSENT channel on a post that HAS a `channelId`
-      // still anonymizes the author above — the row loses its signature rather
-      // than gaining the writer's.
+      // The channel signature. Absent when the post has no channel or its channel
+      // row is gone. Channel deletion deliberately retains `channelId`: an absent
+      // channel on a post that HAS the marker still anonymizes the author above —
+      // the row loses its signature rather than gaining the writer's.
       ...(channel ? { channel } : {}),
       // Include parentPostId for thread hierarchy in replies
       ...(post.parentPostId ? { parentPostId: String(post.parentPostId) } : {}),

--- a/packages/backend/src/utils/postAuthorship.ts
+++ b/packages/backend/src/utils/postAuthorship.ts
@@ -125,7 +125,8 @@ export function collectAuthorshipUserIds(authorship: PostAuthorshipEntry[] | und
  *
  * A stored `null` would satisfy `$exists` and wrongly exclude the post, which is
  * why nothing ever writes one: `PostCreationService` sets `channelId` only when
- * there IS a channel, and the delete cascade `$unset`s it.
+ * there IS a channel. Channel deletion deliberately preserves that id as a
+ * permanent ownership and anonymity marker even after the channel row is gone.
  */
 export const EXCLUDE_CHANNEL_POSTS = { channelId: { $exists: false } } as const;
 


### PR DESCRIPTION
### Motivation

- Deleting a `Channel` previously `$unset` the `channelId` on every post, which removed the sole marker used to enforce anonymous channel posting and made unsigned channel authors reappear on author/follower surfaces.
- The intent is to keep unsigned/anonymous posts permanently anonymized even after the channel row is removed, failing closed rather than exposing author identities.

### Description

- Stop unsetting `channelId` during channel deletion by changing the delete handler to only `$unset: { laneId: '' }` in `POST.updateMany` so the `channelId` marker is preserved (`packages/backend/src/routes/channels.routes.ts`).
- Clarify and update in-code documentation to state that `channelId` is a permanent ownership/anonymity marker (`packages/backend/src/routes/channels.routes.ts`, `packages/backend/src/utils/postAuthorship.ts`, `packages/backend/src/services/PostHydrationService.ts`).
- Preserve the existing DTO-level fail-closed behavior in `PostHydrationService` so posts that retain `channelId` remain anonymous when the channel row is gone (`packages/backend/src/services/PostHydrationService.ts`).
- Update tests and test descriptions to assert the new deletion semantics (retain `channelId`, unset only `laneId`) in `packages/backend/src/__tests__/routes/channelsRoutes.test.ts`.

### Testing

- Ran `git diff --check` and repository diff verification to validate the intended edits succeeded.
- Asserted via source checks that the delete path now contains `await Post.updateMany({ channelId }, { $unset: { laneId: '' } });` and that no occurrences of `$unset: { channelId: '', laneId: '' }` remain.
- Updated unit test expectations in `DELETE /channels/:id` to reflect retained `channelId`; these test changes are committed but the test suite could not be executed end-to-end because `bun install` failed due to npm registry HTTP 403 responses, causing `vitest` to be unavailable.  Automated tests therefore could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f5fef3ccc8323bebe5763f3a3aa1e)