### PR TITLE
Canonicalize base64 intent-media MIME types to reject parameterized SVG

### DIFF
--- a/packages/backend/src/__tests__/routes/intentMedia.test.ts
+++ b/packages/backend/src/__tests__/routes/intentMedia.test.ts
@@ -152,6 +152,31 @@ describe('POST /posts/intent-media', () => {
     expect(uploadServiceUserMediaMock).not.toHaveBeenCalled();
   });
 
+
+  it('rejects base64 SVG when mimeType has parameters', async () => {
+    const svg = Buffer.from('<svg><script>alert(1)</script></svg>');
+    const res = await request(app)
+      .post('/')
+      .send({ base64: svg.toString('base64'), mimeType: 'image/svg+xml;charset=utf-8' });
+
+    expect(res.status).toBe(400);
+    expect(assetUploadMock).not.toHaveBeenCalled();
+    expect(uploadServiceUserMediaMock).not.toHaveBeenCalled();
+  });
+
+  it('canonicalizes base64 mimeType parameters before upload', async () => {
+    const png = Buffer.from('PNG!');
+    const res = await request(app)
+      .post('/')
+      .send({ base64: png.toString('base64'), mimeType: 'IMAGE/PNG; charset=binary' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.contentType).toBe('image/png');
+    expect(assetUploadMock).toHaveBeenCalledTimes(1);
+    const uploadedFile = assetUploadMock.mock.calls[0]?.[0] as File | undefined;
+    expect(uploadedFile?.type).toBe('image/png');
+  });
+
   it('strips path traversal from filename on base64 upload', async () => {
     const png = Buffer.from('PNG!');
     const res = await request(app)

--- a/packages/backend/src/routes/intentMedia.ts
+++ b/packages/backend/src/routes/intentMedia.ts
@@ -12,6 +12,7 @@ import {
   SsrfRejection,
   UpstreamResult,
   contentTypeFamily,
+  contentTypeFamilyFromString,
   fetchUpstreamFollowingRedirects,
 } from '../utils/safeUpstreamFetch';
 import { MEDIA_REJECTED_TYPES } from '../services/mediaCache/mediaTypes';
@@ -303,7 +304,7 @@ router.post('/', intentMediaRateLimiter, async (req: AuthRequest, res: Response)
         res.status(HTTP_STATUS.PAYLOAD_TOO_LARGE).json({ error: 'Media is too large' });
         return;
       }
-      const mimeType = typeof req.body?.mimeType === 'string' ? req.body.mimeType.trim().toLowerCase() : '';
+      const mimeType = contentTypeFamilyFromString(typeof req.body?.mimeType === 'string' ? req.body.mimeType : undefined);
       if (!mimeType || !isComposerMediaType(mimeType)) {
         res.status(HTTP_STATUS.BAD_REQUEST).json({ error: 'Valid "mimeType" (image/* or video/*) is required with base64' });
         return;


### PR DESCRIPTION
### Motivation
- Fix a security regression where base64 uploads could bypass the SVG denylist by supplying parameterized MIME types like `image/svg+xml;charset=utf-8`, enabling storage of active SVG content and potential stored XSS.

### Description
- Normalize caller-supplied MIME types on the base64 upload path by using `contentTypeFamilyFromString(...)` (strips parameters and lowercases) before running the existing media allow/deny checks in `packages/backend/src/routes/intentMedia.ts`.
- Ensure the `contentType` used for upload is the canonical family so the SVG denylist (`image/svg+xml`) and prefix checks apply uniformly across remote-URL and base64 paths.
- Add regression tests in `packages/backend/src/__tests__/routes/intentMedia.test.ts` that assert parameterized SVGs are rejected and that parameterized image types are canonicalized and uploaded correctly.

### Testing
- Ran the backend intent-media tests with `bun --cwd packages/backend test src/__tests__/routes/intentMedia.test.ts --reporter verbose`, and all tests passed (9/9).
- Added the two regression tests verifying rejection of `image/svg+xml;charset=utf-8` and canonicalization of `IMAGE/PNG; charset=binary`, both succeeded in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50ab3fad3483238ceb75fcf9aeb5bc)