### PR TITLE
fix(settings): the colour picker stops giving away the gated presets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -245,7 +245,7 @@
     "socket.io-parser": "4.2.7",
   },
   "catalog": {
-    "@oxyhq/bloom": "^0.82.0",
+    "@oxyhq/bloom": "^0.83.0",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/core": "^19.1.1",
     "@oxyhq/services": "^27.1.3",
@@ -834,7 +834,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.82.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-ajkOz/pEnSQCLkSRDxYUobruizeIzViPznrdru8VUh4o8Erq9VpYwtVqSvtdjWvgQPgbDtRY+wLQCfHdADrEaQ=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.83.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-SDpNU4wG8uN2NUmsDxnYX6NWXLPQpZyslZHJFpIAWTagKUGg4yL+8QMkcqOOSud0lU0GnylOX5y/BOvh/MeNBw=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.24.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-tAd+5USb1T+4CTZIUKBlkr/8WsRG/dyTFXPHwDd/4EQw5GW2GmgcvRnIHKt9+52JxMRTLKwi/sxNnor60036LA=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@oxyhq/bloom": "^0.82.0",
+      "@oxyhq/bloom": "^0.83.0",
       "@oxyhq/contracts": "^0.24.0",
       "@oxyhq/core": "^19.1.1",
       "@oxyhq/services": "^27.1.3",

--- a/packages/frontend/app/(app)/edit-profile.tsx
+++ b/packages/frontend/app/(app)/edit-profile.tsx
@@ -2,7 +2,13 @@ import React, { useMemo } from 'react';
 import { ScrollView, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useAuth, OxyAuthPrompt } from '@oxyhq/services/ui/client';
-import { useBloomTheme, useTheme, PREMIUM_COLOR_NAMES, type AppColorName } from '@oxyhq/bloom/theme';
+import {
+  useBloomTheme,
+  useTheme,
+  FREE_COLOR_NAMES,
+  PREMIUM_COLOR_NAMES,
+  type AppColorName,
+} from '@oxyhq/bloom/theme';
 import { SettingsListDivider } from '@oxyhq/bloom/settings-list';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { Loading } from '@oxyhq/bloom/loading';
@@ -33,16 +39,20 @@ export default function EditProfileScreen() {
   const isOxyUser = normalizedUsername === 'oxy';
   const isFaircoinUser = normalizedUsername === 'faircoin';
 
-  // Reproduces `appearance.tsx`'s premium-color-unlock logic verbatim: full
-  // premium palette for premium users, else only the colors tied to a
-  // username-gated preset (@oxy unlocks "oxy", @faircoin unlocks "faircoin").
-  const unlockedPremiumColors = useMemo<readonly AppColorName[] | undefined>(() => {
-    if (isPremium) return PREMIUM_COLOR_NAMES;
-    const unlocked: AppColorName[] = [];
-    if (isOxyUser) unlocked.push('oxy');
-    if (isFaircoinUser) unlocked.push('faircoin');
-    return unlocked.length > 0 ? unlocked : undefined;
-  }, [isPremium, isOxyUser, isFaircoinUser]);
+  // The full list this viewer may pick, built UP from the free presets rather
+  // than down from all of them. Two different gates, and they are not
+  // interchangeable: `oxy` and `faircoin` belong to those accounts and cannot be
+  // bought, while `mono` — black on white and white on black — is what a
+  // subscription buys.
+  const visibleColors = useMemo<readonly AppColorName[]>(
+    () => [
+      ...FREE_COLOR_NAMES,
+      ...(isOxyUser ? (['oxy'] as const) : []),
+      ...(isFaircoinUser ? (['faircoin'] as const) : []),
+      ...(isPremium ? PREMIUM_COLOR_NAMES : []),
+    ],
+    [isPremium, isOxyUser, isFaircoinUser],
+  );
 
   if (!isAuthenticated) {
     return (
@@ -118,7 +128,7 @@ export default function EditProfileScreen() {
             <Icon name="color-palette" size={22} color={colors.text} />
             <Text className="text-[16px] text-foreground">{t('settings.accentColor', 'Accent color')}</Text>
           </View>
-          <ColorSwatchPicker value={appColor} onChange={saveColor} extraColors={unlockedPremiumColors} />
+          <ColorSwatchPicker value={appColor} onChange={saveColor} colors={visibleColors} />
         </View>
         <SettingsListDivider />
         <PinnedMediaSection />

--- a/packages/frontend/components/settings/ColorSwatchPicker.tsx
+++ b/packages/frontend/components/settings/ColorSwatchPicker.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, Pressable } from 'react-native';
-import { APP_COLOR_PRESETS, APP_COLOR_NAMES, type AppColorName } from '@oxyhq/bloom/theme';
+import { APP_COLOR_PRESETS, type AppColorName } from '@oxyhq/bloom/theme';
 import { cn } from '@/lib/utils';
 
 const SELECTED_SWATCH_TRANSFORM = { transform: [{ scale: 1.1 }] } as const;
@@ -8,17 +8,20 @@ const SELECTED_SWATCH_TRANSFORM = { transform: [{ scale: 1.1 }] } as const;
 interface ColorSwatchPickerProps {
   value: AppColorName;
   onChange: (name: AppColorName) => void;
-  extraColors?: readonly AppColorName[];
+  /**
+   * Exactly the presets this viewer may pick, in order. The caller owns the
+   * policy — this used to take only the EXTRA ones and render them on top of
+   * Bloom's full `APP_COLOR_NAMES`, which offered every gated preset to everybody
+   * (that list contains them) and drew a viewer's own unlocks twice. A component
+   * that appends to a list it does not control cannot express a restriction.
+   */
+  colors: readonly AppColorName[];
 }
 
-export function ColorSwatchPicker({ value, onChange, extraColors }: ColorSwatchPickerProps) {
-  const allColors = extraColors?.length
-    ? [...APP_COLOR_NAMES, ...extraColors]
-    : APP_COLOR_NAMES;
-
+export function ColorSwatchPicker({ value, onChange, colors }: ColorSwatchPickerProps) {
   return (
     <View className="flex-row gap-3 flex-wrap">
-      {allColors.map((name) => {
+      {colors.map((name) => {
         const preset = APP_COLOR_PRESETS[name];
         const isSelected = value === name;
         return (
@@ -38,7 +41,18 @@ export function ColorSwatchPicker({ value, onChange, extraColors }: ColorSwatchP
               // RN-native transform array for the selected pop instead.
               style={isSelected ? SELECTED_SWATCH_TRANSFORM : undefined}
             >
-              <View style={{ backgroundColor: preset.hex, flex: 1 }} />
+              {/* A single-colour chip cannot represent the colourless preset:
+                  its seed is pure black, which vanishes against a dark page — the
+                  one mode where a user is most likely to be reaching for it. Show
+                  what the theme actually is, both halves at once. */}
+              {name === 'mono' ? (
+                <View className="flex-1 flex-row">
+                  <View style={{ backgroundColor: '#000000', flex: 1 }} />
+                  <View style={{ backgroundColor: '#ffffff', flex: 1 }} />
+                </View>
+              ) : (
+                <View style={{ backgroundColor: preset.hex, flex: 1 }} />
+              )}
             </View>
             <Text
               className={cn(

--- a/packages/frontend/components/settings/__tests__/ColorSwatchPicker.test.tsx
+++ b/packages/frontend/components/settings/__tests__/ColorSwatchPicker.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { View } from 'react-native';
+import { ColorSwatchPicker } from '@/components/settings/ColorSwatchPicker';
+
+/**
+ * THE PAYWALL IS THE LIST THIS COMPONENT IS HANDED.
+ *
+ * The shipped version took only the EXTRA presets and rendered them on top of
+ * Bloom's `APP_COLOR_NAMES` — a list that already contains every gated one. So
+ * `oxy` and `faircoin`, which belong to those two accounts, were offered to
+ * everybody, and a subscriber saw their own unlocks a second time. Nothing
+ * failed: a picker rendering more swatches than intended looks exactly like a
+ * picker working.
+ *
+ * These assert the property that closes the class rather than the one
+ * regression: the component renders EXACTLY what it was given, in that order,
+ * and adds nothing of its own. A component that appends to a list it does not
+ * control cannot express a restriction, whatever the appended values are.
+ *
+ * The preset table is MOCKED, as it is in every other suite here (jest cannot
+ * parse Bloom's `react-native` export condition, which resolves to source). That
+ * is the right seam anyway: which presets are gated is Bloom's own question and
+ * is asserted there, in `theme/__tests__/color-preset-gates.test.ts`. Importing
+ * the real lists through a mock would make this file look like it checked them
+ * while checking a fixture.
+ */
+jest.mock('@oxyhq/bloom/theme', () => ({
+  APP_COLOR_PRESETS: {
+    teal: { name: 'teal', hex: '#005c67' },
+    blue: { name: 'blue', hex: '#0085fe' },
+    red: { name: 'red', hex: '#ef4444' },
+    oxy: { name: 'oxy', hex: '#c46ede' },
+    faircoin: { name: 'faircoin', hex: '#9ffb50' },
+    mono: { name: 'mono', hex: '#000000' },
+  },
+}));
+
+type Name = 'teal' | 'blue' | 'red' | 'oxy' | 'faircoin' | 'mono';
+
+const FREE: readonly Name[] = ['teal', 'blue', 'red'];
+const GATED: readonly Name[] = ['oxy', 'faircoin', 'mono'];
+
+const HEX: Record<Name, string> = {
+  teal: '#005c67',
+  blue: '#0085fe',
+  red: '#ef4444',
+  oxy: '#c46ede',
+  faircoin: '#9ffb50',
+  mono: '#000000',
+};
+
+/**
+ * Read the swatches back by the colour each one PAINTS, not by React key: the
+ * repo-wide `react-native` mock replaces `Pressable`, so `findAllByType` against
+ * the real export matches nothing and every assertion below would pass
+ * vacuously. A background colour is what a user actually sees, and the mocked
+ * preset table above gives each name a distinct one.
+ */
+function swatchColors(colors: readonly Name[]): string[] {
+  let created: TestRenderer.ReactTestRenderer | undefined;
+  act(() => {
+    created = TestRenderer.create(
+      <ColorSwatchPicker
+        value="teal"
+        onChange={() => undefined}
+        colors={colors as never}
+      />,
+    );
+  });
+  const tree = created as TestRenderer.ReactTestRenderer;
+  const painted = tree.root.findAllByType(View).flatMap((node) => {
+    const style = node.props.style as { backgroundColor?: string } | undefined;
+    return style?.backgroundColor ? [style.backgroundColor] : [];
+  });
+  act(() => tree.unmount());
+  return painted;
+}
+
+const expected = (colors: readonly Name[]): string[] =>
+  colors.flatMap((name) => (name === 'mono' ? ['#000000', '#ffffff'] : [HEX[name]]));
+
+describe('ColorSwatchPicker', () => {
+  it('renders exactly the presets it is given, in order', () => {
+    const given: readonly Name[] = ['blue', 'teal', 'red'];
+    expect(swatchColors(given)).toEqual(expected(given));
+  });
+
+  it('adds nothing to a free-only list', () => {
+    const rendered = swatchColors(FREE);
+    for (const gated of GATED) expect(rendered).not.toContain(HEX[gated]);
+    // Vacuity floor: rendering nothing at all would satisfy the loop above.
+    expect(rendered).toEqual(expected(FREE));
+  });
+
+  it('draws an unlocked preset once, not twice', () => {
+    const given: readonly Name[] = [...FREE, 'mono'];
+    const rendered = swatchColors(given);
+    expect(rendered).toEqual(expected(given));
+    expect(new Set(rendered).size).toBe(rendered.length);
+  });
+
+  // The colourless preset's seed is pure black, so a single-colour chip vanishes
+  // against a dark page — the one mode a user is most likely reaching for it in.
+  it('draws the colourless preset as both halves, not one black chip', () => {
+    let created: TestRenderer.ReactTestRenderer | undefined;
+    act(() => {
+      created = TestRenderer.create(
+        <ColorSwatchPicker value="teal" onChange={() => undefined} colors={['mono'] as never} />,
+      );
+    });
+    const tree = created as TestRenderer.ReactTestRenderer;
+    const backgrounds = tree.root.findAllByType(View).flatMap((node) => {
+      const style = node.props.style as { backgroundColor?: string } | undefined;
+      return style?.backgroundColor ? [style.backgroundColor] : [];
+    });
+    act(() => tree.unmount());
+    expect(backgrounds).toContain('#000000');
+    expect(backgrounds).toContain('#ffffff');
+  });
+});


### PR DESCRIPTION
Bumps `@oxyhq/bloom` to 0.83.0 and fixes the premium gate, which was inert.

## The bug

The picker rendered Bloom's `APP_COLOR_NAMES` and appended whatever the viewer had unlocked. That list already **contains** every gated preset, so:

- `oxy` and `faircoin` were offered to **every** user
- a subscriber saw their own unlocks drawn **twice**

Nothing failed. A picker rendering more swatches than intended looks exactly like a picker working.

## Why one list could not express it

There are two gates, and they are not interchangeable:

| preset | who | |
|---|---|---|
| `oxy`, `faircoin` | only those accounts | not purchasable |
| `mono` | subscribers | this is what is sold |
| everything else | everyone | |

Bloom 0.83.0 declares the gate on each preset and derives `FREE_COLOR_NAMES` / `HANDLE_COLOR_NAMES` / `PREMIUM_COLOR_NAMES` from it, so a preset cannot be gated in one place and offered in another. This screen now builds its list **up** from the free presets.

`ColorSwatchPicker` takes the visible list outright instead of the extras — a component that appends to a list it does not control cannot express a restriction, whatever the appended values are.

## Also

The colourless swatch draws both halves instead of one chip: its seed is pure black, which vanishes against a dark page — the one mode a user is most likely reaching for it in.

## Verification

- `components/settings/__tests__/ColorSwatchPicker.test.tsx` — gates the property, not the one regression. Mutation-checked: re-appending an uncontrolled list reddens 3 of 4; flattening the mono swatch reddens 2.
- It reads swatches back by the colour each **paints**, not by React key: the repo-wide `react-native` mock replaces `Pressable`, so `findAllByType` against the real export matches nothing and every assertion would have passed vacuously.
- `typecheck:frontend` 0 errors · `test:frontend` 1542 passed (162 suites) · `validate:lockfile` clean.
- `@oxyhq/services`, `core` and `contracts` are already at their published latest here, so only Bloom moves.

## Known limitation, not addressed here

Gating the picker does not revoke an already-applied theme: an account that saved `mono` and then lapses keeps rendering it, since persistence only validates that the preset name exists. Say the word and I'll add the revocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)