### PR TITLE
fix(backend): enforce ACLs for federated orphan hydration

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -408,6 +408,55 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     expect(hydrated.user?.instance).toBe('bsky.brid.gy');
   });
 
+  it('drops non-public orphan federated posts for anonymous/global hydration', async () => {
+    service = new PostHydrationService();
+
+    const orphanRow = {
+      ...originalRow(),
+      oxyUserId: null,
+      authorship: [],
+      status: 'published',
+      visibility: 'followers_only',
+      federation: { activityId: 'https://remote.example/users/alice/statuses/secret' },
+    };
+    postFind.mockReturnValue([]);
+    getUsersByIds.mockResolvedValue([]);
+
+    const hydrated = await service.hydratePosts([orphanRow], {
+      viewerId: undefined,
+      maxDepth: 0,
+      includeLinkMetadata: false,
+      includeFullMetadata: false,
+    });
+
+    expect(hydrated).toEqual([]);
+  });
+
+  it('does not embed a non-public orphan federated boost original for anonymous/global hydration', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.some((v) => String(v) === ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          oxyUserId: null,
+          authorship: [],
+          visibility: 'followers_only',
+          federation: { activityId: 'https://remote.example/users/alice/statuses/secret' },
+        }];
+      }
+      return [];
+    });
+    getUsersByIds.mockResolvedValue([makeOxyUser(BOOSTER_OXY_ID, 'booster', 'Booster')]);
+
+    const [hydrated] = await hydrateBoost(undefined);
+
+    expect(hydrated, 'public boost should still hydrate').toBeTruthy();
+    expect(hydrated.boost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
+  });
+
   it('renders the Oxy name.displayName for a resolved federated boost original', async () => {
     service = new PostHydrationService();
 

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1350,46 +1350,45 @@ export class PostHydrationService {
 
     const authorship = normalizeAuthorship(post.authorship as PostAuthorshipEntry[] | undefined);
 
-    // Privacy checks only apply to local users (federated posts are public by definition).
     // Hydration can be used for globally-broadcast DTOs and for nested quote/boost
     // references fetched by id, so enforce post-level ACL here instead of relying
-    // on callers to pre-filter every referenced post.
-    if (!isFederatedPost) {
-      const viewerEntry = getViewerEntry(authorship, viewerContext.viewerId);
-      // Pending collaborators may PREVIEW the post they were invited to (so the
-      // collab-invite UI can render the actual content before they accept),
-      // alongside the owner and accepted collaborators. All three bypass the
-      // unpublished/private/followers-only/restricted ACL checks below.
-      const viewerOwnsPost =
-        viewerContext.viewerId === authorId ||
-        (viewerEntry?.role === 'collaborator' &&
-          (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending'));
+    // on callers to pre-filter every referenced post. This includes federated
+    // posts: ActivityPub objects without Public addressing are stored as
+    // followers-only, and legacy federated orphans can otherwise be reached by id.
+    const viewerEntry = getViewerEntry(authorship, viewerContext.viewerId);
+    // Pending collaborators may PREVIEW the post they were invited to (so the
+    // collab-invite UI can render the actual content before they accept),
+    // alongside the owner and accepted collaborators. All three bypass the
+    // unpublished/private/followers-only/restricted ACL checks below.
+    const viewerOwnsPost =
+      viewerContext.viewerId === authorId ||
+      (viewerEntry?.role === 'collaborator' &&
+        (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending'));
 
-      if ((post.status ?? 'published') !== 'published' && !viewerOwnsPost) {
+    if ((post.status ?? 'published') !== 'published' && !viewerOwnsPost) {
+      return null;
+    }
+
+    const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility;
+    if (visibility === PostVisibility.PRIVATE && !viewerOwnsPost) {
+      return null;
+    }
+
+    if (visibility === PostVisibility.FOLLOWERS_ONLY && !viewerOwnsPost) {
+      if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
         return null;
       }
+    }
 
-      const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility;
-      if (visibility === PostVisibility.PRIVATE && !viewerOwnsPost) {
+    if (viewerContext.restrictedIds.has(authorId) && !viewerOwnsPost) {
+      return null;
+    }
+
+    // Filter posts from private/followers_only profiles. Own posts are always
+    // visible; public profiles pass through.
+    if (viewerContext.privateProfileIds.has(authorId) && !viewerOwnsPost) {
+      if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
         return null;
-      }
-
-      if (visibility === PostVisibility.FOLLOWERS_ONLY && !viewerOwnsPost) {
-        if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
-          return null;
-        }
-      }
-
-      if (viewerContext.restrictedIds.has(authorId) && !viewerOwnsPost) {
-        return null;
-      }
-
-      // Filter posts from private/followers_only profiles. Own posts are always
-      // visible; public profiles pass through.
-      if (viewerContext.privateProfileIds.has(authorId) && !viewerOwnsPost) {
-        if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
-          return null;
-        }
       }
     }
 
@@ -1460,7 +1459,6 @@ export class PostHydrationService {
       content.text = finalText;
     }
 
-    const viewerEntry = getViewerEntry(authorship, viewerContext.viewerId);
     const includeAuthorship = viewerEntry != null;
 
     return {


### PR DESCRIPTION
### Motivation
- A recent change allowed legacy federated "orphan" posts (null `oxyUserId` with `federation.activityId`) to be hydrated with a synthetic author but skipped post-level ACL checks, which can leak non-public/followers-only or draft federated content via anonymous callers (notably the public OG `/p/:id` web-shell path). 
- ActivityPub addressing is not always public (mapped to `followers_only` when not explicitly Public), so federated posts must still respect visibility and status constraints when hydrated without a viewer. 
- The fix restores the intended privacy boundary by enforcing the same status/visibility/profile/restricted checks during hydration for federated orphans as for native posts.

### Description
- Apply post-level ACL enforcement inside `PostHydrationService` for all posts (including federated orphans) by computing `viewerEntry`/`viewerOwnsPost` and running `status`, `visibility` (`private`/`followers_only`), restricted-user, and private-profile gates before producing a hydrated DTO. 
- Preserve the degraded-author rendering path for public federated orphans (synthetic/degraded author still used when the post passes ACLs), and ensure the user handle never emits a raw id (ghost-handle rule). 
- Add regression tests in `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` that assert anonymous/global hydration drops a `followers_only` orphan and that a boost does not embed a non-public orphan original for an anonymous viewer. 

### Testing
- Added unit tests: `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` (two new cases for non-public orphan hydration/boost embedding) and updated the existing boost determinism tests. 
- Ran the boost test file locally with `bun test packages/backend/src/__tests__/services/postHydrationBoost.test.ts`; an initial run surfaced a duplicate-variable error which was corrected, after which running the test suite was blocked by missing dependencies. 
- Attempted `bun install --frozen-lockfile --ignore-scripts` but the environment could not fetch required packages (registry 403), so full automated test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54db78dad48323b8535ea50fceb698)