### PR TITLE
fix(deploy): open the Postgres pool in the post-deploy reconciliation one-shot

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3324,7 +3324,6 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
-
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -3512,7 +3511,6 @@
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "@redis/client/cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
-
 
     "@syra.fm/sdk/expo-audio": ["expo-audio@56.0.12", "", { "peerDependencies": { "expo": "*", "expo-asset": "*", "react": "*", "react-native": "*" } }, "sha512-ne2UIO/HsQoBL9e+tGs5N9Sf3NyW5sJMm4sDkexbSJRc2IchLDG+9Msu/+l5N4RlZ8SiF42wRyWsh/Usg+SwOw=="],
 

--- a/packages/backend/scripts/reconcile-engagement-projections.ts
+++ b/packages/backend/scripts/reconcile-engagement-projections.ts
@@ -4,25 +4,30 @@
  * This runs only after the new transactional writers have fully replaced the
  * legacy ECS tasks. It closes the narrow pre-rollout migration window without
  * putting reconciliation into request latency.
+ *
+ * Postgres-only, because `reconcileEngagementProjections` reads and writes
+ * exclusively through Drizzle. A one-shot gets none of `server.ts`'s startup,
+ * so it must open the pool itself: without `connectPostgres()` the service's
+ * first `getDb()` throws `PostgreSQL is not connected`, this task exits 1, and
+ * `deploy-aws.yml` rolls the whole service back on every deploy.
  */
 
-import mongoose from 'mongoose';
-import { connectToDatabase } from '../src/utils/database';
+import { closePostgres, connectPostgres } from '../src/db/postgres';
 import { reconcileEngagementProjections } from '../src/services/EngagementProjectionReconciliationService';
 import { logger } from '../src/utils/logger';
 
 async function main(): Promise<void> {
-  await connectToDatabase();
+  await connectPostgres();
   await reconcileEngagementProjections();
 }
 
 void main()
   .then(async () => {
-    await mongoose.disconnect();
+    await closePostgres();
     process.exit(0);
   })
   .catch(async (error) => {
     logger.error('[EngagementProjectionReconciliation] task failed', error);
-    await mongoose.disconnect().catch(() => undefined);
+    await closePostgres().catch(() => undefined);
     process.exit(1);
   });


### PR DESCRIPTION
## What this fixes

Every deploy of `main` has been building an image, deploying it, failing its post-deploy gate and **rolling the service back**. No commit merged to `main` could reach production.

`deploy-aws.yml` runs one post-deploy task:

```
["bun","packages/backend/dist/scripts/reconcile-engagement-projections.js"]
```

`reconcileEngagementProjections` was ported to Drizzle (it is 100% Postgres — `getDb()` at 5 sites), but the one-shot entry point still opened only the Mongo connection. A one-shot gets none of `server.ts`'s startup, so the service's first `getDb()` threw:

```
Connected to MongoDB successfully
error: PostgreSQL is not connected. Call connectPostgres() during startup before issuing queries.
  at getDb (db/postgres.js:129)
  at EngagementProjectionReconciliationService.js:157
→ Post-deploy reconciliation failed.
→ Rolling mention back to oxy-mention:198
```

Observed on deploy runs for `2499fb24` and `64ac5db5`; later runs `skipped` only because CI was red, which masked it.

## The change

The service reads and writes exclusively through Drizzle, so the Mongo connection was vestigial. The script is now Postgres-only and closes the pool on both exit paths.

`DATABASE_URL` is already present on the live `oxy-mention` task definition, so `connectPostgres()` resolves in production.

## Verification

- `bunx tsc --noEmit` on `packages/backend` — exit 0
- All six of the service's transitive imports carry zero `mongoose` references, so removing the Mongo connect cannot regress it

🤖 Generated with [Claude Code](https://claude.com/claude-code)