### PR TITLE
feat(deploy): refuse the rollout when Postgres is empty — MUST SHIP WITH THE CUTOVER

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -101,7 +101,25 @@ fi
 # run. Neither replaces the other — this one applies the migrations, that one
 # survives the case where somebody bypassed this one.
 #
-# Both entries run during the dual-run. Postgres does not replace Mongo yet.
+# Both migration entries run during the dual-run. Postgres does not replace
+# Mongo yet.
+#
+# THE THIRD ENTRY IS THE POPULATION FLOOR, and it is last because it is the only
+# one that reads rows: the schema has to exist before rows can be counted.
+#
+# It exists because a 200 is not evidence of a database. A trunk image went live
+# against an empty Postgres on 2026-08-04, every post-deploy smoke check passed
+# — an empty store answers the anonymous feed 200 with no items — and the
+# rollback came from an unrelated task crashing. Placed HERE rather than in the
+# smoke checks because a failure here has routed nothing; a smoke failure rolls
+# back after the image has already served.
+#
+# ITS LIFETIME IS THE CUTOVER'S. It asserts that Postgres is authoritative,
+# which is false before the cutover and false again after a rollback to Mongo —
+# the planned contingency. It therefore ships INSIDE the cutover commit, so
+# reverting the cutover reverts it. Landing it separately would leave a guard
+# that blocks every deploy after a Mongo rollback, for a reason nothing about
+# that rollback would lead anyone to look for.
 MIGRATION_TASK_COMMANDS_JSON='[
   {
     "label": "Postgres migration",
@@ -110,6 +128,10 @@ MIGRATION_TASK_COMMANDS_JSON='[
   {
     "label": "Mongo migration",
     "command": ["bun", "packages/backend/dist/scripts/migrate.js"]
+  },
+  {
+    "label": "Postgres population floor",
+    "command": ["bun", "packages/backend/dist/src/scripts/assertPostgresPopulated.js"]
   }
 ]'
 # Exit code a smoke script uses to say "this failed, and rolling back cannot fix

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -452,6 +452,7 @@ run_release migration-order true true false 0
 printf '%s\n' \
   'task:bun packages/backend/dist/src/db/migrate.js --target-database=mention' \
   'task:bun packages/backend/dist/scripts/migrate.js' \
+  'task:bun packages/backend/dist/src/scripts/assertPostgresPopulated.js' \
   'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
   task:reconcile \
@@ -459,6 +460,17 @@ printf '%s\n' \
 diff -u \
   "$test_directory/migration-order/expected.log" \
   "$test_directory/migration-order/aws.log"
+
+# THE POPULATION FLOOR IS LAST, AND THAT IS THE ASSERTION ABOVE, not a detail
+# of the diff: it counts rows, so it cannot run before the Postgres migration
+# has created the tables to count. The whole-log `diff` is what notices if
+# someone reorders the list; grepping for the entry would pass either way round.
+#
+# What it buys is the case no HTTP check can see. A trunk image went live
+# against an EMPTY Postgres on 2026-08-04 and every smoke check passed, because
+# an empty store answers the anonymous feed 200 with no items. This entry fails
+# BEFORE `update-service`, so nothing is routed -- which the sequence above
+# proves by position: `service:` comes after it.
 
 # A migration one-shot that never STOPS is the case that reaches the EXIT trap's
 # unfinished-task warning -- the only signal that a migration may still be

