### PR TITLE
chore(follows): take the primary-action rule from the SDK now that it is exported

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -248,7 +248,7 @@
     "@oxyhq/bloom": "^0.79.1",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/core": "^19.1.1",
-    "@oxyhq/services": "^27.1.2",
+    "@oxyhq/services": "^27.1.3",
     "@syra.fm/sdk": "^0.7.0",
     "@types/bun": "1.3.14",
     "@types/jsonwebtoken": "^9.0.10",
@@ -852,7 +852,7 @@
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.1.6", "", { "dependencies": { "@oxyhq/contracts": "^0.18.0", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-modules-core": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-/27AFpvOwxt19XWdZYJy0W4TnIQbK+IhPOfQVlod4s/kEuzIzMXo0zi9MSystegFu1RhZHKGjaxOTo+83Sx3Sw=="],
 
-    "@oxyhq/services": ["@oxyhq/services@27.1.2", "", { "dependencies": { "@oxyhq/contracts": "0.24.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@oxyhq/core": "^19.0.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "expo-web-browser": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-css": "^3.0.6", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "expo-web-browser", "nativewind", "react-native-css", "react-native-keyboard-controller"] }, "sha512-GgISnR3qty9s9q4zU918djRirRLmIU7/1JLAzHhxNGqVlEhaTGS9iZrthyZ2MZBXfX9L9cowxMI8QvZas65fOw=="],
+    "@oxyhq/services": ["@oxyhq/services@27.1.3", "", { "dependencies": { "@oxyhq/contracts": "0.24.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@oxyhq/core": "^19.0.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "expo-web-browser": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-css": "^3.0.6", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "expo-web-browser", "nativewind", "react-native-css", "react-native-keyboard-controller"] }, "sha512-632erXiYYofqPB//6dc2Qc+F7PUjcaosdRKeOUd94rS5uUlu3cb1E9+CGhwpExjaIXdPhq69eVH7lA6sebgpyA=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 
@@ -3453,7 +3453,6 @@
 
     "@oxyhq/federation/@oxyhq/contracts": ["@oxyhq/contracts@0.23.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-2vNM5wRBIDXO1XJ+K3xORGCQr3aWnGLvPswURGvG6PFSuVevLCd2L0NuzzqCcVAOT1/9imfBLq51WKwQ4VdO8w=="],
 
-
     "@oxyhq/protocol/@oxyhq/contracts": ["@oxyhq/contracts@0.18.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-nGdoCp63FIpy29JpAEHSYYVUWl0wH+kHMzfgJJaVa8PvtiKffK8qokEK8bqkneIWRRCUtaR143dp4ZQmQo1eqg=="],
 
     "@oxyhq/protocol/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -3909,7 +3908,6 @@
 
     "zeego/@radix-ui/react-dropdown-menu": ["@radix-ui/react-dropdown-menu@2.1.18", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-menu": "2.1.18", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw=="],
 
-
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
@@ -4028,7 +4026,6 @@
 
     "@oxyhq/federation/@oxyhq/contracts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-
     "@radix-ui/react-context-menu/@radix-ui/react-menu/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.10", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g=="],
 
     "@radix-ui/react-context-menu/@radix-ui/react-menu/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-escape-keydown": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg=="],
@@ -4048,7 +4045,6 @@
     "@react-native/community-cli-plugin/@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
-
 
     "@syra.fm/sdk/expo-image-picker/expo-image-loader": ["expo-image-loader@56.0.3", "", { "peerDependencies": { "expo": "*" } }, "sha512-JgUo4fUeU1ZC+z8iBFj8v7yoGQnZrLbOVPyNE+DWVrld55F2F6R1ck+rmdm/8TNWLz1LhNQfD7c3XYP1ZikxXA=="],
 
@@ -4295,7 +4291,6 @@
     "zeego/@radix-ui/react-dropdown-menu/@radix-ui/react-menu": ["@radix-ui/react-menu@2.1.18", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.10", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.13", "@radix-ui/react-focus-guards": "1.1.4", "@radix-ui/react-focus-scope": "1.1.10", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-popper": "1.3.1", "@radix-ui/react-portal": "1.1.12", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-roving-focus": "1.1.13", "@radix-ui/react-slot": "1.3.0", "@radix-ui/react-use-callback-ref": "1.1.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ=="],
 
     "zeego/@radix-ui/react-dropdown-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
-
 
     "@expo/cli/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       "@oxyhq/bloom": "^0.79.1",
       "@oxyhq/contracts": "^0.24.0",
       "@oxyhq/core": "^19.1.1",
-      "@oxyhq/services": "^27.1.2",
+      "@oxyhq/services": "^27.1.3",
       "@syra.fm/sdk": "^0.7.0",
       "@types/bun": "1.3.14",
       "@types/jsonwebtoken": "^9.0.10",

--- a/packages/frontend/app/(app)/settings/interests.tsx
+++ b/packages/frontend/app/(app)/settings/interests.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Loading } from '@oxyhq/bloom/loading';
 import { SettingsListGroup } from '@oxyhq/bloom/settings-list';
 import { useAuth, OxyAuthPrompt } from '@oxyhq/services/ui/client';
