### PR TITLE
fix(backend): throttle atproto profile graph sync

### DIFF
--- a/packages/backend/src/__tests__/connectors/federatedProfileSync.test.ts
+++ b/packages/backend/src/__tests__/connectors/federatedProfileSync.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
  */
 
 const actorFindOne = vi.fn();
-const actorUpdateOne = vi.fn(async () => undefined);
+const actorUpdateOne = vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => undefined);
 const actorFindOneAndUpdate = vi.fn(async () => null);
 vi.mock('../../models/FederatedActor', () => ({
   default: {
@@ -86,7 +86,12 @@ vi.mock('../../connectors/activitypub/ActivityPubConnector', () => ({
 }));
 
 vi.mock('../../connectors/activitypub/constants', () => ({ FEDERATION_ENABLED: true }));
-vi.mock('../../connectors/atproto/constants', () => ({ ATPROTO_ENABLED: false }));
+vi.mock('../../connectors/atproto/constants', () => ({ ATPROTO_ENABLED: true }));
+
+const syncAtprotoProfileGraph = vi.fn(async () => undefined);
+vi.mock('../../connectors/atproto/profileGraph', () => ({
+  syncAtprotoProfileGraph: (...a: unknown[]) => syncAtprotoProfileGraph(...(a as [string, string])),
+}));
 
 /** atproto backfill: the connector the registry hands back for an atproto URI. */
 const atprotoFetchPosts = vi.fn(async () => ({ posts: [] as unknown[] }));
@@ -144,6 +149,17 @@ function atprotoActor(overrides: Record<string, unknown> = {}) {
 
 function mockActorLookup(actor: unknown) {
   actorFindOne.mockReturnValue({ lean: () => Promise.resolve(actor) });
+}
+
+function isGraphClaim(filter: unknown, update: unknown): boolean {
+  return Boolean(
+    filter
+    && typeof filter === 'object'
+    && (filter as { protocol?: unknown }).protocol === 'atproto'
+    && update
+    && typeof update === 'object'
+    && Boolean((update as { $set?: { atprotoGraphSyncStartedAt?: unknown } }).$set?.atprotoGraphSyncStartedAt),
+  );
 }
 
 beforeEach(() => {
@@ -288,6 +304,30 @@ describe('federatedProfileSync.syncOnProfileView', () => {
       ),
     );
     expect(syncOutboxPostsDetailed).not.toHaveBeenCalled();
+  });
+
+  it('claims atproto graph syncs so concurrent profile views cannot duplicate expensive work', async () => {
+    connectorFor.mockReturnValue({ fetchPosts: atprotoFetchPosts });
+    mockActorLookup(atprotoActor({ postsCount: 5 }));
+    let graphClaimed = false;
+    actorUpdateOne.mockImplementation(async (filter: unknown, update: unknown) => {
+      if (isGraphClaim(filter, update)) {
+        const modifiedCount = graphClaimed ? 0 : 1;
+        graphClaimed = true;
+        return { modifiedCount };
+      }
+      return { modifiedCount: 1 };
+    });
+
+    await Promise.all([
+      federatedProfileSync.syncOnProfileView('at1'),
+      federatedProfileSync.syncOnProfileView('at1'),
+      federatedProfileSync.syncOnProfileView('at1'),
+    ]);
+
+    await vi.waitFor(() => expect(atprotoFetchPosts).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(syncAtprotoProfileGraph).toHaveBeenCalledOnce());
+    expect(syncAtprotoProfileGraph).toHaveBeenCalledWith('did:plc:abc123', 'at1');
   });
 
   it('clears pending for an atproto actor once the backfill has been stamped', async () => {

--- a/packages/backend/src/connectors/federatedProfileSync.ts
+++ b/packages/backend/src/connectors/federatedProfileSync.ts
@@ -53,6 +53,12 @@ const FEDERATED_ACTOR_PROFILE_STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
 /** Max number of recent outbox posts to pull per background profile sync. */
 const OUTBOX_SYNC_LIMIT = 20;
 
+/** Minimum interval between costly atproto starter-pack/feed-reference syncs. */
+const ATPROTO_GRAPH_SYNC_MIN_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/** Expire abandoned graph-sync claims if a worker dies while the detached task runs. */
+const ATPROTO_GRAPH_SYNC_LOCK_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
 class FederatedProfileSync {
   /**
    * Entry point for the feed layer: an author feed was just served EMPTY on its
@@ -140,14 +146,7 @@ class FederatedProfileSync {
             // (no orphan): a re-resolved atproto actor carries `oxyUserId`; when it
             // does not yet, the next view (after the backfill stamps it) picks it up.
             if (ATPROTO_ENABLED && cachedActor.oxyUserId) {
-              const graphDid = cachedActor.uri;
-              const graphOwner = cachedActor.oxyUserId;
-              void syncAtprotoProfileGraph(graphDid, graphOwner).catch((err) => {
-                const message = err instanceof Error ? err.message : String(err);
-          logger.warn('[FedSync] atproto graph sync failed', {
-            error: message,
-          });
-              });
+              await this.syncAtprotoGraphIfDue(cachedActor);
             }
           }
           // Stamp the post-backfill time so `shouldReportPending` can clear. The
@@ -331,6 +330,74 @@ class FederatedProfileSync {
         logger.warn('[FedSync] background profile sync failed', {
           error: message,
         });
+      }
+    })();
+  }
+
+  /**
+   * Claim and run the expensive atproto profile-graph sync at most once per actor
+   * per cooldown window. The claim is stored in Mongo so concurrent public
+   * profile-feed requests (and multiple API tasks) cannot fan out duplicate
+   * starter-pack/member-resolution jobs before the previous one finishes.
+   */
+  private async syncAtprotoGraphIfDue(actor: IFederatedActor): Promise<void> {
+    if (!actor.oxyUserId || !actor.uri) return;
+
+    const now = new Date();
+    const cooldownCutoff = new Date(now.getTime() - ATPROTO_GRAPH_SYNC_MIN_INTERVAL_MS);
+    const staleLockCutoff = new Date(now.getTime() - ATPROTO_GRAPH_SYNC_LOCK_TTL_MS);
+
+    try {
+      const claim = await FederatedActor.updateOne(
+        {
+          _id: actor._id,
+          protocol: 'atproto',
+          oxyUserId: { $exists: true, $ne: null },
+          uri: actor.uri,
+          $and: [
+            {
+              $or: [
+                { lastAtprotoGraphSyncAt: { $exists: false } },
+                { lastAtprotoGraphSyncAt: { $lte: cooldownCutoff } },
+              ],
+            },
+            {
+              $or: [
+                { atprotoGraphSyncStartedAt: { $exists: false } },
+                { atprotoGraphSyncStartedAt: { $lte: staleLockCutoff } },
+              ],
+            },
+          ],
+        },
+        { $set: { atprotoGraphSyncStartedAt: now } },
+      );
+
+      if ((claim.modifiedCount ?? 0) < 1) {
+        logger.info('[FedSync] atproto graph sync skipped (cooldown/lock)', { acct: actor.acct });
+        return;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn('[FedSync] failed to claim atproto graph sync', { acct: actor.acct, error: message });
+      return;
+    }
+
+    const graphDid = actor.uri;
+    const graphOwner = actor.oxyUserId;
+    void (async () => {
+      try {
+        await syncAtprotoProfileGraph(graphDid, graphOwner);
+        await FederatedActor.updateOne(
+          { _id: actor._id, atprotoGraphSyncStartedAt: now },
+          { $set: { lastAtprotoGraphSyncAt: new Date() }, $unset: { atprotoGraphSyncStartedAt: '' } },
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn('[FedSync] atproto graph sync failed', { acct: actor.acct, error: message });
+        await FederatedActor.updateOne(
+          { _id: actor._id, atprotoGraphSyncStartedAt: now },
+          { $unset: { atprotoGraphSyncStartedAt: '' } },
+        );
       }
     })();
   }

--- a/packages/backend/src/models/FederatedActor.ts
+++ b/packages/backend/src/models/FederatedActor.ts
@@ -87,6 +87,10 @@ export interface IFederatedActor extends Document {
   oxyUserId?: string;
   lastFetchedAt?: Date;
   lastOutboxSyncAt?: Date;
+  /** Last completed atproto profile-graph sync (starter packs + feed references). */
+  lastAtprotoGraphSyncAt?: Date;
+  /** In-flight atproto profile-graph sync claim; expires if a worker dies mid-sync. */
+  atprotoGraphSyncStartedAt?: Date;
   outboxBackfill?: FederatedOutboxBackfillState;
   createdAt: Date;
   updatedAt: Date;
@@ -158,6 +162,8 @@ const FederatedActorSchema = new Schema<IFederatedActor>({
   oxyUserId: { type: String, index: { sparse: true } },
   lastFetchedAt: { type: Date },
   lastOutboxSyncAt: { type: Date },
+  lastAtprotoGraphSyncAt: { type: Date },
+  atprotoGraphSyncStartedAt: { type: Date },
   outboxBackfill: {
     status: { type: String, enum: ['pending', 'complete', 'unavailable', 'failed'] },
     outboxUrl: { type: String },
@@ -180,6 +186,8 @@ FederatedActorSchema.index({ domain: 1, username: 1 }, { unique: true });
 FederatedActorSchema.index({ lastFetchedAt: 1 }); // For refreshStaleActors() job queries
 FederatedActorSchema.index({ publicKeyId: 1 }, { sparse: true }); // For HTTP signature verification lookups
 FederatedActorSchema.index({ 'outboxBackfill.status': 1, 'outboxBackfill.lockedUntil': 1 });
+FederatedActorSchema.index({ protocol: 1, lastAtprotoGraphSyncAt: 1 });
+FederatedActorSchema.index({ protocol: 1, atprotoGraphSyncStartedAt: 1 });
 
 export const FederatedActor = mongoose.model<IFederatedActor>('FederatedActor', FederatedActorSchema);
 export default FederatedActor;


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated/profile-view requests from repeatedly launching expensive atproto profile-graph work (starter-pack/member resolution + feed reference mirroring) that could be abused to amplify outbound requests and Oxy user writes.

### Description
- Add persistent per-actor graph-sync state fields `lastAtprotoGraphSyncAt` and `atprotoGraphSyncStartedAt` to `FederatedActor` and add indexes to support cooldown/lock checks.
- Introduce a 24‑hour per-actor cooldown and a 30‑minute stale-lock TTL and implement `syncAtprotoGraphIfDue` which atomically claims a graph sync via a conditional `updateOne` before launching the detached `syncAtprotoProfileGraph` job.
- Route the atproto branch in `runInBackground` through the guarded helper so concurrent profile views cannot start duplicate graph syncs.
- Add a unit test in `connectors/federatedProfileSync.test.ts` that simulates concurrent profile views and asserts only one profile-graph sync is launched while the cheaper per-request backfills still run.

### Testing
- Ran `git diff --check` to validate the working tree and staged changes succeeded. 
- Added a unit test exercising concurrent profile-view behavior, but running `cd packages/backend && bun run test src/__tests__/connectors/federatedProfileSync.test.ts` was blocked in this environment because `vitest` is not available. 
- Attempted dependency install (`bun install --frozen-lockfile`) was blocked by registry HTTP 403 responses, so automated test execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ac7df93cc8323aeb9fba18400e56d)