### PR TITLE
Guard link preview warming against SSRF and amplification

### DIFF
--- a/packages/backend/src/__tests__/utils/linkPreviewWarm.test.ts
+++ b/packages/backend/src/__tests__/utils/linkPreviewWarm.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  assertSafePublicUrl: vi.fn(),
+  getLinkPreview: vi.fn(),
+}));
+
+vi.mock('../../utils/ssrfGuard', () => ({
+  assertSafePublicUrl: mocks.assertSafePublicUrl,
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    getLinkPreview: mocks.getLinkPreview,
+  }),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { debug: vi.fn() },
+}));
+
+import { warmLinkPreviewForText } from '../../utils/linkPreviewWarm';
+
+describe('warmLinkPreviewForText', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.assertSafePublicUrl.mockResolvedValue({ ok: true, ip: '93.184.216.34', family: 4 });
+    mocks.getLinkPreview.mockResolvedValue({});
+  });
+
+  it('validates extracted URLs before warming through Oxy', async () => {
+    await warmLinkPreviewForText('Read https://example.com/post');
+
+    expect(mocks.assertSafePublicUrl).toHaveBeenCalledWith('https://example.com/post');
+    expect(mocks.getLinkPreview).toHaveBeenCalledWith('https://example.com/post', { wait: true });
+  });
+
+  it('does not warm URLs rejected by the SSRF guard', async () => {
+    mocks.assertSafePublicUrl.mockResolvedValue({ ok: false, reason: 'literal ip in blocked range' });
+
+    await warmLinkPreviewForText('metadata http://169.254.169.254/latest/meta-data/');
+
+    expect(mocks.assertSafePublicUrl).toHaveBeenCalledWith('http://169.254.169.254/latest/meta-data/');
+    expect(mocks.getLinkPreview).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/services/PostCreationService.ts
+++ b/packages/backend/src/services/PostCreationService.ts
@@ -299,14 +299,16 @@ class PostCreationService {
       await this.emitMtnRecord(post);
     }
 
+    const shouldWarmLinkPreview = isPublished && params.federation == null;
+
     if (isScheduled || params.skipNotifications) {
-      if (isPublished) {
+      if (shouldWarmLinkPreview) {
         warmLinkPreviewForTextDetached(content.text);
       }
       return post;
     }
 
-    if (isPublished) {
+    if (shouldWarmLinkPreview) {
       warmLinkPreviewForTextDetached(content.text);
     }
 

--- a/packages/backend/src/utils/linkPreviewWarm.ts
+++ b/packages/backend/src/utils/linkPreviewWarm.ts
@@ -1,6 +1,25 @@
 import { getServiceOxyClient } from './oxyHelpers';
 import { extractFirstUrl } from './extractFirstUrl';
 import { logger } from './logger';
+import { assertSafePublicUrl } from './ssrfGuard';
+
+const LINK_PREVIEW_WARM_TIMEOUT_MS = 3000;
+const MAX_CONCURRENT_LINK_PREVIEW_WARMS = 4;
+let activeLinkPreviewWarms = 0;
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error('link preview warm timed out')), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 /**
  * Ask Oxy to resolve (and cache) the first URL in post text synchronously.
@@ -11,13 +30,30 @@ export async function warmLinkPreviewForText(text: string | undefined): Promise<
   if (!text || typeof text !== 'string') return;
   const url = extractFirstUrl(text);
   if (!url) return;
+  if (activeLinkPreviewWarms >= MAX_CONCURRENT_LINK_PREVIEW_WARMS) {
+    logger.debug('[LinkPreviewWarm] Skipping warm because concurrency limit is reached', { url });
+    return;
+  }
+
+  activeLinkPreviewWarms += 1;
   try {
-    await getServiceOxyClient().getLinkPreview(url, { wait: true });
+    const safety = await assertSafePublicUrl(url);
+    if (!safety.ok) {
+      logger.debug('[LinkPreviewWarm] Skipping unsafe preview URL', { url, reason: safety.reason });
+      return;
+    }
+
+    await withTimeout(
+      getServiceOxyClient().getLinkPreview(url, { wait: true }),
+      LINK_PREVIEW_WARM_TIMEOUT_MS,
+    );
   } catch (error) {
     logger.debug('[LinkPreviewWarm] Failed to warm preview', {
       url,
       reason: error instanceof Error ? error.message : 'unknown',
     });
+  } finally {
+    activeLinkPreviewWarms = Math.max(0, activeLinkPreviewWarms - 1);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Close an SSRF/cost amplification gap where extracted URLs from post text were sent straight to the service `getLinkPreview(..., { wait: true })` with no local host/IP/port validation, timeout, or concurrency control.
- Prevent federated or attacker-controlled content processed via the ActivityPub inbox from triggering immediate outbound URL unfurls under the service credential.

### Description
- Validate extracted URLs with the existing SSRF guard by calling `assertSafePublicUrl()` before delegating to the Oxy link-preview resolver in `packages/backend/src/utils/linkPreviewWarm.ts`.
- Add a bounded synchronous warm: a `withTimeout()` helper (3s `LINK_PREVIEW_WARM_TIMEOUT_MS`) and a simple concurrency cap (`MAX_CONCURRENT_LINK_PREVIEW_WARMS = 4`) with an `activeLinkPreviewWarms` counter to limit blocking and amplification.
- Ensure active warm slots are released in a `finally` block so counters never leak.
- Stop eager post-create warming for federated imports by requiring `params.federation == null` before calling `warmLinkPreviewForTextDetached()` in `packages/backend/src/services/PostCreationService.ts` so only local publishes perform eager warming.
- Add unit tests at `packages/backend/src/__tests__/utils/linkPreviewWarm.test.ts` that assert the SSRF guard is called and that unsafe URLs (e.g. metadata IP) are not sent to the Oxy client.

### Testing
- Ran targeted unit tests with `cd packages/backend && bun run test src/__tests__/utils/linkPreviewWarm.test.ts src/__tests__/utils/extractFirstUrl.test.ts`, and both test files passed (all tests green).
- Attempted a full backend build with `cd packages/backend && bun run build`, which failed due to a pre-existing `ioredis` type mismatch in unrelated queue files; this build failure is unrelated to the link-preview changes.
- New tests exercise that `warmLinkPreviewForText()` calls `assertSafePublicUrl()` and only calls the service `getLinkPreview()` when the guard returns `ok: true`, and also verify that unsafe URLs are skipped (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50d5906698832387af63b99b70803d)