### PR TITLE
chore(deps): bloom 0.82.0 — the colour system derives its fills, and amber is gone

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -245,7 +245,7 @@
     "socket.io-parser": "4.2.7",
   },
   "catalog": {
-    "@oxyhq/bloom": "^0.81.0",
+    "@oxyhq/bloom": "^0.82.0",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/core": "^19.1.1",
     "@oxyhq/services": "^27.1.3",
@@ -834,7 +834,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.81.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-OXKexhxAlBq57Z0jEgZaTvBvT+aq8T7sOTbRftuZzcqe/uo1VN/FOgCnsArzuukHoDU0/h8oruQjsS9a3xdtLQ=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.82.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-ajkOz/pEnSQCLkSRDxYUobruizeIzViPznrdru8VUh4o8Erq9VpYwtVqSvtdjWvgQPgbDtRY+wLQCfHdADrEaQ=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.24.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-tAd+5USb1T+4CTZIUKBlkr/8WsRG/dyTFXPHwDd/4EQw5GW2GmgcvRnIHKt9+52JxMRTLKwi/sxNnor60036LA=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@oxyhq/bloom": "^0.81.0",
+      "@oxyhq/bloom": "^0.82.0",
       "@oxyhq/contracts": "^0.24.0",
       "@oxyhq/core": "^19.1.1",
       "@oxyhq/services": "^27.1.3",


### PR DESCRIPTION
Bumps `@oxyhq/bloom` to 0.82.0.

## What lands in the app

The Edit Profile colour picker gains **`mono`** — a black-and-white theme, the way X offers it — plus `pumpkin`, `gray`, `brown`, `peach` and `rose`. No change was needed here: the picker maps over Bloom's own `APP_COLOR_NAMES`.

`orange`, `blue`, `sky`, `pink`, `yellow` and `purple` are retuned to new seeds.

## Breaking: `amber` is removed upstream

`amber` (hue 70.5) and `pumpkin` (hue 64.3) are six degrees apart, and at the tones a white label needs, the gamut is narrow enough there that both flatten to the same gold — the picker was offering a choice that did nothing.

An account still holding `amber` resolves to the default rather than crashing. Both layers that read a stored preset validate it first: `useAccountTheme` filters through `isAppColorName`, and Bloom's own persistence has `isValidPreset`. Neither can hand an unknown name to `buildTheme`, which would otherwise dereference an undefined preset config.

## Upstream system changes

- The brand fill's tone is **searched per hue** for the most vivid tone that still carries a white label at AA, replacing a flat 45 (light) / 49 (dark) for every hue. The sRGB gamut is not a cylinder: from tone 45 an orange keeps gaining chroma until white runs out, while a violet is already past its peak and loses it. Every preset also sat at 5.38 contrast against a 4.5 requirement — headroom that was never spent.
- **Light no longer forces a seed to maximum chroma.** That rule silently renamed colours: a muted blue-grey seed resolved to a vivid cyan and a brown seed to an orange, since each differs from a saturated neighbour by chroma alone.

## Verification

Run against the published package, not a local build:

- `typecheck:frontend` — 0 errors
- `test:frontend` — 1538 passed, 161 suites
- `validate:lockfile` — clean

Upstream: 1508 tests green, `verify:package` clean, and the four system rules mutation-checked (flattening the tone search reddens 38 assertions; a fifth mutation survived and that code was removed rather than kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)