### PR TITLE
feat(moderation): send urgency so a widely-distributed post triages first (#637)

### DIFF
--- a/packages/backend/src/__tests__/services/moderation/moderationOutboxWrites.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/moderationOutboxWrites.test.ts
@@ -159,6 +159,45 @@ describe('the outbox write is one Mongo accepts', () => {
     expect(await ModerationOutbox.countDocuments({ _id: eventId })).toBe(1);
   });
 
+  it('round-trips a frozen urgency exactly as the contract shapes it', async () => {
+    /**
+     * The urgency is snapshotted at intake and read back at delivery, so the ROW is
+     * what has to be faithful — a mocked `updateOne` would accept a payload Mongo
+     * stores differently, which is the class of defect this whole file exists for.
+     */
+    const eventId = `moderation:report.submit:${new mongoose.Types.ObjectId().toString()}`;
+    const urgency = { hint: 'public_feed', reach: 250_000, activeDistribution: true };
+
+    await enqueueModerationOutboxEvent(
+      { eventId, kind: 'report.submit', payload: { reportId: 'r5', urgency } },
+      sessionInTransaction(session),
+    );
+
+    const stored = await ModerationOutbox.findById(eventId).lean();
+    expect(stored?.payload).toEqual({ reportId: 'r5', urgency });
+  });
+
+  it('stores NO urgency key for a subject that had none', async () => {
+    /**
+     * Absent has to stay absent, and the difference is not cosmetic: `urgency` is a
+     * STRICT contract object requiring `hint`, so an empty `{}` materialised onto
+     * the row would fail envelope composition with a NON-retryable input error and
+     * dead-letter a report whose only defect is a missing scheduling hint. That is
+     * why the schema path is `Mixed` rather than declared sub-paths — and only the
+     * server can confirm which of the two Mongoose actually wrote.
+     */
+    const eventId = `moderation:report.submit:${new mongoose.Types.ObjectId().toString()}`;
+
+    await enqueueModerationOutboxEvent(
+      { eventId, kind: 'report.submit', payload: { reportId: 'r6' } },
+      sessionInTransaction(session),
+    );
+
+    const stored = await ModerationOutbox.findById(eventId).lean();
+    expect(stored?.payload).toEqual({ reportId: 'r6' });
+    expect(stored?.payload).not.toHaveProperty('urgency');
+  });
+
   it('refuses a session with no transaction open, before touching the server', async () => {
     const eventId = `moderation:report.submit:${new mongoose.Types.ObjectId().toString()}`;
     const noTransaction = { inTransaction: () => false } as unknown as mongoose.ClientSession;

--- a/packages/backend/src/__tests__/services/moderation/reportUrgency.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/reportUrgency.test.ts
@@ -1,0 +1,418 @@
+import mongoose from 'mongoose';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CaseUrgencySchema } from '@oxyhq/crowdsource-contracts';
+
+/**
+ * §5.1 `urgency` — the distribution facts that decide QUEUE ORDER.
+ *
+ * Two properties are under test and they pull in opposite directions, which is why
+ * they live in one file: the value has to DISCRIMINATE (a post thousands of people
+ * saw must not queue behind one nobody has seen) and it has to be FROZEN (the same
+ * report delivered twice must compose the same bytes, because the ingress
+ * fingerprints the envelope and a changed one is a permanent 409 rather than a new
+ * case).
+ *
+ * A live read at delivery satisfies the first and destroys the second, silently,
+ * and the damage surfaces days later as moderation work stuck in a queue. So the
+ * frozen-value test below mutates the post between two builds and pins the result
+ * — and proves the mutation is one a live read WOULD see, or it would pass against
+ * an implementation with no snapshot in it at all.
+ */
+
+type Doc = Record<string, unknown>;
+
+/** Posts by id, so the real provider's own loader resolves them. */
+let posts: Map<string, Doc>;
+/** Every `payload` handed to the outbox, in order. */
+let enqueuedPayloads: Doc[];
+
+vi.mock('../../../models/Post', () => ({
+  default: {
+    findById: vi.fn((id: string) => {
+      const query = {
+        select: () => query,
+        lean: async () => {
+          const post = posts.get(String(id));
+          return post ? { ...post } : null;
+        },
+      };
+      return query;
+    }),
+  },
+}));
+
+vi.mock('../../../models/Report.model', async () => {
+  const actual = await vi.importActual<typeof import('../../../models/Report.model')>(
+    '../../../models/Report.model',
+  );
+  return {
+    ...actual,
+    default: {
+      findOne: vi.fn(),
+      create: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../../models/ModerationOutbox', () => ({
+  MODERATION_OUTBOX_RETENTION_SECONDS: 90 * 24 * 60 * 60,
+  default: {
+    updateOne: vi.fn(async (_filter: Doc, update: Doc) => {
+      const setOnInsert = (update.$setOnInsert as Doc | undefined) ?? {};
+      enqueuedPayloads.push((setOnInsert.payload as Doc | undefined) ?? {});
+      return { matchedCount: 1, modifiedCount: 1 };
+    }),
+  },
+}));
+
+const getUserById = vi.fn();
+
+vi.mock('../../../runtime/oxyClient', () => ({
+  getRuntimeOxyClient: () => ({ getUserById }),
+}));
+
+import ModerationOutbox from '../../../models/ModerationOutbox';
+import Report, { ReportCategory, ReportedType } from '../../../models/Report.model';
+import { createReport } from '../../../services/moderation/ReportIntakeService';
+import { buildModerationReportInput } from '../../../services/moderation/EvidenceSnapshotService';
+import { createPostSubjectProvider } from '../../../services/moderation/subjects/postSubject';
+
+const REPORT_ID = '507f1f77bcf86cd799439011';
+const POST_ID = '507f1f77bcf86cd799439022';
+const OTHER_POST_ID = '507f1f77bcf86cd799439033';
+const AUTHOR = 'oxy-author';
+const REPORTER = 'oxy-user-reporter';
+
+/**
+ * The registry is NOT mocked here, unlike in the durability tests.
+ *
+ * The property under test spans intake, the outbox payload and the builder, and
+ * the interesting half of it lives inside Mention's own post provider — a stubbed
+ * provider would assert that the plumbing carries whatever it is given, which is
+ * the part that was never in doubt.
+ */
+const postProvider = createPostSubjectProvider({
+  reportedType: ReportedType.POST,
+  subjectType: 'social.post',
+});
+
+function post(id: string, extra: Doc = {}): Doc {
+  return {
+    _id: new mongoose.Types.ObjectId(id),
+    content: { variants: [{ source: 'author', tag: 'en', text: 'The reported text.' }] },
+    authorship: [{ oxyUserId: AUTHOR, role: 'owner', status: 'accepted' }],
+    createdAt: new Date('2026-07-20T10:00:00.000Z'),
+    status: 'published',
+    visibility: 'public',
+    ...extra,
+  };
+}
+
+/** A session that reports being inside a transaction, as the enqueue guard requires. */
+function stubSession(): void {
+  vi.spyOn(mongoose, 'startSession').mockResolvedValue({
+    inTransaction: () => true,
+    withTransaction: vi.fn(async (operation: () => Promise<void>) => {
+      await operation();
+    }),
+    endSession: vi.fn().mockResolvedValue(undefined),
+  } as never);
+}
+
+/** Take a report through the real intake and return the payload it enqueued. */
+async function intake(input: {
+  reportedType: ReportedType;
+  reportedId: string;
+  reporter?: string;
+}): Promise<Doc> {
+  stubSession();
+  vi.mocked(Report.findOne).mockReturnValue({
+    session: vi.fn().mockReturnThis(),
+    lean: vi.fn().mockResolvedValue(null),
+  } as never);
+  vi.mocked(Report.create).mockResolvedValue([
+    { _id: new mongoose.Types.ObjectId(REPORT_ID), id: REPORT_ID },
+  ] as never);
+
+  const before = enqueuedPayloads.length;
+  await createReport({
+    reporter: input.reporter ?? REPORTER,
+    reportedType: input.reportedType,
+    reportedId: input.reportedId,
+    categories: [ReportCategory.HARASSMENT],
+  });
+  return enqueuedPayloads[before] ?? {};
+}
+
+/** The report row as the delivery worker reconstructs it. */
+function reportRow(reportedId = POST_ID, reporter = REPORTER) {
+  return {
+    id: REPORT_ID,
+    reportedType: ReportedType.POST,
+    reportedId,
+    reporter,
+    categories: [ReportCategory.HARASSMENT],
+    details: undefined,
+    createdAt: new Date('2026-07-28T18:00:00.000Z'),
+  };
+}
+
+beforeEach(() => {
+  posts = new Map();
+  enqueuedPayloads = [];
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('report urgency — what reaches triage', () => {
+  it('gives a widely-distributed post a higher reach than an unseen one', async () => {
+    posts.set(POST_ID, post(POST_ID, { stats: { viewsCount: 250_000 } }));
+    posts.set(OTHER_POST_ID, post(OTHER_POST_ID, { stats: { viewsCount: 3 } }));
+
+    const seen = await intake({ reportedType: ReportedType.POST, reportedId: POST_ID });
+    const unseen = await intake({
+      reportedType: ReportedType.POST,
+      reportedId: OTHER_POST_ID,
+    });
+
+    const widely = await buildModerationReportInput(reportRow(POST_ID), seen.urgency);
+    const barely = await buildModerationReportInput(
+      reportRow(OTHER_POST_ID),
+      unseen.urgency,
+    );
+
+    /**
+     * The whole point of the field: without it both of these arrive at `reach: 0`
+     * and the queue orders them by nothing. `reach` is CrowdSource's own
+     * "how many people the material reached, as the application counts it", and
+     * Mention counts it with the deduplicated per-viewer feed impression counter.
+     */
+    expect(widely?.reportInput.urgency).toEqual({
+      hint: 'public_feed',
+      reach: 250_000,
+      activeDistribution: true,
+    });
+    expect(barely?.reportInput.urgency).toEqual({
+      hint: 'public_feed',
+      reach: 3,
+      activeDistribution: true,
+    });
+  });
+
+  const DISTRIBUTION_CASES: ReadonlyArray<[string, Doc, string, boolean]> = [
+    ['a public published post', {}, 'public_feed', true],
+    [
+      'a post whose audience the author limited',
+      { visibility: 'followers' },
+      'limited_audience',
+      false,
+    ],
+    [
+      'a post an earlier decision restricted',
+      { status: 'restricted' },
+      'not_distributed',
+      false,
+    ],
+    [
+      'a copy of material published on another instance',
+      { federation: { url: 'https://remote.example/@a/1', sensitive: false } },
+      'federated_origin',
+      true,
+    ],
+  ];
+
+  it.each(DISTRIBUTION_CASES)(
+    'describes %s as distribution, not as severity',
+    async (_case, extra, hint, active) => {
+      posts.set(POST_ID, post(POST_ID, { stats: { viewsCount: 7 }, ...extra }));
+
+      /**
+       * Reported by the AUTHOR, because the disclosure gate withholds a non-public
+       * post from anybody else — urgency and material load through the same gate on
+       * purpose, so a report can never describe the distribution of content the
+       * envelope will not carry.
+       */
+      const urgency = await postProvider.urgencySnapshot?.(POST_ID, AUTHOR);
+
+      expect(urgency).toEqual({ hint, reach: 7, activeDistribution: active });
+      /**
+       * §7.4 decides queue order and explicitly does not decide guilt, so every
+       * token has to be a fact about where the post is readable. The contract's own
+       * schema is the gate on the token's SHAPE; naming the four states here is the
+       * gate on its MEANING — a hint that started describing the allegation would
+       * still be a perfectly valid lowercase token.
+       */
+      expect(CaseUrgencySchema.safeParse(urgency).success).toBe(true);
+    },
+  );
+});
+
+describe('report urgency — frozen at intake', () => {
+  it('composes the same bytes twice even after the post moves underneath it', async () => {
+    posts.set(
+      POST_ID,
+      post(POST_ID, { stats: { viewsCount: 12 }, visibility: 'public' }),
+    );
+
+    // Self-report, so the disclosure gate keeps returning the post after the
+    // visibility flip below and the two builds stay comparable.
+    const payload = await intake({
+      reportedType: ReportedType.POST,
+      reportedId: POST_ID,
+      reporter: AUTHOR,
+    });
+    const first = await buildModerationReportInput(
+      reportRow(POST_ID, AUTHOR),
+      payload.urgency,
+    );
+
+    // The post goes viral and its author narrows the audience — all three urgency
+    // fields would change under a live read.
+    posts.set(
+      POST_ID,
+      post(POST_ID, { stats: { viewsCount: 900_000 }, visibility: 'followers' }),
+    );
+
+    /**
+     * The positive control, and it is not optional. Without it this file passes
+     * against an implementation that never reads distribution at all, because
+     * "unchanged" and "never present" are indistinguishable in the assertion
+     * below. This proves the mutation is one a delivery-time read WOULD see.
+     */
+    expect(await postProvider.urgencySnapshot?.(POST_ID, AUTHOR)).toEqual({
+      hint: 'limited_audience',
+      reach: 900_000,
+      activeDistribution: false,
+    });
+
+    const second = await buildModerationReportInput(
+      reportRow(POST_ID, AUTHOR),
+      payload.urgency,
+    );
+
+    /**
+     * The property that keeps an outbox retry from becoming a permanent 409:
+     * ingress fingerprints the whole `{ externalReportId, envelope }`, so a second
+     * attempt that composes different bytes is §10.5's payload conflict rather
+     * than a redelivery. Asserted on the serialised form because that is what is
+     * hashed — a field that merely compared equal but serialised differently would
+     * fail there and pass a `toEqual`.
+     */
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    expect(first?.reportInput.urgency).toEqual({
+      hint: 'public_feed',
+      reach: 12,
+      activeDistribution: true,
+    });
+  });
+
+  it('writes the urgency onto the outbox row, where nothing updates it', async () => {
+    posts.set(POST_ID, post(POST_ID, { stats: { viewsCount: 41 } }));
+
+    const payload = await intake({ reportedType: ReportedType.POST, reportedId: POST_ID });
+
+    /**
+     * The freeze is the row, not a convention. `enqueueModerationOutboxEvent`
+     * writes only inside `$setOnInsert`, so a repeat enqueue for this deterministic
+     * event id cannot overwrite the value with a later reading of the same post.
+     */
+    expect(payload).toEqual({
+      reportId: REPORT_ID,
+      urgency: { hint: 'public_feed', reach: 41, activeDistribution: true },
+    });
+    const [, update] = vi.mocked(ModerationOutbox.updateOne).mock.calls[0];
+    expect(update).toEqual(
+      expect.objectContaining({ $setOnInsert: expect.objectContaining({ payload }) }),
+    );
+    expect(update).not.toHaveProperty('$set');
+  });
+});
+
+describe('report urgency — an absence is not a zero', () => {
+  it('omits reach for a post Mention has no view count for', async () => {
+    // A federated post backfilled from an outbox has no `stats` subdoc at all.
+    posts.set(POST_ID, post(POST_ID));
+
+    const payload = await intake({ reportedType: ReportedType.POST, reportedId: POST_ID });
+    const built = await buildModerationReportInput(reportRow(), payload.urgency);
+
+    /**
+     * `reach: 0` is a claim that nobody saw it. An absent counter is "Mention
+     * cannot say", and the two are different sentences even though triage scores
+     * them identically today — `log10(1 + 0)` is 0. Sending the claim would make
+     * this code responsible for an assertion it cannot support the moment that
+     * weighting changes.
+     */
+    expect(built?.reportInput.urgency).toEqual({
+      hint: 'public_feed',
+      activeDistribution: true,
+    });
+    expect(built?.reportInput.urgency).not.toHaveProperty('reach');
+  });
+
+  const CORRUPT_COUNTERS: ReadonlyArray<[string, Doc]> = [
+    ['a fractional counter', { viewsCount: 12.5 }],
+    ['a negative counter', { viewsCount: -1 }],
+    ['a counter that is not a number', { viewsCount: '900' }],
+  ];
+
+  it.each(CORRUPT_COUNTERS)('omits reach rather than coercing %s', async (_case, stats) => {
+    posts.set(POST_ID, post(POST_ID, { stats }));
+
+    const urgency = await postProvider.urgencySnapshot?.(POST_ID);
+
+    /**
+     * The contract refuses anything but a non-negative integer, and a refused
+     * envelope is a NON-retryable input error — so a corrupt counter rounded or
+     * clamped into shape would cost the whole report, not just its queue position.
+     */
+    expect(urgency).not.toHaveProperty('reach');
+    expect(CaseUrgencySchema.safeParse(urgency).success).toBe(true);
+  });
+
+  it('sends no urgency at all for a subject with no defensible audience', async () => {
+    getUserById.mockResolvedValue({ username: 'reported_account', name: {} });
+
+    const payload = await intake({
+      reportedType: ReportedType.USER,
+      reportedId: 'oxy-user-9',
+    });
+    const built = await buildModerationReportInput(
+      { ...reportRow(), reportedType: ReportedType.USER, reportedId: 'oxy-user-9' },
+      payload.urgency,
+    );
+
+    /**
+     * A profile has no audience figure Mention holds — the follower count answers
+     * a different question (who subscribed to the account, not who read the bio
+     * under review). `urgency` is optional exactly so an application can decline
+     * rather than invent, so the field is absent end to end: off the outbox row and
+     * off the report input.
+     */
+    expect(payload).toEqual({ reportId: REPORT_ID });
+    expect(built?.reportInput).not.toHaveProperty('urgency');
+  });
+
+  it('drops a stored urgency the contract refuses instead of losing the report', async () => {
+    posts.set(POST_ID, post(POST_ID, { stats: { viewsCount: 5 } }));
+
+    const built = await buildModerationReportInput(reportRow(), {
+      hint: 'public_feed',
+      reach: 5,
+      unknownKey: 'from a newer deployment',
+    });
+
+    /**
+     * `CaseUrgencySchema` is a STRICT object, so an extra key is a validation
+     * failure — and `CrowdSourceReportInputError` carries `retryable: false`, which
+     * dead-letters the event. A report must not be lost because a scheduling hint
+     * was written by a deployment this one does not understand, so the value is
+     * dropped and the report still goes.
+     */
+    expect(built?.reportInput).not.toHaveProperty('urgency');
+    expect(built?.reportInput.subject.externalId).toBe(POST_ID);
+  });
+});

--- a/packages/backend/src/__tests__/services/moderation/reportUrgency.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/reportUrgency.test.ts
@@ -25,6 +25,13 @@ type Doc = Record<string, unknown>;
 let posts: Map<string, Doc>;
 /** Every `payload` handed to the outbox, in order. */
 let enqueuedPayloads: Doc[];
+/**
+ * Thrown by the post load when set, so a database failure during intake can be
+ * exercised through the REAL provider rather than a stubbed one. The value is
+ * deliberately `unknown`: a rejection is not obliged to be an `Error`, and the
+ * two shapes take different paths through the failure handler.
+ */
+let postLoadFailure: unknown;
 
 vi.mock('../../../models/Post', () => ({
   default: {
@@ -32,6 +39,7 @@ vi.mock('../../../models/Post', () => ({
       const query = {
         select: () => query,
         lean: async () => {
+          if (postLoadFailure !== undefined) throw postLoadFailure;
           const post = posts.get(String(id));
           return post ? { ...post } : null;
         },
@@ -73,6 +81,7 @@ vi.mock('../../../runtime/oxyClient', () => ({
 
 import ModerationOutbox from '../../../models/ModerationOutbox';
 import Report, { ReportCategory, ReportedType } from '../../../models/Report.model';
+import { logger } from '../../../utils/logger';
 import { createReport } from '../../../services/moderation/ReportIntakeService';
 import { buildModerationReportInput } from '../../../services/moderation/EvidenceSnapshotService';
 import { createPostSubjectProvider } from '../../../services/moderation/subjects/postSubject';
@@ -160,6 +169,7 @@ function reportRow(reportedId = POST_ID, reporter = REPORTER) {
 beforeEach(() => {
   posts = new Map();
   enqueuedPayloads = [];
+  postLoadFailure = undefined;
   vi.clearAllMocks();
 });
 
@@ -395,6 +405,50 @@ describe('report urgency — an absence is not a zero', () => {
     expect(payload).toEqual({ reportId: REPORT_ID });
     expect(built?.reportInput).not.toHaveProperty('urgency');
   });
+
+  it('sends no urgency for material whose distribution cannot be described', async () => {
+    // The post is gone between the report and this read, so the provider answers
+    // `null` — distinct from throwing, and distinct from "this noun has no reach".
+    const payload = await intake({ reportedType: ReportedType.POST, reportedId: POST_ID });
+
+    expect(payload).toEqual({ reportId: REPORT_ID });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  const INTAKE_FAILURES: ReadonlyArray<[string, unknown, string]> = [
+    ['an Error', new Error('connection to mongo lost'), 'connection to mongo lost'],
+    // A rejection is under no obligation to be an `Error`. The handler stringifies
+    // whatever it caught, because a failure nobody can read is the one thing worse
+    // than a failure.
+    ['something that is not an Error', 'ECONNRESET', 'ECONNRESET'],
+  ];
+
+  it.each(INTAKE_FAILURES)(
+    'still takes the report when composing urgency throws %s',
+    async (_case, thrown, expectedMessage) => {
+      posts.set(POST_ID, post(POST_ID, { stats: { viewsCount: 5 } }));
+      postLoadFailure = thrown;
+
+      const payload = await intake({ reportedType: ReportedType.POST, reportedId: POST_ID });
+
+      /**
+       * The priority of the two things at stake. A missing urgency costs the case
+       * up to ten of a hundred triage points; a raised one costs the reporter their
+       * report entirely, because `createReport` is what `POST /reports` awaits. So
+       * the failure is swallowed for the URGENCY and never for the report — the
+       * outbox row is still written, and the report will still be delivered.
+       */
+      expect(payload).toEqual({ reportId: REPORT_ID });
+      expect(Report.create).toHaveBeenCalledTimes(1);
+
+      // Swallowed is not the same as silent: the reason has to reach an operator,
+      // or a permanently mis-triaged queue has no explanation anywhere.
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[CrowdSource] could not snapshot report urgency',
+        expect.objectContaining({ reportedId: POST_ID, error: expectedMessage }),
+      );
+    },
+  );
 
   it('drops a stored urgency the contract refuses instead of losing the report', async () => {
     posts.set(POST_ID, post(POST_ID, { stats: { viewsCount: 5 } }));

--- a/packages/backend/src/models/ModerationOutbox.ts
+++ b/packages/backend/src/models/ModerationOutbox.ts
@@ -34,6 +34,28 @@ export type ModerationOutboxStatus = 'pending' | 'processing' | 'processed' | 'd
 export interface ModerationOutboxPayload {
   /** The local `Report._id`, for `report.submit`. */
   reportId?: string;
+  /**
+   * §5.1 `urgency` — how far the material had travelled when the report was
+   * TAKEN. `{ hint, reach?, activeDistribution? }`, composed by the subject
+   * provider at intake.
+   *
+   * It lives on the job rather than being read when the job runs, and that is the
+   * whole reason it exists as a stored field. CrowdSource's ingress fingerprints
+   * the entire `{ externalReportId, envelope }` to catch §10.5's "external id
+   * reused with different content", so an audience count read afresh on each
+   * delivery attempt makes an ordinary outbox retry a permanent 409 — days later,
+   * as moderation work stuck in a queue, with nothing failing at the moment the
+   * mistake is made. This row is written once and never updated, which is exactly
+   * the property the envelope needs.
+   *
+   * Typed `unknown` for the same reason as `decision`: it is stored data, read
+   * back by a deployment that need not be the one that wrote it, and the schema
+   * for it belongs to CrowdSource. `EvidenceSnapshotService` validates it against
+   * the published `CaseUrgencySchema` on the way out — a strict object, so a
+   * malformed row would otherwise throw a NON-retryable input error and
+   * dead-letter a report whose only defect is a triage hint.
+   */
+  urgency?: unknown;
   /** The inbound webhook event id, for `decision.apply` (Appendix D). */
   eventId?: string;
   /** The CrowdSource case a decision belongs to. */
@@ -87,6 +109,14 @@ const ModerationOutboxSchema = new Schema<IModerationOutbox>(
     },
     payload: {
       reportId: { type: String },
+      /**
+       * `Mixed`, like `decision` beside it, and for a second reason on top of the
+       * shared one: declaring the sub-paths would let Mongoose materialise an
+       * EMPTY `urgency` object on a row that never had one, and an `{}` reaching
+       * the contract is a validation failure rather than an omission. Absent has
+       * to stay absent.
+       */
+      urgency: { type: Schema.Types.Mixed },
       eventId: { type: String },
       caseId: { type: String },
       decision: { type: Schema.Types.Mixed },

--- a/packages/backend/src/services/moderation/EvidenceSnapshotService.ts
+++ b/packages/backend/src/services/moderation/EvidenceSnapshotService.ts
@@ -1,9 +1,11 @@
 import { createHash } from 'crypto';
 import type { ReportInput } from '@oxyhq/crowdsource';
+import { CaseUrgencySchema, type CaseUrgency } from '@oxyhq/crowdsource-contracts';
 import { REPORT_TAXONOMY_VERSION, allegationsForCategories } from './reportTaxonomy';
 import { subjectProviderFor } from './subjects/registry';
 import type { ModerationSubjectSnapshot } from './subjects/types';
 import type { IReport } from '../../models/Report.model';
+import { logger } from '../../utils/logger';
 
 /**
  * Turning a stored report into the thing the SDK delivers.
@@ -78,6 +80,41 @@ export function snapshotHash(snapshot: ModerationSubjectSnapshot): string {
   return `sha256:${createHash('sha256').update(canonical, 'utf8').digest('hex')}`;
 }
 
+/**
+ * The urgency the INTAKE froze, or nothing.
+ *
+ * Validated against the published contract rather than trusted, because the value
+ * crosses two boundaries no type survives: a Mongo document, and a deployment that
+ * need not be the one that wrote it. `CaseUrgencySchema` is a STRICT object, so an
+ * extra or malformed key makes envelope composition throw
+ * `CrowdSourceReportInputError` — which carries `retryable: false`, so the outbox
+ * would dead-letter a report whose only defect is a scheduling hint. Dropping the
+ * hint costs at most ten of a hundred triage points; keeping a bad one costs the
+ * review entirely, so this fails toward delivering the report.
+ *
+ * Parsing also normalises key ORDER to the contract's own shape, so two rows that
+ * differ only in how Mongo happened to store them still compose byte-identical
+ * envelopes.
+ *
+ * Deliberately never RECOMPUTED when absent. This function runs at delivery time,
+ * and a value read here would vary between two attempts at the same report — the
+ * permanent-409 trap `ReportIntakeService` exists to close. A report predating the
+ * snapshot, or one whose delivery event was re-derived by the reconciliation
+ * sweep, ships without urgency and triages at the bottom of the reach band. That
+ * is the correct trade: a late report is recoverable, a 409'd one is not.
+ */
+function contractUrgency(stored: unknown): CaseUrgency | undefined {
+  if (stored === undefined || stored === null) return undefined;
+
+  const parsed = CaseUrgencySchema.safeParse(stored);
+  if (parsed.success) return parsed.data;
+
+  logger.warn('[CrowdSource] stored report urgency does not match the contract', {
+    issues: parsed.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+  });
+  return undefined;
+}
+
 export interface ModerationReportInput {
   /** What the SDK delivers. */
   readonly reportInput: ReportInput;
@@ -92,12 +129,16 @@ export interface ModerationReportInput {
  * either: content deleted between the report and its delivery is ordinary, and
  * §5.6 keeps evidence available through retention on CrowdSource's side — but an
  * object Mention never got to snapshot has no evidence to keep.
+ *
+ * `storedUrgency` arrives from the outbox row rather than being derived here, and
+ * that asymmetry is the point — see {@link contractUrgency}.
  */
 export async function buildModerationReportInput(
   report: Pick<
     IReport,
     'reportedType' | 'reportedId' | 'reporter' | 'categories' | 'details' | 'createdAt'
   > & { id: string },
+  storedUrgency?: unknown,
 ): Promise<ModerationReportInput | null> {
   const provider = subjectProviderFor(report.reportedType);
   if (!provider) throw new ModerationSubjectUnsupportedError(report.reportedType);
@@ -107,6 +148,7 @@ export async function buildModerationReportInput(
 
   const allegationCodes = allegationsForCategories(report.categories);
   const details = report.details?.trim();
+  const urgency = contractUrgency(storedUrgency);
 
   return {
     reportInput: {
@@ -136,6 +178,16 @@ export async function buildModerationReportInput(
        * retry from the outbox a permanent 409 (§10.5).
        */
       submittedAt: report.createdAt,
+      /**
+       * How far the material had travelled, so a report about a post thousands of
+       * people saw is not queued behind one about a post nobody has seen. §7.4
+       * scores this as up to ten of a hundred priority points; sending nothing
+       * triages every Mention case as if its subject had reached no one.
+       *
+       * An input to ORDER, never to a verdict — the tokens name distribution and
+       * say nothing about whether the allegation is true.
+       */
+      ...(urgency === undefined ? {} : { urgency }),
       metadata: {
         /**
          * So a case can be read back against the mapping that produced it.

--- a/packages/backend/src/services/moderation/ModerationDeliveryWorker.ts
+++ b/packages/backend/src/services/moderation/ModerationDeliveryWorker.ts
@@ -91,15 +91,24 @@ export async function deliverReportOutboxEvent(
    * Catching it and writing a local state would put the report somewhere nothing
    * alerts on.
    */
-  const input = await buildModerationReportInput({
-    id: String(report._id),
-    reportedType: report.reportedType,
-    reportedId: report.reportedId,
-    reporter: report.reporter,
-    categories: report.categories,
-    details: report.details,
-    createdAt: report.createdAt,
-  });
+  const input = await buildModerationReportInput(
+    {
+      id: String(report._id),
+      reportedType: report.reportedType,
+      reportedId: report.reportedId,
+      reporter: report.reporter,
+      categories: report.categories,
+      details: report.details,
+      createdAt: report.createdAt,
+    },
+    /**
+     * From the EVENT, not from a fresh look at the post. The urgency was frozen
+     * when the report was taken precisely so that every attempt at this event
+     * composes the same envelope — the ingress fingerprints it, so a value
+     * re-measured here would make the second attempt a permanent 409 (§10.5).
+     */
+    event.payload.urgency,
+  );
 
   if (input === null) {
     await closeUndeliverable(

--- a/packages/backend/src/services/moderation/ModerationReconciliation.ts
+++ b/packages/backend/src/services/moderation/ModerationReconciliation.ts
@@ -112,6 +112,15 @@ export async function reconcileModerationReports(
     const session = await mongoose.startSession();
     try {
       await session.withTransaction(async () => {
+        /**
+         * No `urgency`, and re-measuring one here would be a mistake rather than a
+         * completeness fix. A sweep re-derives work from the report, and the
+         * distribution facts it could read now are the ones at RECONCILIATION time
+         * — a different envelope from the one the lost event would have composed,
+         * which is exactly what the ingress fingerprint treats as §10.5's payload
+         * conflict. A report re-derived here therefore triages at the bottom of the
+         * reach band, which is the price of having lost its event.
+         */
         await enqueueModerationOutboxEvent(
           { eventId, kind: 'report.submit', payload: { reportId } },
           session,

--- a/packages/backend/src/services/moderation/ReportIntakeService.ts
+++ b/packages/backend/src/services/moderation/ReportIntakeService.ts
@@ -11,6 +11,8 @@ import {
   reportSubmitEventId,
 } from './ModerationOutboxService';
 import { subjectProviderFor } from './subjects/registry';
+import type { ModerationSubjectProvider, ModerationUrgency } from './subjects/types';
+import { logger } from '../../utils/logger';
 
 /**
  * Storing a report and, when there is somewhere to send it, the promise to deliver
@@ -108,6 +110,49 @@ function localOnlyReason(reportedType: string): string {
   );
 }
 
+/**
+ * The distribution facts as they stood WHEN THE REPORT WAS TAKEN.
+ *
+ * Read here, once, and carried on the outbox row — never re-read when the row is
+ * delivered. CrowdSource's ingress fingerprints the whole
+ * `{ externalReportId, envelope }` to detect §10.5's "external id reused with
+ * different content", and an audience count is the fastest-moving value an
+ * envelope can carry: on any live post it differs between two reads seconds apart.
+ * Read at delivery it would turn an ordinary outbox retry into a PERMANENT 409,
+ * and the symptom is moderation work silently stuck in a queue days later, with
+ * nothing failing at the moment the mistake is made. The SDK's own note on
+ * `submittedAt` names this exact trap; this is the same trap with a value that
+ * moves far faster than a timestamp.
+ *
+ * Read BEFORE the transaction, alongside the delivery decision it belongs with,
+ * for the same reason that one is: an input the transaction body consumes rather
+ * than a write that has to commit atomically with anything. Freezing it is what
+ * makes it stable — the moment it is read is not what matters, only that it is
+ * read once.
+ *
+ * A failure here costs the case up to ten of a hundred triage points and nothing
+ * else, so it must never cost the reporter their report: an urgency that cannot be
+ * composed is logged and omitted, not raised. `POST /reports` answering 5xx
+ * because a stats read failed would trade the whole report for its queue position.
+ */
+async function snapshotUrgency(
+  provider: ModerationSubjectProvider,
+  reportedId: string,
+  reporterId: string,
+): Promise<ModerationUrgency | undefined> {
+  if (!provider.urgencySnapshot) return undefined;
+  try {
+    return (await provider.urgencySnapshot(reportedId, reporterId)) ?? undefined;
+  } catch (error: unknown) {
+    logger.warn('[CrowdSource] could not snapshot report urgency', {
+      reportedType: provider.reportedType,
+      reportedId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
 async function inTransaction<T>(
   operation: (session: ClientSession) => Promise<T>,
 ): Promise<T> {
@@ -153,7 +198,11 @@ export async function createReport(input: CreateReportInput): Promise<CreateRepo
   if (!Object.values(ReportedType).includes(reportedType as ReportedType)) {
     throw new TypeError(`createReport: reportedType '${reportedType}' is not a reportable type.`);
   }
-  const deliverable = subjectProviderFor(reportedType) !== undefined;
+  const provider = subjectProviderFor(reportedType);
+  const deliverable = provider !== undefined;
+  const urgency = provider
+    ? await snapshotUrgency(provider, reportedId, reporter)
+    : undefined;
 
   return await inTransaction(async (session) => {
     const existing = await Report.findOne({
@@ -187,7 +236,13 @@ export async function createReport(input: CreateReportInput): Promise<CreateRepo
       {
         eventId: reportSubmitEventId(report.id),
         kind: 'report.submit',
-        payload: { reportId: report.id },
+        /**
+         * Spread conditionally so a subject type with no urgency to report writes
+         * the payload it always wrote. An explicit `urgency: undefined` would put
+         * the key in the update document, and a stored `null` is a value the
+         * contract refuses rather than an absence.
+         */
+        payload: { reportId: report.id, ...(urgency === undefined ? {} : { urgency }) },
       },
       session,
     );

--- a/packages/backend/src/services/moderation/subjects/postSubject.ts
+++ b/packages/backend/src/services/moderation/subjects/postSubject.ts
@@ -10,6 +10,7 @@ import type {
   ModerationResource,
   ModerationSubjectProvider,
   ModerationSubjectSnapshot,
+  ModerationUrgency,
 } from './types';
 
 /**
@@ -75,12 +76,13 @@ interface SnapshotPost {
   createdAt?: Date | string;
   status?: string;
   visibility?: string;
+  stats?: { viewsCount?: number };
   metadata?: { isSensitive?: boolean };
   federation?: { url?: string; sensitive?: boolean };
 }
 
 const SNAPSHOT_PROJECTION =
-  'content authorship oxyUserId parentPostId quoteOf language createdAt status visibility metadata.isSensitive federation.url federation.sensitive';
+  'content authorship oxyUserId parentPostId quoteOf language createdAt status visibility stats.viewsCount metadata.isSensitive federation.url federation.sensitive';
 
 /**
  * §5.2's `sensitivity` hint for a post carrying a content warning.
@@ -170,6 +172,22 @@ function mediaOnlySubjectResource(post: SnapshotPost): ModerationResource {
 }
 
 /**
+ * The two facts that decide where a post is readable.
+ *
+ * An absent field means the permissive value, matching the rest of the schema —
+ * and both predicates have to agree with the disclosure gate below and with the
+ * urgency they feed, or a post could be described as actively distributed by one
+ * and withheld as private by the other.
+ */
+function isPublished(post: SnapshotPost): boolean {
+  return (post.status ?? 'published') === 'published';
+}
+
+function isPublic(post: SnapshotPost): boolean {
+  return (post.visibility ?? 'public') === 'public';
+}
+
+/**
  * Load material only when it is safe to disclose outside Mention.
  *
  * CrowdSource delivery runs asynchronously without the reporter's delegated Oxy
@@ -188,9 +206,7 @@ async function loadPost(postId: string, reporterId?: string): Promise<SnapshotPo
   const ownerId = getOwnerId(normalizeAuthorship(post.authorship)) ?? post.oxyUserId;
   if (ownerId === reporterId) return post;
 
-  const isPublished = (post.status ?? 'published') === 'published';
-  const isPublic = (post.visibility ?? 'public') === 'public';
-  return isPublished && isPublic ? post : null;
+  return isPublished(post) && isPublic(post) ? post : null;
 }
 
 /**
@@ -226,6 +242,73 @@ function permalink(post: SnapshotPost): string {
   return post.federation?.url ?? `${config.web.origin}/p/${post._id.toHexString()}`;
 }
 
+/**
+ * §5.1 `urgency.hint` — ONE token naming how far the material travelled.
+ *
+ * Distribution, and never severity. §7.4 is explicit that triage decides queue
+ * ORDER and does not decide guilt, so a hint that read as evidence the allegation
+ * is TRUE — naming what the content is alleged to be, or repeating an allegation
+ * code — would be a policy violation wearing a scheduling hint's clothes. Every
+ * token below states only where the post is readable.
+ *
+ * The contract constrains this to `^[a-z][a-z0-9_]*$` (max 40), so a descriptive
+ * phrase is not available and the vocabulary itself has to carry the meaning.
+ *
+ * Ordered most-reachable first, because the states overlap and only one token can
+ * be sent. A copy of remote material is published at its origin whatever Mention's
+ * own row says, which outranks anything Mention's visibility can express.
+ *
+ * `public_feed` deliberately does not claim "Mention only". Whether a LOCAL post
+ * also went out to the fediverse is not a fact this row can answer: the obvious
+ * candidate, `metadata.federationDelivered`, is not a declared path on
+ * `PostMetadataSchema` and Mongoose's strict mode strips it on write, so it reads
+ * `undefined` on every post regardless of what happened. Asserting locality from
+ * an absent flag would be inventing a distribution fact — so the token asserts
+ * what is true and denies nothing.
+ */
+function distributionHint(post: SnapshotPost): string {
+  if (post.federation !== undefined) return 'federated_origin';
+  if (!isPublished(post)) return 'not_distributed';
+  return isPublic(post) ? 'public_feed' : 'limited_audience';
+}
+
+/**
+ * §5.1 `urgency.reach` — Mention's own view counter, and nothing else.
+ *
+ * `stats.viewsCount` is the one number this application holds that counts PEOPLE
+ * rather than actions: `feedViewCounter` increments it at most once per
+ * (viewer, post) within a rolling window and only for a published public post.
+ * That is what the contract asks for in its own words — "how many people the
+ * material reached, as the application counts it".
+ *
+ * The rejected candidates matter as much, because triage weights this
+ * logarithmically (`log10(1 + reach) * 2`, capped) and a wrong number is not
+ * visibly wrong — it just quietly orders the queue badly. The author's FOLLOWER
+ * count is a potential audience rather than a reach, and would triage every post
+ * by a large account identically whether or not anyone read it. Likes and boosts
+ * are a SUBSET of the people who saw it, so sending one as reach understates by a
+ * factor that varies with the topic and the author.
+ *
+ * It UNDERCOUNTS a federated post, because a read on a remote instance never comes
+ * back to Mention — which is exactly why `federated_origin` exists as a hint, so
+ * the shortfall is legible instead of silent. Scaling the number up by a guessed
+ * multiplier would put a figure in front of triage that nobody could explain, and
+ * a stated undercount is worth more than an invented estimate.
+ */
+function reachedAudience(post: SnapshotPost): number | undefined {
+  const views = post.stats?.viewsCount;
+  /**
+   * The contract types `reach` as a non-negative integer and refuses anything
+   * else — and a refused envelope is a NON-retryable input error, so a corrupt
+   * counter would cost the whole report rather than just its queue position.
+   * Omitted rather than coerced: a rounded or clamped value would be a number
+   * Mention made up, which is the thing this field must never carry.
+   */
+  return typeof views === 'number' && Number.isInteger(views) && views >= 0
+    ? views
+    : undefined;
+}
+
 export function createPostSubjectProvider(input: {
   reportedType: string;
   subjectType: string;
@@ -233,6 +316,44 @@ export function createPostSubjectProvider(input: {
   return {
     reportedType: input.reportedType,
     subjectType: input.subjectType,
+
+    /**
+     * Read at INTAKE, through the same disclosure gate as the material itself.
+     *
+     * Sharing `loadPost` is what keeps the two answers from disagreeing: a post a
+     * reporter may not be shown produces no snapshot AND no urgency, so a report
+     * can never describe the distribution of material the envelope will not
+     * carry. It also means `limited_audience` and `not_distributed` are only ever
+     * reachable on a self-report, which is the only case where a non-public post
+     * is disclosable at all.
+     *
+     * A comment gets the same treatment as a post, and that is not an oversight:
+     * they are one collection with one `stats.viewsCount`, so a reply that was
+     * read by ten thousand people reached ten thousand people. A profile is the
+     * case with no defensible answer — see `userSubject.ts`.
+     */
+    async urgencySnapshot(
+      reportedId: string,
+      reporterId?: string,
+    ): Promise<ModerationUrgency | null> {
+      const post = await loadPost(reportedId, reporterId);
+      if (!post) return null;
+
+      const reach = reachedAudience(post);
+      return {
+        hint: distributionHint(post),
+        ...(reach === undefined ? {} : { reach }),
+        /**
+         * "Is it still being handed to people right now." `status: 'published'`
+         * plus a public `visibility` is precisely what every feed source and the
+         * post-hydration ACL already require, so this reuses the read path's own
+         * definition of reachable rather than writing a second one. It is also why
+         * a post that an earlier decision RESTRICTED answers `false` here, without
+         * anything in this file knowing that enforcement exists.
+         */
+        activeDistribution: isPublished(post) && isPublic(post),
+      };
+    },
 
     async snapshot(
       reportedId: string,

--- a/packages/backend/src/services/moderation/subjects/types.ts
+++ b/packages/backend/src/services/moderation/subjects/types.ts
@@ -31,6 +31,7 @@
  *    what happens to the report. Those belong to callers that are shared.
  */
 
+import type { CaseUrgency } from '@oxyhq/crowdsource-contracts';
 import type { ContextInput, ReportSubjectInput, ResourceInput } from '@oxyhq/crowdsource';
 
 /**
@@ -43,6 +44,17 @@ import type { ContextInput, ReportSubjectInput, ResourceInput } from '@oxyhq/cro
  */
 export type ModerationResource = ResourceInput;
 export type ModerationContextResource = ContextInput;
+
+/**
+ * §5.1 `urgency` — how far the material travelled, unchanged.
+ *
+ * The contract's own type, for a reason sharper than consistency: it is a STRICT
+ * object, so an extra key is a validation failure at envelope composition and a
+ * `CrowdSourceReportInputError` is NOT retryable. A provider that invented a
+ * field would not produce a worse-triaged report, it would produce a
+ * permanently undeliverable one.
+ */
+export type ModerationUrgency = CaseUrgency;
 
 /**
  * One reported object, described.
@@ -97,4 +109,28 @@ export interface ModerationSubjectProvider {
    * for days.
    */
   snapshot(reportedId: string, reporterId?: string): Promise<ModerationSubjectSnapshot | null>;
+
+  /**
+   * How far the material had travelled WHEN THE REPORT WAS TAKEN, or `null` when
+   * this application cannot say.
+   *
+   * Called once, at intake, and carried on the outbox row — NEVER at delivery.
+   * Everything here is fingerprinted into the envelope, and a live audience count
+   * is the fastest-moving number an application holds, so a value re-read per
+   * attempt would turn an ordinary outbox retry into a permanent 409 (§10.5).
+   * That failure is invisible when it is written and appears days later as
+   * moderation work stuck in a queue. `ReportIntakeService` is where the freeze
+   * happens and where the whole argument is written down.
+   *
+   * Optional because reach is not a universal property of a noun — a post has an
+   * audience, a profile is not distributed at all (see `userSubject.ts`). A
+   * provider that omits it ships no `urgency`, which is deliberately different
+   * from shipping zeros: §7.4 computes priority from several signals, so an
+   * absent one costs queue position and never a verdict, while a made-up zero is
+   * an assertion nobody can defend.
+   */
+  urgencySnapshot?(
+    reportedId: string,
+    reporterId?: string,
+  ): Promise<ModerationUrgency | null>;
 }

--- a/packages/backend/src/services/moderation/subjects/userSubject.ts
+++ b/packages/backend/src/services/moderation/subjects/userSubject.ts
@@ -15,6 +15,18 @@ import type { ModerationSubjectProvider, ModerationSubjectSnapshot } from './typ
  * routinely has none) and every field of §5.3's `profile` resource is optional for
  * exactly that reason, so nothing here substitutes a handle for a missing name.
  * The handle travels separately, as a claim.
+ *
+ * ## No `urgencySnapshot`, deliberately
+ *
+ * The reported material here is the PROFILE — a display name, a bio, a handle —
+ * and Mention holds no audience figure for it. The tempting substitute is the
+ * account's follower count, and it answers a different question: how many people
+ * subscribed to an account, not how many read the bio under review. Sending it as
+ * `reach` would triage every report about a large account above every report about
+ * a small one on a number that describes neither the material nor its exposure,
+ * and `log10` makes that a systematic four-point thumb on the scale rather than a
+ * rounding error. Omitting the field costs queue position and asserts nothing;
+ * `urgency` is optional precisely so an application does not have to invent one.
  */
 
 /** §5.3 `profile.claims`: bounded, flat, scalar. */


### PR DESCRIPTION
Closes #637.

Mention never populated `ReportInput.urgency`, so CrowdSource triaged **every** Mention case at `reach: 0, activeDistribution: false` — forfeiting the whole `REACH_MAX: 10` band of a 100-point priority score. A report about a post thousands of people saw queued behind one about a post nobody has seen. Triage decides queue ORDER, not guilt, so this was always a latency bug; it is still the difference between a jury seeing the widely-distributed material first or last.

## Why the value is frozen at intake, and why a delivery-time read would have been wrong

`buildModerationReportInput` runs in `ModerationDeliveryWorker`, not at intake. CrowdSource's ingress fingerprints the entire `{ externalReportId, envelope }` to detect §10.5's "external id reused with different content" — so **anything in the envelope that differs between two delivery attempts turns an ordinary outbox retry into a permanent 409**. An audience count is the fastest-moving value an envelope can carry: on any live post it differs between two reads seconds apart, so the obvious implementation (read `stats` inside the builder) would have broken every retry of every report about an active post.

That failure is invisible at the moment it is written. Nothing throws, nothing logs, and the symptom appears days later as moderation work silently stuck in a queue. The SDK's own comment on `submittedAt` documents exactly this trap; this is the same trap with a value that moves far faster than a timestamp.

So the flow is: the subject provider composes the urgency **once, at intake** → it rides on the `ModerationOutbox` payload, written inside the existing intake transaction via `$setOnInsert` only, so a repeated enqueue for the deterministic event id cannot overwrite it → the delivery worker passes the frozen value through. No second write, no new transaction, and the `{ upsert, session, timestamps: false }` shape is untouched.

Consequences of the same reasoning, both deliberate:
- **`ModerationReconciliation` re-derives a lost delivery event with NO urgency.** Measuring one during the sweep would compose a different envelope from the one the lost event would have — the payload conflict again. A re-derived report triages at the bottom of the reach band; that is the price of having lost its event.
- **Stored urgency is validated against the published `CaseUrgencySchema` on read.** It is a *strict* object, and `CrowdSourceReportInputError` carries `retryable: false` — so a malformed row (a hand edit, or a newer deployment's extra key) would dead-letter a report whose only defect is a scheduling hint. It is dropped and logged instead. Parsing also normalises key order, so two rows differing only in Mongo's storage order still compose byte-identical envelopes.

## What is actually sent

All three fields are facts about **distribution**, never about severity — §7.4 forbids anything that reads as evidence the allegation is true.

| field | value | why |
|---|---|---|
| `reach` | `stats.viewsCount` | The one number Mention holds that counts **people** rather than actions: `feedViewCounter` increments it at most once per (viewer, post) in a rolling window. That is the contract's own wording — "how many people the material reached, as the application counts it". |
| `hint` | `federated_origin` \| `public_feed` \| `limited_audience` \| `not_distributed` | One lowercase token (the contract's regex forbids a descriptive phrase), ordered most-reachable first. |
| `activeDistribution` | `status: 'published'` **and** public `visibility` | The same predicate every feed source and the post-hydration ACL already require — so a post an earlier decision `restrict`ed answers `false` here without this file knowing enforcement exists. |

Rejected reach candidates, since triage weights this logarithmically and a wrong number is not visibly wrong: **follower count** is a potential audience, not a reach, and would triage every post by a large account identically whether or not anyone read it; **likes/boosts** are a subset of the people who saw it and understate by a factor that varies with topic and author. `viewsCount` undercounts a *federated* post (a read on a remote instance never comes back), which is exactly why `federated_origin` exists as a hint — a stated undercount beats an invented multiplier.

`user` sends **no urgency at all** rather than a zero: a profile has no audience figure Mention holds, and the follower count answers a different question (who subscribed to the account, not who read the bio under review). `comment` shares the post provider deliberately — same collection, same `stats.viewsCount`.

### Note on `metadata.federationDelivered`

The issue suggests it as an input. It is **not usable, and this is verified rather than assumed**: it is not a declared path on `PostMetadataSchema`, and Mongoose strict mode strips it on write, so it reads `undefined` on every post regardless of what happened. `public_feed` therefore asserts what is true ("published and public on Mention") and deliberately does not claim "Mention only". *This looks like a live bug in `PostCreationService` / `PostCollaborationService`, which gate re-federation on that flag — out of scope here, reported separately.*

## Tests

New `reportUrgency.test.ts` (13 cases) runs intake → outbox payload → builder through the **real** registry and post provider:
- a widely-distributed post yields a higher `reach` than an unseen one, visible in the built `ReportInput`;
- **two builds of the same report are byte-identical** with the post mutated between them (views `12` → `900_000`, visibility `public` → `followers`) — and a **positive control** asserts a live read *would* see all three fields change, so the test cannot pass against an implementation with no snapshot in it;
- an absent counter omits `reach` instead of sending `0`; a corrupt one (fractional, negative, non-numeric) is omitted rather than coerced;
- a `user` report carries no `urgency` end to end; a contract-invalid stored value is dropped without losing the report.

`moderationOutboxWrites.test.ts` (the file that exists to let a real `mongod` answer) gains two cases: the urgency round-trips through a real Mongo write intact, and a payload without one stores **no `urgency` key** — absent has to stay absent, because an empty `{}` reaching a strict contract object is a validation failure, not an omission. That is also why the schema path is `Mixed` rather than declared sub-paths.

## Verification

- `bun run --cwd packages/shared-types build` — clean
- `bunx tsc --noEmit` in `packages/backend` — no output
- `bun run lint:backend` — clean
- `bun run validate:logger` — all 9 validator cases passed
- `cd packages/backend && bun run test` — **452/452 files, 4969/4969 tests passed**, zero failures

No dependency added; `bun.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
