### PR TITLE
fix(federation): cap outbox mention resolution

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/outboxMentionResolution.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/outboxMentionResolution.test.ts
@@ -164,4 +164,67 @@ describe('resolveInboundMentionsForNotes (batched outbox mention resolution)', (
     expect(byNote.size).toBe(0);
     expect(mocks.getOrFetchActor).not.toHaveBeenCalled();
   });
+  it('caps per-note and per-page mention resolution before fetch-and-create work', async () => {
+    mocks.getOrFetchActor.mockImplementation(async (uri: string) => ({
+      oxyUserId: `oxy_${uri.split('/').pop()}`,
+    }));
+
+    const tags = Array.from({ length: 6 }, (_, i) => ({
+      type: 'Mention',
+      href: `${REMOTE}/users/capped-${i}`,
+      name: `@capped-${i}@mastodon.example`,
+    }));
+    const note = {
+      content: tags
+        .map(
+          (_tag, i) =>
+            `<a href="${REMOTE}/@capped-${i}" class="u-url mention">@capped-${i}</a>`,
+        )
+        .join(' '),
+      tag: tags,
+    };
+
+    const byNote = await resolveInboundMentionsForNotes([note], {
+      concurrency: 3,
+      perActorTimeoutMs: 20_000,
+      maxTagsPerNote: 2,
+      maxDistinctActorsPerPage: 10,
+    });
+
+    expect(mocks.getOrFetchActor).toHaveBeenCalledTimes(2);
+    expect(mocks.getOrFetchActor).toHaveBeenCalledWith(`${REMOTE}/users/capped-0`);
+    expect(mocks.getOrFetchActor).toHaveBeenCalledWith(`${REMOTE}/users/capped-1`);
+    const resolved = resolutionFor(byNote, note);
+    expect(resolved.ids).toEqual(['oxy_capped-0', 'oxy_capped-1']);
+    expect(applyMentionPlaceholders(note, resolved.anchorMap).content).toContain(
+      '[mention:oxy_capped-0]',
+    );
+    expect(applyMentionPlaceholders(note, resolved.anchorMap).content).toContain(
+      '[mention:oxy_capped-1]',
+    );
+    expect(applyMentionPlaceholders(note, resolved.anchorMap).content).toContain('@capped-2');
+  });
+
+  it('caps distinct mention actors across the whole outbox page', async () => {
+    mocks.getOrFetchActor.mockImplementation(async (uri: string) => ({
+      oxyUserId: `oxy_${uri.split('/').pop()}`,
+    }));
+
+    const noteA = noteMentioning(`${REMOTE}/users/page-0`, `${REMOTE}/@page-0`, '@page-0');
+    const noteB = noteMentioning(`${REMOTE}/users/page-1`, `${REMOTE}/@page-1`, '@page-1');
+    const noteC = noteMentioning(`${REMOTE}/users/page-2`, `${REMOTE}/@page-2`, '@page-2');
+
+    const byNote = await resolveInboundMentionsForNotes([noteA, noteB, noteC], {
+      concurrency: 3,
+      perActorTimeoutMs: 20_000,
+      maxTagsPerNote: 25,
+      maxDistinctActorsPerPage: 2,
+    });
+
+    expect(mocks.getOrFetchActor).toHaveBeenCalledTimes(2);
+    expect(resolutionFor(byNote, noteA).ids).toEqual(['oxy_page-0']);
+    expect(resolutionFor(byNote, noteB).ids).toEqual(['oxy_page-1']);
+    expect(resolutionFor(byNote, noteC).ids).toEqual([]);
+  });
+
 });

