### PR TITLE
chore(deps): bloom 0.80.0 — the tab strip follows focus, and scroll survives a hidden tab

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -245,7 +245,7 @@
     "socket.io-parser": "4.2.7",
   },
   "catalog": {
-    "@oxyhq/bloom": "^0.79.1",
+    "@oxyhq/bloom": "^0.80.0",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/core": "^19.1.1",
     "@oxyhq/services": "^27.1.3",
@@ -834,7 +834,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.79.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-yQs1WvZTCHc15J7K5/aUrs6vPlV6S0H438+aUZjDUk9GQfxhz5AMv39A6xu50q11E4AY88julklqSdcKDG9jfw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.80.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-isuYh2s24L7E87dNF+jfYmQeIHy+nhVDriEdlUwwYaFc09OFhrtUpE6UoKVY2ZXX/mRVSCvUuL8Dv6h7WvClRg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.24.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-tAd+5USb1T+4CTZIUKBlkr/8WsRG/dyTFXPHwDd/4EQw5GW2GmgcvRnIHKt9+52JxMRTLKwi/sxNnor60036LA=="],
 
@@ -3324,7 +3324,6 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
-
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -3512,7 +3511,6 @@
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "@redis/client/cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
-
 
     "@syra.fm/sdk/expo-audio": ["expo-audio@56.0.12", "", { "peerDependencies": { "expo": "*", "expo-asset": "*", "react": "*", "react-native": "*" } }, "sha512-ne2UIO/HsQoBL9e+tGs5N9Sf3NyW5sJMm4sDkexbSJRc2IchLDG+9Msu/+l5N4RlZ8SiF42wRyWsh/Usg+SwOw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@oxyhq/bloom": "^0.79.1",
+      "@oxyhq/bloom": "^0.80.0",
       "@oxyhq/contracts": "^0.24.0",
       "@oxyhq/core": "^19.1.1",
       "@oxyhq/services": "^27.1.3",


### PR DESCRIPTION
Carries the scroll rewrite (content-keyed restoration, the partial-offset fix, and the hidden-tab and shorter-tab clamp guards) and the shared tabs strip with its `expo-router` adapter.

This unblocks the profile tab conversion: the installed 0.79.1 has neither `@oxyhq/bloom/tabs/expo-router` nor `isFocused`, so the conversion cannot be written against it at all.

## The change

One catalog edit. `workspaces.catalog` is the single place, since the workspace manifest and the root override both read `"catalog:"`. `bun add` is not usable here — an override outranks a workspace range, so it reports success and leaves the old version in both `node_modules` and `bun.lock`.

## Verification

- **Installed version asserted, not trusted**: `0.80.0`.
- **Exactly one resolution recorded** — `grep` over `bun.lock` prints a single line, so no dependent kept a nested 0.79.1.
- **Shipped API present in the copy Metro compiles**: `./tabs/expo-router` export, `isFocused` in `src/tabs/types.ts`, `src/tabs/expo-router/RouterTabs.tsx`.
- Frontend typecheck clean; frontend suite **160 suites / 1533 tests** pass.
- `verify-lockfile.sh origin/main` **passes** — see below.

## It also fixes the lockfile gate that is red on main

`Lockfile resolves cleanly from the base` currently fails on `main` itself (last three runs), asking for two blank lines to be dropped from `bun.lock` at `zustand` and `@redis/client/cluster-key-slot`. A plain `bun install` normalises them, so this bump carries that correction incidentally and the gate passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)