### PR TITLE
fix(mcp): enforce MCP OAuth scopes for API and tools

### DIFF
--- a/packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts
+++ b/packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts
@@ -1,0 +1,72 @@
+import crypto from 'crypto';
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OxyServices } from '@oxyhq/core';
+
+process.env.MENTION_MCP_JWT_SECRET = 'test-mcp-secret';
+
+vi.mock('../../mcp/services/mcpRevocationService', () => ({
+  isRevoked: vi.fn().mockResolvedValue(false),
+}));
+
+import { createRequireMcpOrOxyAuth } from '../../mcp/middleware/mcpAuth';
+import { signAccessToken } from '../../mcp/services/mcpTokenService';
+
+function token(scopes: string[]): string {
+  return signAccessToken({
+    oxyUserId: 'user-1',
+    clientId: 'test-client',
+    scopes,
+    jti: crypto.randomUUID(),
+  });
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  const fakeOxy = {
+    auth: () => (_req: express.Request, res: express.Response) => res.status(401).json({ error: 'oxy_required' }),
+  } as unknown as OxyServices;
+  app.use(createRequireMcpOrOxyAuth(fakeOxy));
+  app.get('/resource', (_req, res) => res.json({ ok: true }));
+  app.post('/resource', (_req, res) => res.status(201).json({ ok: true }));
+  return app;
+}
+
+describe('createRequireMcpOrOxyAuth MCP scope enforcement', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows read-scoped MCP tokens on safe read requests', async () => {
+    const res = await request(app).get('/resource').set('Authorization', `Bearer ${token(['mcp:read'])}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('rejects read-only MCP tokens on mutating requests', async () => {
+    const res = await request(app).post('/resource').set('Authorization', `Bearer ${token(['mcp:read'])}`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('insufficient_scope');
+    expect(res.body.required_scope).toBe('mcp:write');
+  });
+
+  it('rejects offline_access-only MCP tokens on mutating requests', async () => {
+    const res = await request(app).post('/resource').set('Authorization', `Bearer ${token(['offline_access'])}`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('insufficient_scope');
+  });
+
+  it('allows write-scoped MCP tokens on mutating requests', async () => {
+    const res = await request(app).post('/resource').set('Authorization', `Bearer ${token(['mcp:read', 'mcp:write'])}`).send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts
+++ b/packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts
@@ -4,7 +4,7 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { OxyServices } from '@oxyhq/core';
 
-process.env.MENTION_MCP_JWT_SECRET = 'test-mcp-secret';
+process.env.MENTION_MCP_JWT_SECRET = 'test-mcp-secret-that-is-at-least-32-bytes';
 
 vi.mock('../../mcp/services/mcpRevocationService', () => ({
   isRevoked: vi.fn().mockResolvedValue(false),

--- a/packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts
+++ b/packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts
@@ -10,6 +10,18 @@ vi.mock('../../mcp/services/mcpRevocationService', () => ({
   isRevoked: vi.fn().mockResolvedValue(false),
 }));
 
+// `resolveMcpUser` reads the durable connection row before it trusts a token, so
+// without this the middleware waits on a Mongo connection this suite never opens
+// and every case times out rather than exercising the scope check.
+vi.mock('../../mcp/services/mcpBundleService', () => ({
+  resolveBundleContext: vi.fn(async (jti: string, sub: string) => ({
+    connectionId: 'conn-1',
+    bundleId: 'bundle-1',
+    activeOxyUserId: sub,
+    jti,
+  })),
+}));
+
 import { createRequireMcpOrOxyAuth } from '../../mcp/middleware/mcpAuth';
 import { signAccessToken } from '../../mcp/services/mcpTokenService';
 

--- a/packages/backend/src/mcp/middleware/mcpAuth.ts
+++ b/packages/backend/src/mcp/middleware/mcpAuth.ts
@@ -126,6 +126,28 @@ async function resolveMcpUser(token: string): Promise<McpAuthOutcome> {
   };
 }
 
+function parseScopeSet(scope: string): Set<string> {
+  return new Set(scope.split(/\s+/).map((value) => value.trim()).filter(Boolean));
+}
+
+function requiredMcpScopeForRequest(req: Request): 'mcp:read' | 'mcp:write' {
+  return ['GET', 'HEAD', 'OPTIONS'].includes(req.method.toUpperCase()) ? 'mcp:read' : 'mcp:write';
+}
+
+function enforceMcpRequestScope(req: Request, res: Response, outcome: Extract<McpAuthOutcome, { status: 'ok' }>): boolean {
+  const requiredScope = requiredMcpScopeForRequest(req);
+  if (parseScopeSet(outcome.scope).has(requiredScope)) {
+    return true;
+  }
+
+  res.status(403).json({
+    error: 'insufficient_scope',
+    message: `MCP token requires ${requiredScope} scope for this request`,
+    required_scope: requiredScope,
+  });
+  return false;
+}
+
 /** Attach the resolved MCP identity to the request in the Oxy-compatible shape. */
 function attachMcpIdentity(
   req: OxyAuthRequest,
@@ -184,6 +206,9 @@ export function createRequireMcpOrOxyAuth(oxy: OxyServices): RequestHandler {
     if (token && looksLikeMcpToken(token)) {
       const outcome = await resolveMcpUser(token);
       if (outcome.status === 'ok') {
+        if (!enforceMcpRequestScope(req, res, outcome)) {
+          return;
+        }
         attachMcpIdentity(req as OxyAuthRequest, outcome);
         next();
         return;

--- a/packages/mcp/lib/api-client.ts
+++ b/packages/mcp/lib/api-client.ts
@@ -28,6 +28,31 @@ function resolveToken(): string {
   return ctx?.userToken || "";
 }
 
+function tokenScopes(token: string): Set<string> {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return new Set();
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { scope?: unknown };
+    if (typeof decoded.scope !== "string") return new Set();
+    return new Set(decoded.scope.split(/\s+/).map((scope) => scope.trim()).filter(Boolean));
+  } catch {
+    return new Set();
+  }
+}
+
+function assertTokenScopeForMethod(method: string): void {
+  if (["GET", "HEAD", "OPTIONS"].includes(method.toUpperCase())) return;
+  const token = resolveToken();
+  if (token && !tokenScopes(token).has("mcp:write")) {
+    const error: ApiError = {
+      status: 403,
+      message: "This action requires the mcp:write OAuth scope.",
+      body: { error: "insufficient_scope", required_scope: "mcp:write" },
+    };
+    throw error;
+  }
+}
+
 function headers(): Record<string, string> {
   const h: Record<string, string> = {
     "Content-Type": "application/json",
@@ -60,6 +85,7 @@ async function request<T = unknown>(
     body?: unknown;
   },
 ): Promise<T> {
+  assertTokenScopeForMethod(method);
   const url = buildUrl(path, options?.query);
   const attempts = method === "GET" ? 2 : 1;
 

--- a/packages/mcp/lib/auth-guard.ts
+++ b/packages/mcp/lib/auth-guard.ts
@@ -3,6 +3,8 @@ import { requestContext } from "./context.js";
 const AUTH_REQUIRED_MESSAGE =
   "Authentication required. Connect your Mention account in the MCP client to authorize this action.";
 
+type McpScope = "mcp:read" | "mcp:write";
+
 export function getMcpToken(): string {
   return requestContext.getStore()?.userToken ?? "";
 }
@@ -14,12 +16,36 @@ export function authRequiredResponse() {
   };
 }
 
+function insufficientScopeResponse(requiredScope: McpScope) {
+  return {
+    content: [{ type: "text" as const, text: `This tool requires the ${requiredScope} OAuth scope.` }],
+    isError: true as const,
+  };
+}
+
+function tokenScopes(token: string): Set<string> {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return new Set();
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { scope?: unknown };
+    if (typeof decoded.scope !== "string") return new Set();
+    return new Set(decoded.scope.split(/\s+/).map((scope) => scope.trim()).filter(Boolean));
+  } catch {
+    return new Set();
+  }
+}
+
 export function withAuthGuard<T extends unknown[]>(
   handler: (...args: T) => Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }>,
+  options: { requiredScope?: McpScope } = {},
 ) {
   return async (...args: T) => {
-    if (!getMcpToken()) {
+    const token = getMcpToken();
+    if (!token) {
       return authRequiredResponse();
+    }
+    if (options.requiredScope && !tokenScopes(token).has(options.requiredScope)) {
+      return insufficientScopeResponse(options.requiredScope);
     }
     return handler(...args);
   };


### PR DESCRIPTION
### Motivation
- MCP JWTs carried `scope` but the dual-auth middleware accepted any valid MCP token as a full authenticated session, enabling low-privilege tokens (e.g. `mcp:read` or `offline_access`) to perform mutating account actions.
- Enforce least-privilege: read-safe requests should be allowed with `mcp:read`, while mutating requests must require `mcp:write`.

### Description
- Enforce request-level MCP scopes in the dual-auth middleware by parsing the token `scope` and returning `403 insufficient_scope` when the grant lacks the required scope; safe methods (`GET|HEAD|OPTIONS`) require `mcp:read`, others require `mcp:write` (`packages/backend/src/mcp/middleware/mcpAuth.ts`).
- Add a fast-fail check in the MCP tool HTTP client so delegated tool calls throw a clear `insufficient_scope` error before issuing mutating REST requests (`packages/mcp/lib/api-client.ts`).
- Extend the MCP tool-side `withAuthGuard` to accept an optional `requiredScope` and validate the token's scopes, returning a tool-friendly insufficient-scope response when missing (`packages/mcp/lib/auth-guard.ts`).
- Add regression tests covering read vs mutate enforcement for MCP tokens (`packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts`).

### Testing
- Ran backend unit tests: `cd packages/backend && bun run test src/__tests__/mcp/mcpOAuthToken.test.ts src/__tests__/mcp/mcpTokenService.test.ts src/__tests__/mcp/mcpAuthScope.test.ts` — all tests passed.
- Built the MCP package: `cd packages/mcp && bun run build` — build succeeded.
- Attempted backend TypeScript build: `cd packages/backend && bun run build` — this failed due to existing unrelated type issues (duplicate `ioredis` type instances and `PostMetadata` shape mismatches) that predate and are unrelated to the scope enforcement change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cca7d50a88323b656434268903a55)