--- a/docs/MONGO-TO-POSTGRES-CUTOVER.md
+++ b/docs/MONGO-TO-POSTGRES-CUTOVER.md
@@ -127,18 +127,29 @@ aws ecs run-task --cluster oxy-cluster --launch-type FARGATE \
      "--source-database=mention-production","--audit-only"]}]}'
 ```
 
-**`--source-database` is REQUIRED on every mode, and the name in these commands
-was taken from this document and from `resolutions.ts`, not measured against the
-cluster.** It is the mirror of `--target-database`: the operator states which
-Mongo database they believe `MONGODB_URI` points at, and the run refuses unless
-the driver's own `db.databaseName` agrees. That closes the direction nothing
-guarded — a wrong-but-connectable URI makes every collection read as empty, so
-the copy writes nothing and exits 0, and `--verify-only` cannot catch it because
-it reads the same URI.
+**`--source-database` is REQUIRED on every mode.** It is the mirror of
+`--target-database`: the operator states which Mongo database they believe
+`MONGODB_URI` points at, and the run refuses unless the driver's own
+`db.databaseName` agrees. That closes the direction nothing guarded — a
+wrong-but-connectable URI makes every collection read as empty, so the copy
+writes nothing and exits 0, and `--verify-only` cannot catch it because it reads
+the same URI.
 
-**Confirm the name on this run, the day before.** If it is wrong the audit
-refuses immediately and says both sides — which is the failure you want, here,
-outside the window rather than inside it.
+**`mention-production` is MEASURED, not inferred.** Read on 2026-08-04 by a
+read-only one-shot on the `oxy-mention` task definition — so it resolved through
+**the same `MONGODB_URI` secret the copy will use** — which returned
+`DBNAME=mention-production`, `COLLECTIONS=70`. The provenance is the claim: not
+"the database is named this" in the abstract, but "the URI §3.3 connects with
+resolves to this", which is exactly what the guard compares against. A name
+confirmed from anywhere else would be a different fact wearing the same string.
+
+**Why it is still required on `--audit-only`, now that the name is known.** The
+requirement does not exist to compensate for an unverified name; it exists so a
+FUTURE wrong declaration — a copied command line, a renamed database, a second
+environment — surfaces on the day-before run rather than at §3.3. A guard that
+takes an operator-supplied expected value inherits the reliability of that
+value, and no rigour inside the check touches that; what helps is where the
+mismatch first fires.
 
 Read the log by paging `get-log-events` with `nextForwardToken` to exhaustion and
 **confirm you reached the verdict banner**. `filter-log-events` truncates at

--- a/docs/MONGO-TO-POSTGRES-CUTOVER.md
+++ b/docs/MONGO-TO-POSTGRES-CUTOVER.md
@@ -123,8 +123,22 @@ aws ecs run-task --cluster oxy-cluster --launch-type FARGATE \
   --task-definition <pgaudit revision pointing at PROBE_DATABASE_URL> \
   --network-configuration 'awsvpcConfiguration={subnets=[subnet-08f5cc132b3cab15c,subnet-0bfb367f29d1fd375],securityGroups=[sg-0f0ca416eacab578c],assignPublicIp=ENABLED}' \
   --overrides '{"containerOverrides":[{"name":"mention","command":[
-     "bun","packages/backend/dist/scripts/backfill-mongo-to-postgres.js","--audit-only"]}]}'
+     "bun","packages/backend/dist/scripts/backfill-mongo-to-postgres.js",
+     "--source-database=mention-production","--audit-only"]}]}'
 ```
+
+**`--source-database` is REQUIRED on every mode, and the name in these commands
+was taken from this document and from `resolutions.ts`, not measured against the
+cluster.** It is the mirror of `--target-database`: the operator states which
+Mongo database they believe `MONGODB_URI` points at, and the run refuses unless
+the driver's own `db.databaseName` agrees. That closes the direction nothing
+guarded — a wrong-but-connectable URI makes every collection read as empty, so
+the copy writes nothing and exits 0, and `--verify-only` cannot catch it because
+it reads the same URI.
+
+**Confirm the name on this run, the day before.** If it is wrong the audit
+refuses immediately and says both sides — which is the failure you want, here,
+outside the window rather than inside it.
 
 Read the log by paging `get-log-events` with `nextForwardToken` to exhaustion and
 **confirm you reached the verdict banner**. `filter-log-events` truncates at
@@ -448,7 +462,7 @@ wrong environment, or a database recreated under another name all fail closed.
 ```bash
 --overrides '{"containerOverrides":[{"name":"mention","command":[
    "bun","packages/backend/dist/scripts/backfill-mongo-to-postgres.js",
-   "--target-database=mention"]}]}'
+   "--source-database=mention-production","--target-database=mention"]}]}'
 ```
 
 Still true and still worth doing, now as belt-and-braces rather than as the only
@@ -752,7 +766,7 @@ Run it after §3.4 and before admitting anyone:
 ```bash
 --overrides '{"containerOverrides":[{"name":"mention","command":[
    "bun","packages/backend/dist/scripts/backfill-mongo-to-postgres.js",
-   "--verify-only","--target-database=mention"]}]}'
+   "--source-database=mention-production","--verify-only","--target-database=mention"]}]}'
 ```
 
 `VERIFY PASS` is the line to look for. A failure prints, per table, the row count

