### PR TITLE
fix(moderation): prevent private post disclosure in report snapshots

### DIFF
--- a/packages/backend/src/__tests__/services/moderation/subjectProviders.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/subjectProviders.test.ts
@@ -97,6 +97,16 @@ describe('post subject provider', () => {
     expect(await postProvider.snapshot('not-an-object-id')).toBeNull();
   });
 
+  it('does not disclose unpublished or non-public posts to another reporter', async () => {
+    posts.set(
+      POST_ID,
+      textPost(POST_ID, 'Private draft.', { status: 'draft', visibility: 'private' }),
+    );
+
+    expect(await postProvider.snapshot(POST_ID, 'oxy-attacker')).toBeNull();
+    expect(await postProvider.snapshot(POST_ID, 'oxy-author')).not.toBeNull();
+  });
+
   it('drops a language tag the contract would refuse rather than failing the report', async () => {
     posts.set(
       POST_ID,
@@ -157,6 +167,19 @@ describe('post subject provider', () => {
 
     // A jury judging a reply needs what it replied to; a missing parent is context that
     // does not exist, not a reason to fail the report.
+    expect(snapshot?.context).toBeUndefined();
+  });
+
+  it('omits private or unpublished neighbouring context', async () => {
+    posts.set(
+      PARENT_ID,
+      textPost(PARENT_ID, 'Private parent.', { status: 'scheduled', visibility: 'private' }),
+    );
+    posts.set(POST_ID, textPost(POST_ID, 'Public reply.', { parentPostId: PARENT_ID }));
+
+    const snapshot = await postProvider.snapshot(POST_ID, 'oxy-attacker');
+
+    expect(snapshot?.content).toMatchObject({ data: { text: 'Public reply.' } });
     expect(snapshot?.context).toBeUndefined();
   });
 

--- a/packages/backend/src/services/moderation/EvidenceSnapshotService.ts
+++ b/packages/backend/src/services/moderation/EvidenceSnapshotService.ts
@@ -102,7 +102,7 @@ export async function buildModerationReportInput(
   const provider = subjectProviderFor(report.reportedType);
   if (!provider) throw new ModerationSubjectUnsupportedError(report.reportedType);
 
-  const snapshot = await provider.snapshot(report.reportedId);
+  const snapshot = await provider.snapshot(report.reportedId, report.reporter);
   if (!snapshot) return null;
 
   const allegationCodes = allegationsForCategories(report.categories);

--- a/packages/backend/src/services/moderation/subjects/postSubject.ts
+++ b/packages/backend/src/services/moderation/subjects/postSubject.ts
@@ -73,12 +73,14 @@ interface SnapshotPost {
   quoteOf?: string;
   language?: string;
   createdAt?: Date | string;
+  status?: string;
+  visibility?: string;
   metadata?: { isSensitive?: boolean };
   federation?: { url?: string; sensitive?: boolean };
 }
 
 const SNAPSHOT_PROJECTION =
-  'content authorship oxyUserId parentPostId quoteOf language createdAt metadata.isSensitive federation.url federation.sensitive';
+  'content authorship oxyUserId parentPostId quoteOf language createdAt status visibility metadata.isSensitive federation.url federation.sensitive';
 
 /**
  * §5.2's `sensitivity` hint for a post carrying a content warning.
@@ -167,11 +169,28 @@ function mediaOnlySubjectResource(post: SnapshotPost): ModerationResource {
   };
 }
 
-async function loadPost(postId: string): Promise<SnapshotPost | null> {
+/**
+ * Load material only when it is safe to disclose outside Mention.
+ *
+ * CrowdSource delivery runs asynchronously without the reporter's delegated Oxy
+ * credentials, so it cannot reliably re-evaluate follower, profile, block, or
+ * restriction relationships. Fail closed to public, published material while still
+ * allowing an author to report their own post. Object ids are never treated as an
+ * authorization boundary.
+ */
+async function loadPost(postId: string, reporterId?: string): Promise<SnapshotPost | null> {
   if (!mongoose.isValidObjectId(postId)) return null;
-  return await Post.findById(postId)
+  const post = await Post.findById(postId)
     .select(SNAPSHOT_PROJECTION)
     .lean<SnapshotPost | null>();
+  if (!post) return null;
+
+  const ownerId = getOwnerId(normalizeAuthorship(post.authorship)) ?? post.oxyUserId;
+  if (ownerId === reporterId) return post;
+
+  const isPublished = (post.status ?? 'published') === 'published';
+  const isPublic = (post.visibility ?? 'public') === 'public';
+  return isPublished && isPublic ? post : null;
 }
 
 /**
@@ -184,9 +203,10 @@ async function loadPost(postId: string): Promise<SnapshotPost | null> {
 async function contextResource(
   postId: string | undefined,
   role: ModerationContextResource['role'],
+  reporterId?: string,
 ): Promise<ModerationContextResource | null> {
   if (postId === undefined) return null;
-  const neighbour = await loadPost(postId);
+  const neighbour = await loadPost(postId, reporterId);
   if (!neighbour) return null;
   const body = postText(neighbour);
   if (!body) return null;
@@ -214,8 +234,11 @@ export function createPostSubjectProvider(input: {
     reportedType: input.reportedType,
     subjectType: input.subjectType,
 
-    async snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null> {
-      const post = await loadPost(reportedId);
+    async snapshot(
+      reportedId: string,
+      reporterId?: string,
+    ): Promise<ModerationSubjectSnapshot | null> {
+      const post = await loadPost(reportedId, reporterId);
       if (!post) return null;
 
       const ownerId = getOwnerId(normalizeAuthorship(post.authorship)) ?? post.oxyUserId;
@@ -226,7 +249,7 @@ export function createPostSubjectProvider(input: {
         [post.parentPostId, 'parent'],
         [post.quoteOf, 'quoted'],
       ] as const) {
-        const resource = await contextResource(id, role);
+        const resource = await contextResource(id, role, reporterId);
         if (resource) context.push(resource);
       }
 

--- a/packages/backend/src/services/moderation/subjects/types.ts
+++ b/packages/backend/src/services/moderation/subjects/types.ts
@@ -88,12 +88,13 @@ export interface ModerationSubjectProvider {
   /** §5.4's namespaced subject type, or `custom.<organization>.<object_type>`. */
   readonly subjectType: string;
   /**
-   * Describes the object, or returns `null` when it no longer exists.
+   * Describes the object for the reporter, or returns `null` when it no longer
+   * exists or cannot safely be disclosed to that reporter.
    *
    * `null` is not a failure. Content deleted between the report and its delivery
    * is ordinary, and it is the caller's job to decide what that means — a
    * provider that threw would make deletion look like an outage and be retried
    * for days.
    */
-  snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null>;
+  snapshot(reportedId: string, reporterId?: string): Promise<ModerationSubjectSnapshot | null>;
 }


### PR DESCRIPTION
### Motivation
- Close an authorization gap where an authenticated reporter could cause private, draft, or followers-only posts (and their private parent/quote context) to be snapshotted and sent to CrowdSource simply by supplying an ObjectId.

### Description
- Add reporter identity to the moderation subject provider API (`snapshot(reportedId, reporterId?)`) and pass the authenticated `report.reporter` through when composing the `ReportInput`.
- Restrict post snapshots by adding `status` and `visibility` to the projection and only returning a post when the reporter is the owner or the post is published and public, failing closed otherwise.
- Thread the reporter identity into context lookups so parent/quoted context that is unpublished/non-public is omitted from the evidence snapshot.
- Add unit-test coverage asserting that unpublished/non-public posts are not disclosed to other reporters and that private neighbouring context is omitted.

### Testing
- Ran repository checks (`git diff --check`) and updated unit tests under `packages/backend/src/__tests__/services/moderation/subjectProviders.test.ts` to cover the regression scenarios.
- Attempted to build and run tests: `bun run --cwd packages/shared-types build` was blocked by a TypeScript configuration deprecation (`TS5107`), and `cd packages/backend && bun run test -- src/__tests__/services/moderation/subjectProviders.test.ts` could not execute in this environment because `node_modules/vitest` is absent; as a result the new tests could not be executed here.
- The change is narrowly scoped to moderation snapshot composition and subject providers so behaviour is covered by the new tests once the test environment dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ba0e1a96083238dc842489484adf1)