### PR TITLE
fix(mcp): restrict dynamic OAuth client redirects

### DIFF
--- a/packages/backend/src/__tests__/mcp/mcpOAuthRegister.test.ts
+++ b/packages/backend/src/__tests__/mcp/mcpOAuthRegister.test.ts
@@ -105,6 +105,16 @@ describe('POST /mcp/oauth/register (RFC 7591 DCR)', () => {
     expect(res.body.error).toBe('invalid_redirect_uri');
     expect(mocks.registeredClientCreate).not.toHaveBeenCalled();
   });
+
+  it('rejects an arbitrary HTTPS redirect_uri that is not a trusted MCP callback', async () => {
+    const res = await request(app)
+      .post('/mcp/oauth/register')
+      .send({ redirect_uris: ['https://attacker.example/oauth/callback'] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_redirect_uri');
+    expect(res.body.error_description).toContain('trusted MCP client callback');
+    expect(mocks.registeredClientCreate).not.toHaveBeenCalled();
+  });
 });
 
 describe('authorize honours a dynamically-registered client', () => {
@@ -114,7 +124,7 @@ describe('authorize honours a dynamically-registered client', () => {
     vi.clearAllMocks();
   });
 
-  it('redirects to consent when the client + redirect_uri come from Mongo', async () => {
+  it('redirects to consent when the client + redirect_uri come from Mongo and match a trusted callback', async () => {
     const dynamicRedirect = 'https://claude.ai/api/mcp/auth_callback';
     mocks.registeredClientFindOne.mockReturnValue({
       lean: () => Promise.resolve({
@@ -137,5 +147,28 @@ describe('authorize honours a dynamically-registered client', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('/oauth/mcp/authorize');
     expect(res.headers.location).toContain('client_id=mcp-dcr-abc');
+  });
+
+  it('rejects a stored dynamic client whose redirect_uri is not trusted', async () => {
+    const attackerRedirect = 'https://attacker.example/oauth/callback';
+    mocks.registeredClientFindOne.mockReturnValue({
+      lean: () => Promise.resolve({
+        clientId: 'mcp-dcr-evil',
+        label: 'Evil Client',
+        redirectUris: [attackerRedirect],
+      }),
+    });
+
+    const res = await request(app).get('/mcp/oauth/authorize').query({
+      response_type: 'code',
+      client_id: 'mcp-dcr-evil',
+      redirect_uri: attackerRedirect,
+      code_challenge: 'a'.repeat(43),
+      code_challenge_method: 'S256',
+      scope: 'mcp:read',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_client');
   });
 });

--- a/packages/backend/src/mcp/config/mcpClients.ts
+++ b/packages/backend/src/mcp/config/mcpClients.ts
@@ -11,9 +11,10 @@
  *     configurable per client via env (comma-separated) so a new first-party
  *     callback can be added without a code change.
  *  2. DYNAMICALLY-registered clients (RFC 7591) persisted in Mongo as
- *     `McpRegisteredClient` — created by `POST /mcp/oauth/register`. Clients
- *     that refuse to use a pre-shared `client_id` (Claude) register themselves
- *     this way. Use {@link getMcpClientAsync} to resolve a client id against
+ *     `McpRegisteredClient` — created by `POST /mcp/oauth/register`. Dynamic
+ *     registration is limited to the trusted first-party redirect URIs below;
+ *     arbitrary HTTPS callbacks must never become OAuth clients for account
+ *     API tokens. Use {@link getMcpClientAsync} to resolve a client id against
  *     BOTH sources; the sync {@link getMcpClient} only sees static clients.
  */
 import { McpRegisteredClient } from '../models/McpRegisteredClient';
@@ -58,6 +59,17 @@ const CLIENTS: Record<string, McpClient> = {
 };
 
 /**
+ * Dynamic registration is public for MCP compatibility, so it must not create
+ * trust for arbitrary web origins. Only callbacks that are already trusted by a
+ * first-party static client may be registered dynamically.
+ */
+export function areTrustedDynamicRedirectUris(redirectUris: string[]): boolean {
+  if (redirectUris.length === 0) return false;
+  const trustedRedirects = new Set(Object.values(CLIENTS).flatMap((client) => client.redirectUris));
+  return redirectUris.every((uri) => trustedRedirects.has(uri));
+}
+
+/**
  * Look up a STATIC client by id; returns `undefined` for unknown clients. Does
  * NOT see dynamically-registered clients — use {@link getMcpClientAsync} for a
  * lookup that covers both static config and the `McpRegisteredClient` store.
@@ -80,7 +92,7 @@ export async function getMcpClientAsync(
   if (staticClient) return staticClient;
 
   const registered = await McpRegisteredClient.findOne({ clientId }).lean();
-  if (!registered) return undefined;
+  if (!registered || !areTrustedDynamicRedirectUris(registered.redirectUris)) return undefined;
   return {
     clientId: registered.clientId,
     label: registered.label,

--- a/packages/backend/src/mcp/routes/mcpOAuth.routes.ts
+++ b/packages/backend/src/mcp/routes/mcpOAuth.routes.ts
@@ -5,7 +5,7 @@ import crypto from 'crypto';
 import { McpAuthCode } from '../models/McpAuthCode';
 import { McpConnection } from '../models/McpConnection';
 import { McpRegisteredClient } from '../models/McpRegisteredClient';
-import { getMcpClientAsync, isAllowedRedirectUri } from '../config/mcpClients';
+import { areTrustedDynamicRedirectUris, getMcpClientAsync, isAllowedRedirectUri } from '../config/mcpClients';
 import {
   MCP_ACCESS_TOKEN_TTL_SECONDS,
   MCP_AUTH_CODE_TTL_SECONDS,
@@ -91,9 +91,10 @@ export function createMcpOAuthRoutes(oxy: OxyServices): Router {
   });
 
   // --- Dynamic client registration (RFC 7591) ---
-  // Public clients only: no secret is issued, token_endpoint_auth_method is
-  // `none`, and PKCE + the exact redirect_uri allowlist below carry the
-  // security. redirect_uris MUST be HTTPS.
+  // Public clients only: no secret is issued and token_endpoint_auth_method is
+  // `none`. Because these tokens authenticate to Mention APIs, public DCR does
+  // NOT establish new trust: requested callbacks must already match a trusted
+  // first-party redirect URI from the static MCP client config.
   router.post('/mcp/oauth/register', async (req: Request, res: Response) => {
     try {
       const rawRedirects = req.body?.redirect_uris;
@@ -119,6 +120,13 @@ export function createMcpOAuthRoutes(oxy: OxyServices): Router {
         return res.status(400).json({
           error: 'invalid_redirect_uri',
           error_description: 'All redirect_uris must be valid HTTPS URLs',
+        });
+      }
+
+      if (!areTrustedDynamicRedirectUris(redirectUris)) {
+        return res.status(400).json({
+          error: 'invalid_redirect_uri',
+          error_description: 'redirect_uris must match a trusted MCP client callback',
         });
       }
 


### PR DESCRIPTION
### Motivation

- Prevent public RFC 7591 dynamic client registration from creating arbitrary trusted MCP OAuth clients that would allow attacker-controlled HTTPS callbacks to receive account-level access and refresh tokens after user consent. 
- Preserve compatibility with MCP clients that require dynamic registration while restoring a narrow trusted-client policy so backend APIs are not exposed to attacker-registered callbacks.

### Description

- Add `areTrustedDynamicRedirectUris(redirectUris: string[])` in `packages/backend/src/mcp/config/mcpClients.ts` to assert that requested redirect URIs must match the existing static first-party client redirect allowlist. 
- Enforce the trust check in the DCR endpoint `POST /mcp/oauth/register` in `packages/backend/src/mcp/routes/mcpOAuth.routes.ts` and return a 400 when arbitrary HTTPS callbacks are requested. 
- Harden dynamic-client resolution by making `getMcpClientAsync` ignore stored `McpRegisteredClient` documents whose redirect URIs are no longer (or never were) trusted. 
- Add regression tests in `packages/backend/src/__tests__/mcp/mcpOAuthRegister.test.ts` covering rejection of arbitrary HTTPS registrations and rejection of stored dynamic clients whose redirects are untrusted while preserving valid trusted-client flows.

### Testing

- Ran the MCP OAuth unit tests: `bun --cwd packages/backend vitest run src/__tests__/mcp/mcpOAuthRegister.test.ts src/__tests__/mcp/mcpOAuthToken.test.ts`, and all tests passed (17 tests, 17 passed). 
- Ran `git diff --check` locally to ensure no whitespace/format issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ce25c3094832387bd3d25367dabc8)