### PR TITLE
fix(activitypub): bound inbound mention resolution

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/inboundMentionIngestion.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/inboundMentionIngestion.test.ts
@@ -314,4 +314,23 @@ describe('handleCreate — inbound @mention ingestion', () => {
     expect(primaryVariantText()).not.toContain('[mention:');
     expect(mocks.createMentionNotifications).not.toHaveBeenCalled();
   });
+
+  it('caps inbound Mention tag resolution and ignores non-http hrefs', async () => {
+    const actorMap: Record<string, string> = { [AUTHOR_URI]: AUTHOR_OXY_ID };
+    const tag = Array.from({ length: 30 }, (_, index) => {
+      const href = `${REMOTE}/users/mention-${index}`;
+      actorMap[href] = `oxy_mention_${index}`;
+      return { type: 'Mention', href, name: `@mention-${index}@remote.example` };
+    });
+    tag.unshift({ type: 'Mention', href: 'ftp://remote.example/users/ignored', name: '@ignored@remote.example' });
+    stubActors(actorMap);
+
+    await inboxProcessingService.processInboxActivity(createActivity('<p>many mentions</p>', tag), AUTHOR_URI);
+
+    expect(createdPost().mentions).toHaveLength(25);
+    expect(createdPost().mentions).toContain('oxy_mention_0');
+    expect(createdPost().mentions).toContain('oxy_mention_24');
+    expect(createdPost().mentions).not.toContain('oxy_mention_25');
+    expect(createdPost().mentions).not.toContain('oxy_ignored');
+  });
 });

--- a/packages/backend/src/__tests__/connectors/activitypub/inboundUpdateSecurity.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/inboundUpdateSecurity.test.ts
@@ -211,4 +211,22 @@ describe('handleUpdate — NoSQL-injection safety + ownership scope', () => {
 
     expect(mocks.postUpdateOne).not.toHaveBeenCalled();
   });
+
+  it('returns early for an Update whose target post is not stored locally', async () => {
+    mocks.postFindOne.mockReturnValue({ lean: vi.fn().mockResolvedValue(null) });
+
+    await inboxProcessingService.processInboxActivity(
+      updateActivity({
+        tag: Array.from({ length: 50 }, (_, index) => ({
+          type: 'Mention',
+          href: `https://remote.example/users/mention-${index}`,
+          name: `@mention-${index}@remote.example`,
+        })),
+      }),
+      ACTOR_URI,
+    );
+
+    expect(mocks.postUpdateOne).not.toHaveBeenCalled();
+    expect(mocks.actorFindOne).not.toHaveBeenCalled();
+  });
 });

--- a/packages/backend/src/connectors/activitypub/apMentions.ts
+++ b/packages/backend/src/connectors/activitypub/apMentions.ts
@@ -65,6 +65,9 @@ export interface ResolvedInboundMentions {
 
 /** Matches a whole `<a …>…</a>` anchor, capturing its `href`. Anchors never nest. */
 const MENTION_ANCHOR_REGEX = /<a\b[^>]*?\bhref="([^"]*)"[^>]*>.*?<\/a>/gis;
