### PR TITLE
fix(feed): authorize quote feed anchor

### DIFF
--- a/packages/backend/src/__tests__/controllers/quotesFeed.test.ts
+++ b/packages/backend/src/__tests__/controllers/quotesFeed.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
  */
 
 const postFind = vi.fn();
+const anchorFind = vi.fn();
 const hydratePosts = vi.fn();
 
 /** Chainable Mongoose query stub that records what the controller asked for. */
@@ -21,6 +22,7 @@ let lastLimit: number | undefined;
 
 vi.mock('../../models/Post', () => ({
   Post: {
+    findById: () => ({ lean: async () => anchorFind() }),
     find: (query: Record<string, unknown>) => {
       lastQuery = query;
       const q: Record<string, unknown> = {};
@@ -78,6 +80,7 @@ beforeEach(() => {
   lastSort = undefined;
   lastLimit = undefined;
   vi.clearAllMocks();
+  anchorFind.mockReturnValue({ _id: QUOTED_ID, oxyUserId: 'anchor-author' });
   postFind.mockReturnValue([]);
   hydratePosts.mockImplementation(async (posts: { _id: string }[]) =>
     posts.map((p) => ({ id: String(p._id), user: { id: 'author' } })),
@@ -93,6 +96,27 @@ describe('FeedController.getQuotesFeed', () => {
       visibility: 'public',
       status: 'published',
     });
+  });
+
+  it('does not enumerate quotes when the anchor is unavailable to the viewer', async () => {
+    hydratePosts.mockResolvedValueOnce([null]);
+    const res = makeRes();
+
+    await feedController.getQuotesFeed(makeReq(), res as never);
+
+    expect(res.statusCode).toBe(404);
+    expect(postFind).not.toHaveBeenCalled();
+  });
+
+  it('returns not found without querying quotes when the anchor does not exist', async () => {
+    anchorFind.mockReturnValue(null);
+    const res = makeRes();
+
+    await feedController.getQuotesFeed(makeReq(), res as never);
+
+    expect(res.statusCode).toBe(404);
+    expect(hydratePosts).not.toHaveBeenCalled();
+    expect(postFind).not.toHaveBeenCalled();
   });
 
   it('pages on _id, never on createdAt', async () => {
@@ -129,9 +153,9 @@ describe('FeedController.getQuotesFeed', () => {
 
     await feedController.getQuotesFeed(makeReq(), makeRes() as never);
 
-    expect(hydratePosts).toHaveBeenCalledWith(
+    expect(hydratePosts).toHaveBeenLastCalledWith(
       [{ _id: QUOTE_A }],
-      expect.objectContaining({ maxDepth: 1 }),
+      expect.objectContaining({ maxDepth: 1, publicReferencesOnly: true }),
     );
   });
 

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -859,6 +859,27 @@ class FeedController {
       const currentUserId = req.user?.id;
       const limit = validateAndNormalizeLimit(req.query.limit, FEED_CONSTANTS.DEFAULT_LIMIT);
       const cursor = queryString(req.query.cursor);
+      const requestOxyClient = createScopedOxyClient(req);
+
+      // This is a public route, but the relationship it exposes is only public
+      // when the quoted post itself is viewable. Hydrate the anchor first so it
+      // passes through the same post/profile ACL as post detail before either
+      // enumerating its quotes or embedding it as nested quote context.
+      if (!mongoose.Types.ObjectId.isValid(String(postId))) {
+        return res.status(404).json({ message: 'Post not found' });
+      }
+      const anchorPost = await Post.findById(postId).lean();
+      if (!anchorPost) {
+        return res.status(404).json({ message: 'Post not found' });
+      }
+      const [visibleAnchor] = await postHydrationService.hydratePosts([anchorPost], {
+        viewerId: currentUserId,
+        oxyClient: requestOxyClient,
+        maxDepth: 0,
+      });
+      if (!visibleAnchor) {
+        return res.status(404).json({ message: 'Post not available' });
+      }
 
       const query: FilterQuery<IPost> = {
         quoteOf: String(postId),
@@ -880,7 +901,6 @@ class FeedController {
 
       const hasMore = posts.length > limit;
       const slicedPosts = hasMore ? posts.slice(0, limit) : posts;
-      const requestOxyClient = createScopedOxyClient(req);
 
       let filteredPosts = slicedPosts;
       if (currentUserId) {
@@ -897,6 +917,7 @@ class FeedController {
         viewerId: currentUserId,
         oxyClient: requestOxyClient,
         maxDepth: 1,
+        publicReferencesOnly: true,
         includeLinkMetadata: true,
       });
       const items = hydrated.filter((post) => post?.id && post.user?.id);


### PR DESCRIPTION
### Motivation
- A public `GET /feed/quotes/:postId` endpoint exposed quotes for any supplied post id without first confirming that the quoted (anchor) post is viewable to the requester, allowing enumeration and embedding of posts authored by private/followers-only profiles.

### Description
- Validate and load the anchor `postId` and return `404` for malformed or missing ids by checking `mongoose.Types.ObjectId.isValid` and `Post.findById` in `getQuotesFeed` (`packages/backend/src/controllers/feed.controller.ts`).
- Hydrate the anchor through the existing post/profile ACL via `postHydrationService.hydratePosts([anchorPost], { viewerId, oxyClient, maxDepth: 0 })` and return `404` when the anchor is not viewable, preventing quote enumeration for inaccessible anchors.
- Constrain nested reference hydration on the quotes feed by enabling `publicReferencesOnly: true` when calling `postHydrationService.hydratePosts` for the quote rows so embedded referenced posts respect publication/visibility filters.
- Add regression tests to `packages/backend/src/__tests__/controllers/quotesFeed.test.ts` that assert the controller returns `404` when the anchor is missing or unavailable and that the existing pagination and hydration semantics remain intact.

### Testing
- Ran `git diff --check` which completed successfully.
- Added unit test coverage in `packages/backend/src/__tests__/controllers/quotesFeed.test.ts` exercising: anchor-not-found, anchor-unavailable (returns `404` without querying quotes), `_id`-based pagination, cursor handling, overfetch behavior, and hydration options; these tests were added to the checkout but running the test runner was blocked in this environment.
- Attempted `bun run test -- src/__tests__/controllers/quotesFeed.test.ts` but the run failed because `vitest` is not installed in the checkout (`MODULE_NOT_FOUND`), and `bun install --frozen-lockfile` could not complete due to npm registry `403` responses; no further automated test runs were possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a698418011c832397c4a5d3b13394e5)