### PR TITLE
fix(deploy): a floor of 1 is not a floor — set it above RESIDUE, not above zero

### DIFF
--- a/packages/backend/src/__tests__/scripts/assertPostgresPopulated.test.ts
+++ b/packages/backend/src/__tests__/scripts/assertPostgresPopulated.test.ts
@@ -82,8 +82,24 @@ describe('the pre-rollout population floor', () => {
     // assertion above.
     expect(POPULATION_FLOORS.length).toBeGreaterThanOrEqual(2);
     for (const floor of POPULATION_FLOORS) {
-      expect(floor.minimum).toBeGreaterThanOrEqual(1);
       expect(floor.why.length).toBeGreaterThan(40);
+    }
+  });
+
+  it('sets every floor far above RESIDUE, not merely above zero', () => {
+    // This assertion previously read `toBeGreaterThanOrEqual(1)`, and a floor of
+    // 1 is what shipped. It did not hold: on 2026-08-04 the deploy ran this
+    // check against a Postgres carrying 100 posts and 19 federated actors of
+    // smoke-test and federated-ingest residue, reported `completed
+    // successfully`, and let a trunk image serve 0.016% of production.
+    //
+    // "Above zero" and "holds production" are different questions, and only the
+    // second one is worth a deploy gate. Residue is not hypothetical here:
+    // federated ingest writes `federated_actors` continuously while the site
+    // still serves Mongo, so the number it accrues only ever grows.
+    const OBSERVED_RESIDUE_HIGH_WATER = 100;
+    for (const floor of POPULATION_FLOORS) {
+      expect(floor.minimum).toBeGreaterThan(OBSERVED_RESIDUE_HIGH_WATER * 10);
     }
   });
 });

--- a/packages/backend/src/scripts/assertPostgresPopulated.ts
+++ b/packages/backend/src/scripts/assertPostgresPopulated.ts
@@ -76,19 +76,25 @@ export interface PopulationFloor {
 export const POPULATION_FLOORS: readonly PopulationFloor[] = [
   {
     table: 'posts',
-    minimum: 1,
+    minimum: 100_000,
     why:
-      'The copy moved 4,989,522 rows across 58 collections, the overwhelming ' +
-      'majority of them posts. An empty `posts` is not a quiet production — it ' +
-      'is no production.',
+      'The source holds 622,474 posts (counted on production Mongo, 2026-08-04). ' +
+      'A floor of 1 was satisfied by 100 rows of smoke-test residue and let a ' +
+      'trunk image serve a database with 0.016% of production in it — the check ' +
+      'asked "is this literally empty" when the property is "does this hold ' +
+      'production". 100,000 is ~6x below the real count, so a legitimately ' +
+      'smaller copy still passes, and ~1000x above any plausible residue.',
   },
   {
     table: 'federated_actors',
-    minimum: 1,
+    minimum: 10_000,
     why:
-      '64,156 remote actors were measured in the source. It is written at a ' +
-      'DIFFERENT level of the copy than `posts`, which is what makes the pair ' +
-      'able to tell a partial copy from an empty one.',
+      'The source holds 66,258 remote actors (same count, same day). It is ' +
+      'written at a DIFFERENT level of the copy than `posts`, which is what ' +
+      'makes the pair able to tell a partial copy from an empty one — and ' +
+      'federated ingest keeps writing this table while the site serves Mongo, ' +
+      'so it accrues residue fastest and needs the wider margin most. 10,000 is ' +
+      '~6x below the real count and ~500x above the residue observed.',
   },
 ];
 


### PR DESCRIPTION
## The floor passed on its own first deploy

```
16:57:45Z Running Postgres population floor with oxy-mention:203
16:58:34Z Postgres population floor completed successfully
```

Postgres held **100 posts and 19 federated actors** — smoke-test residue plus federated ingest — against a source of **622,474 posts**. Both cleared `minimum: 1`, `update-service` ran, and a trunk image served **0.016% of production** until the reconcile crash rolled it back.

**The mechanism was correct** — it ran before `update-service`, on the newly registered task definition, and a failure there does abort the rollout. Only the threshold was wrong, and the file's own docblock shows how: it reasons about 4,989,522 rows and then sets the bar to 1.

## Measured, not guessed

Production Mongo, counted 2026-08-04: **622,474 posts**, **66,258 federated actors**.

| table | was | now | real | residue |
|---|---|---|---|---|
| `posts` | 1 | 100,000 | 622,474 | 100 |
| `federated_actors` | 1 | 10,000 | 66,258 | 19 |

~6× below the real counts so a legitimately smaller copy still passes; 2–3 orders of magnitude above the residue. **Guessing would have repeated the mistake in the other direction** — "the overwhelming majority of 4,989,522" reads as millions of posts, and a floor of 1,000,000 would have blocked every correct copy forever.

`federated_actors` gets the wider relative margin deliberately: federated ingest writes it continuously while the site still serves Mongo, so its residue only ever grows.

## The test explicitly permitted it

It asserted `expect(floor.minimum).toBeGreaterThanOrEqual(1)`. That is not a missing case — it is the defect written down as an invariant. Replaced with a bound stated against the observed residue high-water, and **mutation-tested**: restoring `minimum: 1` reds the new assertion by name.

Verified: 537 files / 6397 tests, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)