### PR TITLE
fix(web): release the realtime sockets while the page is in the back/forward cache

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -29,6 +29,7 @@ import { AppInitializer } from '@/lib/appInitializer';
 import { logger } from '@oxyhq/core/logger';
 import { configureAppLogging } from '@/lib/logging';
 import { BLOOM_THEME_PERSIST_KEY, BLOOM_THEME_STORAGE } from '@/lib/themePersistence';
+import { registerSocketBfcacheRelease } from '@/lib/socketBfcache';
 import { initializeWebTelemetry } from '@/lib/webTelemetry';
 
 // Styles
@@ -107,6 +108,11 @@ export default function RootLayout() {
   }, []);
 
   useEffect(() => initializeWebTelemetry(), []);
+
+  // Release the realtime sockets while the browser holds this document in its
+  // back/forward cache — an open WebSocket makes the page ineligible, which is
+  // what turns a cross-document Back into a full app reload.
+  useEffect(() => registerSocketBfcacheRelease(), []);
 
   // React Query managers - setup once on mount
   useEffect(() => {

--- a/packages/frontend/lib/socketBfcache.native.ts
+++ b/packages/frontend/lib/socketBfcache.native.ts
@@ -1,0 +1,10 @@
+/**
+ * Native no-op for the web-only back/forward-cache socket release.
+ *
+ * There is no page lifecycle on native — the app is never frozen into a document
+ * cache, and `socketService` already reconnects from its own AppState handler
+ * when the app returns to the foreground. See `socketBfcache.web.ts`.
+ */
+export function registerSocketBfcacheRelease(): () => void {
+  return () => undefined;
+}

--- a/packages/frontend/lib/socketBfcache.ts
+++ b/packages/frontend/lib/socketBfcache.ts
@@ -1,0 +1,3 @@
+// Base module for ESLint / tsc import resolution.
+// At build time, bundlers resolve socketBfcache.native.ts or socketBfcache.web.ts instead.
+export { registerSocketBfcacheRelease } from './socketBfcache.web';

--- a/packages/frontend/lib/socketBfcache.web.ts
+++ b/packages/frontend/lib/socketBfcache.web.ts
@@ -1,0 +1,50 @@
+/**
+ * Web-only release of the realtime sockets while the document sits in the
+ * browser's back/forward cache.
+ *
+ * An open WebSocket makes a whole document ineligible for that cache in Chrome,
+ * which reports the refusal as `SupportPending:WebSocket`. Mention holds one open
+ * at all times — the authenticated posts socket and the public trends socket
+ * share a single Socket.IO Manager, and therefore a single WebSocket — so every
+ * Back or Forward that crosses a document boundary rebuilds the app from scratch:
+ * white flash, splash, session restore, every screen refetched. The most common
+ * boundary is simply whatever page the reader was on before this one.
+ *
+ * `pagehide` is early enough to fix it. The browser dispatches it BEFORE deciding
+ * whether the page is storable — measured in Chrome 150, which fires
+ * `pagehide` with `persisted: true` and then still refuses the traversal for the
+ * open WebSocket — so a socket released here is released in time to change the
+ * verdict. That ordering is also what web.dev's bfcache guidance relies on.
+ *
+ * Native has no page lifecycle; `socketBfcache.native.ts` is a no-op.
+ */
+
+import { publicRealtimeService } from '@/services/publicRealtimeService';
+import { socketService } from '@/services/socketService';
+
+export function registerSocketBfcacheRelease(): () => void {
+  const onPageHide = (event: PageTransitionEvent): void => {
+    // `persisted: false` means the browser has already committed to destroying
+    // this document, so there is nothing left for a released socket to buy.
+    if (!event.persisted) return;
+    socketService.suspendForPageFreeze();
+    publicRealtimeService.suspendForPageFreeze();
+  };
+
+  const onPageShow = (event: PageTransitionEvent): void => {
+    // A non-persisted `pageshow` is a fresh document booting normally, whose
+    // sockets are opened by the bridges that own them. Reconnecting here would
+    // open a second connection alongside the one they are about to make.
+    if (!event.persisted) return;
+    socketService.resumeAfterPageRestore();
+    publicRealtimeService.resumeAfterPageRestore();
+  };
+
+  window.addEventListener('pagehide', onPageHide);
+  window.addEventListener('pageshow', onPageShow);
+
+  return () => {
+    window.removeEventListener('pagehide', onPageHide);
+    window.removeEventListener('pageshow', onPageShow);
+  };
+}

--- a/packages/frontend/services/__tests__/postEngagementLiveCounts.test.ts
+++ b/packages/frontend/services/__tests__/postEngagementLiveCounts.test.ts
@@ -132,6 +132,7 @@ describe('live post engagement counts, over a real socket', () => {
   let ioServer: SocketIOServer;
   let serverSockets: ServerSocket[] = [];
   let joinedRooms: string[] = [];
+  let handshakeAuths: Array<Record<string, unknown>> = [];
   let socketService: typeof import('@/services/socketService').socketService;
 
   beforeAll(async () => {
@@ -142,6 +143,7 @@ describe('live post engagement counts, over a real socket', () => {
     // one; the admission decision is the backend's and is tested there.
     ioServer.on('connection', (socket) => {
       serverSockets.push(socket);
+      handshakeAuths.push(socket.handshake.auth);
       socket.on('joinPost', (postId: string) => {
         joinedRooms.push(postId);
         socket.join(postEngagementRoom(postId));
@@ -169,6 +171,7 @@ describe('live post engagement counts, over a real socket', () => {
   beforeEach(async () => {
     mockPosts.clear();
     joinedRooms = [];
+    handshakeAuths = [];
     seedPost(WATCHED_POST);
     seedPost(UNWATCHED_POST);
 
@@ -413,5 +416,97 @@ describe('live post engagement counts, over a real socket', () => {
       () => joinedRooms.includes(WATCHED_POST),
       'the client to re-assert its room after reconnecting',
     );
+  });
+
+  // The web app is frozen into the browser's back/forward cache on a
+  // cross-document Back, and an open WebSocket makes the page ineligible for
+  // that cache. `lib/socketBfcache.web.ts` drives this pair from
+  // `pagehide`/`pageshow`; these tests are what stands behind the authenticated
+  // socket, which a signed-out browser check cannot reach.
+  describe('back/forward-cache freeze and restore', () => {
+    it('stays down for the whole frozen period instead of reconnecting', async () => {
+      const live = serverSockets.at(-1);
+      if (!live) throw new Error('no server-side socket for this connection');
+      const connectionsBefore = serverSockets.length;
+
+      socketService.suspendForPageFreeze();
+      // Asked of THIS connection's server-side socket, not of the client's own
+      // flag: `suspendForPageFreeze` sets that flag itself, so it would read
+      // "closed" even for a suspend that never touched the transport — the exact
+      // case this test exists to catch.
+      await waitFor(() => live.disconnected, 'the server to see this client leave');
+
+      // Long enough to cover several turns of the 1s reconnection delay. A
+      // Socket.IO retry loop left running here reopens the connection within a
+      // second and the page is refused the cache all over again — which is why
+      // closing the socket without suppressing reconnection is not a fix.
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      expect(serverSockets).toHaveLength(connectionsBefore);
+      expect(socketService.getConnectionStatus().isConnected).toBe(false);
+    }, 15000);
+
+    it('comes back live on the SAME session, with its post rooms replayed', async () => {
+      socketService.suspendForPageFreeze();
+      await waitFor(
+        () => !socketService.getConnectionStatus().isConnected,
+        'the transport to close',
+      );
+      joinedRooms = [];
+      handshakeAuths = [];
+
+      socketService.resumeAfterPageRestore();
+      await waitFor(
+        () => socketService.getConnectionStatus().isConnected,
+        'the transport to reopen',
+      );
+
+      // The credentials survived the freeze. A `disconnect()` here instead would
+      // have dropped them, leaving nothing to reconnect WITH — the restored page
+      // would have had to wait for the auth cold boot all over again.
+      expect(handshakeAuths).toHaveLength(1);
+      expect(handshakeAuths[0]).toEqual({ token: 'test-token', userId: VIEWER_ID });
+
+      // Room membership died with the connection, so the counts only keep moving
+      // if the client says so again.
+      await waitFor(
+        () => joinedRooms.includes(WATCHED_POST),
+        'the client to re-assert its post room after the restore',
+      );
+
+      broadcast(POST_ENGAGEMENT_EVENTS.LIKED, {
+        postId: WATCHED_POST,
+        likesCount: 77,
+        actorId: OTHER_ACTOR_ID,
+      });
+      await waitFor(
+        () => storedPost(WATCHED_POST).engagement.likes === 77,
+        'a live broadcast to reach the store after the restore',
+      );
+    }, 15000);
+
+    it('leaves the retry loop armed, so a LATER drop still reconnects', async () => {
+      socketService.suspendForPageFreeze();
+      await waitFor(
+        () => (serverSockets.at(-1)?.disconnected ?? false),
+        'the transport to close',
+      );
+      socketService.resumeAfterPageRestore();
+      await waitFor(
+        () => socketService.getConnectionStatus().isConnected,
+        'the transport to reopen',
+      );
+
+      // Reopening the socket by hand clears Socket.IO's one-shot skip flag, so a
+      // restore that forgot to turn reconnection back ON looks entirely healthy
+      // until the next blip — after which the socket never comes back at all.
+      const connectionsBefore = serverSockets.length;
+      for (const socket of serverSockets) socket.conn.close();
+
+      await waitFor(
+        () => serverSockets.length > connectionsBefore,
+        'the client to reconnect after a drop that follows a restore',
+      );
+    }, 15000);
   });
 });

--- a/packages/frontend/services/__tests__/publicRealtimeTrends.test.ts
+++ b/packages/frontend/services/__tests__/publicRealtimeTrends.test.ts
@@ -25,6 +25,9 @@ class MockSocket {
   connected = true;
   active = false;
   disconnectCalls = 0;
+  connectCalls = 0;
+  /** Every value passed to the Manager's `reconnection()`, in order. */
+  readonly reconnectionSettings: boolean[] = [];
 
   readonly io = {
     on: (event: string, handler: MockHandler) => {
@@ -32,6 +35,9 @@ class MockSocket {
     },
     off: (event: string) => {
       this.managerHandlers.delete(event);
+    },
+    reconnection: (value: boolean) => {
+      this.reconnectionSettings.push(value);
     },
   };
 
@@ -46,6 +52,11 @@ class MockSocket {
   disconnect() {
     this.disconnectCalls += 1;
     this.connected = false;
+  }
+
+  connect() {
+    this.connectCalls += 1;
+    this.connected = true;
   }
 
   /** Deliver a server broadcast to whatever the service registered. */
@@ -216,5 +227,66 @@ describe('reconnect resync', () => {
     liveSocket().emitReconnect();
 
     expect(mockApiGet).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * An open WebSocket makes the whole document ineligible for the browser's
+ * back/forward cache, which is what turns a cross-document Back into a full app
+ * reload. `lib/socketBfcache.web.ts` drives this pair from `pagehide`/`pageshow`.
+ */
+describe('back/forward-cache freeze and restore', () => {
+  it('suppresses reconnection rather than only closing the socket', () => {
+    publicRealtimeService.connect();
+    const socket = liveSocket();
+
+    publicRealtimeService.suspendForPageFreeze();
+
+    expect(socket.disconnectCalls).toBe(1);
+    // Without this the Manager reopens the transport within a second and the
+    // page is refused the cache again, before the traversal even happens.
+    expect(socket.reconnectionSettings).toEqual([false]);
+  });
+
+  it('keeps the socket and its listeners, unlike a disconnect', () => {
+    publicRealtimeService.connect();
+    const socket = liveSocket();
+
+    publicRealtimeService.suspendForPageFreeze();
+    publicRealtimeService.resumeAfterPageRestore();
+
+    // The same Socket, reopened — not a replacement. A second `io()` call here
+    // would mean the frozen page lost its listeners and had to renegotiate.
+    expect(mockIoCalls).toHaveLength(1);
+    expect(socket.connectCalls).toBe(1);
+    expect(socket.reconnectionSettings).toEqual([false, true]);
+    expect(socket.handlers.has(PUBLIC_REALTIME_EVENTS.TRENDS_UPDATED)).toBe(true);
+  });
+
+  it('refetches the whole list on restore, having slept through every batch', async () => {
+    publicRealtimeService.connect();
+    respond([trend('tech', 40, [1, 2, 3, 4, 5, 6])], 'batch-1');
+    await useTrendsStore.getState().fetchTrends();
+
+    // Reopening by hand is not a Manager `reconnect`, so the handler bound to
+    // that event never fires on this path — without its own resync the restored
+    // page would show however stale a chart it was frozen with.
+    respond([trend('tech', 90, [11, 12, 13, 14, 15, 16])], 'batch-7');
+    publicRealtimeService.suspendForPageFreeze();
+    publicRealtimeService.resumeAfterPageRestore();
+    await settle();
+
+    expect(useTrendsStore.getState().trends[0].series).toEqual([11, 12, 13, 14, 15, 16]);
+  });
+
+  it('does nothing on a restore it was never frozen for', () => {
+    publicRealtimeService.connect();
+    const socket = liveSocket();
+
+    publicRealtimeService.resumeAfterPageRestore();
+
+    // A `pageshow` that follows no freeze must not touch a live connection.
+    expect(socket.connectCalls).toBe(0);
+    expect(socket.reconnectionSettings).toEqual([]);
   });
 });

--- a/packages/frontend/services/publicRealtimeService.ts
+++ b/packages/frontend/services/publicRealtimeService.ts
@@ -30,6 +30,10 @@ const logger = createLogger('PublicRealtime');
  */
 class PublicRealtimeService {
   private socket: Socket | null = null;
+  // Web only: the document is frozen in the browser's back/forward cache, so the
+  // transport is deliberately released and NOTHING may reopen it until it is
+  // restored. See `lib/socketBfcache.web.ts`.
+  private frozenForPageCache = false;
 
   private readonly handleTrendsUpdated = () => {
     // The payload is a notice; the data arrives through the one cached, filtered
@@ -76,12 +80,51 @@ class PublicRealtimeService {
   }
 
   disconnect(): void {
+    this.frozenForPageCache = false;
     if (!this.socket) return;
     this.socket.off(PUBLIC_REALTIME_EVENTS.TRENDS_UPDATED, this.handleTrendsUpdated);
     this.socket.off('connect_error');
     this.socket.io.off('reconnect', this.handleReconnect);
     this.socket.disconnect();
     this.socket = null;
+  }
+
+  /**
+   * Release the transport because the browser is about to freeze the document
+   * into its back/forward cache.
+   *
+   * Deliberately NOT `disconnect()`: that drops the socket and its listeners for
+   * good, and this connection is the one that must survive everything (see the
+   * class comment). The Socket is kept so `resumeAfterPageRestore` reopens it.
+   *
+   * Both realtime services share ONE Socket.IO Manager — same origin, same path,
+   * two namespaces, one WebSocket — so the transport only actually closes once
+   * BOTH of them have released their namespace socket. Which is also why
+   * reconnection is turned off explicitly rather than left to the Manager's own
+   * behaviour: it stops retrying once every namespace socket is released, but
+   * only as a side effect of an internal flag and only in that order, and until
+   * then its retry loop is free to reopen the transport within a second.
+   */
+  suspendForPageFreeze(): void {
+    if (this.frozenForPageCache) return;
+    this.frozenForPageCache = true;
+    if (!this.socket) return;
+    this.socket.io.reconnection(false);
+    this.socket.disconnect();
+  }
+
+  /** The document came back out of the back/forward cache: reopen the socket. */
+  resumeAfterPageRestore(): void {
+    if (!this.frozenForPageCache) return;
+    this.frozenForPageCache = false;
+    if (!this.socket) return;
+    this.socket.io.reconnection(true);
+    this.socket.connect();
+    // Reopening the transport by hand is not a Manager `reconnect`, so the
+    // handler bound to that event never runs on this path — and the list on
+    // screen is stale by however many batches the document slept through. Ask
+    // for the same whole-list resync here, from the one owner of that policy.
+    useTrendsStore.getState().resyncAfterReconnect();
   }
 
   /** Whether the transport is currently up. Used by tests and diagnostics. */

--- a/packages/frontend/services/socketService.ts
+++ b/packages/frontend/services/socketService.ts
@@ -115,6 +115,10 @@ class SocketService {
   private liveRoomsRefetchTimer: ReturnType<typeof setTimeout> | null = null;
   // Post rooms the mounted screens have asked for; replayed on every connect.
   private joinedPostIds = new Set<string>();
+  // Web only: the document is frozen in the browser's back/forward cache, so the
+  // transport is deliberately released and NOTHING may reopen it until it is
+  // restored. See `lib/socketBfcache.web.ts`.
+  private frozenForPageCache = false;
 
   constructor() {
     this.setupEventListeners();
@@ -130,6 +134,7 @@ class SocketService {
 
   private readonly handleManagerReconnectFailed = () => {
     this.isConnected = false;
+    if (this.frozenForPageCache) return;
     const manager = this.socket?.io;
     if (!manager || !this.currentUserId) return;
 
@@ -327,6 +332,46 @@ class SocketService {
     this.currentUserId = undefined;
     this.currentToken = undefined;
     this.reconnectAttempts = 0;
+    this.frozenForPageCache = false;
+  }
+
+  /**
+   * Release the transport because the browser is about to freeze the document
+   * into its back/forward cache.
+   *
+   * Deliberately NOT `disconnect()`, which is the sign-out teardown: it drops the
+   * viewer's credentials, the post rooms their mounted screens are watching and
+   * every queued update, none of which a frozen page consented to losing. The
+   * Socket and all of its listeners survive, so `resumeAfterPageRestore` reopens
+   * the SAME session rather than negotiating a new one.
+   */
+  suspendForPageFreeze(): void {
+    if (this.frozenForPageCache) return;
+    this.frozenForPageCache = true;
+    if (!this.socket) return;
+    // Reconnection belongs to the Manager, and BOTH realtime services share one
+    // — same origin, same path, two namespaces, one WebSocket. Releasing this
+    // namespace socket alone therefore leaves the Manager live and free to
+    // retry, reopening the transport within a second and making the page
+    // ineligible again before the browser has finished deciding. Socket.IO does
+    // stop retrying once EVERY namespace socket has been released, but only as
+    // a side effect of an internal flag and only in that order; saying it
+    // outright is what makes the frozen window safe either way.
+    this.socket.io.reconnection(false);
+    this.socket.disconnect();
+    this.isConnected = false;
+  }
+
+  /** The document came back out of the back/forward cache: reopen the session. */
+  resumeAfterPageRestore(): void {
+    if (!this.frozenForPageCache) return;
+    this.frozenForPageCache = false;
+    if (!this.socket) return;
+    this.socket.io.reconnection(true);
+    // Room membership is server-side state the closed connection destroyed. The
+    // `connect` handler re-joins the feed room and replays `joinedPostIds`, so
+    // the screens still mounted behind the restored page come back live.
+    this.socket.connect();
   }
 
   /** Final teardown for tests or a host that unloads the singleton entirely. */
@@ -490,9 +535,13 @@ class SocketService {
     // Handle app state changes (React Native)
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
       if (nextAppState === 'active') {
-        // App came to foreground - reconnect if needed
+        // App came to foreground - reconnect if needed. A frozen document is
+        // exempt: on web this fires from `visibilitychange`, which also fires
+        // around a back/forward-cache restore, and reopening the socket there
+        // would undo the release the freeze depends on.
         if (
           !this.isConnected
+          && !this.frozenForPageCache
           && this.socket
           && !this.socket.connected
           && !this.socket.active


### PR DESCRIPTION
## The bug

Mention's web app can never enter the browser's back/forward cache, because it holds a Socket.IO WebSocket open at all times. An open WebSocket makes the whole **document** ineligible, so every Back or Forward that **crosses a document boundary** is a cold boot — white flash, splash, session restore, every screen refetched. Traversal that stays inside the SPA is unaffected, which is why this reads as intermittent. The most common boundary is simply whatever page the reader was on before this one; another is `syncHubAfterSignIn` bouncing through `auth.oxy.so/sync`.

Chrome names the refusal itself, so this is not an inference:

```
before:  RESULT bfcache=MISS pageshow.persisted=false
         socket readyState INSIDE pagehide, after the app's handler: [1]   (1=OPEN)
         doc 4rozcs -> semw0n (REBUILT new document)
         Page.backForwardCacheNotUsed events=1 reasons=["SupportPending:WebSocket"]

after:   RESULT bfcache=HIT  pageshow.persisted=true
         socket readyState INSIDE pagehide, after the app's handler: [2]   (2=CLOSING)
         doc f0pi1k -> f0pi1k (RESTORED same document)
         Page.backForwardCacheNotUsed events=0 reasons=[]
         POST-TRAVERSAL ws events: ["created","closed","handshake:101"]
         POST-TRAVERSAL inbound frames: 2  e.g. ["0{\"sid\":\"Qeqlf51Cudd92b6pAAAM\"...","40/public,{\"sid\":\"qYGqor5je68xKxDgAAAN\"}"]
```

Same Chrome, same origin `https://mention.earth`, same production API and socket — a local `expo export` served into the real origin over CDP, so only the JS differs. Arms alternated three times, consistent every run. Two properties make the check able to fail rather than able to pass: each run asserts a socket is **open at the traversal** (`OPEN_AT_NAV=1`, otherwise the probe prints a vacuity warning and the run proves nothing), and the `readyState` is sampled inside a `pagehide` listener registered **after** the app's own — so it is the mechanism, not an inference. Liveness after restore is asserted through Socket.IO's namespace-connect ack (`40/public,{sid}`), not through "the page came back fast"; one run also caught a live `42/public,["trends:updated",…]` broadcast.

## The fix

A `pagehide` / `pageshow` lifecycle over the connect/disconnect the two services already own — `lib/socketBfcache.web.ts`, platform-split with a native no-op, registered from `app/_layout.tsx`.

`pagehide` is early enough: the browser dispatches it **before** deciding whether the page is storable. Measured — it fires with `persisted: true` and Chrome then *still* refuses the traversal for the WebSocket. So a socket released in that handler is released in time to change the verdict, which is also what web.dev's bfcache guidance relies on. `pageshow` restores, gated on `persisted` so a fresh document booting normally is not double-connected.

Three things the fix depends on, each mutation-tested (removing the line fails a named test):

- **Both services share ONE Socket.IO Manager** — same origin, same path, two namespaces, one WebSocket. Production shows exactly one `Network.webSocketCreated`. The transport therefore only closes once *both* have released their namespace socket; fixing one service alone leaves the page ineligible.
- **Suspending turns Manager reconnection OFF**, not merely disconnecting. Socket.IO does stop retrying once every namespace socket is released, but only as a side effect of an internal `skipReconnect` and only in that order; until then the retry loop reopens the transport within a second, before the browser has finished deciding.
- **Restoring turns reconnection back ON.** `socket.connect()` clears that one-shot skip flag, so a restore that forgot this looks entirely healthy until the **next** network blip, after which the socket never comes back at all. This one was found because the mutation initially survived; `leaves the retry loop armed, so a LATER drop still reconnects` now covers it.

Suspend is deliberately **not** `disconnect()`. That method is the sign-out teardown: it drops the viewer's credentials, their joined post rooms and the queued updates, none of which a frozen page consented to losing. The Socket and its listeners survive, so the restore reopens the *same* session — a test asserts the reconnect presents the identical `{token, userId}` handshake — and the existing `connect` handler replays `joinedPostIds` and the feed room. The public service additionally asks the trends store for its whole-list resync, which is otherwise bound to a Manager `reconnect` that reopening by hand never fires.

## Reviewing this: a casual re-check may show no bug

Chrome's variations seed removes the blocker for part of the population. On Chrome 150.0.7871.181 here, a fresh profile that had not yet fetched its seed refused the traversal with `SupportPending:WebSocket`; after Chrome downloaded the seed and restarted, the **identical unmodified production page** came back `bfcache=HIT` with the socket open. So the blocker is being rolled out away upstream — but it is live for everyone not in that trial, which is where the report came from.

Deterministic repro: a **fresh** `--user-data-dir` plus `--disable-background-networking` (binary defaults, no seed). Two further traps for anyone rebuilding the harness:

- Playwright's own `chromium.launch()` passes `--disable-back-forward-cache`, so a harness built the obvious way can **never** observe this. It has to be `connectOverCDP` against a manually launched Chrome.
- Serving the app from `http://127.0.0.1:<port>` is not a valid substitute: the socket never connects from that origin, so the page is trivially cacheable and the run passes for the wrong reason.

## Tests

- `services/__tests__/postEngagementLiveCounts.test.ts` — three freeze/restore tests against the suite's **real** socket.io server and client. This is the gate for the authenticated socket, which the browser check (signed out) cannot reach. Assertions are keyed on this connection's own server-side socket rather than on the client's own flag, which `suspendForPageFreeze` sets itself and would otherwise report "closed" for a suspend that never touched the transport.
- `services/__tests__/publicRealtimeTrends.test.ts` — four tests for suspend/resume, the reconnection toggles, listener survival, and the restore resync.

Repo gate: `bun run build` and `bun run check:types` exit 0; `validate:workflows`, `validate:lockfile`, `validate:i18n`, `validate:logger`, `validate:suite-collection` and `audit:security` all pass. `doctor` fails on this machine's Node version alone (22.23.1 available, 22.17.0 pinned) and SIGINTs its parallel siblings; each survivor was re-run individually and passes.

## Known follow-ups — real, pre-existing, deliberately NOT in this PR

- **A restored page shows data as of the freeze.** React Query screens revalidate through the existing `focusManager` AppState wiring (`visibilitychange` fires on restore) and trends resync explicitly, but the feed store's retained slice has no staleness notion of its own — it serves what it was frozen with. Pre-existing property of the warm-start design; this PR is about page lifecycle and absorbing it silently would be wrong.
- **The authenticated socket reconnects with the token captured at connect time.** Pre-existing behaviour of the reconnect loop, not introduced here, but a long freeze makes it more reachable.
- **Presence has no server handler at all.** `registerSocketPresence` in `packages/backend/src/services/SocketPresenceLifecycle.ts` is never called from anywhere, so `subscribePresence` / `getPresence` / `user:presence` go nowhere. That is why nothing is replayed for presence on restore. Out of scope here.
