### PR TITLE
Migration 0026: fail-closed when legacy channel posts remain

### DIFF
--- a/packages/backend/src/__tests__/migrations/channelAccounts.test.ts
+++ b/packages/backend/src/__tests__/migrations/channelAccounts.test.ts
@@ -16,9 +16,9 @@ import { migrationChannelAccounts } from '../../migrations/0026-channel-accounts
  *  - IDEMPOTENCE. `dropIndex` on a missing index raises `IndexNotFound`, and a
  *    migration that throws on its second run blocks every later migration on any
  *    database where this one already succeeded;
- *  - that the dead FIELDS are unset, not just the indexes dropped. `channelId` is
- *    no longer declared on the schema, so a surviving value would be invisible to
- *    Mongoose and yet still present in the collection.
+ *  - that legacy channel posts make the migration fail closed before any data or
+ *    indexes are changed. Removing their only marker would expose their human
+ *    writer on profile and follower feeds.
  */
 
 interface Call {
@@ -28,7 +28,13 @@ interface Call {
   options?: unknown;
 }
 
-function makeDb(options: { existingIndexes?: string[]; existingCollections?: string[] } = {}) {
+function makeDb(
+  options: {
+    existingIndexes?: string[];
+    existingCollections?: string[];
+    legacyChannelPost?: { _id: string; channelId: string };
+  } = {},
+) {
   const existingIndexes = new Set(
     options.existingIndexes ?? [
       'ownerType_1_ownerId_1_createdAt_-1',
@@ -45,6 +51,12 @@ function makeDb(options: { existingIndexes?: string[]; existingCollections?: str
   const db = {
     collection: (collectionName: string) => ({
       collectionName,
+      findOne: (filter: Record<string, unknown>, findOptions?: Record<string, unknown>) => {
+        calls.push({ op: 'findOne', collection: collectionName, arg: filter, options: findOptions });
+        return Promise.resolve(
+          collectionName === 'posts' ? (options.legacyChannelPost ?? null) : null,
+        );
+      },
       createIndex: (key: Record<string, unknown>, opts?: Record<string, unknown>) => {
         calls.push({ op: 'createIndex', collection: collectionName, arg: key, options: opts });
         return Promise.resolve('ok');
@@ -134,7 +146,7 @@ describe('migration 0026 — channel accounts', () => {
     ]);
   });
 
-  it('unsets the undeclared fields, not just the indexes', async () => {
+  it('unsets the obsolete lane owner type', async () => {
     const { db, calls } = makeDb();
 
     await migrationChannelAccounts.run(db);
@@ -147,11 +159,24 @@ describe('migration 0026 — channel accounts', () => {
         arg: { ownerType: { $exists: true } },
         options: { $unset: { ownerType: '' } },
       },
+    ]);
+  });
+
+  it('fails before changing anything when a legacy channel post exists', async () => {
+    const { db, calls } = makeDb({
+      legacyChannelPost: { _id: 'legacy-post', channelId: 'legacy-channel' },
+    });
+
+    await expect(migrationChannelAccounts.run(db)).rejects.toThrow(
+      'Migration 0026 cannot retire channels while legacy channel posts exist',
+    );
+
+    expect(calls).toEqual([
       {
-        op: 'updateMany',
+        op: 'findOne',
         collection: 'posts',
         arg: { channelId: { $exists: true } },
-        options: { $unset: { channelId: '' } },
+        options: { projection: { _id: 1, channelId: 1 } },
       },
     ]);
   });

--- a/packages/backend/src/migrations/0026-channel-accounts.ts
+++ b/packages/backend/src/migrations/0026-channel-accounts.ts
@@ -25,29 +25,23 @@
  *  2. **`ownerType` is unset from every `lanes` row.** After the index re-key
  *     nothing reads it; leaving it would make a `lanes` document disagree with its
  *     own schema forever.
- *  3. **`channelId` is unset from every `posts` row, and `post_channel_chrono_v1`
- *     dropped.** The field is no longer declared on the schema, so a surviving
- *     value would be invisible to Mongoose and yet still present in the
- *     collection — the exact shape that makes a later `$exists` query lie.
+ *  3. **The migration refuses to run while any legacy channel post exists, then
+ *     drops `post_channel_chrono_v1`.** `channelId` was the only marker keeping a
+ *     person-authored channel post off that person's profile and follower feeds.
+ *     Deleting it would disclose the writer, so those posts must be migrated to
+ *     provisioned Oxy channel accounts (or explicitly removed) first.
  *  4. **The three channel collections are DROPPED** (`channels`,
  *     `channelmembers`, `channelfollows`). Membership lives in Oxy's account
  *     graph and a follow is an ordinary Oxy follow, so nothing here has a reader
  *     any more.
  *
- * **This is a CLEAN CUT with no data migration, and that is a deliberate
- * decision rather than an omission.** Rewriting the existing channel posts —
- * moving `oxyUserId`/`authorship` to an Oxy account that does not exist and
- * cannot be created from here — is not something a migration can do; the channel
- * accounts would have to be provisioned in Oxy first. The rows that would need it
- * are test data, confirmed disposable, so they are left exactly as they are minus
- * the dead field. `__tests__/models/channelAccountSchema.test.ts` states the
- * precondition this satisfies: a person-authored post carrying a channel marker
- * was held off its author's surfaces by that marker and nothing else, so the
- * marker cannot be dropped while one that matters still exists.
+ * Rewriting legacy channel posts is not something this migration can do: their
+ * replacement Oxy channel accounts must be provisioned first. The preflight is
+ * therefore deliberately fail-closed and runs before ANY destructive operation.
  *
  * Idempotent: `createIndex` with an identical spec is a no-op, `dropIndex` and
  * `drop` tolerate an absent target (checked, not assumed — see `dropIfPresent`),
- * and an `$unset` over rows that no longer carry the field matches nothing.
+ * and the lane `$unset` matches nothing after the first successful run.
  */
 
 import mongoose from 'mongoose';
@@ -90,6 +84,18 @@ export const migrationChannelAccounts: Migration = {
   id: MIGRATION_CHANNEL_ACCOUNTS,
 
   async run(db: mongoose.mongo.Db): Promise<void> {
+    const posts = db.collection(Post.collection.collectionName);
+    const legacyChannelPost = await posts.findOne(
+      { channelId: { $exists: true } },
+      { projection: { _id: 1, channelId: 1 } },
+    );
+    if (legacyChannelPost) {
+      throw new Error(
+        'Migration 0026 cannot retire channels while legacy channel posts exist; ' +
+          'migrate them to provisioned Oxy channel accounts or explicitly remove them first',
+      );
+    }
+
     const lanes = db.collection(Lane.collection.collectionName);
 
     // New first, old second — see the docstring: the unique constraint must never
@@ -108,12 +114,7 @@ export const migrationChannelAccounts: Migration = {
       { $unset: { ownerType: '' } },
     );
 
-    const posts = db.collection(Post.collection.collectionName);
     const droppedPostIndex = await dropIndexIfPresent(posts, 'post_channel_chrono_v1');
-    const unsetChannelId = await posts.updateMany(
-      { channelId: { $exists: true } },
-      { $unset: { channelId: '' } },
-    );
 
     const droppedCollections: string[] = [];
     for (const name of RETIRED_COLLECTIONS) {
@@ -131,7 +132,6 @@ export const migrationChannelAccounts: Migration = {
       laneIndexesDropped: droppedLaneIndexes,
       lanesOwnerTypeUnset: unsetOwnerType.modifiedCount,
       postChannelIndexDropped: droppedPostIndex,
-      postsChannelIdUnset: unsetChannelId.modifiedCount,
       collectionsDropped: droppedCollections,
     });
   },


### PR DESCRIPTION
### Motivation
- Prevent accidental de-anonymization and unintended feed distribution by avoiding removal of the only legacy `channelId` marker without a safe data migration. 
- Ensure the migration is fail-closed when any legacy channel-post rows exist, so operators must provision Oxy channel accounts or explicitly remove affected rows before destructive changes.

### Description
- Add a preflight that queries `posts.findOne({ channelId: { $exists: true } })` and throws if any legacy channel post is present in `packages/backend/src/migrations/0026-channel-accounts.ts`. 
- Remove the destructive `updateMany({ channelId: { $exists: true } }, { $unset: { channelId: '' } })` step so legacy `channelId` markers are preserved until an explicit migration path is taken. 
- Keep dropping the `post_channel_chrono_v1` index but only after the preflight passes, and preserve the other lane/index changes and retired collection drops. 
- Add regression coverage in `packages/backend/src/__tests__/migrations/channelAccounts.test.ts` that simulates a legacy channel post and asserts the migration performs only the preflight `findOne` and fails before changing indexes or documents.

### Testing
- Ran `git diff --check` with no style/patch issues detected. 
- Added a unit test that asserts the migration throws when a legacy `channelId` post exists, but running `bun run test -- src/__tests__/migrations/channelAccounts.test.ts` was blocked because the test runner dependencies (`vitest`) are not installed in this environment. 
- Attempted `bun install --frozen-lockfile` but it failed to fetch registry packages (HTTP 403) in this environment, so the added test could not be executed here. 
- The test asserts that only a `findOne` preflight is executed against `posts` and that no `updateMany` to unset `channelId` is attempted when a legacy post exists.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fd65de7ec832397b9e4d37d43042b)