-import { useFollowTarget } from '@oxyhq/services';
+import { resolveFollowPrimaryAction, useFollowTarget } from '@oxyhq/services';
 import type { TopicData } from '@oxyhq/core';
 import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
@@ -20,7 +20,7 @@ import {
     useTopicFollowTargetId,
     type FollowedTopic,
 } from '@/hooks/useTopicFollows';
-import { resolveTopicChipAction, topicFollowUri } from '@/services/followGraph';
+import { topicFollowUri } from '@/services/followGraph';
 
 /**
  * Your interests — a searchable grid of topics, where selecting one FOLLOWS it.
@@ -226,13 +226,23 @@ function TopicChip({ topic, seeded, followsReady }: TopicChipProps) {
 
     const isOffHere = follow.isFollowing && follow.status.applicationMode === 'disabled';
 
+    /*
+     * The SDK decides WHAT a press means; this only routes its answer to the
+     * matching mutation. The middle case is the one worth naming: a follow the
+     * viewer switched OFF in Mention still reads as followed globally, so a
+     * press turns it back on HERE rather than unfollowing it everywhere and
+     * throwing away a relationship they still hold in every other Oxy app.
+     *
+     * The `never` arm is what keeps this honest as that rule grows: a new action
+     * upstream becomes a type error here instead of a press that silently does
+     * nothing.
+     */
     const onPress = useCallback(() => {
-        switch (
-        resolveTopicChipAction({
+        const action = resolveFollowPrimaryAction({
             isFollowing: follow.isFollowing,
             applicationMode: follow.status.applicationMode,
-        })
-        ) {
+        });
+        switch (action) {
             case 'follow':
                 void follow.follow();
                 return;
@@ -241,6 +251,11 @@ function TopicChip({ topic, seeded, followsReady }: TopicChipProps) {
                 return;
             case 'unfollow':
                 void follow.unfollow();
+                return;
+            default: {
+                const unhandled: never = action;
+                throw new Error(`Unhandled follow action: ${String(unhandled)}`);
+            }
         }
     }, [follow]);
 

--- a/packages/frontend/services/__tests__/followGraph.test.ts
+++ b/packages/frontend/services/__tests__/followGraph.test.ts
@@ -1,17 +1,20 @@
 /**
- * The two decisions in `followGraph.ts` that are expensive to get wrong and
- * silent when they are.
+ * The decision in `followGraph.ts` that is expensive to get wrong and silent
+ * when it is.
  *
  * A target's URI becomes a permanent row in a graph every Oxy application
  * shares, and `ensureFollowTarget` is idempotent on it — so a URI that differs
  * from what another surface would build does not fail, it quietly gives one
- * person two parallel follows of one topic. And the chip's press rule has a
- * middle case whose wrong answer discards a relationship the person still holds
- * in every other application, while looking like an ordinary unfollow.
+ * person two parallel follows of one topic.
+ *
+ * The chip's press rule used to be tested here too. It is now
+ * `resolveFollowPrimaryAction` from `@oxyhq/services`, tested where it lives;
+ * what remains on this side is routing its answer to a mutation, which the
+ * `never` arm at the call site turns into a type error rather than a silent
+ * no-op.
  */
 
-import type { FollowApplicationMode } from '@oxyhq/contracts';
-import { OXY_TOPIC_KIND, resolveTopicChipAction, topicFollowUri } from '../followGraph';
+import { OXY_TOPIC_KIND, topicFollowUri } from '../followGraph';
 
 /** The registry accepts a target URI only if it is absolute. */
 const ABSOLUTE_URI = /^[a-z][a-z0-9+.-]*:/i;
@@ -49,45 +52,5 @@ describe('topicFollowUri', () => {
 
   it('is absolute, which the registry requires', () => {
     expect(topicFollowUri('climate')).toMatch(ABSOLUTE_URI);
-  });
-});
-
-describe('resolveTopicChipAction', () => {
-  /**
-   * Every combination, because the interesting one is a state no fixture
-   * produces by accident: followed globally AND switched off in this
-   * application. `effectiveState` reports `not_following` for it — correctly,
-   * since the question it answers is "does this act here" — so a rule derived
-   * from that field alone lands on `follow`, while a rule that only asks
-   * "following?" lands on `unfollow`. Both are wrong, and differently.
-   */
-  const cases: Array<{
-    isFollowing: boolean;
-    applicationMode: FollowApplicationMode;
-    expected: 'follow' | 'unfollow' | 'enable-here';
-  }> = [
-    { isFollowing: false, applicationMode: 'inherit', expected: 'follow' },
-    { isFollowing: false, applicationMode: 'enabled', expected: 'follow' },
-    // Not following, and explicitly off here — still nothing to re-enable.
-    { isFollowing: false, applicationMode: 'disabled', expected: 'follow' },
-    { isFollowing: true, applicationMode: 'inherit', expected: 'unfollow' },
-    { isFollowing: true, applicationMode: 'enabled', expected: 'unfollow' },
-    { isFollowing: true, applicationMode: 'disabled', expected: 'enable-here' },
-  ];
-
-  it.each(cases)(
-    'isFollowing=$isFollowing applicationMode=$applicationMode -> $expected',
-    ({ isFollowing, applicationMode, expected }) => {
-      expect(resolveTopicChipAction({ isFollowing, applicationMode })).toBe(expected);
-    },
-  );
-
-  it('never unfollows everywhere a relationship that is merely off here', () => {
-    // Stated separately from the table because it is the damage, not the
-    // mapping: this press must not be able to reach `unfollow`, whatever the
-    // rule is later refactored into.
-    expect(resolveTopicChipAction({ isFollowing: true, applicationMode: 'disabled' })).not.toBe(
-      'unfollow',
-    );
   });
 });

--- a/packages/frontend/services/followGraph.ts
+++ b/packages/frontend/services/followGraph.ts
@@ -25,8 +25,6 @@
  * anybody pressed either. Channels join when the user graph itself migrates.
  */
 
-import type { FollowApplicationMode } from '@oxyhq/contracts';
-
 /**
  * The platform kind for a topic. Seeded by the API, owned by nobody — named here
  * rather than inlined so the one place that has to agree with the migration is
@@ -61,28 +59,4 @@ const OXY_IDENTITY_ORIGIN = 'https://oxy.so';
  */
 export function topicFollowUri(slug: string): string {
   return `${OXY_IDENTITY_ORIGIN}/topics/${encodeURIComponent(slug.trim().toLowerCase())}`;
-}
-
-/**
- * What ONE press of a chip should do, given the viewer's current relationship.
- *
- * The middle case is the whole reason this is a function rather than an `if` at
- * the call site: a follow the viewer switched OFF in Mention still reads as
- * followed globally, so pressing it must turn it back on HERE — not unfollow it
- * everywhere, which would throw away a relationship the person still holds in
- * every other Oxy application.
- *
- * `@oxyhq/services` decides the identical rule for its own button
- * (`resolveFollowPrimaryAction`) and exports it from the component module, but
- * the package barrel does not re-export it and no subpath reaches it — `.`,
- * `./ui` and `./ui/client` all omit it. Delete this and import theirs the moment
- * that is fixed; until then a chip either duplicates the rule or gets it wrong.
- */
-export function resolveTopicChipAction(input: {
-  isFollowing: boolean;
-  applicationMode: FollowApplicationMode;
-}): 'follow' | 'unfollow' | 'enable-here' {
-  if (!input.isFollowing) return 'follow';
-  if (input.applicationMode === 'disabled') return 'enable-here';
-  return 'unfollow';
 }


### PR DESCRIPTION
`resolveTopicChipAction` existed for one reason: `@oxyhq/services` decided the identical rule for its own button and did not re-export it — the symbol was reachable from `FollowTargetButton.tsx` but from no package entry point (`.`, `./ui`, `./ui/client` all omitted it). A chip drawing its own affordance therefore either duplicated the rule or got it wrong. It is exported as of **27.1.3**, so the duplicate goes.

Verified reachable in **both** resolution paths before taking it, since Metro and tsc resolve different files: `resolveFollowPrimaryAction` is in `src/index.ts` (the `react-native` condition, what Metro compiles) and in `lib/typescript/commonjs/index.d.ts` (what tsc reads).

## Why that rule was worth duplicating rather than approximating

It is the "off here" case. A follow the viewer switched off in Mention still reads as followed globally, so a press must **re-enable it here** rather than unfollow it everywhere and discard a relationship they still hold in every other Oxy app. Getting it wrong is silent and destructive in one press.

## What is left on this side

Routing the SDK's answer to a mutation — and that now carries a `never` arm, so a new action upstream becomes a type error here instead of a press that silently does nothing.

Mutation-tested: deleting the `enable-here` case fails the type-check (`1 unexpected type error(s)`), against a clean baseline. The arm is a real gate, not decoration.

The press-rule tests go with the function; they exist upstream where the rule now lives. `services/__tests__/followGraph.test.ts` keeps the URI tests, which are the decision Mention still owns — a URI that differs from what another Oxy surface builds does not fail, it quietly gives one person two parallel follows of one topic.

## Verified in a real browser against the shipped 27.1.3

Re-run rather than assumed from the signature, because the rule driving the press changed hands.

| seeded state | renders | one press does |
|---|---|---|
| followed, active here | filled, "Unfollow X" | `DELETE /v2/follows/:rel` |
| followed, **off here** | filled at 0.6 opacity, "Show X in Mention again" | `DELETE /v2/follows/:rel/context` — re-enables here |
| not followed | neutral, "Follow X" | `POST /v2/follow-targets` then `PUT /v2/follows/:id` |

One `ensureFollowTarget` for the whole grid, zero requests to `/v2/follow-targets/namespaces` or `/kinds`, no page errors.

## The lockfile gate will fail again, for the same reason as #642

Unchanged and previously decided: `verify-lockfile.sh` reproduces the lockfile incrementally, and incremental resolution does not re-apply a root `override` to an already-resolved nested dependency — so it demands a lockfile nesting `@oxyhq/services@27.1.2` under `@alia.onl/sdk` and `@syra.fm/sdk`. `@syra.fm/sdk/src/live/components/RoomCard.tsx` imports `useAuth` from `@oxyhq/services` and Mention renders that component, so Metro would hand live rooms a second React context and a second zustand auth store. `main` has no such nesting; matching the gate would introduce it.

## Still open, and unchanged by this PR

The signed-in path remains unverified against production — every call is refused at the capability step with `no_grant`, because the consent record only comes from `POST /auth/oauth/authorize` and first-party apps never run it. Tracked separately. **A green merge is not evidence this works end to end.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)