### PR TITLE
chore(types): remove the last any occurrences (#112)

### DIFF
--- a/packages/backend/src/__tests__/migrations/mtnEventIdempotencyIndex.test.ts
+++ b/packages/backend/src/__tests__/migrations/mtnEventIdempotencyIndex.test.ts
@@ -15,7 +15,55 @@ import {
 } from '../../models/MentionSignedRecord';
 import { MENTION_REPO_HEAD_COLLECTION } from '../../models/MentionRepoHead';
 
-type TestDocument = Record<string, any>;
+type TestDocument = Record<string, unknown>;
+
+/** A `MentionSignedRecord` fixture row — mirrors the migration's own `ChainRow`. */
+interface RecordFixtureRow {
+  _id: string;
+  oxyUserId: string;
+  subjectDid: string;
+  seq?: number;
+  prev?: string | null;
+  recordId: string;
+  verified?: boolean;
+  envelope: SignedRecordEnvelope;
+  chainStatus?: string;
+}
+
+/** A `MentionRepoHead` fixture row — mirrors the migration's own `RepoHeadRow`. */
+interface HeadFixtureRow {
+  _id: string;
+  oxyUserId: string;
+  subjectDid: string;
+  seq: number;
+  headRecordId: string;
+  recordCount: number;
+}
+
+/** The two `records.find(...)` filter shapes the migration actually issues. */
+interface RecordFindFilter {
+  oxyUserId?: string;
+  seq?: { $lte?: number; $exists?: boolean; $type?: string };
+  chainStatus?: { $exists?: boolean };
+}
+
+interface IndexOptions {
+  name?: string;
+  unique?: boolean;
+}
+
+interface CommandInput {
+  collMod?: string;
+  index?: { prepareUnique?: boolean; unique?: boolean };
+  dryRun?: boolean;
+}
+
+interface BulkWriteOperation {
+  updateOne: {
+    filter: TestDocument;
+    update: { $set?: TestDocument; $unset?: TestDocument };
+  };
+}
 
 function cursor<T>(rows: T[]) {
   const value = {
@@ -29,20 +77,21 @@ function cursor<T>(rows: T[]) {
   return value;
 }
 
-function matchesId(document: TestDocument, filter: TestDocument): boolean {
-  const ids = filter._id?.$in;
-  if (Array.isArray(ids)) {
+function matchesId(document: { _id: unknown }, filter: TestDocument): boolean {
+  const idFilter = filter._id;
+  if (idFilter && typeof idFilter === 'object' && '$in' in idFilter) {
+    const ids = (idFilter as { $in: unknown[] }).$in;
     return ids.some((id) => String(id) === String(document._id));
   }
   return filter._id === undefined || String(filter._id) === String(document._id);
 }
 
 interface HarnessOptions {
-  records: TestDocument[];
-  heads: TestDocument[];
+  records: RecordFixtureRow[];
+  heads: HeadFixtureRow[];
   recordIndexes?: TestDocument[];
   headIndexes?: TestDocument[];
-  headSnapshots?: TestDocument[];
+  headSnapshots?: HeadFixtureRow[];
 }
 
 function createHarness(options: HarnessOptions) {
@@ -55,7 +104,7 @@ function createHarness(options: HarnessOptions) {
 
   const recordCollection = {
     indexes: vi.fn(async () => recordIndexes),
-    createIndex: vi.fn(async (key: TestDocument, indexOptions: TestDocument) => {
+    createIndex: vi.fn(async (key: TestDocument, indexOptions: IndexOptions) => {
       if (indexOptions.name === MTN_SEQUENCE_INDEX.name) {
         events.push('createSequence');
       }
@@ -66,7 +115,7 @@ function createHarness(options: HarnessOptions) {
       if (index >= 0) recordIndexes.splice(index, 1);
       return { ok: 1 };
     }),
-    aggregate: vi.fn((pipeline: TestDocument[]) => {
+    aggregate: vi.fn((pipeline: { $group?: { _id?: unknown } }[]) => {
       const ownerAggregation = pipeline.some(
         (stage) => stage.$group?._id === '$_id.oxyUserId',
       );
@@ -85,14 +134,16 @@ function createHarness(options: HarnessOptions) {
       ].map((_id) => ({ _id }));
       return cursor(ownerAggregation ? duplicateOwners : duplicateOwners.slice(0, 1));
     }),
-    find: vi.fn((filter: TestDocument) => {
-      let rows: TestDocument[];
+    find: vi.fn((filter: RecordFindFilter) => {
+      let rows: RecordFixtureRow[];
       if (typeof filter.oxyUserId === 'string') {
+        const maxSeq = filter.seq?.$lte;
         rows = records.filter(
           (row) =>
             row.oxyUserId === filter.oxyUserId &&
             typeof row.seq === 'number' &&
-            row.seq <= filter.seq.$lte,
+            typeof maxSeq === 'number' &&
+            row.seq <= maxSeq,
         );
       } else if (filter.chainStatus?.$exists === false) {
         rows = records.filter((row) => {
@@ -111,7 +162,7 @@ function createHarness(options: HarnessOptions) {
       }
       return cursor(rows);
     }),
-    bulkWrite: vi.fn(async (operations: TestDocument[]) => {
+    bulkWrite: vi.fn(async (operations: BulkWriteOperation[]) => {
       events.push('repair');
       for (const operation of operations) {
         const target = records.find((row) =>
@@ -119,12 +170,12 @@ function createHarness(options: HarnessOptions) {
         if (!target) continue;
         Object.assign(target, operation.updateOne.update.$set ?? {});
         for (const field of Object.keys(operation.updateOne.update.$unset ?? {})) {
-          delete target[field];
+          delete (target as unknown as TestDocument)[field];
         }
       }
       return { modifiedCount: operations.length };
     }),
-    updateMany: vi.fn(async (filter: TestDocument, update: TestDocument) => {
+    updateMany: vi.fn(async (filter: TestDocument, update: { $set?: TestDocument }) => {
       let modifiedCount = 0;
       for (const row of records) {
         if (!matchesId(row, filter)) continue;
@@ -137,7 +188,7 @@ function createHarness(options: HarnessOptions) {
 
   const headCollection = {
     indexes: vi.fn(async () => headIndexes),
-    createIndex: vi.fn(async (key: TestDocument, indexOptions: TestDocument) => {
+    createIndex: vi.fn(async (key: TestDocument, indexOptions: IndexOptions) => {
       events.push('headUnique');
       headIndexes.push({
         name: indexOptions.name,
@@ -172,7 +223,7 @@ function createHarness(options: HarnessOptions) {
     }),
   };
 
-  const command = vi.fn(async (input: TestDocument) => {
+  const command = vi.fn(async (input: CommandInput) => {
     if (input.collMod === MENTION_SIGNED_RECORD_COLLECTION) {
       if (input.index?.prepareUnique === true) events.push('prepare');
       if (input.index?.unique === true && input.dryRun === true) {
@@ -241,7 +292,7 @@ async function forkFixture() {
   const canonicalId = await computeRecordId(canonicalEnvelope);
   const conflictEnvelope = makeEnvelope(subject, 1, genesisId, 'conflict');
   const conflictId = await computeRecordId(conflictEnvelope);
-  const records = [
+  const records: RecordFixtureRow[] = [
     {
       _id: 'r0',
       oxyUserId,
@@ -273,7 +324,7 @@ async function forkFixture() {
       envelope: conflictEnvelope,
     },
   ];
-  const head = {
+  const head: HeadFixtureRow = {
     _id: 'head-1',
     oxyUserId,
     subjectDid: subject,

--- a/packages/backend/src/__tests__/scripts/backfillThreadRootThreadId.test.ts
+++ b/packages/backend/src/__tests__/scripts/backfillThreadRootThreadId.test.ts
@@ -39,9 +39,9 @@ const h = vi.hoisted(() => {
 
   const aggregate = vi.fn(async () => state.candidates);
 
-  const find = vi.fn((query: Record<string, any>) => ({
+  const find = vi.fn((query: { _id?: { $in?: mongoose.Types.ObjectId[] } }) => ({
     lean: async () => {
-      const inClause = query?._id?.$in as mongoose.Types.ObjectId[] | undefined;
+      const inClause = query?._id?.$in;
       if (!Array.isArray(inClause)) return [];
       const wanted = new Set(inClause.map((id) => id.toString()));
       return state.roots.filter((r) => wanted.has(r._id.toString()));

--- a/packages/backend/src/__tests__/scripts/migrateThreadFanToChain.test.ts
+++ b/packages/backend/src/__tests__/scripts/migrateThreadFanToChain.test.ts
@@ -37,9 +37,9 @@ const h = vi.hoisted(() => {
 
   const aggregate = vi.fn(async () => state.candidates);
 
-  const find = vi.fn((query: Record<string, any>) => ({
+  const find = vi.fn((query: { _id?: { $in?: mongoose.Types.ObjectId[] } }) => ({
     lean: async () => {
-      const inClause = query?._id?.$in as mongoose.Types.ObjectId[] | undefined;
+      const inClause = query?._id?.$in;
       if (!Array.isArray(inClause)) return [];
       const wanted = new Set(inClause.map((id) => id.toString()));
       return state.roots.filter((r) => wanted.has(r._id.toString()));

--- a/packages/backend/src/__tests__/services/federationThreadLinking.test.ts
+++ b/packages/backend/src/__tests__/services/federationThreadLinking.test.ts
@@ -26,6 +26,49 @@ interface StoredPost {
   content?: { text?: string };
 }
 
+/**
+ * Shape of a `records.find({...})` query, narrowed from the two real call
+ * sites: the bulk-dedup `$in` lookup and the reconciliation script's
+ * cursor-paginated orphan scan.
+ */
+interface PostFindQuery {
+  'federation.activityId'?: { $in?: string[] };
+  'federation.inReplyTo'?: unknown;
+  _id?: { $gt?: string };
+}
+
+/** The `$set` shape every `Post.updateOne` call in this suite writes. */
+interface PostUpdateBody {
+  $set?: { parentPostId?: string | null; threadId?: string | null };
+}
+
+/** A raw Mongo document as `Post.collection.insertMany` receives it. */
+interface InsertManyDoc {
+  federation?: { activityId?: string; inReplyTo?: string };
+  threadId?: string | null;
+  parentPostId?: string | null;
+  status?: string;
+  visibility?: string;
+  content?: { text?: string };
+}
+
+/** One `Post.bulkWrite` operation, narrowed to the fields this store applies. */
+interface BulkWriteOp {
+  updateOne?: {
+    filter: { _id?: unknown };
+    update: { $set?: { parentPostId?: string | null; threadId?: string | null } };
+  };
+}
+
+/** Params the `PostCreationService.create` stand-in below is called with. */
+interface PostCreatorParams {
+  federation?: { activityId?: string; inReplyTo?: string };
+  threadId?: string | null;
+  parentPostId?: string | null;
+  visibility?: string;
+  content?: { text?: string };
+}
+
 const h = vi.hoisted(() => {
   const store: StoredPost[] = [];
   const state = { counter: 0 };
@@ -40,7 +83,7 @@ const h = vi.hoisted(() => {
   };
 
   // --- Post model (stateful) ---
-  const postFindOne = vi.fn((query: Record<string, any>) => ({
+  const postFindOne = vi.fn((query: Record<string, unknown>) => ({
     lean: async () => {
       if (query?.['federation.activityId'] !== undefined) {
         const found = findByActivityId(query['federation.activityId']);
@@ -73,18 +116,18 @@ const h = vi.hoisted(() => {
 
   // Supports BOTH the bulk-dedup call (`.lean()` directly) and the
   // reconciliation script's paginated call (`.sort().limit().lean()`).
-  const postFind = vi.fn((query: Record<string, any>) => {
+  const postFind = vi.fn((query: PostFindQuery) => {
     const run = async () => {
-      const inClause = query?.['federation.activityId']?.$in;
+      const inClause = query['federation.activityId']?.$in;
       if (Array.isArray(inClause)) {
         return store
           .filter((p) => p.federation?.activityId !== undefined && inClause.includes(p.federation.activityId))
           .map((p) => ({ federation: { activityId: p.federation?.activityId } }));
       }
       // Reconciliation orphan query: federation.inReplyTo set, parentPostId null.
-      const wantsOrphans = query?.['federation.inReplyTo'] !== undefined;
+      const wantsOrphans = query['federation.inReplyTo'] !== undefined;
       if (wantsOrphans) {
-        const gt = query?._id?.$gt as string | undefined;
+        const gt = query._id?.$gt;
         return store
           .filter(
             (p) =>
@@ -105,7 +148,7 @@ const h = vi.hoisted(() => {
     return chain;
   });
 
-  const postUpdateOne = vi.fn(async (query: Record<string, any>, update: Record<string, any>) => {
+  const postUpdateOne = vi.fn(async (query: Record<string, unknown>, update: PostUpdateBody) => {
     let target: StoredPost | undefined;
     if (query?.['federation.activityId'] !== undefined) target = findByActivityId(query['federation.activityId']);
     else if (query?._id !== undefined) target = findById(query._id);
@@ -116,30 +159,30 @@ const h = vi.hoisted(() => {
     return { modifiedCount: target ? 1 : 0 };
   });
 
-  const postExists = vi.fn(async (query: Record<string, any>) => {
+  const postExists = vi.fn(async (query: Record<string, unknown>) => {
     const found = findByActivityId(query?.['federation.activityId']);
     return found ? { _id: found._id } : null;
   });
 
-  const postInsertMany = vi.fn(async (docs: Record<string, any>[]) => {
+  const postInsertMany = vi.fn(async (docs: InsertManyDoc[]) => {
     for (const doc of docs) {
       store.push({
         _id: nextId('inserted'),
         federation: {
-          activityId: (doc.federation as { activityId?: string })?.activityId,
-          inReplyTo: (doc.federation as { inReplyTo?: string })?.inReplyTo,
+          activityId: doc.federation?.activityId,
+          inReplyTo: doc.federation?.inReplyTo,
         },
-        threadId: (doc.threadId as string | null | undefined) ?? null,
-        parentPostId: (doc.parentPostId as string | null | undefined) ?? null,
-        status: doc.status as string | undefined,
-        visibility: doc.visibility as string | undefined,
-        content: doc.content as { text?: string } | undefined,
+        threadId: doc.threadId ?? null,
+        parentPostId: doc.parentPostId ?? null,
+        status: doc.status,
+        visibility: doc.visibility,
+        content: doc.content,
       });
     }
     return { insertedCount: docs.length };
   });
 
-  const postCountDocuments = vi.fn(async (query: Record<string, any>) => {
+  const postCountDocuments = vi.fn(async (query: Record<string, unknown>) => {
     if (query?.['federation.inReplyTo'] !== undefined) {
       return store.filter(
         (p) => p.federation?.inReplyTo != null && (p.parentPostId === null || p.parentPostId === undefined),
@@ -148,7 +191,7 @@ const h = vi.hoisted(() => {
     return store.length;
   });
 
-  const postBulkWrite = vi.fn(async (ops: Array<{ updateOne?: { filter: Record<string, any>; update: Record<string, any> } }>) => {
+  const postBulkWrite = vi.fn(async (ops: BulkWriteOp[]) => {
     let modified = 0;
     for (const op of ops) {
       const u = op.updateOne;
@@ -164,18 +207,18 @@ const h = vi.hoisted(() => {
   });
 
   // --- post creator (PostCreationService stand-in) ---
-  const postCreatorCreate = vi.fn(async (params: Record<string, any>) => {
+  const postCreatorCreate = vi.fn(async (params: PostCreatorParams) => {
     const created: StoredPost = {
       _id: nextId('created'),
       federation: {
-        activityId: (params.federation as { activityId?: string })?.activityId,
-        inReplyTo: (params.federation as { inReplyTo?: string })?.inReplyTo,
+        activityId: params.federation?.activityId,
+        inReplyTo: params.federation?.inReplyTo,
       },
-      threadId: (params.threadId as string | null | undefined) ?? null,
-      parentPostId: (params.parentPostId as string | null | undefined) ?? null,
+      threadId: params.threadId ?? null,
+      parentPostId: params.parentPostId ?? null,
       status: 'published',
-      visibility: (params.visibility as string | undefined) ?? 'public',
-      content: params.content as { text?: string } | undefined,
+      visibility: params.visibility ?? 'public',
+      content: params.content,
     };
     store.push(created);
     return created;

--- a/packages/shared-types/src/interaction.ts
+++ b/packages/shared-types/src/interaction.ts
@@ -28,7 +28,7 @@ export interface Interaction {
   targetType: 'post' | 'user' | 'comment';
   type: InteractionType;
   status: InteractionStatus;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/shared-types/src/notification.ts
+++ b/packages/shared-types/src/notification.ts
@@ -54,7 +54,7 @@ export interface NotificationData {
   targetType?: 'post' | 'comment' | 'user' | 'hashtag';
   actionUrl?: string; // deep link to the relevant content
   imageUrl?: string; // avatar or preview image
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface LikeNotification extends Notification {


### PR DESCRIPTION
## Summary

Closes #112. The issue's numbers were from February and stale — the fix-upstream/AGENTS.md cleanup work already resolved most of it (every file the issue names as a worst offender is now at zero). This PR removes what was actually left: **13 `any` occurrences -> 0**.

- **Production (2):** `packages/shared-types/src/interaction.ts` (`Interaction.metadata`) and `packages/shared-types/src/notification.ts` (`NotificationData.metadata`) — both `Record<string, any>` -> `Record<string, unknown>`. Verified via grep across `packages/backend`, `packages/frontend`, and `packages/mcp` that neither the `Interaction` nor `NotificationData` shared-types interface has any consumer (the app's notification surfaces go through the Mongoose `Notification` model, not this DTO) — no read-site narrowing was required, and no cast was added anywhere to compensate.
- **Test mocks (11), 4 files:** `Record<string, any>` standing in for Mongoose filter/update documents, replaced with `Record<string, unknown>` plus small local interfaces describing exactly the fields each mock reads (matching the existing "precise structural interface, no `as any`" pattern already used in `postHydrationMentions.test.ts` / `postHydrationPodcast.test.ts`):
  - `packages/backend/src/__tests__/scripts/backfillThreadRootThreadId.test.ts`
  - `packages/backend/src/__tests__/scripts/migrateThreadFanToChain.test.ts`
  - `packages/backend/src/__tests__/migrations/mtnEventIdempotencyIndex.test.ts`
  - `packages/backend/src/__tests__/services/federationThreadLinking.test.ts`

No `as any`, `@ts-ignore`, `@ts-expect-error`, or `!` non-null assertions were introduced.

## Test plan
- [x] `bun run --cwd packages/shared-types build` (rebuilt `dist` before trusting any typecheck)
- [x] `bun run lint` in `packages/backend` (`tsc --noEmit`) — clean
- [x] `bunx tsc --noEmit` in `packages/mcp` — clean
- [x] `bun run typecheck` in `packages/frontend` — could not run in this environment (worktree had no local `node_modules`/`tsc` binary before a `bun install`; independently confirmed via grep that frontend has zero imports of the two changed interfaces)
- [x] `bun run test` in `packages/backend` — 443/450 files, 4831/4945 tests pass; the 7 failing files all fail identically on `mongodb-memory-server` ("Mongod internal error (fassert() failure)") failing to start an embedded MongoDB in this sandboxed CI-adjacent environment — pre-existing, unrelated to this change, none of the 4 edited files are among them
- [x] `bun test` in `packages/mcp` — 32/32 pass
- [x] Re-ran the issue's own verification regex (comment-excluding) — 0 matches across `packages/backend/src`, `packages/frontend`, `packages/shared-types/src`, `packages/mcp/lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)