--- a/packages/backend/src/connectors/activitypub/apMentions.ts
+++ b/packages/backend/src/connectors/activitypub/apMentions.ts
@@ -244,8 +244,9 @@ type MentionTagResolver = (tag: InboundMentionTag) => Promise<MentionActorResolu
 async function buildResolvedInboundMentions(
   object: Record<string, unknown>,
   resolveTag: MentionTagResolver,
+  tagsOverride?: ReadonlyArray<InboundMentionTag>,
 ): Promise<ResolvedInboundMentions> {
-  const tags = extractMentionTags(object);
+  const tags = tagsOverride ? [...tagsOverride] : extractMentionTags(object);
   if (tags.length === 0) return { ids: [], localIds: [], anchorMap: new Map() };
 
   // Dedupe by actor href so a user mentioned twice is resolved once.
@@ -334,6 +335,10 @@ export interface BatchMentionResolveOptions {
    * "unresolved" (its anchor stays bare text) rather than stalling the batch.
    */
   perActorTimeoutMs: number;
+  /** Max Mention tags considered on any single note before network I/O. */
+  maxTagsPerNote?: number;
+  /** Max distinct mention actor hrefs resolved across the whole page. */
+  maxDistinctActorsPerPage?: number;
 }
 
 /**
@@ -362,10 +367,39 @@ export async function resolveInboundMentionsForNotes(
   const byNote = new Map<Record<string, unknown>, ResolvedInboundMentions>();
   if (objects.length === 0) return byNote;
 
-  // 1. Union of DISTINCT mention actor hrefs across every note in the page.
+  // 1. Union of DISTINCT mention actor hrefs across every note in the page,
+  //    with hard caps before any network/Oxy work. Remote AP tag arrays are
+  //    attacker-controlled, so concurrency/timeouts alone are not enough: without
+  //    a total cap a single outbox page could force unbounded batches of actor
+  //    fetches. Tags beyond these caps intentionally degrade to bare text.
+  const maxTagsPerNote = options.maxTagsPerNote ?? Number.POSITIVE_INFINITY;
+  const maxDistinctActorsPerPage = options.maxDistinctActorsPerPage ?? Number.POSITIVE_INFINITY;
   const distinctHrefs = new Set<string>();
+  const tagsByNote = new Map<Record<string, unknown>, InboundMentionTag[]>();
+  let droppedForCaps = 0;
   for (const object of objects) {
-    for (const tag of extractMentionTags(object)) distinctHrefs.add(tag.href);
+    const tags = extractMentionTags(object);
+    const tagsToConsider = Number.isFinite(maxTagsPerNote)
+      ? tags.slice(0, Math.max(0, maxTagsPerNote))
+      : tags;
+    droppedForCaps += Math.max(0, tags.length - tagsToConsider.length);
+    const allowedTags: InboundMentionTag[] = [];
+    for (const tag of tagsToConsider) {
+      if (!distinctHrefs.has(tag.href)) {
+        if (distinctHrefs.size >= maxDistinctActorsPerPage) {
+          droppedForCaps++;
+          continue;
+        }
+        distinctHrefs.add(tag.href);
+      }
+      allowedTags.push(tag);
+    }
+    tagsByNote.set(object, allowedTags);
+  }
+  if (droppedForCaps > 0) {
+    logger.warn(
+      `[Federation] skipped ${droppedForCaps} outbox mention tag(s) due to per-note/page caps`,
+    );
   }
 
   // 2. Resolve each distinct href AT MOST once (fetch-and-create) in bounded
@@ -399,8 +433,10 @@ export async function resolveInboundMentionsForNotes(
   for (const object of objects) {
     byNote.set(
       object,
-      await buildResolvedInboundMentions(object, (tag) =>
-        Promise.resolve(resolutions.get(tag.href) ?? null),
+      await buildResolvedInboundMentions(
+        object,
+        (tag) => Promise.resolve(resolutions.get(tag.href) ?? null),
+        tagsByNote.get(object) ?? [],
       ),
     );
   }

--- a/packages/backend/src/connectors/activitypub/outbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/outbox.service.ts
@@ -68,6 +68,14 @@ const OUTBOX_ACTOR_RESOLVE_CONCURRENCY = 3;
 const OUTBOX_ACTOR_RESOLVE_TIMEOUT_MS = 20 * 1000; // 20 seconds
 
 /**
+ * Hard caps for resolving @mentions in an outbox page. ActivityPub `tag` arrays
+ * are remote-controlled and can be huge; mentions beyond these bounds degrade to
+ * bare text rather than triggering more actor fetch/Oxy resolution work.
+ */
+const OUTBOX_MENTION_TAGS_PER_NOTE_LIMIT = 25;
+const OUTBOX_MENTION_ACTORS_PER_PAGE_LIMIT = 100;
+
+/**
  * Bounded concurrency for importing boosts (Announce) during outbox backfill.
  * Each import may fetch the boosted Note from a remote instance, so this is
  * parallelized in small batches rather than run strictly sequentially.
@@ -638,9 +646,13 @@ export class OutboxSyncService {
       // build loop below to rewrite each anchor into a `[mention:<id>]` placeholder
       // BEFORE the body is derived and to set the post's `mentions` allowlist,
       // mirroring the inbox Create path (the raw `insertMany` bypasses that path).
-      const pendingNoteCandidates = noteCandidates.filter(
-        (c) => !existingIds.has(c.activityId),
-      );
+      const pendingNoteCandidates = noteCandidates.filter((c) => {
+        if (existingIds.has(c.activityId)) return false;
+        const rawContent = c.note.content || '';
+        return (
+          typeof rawContent !== 'string' || rawContent.length <= FEDERATION_MAX_CONTENT_LENGTH
+        );
+      });
 
       // SELF-HEAL candidates: notes that match an EXISTING post whose stored body
       // still shows its @mentions as bare `@name` text. Such posts were imported
@@ -686,6 +698,8 @@ export class OutboxSyncService {
         {
           concurrency: OUTBOX_ACTOR_RESOLVE_CONCURRENCY,
           perActorTimeoutMs: OUTBOX_ACTOR_RESOLVE_TIMEOUT_MS,
+          maxTagsPerNote: OUTBOX_MENTION_TAGS_PER_NOTE_LIMIT,
+          maxDistinctActorsPerPage: OUTBOX_MENTION_ACTORS_PER_PAGE_LIMIT,
         },
       );
       // Shared no-mention default for a note the map has no entry for (never


### PR DESCRIPTION
### Motivation
- Prevent unbounded, attacker-controlled ActivityPub `tag` arrays from driving arbitrarily many outbound actor fetches during outbox backfill and exhausting worker/network/Oxy resolution resources.

### Description
- Add hard caps before any network or Oxy work: `OUTBOX_MENTION_TAGS_PER_NOTE_LIMIT` and `OUTBOX_MENTION_ACTORS_PER_PAGE_LIMIT` and thread them into the outbox resolver so mentions beyond the caps degrade to bare text. (`packages/backend/src/connectors/activitypub/outbox.service.ts`)
- Extend the batched resolver options with `maxTagsPerNote` and `maxDistinctActorsPerPage` and apply those caps when building the distinct actor href set. (`packages/backend/src/connectors/activitypub/apMentions.ts`)
- Teach `buildResolvedInboundMentions` to accept a per-note `tagsOverride` so the page-level capped tag list is used when assembling placeholders/ids with no further I/O. (`packages/backend/src/connectors/activitypub/apMentions.ts`)
- Skip mention-resolution work for outbox notes that will be rejected due to `FEDERATION_MAX_CONTENT_LENGTH`, avoiding wasted pre-filter work. (`packages/backend/src/connectors/activitypub/outbox.service.ts`)
- Add regression tests covering per-note and per-page mention caps for the batched outbox mention resolver. (`packages/backend/src/__tests__/connectors/activitypub/outboxMentionResolution.test.ts`)

### Testing
- Ran `git diff --check` which passed locally after the change.  
- Attempted `cd packages/backend && bun run test src/__tests__/connectors/activitypub/outboxMentionResolution.test.ts` but the environment lacked installed test runner deps (`vitest` not found), so tests could not be executed here.  
- Attempted `bun install` and `cd packages/backend && bun run build` but both were blocked by the environment (registry `403` and TypeScript deprecation errors in local toolchain), so full automated verification could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ac7df70c48323941bea3858e82985)