### PR TITLE
fix(feed): enforce ACLs for federated hydrated posts

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationBoost.test.ts
@@ -398,4 +398,31 @@ describe('PostHydrationService — boost original embedding is deterministic', (
     expect(hydrated.originalPost).toBeNull();
   });
 
+  it('does not treat federated followers-only originals as public for anonymous hydration', async () => {
+    service = new PostHydrationService();
+
+    postFind.mockImplementation((query: Record<string, unknown> | undefined) => {
+      const idIn = (query?._id as { $in?: unknown[] } | undefined)?.$in;
+      if (Array.isArray(idIn) && idIn.map(String).includes(ORIGINAL_ID)) {
+        return [{
+          ...originalRow(),
+          visibility: 'followers_only',
+          status: 'published',
+          federation: {
+            activityId: 'https://remote.example/users/author/statuses/private-parent',
+            actorUri: 'https://remote.example/users/author',
+          },
+          content: { text: 'federated followers-only secret' },
+        }];
+      }
+      return [];
+    });
+
+    const [hydrated] = await hydrateBoost(undefined);
+
+    expect(hydrated, 'public boost should still hydrate').toBeTruthy();
+    expect(hydrated.boost).toBeNull();
+    expect(hydrated.originalPost).toBeNull();
+  });
+
 });

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1206,8 +1206,6 @@ export class PostHydrationService {
     const postId = this.resolveId(post);
     if (!postId) return null;
 
-    const isFederatedPost = !!post?.federation;
-
     // Every post — federated or native — now carries a mandatory `oxyUserId`:
     // the federated-actor → Oxy user link is enforced at ingest, so orphaned
     // federated posts no longer exist. A post with no author is a genuine data
@@ -1218,46 +1216,45 @@ export class PostHydrationService {
 
     const authorship = normalizeAuthorship(post.authorship as PostAuthorshipEntry[] | undefined);
 
-    // Privacy checks only apply to local users (federated posts are public by definition).
     // Hydration can be used for globally-broadcast DTOs and for nested quote/boost
     // references fetched by id, so enforce post-level ACL here instead of relying
-    // on callers to pre-filter every referenced post.
-    if (!isFederatedPost) {
-      const viewerEntry = getViewerEntry(authorship, viewerContext.viewerId);
-      // Pending collaborators may PREVIEW the post they were invited to (so the
-      // collab-invite UI can render the actual content before they accept),
-      // alongside the owner and accepted collaborators. All three bypass the
-      // unpublished/private/followers-only/restricted ACL checks below.
-      const viewerOwnsPost =
-        viewerContext.viewerId === authorId ||
-        (viewerEntry?.role === 'collaborator' &&
-          (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending'));
+    // on callers to pre-filter every referenced post. Federated posts are not
+    // necessarily public: ActivityPub objects without Public addressing are stored
+    // as followers_only and must obey the same visibility checks.
+    const viewerEntry = getViewerEntry(authorship, viewerContext.viewerId);
+    // Pending collaborators may PREVIEW the post they were invited to (so the
+    // collab-invite UI can render the actual content before they accept),
+    // alongside the owner and accepted collaborators. All three bypass the
+    // unpublished/private/followers-only/restricted ACL checks below.
+    const viewerOwnsPost =
+      viewerContext.viewerId === authorId ||
+      (viewerEntry?.role === 'collaborator' &&
+        (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending'));
 
-      if ((post.status ?? 'published') !== 'published' && !viewerOwnsPost) {
+    if ((post.status ?? 'published') !== 'published' && !viewerOwnsPost) {
+      return null;
+    }
+
+    const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility;
+    if (visibility === PostVisibility.PRIVATE && !viewerOwnsPost) {
+      return null;
+    }
+
+    if (visibility === PostVisibility.FOLLOWERS_ONLY && !viewerOwnsPost) {
+      if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
         return null;
       }
+    }
 
-      const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility;
-      if (visibility === PostVisibility.PRIVATE && !viewerOwnsPost) {
+    if (viewerContext.restrictedIds.has(authorId) && !viewerOwnsPost) {
+      return null;
+    }
+
+    // Filter posts from private/followers_only profiles. Own posts are always
+    // visible; public profiles pass through.
+    if (viewerContext.privateProfileIds.has(authorId) && !viewerOwnsPost) {
+      if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
         return null;
-      }
-
-      if (visibility === PostVisibility.FOLLOWERS_ONLY && !viewerOwnsPost) {
-        if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
-          return null;
-        }
-      }
-
-      if (viewerContext.restrictedIds.has(authorId) && !viewerOwnsPost) {
-        return null;
-      }
-
-      // Filter posts from private/followers_only profiles. Own posts are always
-      // visible; public profiles pass through.
-      if (viewerContext.privateProfileIds.has(authorId) && !viewerOwnsPost) {
-        if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
-          return null;
-        }
       }
     }
 
@@ -1321,7 +1318,6 @@ export class PostHydrationService {
       content.text = finalText;
     }
 
-    const viewerEntry = getViewerEntry(authorship, viewerContext.viewerId);
     const includeAuthorship = viewerEntry != null;
 
     return {


### PR DESCRIPTION
### Motivation
- Prevent disclosure where a public federated reply could cause a non-public federated parent to be included in public feed reply-context because hydration previously skipped ACLs for any post with a `federation` subdoc.

### Description
- Apply post-level ACLs (status, `visibility` including `FOLLOWERS_ONLY`, `PRIVATE`, restricted and private-profile checks) inside `PostHydrationService.buildPostSummary` for all posts instead of skipping the checks when `post.federation` is present, preserving collaborator preview behavior via the existing collaborator check logic.
- Add a regression unit test to `packages/backend/src/__tests__/services/postHydrationBoost.test.ts` that verifies an anonymous/global-hydration path does not embed a federated `followers_only` original into a public boost.
- Key files changed: `packages/backend/src/services/PostHydrationService.ts` and `packages/backend/src/__tests__/services/postHydrationBoost.test.ts`.

### Testing
- Ran the targeted unit test: `cd packages/backend && bun run test src/__tests__/services/postHydrationBoost.test.ts`, and the test file passed (all tests in that suite passed).
- Attempted full backend build: `bun run build:backend` failed due to pre-existing duplicate `ioredis` type instances between workspace and package `node_modules` (type resolution issue), unrelated to the ACL logic change.
- Ran lint checks: `bun run lint` (repo-level) and backend lint invocations surfaced existing repo lint/config problems (shared-types missing ESLint v9 flat config and frontend warnings); these are pre-existing and not caused by this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a506e6ff8308323b82be1fb80ed2b51)