### PR TITLE
chore(deps): bloom 0.81.0 — the tab underline survives a tab arriving late

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -245,7 +245,7 @@
     "socket.io-parser": "4.2.7",
   },
   "catalog": {
-    "@oxyhq/bloom": "^0.80.0",
+    "@oxyhq/bloom": "^0.81.0",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/core": "^19.1.1",
     "@oxyhq/services": "^27.1.3",
@@ -834,7 +834,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.80.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-isuYh2s24L7E87dNF+jfYmQeIHy+nhVDriEdlUwwYaFc09OFhrtUpE6UoKVY2ZXX/mRVSCvUuL8Dv6h7WvClRg=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.81.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-OXKexhxAlBq57Z0jEgZaTvBvT+aq8T7sOTbRftuZzcqe/uo1VN/FOgCnsArzuukHoDU0/h8oruQjsS9a3xdtLQ=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.24.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-tAd+5USb1T+4CTZIUKBlkr/8WsRG/dyTFXPHwDd/4EQw5GW2GmgcvRnIHKt9+52JxMRTLKwi/sxNnor60036LA=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@oxyhq/bloom": "^0.80.0",
+      "@oxyhq/bloom": "^0.81.0",
       "@oxyhq/contracts": "^0.24.0",
       "@oxyhq/core": "^19.1.1",
       "@oxyhq/services": "^27.1.3",


### PR DESCRIPTION
Catalog bump to `@oxyhq/bloom@0.81.0`, published and propagation-verified.

Carries two fixes to the shared tab strip, both reproduced in production before the fix and both mutation-tested:

- **A tab arriving after first layout left the underline one tab back.** `onLayout` on react-native-web is backed by a `ResizeObserver`, which never fires for a position-only move, so triggers pushed sideways by a late insertion never re-reported their x. Verified against the pre-fix component rendered side by side as a positive control: after inserting a tab the old strip stays at 306 while the fixed one moves to 368 — a difference of exactly the inserted tab width.
- **The strip emitted no `aria-selected`**, so no screen reader was told which tab is current.

Delta is the catalog entry plus its resolution record — 3 lines, no unrelated version churn.

Note: Mention has no live consumer of `@oxyhq/bloom/tabs` right now, since the profile tab conversion was reverted in #651. This keeps the tree current and means the fix is already in place when that work re-lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)