### PR TITLE
fix(feed): a hidden feed must not adopt the visible one's scroll position

### DIFF
--- a/packages/frontend/components/Feed/Feed.web.tsx
+++ b/packages/frontend/components/Feed/Feed.web.tsx
@@ -23,6 +23,7 @@ import {
     renderFeedRow,
     feedRowKey,
 } from './feedRows';
+import { useScrollMarginOrigin } from './useScrollMarginOrigin';
 
 const logger = createLogger('Feed');
 
@@ -291,7 +292,10 @@ function VirtualizedWebFeed(props: FeedProps) {
     // the scroller; `scrollMargin` is the wrapper's offset from the document top
     // (header + anything above the list), so virtual offsets map to page offsets.
     const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const [scrollMargin, setScrollMargin] = useState(0);
+    // The virtualizer's measurement origin. Box-driven, never stored while the
+    // wrapper is collapsed — see the hook for why the old row-count key was
+    // wrong once a feed can be mounted and hidden at once.
+    const scrollMargin = useScrollMarginOrigin(wrapperRef);
 
     // `contentContainerStyle` (a caller-provided RN style, e.g. paddingBottom) is
     // flattened to a CSS object for the DOM wrapper. It sits OUTSIDE the measured
@@ -300,16 +304,6 @@ function VirtualizedWebFeed(props: FeedProps) {
         () => StyleSheet.flatten(merged.contentContainerStyle) as React.CSSProperties | undefined,
         [merged.contentContainerStyle]
     );
-
-    // Read the wrapper's top offset synchronously after layout so the first
-    // virtual frame already positions rows correctly (no visible jump). This is
-    // a DOM measurement subscription, not a data effect.
-    useLayoutEffect(() => {
-        const node = wrapperRef.current;
-        if (!node) return;
-        const top = node.getBoundingClientRect().top + window.scrollY;
-        setScrollMargin((prev) => (prev !== top ? top : prev));
-    }, [feedRows.length]);
 
     const count = feedRows.length;
 

--- a/packages/frontend/components/Feed/__tests__/useScrollMarginOrigin.test.tsx
+++ b/packages/frontend/components/Feed/__tests__/useScrollMarginOrigin.test.tsx
@@ -1,0 +1,158 @@
+import React, { useRef } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { useScrollMarginOrigin } from '../useScrollMarginOrigin';
+
+/**
+ * The virtualizer's measurement origin, across a hide/show cycle.
+ *
+ * This exists because the shape it guards is invisible to any test that only
+ * looks at a VISIBLE node: the old row-count-keyed measurement was correct
+ * there, before and after the fix. What distinguishes them is a wrapper that is
+ * collapsed (`display: none`, so `{top:0,height:0,width:0}`) while the DOCUMENT
+ * is scrolled somewhere else — which is what a tab navigator produces, since it
+ * keeps non-focused tabs mounted and hidden.
+ *
+ * Both assertions below are mutation-tested against the implementation:
+ *  - remove the zero-box skip  -> "ignores a collapsed wrapper" fails
+ *  - remove the ResizeObserver -> "re-measures when the wrapper is shown" fails
+ * If either can pass without its half of the fix, this file is worthless.
+ */
+
+type Rect = { top: number; width: number; height: number };
+
+/** The observer callbacks currently registered, so a test can fire a layout change. */
+let observerCallbacks: (() => void)[] = [];
+
+class FakeResizeObserver {
+  constructor(private readonly cb: () => void) {
+    observerCallbacks.push(() => this.cb());
+  }
+  observe() {}
+  disconnect() {
+    observerCallbacks = observerCallbacks.filter((fn) => fn !== this.cb);
+  }
+}
+
+function fireLayoutChange() {
+  act(() => {
+    for (const fn of [...observerCallbacks]) fn();
+  });
+}
+
+/** A stand-in for the wrapper whose box and document scroll the test drives. */
+function makeNode(rect: Rect) {
+  const current = { ...rect };
+  return {
+    node: { getBoundingClientRect: () => ({ ...current }) } as unknown as HTMLElement,
+    setRect: (next: Rect) => Object.assign(current, next),
+  };
+}
+
+function setScrollY(value: number) {
+  Object.defineProperty(window, 'scrollY', { value, configurable: true, writable: true });
+}
+
+function renderHookWith(node: HTMLElement) {
+  const seen: number[] = [];
+  function Probe() {
+    const ref = useRef<HTMLElement | null>(node);
+    seen.push(useScrollMarginOrigin(ref));
+    return null;
+  }
+  let renderer: TestRenderer.ReactTestRenderer | undefined;
+  act(() => {
+    renderer = TestRenderer.create(<Probe />);
+  });
+  return {
+    latest: () => seen[seen.length - 1],
+    unmount: () => act(() => renderer?.unmount()),
+  };
+}
+
+describe('useScrollMarginOrigin', () => {
+  const OriginalObserver = (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+
+  beforeEach(() => {
+    observerCallbacks = [];
+    setScrollY(0);
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = FakeResizeObserver;
+  });
+
+  afterEach(() => {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = OriginalObserver;
+  });
+
+  it('measures a visible wrapper as its offset from the document top', () => {
+    setScrollY(120);
+    const { node } = makeNode({ top: 80, width: 600, height: 4000 });
+    const hook = renderHookWith(node);
+    // 80 above the viewport top, 120 already scrolled past = 200 from the document top.
+    expect(hook.latest()).toBe(200);
+    hook.unmount();
+  });
+
+  it('ignores a collapsed wrapper instead of storing the visible screen position', () => {
+    // Visible and measured first, so there is a good value to destroy.
+    setScrollY(0);
+    const { node, setRect } = makeNode({ top: 300, width: 600, height: 4000 });
+    const hook = renderHookWith(node);
+    expect(hook.latest()).toBe(300);
+
+    // The tab is hidden: the wrapper collapses, and the DOCUMENT is now showing
+    // — and scrolled by — a different tab. The old code stored `0 + 5000`.
+    setRect({ top: 0, width: 0, height: 0 });
+    setScrollY(5000);
+    fireLayoutChange();
+
+    expect(hook.latest()).toBe(300);
+    expect(hook.latest()).not.toBe(5000);
+    hook.unmount();
+  });
+
+  it('re-measures when the wrapper is shown again', () => {
+    setScrollY(0);
+    const { node, setRect } = makeNode({ top: 300, width: 600, height: 4000 });
+    const hook = renderHookWith(node);
+    expect(hook.latest()).toBe(300);
+
+    setRect({ top: 0, width: 0, height: 0 });
+    setScrollY(5000);
+    fireLayoutChange();
+    expect(hook.latest()).toBe(300);
+
+    // Shown again, at a different offset than before — chrome above it changed
+    // while it was away. Without a re-measure the stale 300 would persist for
+    // the rest of the session, because the row count never changes again.
+    setScrollY(0);
+    setRect({ top: 460, width: 600, height: 4000 });
+    fireLayoutChange();
+
+    expect(hook.latest()).toBe(460);
+    hook.unmount();
+  });
+
+  it('re-measures when content ABOVE the wrapper grows without it resizing', () => {
+    // The wrapper keeps its own size; only its top moves. This is why the
+    // document is observed as well as the wrapper.
+    setScrollY(0);
+    const { node, setRect } = makeNode({ top: 200, width: 600, height: 4000 });
+    const hook = renderHookWith(node);
+    expect(hook.latest()).toBe(200);
+
+    setRect({ top: 640, width: 600, height: 4000 });
+    fireLayoutChange();
+
+    expect(hook.latest()).toBe(640);
+    hook.unmount();
+  });
+
+  it('still measures once where ResizeObserver does not exist', () => {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = undefined;
+    setScrollY(50);
+    const { node } = makeNode({ top: 10, width: 600, height: 4000 });
+    const hook = renderHookWith(node);
+    expect(hook.latest()).toBe(60);
+    hook.unmount();
+  });
+});

--- a/packages/frontend/components/Feed/useScrollMarginOrigin.ts
+++ b/packages/frontend/components/Feed/useScrollMarginOrigin.ts
@@ -1,0 +1,68 @@
+import { useLayoutEffect, useState, type RefObject } from 'react';
+
+/**
+ * The virtualizer's measurement origin: the wrapper's offset from the document
+ * top (header + anything above the list), so virtual offsets map to page
+ * offsets. The window is the scroller.
+ *
+ * Driven by the wrapper's own BOX, and a zero-sized box is never stored. Both
+ * halves are load-bearing, and the reason is not obvious from the code that
+ * replaced — so it is written down here rather than rediscovered.
+ *
+ * This used to be a `useLayoutEffect` keyed on the ROW COUNT, which was correct
+ * only while a feed could not be mounted and hidden at the same time. A tab
+ * navigator makes exactly that happen: the non-focused tab renders at
+ * `display: none`, and a hidden wrapper measures `{top: 0, height: 0, width: 0}`.
+ * Two failure modes followed, and closing either one alone is not enough:
+ *
+ *  - It RAN while box-less, so `top + window.scrollY` evaluated to the scroll
+ *    position of whichever tab was VISIBLE and stored it as this feed's origin.
+ *    Every row is then positioned against a number belonging to another screen.
+ *  - It never re-ran on RETURN, because the row count does not change again —
+ *    so a single poisoned measurement lasted the rest of the session. The
+ *    ordinary causes all reached it: a background refresh, a socket update, the
+ *    memory-mode new-post broadcast.
+ *
+ * A `ResizeObserver` closes both. It fires on the 0 -> real transition when the
+ * element is shown again, and on any later layout change, so the origin is
+ * re-derived whenever it could genuinely have moved — and it covers every cause
+ * of the box appearing, not just a tab becoming visible. It also keeps the
+ * router out of the feed: the box is the honest signal and it does not care WHY
+ * the element became visible.
+ *
+ * It observes TWO targets, and the second is not redundant: the wrapper's TOP
+ * can move without the wrapper itself resizing at all — a header or a media
+ * embed ABOVE the list growing does it, which is the stale-origin case where
+ * rows are positioned against a point that has since shifted. Observing only
+ * the wrapper would be a regression against the old row-count key there, since
+ * a row-count change at least correlated with content moving.
+ */
+export function useScrollMarginOrigin(ref: RefObject<HTMLElement | null>): number {
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  useLayoutEffect(() => {
+    const node = ref.current;
+    if (!node) return undefined;
+
+    const measure = () => {
+      const rect = node.getBoundingClientRect();
+      // No box: the element is `display: none`, or not laid out yet. There is
+      // nothing true to read, and reading anyway is the bug described above.
+      if (rect.width === 0 && rect.height === 0) return;
+      const top = rect.top + window.scrollY;
+      setScrollMargin((prev) => (prev !== top ? top : prev));
+    };
+
+    measure();
+
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    if (typeof document !== 'undefined' && document.body) {
+      observer.observe(document.body);
+    }
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return scrollMargin;
+}


### PR DESCRIPTION
The virtualizer's measurement origin was read in a `useLayoutEffect` keyed on the ROW COUNT. That is correct only while a feed cannot be mounted and hidden at the same time — which a tab navigator changes, since non-focused tabs stay mounted at `display: none` and a hidden wrapper measures `{top: 0, height: 0, width: 0}`.

Two failure modes, and closing either alone is insufficient:

- It **ran while box-less**, so `top + window.scrollY` evaluated to the scroll position of whichever tab was *visible* and stored it as this feed's origin.
- It **never re-ran on return**, because the row count does not change again — so one poisoned measurement lasted the rest of the session. A background refresh, a socket update or the memory-mode new-post broadcast all reach it.

The measurement is now driven by the wrapper's own **box**, and a zero-sized box is never stored. A `ResizeObserver` fires on the 0 → real transition, which is what makes skipping the bad read safe rather than merely permanent. It observes the document as well as the wrapper: the wrapper's top can move without the wrapper resizing (a header or media embed above the list growing), and observing only the wrapper would have been a regression against the old key for that case.

Keeping the box as the signal also keeps any router dependency out of the feed — it holds for a modal or an accordion as much as a tab.

## Verification

- Frontend suite: **161 suites / 1545 tests** pass.
- **Mutation-tested, both halves.** Removing the zero-box skip fails `ignores a collapsed wrapper`; removing the observer fails both re-measure cases. A test that only inspects a visible node cannot tell the old code from the new, so the fixtures drive a hide/show cycle with the document scrolled elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)