--- a/packages/backend/scripts/backfill-mongo-to-postgres.ts
+++ b/packages/backend/scripts/backfill-mongo-to-postgres.ts
@@ -128,6 +128,11 @@ import {
   assertTargetDeclared,
 } from '../src/db/backfill/targetDatabase';
 import {
+  assertSourceDatabase,
+  assertSourceDeclared,
+  assertSourceNotEmpty,
+} from '../src/db/backfill/sourceDatabase';
+import {
   CHECKPOINT_TABLE,
   clearState,
   loadState,
@@ -209,6 +214,15 @@ interface Options {
    * denylist.
    */
   readonly targetDatabase: string | undefined;
+  /**
+   * The SOURCE database this run believes it is reading. REQUIRED.
+   *
+   * The mirror of {@link targetDatabase}, and it closes the direction nothing
+   * guarded: a wrong `MONGODB_URI` that still connects makes every collection
+   * read as empty, the copy writes nothing, and the run exits 0. See
+   * `db/backfill/sourceDatabase.ts`.
+   */
+  readonly sourceDatabase: string | undefined;
   /** Must repeat `targetDatabase` to arm `--start-from-empty`. */
   readonly confirmTruncate: string | undefined;
   readonly batchSize: number;
@@ -241,6 +255,7 @@ function parseOptions(argv: readonly string[]): Options {
     restart: flag('restart'),
     startFromEmpty: flag('start-from-empty'),
     targetDatabase: value('target-database'),
+    sourceDatabase: value('source-database'),
     confirmTruncate: value('confirm-truncate'),
     batchSize: numeric('batch-size', DEFAULT_BATCH_SIZE),
     concurrency: numeric('concurrency', DEFAULT_CONCURRENCY),
@@ -283,6 +298,7 @@ async function main(): Promise<number> {
   // against the connection below. Argument-only, so a mistyped flag is refused
   // before a socket is opened rather than after two handshakes.
   const targetDatabase = assertTargetDeclared(options);
+  const sourceDatabase = assertSourceDeclared(options);
 
   const mongoUri = process.env.MONGODB_URI;
   if (!mongoUri) throw new Error('MONGODB_URI is not set — it names the SOURCE database');
@@ -321,6 +337,12 @@ async function main(): Promise<number> {
     // table is touched: is this the database the operator named? Everything
     // else in this file assumes the answer is yes.
     await assertTargetDatabase(db, targetDatabase);
+    // The same question asked of the other end, and the one nothing asked
+    // before: a `MONGODB_URI` pointing somewhere unintended reads every
+    // collection as empty, so the copy writes nothing and exits 0. Checked from
+    // the driver's own `databaseName`, never parsed out of the URI.
+    assertSourceDatabase(source.databaseName, sourceDatabase);
+    say(`Source database:   ${source.databaseName} (declared, and it agrees)`);
 
     // Both bookkeeping tables, checked HERE rather than where they are first
     // written. The checkpoint table is touched at the START of the copy and the
@@ -343,6 +365,14 @@ async function main(): Promise<number> {
     const discovery = await discover(source);
     reportDiscovery(discovery);
     if (discovery.unknown.length > 0) throw new UnknownCollectionError(discovery.unknown);
+    // The COARSEST possible count, and deliberately not per-collection floors:
+    // a single collection can legitimately empty out, so a floor on one encodes
+    // a population claim that rots — and a false refusal here costs the cutover
+    // window. Zero across ALL of them cannot be a production source, so this
+    // has no false-positive mode. Reported on success by `reportDiscovery`
+    // above, which stays a REPORTER: the refusal lives here, beside the other
+    // refusals, rather than inside something whose name promises only printing.
+    assertSourceNotEmpty(discovery.migrated.map((entry) => entry.documents));
 
     // ---- audit (pre-pass) -------------------------------------------------
     if (options.auditOnly || options.startFromEmpty) {

--- a/packages/backend/src/__tests__/adminScriptSafety.test.ts
+++ b/packages/backend/src/__tests__/adminScriptSafety.test.ts
@@ -14,6 +14,11 @@ const ts = createRequire(path.join(__dirname, 'adminScriptSafety.test.ts'))(
 const SCRIPTS_DIRECTORY = path.resolve(__dirname, '../scripts');
 const SCRIPT_NAME = 'purgeGoneFederatedActors';
 const READ_ONLY_SCRIPTS = new Set([
+  // Counts rows and exits. Its entire database surface is
+  // `select count(*) from <table>` — no insert, update or delete — and it runs
+  // before `update-service` precisely so it can refuse a rollout without ever
+  // having changed anything.
+  'assertPostgresPopulated.ts',
   'evalFeedQuality.ts',
   // Prints what a term's posts store; makes no write of any kind.
   'inspectTrendTerms.ts',

--- a/packages/backend/src/__tests__/db/backfillSourceDatabase.test.ts
+++ b/packages/backend/src/__tests__/db/backfillSourceDatabase.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The SOURCE-side guards — the mirror of `targetDatabase.ts`.
+ *
+ * The gap they close: `assertTargetsEmpty` refuses a target that holds rows and
+ * `assertTargetDatabase` refuses a target the operator did not predict, while
+ * nothing did either for the source. A copy pointed at an empty or wrong Mongo
+ * database discovers zeros, writes nothing, prints `0 row(s) written` and exits
+ * 0 — which the runbook reads as success. `--verify-only` cannot catch it
+ * because it reads the same `MONGODB_URI`, so a wrong-but-empty source and an
+ * empty target agree.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  assertSourceDatabase,
+  assertSourceDeclared,
+  assertSourceNotEmpty,
+  EmptySourceError,
+  MissingSourceDatabaseError,
+  WrongSourceDatabaseError,
+} from '../../db/backfill/sourceDatabase';
+
+describe('the source database identity guard', () => {
+  it('accepts the database the operator named', () => {
+    expect(() => assertSourceDatabase('mention-production', 'mention-production')).not.toThrow();
+  });
+
+  it('REFUSES a different database and names BOTH sides', () => {
+    // "Wrong database" tells an operator they are wrong. Naming both ends tells
+    // them WHICH of the two is misconfigured, which is the difference between
+    // fixing it and re-running it hopefully.
+    let raised: unknown;
+    try {
+      assertSourceDatabase('mention-staging', 'mention-production');
+    } catch (error) {
+      raised = error;
+    }
+    expect(raised).toBeInstanceOf(WrongSourceDatabaseError);
+    const message = (raised as Error).message;
+    expect(message).toContain('"mention-production"');
+    expect(message).toContain('"mention-staging"');
+    expect(message).toContain('MONGODB_URI');
+  });
+
+  it('has no opinion about how much data is present, so it cannot cry wolf', () => {
+    // The whole reason this is an identity check and not a population floor: a
+    // false refusal in the cutover window costs the window. A name match is
+    // exact and says nothing about row counts.
+    expect(() => assertSourceDatabase('mention-production', 'mention-production')).not.toThrow();
+  });
+
+  it('REFUSES a run that never said which source it believes it reads', () => {
+    for (const sourceDatabase of [undefined, '', '   ']) {
+      expect(() => assertSourceDeclared({ sourceDatabase })).toThrow(MissingSourceDatabaseError);
+    }
+  });
+
+  it('returns the declared name, trimmed', () => {
+    expect(assertSourceDeclared({ sourceDatabase: ' mention-production ' })).toBe(
+      'mention-production'
+    );
+  });
+});
+
+describe('the empty-source guard', () => {
+  it('REFUSES when every migrated collection is empty', () => {
+    let raised: unknown;
+    try {
+      assertSourceNotEmpty([0, 0, 0]);
+    } catch (error) {
+      raised = error;
+    }
+    expect(raised).toBeInstanceOf(EmptySourceError);
+    // It must not read as "wrong database": the name already matched, so this
+    // is the right name on an empty one, and that sends an operator somewhere
+    // different.
+    expect((raised as Error).message).toContain('correctly named');
+    expect((raised as Error).message).toContain('3 migrated collection(s)');
+  });
+
+  it('accepts a source where ONE collection holds documents and the rest are empty', () => {
+    // The coarsest granularity on purpose. A per-collection floor would refuse
+    // this, and a collection that legitimately empties out is exactly how such
+    // a floor rots into a false refusal mid-window.
+    expect(() => assertSourceNotEmpty([0, 0, 1])).not.toThrow();
+  });
+
+  it('accepts a real production shape', () => {
+    expect(() => assertSourceNotEmpty([4_989_522, 64_156, 0, 118])).not.toThrow();
+  });
+
+  it('REFUSES an empty LIST, rather than passing because there was nothing to add up', () => {
+    // `[].reduce(sum, 0)` is 0, so this falls out of the same comparison — but
+    // it is a different failure (the discovery pass found no migrated
+    // collections at all) and it must not be the one case that slips through.
+    expect(() => assertSourceNotEmpty([])).toThrow(EmptySourceError);
+  });
+});

--- a/packages/backend/src/__tests__/scriptScope.ts
+++ b/packages/backend/src/__tests__/scriptScope.ts
@@ -127,6 +127,15 @@ export const SCRIPT_SCOPE: Readonly<Record<string, ScriptScopeDeclaration>> = {
   },
 
   // ── Caller-scoped, or read-only. Safe to share the run's database. ──────────
+  assertPostgresPopulated: {
+    scope: 'caller-scoped',
+    reason:
+      'Read-only: its whole database surface is `select count(*) from <table>`, and it holds ' +
+      'no insert, update or delete. Unscoped by table — it counts every row on purpose — but ' +
+      'the rule this list enforces is about rows a test can CORRUPT, and a count writes ' +
+      'nothing. Its suite additionally never reaches the counting: it imports the pure ' +
+      'evaluatePopulation and passes readings in, so no test drives a query at all.',
+  },
   backfillFederatedBoostCounts: {
     scope: 'caller-scoped',
     reason:

--- a/packages/backend/src/__tests__/scripts/assertPostgresPopulated.test.ts
+++ b/packages/backend/src/__tests__/scripts/assertPostgresPopulated.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The pre-rollout population floor.
+ *
+ * The decision is tested apart from the counting on purpose: the failure this
+ * guards is "a reachable database with nothing in it", and a test that needed a
+ * real empty database could only be written by emptying a shared one. So
+ * `evaluatePopulation` takes readings and returns a verdict, and these assert
+ * the verdict — including the two failures it must not conflate.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  evaluatePopulation,
+  POPULATION_FLOORS,
+  type PopulationFloor,
+} from '../../scripts/assertPostgresPopulated';
+
+const floors: readonly PopulationFloor[] = [
+  { table: 'posts', minimum: 1, why: 'why posts' },
+  { table: 'federated_actors', minimum: 1, why: 'why actors' },
+];
+
+describe('the pre-rollout population floor', () => {
+  it('passes a populated database and SAYS WHAT IT COUNTED', () => {
+    const verdict = evaluatePopulation(floors, [
+      { table: 'posts', rows: 4_989_522 },
+      { table: 'federated_actors', rows: 64_156 },
+    ]);
+    expect(verdict.ok).toBe(true);
+    // On success as well as failure. A check that reports only "passed" cannot
+    // be audited afterwards, which is how a measurement becomes a claim.
+    expect(verdict.lines).toEqual([
+      'posts: 4989522 row(s), floor 1 — ok',
+      'federated_actors: 64156 row(s), floor 1 — ok',
+    ]);
+  });
+
+  it('REFUSES an empty database and names the table that was empty', () => {
+    // The 2026-08-04 shape: schema present, connection fine, no rows.
+    const verdict = evaluatePopulation(floors, [
+      { table: 'posts', rows: 0 },
+      { table: 'federated_actors', rows: 0 },
+    ]);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.lines[0]).toContain('posts: 0 row(s), floor 1 — BELOW FLOOR');
+    expect(verdict.lines[1]).toContain('federated_actors: 0 row(s), floor 1 — BELOW FLOOR');
+  });
+
+  it('REFUSES a PARTIAL copy, which one table alone would report as healthy', () => {
+    // The copy walks collections in level order, so it can write actors and die
+    // before posts. This is the case the second floor exists for — with only
+    // `federated_actors` declared, this reading passes.
+    const verdict = evaluatePopulation(floors, [
+      { table: 'posts', rows: 0 },
+      { table: 'federated_actors', rows: 64_156 },
+    ]);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.lines[0]).toContain('BELOW FLOOR');
+    expect(verdict.lines[1]).toContain('ok');
+  });
+
+  it('treats a floor that was NEVER MEASURED as a refusal, not a pass', () => {
+    // Whatever stopped the count left the question unanswered, and an
+    // unanswered question about whether production has data must not read as
+    // yes. Distinguished from BELOW FLOOR because they send an operator to
+    // different places.
+    const verdict = evaluatePopulation(floors, [{ table: 'posts', rows: 4_989_522 }]);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.lines[1]).toContain('federated_actors: NOT MEASURED');
+    expect(verdict.lines[1]).not.toContain('BELOW FLOOR');
+  });
+
+  it('refuses when NO floors are declared, rather than passing vacuously', () => {
+    const verdict = evaluatePopulation([], []);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.lines.join(' ')).toContain('nothing was checked');
+  });
+
+  it('declares at least two tables, written at DIFFERENT levels of the copy', () => {
+    // The vacuity floor on the floor: one table cannot tell a partial copy from
+    // an empty one, and a list that shrank to one would still pass every
+    // assertion above.
+    expect(POPULATION_FLOORS.length).toBeGreaterThanOrEqual(2);
+    for (const floor of POPULATION_FLOORS) {
+      expect(floor.minimum).toBeGreaterThanOrEqual(1);
+      expect(floor.why.length).toBeGreaterThan(40);
+    }
+  });
+});

--- a/packages/backend/src/db/backfill/mongoSource.ts
+++ b/packages/backend/src/db/backfill/mongoSource.ts
@@ -118,6 +118,15 @@ export function readOnlyCollection(collection: DriverCollection): ReadOnlyCollec
 
 /** The source database, connected read-only-by-construction. */
 export interface MongoSource {
+  /**
+   * The name the driver actually connected to.
+   *
+   * Read from the connection rather than parsed out of `MONGODB_URI`: a URI
+   * carries the name in more than one place, so parsing re-derives — badly —
+   * something the driver already knows. `db/backfill/sourceDatabase.ts` is the
+   * consumer, and it is the mirror of `current_database()` on the target side.
+   */
+  readonly databaseName: string;
   /** Live collection names, from `db.listCollections()`. */
   listCollections(): Promise<string[]>;
   /** A read-only handle on one collection. */
@@ -142,6 +151,7 @@ export interface MongoSource {
  *   connection's lifetime because it owns its creation.
  */
 export function mongoSourceFromDb(db: DriverDb, close: () => Promise<void>): MongoSource {
+  const databaseName = db.databaseName;
   const existing = new Set<string>();
   let listed = false;
 
@@ -155,6 +165,7 @@ export function mongoSourceFromDb(db: DriverDb, close: () => Promise<void>): Mon
   }
 
   return {
+    databaseName,
     listCollections,
     collection(name) {
       return readOnlyCollection(db.collection<SourceDocument>(name));

--- a/packages/backend/src/db/backfill/sourceDatabase.ts
+++ b/packages/backend/src/db/backfill/sourceDatabase.ts
@@ -1,0 +1,134 @@
+/**
+ * Which database is this run allowed to READ from — asserted, not assumed.
+ *
+ * ## The mirror of `targetDatabase.ts`, and the gap it closes
+ *
+ * `assertTargetsEmpty` refuses a target that already holds rows, and
+ * `assertTargetDatabase` refuses a target whose name the operator did not
+ * predict. Nothing did either for the SOURCE. A copy pointed at an empty or
+ * wrong Mongo database discovers its collections at zero documents,
+ * `reportDiscovery` prints those zeros and blocks nothing, the copy writes
+ * nothing, and the run prints `0 row(s) written` and EXITS 0 — which the
+ * runbook's success criterion for §3.3 reads as done.
+ *
+ * ## `--verify-only` cannot be the second opinion, because it shares the premise
+ *
+ * §3.4c verifies the copy against the same `MONGODB_URI`. A wrong-but-empty
+ * source and an empty target AGREE, so verification confirms a faithful copy of
+ * the wrong thing. Two checks that share a premise prove one thing, not two —
+ * which is why this refusal has to sit BEFORE the read, not after it.
+ *
+ * ## Why an identity check and not a population floor
+ *
+ * The error class is "connected to the wrong database", and that has an exact
+ * answer rather than a statistical one. A per-collection floor would encode a
+ * population claim that rots — a collection can legitimately empty out — and a
+ * false positive HERE costs the cutover window, which is the most expensive
+ * false positive in this repository. A name either matches or it does not, and
+ * it has no opinion about how much data is present, so it has no false-positive
+ * mode at all.
+ *
+ * The one count kept is the COARSEST possible: zero documents across every
+ * migrated collection combined. That cannot be a legitimate production source
+ * either, so it also cannot cry wolf.
+ *
+ * ## Read from the DRIVER, never parsed out of the URI
+ *
+ * `db.databaseName` is what the driver actually connected to. A URI carries the
+ * name in more than one place (path, `authSource`, query defaults), so parsing
+ * it re-derives — badly — something the connection already knows. The same
+ * reasoning as comparing against `current_database()` rather than against
+ * `DATABASE_URL`.
+ *
+ * ## This is deliberately a THIRD guard
+ *
+ * #115 is "collapse the two target-database guards, after the cutover". This
+ * adds a third, on the other end of the copy. Anyone doing #115 should treat it
+ * as in scope and decide about it — not discover it by deleting it.
+ */
+
+/** Raised when the connected Mongo database is not the one the operator named. */
+export class WrongSourceDatabaseError extends Error {
+  constructor(
+    readonly expected: string,
+    readonly actual: string
+  ) {
+    super(
+      `Refusing to run: --source-database=${JSON.stringify(expected)} but ` +
+        `MONGODB_URI is connected to ${JSON.stringify(actual)}.\n` +
+        'One of those two is wrong, and this tool cannot tell which. Fix the ' +
+        'flag if you named the wrong source; fix the MONGODB_URI secret on the ' +
+        'task definition if you are pointed somewhere unintended. Nothing has ' +
+        'been read and nothing has been written.'
+    );
+    this.name = 'WrongSourceDatabaseError';
+  }
+}
+
+/** Raised when a run did not say which source it believes it is reading. */
+export class MissingSourceDatabaseError extends Error {
+  constructor() {
+    super(
+      'Refusing to run: --source-database=<name> is REQUIRED, on every mode ' +
+        'including --audit-only and --verify-only.\n' +
+        'The database this reads from is decided entirely by the MONGODB_URI ' +
+        'secret. Naming it here is the operator saying where they believe that ' +
+        'points, so a stale or wrong-environment URI fails closed instead of ' +
+        'copying nothing and reporting success.'
+    );
+    this.name = 'MissingSourceDatabaseError';
+  }
+}
+
+/** Raised when every migrated collection is empty. */
+export class EmptySourceError extends Error {
+  constructor(readonly collections: number) {
+    super(
+      `Refusing to run: the source database is connected and correctly named, ` +
+        `but all ${collections} migrated collection(s) hold ZERO documents ` +
+        'between them.\n' +
+        'A production source cannot be empty. The name matched, so this is not ' +
+        'the wrong database by name — it is the right name on an empty or ' +
+        'freshly created one. Nothing has been written.'
+    );
+    this.name = 'EmptySourceError';
+  }
+}
+
+/**
+ * The declared source name, or refuse.
+ *
+ * Separated from the comparison for the same reason the target guard is: this
+ * one can be answered before any connection exists, so a missing flag fails
+ * before the tool spends a connection finding out.
+ */
+export function assertSourceDeclared(options: {
+  readonly sourceDatabase: string | undefined;
+}): string {
+  const declared = options.sourceDatabase?.trim();
+  if (declared === undefined || declared.length === 0) throw new MissingSourceDatabaseError();
+  return declared;
+}
+
+/**
+ * Refuse unless the connected database has the name the operator predicted.
+ *
+ * @throws {WrongSourceDatabaseError}
+ */
+export function assertSourceDatabase(actual: string, expected: string): void {
+  if (actual !== expected) throw new WrongSourceDatabaseError(expected, actual);
+}
+
+/**
+ * Refuse when every migrated collection is empty.
+ *
+ * Takes the counts the discovery pass already read rather than re-counting:
+ * a second count would be a second measurement of a moving source, and the one
+ * the report printed is the one the operator is looking at.
+ *
+ * @throws {EmptySourceError}
+ */
+export function assertSourceNotEmpty(documentCounts: readonly number[]): void {
+  const total = documentCounts.reduce((sum, count) => sum + count, 0);
+  if (total === 0) throw new EmptySourceError(documentCounts.length);
+}

--- a/packages/backend/src/scripts/assertPostgresPopulated.ts
+++ b/packages/backend/src/scripts/assertPostgresPopulated.ts
@@ -1,0 +1,204 @@
+/**
+ * Refuse the rollout when the database it is about to serve is EMPTY.
+ *
+ * ## What this is for
+ *
+ * On 2026-08-04 a trunk image went live against an empty Postgres. Every
+ * post-deploy smoke check passed — `GET /feed/mtn` answers 200 with
+ * `{"data":{"items":[]}}` when the store holds nothing, so "the process
+ * answered" was standing in for "the process has a database behind it". What
+ * reverted the deployment was an unrelated post-deploy task crashing. The
+ * breakage was load-bearing, and this is the control that replaces it.
+ *
+ * It runs as the THIRD migration one-shot in `deploy-ecs-image.sh`, after both
+ * migrations (the schema has to exist before rows can be counted) and before
+ * `update-service`. A non-zero exit there stops the release having routed
+ * nothing, which is the whole reason it lives at that point rather than in the
+ * post-deploy smoke: a smoke failure rolls back after the image has served.
+ *
+ * ## READ-ONLY, deliberately
+ *
+ * A one-shot that fails may still be RUNNING against the database afterwards —
+ * the deploy role cannot call `ecs:StopTask`, which `deploy-ecs-image.sh` warns
+ * about in its own comments. Anything this file did to the data could therefore
+ * still be happening after the deploy gave up. It counts and it exits.
+ *
+ * ## ITS LIFETIME IS THE CUTOVER'S LIFETIME — do not land it separately
+ *
+ * This asserts that Postgres is authoritative. That is TRUE from the cutover
+ * onward and FALSE before it, and it is false again the moment we exercise the
+ * planned rollback: Mongo is the rollback target, and reverting to it makes an
+ * empty Postgres correct again. A floor that outlived the cutover would then
+ * block every subsequent deploy for a reason nothing about a Mongo rollback
+ * would lead anyone to look for.
+ *
+ * So it ships INSIDE the cutover commit, and reverting the cutover reverts it.
+ * No flag, nothing to remember, and the guard's scope equals the scope of the
+ * claim it makes. That is the same objection that kept this out of
+ * `/health/ready`: a permanent claim about the app becomes a trap for whoever
+ * first boots on a fresh database.
+ *
+ * ## It needs no "we are mid-migration" escape hatch
+ *
+ * `docs/MONGO-TO-POSTGRES-CUTOVER.md` §3.4 deploys AFTER §3.3 copies, and the
+ * service sits at desired count 0 in between, so the only moment the store is
+ * legitimately empty is a moment no deploy is running. That dependency on the
+ * runbook's ORDER is now executable rather than prose: change the order and
+ * this is what notices.
+ */
+
+import { sql } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../db/postgres';
+import { logger } from '../utils/logger';
+
+/**
+ * One table that cannot legitimately be empty once Postgres is authoritative,
+ * with the reason it cannot — the reason is what a later reader needs in order
+ * to decide whether a failure is real.
+ */
+export interface PopulationFloor {
+  readonly table: string;
+  readonly minimum: number;
+  readonly why: string;
+}
+
+/**
+ * Two tables, not one, and not twenty.
+ *
+ * One is not enough: the copy walks collections in level order, so it can write
+ * `federated_actors` and die before `posts`, and a single-table floor would
+ * report a partial copy as a healthy one. Twenty would be a list where any
+ * entry that is legitimately empty in some future state becomes a false
+ * refusal mid-window — and a false refusal here costs the window.
+ *
+ * Both counts come from the rehearsed copy of production (2026-08-03).
+ */
+export const POPULATION_FLOORS: readonly PopulationFloor[] = [
+  {
+    table: 'posts',
+    minimum: 1,
+    why:
+      'The copy moved 4,989,522 rows across 58 collections, the overwhelming ' +
+      'majority of them posts. An empty `posts` is not a quiet production — it ' +
+      'is no production.',
+  },
+  {
+    table: 'federated_actors',
+    minimum: 1,
+    why:
+      '64,156 remote actors were measured in the source. It is written at a ' +
+      'DIFFERENT level of the copy than `posts`, which is what makes the pair ' +
+      'able to tell a partial copy from an empty one.',
+  },
+];
+
+/** What one floor read. */
+export interface PopulationReading {
+  readonly table: string;
+  readonly rows: number;
+}
+
+/** The verdict, and the lines an operator reads. */
+export interface PopulationVerdict {
+  readonly ok: boolean;
+  readonly lines: readonly string[];
+}
+
+/**
+ * Decide from the readings alone — separated from the counting so the decision
+ * is testable without a database, and so the two failures it distinguishes
+ * (below the floor / never measured) cannot be conflated by a query error.
+ *
+ * Reports what it counted AND what it required, on SUCCESS as well as failure.
+ * A check that says only "passed" leaves nobody able to tell afterwards whether
+ * it looked at anything — which is how a capped report becomes a claim about a
+ * system when it was a claim about a measurement.
+ */
+export function evaluatePopulation(
+  floors: readonly PopulationFloor[],
+  readings: readonly PopulationReading[]
+): PopulationVerdict {
+  const lines: string[] = [];
+  let ok = true;
+
+  // A floor with no reading is NOT a pass. Whatever stopped the count from
+  // happening left the question unanswered, and an unanswered question about
+  // whether production has data must not read as yes.
+  if (floors.length === 0) {
+    return {
+      ok: false,
+      lines: ['no population floors are declared, so nothing was checked'],
+    };
+  }
+
+  for (const floor of floors) {
+    const reading = readings.find((entry) => entry.table === floor.table);
+    if (reading === undefined) {
+      ok = false;
+      lines.push(`${floor.table}: NOT MEASURED (floor ${floor.minimum}) — ${floor.why}`);
+      continue;
+    }
+    const verdict = reading.rows >= floor.minimum ? 'ok' : 'BELOW FLOOR';
+    if (reading.rows < floor.minimum) ok = false;
+    lines.push(
+      `${floor.table}: ${reading.rows} row(s), floor ${floor.minimum} — ${verdict}`
+    );
+  }
+  return { ok, lines };
+}
+
+/** `count(*)`, read-only. */
+async function countRows(table: string): Promise<number> {
+  // The table names come from POPULATION_FLOORS, a constant in this file — not
+  // from input — so the identifier is interpolated rather than parameterised,
+  // which a table name cannot be anyway.
+  const rows = await getDb().execute<{ count: string }>(
+    sql.raw(`select count(*)::text as count from ${table}`)
+  );
+  const first = Array.isArray(rows) ? rows[0] : (rows as { rows?: unknown[] }).rows?.[0];
+  const value = (first as { count?: string } | undefined)?.count;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`count(*) on ${table} returned ${String(value)}, which is not a number`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<number> {
+  await connectPostgres();
+  const readings: PopulationReading[] = [];
+  for (const floor of POPULATION_FLOORS) {
+    readings.push({ table: floor.table, rows: await countRows(floor.table) });
+  }
+
+  const verdict = evaluatePopulation(POPULATION_FLOORS, readings);
+  for (const line of verdict.lines) logger.info(`[assertPostgresPopulated] ${line}`);
+
+  if (!verdict.ok) {
+    logger.error(
+      '[assertPostgresPopulated] REFUSING THE ROLLOUT. The schema is present and ' +
+        'the connection works, so this is not an unreachable database — it is a ' +
+        'REACHABLE EMPTY ONE, which every HTTP check in this pipeline reports as ' +
+        'healthy. If the copy has not run yet, that is the answer: run it. If it ' +
+        'has, something emptied the target and the deploy must not proceed.'
+    );
+    return 1;
+  }
+  logger.info('[assertPostgresPopulated] every floor satisfied; the rollout may proceed.');
+  return 0;
+}
+
+// Guarded so the exported helpers above stay importable by the tests without
+// the file counting rows on import.
+if (require.main === module) {
+  void main()
+    .then(async (code) => {
+      await closePostgres();
+      process.exit(code);
+    })
+    .catch(async (error) => {
+      logger.error('[assertPostgresPopulated] failed', error);
+      await closePostgres().catch(() => undefined);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Why this is urgent rather than scheduled

At 09:22Z a deploy fired on `acc526e3`, `oxy-mention:201` went PRIMARY, and **production served an empty Postgres for ~4 minutes** before the post-deploy reconcile crash rolled it back to `:198`. The same sequence ran at 08:14Z. In both cases the post-deploy smoke reported `passed` — an empty store answers `GET /feed/mtn?limit=1` with `200` and no items.

`main` already carries the full Drizzle port, so any deploy of `main` points the app at a Postgres holding ~100 rows of residue and no real data.

**Measured: no data loss.** All six posts written to Postgres in the last 6h have `federation_actor_uri` set — federated ingest, re-fetchable — and Mongo took 110 posts in the same window. The cost was reads.

Until now the only thing preventing this was a *bug* (the reconcile one-shot crashing), plus a CI-red lockfile that #647 regenerated away as a side effect of a Bloom bump. Neither is a control.

## What this adds

A third entry in `MIGRATION_TASK_COMMANDS_JSON`, after both migrations (it counts rows, so the schema must exist) and therefore **before `update-service`**. A failed entry `exit 1`s, so the rollout is refused before the service is touched — no traffic is ever served from an empty store.

Also `--source-database=<name>`, the mirror of the existing `--target-database` / `current_database()` guard: the copy refuses a non-empty TARGET but nothing refused an empty or WRONG SOURCE, and `--verify-only` reads the same `MONGODB_URI` so it shares the premise and cannot catch it. Verified against the live cluster: the URI the copy will use resolves to `mention-production`, 70 collections.

## MUST SHIP WITH THE CUTOVER

Mongo is the rollback target. Reverting to it makes an empty Postgres correct again, and a floor that outlived the cutover would block every later deploy for a reason nothing about a Mongo rollback would surface. **Reverting the cutover reverts this.** The reasoning is in the deploy script comment and the script's own docblock, not only here.

## Known and accepted

**No Mention deploy can succeed until the copy runs.** That is the same property that makes this valuable, and it is deliberate — there is no safe hotfix path today anyway, since `main` is the trunk while production runs `:198`.

This PR's own deploy will therefore abort at the floor, before touching the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)