+const MAX_INBOUND_MENTION_TAGS = 25;
+const MAX_INBOUND_MENTION_HREF_LENGTH = 2048;
+const INBOUND_MENTION_RESOLUTION_CONCURRENCY = 4;
 
 /**
  * Canonicalize an actor/profile href for equality matching: drop the fragment and
@@ -131,9 +134,18 @@ export function extractMentionTags(object: Record<string, unknown>): InboundMent
     if (!entry || typeof entry !== 'object') continue;
     const record = entry as { type?: unknown; href?: unknown; name?: unknown };
     if (primaryApType(record.type as string | string[] | undefined) !== 'Mention') continue;
-    if (typeof record.href !== 'string' || record.href.trim().length === 0) continue;
+    if (tags.length >= MAX_INBOUND_MENTION_TAGS) break;
+    if (typeof record.href !== 'string') continue;
+    const href = record.href.trim();
+    if (href.length === 0 || href.length > MAX_INBOUND_MENTION_HREF_LENGTH) continue;
+    try {
+      const url = new URL(href);
+      if (url.protocol !== 'https:' && url.protocol !== 'http:') continue;
+    } catch {
+      continue;
+    }
     tags.push({
-      href: record.href.trim(),
+      href,
       name: typeof record.name === 'string' ? record.name.trim() : undefined,
     });
   }
@@ -194,25 +206,29 @@ export async function resolveInboundMentions(
   const ids = new Set<string>();
   const localIds = new Set<string>();
 
-  await Promise.all(
-    [...byHref.values()].map(async (tag) => {
-      try {
-        const resolved = await resolveMentionOxyId(tag.href);
-        if (!resolved) return;
-        ids.add(resolved.oxyUserId);
-        if (resolved.isLocal) localIds.add(resolved.oxyUserId);
-        // Map BOTH candidate anchor hrefs (actor URI + reconstructed profile URL)
-        // to this id so the content anchor matches regardless of which form the
-        // origin server used.
-        anchorMap.set(normalizeActorHref(tag.href), resolved.oxyUserId);
-        const profileHref = reconstructProfileHref(tag.name);
-        if (profileHref) anchorMap.set(normalizeActorHref(profileHref), resolved.oxyUserId);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        logger.warn(`[Federation] failed to resolve inbound mention ${tag.href}: ${message}`);
-      }
-    }),
-  );
+  const distinctTags = [...byHref.values()];
+  for (let index = 0; index < distinctTags.length; index += INBOUND_MENTION_RESOLUTION_CONCURRENCY) {
+    const batch = distinctTags.slice(index, index + INBOUND_MENTION_RESOLUTION_CONCURRENCY);
+    await Promise.all(
+      batch.map(async (tag) => {
+        try {
+          const resolved = await resolveMentionOxyId(tag.href);
+          if (!resolved) return;
+          ids.add(resolved.oxyUserId);
+          if (resolved.isLocal) localIds.add(resolved.oxyUserId);
+          // Map BOTH candidate anchor hrefs (actor URI + reconstructed profile URL)
+          // to this id so the content anchor matches regardless of which form the
+          // origin server used.
+          anchorMap.set(normalizeActorHref(tag.href), resolved.oxyUserId);
+          const profileHref = reconstructProfileHref(tag.name);
+          if (profileHref) anchorMap.set(normalizeActorHref(profileHref), resolved.oxyUserId);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(`[Federation] failed to resolve inbound mention ${tag.href}: ${message}`);
+        }
+      }),
+    );
+  }
 
   return { ids: [...ids], localIds: [...localIds], anchorMap };
 }

--- a/packages/backend/src/connectors/activitypub/inbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/inbox.service.ts
@@ -965,7 +965,11 @@ export class InboxProcessingService {
       }).lean<
         { _id: mongoose.Types.ObjectId; oxyUserId?: string | null; mentions?: unknown; parentPostId?: string | null } | null
       >();
-      const ownerOxyUserId = existingPost?.oxyUserId ?? (await actorService.getOrFetchActor(actorUri))?.oxyUserId ?? null;
+      if (!existingPost) {
+        logger.debug(`Skipping federated Update for unknown post: ${objectActivityId}`);
+        return;
+      }
+      const ownerOxyUserId = existingPost.oxyUserId ?? null;
 
       // Re-resolve the edited Note's @mentions the SAME way as fresh ingest so an
       // edit's mentions stay correct: each `Mention` tag → federated/local Oxy user


### PR DESCRIPTION
### Motivation
- Inbound ActivityPub `Mention` tags were extracted and resolved without limits, allowing a remote actor to trigger unbounded parallel actor fetches and downstream DB/Oxy work (DoS/availability risk). 
- The `Update(Note)` path also resolved mentions even when the target post did not exist, letting an attacker avoid needing a stored activityId.

### Description
- Cap extracted inbound mention tags to `MAX_INBOUND_MENTION_TAGS = 25` and limit href size to `MAX_INBOUND_MENTION_HREF_LENGTH = 2048`, rejecting non-`http(s)` hrefs in `extractMentionTags`.
- Replace unbounded `Promise.all()` resolution with batched resolution using `INBOUND_MENTION_RESOLUTION_CONCURRENCY = 4` so actor lookups run with bounded concurrency in `resolveInboundMentions`.
- Short-circuit inbound `Update(Note|Article)` processing and return early when the looked-up `existingPost` is `null`, preventing mention resolution/materialization for missing posts in `inbox.service`.
- Add regression tests covering capped Create mention ingestion, non-http href handling, and early return for Update of non-stored posts.

### Testing
- Ran targeted unit tests: `bunx vitest run packages/backend/src/__tests__/connectors/activitypub/inboundMentionIngestion.test.ts packages/backend/src/__tests__/connectors/activitypub/inboundUpdateSecurity.test.ts --reporter=verbose`, both test files passed.
- Ran package tests: `cd packages/backend && bun run test -- src/__tests__/connectors/activitypub/inboundMentionIngestion.test.ts src/__tests__/connectors/activitypub/inboundUpdateSecurity.test.ts`, which passed.
- Performed `git diff --check` with no issues; repository-wide `bun run lint` was attempted but blocked by an existing `@mention/shared-types` ESLint v9 configuration issue unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58d1c4b3808323831ab76ddc2400cc)