### PR TITLE
chore: drop two stray blank lines so bun.lock matches what bun produces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3324,7 +3324,6 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
-
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -3512,7 +3511,6 @@
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "@redis/client/cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
-
 
     "@syra.fm/sdk/expo-audio": ["expo-audio@56.0.12", "", { "peerDependencies": { "expo": "*", "expo-asset": "*", "react": "*", "react-native": "*" } }, "sha512-ne2UIO/HsQoBL9e+tGs5N9Sf3NyW5sJMm4sDkexbSJRc2IchLDG+9Msu/+l5N4RlZ8SiF42wRyWsh/Usg+SwOw=="],
 


### PR DESCRIPTION
`Lockfile resolves cleanly from the base` **has been failing on `main` itself since `b6acad8a`**, so every open PR inherits a red `CI complete` regardless of what it changes.

The check reproduces `bun.lock` by installing from the base revision's lockfile plus the current manifests. The committed file differs from that result by exactly **two blank lines** — a doubled separator after `zustand` and after `@redis/client/cluster-key-slot`.

## Scope

Whitespace, and nothing else.

- Diff is **2 deletions, both empty lines**. No manifest changes.
- **All 2095 resolution entries byte-identical** before and after — verified by comparing the resolved versions, not the line count.
- `bun install --frozen-lockfile` accepts it unchanged: "Checked 1920 installs across 1782 packages (no changes)".
- `.github/scripts/verify-lockfile.sh origin/main` now passes.

## Why by hand rather than by regenerating

A from-scratch resolve in this repo re-chooses every range under the `minimumReleaseAge` quarantine and silently rolls back anything published in the last week, native dependencies included. That is a far worse trade than the red gate it would fix, so the two lines are removed directly.

## Unblocks

Merging this should turn #645 (feed `scrollMargin` fix) fully green — its every code check already passes and it fails only on this inherited gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)