### PR TITLE
fix(frontend): the profile media grid stops freezing after its first window

### DIFF
--- a/packages/frontend/components/Feed/Feed.web.tsx
+++ b/packages/frontend/components/Feed/Feed.web.tsx
@@ -315,6 +315,28 @@ function VirtualizedWebFeed(props: FeedProps) {
         getItemKey: (index) => feedRowKey(feedRows[index]),
     });
 
+    // THE REACT COMPILER MUST NOT MEMOIZE THIS COMPONENT — and today it doesn't,
+    // by accident. `virtualizer` has a STABLE identity for this component's
+    // lifetime and forces re-renders through a reducer INTERNAL to
+    // `useWindowVirtualizer`, so a scroll changes nothing this function can see.
+    // If the compiler memoizes the render, both reads below and the row JSX get
+    // cached on deps that never change and the feed freezes on its first window
+    // — no error, virtualizer healthy, DOM stuck. What prevents that is two
+    // ref-`.current` reads during render, each of which makes the compiler
+    // refuse this whole function (verified: it emits no memo cache at all):
+    //   1. `loadMoreRef.current = handleLoadMore` below
+    //   2. `getPostRowRef`/`getMeasureRef` read their caches inside the row map
+    // Removing BOTH makes this compile to a 64-slot cache and reintroduces the
+    // freeze. Judge that by the compiler's own CompileError/CompileSuccess
+    // events, not by grepping the output for a cache call — this comment would
+    // match such a grep.
+    // This is not hypothetical: `ProfileGridList.web.tsx` has the same shape,
+    // compiles, and shipped frozen — it now carries an explicit `'use no memo'`.
+    // Do not reason about which of these is "safe" structurally; the compiler's
+    // grouping is per-file and a captured ref does NOT reliably prevent it
+    // (measured both ways). If you change this render path, re-verify by
+    // compiling this file with the app's own babel-plugin-react-compiler and
+    // confirming `getVirtualItems()` is still called unguarded.
     const virtualItems = virtualizer.getVirtualItems();
     const totalSize = virtualizer.getTotalSize();
 

--- a/packages/frontend/components/Profile/ProfileGridList.web.tsx
+++ b/packages/frontend/components/Profile/ProfileGridList.web.tsx
@@ -35,6 +35,22 @@ export function ProfileGridList<T extends ProfileGridEntry>({
     listHeaderComponent,
     listStickyHeaderComponent,
 }: ProfileGridListProps<T>) {
+    // REQUIRED — without it this grid renders its first window of rows and then
+    // never updates again. `useWindowVirtualizer` returns an instance whose
+    // identity is stable for the component's lifetime and which forces
+    // re-renders through a reducer INTERNAL to the hook, so scrolling changes
+    // nothing this component can see. The React Compiler therefore groups the
+    // whole render — `getVirtualItems()` included — into one block keyed on
+    // props plus that stable instance, none of which change on scroll, and
+    // serves the first result forever. Measured on production (build
+    // `entry-ff9a95e94…`): mounted rows stayed [0..7] across a 1899px scroll of
+    // a 2322px grid, leaving ~550px of blank space below the last row.
+    // There is no `subscribe` on the virtualizer to drive `useSyncExternalStore`
+    // from, so opting this function out is the available fix; it restores the
+    // behaviour the other three virtualized web lists already have (they opt out
+    // accidentally, by reading a ref during render — see `Feed.web.tsx`).
+    'use no memo';
+
     const rootRef = useRef<HTMLDivElement | null>(null);
     const gridRef = useRef<HTMLDivElement | null>(null);
     const [containerWidth, setContainerWidth] = useState(


### PR DESCRIPTION
## What

The profile **Media** / **Videos** grid renders its first window of rows and then never updates again. Scrolling past that window shows blank space.

Measured on **production** (build `entry-ff9a95e946baa21e28e2f72eb401a9f7.js`, profile `@bagder@mastodon.social`, anonymous viewer):

```
scrollY   0 -> 1899       spacer 2322 -> 2322   (content did not change)
rows      [0,1,2,3,4,5,6,7]
       -> [0,1,2,3,4,5,6,7]     <- unchanged
```

Row 7 ends at y=389 with ~550px of empty background below it, where rows 8–9 should be.

## Why

The React Compiler (`app.config.js` → `experiments.reactCompiler`) is active in the shipped bundle — 112 of 1895 live fibers carry a memo cache.

`useWindowVirtualizer` returns an instance whose identity is **stable for the component's lifetime** (`useState(() => new Virtualizer(...))`) and forces re-renders through a `useReducer` **internal to the hook**. So on scroll, nothing the component can see changes. The compiler grouped the whole render — `getVirtualItems()` included — into one block keyed on props plus that stable instance, and serves the first result forever.

The production bundle ships exactly that:

```js
_e.ProfileGridList=function(n){const p=(0,e.c)(53), ...
if(p[13]!==v||p[14]!==w||p[15]!==x||p[16]!==N||p[17]!==_||p[18]!==b||p[19]!==y||p[20]!==P){
  e:{const e=P.getVirtualItems();   // never re-called
```

Confirmed in the browser by reading that live memo cache across a scroll — **all eight guard deps unchanged**.

## Fix

`'use no memo'` on `ProfileGridList`. There is no `subscribe` on the virtualizer to drive `useSyncExternalStore` from, so opting the function out is the available fix. It restores the behaviour the other three virtualized web lists already have — they opt out *accidentally*, by reading a ref during render.

## Feed.web.tsx — comment only, no behaviour change

`VirtualizedWebFeed` has the **identical** hazard and is safe today only because two render-phase ref reads make the compiler refuse the whole function (it emits no memo cache at all):

1. `loadMoreRef.current = handleLoadMore`
2. `getPostRowRef`/`getMeasureRef` reading their caches inside the row map

Removing **both** makes it compile and reintroduces the freeze — in the most-used screen in the app. That was written down nowhere and is an easy "cleanup". Hence the comment.

Worth knowing: a captured ref does **not** reliably prevent this. Measured both ways — grouping is per-file, so it must be compiled to be known, never reasoned about structurally.

## Verification

- Frontend typecheck: **0 errors**
- `expo export --platform web`: **exit 0**
- Exported bundle's `ProfileGridList` no longer allocates a memo cache (`function({data:f,…}){const y=(0` vs production's `function(n){const p=(0,e.c)(53)`)
- In-browser positive control: the explore feed (`Feed.web.tsx`, which bails) advances `[0..11] → [23..39]` on the same instrument that shows the grid frozen

Jest was deliberately not used as a gate here — it resolves `.native.tsx` and never `.web.tsx`.

## Follow-up (not in this PR)

`SavedPostsList.web.tsx` compiles with `getTotalSize()` frozen on the virtualizer (`$[11] !== virtualizer`), while its rows stay live. Same bug class, smaller blast radius; I could not verify it in a browser because it needs auth. Happy to take it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)