### PR TITLE
The profile tab strip stops being rebuilt by the navigation it performs

### DIFF
--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -118,6 +118,7 @@ whatever is already live.
 | 3 | `/@<handle>` as a page, and as ActivityPub | `webShell.routes.ts` content negotiation — breaks fediverse discovery while the profile still looks healthy |
 | 4 | Search suggestions survive typing and blur; submit carries the full query | The suggestion surface vanishing on the first keystroke or on blur; the stale-closure submit that drops the final character |
 | 5 | An image post whose dimensions the feed KNEW settles on ONE layout | The 280x180 fallback box jumping to the real aspect ratio, i.e. media geometry being dropped from the DTO |
+| 6 | `/@<handle>` is the Posts tab, on a cold load and after a client-side push from another profile; the strip survives a tab switch | The profile tab strip being unmounted by the navigation it performs (597ms with no strip); a pushed profile resolving to `/about` because its tab routes sat in a nested group |
 
 ### Reading a red run of flow 5
 

--- a/packages/e2e/tests/profile-tabs.spec.ts
+++ b/packages/e2e/tests/profile-tabs.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Flow 6 — a profile URL resolves to the tab it names, and the strip that says
+ * so is never rebuilt by the navigation it performs.
+ *
+ * Two failures live here, and the file-tree gate next door
+ * (`packages/frontend/app/(app)/[username]/__tests__/profileTabRouteTargets.test.ts`)
+ * cannot see either of them. It asserts that every tab has a route FILE. Both of
+ * these are about which screen the ROUTER then picks, and what the reader sees
+ * while it picks it:
+ *
+ *  - **The tab strip disappearing on every tab switch.** Measured at 597ms with
+ *    no strip at all on production — the strip used to be rendered inside each
+ *    tab screen, so the `<Slot/>` swapped it away and the incoming route's async
+ *    chunk had to arrive before anything could replace it. It is chrome on the
+ *    `[username]` layout now, and a layout does not remount.
+ *  - **A pushed profile landing on `/about`.** The first attempt at the fix
+ *    grouped the tab routes under a nested `(tabs)` segment. `router.push` of
+ *    another profile then created a `[username]` entry carrying no nested state,
+ *    its child navigator settled on a sibling, and expo-router wrote
+ *    `/@handle/about` into the URL. It shipped and was reverted.
+ *
+ *    Mutation-tested, which is the only reason the second flow is shaped the way
+ *    it is. Against a real web export of the reverted commit `da4e2d8d`, three
+ *    runs each: pushing a FEDERATED account landed on
+ *    `/@aurius@mastodon.social/about` 3/3, while pushing a LOCAL one landed
+ *    correctly 3/3 — so the obvious version of this flow passes against the very
+ *    build it exists to catch. Controls on the same probe: this branch and
+ *    `main` both land on the bare profile URL 3/3 with the federated target.
+ *
+ * Neither is reachable from jest: `jest-expo` resolves `.native.tsx` and never
+ * `.web.tsx`, the failure is a navigation race rather than a render, and the
+ * 597ms window only exists where routes are async chunks. A real browser is the
+ * only instrument.
+ */
+
+import { APP_ORIGIN, PROFILE_HANDLE } from '../environment';
+import { expect, test } from '../fixtures';
+import type { Page } from '@playwright/test';
+
+/** The tab a bare profile URL must resolve to. */
+const DEFAULT_TAB = 'Posts';
+
+/** A tab to switch to. Any tab other than the default would do. */
+const SECOND_TAB = 'Media';
+
+/**
+ * How often to look for the strip while a tab switch is in flight. The bug this
+ * samples for lasted ~600ms, so a sample every ~50ms cannot miss it; the loop is
+ * bounded by the navigation completing, not by a fixed count.
+ */
+const STRIP_SAMPLE_INTERVAL_MS = 50;
+
+/** The strip's currently selected tab, or `null` when no strip is showing. */
+async function selectedTab(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const selected = document.querySelector('[role="tab"][aria-selected="true"]');
+    return selected?.textContent?.trim() ?? null;
+  });
+}
+
+/** Whether a profile tab strip is on screen at all. */
+async function stripIsShowing(page: Page): Promise<boolean> {
+  return page.evaluate(() => document.querySelectorAll('[role="tab"]').length > 0);
+}
+
+/**
+ * Fails with the URL the browser is actually on, not merely with "expected
+ * Posts, got null" — the whole point of the second flow is that the router chose
+ * a DIFFERENT SCREEN, and a message that does not name it sends the reader
+ * looking through their own diff.
+ */
+async function expectProfileRootOnDefaultTab(page: Page, handle: string) {
+  const pathname = decodeURIComponent(new URL(page.url()).pathname);
+  const tab = await selectedTab(page);
+  expect(
+    { pathname, tab },
+    `expected the bare profile URL to resolve to the ${DEFAULT_TAB} tab`,
+  ).toEqual({ pathname: `/@${handle}`, tab: DEFAULT_TAB });
+}
+
+test('a bare profile URL is the default tab, and the strip survives a tab switch', async ({
+  page,
+  candidate,
+}) => {
+  await page.goto(`/@${PROFILE_HANDLE}`);
+
+  // The strip is the layout's, so it paints as soon as the account resolves —
+  // waiting on it is waiting on the chrome, not on the feed.
+  await expect(page.getByRole('tab', { name: DEFAULT_TAB, exact: true })).toBeVisible();
+  await expectProfileRootOnDefaultTab(page, PROFILE_HANDLE);
+
+  // Focus + Enter, never a click: `mention.earth` renders zero anchors — every
+  // row is an RNW `Pressable` — and a real `page.mouse.click` on a tab trigger
+  // is a measured no-op.
+  const target = page.getByRole('tab', { name: SECOND_TAB, exact: true });
+  await target.focus();
+
+  // Sample the strip's presence for the whole transition. This is the reported
+  // symptom itself: not "the strip came back", but "the strip was never gone".
+  // An evaluate that throws mid-navigation counts as STILL SHOWING, so a
+  // transport hiccup cannot manufacture a failure.
+  let sawStripDisappear = false;
+  let stopSampling = false;
+  const sampling = (async () => {
+    while (!stopSampling && !sawStripDisappear) {
+      if (!(await stripIsShowing(page).catch(() => true))) {
+        sawStripDisappear = true;
+        return;
+      }
+      await page.waitForTimeout(STRIP_SAMPLE_INTERVAL_MS);
+    }
+  })();
+
+  await page.keyboard.press('Enter');
+  await expect(page).toHaveURL(`${APP_ORIGIN}/@${PROFILE_HANDLE}/${SECOND_TAB.toLowerCase()}`);
+  await expect(page.getByRole('tab', { name: SECOND_TAB, exact: true })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+
+  stopSampling = true;
+  await sampling;
+  expect(sawStripDisappear, 'the tab strip was unmounted by the navigation it performed').toBe(
+    false,
+  );
+  expect(candidate.scriptErrors).toEqual([]);
+});
+
+test('a profile pushed from another profile still opens on the default tab', async ({
+  page,
+  candidate,
+}) => {
+  // The target must be a FEDERATED account, and that is the whole flow rather
+  // than a detail. Measured against real exports of `da4e2d8d`, three runs each,
+  // pushing from this same page: a LOCAL target landed on `/@handle` 3/3 — it
+  // does not reproduce — while a federated one landed on `/@handle/about` 3/3.
+  // A remote actor resolves slowly enough to flip the profile's loading state,
+  // which is the condition the reverted build's nested navigator was rebuilt
+  // under; a warm local account never flips it. So a gate that pushed whichever
+  // card came first would pass against the very build it exists to catch.
+  //
+  // The followers list is the origin because it needs only the follow graph,
+  // which Oxy serves — the flow keeps working when Mention's own API is the
+  // thing that has broken, and each row is a `ProfileCard`, i.e. a literal
+  // `router.push('/@handle')`.
+  await page.goto(`/@${PROFILE_HANDLE}/followers`);
+  await expect(page.locator('[role="button"]').first()).toBeVisible();
+
+  const pushed = await page.evaluate((here: string) => {
+    const cards = Array.from(document.querySelectorAll('[role="button"]')).filter((element) => {
+      const text = (element.textContent || '').replace(/\s+/g, ' ').trim();
+      if (text.length > 200 || text.includes('·')) return false;
+      const match = text.match(/@([a-z0-9_.@-]+)/i);
+      // An instance suffix is what makes the actor remote, and therefore cold.
+      return Boolean(match) && match?.[1] !== here && Boolean(match?.[1]?.includes('@'));
+    });
+    const first = cards[0];
+    if (!first) return false;
+    // Focus + Enter: `mention.earth` renders zero anchors, and a real mouse
+    // click on an RNW `Pressable` is a measured no-op.
+    (first as HTMLElement).focus();
+    return true;
+  }, PROFILE_HANDLE);
+
+  // Not a skip. A skip is indistinguishable from a pass in a report, and this
+  // flow exists to block a promotion. If no federated card rendered, the gate
+  // could not reach a verdict, and it says which dependency is at fault — the
+  // same distinction `preflight.ts` draws for the API.
+  expect(
+    pushed,
+    'GATE COULD NOT EVALUATE THIS CANDIDATE: no FEDERATED account appeared in ' +
+      `@${PROFILE_HANDLE}'s followers, and a local target does not reproduce the failure this ` +
+      'flow exists for. Set MENTION_E2E_PROFILE_HANDLE to an account with at least one ' +
+      'remote follower.',
+  ).toBe(true);
+
+  await page.keyboard.press('Enter');
+  await expect(page).toHaveURL(/\/@[^/]+(\/|$)/);
+  await expect(page).not.toHaveURL(/\/followers$/);
+  // Then let the router settle before judging. On the reverted build the rewrite
+  // was already in place 16-20ms after the key press — it never showed the bare
+  // profile URL at all — so this window is not what makes the check work today.
+  // It is here because the failure is a navigator settling, not a paint, and a
+  // variant that settles a beat later would otherwise read as a clean pass.
+  await page.waitForTimeout(6_000);
+
+  // Asserted as a SHAPE — one segment, on the default tab — rather than against
+  // a handle read out of the card. A `ProfileCard` renders the bio straight
+  // after the handle with no separator in `textContent`, so scraping the handle
+  // yields `@user@instance.socialTheirBioHere`; the property under test is that
+  // nothing was appended to the URL, and that is what this says.
+  const pathname = decodeURIComponent(new URL(page.url()).pathname);
+  const tab = await selectedTab(page);
+  expect(
+    pathname.startsWith('/@'),
+    `expected a profile URL after the push, landed on ${pathname}`,
+  ).toBe(true);
+  expect(
+    { segments: pathname.split('/').filter(Boolean).length, tab },
+    `the pushed profile did not open on its own default tab — landed on ${pathname}`,
+  ).toEqual({ segments: 1, tab: DEFAULT_TAB });
+
+  expect(candidate.scriptErrors).toEqual([]);
+});

--- a/packages/frontend/app/(app)/[username]/__tests__/profileTabRouteTargets.test.ts
+++ b/packages/frontend/app/(app)/[username]/__tests__/profileTabRouteTargets.test.ts
@@ -1,0 +1,146 @@
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+import { TAB_NAMES, CHANNEL_ONLY_TAB_NAMES } from '@/components/Profile/types';
+
+/**
+ * Every profile tab must have a route file behind it.
+ *
+ * The profile strip navigates by building a path from a tab NAME
+ * (`/@handle/${tab}`, with `posts` collapsing to `/@handle` — see
+ * `profileTabHref`), so a tab whose route file is missing, renamed, or moved
+ * into another directory produces a dead tab, and nothing else catches it.
+ * `typedRoutes` is on and does not narrow `Href` on this expo-router major
+ * (measured in this repo and documented in the settings gate next door), so a
+ * dead tab type-checks, ships, and fails under a user's thumb.
+ *
+ * This asserts that the routes EXIST. It does not, and cannot, assert which
+ * screen the router picks for a given URL — it passed unchanged through the
+ * whole `(tabs)`-group regression, where every route below existed and
+ * `/@handle` nonetheless resolved to `about`. Only a real browser can answer
+ * that; `packages/e2e/tests/profile-tabs.spec.ts` is where it is answered.
+ *
+ * The tab list is read from the SOURCE OF TRUTH (`Profile/types.ts`) rather than
+ * restated here, so adding a tab without a route fails immediately instead of
+ * whenever someone next opens the profile.
+ *
+ * Scoped to profile tabs deliberately. `[username]` is a dynamic segment, but
+ * these routes are static BELOW it, so the check compares route SHAPES
+ * (`/[username]/replies`) and has no dynamic-segment false positives to
+ * litigate — the same reason the settings gate is scoped the way it is.
+ */
+
+const appRoot = resolve(__dirname, '../../..');
+const profileRoot = resolve(__dirname, '..');
+
+/** Vacuity floors — a broken walk must not read as "nothing is wrong". */
+const MINIMUM_KNOWN_ROUTES = 40;
+const MINIMUM_PROFILE_FILES = 12;
+const MINIMUM_TABS = 6;
+
+function walk(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) {
+      return entry === '__tests__' || entry === 'node_modules' ? [] : walk(path);
+    }
+    return /\.tsx?$/.test(path) && !/\.(test|spec)\.tsx?$/.test(path) ? [path] : [];
+  });
+}
+
+/**
+ * The route path expo-router serves a file at: `(group)` segments are
+ * transparent, `index` is the directory itself, a platform extension names the
+ * same route as its default, and the extension is dropped. A layout is not a
+ * route.
+ */
+function routePathFor(file: string): string {
+  const withoutExtension = relative(appRoot, file).replace(/(\.(web|native|ios|android))?\.tsx?$/, '');
+  const segments = withoutExtension
+    .split('/')
+    .filter((segment) => !/^\(.+\)$/.test(segment));
+  if (segments.at(-1) === 'index') segments.pop();
+  return `/${segments.join('/')}`;
+}
+
+const routeFiles = walk(appRoot).filter((file) => !/_layout(\.\w+)?\.tsx?$/.test(file));
+const knownRoutes = new Set(routeFiles.map(routePathFor));
+const profileFiles = walk(profileRoot);
+
+/** Where the strip sends each tab, mirroring `profileTabHref`. */
+function routeForTab(tab: string): string {
+  return tab === 'posts' ? '/[username]' : `/[username]/${tab}`;
+}
+
+describe('every profile tab has a route behind it', () => {
+  it('inspected a plausible amount of the tree', () => {
+    expect(knownRoutes.size).toBeGreaterThanOrEqual(MINIMUM_KNOWN_ROUTES);
+    expect(profileFiles.length).toBeGreaterThanOrEqual(MINIMUM_PROFILE_FILES);
+    expect(TAB_NAMES.length).toBeGreaterThanOrEqual(MINIMUM_TABS);
+  });
+
+  it.each(TAB_NAMES)('%s resolves to a route file', (tab) => {
+    expect(knownRoutes.has(routeForTab(tab))).toBe(true);
+  });
+
+  /**
+   * The channel-only tabs are deliberately NOT routes, and asserting that is the
+   * point: `/c/<handle>` is ONE route with no sub-tabs beneath it
+   * (`components/ChannelScreen.tsx`), so a channel's tabs are local state and
+   * carry nothing in the URL. Only `TAB_NAMES` — the person-profile tabs — are
+   * routed, which is why the loop above uses that list rather than `ProfileTab`.
+   *
+   * Written as an assertion rather than an omission so that giving a channel tab
+   * a route, or routing channel tabs generally, fails here and forces the person
+   * making that change to decide what it means for this gate.
+   */
+  it.each(CHANNEL_ONLY_TAB_NAMES)('%s is a channel tab and therefore NOT routed', (tab) => {
+    expect(knownRoutes.has(routeForTab(tab))).toBe(false);
+    expect(knownRoutes.has(`/c/[username]/${tab}`)).toBe(false);
+  });
+
+  it('serves the default tab at the bare profile path', () => {
+    // `/@handle` must be the posts tab, not a redirect — every link in the wild
+    // points at it, including the OG shell the backend serves.
+    expect(knownRoutes.has('/[username]')).toBe(true);
+  });
+
+  it('keeps a lane reachable under its own segment', () => {
+    // Lanes route by id rather than by name, so they cannot collide with a
+    // static tab file however a publisher names their lane.
+    expect(knownRoutes.has('/[username]/lane/[laneId]')).toBe(true);
+  });
+
+  it('keeps the non-tab profile routes reachable', () => {
+    // These are siblings of the tabs, NOT tabs — full screens with their own
+    // header and back arrow. They are flat beside the tab files, and the layout
+    // tells the two families apart from the pathname rather than from a folder
+    // (`profileTabSelectionFromPathname`). Grouping the tabs to draw that
+    // boundary with a directory shipped once and was reverted: a pushed
+    // `[username]` entry carries no nested state, and its child navigator
+    // settled on `about`.
+    for (const route of [
+      '/[username]/followers',
+      '/[username]/following',
+      '/[username]/about',
+      '/[username]/connections',
+      '/[username]/in-common',
+      '/[username]/who-may-know',
+    ]) {
+      expect(knownRoutes.has(route)).toBe(true);
+    }
+  });
+
+  it('keeps every tab route a DIRECT child of the segment', () => {
+    // The reverted regression is the reason this is asserted rather than left
+    // implied: the tabs were moved into a `(tabs)` group, every path above
+    // stayed identical (a `(group)` segment is URL-transparent, so this file
+    // passed), and `/@handle` still stopped resolving to the posts tab. A group
+    // between the segment and its tabs is the shape that broke.
+    for (const tab of TAB_NAMES) {
+      const file = profileFiles.find((path) => routePathFor(path) === routeForTab(tab));
+      expect(file).toBeDefined();
+      expect(relative(profileRoot, file as string)).not.toMatch(/\(.+\)/);
+    }
+  });
+});

--- a/packages/frontend/app/(app)/[username]/_layout.tsx
+++ b/packages/frontend/app/(app)/[username]/_layout.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useLocalSearchParams, Slot } from 'expo-router';
 import NotFoundScreen from '@/components/NotFoundScreen';
+import ProfileChromeFrame from '@/components/Profile/ProfileChromeFrame';
 
 /**
- * The `[username]` segment's navigator.
+ * The `[username]` segment's navigator, and — on web — the profile chrome above
+ * it.
  *
  * It renders `<Slot />` — a navigator — for every profile URL, and the screen
  * files in this directory render the surfaces themselves. That split is not
@@ -22,6 +24,16 @@ import NotFoundScreen from '@/components/NotFoundScreen';
  * for unknown single-segment paths, and whether a handle is `@`-prefixed is
  * fixed for the lifetime of a route instance. It cannot appear and disappear
  * underneath a mounted child the way the pathname could.
+ *
+ * Every route this segment serves is FLAT — the nine tab files and
+ * `lane/[laneId]` sit beside `/about`, `/followers`, `/following`,
+ * `/connections`, `/in-common` and `/who-may-know`, with no group between them.
+ * `ProfileChromeFrame` is what tells the two families apart, from the pathname,
+ * and draws the banner and the tab strip over the tabs only — while rendering
+ * the `<Slot/>` at one position in every branch. Grouping the tabs instead was
+ * tried, shipped and reverted: `router.push('/@handle')` from another profile
+ * created a `[username]` entry with no nested state, and its child navigator
+ * settled on `about`. That file carries the trace.
  */
 const UsernameLayout = () => {
     const { username } = useLocalSearchParams<{ username: string }>();
@@ -30,7 +42,11 @@ const UsernameLayout = () => {
         return <NotFoundScreen />;
     }
 
-    return <Slot />;
+    return (
+        <ProfileChromeFrame>
+            <Slot />
+        </ProfileChromeFrame>
+    );
 };
 
 export default UsernameLayout;

--- a/packages/frontend/components/Profile/ProfileChromeFrame.tsx
+++ b/packages/frontend/components/Profile/ProfileChromeFrame.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import type { ProfileChromeFrameProps } from './types';
+
+/**
+ * The `[username]` layout's body — NATIVE, where it is only a passthrough.
+ *
+ * WEB renders the whole profile chrome here instead (`.web.tsx` beside this
+ * file): the banner, the identity summary, the action cluster and the tab strip
+ * all belong to the LAYOUT there, so switching tabs swaps only the routed
+ * content beneath them. That is the fix this pair exists for — a strip rendered
+ * inside each tab SCREEN is unmounted by the very navigation it performs, which
+ * on web (every route is an async chunk) leaves the profile with no tab strip at
+ * all for as long as the incoming tab's fetch takes: 597ms, measured on
+ * production, before a skeleton and then the real bar snapping into place.
+ *
+ * NATIVE IS NOT ALREADY CORRECT — it has the same remount, and it is left alone
+ * anyway. Two things to know before "unifying" these:
+ *
+ *  - The remount is INVISIBLE there, not absent. Native code is bundled, so the
+ *    incoming tab has no chunk to fetch and the rebuild finishes inside a frame.
+ *    The web symptom is the fetch, and only web has one.
+ *  - The chrome CANNOT move up on native. On the post and grid tabs the feed's
+ *    own virtualized list is the scroll container, and `ProfileShell` hands it
+ *    the summary as `listHeaderComponent` and the strip as
+ *    `listStickyHeaderComponent`, plus the scroll handler and ref the chrome
+ *    animations read (`ProfileShell.tsx`, the `nativeListOwnsScroll` branch). A
+ *    strip that is a route-owned list's sticky header cannot simultaneously be
+ *    layout chrome, and moving that scroller — or routing its wiring through
+ *    context across the route boundary — changes feed scroll behaviour, which is
+ *    settled. Web has no such constraint: the DOCUMENT scrolls, and the chrome
+ *    and the content are already siblings.
+ *
+ * So the split is real and deliberate. If native's scroll ownership ever
+ * changes, this file is where the two meet again.
+ *
+ * A FRAGMENT, not a `<View>`: the children here are the segment's navigator, and
+ * wrapping it in a box native did not have before would change every profile
+ * sub-route's layout to buy nothing.
+ */
+export default function ProfileChromeFrame({ children }: ProfileChromeFrameProps) {
+  return <>{children}</>;
+}

--- a/packages/frontend/components/Profile/ProfileChromeFrame.web.tsx
+++ b/packages/frontend/components/Profile/ProfileChromeFrame.web.tsx
@@ -1,0 +1,240 @@
+import React, { useCallback, useMemo } from 'react';
+import { View } from 'react-native';
+import { router, usePathname, type Href } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { BloomColorScope } from '@oxyhq/bloom/theme';
+import { RouterTabs, type RouterTabItem } from '@oxyhq/bloom/tabs/expo-router';
+
+import { BottomBarAwareFab } from '@/components/BottomBarAwareFab';
+import { EmptyState } from '@/components/common/EmptyState';
+import { NoUpdatesIllustration } from '@/assets/illustrations/NoUpdates';
+import { ComposeIcon } from '@/assets/icons/compose-icon';
+import { useSafeBack } from '@/hooks/useSafeBack';
+
+import { ProfileChromeLayers } from './ProfileChromeLayers';
+import { ProfileSkeleton } from './ProfileSkeleton';
+import { ProfileTabBarRow } from './ProfileTabBarRow';
+import { usePersonProfileView } from './hooks/usePersonProfileView';
+import { profileTabHref, profileTabSelectionFromPathname } from './profileTabRoute';
+import type { ProfileChromeFrameProps, ProfileTabDescriptor } from './types';
+
+/** What the frame is drawing above the routed child right now. */
+type ChromeState = 'off' | 'skeleton' | 'notFound' | 'ready';
+
+/**
+ * The `[username]` layout's body — WEB, where it owns the profile chrome.
+ *
+ * The banner, the identity summary, the action cluster and the tab strip are
+ * rendered HERE, above the `<Slot/>` that renders whichever child the URL names.
+ * The placement is the whole fix: a strip rendered inside each tab screen is
+ * unmounted by the navigation it performs, so the chrome blanked for the 597ms
+ * the incoming tab's async chunk took to arrive (measured on production), the
+ * skeleton that replaced it guessed the first tab was selected, and the real bar
+ * snapped into place when the screen finally committed. None of that is a page
+ * load — the JS context survives throughout — it is a remount, and a layout does
+ * not remount. `/explore` has the identical `<Slot/>` and has never had the
+ * problem, because it renders its strip in the LAYOUT.
+ *
+ * Back is fixed by the same move for a different reason: `RouterTabs` PUSHES, so
+ * each tab is a history entry and Back returns to the tab the reader came from
+ * rather than leaving the profile. The strip could not push while it lived in
+ * the screens, because every entry would then rebuild it.
+ *
+ * See `ProfileChromeFrame.tsx` (the native half) for why the two platforms
+ * differ, and why native is not simply behind.
+ *
+ * ## The tab routes are FLAT, and that is load-bearing
+ *
+ * `index.tsx`, `replies.tsx`, … and `lane/[laneId].tsx` are direct children of
+ * `[username]`, beside `/followers`, `/following`, `/about`, `/connections`,
+ * `/in-common` and `/who-may-know`. An earlier version of this change grouped
+ * the tabs under a nested `(tabs)` segment so that a layout could wrap exactly
+ * them; it shipped and was reverted. `router.push('/@handle')` from another
+ * profile creates a second `[username]` entry carrying NO nested state, its
+ * child navigator then has to choose an initial route, and it settled on
+ * `about` — which expo-router wrote into the URL. Traced with
+ * `useRootNavigationState()`, reproduced 3/3 locally and once on production.
+ * `unstable_settings = { anchor: '(tabs)' }` — the router's own documented
+ * mechanism for it — had no effect. So a pushed `[username]` entry's default
+ * child must be a real route, and the boundary the group used to draw is drawn
+ * here instead, by asking the pathname.
+ *
+ * ## THREE INVARIANTS, all load-bearing
+ *
+ *  - **`children` is rendered in EVERY branch, at ONE tree position.** It is the
+ *    segment's NAVIGATOR. A layout that swaps its navigator for a plain screen
+ *    leaves the segment with no navigator in the navigation state, and on web
+ *    the remount that follows chases `usePathname()` until React aborts the
+ *    render ("Maximum update depth exceeded", React error #185) —
+ *    `[username]/_layout.tsx` carries that account. React reconciles by
+ *    POSITION, so a conditional that moved it between two parents would destroy
+ *    and rebuild it on every crossing into `/followers` and back; the chrome
+ *    around it comes and goes instead, and the navigator never moves.
+ *  - **The six non-tab siblings get NO chrome.** Each is a full screen with its
+ *    own header and back arrow (`connections.tsx`, `AccountInfoScreen`), and a
+ *    banner and identity summary stacked above one would be a second,
+ *    contradictory chrome. `profileTabSelectionFromPathname` answers `null`
+ *    there — and for any child added later that it has never heard of, which is
+ *    the direction that fails safe.
+ *  - **The active tab is read from the PATHNAME, not from the routed screen.**
+ *    This layout owns `useProfileChrome`, and on web that hook's scroll listener
+ *    is the profile's only paginator — it pages the ACTIVE tab's feed. A layout
+ *    that did not know which tab is showing would page the wrong one, and
+ *    nothing would fail.
+ */
+export default function ProfileChromeFrame({ children }: ProfileChromeFrameProps) {
+  const { t } = useTranslation();
+  const safeBack = useSafeBack();
+  const pathname = usePathname();
+  const selection = useMemo(() => profileTabSelectionFromPathname(pathname), [pathname]);
+  const active = selection !== null;
+
+  // The strip navigates on its own (it is a `RouterTabs`), so this is reached
+  // only from the summary's stats row — "12 posts" jumping to the posts tab.
+  // PUSH for the same reason the strip does: a jump the reader can come back
+  // from.
+  const onSelectTab = useCallback((_descriptor: ProfileTabDescriptor, href: Href) => {
+    router.push(href);
+  }, []);
+
+  const view = usePersonProfileView({ active, activeKey: selection?.key ?? 'posts', onSelectTab });
+
+  const items = useMemo<RouterTabItem[]>(
+    () =>
+      view.tabDescriptors.map((descriptor) => ({
+        value: descriptor.key,
+        label: descriptor.label,
+        href: profileTabHref(view.handle, descriptor),
+      })),
+    [view.tabDescriptors, view.handle],
+  );
+
+  // A wrong-family URL (a channel sitting on `/@handle`) holds the skeleton
+  // rather than painting a person-shaped chrome for the frame before the routed
+  // screen below redirects. The redirect itself is the screen's — see the
+  // navigator invariant above.
+  const chromeState: ChromeState = !active
+    ? 'off'
+    : view.loading || view.canonicalHref !== null
+      ? 'skeleton'
+      : view.profileData
+        ? 'ready'
+        : 'notFound';
+  /**
+   * The account the chrome is drawing, or `null` in every other state.
+   *
+   * One value rather than a boolean beside a null check: each slot below both
+   * decides whether to render and narrows `profileData`, and two expressions
+   * doing that separately is one edit away from disagreeing.
+   */
+  const drawing = chromeState === 'ready' ? view.profileData : null;
+
+  const tabBar = (
+    <ProfileTabBarRow showLanes={view.isOwnProfile}>
+      <RouterTabs
+        items={items}
+        // The profile strip is itself horizontally scrollable — nine static tabs
+        // plus one per lane — so a horizontal pan here means "scroll the strip",
+        // and a swipe-to-change-tab gesture would take that drag away from it.
+        swipeEnabled={false}
+        // Re-tapping the tab you are on conventionally means "back to the top",
+        // and here that is the top of the CONTENT rather than of the document —
+        // the same place the stats row jumps to, so the two agree.
+        onReselect={() => view.chrome.scrollToContent(view.chrome.contentHeight)}
+      />
+    </ProfileTabBarRow>
+  );
+
+  return (
+    <BloomColorScope colorPreset={active ? view.colorName : undefined} asChild>
+      {/* `web:z-auto` so this profile wrapper does not become its own stacking
+          context and trap the sticky header chrome below the panel's
+          bleed-mask/border overlays (see ProfileShell's root for the full
+          rationale). */}
+      <View
+        className="flex-1 bg-background web:z-auto relative flex-col"
+        style={active ? [rootOverflow, view.chrome.themedStyles.container] : rootOverflow}
+      >
+        {view.seo}
+
+        {chromeState === 'skeleton' ? <ProfileSkeleton variant="person" /> : null}
+
+        {chromeState === 'notFound' ? (
+          <EmptyState
+            customIcon={<NoUpdatesIllustration width={200} height={200} />}
+            title={t('profile.notFound.title', { defaultValue: 'Profile not found' })}
+            subtitle={t('profile.notFound.message', {
+              defaultValue:
+                "This profile couldn't be loaded. The user may not exist or their server may be unavailable.",
+            })}
+            action={{ label: t('common.goBack', { defaultValue: 'Go Back' }), onPress: safeBack }}
+          />
+        ) : null}
+
+        {drawing ? (
+          <ProfileChromeLayers
+            chrome={view.chrome}
+            banner={{ uri: view.bannerUri }}
+            headerActions={view.headerActions}
+            profileData={drawing}
+          />
+        ) : null}
+
+        {/* The one flow column: summary, sticky strip and the routed child, in
+            that order. They share a parent on purpose — `position: sticky` is
+            scoped to its own flow parent, so a strip in a box that ended above
+            the content would unstick the instant the reader scrolled past it.
+            The banner/header offsets ride here rather than on each piece, which
+            is where `ProfileShell` puts them too.
+
+            When no tab is showing this is a bare `flex-1` box, so the sibling
+            screen inside it gets the same room it had when the layout rendered
+            nothing but a `<Slot/>`. */}
+        <View
+          className={drawing ? undefined : 'flex-1'}
+          style={
+            drawing
+              ? [
+                  contentLayer,
+                  view.chrome.themedStyles.scrollView,
+                  view.chrome.themedStyles.contentContainer,
+                ]
+              : undefined
+          }
+        >
+          {drawing ? view.summary : null}
+
+          {/* Tabs — sticky in the SECOND tier, pinned flush BELOW the header
+              chrome band (`panelStickyTabsTopInset`); the chrome layers all pin
+              at the FIRST tier, and pinning the strip at that same inset made
+              the two bands occupy the same vertical space and OVERLAP. */}
+          {drawing ? (
+            <View className="web:sticky web:z-[5]" style={view.chrome.panelStickyTabsTopInset}>
+              {tabBar}
+            </View>
+          ) : null}
+
+          {children}
+        </View>
+
+        {/* FAB that rides the BottomBar's show/hide (web mobile). */}
+        {drawing ? (
+          <BottomBarAwareFab
+            onPress={() => router.push('/compose')}
+            icon={<ComposeIcon size={20} className="text-primary-foreground" />}
+            accessibilityLabel={t('compose.newPost', { defaultValue: 'New post' })}
+          />
+        ) : null}
+      </View>
+    </BloomColorScope>
+  );
+}
+
+const rootOverflow = { overflow: 'visible' } as const;
+
+/**
+ * Keeps the flow column above the banner (`z-1`) and below the header band
+ * (`z-100`), exactly as `ProfileShell` does — the layers and the content are
+ * siblings in both compositions, so they need the same tier.
+ */
+const contentLayer = { zIndex: 3 } as const;

--- a/packages/frontend/components/Profile/ProfileChromeLayers.tsx
+++ b/packages/frontend/components/Profile/ProfileChromeLayers.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import { Animated, ImageBackground, Platform, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Avatar } from '@oxyhq/bloom/avatar';
+import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types/post';
+import UserName from '@/components/UserName';
+import { PANEL_HEADER_HEIGHT } from '@/components/shell/PanelChrome';
+import type { ProfileData } from '@/hooks/useProfileData';
+import { LAYOUT } from './types';
+import type { ProfileChrome } from './hooks/useProfileChrome';
+
+const IS_WEB = Platform.OS === 'web';
+
+// Banner image wrapped for the pull-to-zoom parallax (scale driven by the shared
+// scrollY). Created once at module scope so it is a stable component type.
+const AnimatedImageBackground = Animated.createAnimatedComponent(ImageBackground);
+
+/** Full height of the banner band. */
+const BANNER_HEIGHT = LAYOUT.HEADER_HEIGHT_EXPANDED + LAYOUT.HEADER_HEIGHT_NARROWED;
+
+export interface ProfileChromeLayersProps {
+  chrome: ProfileChrome;
+  /**
+   * The banner band, or `null` for a layout that has none. A channel passes
+   * `null`: the account has no banner field to set, so there is nothing to
+   * reach — not a band left empty.
+   */
+  banner: { uri?: string } | null;
+  /** The top-right icon cluster's contents. */
+  headerActions: React.ReactNode;
+  /** Resolved account, for the compact name overlay. */
+  profileData: ProfileData;
+}
+
+/**
+ * The four overlapping layers pinned above a profile's content: the banner, the
+ * opaque header band, the top-right action cluster and the compact-name overlay.
+ *
+ * ONE copy on purpose. Every layer here carries hand-tuned z-indices, negative
+ * margins and pointer-event rules that only make sense relative to each other,
+ * and there are now two compositions that need them: {@link ProfileShell}, which
+ * renders the whole page as one screen (native, and a channel on both
+ * platforms), and `ProfileChromeFrame.web.tsx`, where the person profile's
+ * chrome belongs to the `[username]` LAYOUT and the tab content is a routed
+ * screen beneath it. A second copy would be correct for exactly as long as
+ * nobody touched either.
+ *
+ * Every layer occupies ZERO net flow height — each is either `absolute`
+ * (native) or `web:sticky` with a negative margin that cancels its own box — so
+ * a caller composes them by rendering this ABOVE its content and offsetting that
+ * content itself (`chrome.themedStyles.scrollView` +
+ * `chrome.themedStyles.contentContainer`). Rendering it anywhere else changes
+ * nothing about the layout and everything about the stacking order.
+ */
+export function ProfileChromeLayers({
+  chrome,
+  banner,
+  headerActions,
+  profileData,
+}: ProfileChromeLayersProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {/* Banner. NATIVE: `absolute left-0 right-0 top:0` (height 170,
+          zIndex 1) over the NON-scrolling root — the content scrolls OVER
+          it, and the `bg-background` overlay fades it out over the first
+          120px via `headerBackgroundOpacity`. WEB: there is no inner
+          ScrollView (the DOCUMENT scrolls), so an `absolute` banner would
+          scroll away. Instead it is `web:sticky` + `panelStickyTopInset`
+          (pinned to the rounded panel's PANEL_TOP_INSET top-gutter inset —
+          from the single shared constant, no literal `top-2` here — and
+          sticky's containing block is the panel column, so it stays INSIDE
+          the panel, never viewport-fixed). The negative bottom margin
+          (`-170px`) cancels its flow height so the content's own
+          `marginTop + paddingTop` offset is NOT double-counted — the banner
+          occupies 0 net flow and the content still starts ~170px down and
+          scrolls over it, then fades to the background, exactly as on
+          native. Its `web:z-[1]` keeps it BELOW the content (`zIndex: 3`),
+          preserving native's content-over-banner layering. */}
+      {banner &&
+        (banner.uri ? (
+          <View
+            className="left-0 right-0 overflow-hidden web:sticky web:z-[1] web:[margin-bottom:-170px]"
+            style={[webStickyChrome.banner, chrome.panelStickyTopInset, { height: BANNER_HEIGHT }]}
+          >
+            <AnimatedImageBackground
+              source={{ uri: banner.uri }}
+              className="absolute left-0 right-0 top-0 overflow-hidden"
+              style={{ height: BANNER_HEIGHT, transform: [{ scale: chrome.bannerScale }] }}
+            />
+            <Animated.View
+              className="absolute left-0 right-0 top-0 overflow-hidden bg-background"
+              style={{
+                height: BANNER_HEIGHT,
+                zIndex: 1,
+                pointerEvents: 'none',
+                opacity: chrome.headerBackgroundOpacity,
+              }}
+            />
+          </View>
+        ) : (
+          <View
+            className="left-0 right-0 overflow-hidden bg-primary/[0.125] web:sticky web:z-[1] web:[margin-bottom:-170px]"
+            style={[webStickyChrome.banner, chrome.panelStickyTopInset, { height: BANNER_HEIGHT }]}
+          >
+            <Animated.View
+              className="bg-background"
+              style={[StyleSheet.absoluteFill, { opacity: chrome.headerBackgroundOpacity }]}
+            />
+          </View>
+        ))}
+
+      {/* Pinned header-band surface (WEB only). When the header chrome is
+          pinned in contact with the tab bar, the action cluster +
+          compact-name overlay are 0-flow-height anchors with NO background
+          of their own — so the scrolling feed (z-3) would show THROUGH the
+          header band while the opaque tabs (`bg-background`) sit right
+          below, reading as an incoherent transparent-header / opaque-tabs
+          split. This sticky surface fills the 48px header band with the SAME
+          `bg-background` token the tab bar uses, so header + tabs read as
+          ONE cohesive opaque bar. Its opacity is driven by the SAME
+          `headerBackgroundOpacity` as the banner fade: 0 when expanded (the
+          banner shows through — restored parallax preserved) → 1 once
+          scrolled (opaque, matching the tabs). `web:z-[100]` paints it ABOVE
+          the feed content (z-3) and the tabs (z-5) but BELOW the chrome
+          icons/name overlay (z-101). It intentionally receives web pointer
+          events to prevent clicks from reaching covered feed content while
+          the band is opaque; the higher z-101 header controls remain
+          interactive. The `-48px` bottom margin keeps it a 0-flow overlay.
+          Empty on native, where the chrome is an absolute overlay over the
+          non-scrolling root. */}
+      {IS_WEB && (
+        <View
+          className="left-0 right-0 web:sticky web:z-[100] web:pointer-events-auto web:[margin-bottom:-48px]"
+          style={[chrome.panelStickyTopInset, { height: PANEL_HEADER_HEIGHT }]}
+        >
+          <Animated.View
+            className="bg-background"
+            style={[StyleSheet.absoluteFill, { opacity: chrome.headerBackgroundOpacity }]}
+          />
+        </View>
+      )}
+
+      {/* Header actions cluster. NATIVE: `absolute`, `top: insets.top+6`,
+          `right: DEFAULT_PADDING-8`, zIndex 10 — pinned at the top of the
+          non-scrolling root. WEB: the cluster lives inside a full-width
+          `web:sticky` + `panelStickyTopInset` wrapper pinned to the panel's
+          top-gutter inset (same pattern as the PanelStickyHeader the home
+          header uses). The wrapper has 0 flow height (its only child is
+          `absolute`) and is `pointer-events-none` so it never blocks the
+          feed; the cluster itself re-enables pointer events. */}
+      <View
+        className="left-0 right-0 web:sticky web:z-[101] web:pointer-events-none"
+        style={[webStickyChrome.chromeAnchor, chrome.panelStickyTopInset]}
+      >
+        <View
+          className="absolute flex-row items-center gap-1 web:pointer-events-auto"
+          style={[
+            { zIndex: 10, right: LAYOUT.DEFAULT_PADDING - 8 },
+            chrome.themedStyles.headerActions,
+          ]}
+        >
+          {headerActions}
+        </View>
+      </View>
+
+      {/* Compact name overlay (avatar + name + posts-count), fading in via
+          `headerNameOpacity` once the real name scrolls past.
+
+          It is `aria-hidden` because it is a purely visual restatement of
+          the avatar, name, verified badge and post count the summary below
+          already renders — a screen reader would otherwise announce that
+          identity twice on every profile, and the overlay holds nothing
+          focusable to lose. One prop covers all three platforms: RN's View
+          maps `aria-hidden` onto `accessibilityElementsHidden` (iOS) AND
+          `importantForAccessibility: 'no-hide-descendants'` (Android), and
+          react-native-web emits the DOM attribute. */}
+      <View
+        className="left-0 right-0 web:sticky web:z-[101] web:pointer-events-none"
+        style={[webStickyChrome.chromeAnchor, chrome.panelStickyTopInset]}
+      >
+        <Animated.View
+          className="absolute"
+          aria-hidden
+          style={[
+            {
+              zIndex: 10,
+              left: LAYOUT.DEFAULT_PADDING,
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 10,
+            },
+            chrome.themedStyles.headerNameOverlay,
+            { opacity: chrome.headerNameOpacity },
+            { pointerEvents: 'none' },
+          ]}
+        >
+          <Avatar source={profileData.design.avatar} size={32} variant={MEDIA_VARIANT_AVATAR} />
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <UserName
+              name={profileData.design.displayName}
+              verified={profileData.verified}
+              style={{ name: { fontSize: 18, fontWeight: 'bold', marginBottom: -3 } }}
+              unifiedColors={true}
+            />
+            <Text className="text-muted-foreground text-[13px]" numberOfLines={1}>
+              {t('profile.postsCount', {
+                count: profileData.postsCount,
+                defaultValue: `${profileData.postsCount} posts`,
+              })}
+            </Text>
+          </View>
+        </Animated.View>
+      </View>
+    </>
+  );
+}
+
+// WEB vs NATIVE positioning for the profile header chrome (banner, action
+// cluster, compact-name overlay). NATIVE pins each piece `absolute` to the top
+// of the NON-scrolling root (the content scrolls over them inside the inner
+// Animated.ScrollView). WEB has no inner ScrollView — the DOCUMENT scrolls — so
+// each piece pins via `web:sticky` + the shared `panelStickyTopInset` style (the
+// rounded panel's PANEL_TOP_INSET top-gutter inset, from the single PanelChrome
+// source of truth — no literal `top-2` here). `position: sticky` keeps the panel
+// column as its containing block, so the chrome stays INSIDE the rounded center
+// panel (never viewport-fixed), mirroring the home header's PanelStickyHeader.
+// These bespoke overlapping layers keep their own `web:z-[…]`, negative margins
+// and pointer-events, so they consume `panelStickyTopInset` rather than the full
+// <PanelStickyHeader> wrapper (which would flatten their z-layout and break the
+// banner/name fades). The web `position`/`z` live in NativeWind classes; this
+// StyleSheet only supplies the native `absolute` anchor (web entries are empty
+// so the classes win).
+const webStickyChrome = StyleSheet.create({
+  banner: {
+    ...Platform.select({
+      web: {},
+      default: { position: 'absolute' as const, top: 0, zIndex: 1 },
+    }),
+  },
+  chromeAnchor: {
+    ...Platform.select({
+      web: {},
+      default: { position: 'absolute' as const, top: 0, zIndex: 10 },
+    }),
+  },
+});

--- a/packages/frontend/components/Profile/ProfileShell.tsx
+++ b/packages/frontend/components/Profile/ProfileShell.tsx
@@ -1,32 +1,22 @@
 import React from 'react';
-import { Animated, ImageBackground, Platform, StatusBar, StyleSheet, Text, View } from 'react-native';
+import { Animated, Platform, StatusBar, View } from 'react-native';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@oxyhq/bloom/theme';
-import { Avatar } from '@oxyhq/bloom/avatar';
-import { MEDIA_VARIANT_AVATAR } from '@mention/shared-types/post';
-import UserName from '@/components/UserName';
 import { BottomBarAwareFab } from '@/components/BottomBarAwareFab';
 import { EmptyState } from '@/components/common/EmptyState';
 import { NoUpdatesIllustration } from '@/assets/illustrations/NoUpdates';
 import { ComposeIcon } from '@/assets/icons/compose-icon';
-import { PANEL_HEADER_HEIGHT } from '@/components/shell/PanelChrome';
 import { useSafeBack } from '@/hooks/useSafeBack';
 import type { ProfileData } from '@/hooks/useProfileData';
+import { ProfileChromeLayers } from './ProfileChromeLayers';
 import { ProfileSkeleton } from './ProfileSkeleton';
 import { ProfileTabs } from './ProfileTabs';
-import { LAYOUT, shouldFeedOwnProfileScroll, shouldGridOwnProfileScroll } from './types';
+import { shouldFeedOwnProfileScroll, shouldGridOwnProfileScroll } from './types';
 import type { ProfileTabsProps } from './types';
 import type { ProfileChrome } from './hooks/useProfileChrome';
 
 const IS_WEB = Platform.OS === 'web';
-
-// Banner image wrapped for the pull-to-zoom parallax (scale driven by the shared
-// scrollY). Created once at module scope so it is a stable component type.
-const AnimatedImageBackground = Animated.createAnimatedComponent(ImageBackground);
-
-/** Full height of the banner band. */
-const BANNER_HEIGHT = LAYOUT.HEADER_HEIGHT_EXPANDED + LAYOUT.HEADER_HEIGHT_NARROWED;
 
 export interface ProfileShellProps {
   chrome: ProfileChrome;
@@ -61,19 +51,25 @@ export interface ProfileShellProps {
 }
 
 /**
- * The chrome and scroll model every profile page shares, whoever the account is.
+ * A whole profile page rendered as ONE screen: the chrome, the scroll model and
+ * the tab content together.
  *
- * This is the half of a profile screen that is genuinely common: the banner
- * fade, the pinned header band, the two sticky tiers, the compact-name overlay,
- * the three-way scroll ownership (web document / native virtualized list /
- * native ScrollView), the skeleton and not-found states, and the compose FAB.
- * None of it depends on whether the account is a person or a channel — the
- * differences arrive as slots and as {@link ProfileShellProps.banner}.
+ * Two callers, and the difference between them is worth knowing before editing
+ * either. `ChannelScreen` uses this on BOTH platforms — `/c/<handle>` is a
+ * single route with no sub-tabs, so a channel's tabs are local state and there
+ * is no navigation for a strip to survive. `ProfileScreen` uses it on NATIVE
+ * only: on web a person's chrome belongs to the `[username]` layout and each tab
+ * is its own route (see `ProfileChromeFrame.tsx` for the whole seam, including
+ * why native is not simply behind).
  *
- * It exists so that splitting the two screens does not duplicate this. Every
- * layer below carries hand-tuned z-indices, negative margins and pointer-event
- * rules that only make sense relative to each other; a second copy would be
- * correct for exactly as long as nobody touched either.
+ * What is genuinely common to every profile is the banner fade, the pinned
+ * header band, the two sticky tiers, the compact-name overlay, the three-way
+ * scroll ownership (web document / native virtualized list / native ScrollView),
+ * the skeleton and not-found states, and the compose FAB. None of it depends on
+ * whether the account is a person or a channel — the differences arrive as slots
+ * and as {@link ProfileShellProps.banner}. The four pinned layers live in
+ * {@link ProfileChromeLayers} so the web layout can render exactly the same
+ * ones rather than a second copy of their z-indices and negative margins.
  */
 export function ProfileShell({
   chrome,
@@ -133,157 +129,12 @@ export function ProfileShell({
         />
       ) : (
         <>
-          {/* Banner. NATIVE: `absolute left-0 right-0 top:0` (height 170,
-              zIndex 1) over the NON-scrolling root — the content scrolls OVER
-              it, and the `bg-background` overlay fades it out over the first
-              120px via `headerBackgroundOpacity`. WEB: there is no inner
-              ScrollView (the DOCUMENT scrolls), so an `absolute` banner would
-              scroll away. Instead it is `web:sticky` + `panelStickyTopInset`
-              (pinned to the rounded panel's PANEL_TOP_INSET top-gutter inset —
-              from the single shared constant, no literal `top-2` here — and
-              sticky's containing block is the panel column, so it stays INSIDE
-              the panel, never viewport-fixed). The negative bottom margin
-              (`-170px`) cancels its flow height so the content's own
-              `marginTop + paddingTop` offset is NOT double-counted — the banner
-              occupies 0 net flow and the content still starts ~170px down and
-              scrolls over it, then fades to the background, exactly as on
-              native. Its `web:z-[1]` keeps it BELOW the content (`zIndex: 3`),
-              preserving native's content-over-banner layering. */}
-          {banner &&
-            (banner.uri ? (
-              <View
-                className="left-0 right-0 overflow-hidden web:sticky web:z-[1] web:[margin-bottom:-170px]"
-                style={[webStickyChrome.banner, chrome.panelStickyTopInset, { height: BANNER_HEIGHT }]}
-              >
-                <AnimatedImageBackground
-                  source={{ uri: banner.uri }}
-                  className="absolute left-0 right-0 top-0 overflow-hidden"
-                  style={{ height: BANNER_HEIGHT, transform: [{ scale: chrome.bannerScale }] }}
-                />
-                <Animated.View
-                  className="absolute left-0 right-0 top-0 overflow-hidden bg-background"
-                  style={{
-                    height: BANNER_HEIGHT,
-                    zIndex: 1,
-                    pointerEvents: 'none',
-                    opacity: chrome.headerBackgroundOpacity,
-                  }}
-                />
-              </View>
-            ) : (
-              <View
-                className="left-0 right-0 overflow-hidden bg-primary/[0.125] web:sticky web:z-[1] web:[margin-bottom:-170px]"
-                style={[webStickyChrome.banner, chrome.panelStickyTopInset, { height: BANNER_HEIGHT }]}
-              >
-                <Animated.View
-                  className="bg-background"
-                  style={[StyleSheet.absoluteFill, { opacity: chrome.headerBackgroundOpacity }]}
-                />
-              </View>
-            ))}
-
-          {/* Pinned header-band surface (WEB only). When the header chrome is
-              pinned in contact with the tab bar, the action cluster +
-              compact-name overlay are 0-flow-height anchors with NO background
-              of their own — so the scrolling feed (z-3) would show THROUGH the
-              header band while the opaque tabs (`bg-background`) sit right
-              below, reading as an incoherent transparent-header / opaque-tabs
-              split. This sticky surface fills the 48px header band with the SAME
-              `bg-background` token the tab bar uses, so header + tabs read as
-              ONE cohesive opaque bar. Its opacity is driven by the SAME
-              `headerBackgroundOpacity` as the banner fade: 0 when expanded (the
-              banner shows through — restored parallax preserved) → 1 once
-              scrolled (opaque, matching the tabs). `web:z-[100]` paints it ABOVE
-              the feed content (z-3) and the tabs (z-5) but BELOW the chrome
-              icons/name overlay (z-101). It intentionally receives web pointer
-              events to prevent clicks from reaching covered feed content while
-              the band is opaque; the higher z-101 header controls remain
-              interactive. The `-48px` bottom margin keeps it a 0-flow overlay.
-              Empty on native, where the chrome is an absolute overlay over the
-              non-scrolling root. */}
-          {IS_WEB && (
-            <View
-              className="left-0 right-0 web:sticky web:z-[100] web:pointer-events-auto web:[margin-bottom:-48px]"
-              style={[chrome.panelStickyTopInset, { height: PANEL_HEADER_HEIGHT }]}
-            >
-              <Animated.View
-                className="bg-background"
-                style={[StyleSheet.absoluteFill, { opacity: chrome.headerBackgroundOpacity }]}
-              />
-            </View>
-          )}
-
-          {/* Header actions cluster. NATIVE: `absolute`, `top: insets.top+6`,
-              `right: DEFAULT_PADDING-8`, zIndex 10 — pinned at the top of the
-              non-scrolling root. WEB: the cluster lives inside a full-width
-              `web:sticky` + `panelStickyTopInset` wrapper pinned to the panel's
-              top-gutter inset (same pattern as the PanelStickyHeader the home
-              header uses). The wrapper has 0 flow height (its only child is
-              `absolute`) and is `pointer-events-none` so it never blocks the
-              feed; the cluster itself re-enables pointer events. */}
-          <View
-            className="left-0 right-0 web:sticky web:z-[101] web:pointer-events-none"
-            style={[webStickyChrome.chromeAnchor, chrome.panelStickyTopInset]}
-          >
-            <View
-              className="absolute flex-row items-center gap-1 web:pointer-events-auto"
-              style={[
-                { zIndex: 10, right: LAYOUT.DEFAULT_PADDING - 8 },
-                chrome.themedStyles.headerActions,
-              ]}
-            >
-              {headerActions}
-            </View>
-          </View>
-
-          {/* Compact name overlay (avatar + name + posts-count), fading in via
-              `headerNameOpacity` once the real name scrolls past.
-
-              It is `aria-hidden` because it is a purely visual restatement of
-              the avatar, name, verified badge and post count the summary below
-              already renders — a screen reader would otherwise announce that
-              identity twice on every profile, and the overlay holds nothing
-              focusable to lose. One prop covers all three platforms: RN's View
-              maps `aria-hidden` onto `accessibilityElementsHidden` (iOS) AND
-              `importantForAccessibility: 'no-hide-descendants'` (Android), and
-              react-native-web emits the DOM attribute. */}
-          <View
-            className="left-0 right-0 web:sticky web:z-[101] web:pointer-events-none"
-            style={[webStickyChrome.chromeAnchor, chrome.panelStickyTopInset]}
-          >
-            <Animated.View
-              className="absolute"
-              aria-hidden
-              style={[
-                {
-                  zIndex: 10,
-                  left: LAYOUT.DEFAULT_PADDING,
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: 10,
-                },
-                chrome.themedStyles.headerNameOverlay,
-                { opacity: chrome.headerNameOpacity },
-                { pointerEvents: 'none' },
-              ]}
-            >
-              <Avatar source={profileData.design.avatar} size={32} variant={MEDIA_VARIANT_AVATAR} />
-              <View style={{ flex: 1, minWidth: 0 }}>
-                <UserName
-                  name={profileData.design.displayName}
-                  verified={profileData.verified}
-                  style={{ name: { fontSize: 18, fontWeight: 'bold', marginBottom: -3 } }}
-                  unifiedColors={true}
-                />
-                <Text className="text-muted-foreground text-[13px]" numberOfLines={1}>
-                  {t('profile.postsCount', {
-                    count: profileData.postsCount,
-                    defaultValue: `${profileData.postsCount} posts`,
-                  })}
-                </Text>
-              </View>
-            </Animated.View>
-          </View>
+          <ProfileChromeLayers
+            chrome={chrome}
+            banner={banner}
+            headerActions={headerActions}
+            profileData={profileData}
+          />
 
           {/* Main scroll content.
 
@@ -371,33 +222,3 @@ export function ProfileShell({
     </View>
   );
 }
-
-// WEB vs NATIVE positioning for the profile header chrome (banner, action
-// cluster, compact-name overlay). NATIVE pins each piece `absolute` to the top
-// of the NON-scrolling root (the content scrolls over them inside the inner
-// Animated.ScrollView). WEB has no inner ScrollView — the DOCUMENT scrolls — so
-// each piece pins via `web:sticky` + the shared `panelStickyTopInset` style (the
-// rounded panel's PANEL_TOP_INSET top-gutter inset, from the single PanelChrome
-// source of truth — no literal `top-2` here). `position: sticky` keeps the panel
-// column as its containing block, so the chrome stays INSIDE the rounded center
-// panel (never viewport-fixed), mirroring the home header's PanelStickyHeader.
-// These bespoke overlapping layers keep their own `web:z-[…]`, negative margins
-// and pointer-events, so they consume `panelStickyTopInset` rather than the full
-// <PanelStickyHeader> wrapper (which would flatten their z-layout and break the
-// banner/name fades). The web `position`/`z` live in NativeWind classes; this
-// StyleSheet only supplies the native `absolute` anchor (web entries are empty
-// so the classes win).
-const webStickyChrome = StyleSheet.create({
-  banner: {
-    ...Platform.select({
-      web: {},
-      default: { position: 'absolute' as const, top: 0, zIndex: 1 },
-    }),
-  },
-  chromeAnchor: {
-    ...Platform.select({
-      web: {},
-      default: { position: 'absolute' as const, top: 0, zIndex: 10 },
-    }),
-  },
-});

--- a/packages/frontend/components/Profile/ProfileTabBarRow.tsx
+++ b/packages/frontend/components/Profile/ProfileTabBarRow.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '@/lib/icons';
+
+export interface ProfileTabBarRowProps {
+  /** The strip itself — a routed one on web, a locally-driven one on native. */
+  children: React.ReactNode;
+  /** Shows the way in to the viewer's lanes. Own profile only. */
+  showLanes: boolean;
+}
+
+/**
+ * The row the profile's tab strip sits in.
+ *
+ * It carries the hairline rather than the strip does, so the border stays
+ * continuous under the lanes button, which sits OUTSIDE the strip's own scroller
+ * (a strip that scrolls must not scroll the button away). The button belongs
+ * beside these tabs because a lane's whole effect is on which of them a post
+ * lands on, and because the composer's lane icon was otherwise the only door to
+ * the screen that manages them.
+ *
+ * Shared because the two platforms put different strips in it — see
+ * `ProfileChromeFrame.tsx` — and the row around them is the part that is
+ * genuinely the same.
+ */
+export function ProfileTabBarRow({ children, showLanes }: ProfileTabBarRowProps) {
+  const { t } = useTranslation();
+  return (
+    <View className="flex-row items-center border-b border-border bg-background">
+      <View className="flex-1" style={{ minWidth: 0 }}>
+        {children}
+      </View>
+      {showLanes ? (
+        <TouchableOpacity
+          onPress={() => router.push('/lanes')}
+          activeOpacity={0.7}
+          accessibilityRole="link"
+          accessibilityLabel={t('lanes.title', { defaultValue: 'Lanes' })}
+          className="px-3 py-2.5"
+        >
+          <Icon name="git-branch-outline" size={20} className="text-muted-foreground" />
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+}

--- a/packages/frontend/components/Profile/__tests__/channelScreenSeparation.test.ts
+++ b/packages/frontend/components/Profile/__tests__/channelScreenSeparation.test.ts
@@ -90,12 +90,20 @@ describe('channel and person profiles are separate screens', () => {
   /**
    * The canonicalization between `/@` and `/c/` is the ONE piece that cannot be
    * duplicated: two screens each deciding where to redirect can build a bounce
-   * loop between them. Both screens must reach it through the shared helper.
+   * loop between them. Every screen must reach it through the shared helper.
+   *
+   * There are three of them because the person profile is a platform pair — on
+   * web its chrome belongs to the `[username]` layout and the screen is only the
+   * tab's content (`ProfileChromeFrame.web.tsx`) — and BOTH halves redirect,
+   * because a layout may not: it must render its navigator in every branch, and
+   * a `<Redirect/>` renders null. `usePersonProfileView` counts as reaching the
+   * helper; it is `useProfileAccount` with the rest of the page around it, and
+   * it passes `canonicalHref` straight through.
    */
-  it('routes both screens through the one canonicalization', () => {
-    for (const screen of ['ProfileScreen.tsx', 'ChannelScreen.tsx']) {
+  it('routes every profile screen through the one canonicalization', () => {
+    for (const screen of ['ProfileScreen.tsx', 'ProfileScreen.web.tsx', 'ChannelScreen.tsx']) {
       const source = code(read('components', screen));
-      expect(source).toMatch(/useProfileAccount\(/);
+      expect(source).toMatch(/useProfileAccount\(|usePersonProfileView\(/);
       expect(source).toMatch(/canonicalHref/);
       // A screen that builds its own redirect target has left the shared rule.
       expect(source).not.toMatch(/<Redirect href={`/);
@@ -146,7 +154,9 @@ describe('a channel has its own about page', () => {
   });
 
   it('keeps the person profile on the person family, so the check is not vacuous', () => {
-    const source = code(read('components', 'ProfileScreen.tsx'));
+    // The person profile's summary is built in `usePersonProfileView`, which is
+    // where both platforms read it from — the screen files compose it.
+    const source = code(read('components', 'Profile', 'hooks', 'usePersonProfileView.tsx'));
     expect(source).toMatch(/aboutHref=\{`\/@\$\{handle\}\/about`\}/);
   });
 

--- a/packages/frontend/components/Profile/__tests__/profileTabRoute.test.ts
+++ b/packages/frontend/components/Profile/__tests__/profileTabRoute.test.ts
@@ -1,0 +1,148 @@
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+import {
+  profileTabHref,
+  profileTabSelectionFromPathname,
+} from '../profileTabRoute';
+import { TAB_NAMES, laneTabKey } from '../types';
+
+/**
+ * Which profile URLs get the tab chrome, and which get none.
+ *
+ * This is the boundary the reverted `(tabs)` group used to draw with a folder.
+ * Drawing it from the pathname instead is what lets the tab routes stay FLAT —
+ * a pushed `[username]` entry's default child has to be a real route, or the
+ * child navigator picks a sibling and expo-router writes `/@handle/about` into
+ * the URL (see `ProfileChromeFrame.web.tsx`). So the classification below is
+ * load-bearing in both directions, and neither direction fails loudly on its
+ * own: a tab misread as a sibling silently loses its chrome, and a sibling
+ * misread as a tab gets a banner and a tab strip stacked above its own header.
+ *
+ * The two route families are read from the REAL directory rather than restated,
+ * so a route added later is classified by this test the day it lands.
+ */
+
+const PROFILE_ROUTES = join(__dirname, '..', '..', '..', 'app', '(app)', '[username]');
+
+/** Vacuity floors — a broken walk must not read as "nothing is wrong". */
+const MINIMUM_ROUTE_FILES = 12;
+const MINIMUM_TABS = 6;
+
+function walk(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) {
+      return entry === '__tests__' ? [] : walk(path);
+    }
+    return /\.tsx?$/.test(path) && !/_layout\.tsx?$/.test(path) ? [path] : [];
+  });
+}
+
+/**
+ * The pathname a route file is served at, for the handle `@ana`. `index` is the
+ * directory itself; a dynamic segment gets a value, since this function's whole
+ * job is to produce something a reader could actually be sitting on.
+ */
+function pathnameFor(file: string): string {
+  const segments = relative(PROFILE_ROUTES, file)
+    .replace(/\.tsx?$/, '')
+    .split('/')
+    .map((segment) => (segment === '[laneId]' ? 'lane-42' : segment))
+    .filter((segment) => segment !== 'index');
+  return ['/@ana', ...segments].join('/');
+}
+
+const ROUTE_FILES = walk(PROFILE_ROUTES);
+const ROUTE_PATHNAMES = ROUTE_FILES.map(pathnameFor);
+
+/** Every route this segment serves that IS one of the profile's tabs. */
+const TAB_PATHNAMES = ROUTE_PATHNAMES.filter((pathname) => {
+  const [, second] = pathname.split('/').filter(Boolean);
+  return second === undefined || second === 'lane' || (TAB_NAMES as readonly string[]).includes(second);
+});
+
+/** Everything else it serves: full screens with their own header and back arrow. */
+const SIBLING_PATHNAMES = ROUTE_PATHNAMES.filter((pathname) => !TAB_PATHNAMES.includes(pathname));
+
+describe('which profile URLs are tabs', () => {
+  it('walked a plausible amount of the segment', () => {
+    expect(ROUTE_FILES.length).toBeGreaterThanOrEqual(MINIMUM_ROUTE_FILES);
+    expect(TAB_NAMES.length).toBeGreaterThanOrEqual(MINIMUM_TABS);
+    // Both halves must be non-empty, or one of the two loops below asserts
+    // nothing while still reporting green.
+    expect(TAB_PATHNAMES.length).toBeGreaterThan(1);
+    expect(SIBLING_PATHNAMES.length).toBeGreaterThan(1);
+  });
+
+  it.each(TAB_PATHNAMES)('%s is a tab and gets the chrome', (pathname) => {
+    expect(profileTabSelectionFromPathname(pathname)).not.toBeNull();
+  });
+
+  it.each(SIBLING_PATHNAMES)('%s is its own screen and gets none', (pathname) => {
+    expect(profileTabSelectionFromPathname(pathname)).toBeNull();
+  });
+
+  it('serves the posts tab at the bare profile path', () => {
+    // `/@handle` must BE the posts tab rather than redirect to it: every link in
+    // the wild points there, including the OG shell the backend serves.
+    expect(profileTabSelectionFromPathname('/@ana')).toEqual({ tab: 'posts', key: 'posts' });
+  });
+
+  it('reads a federated handle positionally, not by matching it', () => {
+    // A federated handle carries a second `@` and a dot, and arrives
+    // percent-encoded often enough that comparing it is a way to be wrong.
+    expect(profileTabSelectionFromPathname('/@ana@mastodon.social/replies')).toEqual({
+      tab: 'replies',
+      key: 'replies',
+    });
+    expect(profileTabSelectionFromPathname('/@ana@mastodon.social/followers')).toBeNull();
+  });
+
+  it('carries the lane id out of the URL', () => {
+    expect(profileTabSelectionFromPathname('/@ana/lane/abc123')).toEqual({
+      tab: 'posts',
+      laneId: 'abc123',
+      key: laneTabKey('abc123'),
+    });
+    // The segment without an id is not a route, and must not read as one.
+    expect(profileTabSelectionFromPathname('/@ana/lane')).toBeNull();
+  });
+
+  it('gives an unknown child no chrome rather than a guess', () => {
+    // The direction that fails safe: a route added to this segment later gets
+    // its own screen untouched until somebody decides it is a tab.
+    expect(profileTabSelectionFromPathname('/@ana/something-new')).toBeNull();
+    expect(profileTabSelectionFromPathname('/@ana/replies/deeper')).toBeNull();
+    expect(profileTabSelectionFromPathname('/')).toBeNull();
+  });
+
+  it('does not accept the URL the posts tab collapses away', () => {
+    // `profileTabHref` sends `posts` to the bare path, so `/@ana/posts` is a URL
+    // nothing produces and no file serves.
+    expect(profileTabSelectionFromPathname('/@ana/posts')).toBeNull();
+  });
+});
+
+describe('where the strip sends each tab', () => {
+  it.each(TAB_NAMES)('%s round-trips through its own href', (tab) => {
+    const href = profileTabHref('ana', { key: tab, label: tab, tab });
+    expect(typeof href).toBe('string');
+    expect(profileTabSelectionFromPathname(href as string)?.key).toBe(tab);
+  });
+
+  it('round-trips a lane tab', () => {
+    const href = profileTabHref('ana', {
+      key: laneTabKey('abc123'),
+      label: 'Reviews',
+      tab: 'posts',
+      laneId: 'abc123',
+    });
+    expect(href).toBe('/@ana/lane/abc123');
+    expect(profileTabSelectionFromPathname(href as string)).toEqual({
+      tab: 'posts',
+      laneId: 'abc123',
+      key: laneTabKey('abc123'),
+    });
+  });
+});

--- a/packages/frontend/components/Profile/hooks/usePersonProfileView.tsx
+++ b/packages/frontend/components/Profile/hooks/usePersonProfileView.tsx
@@ -1,0 +1,570 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { Share, Text, View } from 'react-native';
+import { router, type Href } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { FollowButton as OxyFollowButton, useAuth, useFollow } from '@oxyhq/services/ui/client';
+import { logger } from '@oxyhq/core/logger';
+import type { FeedType } from '@mention/shared-types';
+
+import { usePostsStore } from '@/stores/postsStore';
+import { lanesService } from '@/services/lanesService';
+import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
+import { openExternalLink } from '@/utils/openExternalLink';
+import { IconButton } from '@/components/ui/Button';
+import { SEO } from '@/components/SEO';
+import { FediverseSharingBadge } from '@/components/AccountBadge';
+import { showFediverseInfo } from '@/components/Fediverse/FediverseInfoDialog';
+import { SuggestedUsers } from '@/components/suggestions/SuggestedUsers';
+import UserName from '@/components/UserName';
+import { Bell, BellActive } from '@/assets/icons/bell-icon';
+import { ShareIcon } from '@/assets/icons/share-icon';
+import { MailIcon } from '@/assets/icons/mail-icon';
+import { MoreIcon } from '@/assets/icons/more-icon';
+import { ExternalLinkIcon } from '@/assets/icons/external-link-icon';
+
+import { AccountCategoryLine } from '../AccountCategoryLine';
+import { PrivateBadge } from '../PrivateBadge';
+import { ProfileContent } from '../ProfileContent';
+import { ProfileHeader } from '../ProfileHeader';
+import {
+  buildProfileTabDescriptors,
+  profileTabIndex,
+  profileTabsForAccountKind,
+  type LaneTabInput,
+  type ProfileTabDescriptor,
+  type ProfileTabsProps,
+} from '../types';
+import { isProfilePrivate, viewerOwnsProfile } from '../profileViewer';
+import { profileTabHref } from '../profileTabRoute';
+import { useProfileAccount, type ProfileAccount } from './useProfileAccount';
+import { useProfileChrome, type ProfileChrome } from './useProfileChrome';
+import { useProfileMoreMenu } from './useProfileMoreMenu';
+import { useOperatesAccount } from './useOperatesAccount';
+import { useJustFollowed } from './useJustFollowed';
+import { useSubscription } from './useSubscription';
+
+/** Feed types cleared from the local store when a profile turns out to be private. */
+const FEED_TYPES: FeedType[] = ['posts', 'replies', 'media', 'likes', 'boosts'];
+
+export interface PersonProfileViewOptions {
+  /**
+   * Whether this profile page is what the reader is actually looking at.
+   *
+   * `false` on web while one of the profile's NON-tab siblings is showing —
+   * `/followers`, `/about` and the four others are children of the same layout
+   * that owns the chrome, so this hook keeps being called there and must do
+   * nothing when it is. See the mask in the body for how, and why it is one
+   * line rather than an `enabled` flag threaded through six hooks.
+   */
+  active?: boolean;
+  /**
+   * The descriptor key currently selected — `posts`, `replies`, `lane:<id>`, …
+   *
+   * Passed IN rather than held here, because the two platforms answer it from
+   * different places: on web the route does (the strip lives in the layout and
+   * every tab is its own URL), on native the screen's own state does. Deriving
+   * it here would mean picking one of those and breaking the other.
+   */
+  activeKey: string;
+  /**
+   * Go to another tab. Called only when the target differs from
+   * {@link PersonProfileViewOptions.activeKey} — re-selecting the active tab
+   * scrolls to the top of its content instead, which is handled here so both
+   * platforms behave the same way.
+   *
+   * The `href` is supplied rather than rebuilt by the caller: the handle it is
+   * built from is resolved HERE, and a caller that had to wait for it could not
+   * define this callback without a circular dependency on its own result.
+   */
+  onSelectTab: (descriptor: ProfileTabDescriptor, href: Href) => void;
+}
+
+export interface PersonProfileView extends ProfileAccount {
+  isOwnProfile: boolean;
+  isPrivate: boolean;
+  /** The banner band's image, if the account has set one. */
+  bannerUri?: string;
+  /** The strip's contents, lanes spliced in after `posts`. */
+  tabDescriptors: ProfileTabDescriptor[];
+  /** The selected tab, or the first one while a lane key is still resolving. */
+  activeDescriptor: ProfileTabDescriptor | undefined;
+  chrome: ProfileChrome;
+  headerActions: React.ReactNode;
+  summary: React.ReactElement | null;
+  seo: React.ReactElement | null;
+  tabs: ProfileTabsProps;
+  /** Select a tab by descriptor key: navigates, or scrolls if already there. */
+  selectTab: (key: string) => void;
+}
+
+/**
+ * Everything ONE PERSON's profile page is, apart from where its pieces are
+ * rendered.
+ *
+ * It exists because those pieces stopped being rendered in one place. On web the
+ * chrome — banner, identity summary, action cluster, tab strip — belongs to the
+ * `[username]` LAYOUT so that switching tabs cannot unmount it, while the tab's
+ * content is a routed screen; on native the whole page is still one screen (see
+ * `ProfileChromeFrame.tsx` for why the two differ). Both need the same account
+ * lookup, the same lane query, the same strip, the same summary and the same
+ * scroll chrome, and every value here is tuned against the others — a second
+ * copy would be correct for exactly as long as nobody touched either.
+ *
+ * This serves more than people: only a `channel` routes to `/c/<handle>`, so an
+ * ORGANIZATION, PROJECT or BOT renders through here at `/@<handle>` too.
+ */
+export function usePersonProfileView({
+  active = true,
+  activeKey,
+  onSelectTab,
+}: PersonProfileViewOptions): PersonProfileView {
+  const account = useProfileAccount('person');
+  const { username, handle, isFederated } = account;
+  const { user: currentUser } = useAuth();
+  const { t } = useTranslation();
+
+  /**
+   * The whole of "do nothing while a non-tab sibling is showing", in one place.
+   *
+   * Every piece of work below is already gated on a resolved account: the lane
+   * query is `enabled` on the id, `useFollow`/`useSubscription`/
+   * `useOperatesAccount` each skip without one, `useProfileScroll`'s pager
+   * returns before touching the store when `profileId` is undefined, and every
+   * rendered slot is `profileData ? … : null`. Withholding the account is
+   * therefore the same statement as an `enabled: active` on each of them, made
+   * once — and it cannot drift the way six separate flags would, nor leave the
+   * profile's document-scroll pager quietly paging a feed nobody is looking at
+   * while the reader scrolls a followers list.
+   *
+   * `useProfileData` inside `useProfileAccount` still runs, deliberately: it is
+   * a React Query read the sibling screens make themselves (`connections.tsx`,
+   * `AccountInfoScreen`) under the same key, so it is a cache hit rather than a
+   * second fetch, and masking it would only delay the chrome on the way back.
+   */
+  const profileData = active ? account.profileData : null;
+  const loading = active ? account.loading : false;
+  const canonicalHref = active ? account.canonicalHref : null;
+
+  // The publisher's lanes that HAVE a tab. Public and reader-agnostic, so a
+  // signed-out visitor sees the same strip; keyed by viewer anyway, like every
+  // other private read, so an account switch drops it with the namespace.
+  const { data: laneTabs = [] } = useQuery<LaneTabInput[]>({
+    queryKey: viewerQueryKeys.lanesForOwner(currentUser?.id, profileData?.id),
+    enabled: Boolean(profileData?.id) && !isFederated,
+    queryFn: async () => {
+      const lanes = await lanesService.listForOwner(profileData?.id ?? '');
+      return lanes.map((lane) => ({ id: lane.id, name: lane.name }));
+    },
+  });
+
+  // Every person — federated included — gets the full static strip, since the
+  // data behind each tab is in Oxy/Mention's DB either way. Lane tabs are
+  // spliced in after `posts`.
+  const tabDescriptors = useMemo(
+    () =>
+      buildProfileTabDescriptors(
+        {
+          posts: t('profile.tabs.posts'),
+          replies: t('profile.tabs.replies'),
+          media: t('profile.tabs.media'),
+          videos: t('profile.tabs.videos'),
+          likes: t('profile.tabs.likes'),
+          boosts: t('profile.tabs.boosts'),
+          feeds: t('profile.tabs.feeds', { defaultValue: 'Feeds' }),
+          starter_packs: t('profile.tabs.starter_packs', { defaultValue: 'Starter Packs' }),
+          lists: t('profile.tabs.lists', { defaultValue: 'Lists' }),
+          // A person has no writers tab — `profileTabsForAccountKind` drops it
+          // for every kind but `channel`. The label is still passed because
+          // `labels` covers every `ProfileTab` by contract: the caller has no
+          // reason to know which subset survives, and an unused label costs one
+          // `t()`.
+          writers: t('profile.tabs.writers', { defaultValue: 'Writers' }),
+        },
+        laneTabs,
+        profileData?.kind,
+      ),
+    [t, laneTabs, profileData?.kind],
+  );
+
+  const activeIndex = profileTabIndex(tabDescriptors, activeKey);
+  const activeDescriptor = tabDescriptors[activeIndex];
+  const activeProfileTab = activeDescriptor?.tab ?? 'posts';
+  const activeLaneId = activeDescriptor?.laneId;
+
+  // Follow data — federated users are stored in Oxy, so useFollow works with
+  // their Oxy ID.
+  const stableUserId = profileData?.id || '';
+  const {
+    followerCount: rawFollowerCount,
+    followingCount: rawFollowingCount,
+    isFollowing: isFollowingProfileUser = false,
+  } = useFollow(stableUserId);
+  const followerCount = rawFollowerCount ?? 0;
+  const followingCount = rawFollowingCount ?? 0;
+
+  // Show suggestions only on the follow ACTION, never on a revisit.
+  const justFollowed = useJustFollowed(stableUserId, isFollowingProfileUser);
+
+  const { subscribed, loading: subLoading, toggle: toggleSubscription } = useSubscription(
+    profileData?.id,
+    currentUser?.id,
+    currentUser?.id === profileData?.id,
+  );
+
+  const design = profileData?.design;
+  const avatarUri = design?.avatar;
+  // A stored banner is shown whenever there is one. Whether the banner BAND
+  // exists at all is not in question here — a person's layout has one, and an
+  // account with no image set gets the tinted placeholder.
+  const bannerUri = design?.bannerUrl;
+
+  const isOwnProfile = viewerOwnsProfile(profileData, currentUser?.id, isFederated);
+  const isPrivate = useMemo(() => isProfilePrivate(profileData), [profileData]);
+
+  // Number of action icons in the top-right cluster; sizes the scrolled name
+  // overlay so a long display name truncates instead of sliding under them.
+  const headerActionCount = useMemo(() => {
+    let count = 1; // share is always present
+    if (!isOwnProfile) count += 2; // subscribe + more
+    // DM is local-only — remote (federated) actors have no Mention inbox.
+    if (!isOwnProfile && !isFederated) count += 1;
+    if (isFederated) count += 1; // open-on-instance
+    return count;
+  }, [isOwnProfile, isFederated]);
+
+  const chrome = useProfileChrome({
+    profileId: profileData?.id,
+    currentTab: activeProfileTab,
+    currentLaneId: activeLaneId,
+    headerActionCount,
+    hasBannerBand: true,
+  });
+
+  // Clear cached feed data for private profiles
+  useEffect(() => {
+    if (isPrivate && !isOwnProfile && profileData?.id) {
+      const { clearUserFeed } = usePostsStore.getState();
+      FEED_TYPES.forEach((type) => {
+        clearUserFeed(profileData.id, type);
+      });
+    }
+  }, [isPrivate, isOwnProfile, profileData?.id]);
+
+  // The stats row jumps to a tab BY NAME. Resolving the index at press time is
+  // the whole reason `REPLIES_TAB_INDEX = 1` / `BOOSTS_TAB_INDEX = 5` are gone:
+  // one lane on the profile shifts every tab after `posts`, and a stale constant
+  // sends the reader somewhere else without failing anything.
+  const selectTab = useCallback(
+    (key: string) => {
+      const index = profileTabIndex(tabDescriptors, key);
+      const descriptor = tabDescriptors[index];
+      if (!descriptor) return;
+      if (descriptor.key === activeDescriptor?.key) {
+        chrome.scrollToContent(chrome.contentHeight);
+        return;
+      }
+      onSelectTab(descriptor, profileTabHref(handle, descriptor));
+    },
+    [activeDescriptor?.key, chrome, handle, onSelectTab, tabDescriptors],
+  );
+
+  const handlePostsPress = useCallback(() => selectTab('posts'), [selectTab]);
+  const handleBoostsPress = useCallback(() => selectTab('boosts'), [selectTab]);
+  const handleRepliesPress = useCallback(() => selectTab('replies'), [selectTab]);
+
+  const handleShare = useCallback(async () => {
+    if (!profileData) return;
+    try {
+      const shareUrl = `https://mention.earth/@${handle}`;
+      const shareMessage = t('profile.share.message', {
+        name: profileData.design.displayName,
+        defaultValue: `Check out ${profileData.design.displayName}'s profile on Mention!`,
+      });
+      await Share.share({
+        message: `${shareMessage}\n\n${shareUrl}`,
+        url: shareUrl,
+        title: t('profile.share.title', {
+          name: profileData.design.displayName,
+          defaultValue: `${profileData.design.displayName} on Mention`,
+        }),
+      });
+    } catch {
+      logger.error('Error sharing profile');
+    }
+  }, [profileData, handle, t]);
+
+  /**
+   * `isOwnProfile` still governs everything else on this screen, and correctly:
+   * edit-profile, analytics, settings and the lanes button all act on the
+   * VIEWER'S OWN account, so operating an organization must not put them within
+   * reach. Only the hostile menu asks the wider question.
+   */
+  const operatesThisAccount = useOperatesAccount({
+    accountId: profileData?.id,
+    accountKind: profileData?.kind,
+  });
+
+  const handleMoreOptions = useProfileMoreMenu({
+    profileData,
+    viewerOperatesAccount: isOwnProfile || operatesThisAccount,
+  });
+
+  const handleDM = useCallback(() => {
+    if (!profileData?.id) return;
+    const params = new URLSearchParams({
+      userId: profileData.id,
+      username: profileData.username,
+    });
+    router.push(`/ai?${params.toString()}`);
+  }, [profileData?.id, profileData?.username]);
+
+  // Open on remote instance (federated only)
+  const handleOpenOnInstance = useCallback(() => {
+    if (profileData?.actorUri) openExternalLink(profileData.actorUri);
+  }, [profileData?.actorUri]);
+
+  const userNameStyle = useMemo(
+    () => ({
+      name: { fontSize: 24, fontWeight: 'bold' as const, marginTop: 10, marginBottom: 4 },
+      handle: { fontSize: 15, marginBottom: 12 },
+      container: undefined,
+    }),
+    [],
+  );
+
+  const identity = useMemo(() => {
+    if (!profileData) return null;
+    // Own, non-federated profile opted into fediverse sharing (absent flag ⇒
+    // on): a tappable badge next to the handle explaining the fediverse.
+    // The PROFILE is where the explainer is opted into — the marker is inert
+    // on every other surface (see `AccountBadge`).
+    const fediverseBadge =
+      isOwnProfile && !profileData.isFederated && currentUser?.fediverseSharing !== false ? (
+        <FediverseSharingBadge size={20} onExplainNetwork={showFediverseInfo} />
+      ) : undefined;
+    // Passive "Follows you" tag inline to the right of the @handle when this
+    // profile follows the viewer. Never shown on the viewer's own profile.
+    const followsYouTag =
+      !isOwnProfile && currentUser?.id && profileData.followsYou ? (
+        <View className="bg-muted px-2 py-0.5 rounded-full">
+          <Text className="text-muted-foreground text-xs font-medium" numberOfLines={1}>
+            {t('profile.followsYou', { defaultValue: 'Follows you' })}
+          </Text>
+        </View>
+      ) : undefined;
+    return (
+      <>
+        <ProfileHeader
+          username={profileData.username}
+          avatarUri={avatarUri}
+          isOwnProfile={isOwnProfile}
+          isFederated={profileData.isFederated}
+          actorUri={profileData.actorUri}
+          isFollowing={profileData.isFollowing}
+          currentUsername={currentUser?.username}
+          profileId={profileData.id}
+          FollowButtonComponent={OxyFollowButton}
+        />
+        <View>
+          <UserName
+            name={profileData.design.displayName}
+            handle={profileData.username}
+            verified={profileData.verified}
+            isFederated={profileData.isFederated}
+            kind={profileData.kind}
+            // The profile is the ONE surface that opts the marker in: a reader
+            // here has room for the answer, and the identity line is not itself
+            // a link to somewhere else.
+            onExplainNetwork={showFediverseInfo}
+            copyableHandle
+            variant="default"
+            style={userNameStyle}
+            trailingBadge={fediverseBadge}
+            handleTrailing={followsYouTag}
+          />
+          {/* Non-personal accounts route here too — an organization, a project
+              or a bot is a `person`-FAMILY url (only `channel` gets `/c/`), and
+              all four kinds carry categories. A personal account never has any,
+              so this renders nothing for the overwhelming majority of
+              profiles. */}
+          <AccountCategoryLine accountCategories={profileData.accountCategories} align="start" />
+          {isPrivate && (
+            <View className="flex-row items-center gap-2 flex-wrap">
+              <PrivateBadge privacySettings={profileData.privacy} />
+            </View>
+          )}
+        </View>
+      </>
+    );
+  }, [profileData, isOwnProfile, isPrivate, avatarUri, currentUser, userNameStyle, t]);
+
+  const summary = useMemo(() => {
+    if (!profileData) return null;
+    return (
+      <View>
+        <ProfileContent
+          profileData={profileData}
+          isOwnProfile={isOwnProfile}
+          isPrivate={isPrivate}
+          followingCount={followingCount}
+          followerCount={followerCount}
+          profileHandle={handle}
+          identity={identity}
+          showReplies={profileTabsForAccountKind(profileData.kind).includes('replies')}
+          aboutHref={`/@${handle}/about`}
+          followingHref={`/@${handle}/following`}
+          followersHref={`/@${handle}/followers`}
+          onPostsPress={handlePostsPress}
+          onBoostsPress={handleBoostsPress}
+          onRepliesPress={handleRepliesPress}
+          onLayout={chrome.setContentHeight}
+        />
+        {!isOwnProfile && <SuggestedUsers visible={justFollowed} sourceUserId={profileData.id} />}
+      </View>
+    );
+  }, [
+    chrome.setContentHeight,
+    followerCount,
+    followingCount,
+    handle,
+    handleBoostsPress,
+    handlePostsPress,
+    handleRepliesPress,
+    identity,
+    isOwnProfile,
+    isPrivate,
+    justFollowed,
+    profileData,
+  ]);
+
+  const headerActions = (
+    <>
+      {/* The bell is a toggle rendered as two different glyphs, so its label has
+          to carry the state a sighted user reads from the icon — a static
+          "Notifications" would leave a screen reader unable to tell subscribed
+          from not. */}
+      {!isOwnProfile && (
+        <IconButton
+          variant="icon"
+          onPress={toggleSubscription}
+          disabled={subLoading}
+          accessibilityLabel={
+            subscribed
+              ? t('profile.actions.unsubscribe', {
+                  handle,
+                  defaultValue: 'Stop notifying me about new posts from @{{handle}}',
+                })
+              : t('profile.actions.subscribe', {
+                  handle,
+                  defaultValue: 'Notify me about new posts from @{{handle}}',
+                })
+          }
+        >
+          {subscribed ? (
+            <BellActive size={18} className="text-primary" />
+          ) : (
+            <Bell size={18} className="text-foreground" />
+          )}
+        </IconButton>
+      )}
+      {!isOwnProfile && !isFederated && (
+        <IconButton
+          variant="icon"
+          onPress={handleDM}
+          accessibilityLabel={t('profile.actions.message', {
+            handle,
+            defaultValue: 'Message @{{handle}}',
+          })}
+        >
+          <MailIcon size={18} className="text-foreground" />
+        </IconButton>
+      )}
+      {isFederated && (
+        <IconButton
+          variant="icon"
+          onPress={handleOpenOnInstance}
+          accessibilityLabel={t('profile.actions.openOnInstance', {
+            handle,
+            defaultValue: 'Open @{{handle}} on their home instance',
+          })}
+        >
+          <ExternalLinkIcon size={18} className="text-foreground" />
+        </IconButton>
+      )}
+      <IconButton
+        variant="icon"
+        onPress={handleShare}
+        accessibilityLabel={t('profile.actions.share', {
+          handle,
+          defaultValue: "Share @{{handle}}'s profile",
+        })}
+      >
+        <ShareIcon size={18} className="text-foreground" />
+      </IconButton>
+      {!isOwnProfile && (
+        <IconButton
+          variant="icon"
+          onPress={handleMoreOptions}
+          accessibilityLabel={t('profile.actions.more', {
+            handle,
+            defaultValue: 'More options for @{{handle}}',
+          })}
+        >
+          <MoreIcon size={18} className="text-foreground" />
+        </IconButton>
+      )}
+    </>
+  );
+
+  const seo = profileData ? (
+    <SEO
+      title={t('seo.profile.title', {
+        name: profileData.design.displayName,
+        username,
+        defaultValue: `${profileData.design.displayName} (@${username}) on Mention`,
+      })}
+      description={
+        profileData.bio
+          ? t('seo.profile.description', {
+              name: profileData.design.displayName,
+              bio: profileData.bio,
+              defaultValue: `View ${profileData.design.displayName}'s profile on Mention. ${profileData.bio}`,
+            })
+          : t('seo.profile.description', {
+              name: profileData.design.displayName,
+              bio: '',
+              defaultValue: `View ${profileData.design.displayName}'s profile on Mention.`,
+            })
+      }
+      image={avatarUri || bannerUri}
+      type="profile"
+    />
+  ) : null;
+
+  return {
+    ...account,
+    profileData,
+    loading,
+    canonicalHref,
+    isOwnProfile,
+    isPrivate,
+    bannerUri,
+    tabDescriptors,
+    activeDescriptor,
+    chrome,
+    headerActions,
+    summary,
+    seo,
+    tabs: {
+      tab: activeProfileTab,
+      laneId: activeLaneId,
+      profileId: profileData?.id,
+      isPrivate,
+      isOwnProfile,
+      isFederated,
+      actorUri: profileData?.actorUri,
+    },
+    selectTab,
+  };
+}

--- a/packages/frontend/components/Profile/index.ts
+++ b/packages/frontend/components/Profile/index.ts
@@ -1,9 +1,12 @@
 // Types
 export * from './types';
 export * from './profileRoute';
+export * from './profileTabRoute';
+export * from './profileViewer';
 
 // Hooks
 export { useSubscription } from './hooks/useSubscription';
+export { usePersonProfileView } from './hooks/usePersonProfileView';
 export { useProfileScroll } from './hooks/useProfileScroll';
 export { useProfileAccount } from './hooks/useProfileAccount';
 export { useProfileChrome } from './hooks/useProfileChrome';
@@ -15,6 +18,8 @@ export { useChannelWriters } from './hooks/useChannelWriters';
 // Components
 export { ProfileSkeleton } from './ProfileSkeleton';
 export { ProfileShell } from './ProfileShell';
+export { ProfileChromeLayers } from './ProfileChromeLayers';
+export { ProfileTabBarRow } from './ProfileTabBarRow';
 export { ProfileHeader } from './ProfileHeader';
 export { ChannelHeader, ChannelActions } from './ChannelHeader';
 export { ProfileStats } from './ProfileStats';

--- a/packages/frontend/components/Profile/profileTabRoute.ts
+++ b/packages/frontend/components/Profile/profileTabRoute.ts
@@ -1,0 +1,80 @@
+import type { Href } from 'expo-router';
+import { TAB_NAMES, laneTabKey, type ProfileTab, type ProfileTabDescriptor } from './types';
+
+/**
+ * A profile tab's URL, and the reverse reading of one.
+ *
+ * Both directions live here because they are the SAME rule stated twice, and on
+ * web they have two independent readers: the strip builds an `href` per tab, and
+ * the layout that renders the strip has to answer which tab — if any — the
+ * current pathname means. A disagreement between them underlines one tab while
+ * paging another's feed, and nothing fails.
+ */
+
+/** The selection a profile URL names, as the strip and the chrome both read it. */
+export interface ProfileTabSelection {
+  /** The surface the tab renders. A lane tab renders `posts`. */
+  tab: ProfileTab;
+  /** Set on a LANE tab only. */
+  laneId?: string;
+  /** The descriptor key this selection matches (`posts`, `lane:<id>`, …). */
+  key: string;
+}
+
+/** The segment a lane tab lives under, so a lane id can never shadow a tab file. */
+const LANE_SEGMENT = 'lane';
+
+/**
+ * Where the strip sends one tab.
+ *
+ * `posts` collapses to the bare profile path: every link in the wild points at
+ * `/@handle`, including the OG shell the backend serves, so it must BE the posts
+ * tab rather than redirect to it.
+ */
+export function profileTabHref(handle: string, descriptor: ProfileTabDescriptor): Href {
+  if (descriptor.laneId) return `/@${handle}/${LANE_SEGMENT}/${descriptor.laneId}`;
+  return descriptor.tab === 'posts' ? `/@${handle}` : `/@${handle}/${descriptor.tab}`;
+}
+
+/**
+ * Which tab a profile pathname is showing, or `null` when it is showing
+ * something that is not a tab at all.
+ *
+ * `null` is the load-bearing half. The `[username]` layout serves the tabs AND
+ * six full screens beside them — `/followers`, `/following`, `/about`,
+ * `/connections`, `/in-common`, `/who-may-know` — each with its own header and
+ * back arrow, and a banner and tab strip stacked above one would be a second,
+ * contradictory chrome. So the layout draws chrome only where this answers with
+ * a selection, and a child it has never heard of gets none rather than a guess.
+ * That is why this is the exact INVERSE of `profileTabIndex`, which falls back
+ * to the first tab: there an unknown key means "a lane that has not loaded yet",
+ * here it means "not a tab".
+ *
+ * Read POSITIONALLY, from the segments after the handle, rather than by matching
+ * the handle itself: a federated handle carries an `@` and a dot
+ * (`/@ana@mastodon.social/replies`) and arrives percent-encoded often enough
+ * that comparing it is a second way to be wrong. Only ASCII tab names are ever
+ * compared. `(group)` segments never appear — expo-router's `usePathname()` has
+ * already dropped them.
+ *
+ * The shapes are enumerated rather than prefix-matched, because every one of
+ * them is a route file that exists: the bare handle is `index.tsx`, a named tab
+ * is `<tab>.tsx`, and a lane is `lane/[laneId].tsx`. `posts` is deliberately not
+ * accepted as a named segment — `profileTabHref` collapses it to the bare path,
+ * so `/@ana/posts` is a URL nothing produces and no file serves.
+ */
+export function profileTabSelectionFromPathname(pathname: string): ProfileTabSelection | null {
+  const segments = pathname.split('/').filter(Boolean);
+  const [handleSegment, second, third] = segments;
+  if (!handleSegment) return null;
+  if (segments.length === 1) return { tab: 'posts', key: 'posts' };
+  if (segments.length === 2) {
+    return second !== 'posts' && (TAB_NAMES as readonly string[]).includes(second ?? '')
+      ? { tab: second as ProfileTab, key: second as string }
+      : null;
+  }
+  if (segments.length === 3 && second === LANE_SEGMENT && third) {
+    return { tab: 'posts', laneId: third, key: laneTabKey(third) };
+  }
+  return null;
+}

--- a/packages/frontend/components/Profile/profileViewer.ts
+++ b/packages/frontend/components/Profile/profileViewer.ts
@@ -1,0 +1,43 @@
+import type { ProfileData } from '@/hooks/useProfileData';
+
+/**
+ * The two questions every profile surface asks about the VIEWER, answered once.
+ *
+ * They were derived inline in the profile screen while that screen was the only
+ * reader. On web it is no longer: the chrome lives in the `[username]` LAYOUT
+ * and the tab content in a routed SCREEN, and both have to reach the same
+ * verdict — a disagreement shows a private profile's posts under a "this profile
+ * is private" chrome, or the reverse.
+ */
+
+/**
+ * Whether the account withholds its posts from non-followers.
+ *
+ * `followers_only` counts: the profile-visibility gate the feed applies is the
+ * same for both values (`canViewAuthorFeed` serves an empty author feed to a
+ * non-follower either way), so a surface that treated them differently would
+ * promise content the server will not send.
+ */
+export function isProfilePrivate(profileData: ProfileData | null): boolean {
+  if (!profileData) return false;
+  const visibility = profileData.privacy?.profileVisibility;
+  return visibility === 'private' || visibility === 'followers_only';
+}
+
+/**
+ * Whether this profile is the viewer's own.
+ *
+ * A FEDERATED profile never is, whatever the ids say: a remote actor is mirrored
+ * into Oxy under an id of its own, and the viewer's session can never be that
+ * actor. Checked first so an id collision cannot hand somebody the owner's view
+ * of a remote account.
+ */
+export function viewerOwnsProfile(
+  profileData: ProfileData | null,
+  currentUserId: string | undefined,
+  isFederated: boolean,
+): boolean {
+  if (isFederated) return false;
+  if (!currentUserId || !profileData?.id) return false;
+  return currentUserId === profileData.id;
+}

--- a/packages/frontend/components/Profile/types.ts
+++ b/packages/frontend/components/Profile/types.ts
@@ -479,6 +479,23 @@ export interface ProfileTabsProps {
   actorUri?: string;
 }
 
+/**
+ * The `[username]` layout's body.
+ *
+ * Declared here rather than beside either implementation because the component
+ * is a PLATFORM PAIR (`ProfileChromeFrame.tsx` / `.web.tsx`): a type exported
+ * from one half would resolve to the other half on the platform that shadows it,
+ * and on web that is a module importing itself.
+ */
+export interface ProfileChromeFrameProps {
+  /**
+   * The `[username]` segment's navigator — a `<Slot/>`. Every implementation
+   * must render it, in every branch, at one tree position; see
+   * `ProfileChromeFrame.web.tsx` for what breaks when it moves.
+   */
+  children: React.ReactNode;
+}
+
 // Private badge props
 export interface PrivateBadgeProps {
   privacySettings?: ProfileData['privacy'];

--- a/packages/frontend/components/ProfileScreen.tsx
+++ b/packages/frontend/components/ProfileScreen.tsx
@@ -1,629 +1,102 @@
-import React, { useMemo, useCallback, useState, useEffect } from 'react';
-import { Text, TouchableOpacity, View, Share } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { View } from 'react-native';
 import { Redirect, router, type Href } from 'expo-router';
-import { useQuery } from '@tanstack/react-query';
 import { BloomColorScope } from '@oxyhq/bloom/theme';
-import { useTranslation } from 'react-i18next';
-import { FollowButton as OxyFollowButton, useAuth, useFollow } from '@oxyhq/services/ui/client';
-import { usePostsStore } from '@/stores/postsStore';
-import { lanesService } from '@/services/lanesService';
-import { viewerQueryKeys } from '@/lib/viewerQueryKeys';
-import { openExternalLink } from '@/utils/openExternalLink';
-import type { FeedType } from '@mention/shared-types';
-import { logger } from '@oxyhq/core/logger';
-import type { ProfileData } from '@/hooks/useProfileData';
 
-// Icons
-import { Bell, BellActive } from '@/assets/icons/bell-icon';
-import { Icon } from '@/lib/icons';
-import { ShareIcon } from '@/assets/icons/share-icon';
-import { MailIcon } from '@/assets/icons/mail-icon';
-import { MoreIcon } from '@/assets/icons/more-icon';
-import { ExternalLinkIcon } from '@/assets/icons/external-link-icon';
-
-// Components
-import UserName from './UserName';
 import AnimatedTabBar from './common/AnimatedTabBar';
-import { IconButton } from '@/components/ui/Button';
-import { SEO } from '@/components/SEO';
-import { FediverseSharingBadge } from '@/components/AccountBadge';
-import { showFediverseInfo } from '@/components/Fediverse/FediverseInfoDialog';
-
-// Profile components
 import {
-    ProfileContent,
-    ProfileHeader,
     ProfileShell,
-    PrivateBadge,
-    AccountCategoryLine,
-    useSubscription,
-    useProfileAccount,
-    useProfileChrome,
-    useProfileMoreMenu,
-    useOperatesAccount,
-    useJustFollowed,
-    buildProfileTabDescriptors,
+    ProfileTabBarRow,
     laneTabKey,
-    profileTabIndex,
-    profileTabsForAccountKind,
-    type LaneTabInput,
+    usePersonProfileView,
     type ProfileScreenProps,
-    type ProfileTab,
+    type ProfileTabDescriptor,
 } from './Profile';
-import { SuggestedUsers } from './suggestions/SuggestedUsers';
-
-// Helper functions
-const isProfilePrivate = (
-    profileData: ProfileData | null,
-    privacySettings?: ProfileData['privacy']
-): boolean => {
-    if (!profileData) return false;
-    const privacy = profileData.privacy || privacySettings;
-    return Boolean(
-        privacy?.profileVisibility === 'private' ||
-        privacy?.profileVisibility === 'followers_only'
-    );
-};
-
-// Feed types for clearing cache
-const FEED_TYPES: FeedType[] = ['posts', 'replies', 'media', 'likes', 'boosts'];
-
-interface PersonProfileProps extends ProfileScreenProps {
-    username: string;
-    handle: string;
-    isFederated: boolean;
-    profileData: ProfileData | null;
-    loading: boolean;
-}
 
 /**
- * ONE PERSON's profile page, at `/@<handle>`.
+ * ONE PERSON's profile page, at `/@<handle>` — the NATIVE composition.
  *
  * Person-shaped throughout, and deliberately so: it has a banner, a poke, the
  * full tab strip, a self view with edit/analytics/settings, and sub-routes under
  * its own URL family. A CHANNEL satisfies none of that and has its own screen
  * (`ChannelScreen`); the two share the chrome, the body, the account lookup and
  * the canonicalization, and nothing else.
+ *
+ * This file renders the WHOLE page — chrome and tab content together — because
+ * on native it has to: on the post and grid tabs the feed's own list IS the
+ * scroll container, and it is handed the profile summary as its list header and
+ * the tab strip as its sticky row. A strip that is a route-owned list's sticky
+ * header cannot simultaneously be layout chrome. The web build has no such
+ * constraint (the DOCUMENT scrolls) and does split the two — see
+ * `Profile/ProfileChromeFrame.tsx`, which carries the full account of the seam.
+ *
+ * `ProfileScreen.web.tsx` is the other half of that pair: on web this component
+ * renders only the tab's CONTENT, and everything above it comes from the
+ * `[username]` layout.
  */
-const PersonProfile: React.FC<PersonProfileProps> = ({
-    tab = 'posts',
-    laneId,
-    username,
-    handle,
-    isFederated,
-    profileData,
-    loading,
-}) => {
-    const { user: currentUser } = useAuth();
-    const { t } = useTranslation();
-
-    // Active tab — local state so tab switching doesn't trigger router
-    // navigation. Held as the tab's KEY, not its index: the strip's length
-    // depends on how many lanes the publisher has, so an index means a different
-    // tab before and after that list loads. A lane deep link therefore paints
-    // `posts` for one frame and settles on the lane once its key resolves.
+const ProfileScreen: React.FC<ProfileScreenProps> = ({ tab = 'posts', laneId }) => {
+    // Active tab — local state so switching tabs does not remount the page.
+    // Held as the tab's KEY, not its index: the strip's length depends on how
+    // many lanes the publisher has, so an index means a different tab before and
+    // after that list loads. A lane deep link therefore paints `posts` for one
+    // frame and settles on the lane once its key resolves.
     const [activeTabKey, setActiveTabKey] = useState<string>(
         () => (laneId ? laneTabKey(laneId) : tab),
     );
 
-    // The publisher's lanes that HAVE a tab. Public and reader-agnostic, so a
-    // signed-out visitor sees the same strip; keyed by viewer anyway, like every
-    // other private read, so an account switch drops it with the namespace.
-    const { data: laneTabs = [] } = useQuery<LaneTabInput[]>({
-        queryKey: viewerQueryKeys.lanesForOwner(currentUser?.id, profileData?.id),
-        enabled: Boolean(profileData?.id) && !isFederated,
-        queryFn: async () => {
-            const lanes = await lanesService.listForOwner(profileData?.id ?? '');
-            return lanes.map((lane) => ({ id: lane.id, name: lane.name }));
-        },
-    });
+    // The strip owns the selection and the URL follows it: `replace`, so the
+    // page is deep-linkable and shareable without a history entry per tab.
+    // WEB does the opposite — there the route owns the selection and each tab
+    // is pushed, which is what makes Back return to the tab you came from. It
+    // can, because there the strip outlives the navigation; here it does not.
+    const onSelectTab = useCallback((descriptor: ProfileTabDescriptor, href: Href) => {
+        setActiveTabKey(descriptor.key);
+        router.replace(href);
+    }, []);
 
-    // Every person — federated included — gets the full static strip, since the
-    // data behind each tab is in Oxy/Mention's DB either way. Lane tabs are
-    // spliced in after `posts`.
-    const tabDescriptors = useMemo(
-        () =>
-            buildProfileTabDescriptors(
-                {
-                    posts: t('profile.tabs.posts'),
-                    replies: t('profile.tabs.replies'),
-                    media: t('profile.tabs.media'),
-                    videos: t('profile.tabs.videos'),
-                    likes: t('profile.tabs.likes'),
-                    boosts: t('profile.tabs.boosts'),
-                    feeds: t('profile.tabs.feeds', { defaultValue: 'Feeds' }),
-                    starter_packs: t('profile.tabs.starter_packs', { defaultValue: 'Starter Packs' }),
-                    lists: t('profile.tabs.lists', { defaultValue: 'Lists' }),
-                    // A person has no writers tab — `profileTabsForAccountKind`
-                    // drops it for every kind but `channel`. The label is still
-                    // passed because `labels` covers every `ProfileTab` by
-                    // contract: the caller has no reason to know which subset
-                    // survives, and an unused label costs one `t()`.
-                    writers: t('profile.tabs.writers', { defaultValue: 'Writers' }),
-                },
-                laneTabs,
-                profileData?.kind,
-            ),
-        [t, laneTabs, profileData?.kind],
-    );
-
-    const activeTab = profileTabIndex(tabDescriptors, activeTabKey);
-    const activeDescriptor = tabDescriptors[activeTab];
-    const activeProfileTab: ProfileTab = activeDescriptor?.tab ?? 'posts';
-    const activeLaneId = activeDescriptor?.laneId;
-
-    // Follow data — federated users are stored in Oxy, so useFollow works with their Oxy ID
-    const stableUserId = profileData?.id || '';
-    const {
-        followerCount: rawFollowerCount,
-        followingCount: rawFollowingCount,
-        isFollowing: isFollowingProfileUser = false,
-    } = useFollow(stableUserId);
-    const followerCount = rawFollowerCount ?? 0;
-    const followingCount = rawFollowingCount ?? 0;
-
-    // Show suggestions only on the follow ACTION, never on a revisit.
-    const justFollowed = useJustFollowed(stableUserId, isFollowingProfileUser);
-
-    const { subscribed, loading: subLoading, toggle: toggleSubscription } = useSubscription(
-        profileData?.id,
-        currentUser?.id,
-        currentUser?.id === profileData?.id,
-    );
-
-    const design = profileData?.design;
-    const avatarUri = design?.avatar;
-    // A stored banner is shown whenever there is one. Whether the banner BAND
-    // exists at all is not in question here — a person's layout has one, and an
-    // account with no image set gets the tinted placeholder.
-    const bannerUri = design?.bannerUrl;
-
-    const isOwnProfile = useMemo(() => {
-        if (isFederated) return false;
-        if (!currentUser?.id || !profileData?.id) return false;
-        return currentUser.id === profileData.id;
-    }, [currentUser?.id, profileData?.id, isFederated]);
-
-    const isPrivate = useMemo(
-        () => isProfilePrivate(profileData, profileData?.privacy),
-        [profileData],
-    );
-
-    // Number of action icons in the top-right cluster; sizes the scrolled name
-    // overlay so a long display name truncates instead of sliding under them.
-    const headerActionCount = useMemo(() => {
-        let count = 1; // share is always present
-        if (!isOwnProfile) count += 2; // subscribe + more
-        // DM is local-only — remote (federated) actors have no Mention inbox.
-        if (!isOwnProfile && !isFederated) count += 1;
-        if (isFederated) count += 1; // open-on-instance
-        return count;
-    }, [isOwnProfile, isFederated]);
-
-    const chrome = useProfileChrome({
-        profileId: profileData?.id,
-        currentTab: activeProfileTab,
-        currentLaneId: activeLaneId,
-        headerActionCount,
-        hasBannerBand: true,
-    });
-
-    // Clear cached feed data for private profiles
-    useEffect(() => {
-        if (isPrivate && !isOwnProfile && profileData?.id) {
-            const { clearUserFeed } = usePostsStore.getState();
-            FEED_TYPES.forEach((type) => {
-                clearUserFeed(profileData.id, type);
-            });
-        }
-    }, [isPrivate, isOwnProfile, profileData?.id]);
-
-    const onTabPress = useCallback(
-        (index: number) => {
-            if (!username) return;
-            const descriptor = tabDescriptors[index];
-            if (!descriptor) return;
-            setActiveTabKey(descriptor.key);
-            // Update the URL silently for deep-linking / sharing without
-            // triggering navigation. A lane tab routes by id under its own
-            // segment, so it can never collide with a static tab's file name.
-            const path: Href = descriptor.laneId
-                ? `/@${handle}/lane/${descriptor.laneId}`
-                : descriptor.tab === 'posts'
-                    ? `/@${handle}`
-                    : `/@${handle}/${descriptor.tab}`;
-            router.replace(path);
-        },
-        [username, handle, tabDescriptors],
-    );
-
-    // The stats row jumps to a tab BY NAME. Resolving the index at press time is
-    // the whole reason `REPLIES_TAB_INDEX = 1` / `BOOSTS_TAB_INDEX = 5` are gone:
-    // one lane on the profile shifts every tab after `posts`, and a stale
-    // constant sends the reader somewhere else without failing anything.
-    const scrollOrSwitch = useCallback(
-        (key: string) => {
-            const index = profileTabIndex(tabDescriptors, key);
-            if (index === activeTab) {
-                chrome.scrollToContent(chrome.contentHeight);
-            } else {
-                onTabPress(index);
-            }
-        },
-        [activeTab, chrome, onTabPress, tabDescriptors],
-    );
-
-    const handlePostsPress = useCallback(() => scrollOrSwitch('posts'), [scrollOrSwitch]);
-    const handleBoostsPress = useCallback(() => scrollOrSwitch('boosts'), [scrollOrSwitch]);
-    const handleRepliesPress = useCallback(() => scrollOrSwitch('replies'), [scrollOrSwitch]);
-
-    const handleShare = useCallback(async () => {
-        if (!profileData) return;
-        try {
-            const shareUrl = `https://mention.earth/@${handle}`;
-            const shareMessage = t('profile.share.message', {
-                name: profileData.design.displayName,
-                defaultValue: `Check out ${profileData.design.displayName}'s profile on Mention!`,
-            });
-            await Share.share({
-                message: `${shareMessage}\n\n${shareUrl}`,
-                url: shareUrl,
-                title: t('profile.share.title', {
-                    name: profileData.design.displayName,
-                    defaultValue: `${profileData.design.displayName} on Mention`,
-                }),
-            });
-        } catch {
-            logger.error('Error sharing profile');
-        }
-    }, [profileData, handle, t]);
-
-    /**
-     * This screen serves more than people. Only a `channel` routes to
-     * `/c/<handle>`, so an ORGANIZATION, PROJECT or BOT renders here at
-     * `/@<handle>` — and the viewer may operate one of those without it ever being
-     * their own id, which is precisely the case `isOwnProfile` cannot see.
-     *
-     * `isOwnProfile` still governs everything else on this screen, and correctly:
-     * edit-profile, analytics, settings and the lanes button all act on the
-     * VIEWER'S OWN account, so operating an organization must not put them within
-     * reach. Only the hostile menu asks the wider question.
-     */
-    const operatesThisAccount = useOperatesAccount({
-        accountId: profileData?.id,
-        accountKind: profileData?.kind,
-    });
-
-    const handleMoreOptions = useProfileMoreMenu({
-        profileData,
-        viewerOperatesAccount: isOwnProfile || operatesThisAccount,
-    });
-
-    const handleDM = useCallback(() => {
-        if (!profileData?.id) return;
-        const params = new URLSearchParams({
-            userId: profileData.id,
-            username: profileData.username,
-        });
-        router.push(`/ai?${params.toString()}`);
-    }, [profileData?.id, profileData?.username]);
-
-    // Open on remote instance (federated only)
-    const handleOpenOnInstance = useCallback(() => {
-        if (profileData?.actorUri) openExternalLink(profileData.actorUri);
-    }, [profileData?.actorUri]);
-
-    const userNameStyle = useMemo(
-        () => ({
-            name: { fontSize: 24, fontWeight: 'bold' as const, marginTop: 10, marginBottom: 4 },
-            handle: { fontSize: 15, marginBottom: 12 },
-            container: undefined,
-        }),
-        [],
-    );
-
-    const identity = useMemo(() => {
-        if (!profileData) return null;
-        // Own, non-federated profile opted into fediverse sharing (absent flag ⇒
-        // on): a tappable badge next to the handle explaining the fediverse.
-        // The PROFILE is where the explainer is opted into — the marker is inert
-        // on every other surface (see `AccountBadge`).
-        const fediverseBadge =
-            isOwnProfile && !profileData.isFederated && currentUser?.fediverseSharing !== false ? (
-                <FediverseSharingBadge size={20} onExplainNetwork={showFediverseInfo} />
-            ) : undefined;
-        // Passive "Follows you" tag inline to the right of the @handle when this
-        // profile follows the viewer. Never shown on the viewer's own profile.
-        const followsYouTag =
-            !isOwnProfile && currentUser?.id && profileData.followsYou ? (
-                <View className="bg-muted px-2 py-0.5 rounded-full">
-                    <Text className="text-muted-foreground text-xs font-medium" numberOfLines={1}>
-                        {t('profile.followsYou', { defaultValue: 'Follows you' })}
-                    </Text>
-                </View>
-            ) : undefined;
-        return (
-            <>
-                <ProfileHeader
-                    username={profileData.username}
-                    avatarUri={avatarUri}
-                    isOwnProfile={isOwnProfile}
-                    isFederated={profileData.isFederated}
-                    actorUri={profileData.actorUri}
-                    isFollowing={profileData.isFollowing}
-                    currentUsername={currentUser?.username}
-                    profileId={profileData.id}
-                    FollowButtonComponent={OxyFollowButton}
-                />
-                <View>
-                    <UserName
-                        name={profileData.design.displayName}
-                        handle={profileData.username}
-                        verified={profileData.verified}
-                        isFederated={profileData.isFederated}
-                        kind={profileData.kind}
-                        // The profile is the ONE surface that opts the marker in:
-                        // a reader here has room for the answer, and the identity
-                        // line is not itself a link to somewhere else.
-                        onExplainNetwork={showFediverseInfo}
-                        copyableHandle
-                        variant="default"
-                        style={userNameStyle}
-                        trailingBadge={fediverseBadge}
-                        handleTrailing={followsYouTag}
-                    />
-                    {/* Non-personal accounts route here too — an organization, a
-                        project or a bot is a `person`-FAMILY url (only `channel`
-                        gets `/c/`), and all four kinds carry categories. A
-                        personal account never has any, so this renders nothing
-                        for the overwhelming majority of profiles. */}
-                    <AccountCategoryLine
-                        accountCategories={profileData.accountCategories}
-                        align="start"
-                    />
-                    {isPrivate && (
-                        <View className="flex-row items-center gap-2 flex-wrap">
-                            <PrivateBadge privacySettings={profileData.privacy} />
-                        </View>
-                    )}
-                </View>
-            </>
-        );
-    }, [profileData, isOwnProfile, isPrivate, avatarUri, currentUser, userNameStyle, t]);
-
-    const summary = useMemo(() => {
-        if (!profileData) return null;
-        return (
-            <View>
-                <ProfileContent
-                    profileData={profileData}
-                    isOwnProfile={isOwnProfile}
-                    isPrivate={isPrivate}
-                    followingCount={followingCount}
-                    followerCount={followerCount}
-                    profileHandle={handle}
-                    identity={identity}
-                    showReplies={profileTabsForAccountKind(profileData.kind).includes('replies')}
-                    aboutHref={`/@${handle}/about`}
-                    followingHref={`/@${handle}/following`}
-                    followersHref={`/@${handle}/followers`}
-                    onPostsPress={handlePostsPress}
-                    onBoostsPress={handleBoostsPress}
-                    onRepliesPress={handleRepliesPress}
-                    onLayout={chrome.setContentHeight}
-                />
-                {!isOwnProfile && (
-                    <SuggestedUsers visible={justFollowed} sourceUserId={profileData.id} />
-                )}
-            </View>
-        );
-    }, [
-        chrome.setContentHeight,
-        followerCount,
-        followingCount,
-        handle,
-        handleBoostsPress,
-        handlePostsPress,
-        handleRepliesPress,
-        identity,
-        isOwnProfile,
-        isPrivate,
-        justFollowed,
-        profileData,
-    ]);
-
-    // The tab bar, and — on the viewer's OWN profile only — the way in to their
-    // lanes. It belongs beside these tabs because a lane's whole effect is on
-    // which of them a post lands on, and because the composer's lane icon was
-    // otherwise the only door to the screen that manages them. The row carries
-    // the hairline so it stays continuous under the button, which sits outside
-    // the tab bar's own bordered box.
-    const tabBar = useMemo(
-        () => (
-            <View className="flex-row items-center border-b border-border bg-background">
-                <View className="flex-1" style={{ minWidth: 0 }}>
-                    <AnimatedTabBar
-                        tabs={tabDescriptors.map((descriptor) => ({
-                            id: descriptor.key,
-                            label: descriptor.label,
-                        }))}
-                        activeTabId={activeDescriptor?.key ?? 'posts'}
-                        onTabPress={(id) => onTabPress(profileTabIndex(tabDescriptors, id))}
-                        scrollEnabled
-                        instanceId={username || 'default'}
-                    />
-                </View>
-                {isOwnProfile ? (
-                    <TouchableOpacity
-                        onPress={() => router.push('/lanes')}
-                        activeOpacity={0.7}
-                        accessibilityRole="link"
-                        accessibilityLabel={t('lanes.title', { defaultValue: 'Lanes' })}
-                        className="px-3 py-2.5"
-                    >
-                        <Icon name="git-branch-outline" size={20} className="text-muted-foreground" />
-                    </TouchableOpacity>
-                ) : null}
-            </View>
-        ),
-        [activeDescriptor?.key, onTabPress, tabDescriptors, username, isOwnProfile, t],
-    );
-
-    const headerActions = (
-        <>
-            {/* The bell is a toggle rendered as two different glyphs, so its
-                label has to carry the state a sighted user reads from the icon —
-                a static "Notifications" would leave a screen reader unable to
-                tell subscribed from not. */}
-            {!isOwnProfile && (
-                <IconButton
-                    variant="icon"
-                    onPress={toggleSubscription}
-                    disabled={subLoading}
-                    accessibilityLabel={
-                        subscribed
-                            ? t('profile.actions.unsubscribe', {
-                                handle,
-                                defaultValue: 'Stop notifying me about new posts from @{{handle}}',
-                            })
-                            : t('profile.actions.subscribe', {
-                                handle,
-                                defaultValue: 'Notify me about new posts from @{{handle}}',
-                            })
-                    }
-                >
-                    {subscribed ? (
-                        <BellActive size={18} className="text-primary" />
-                    ) : (
-                        <Bell size={18} className="text-foreground" />
-                    )}
-                </IconButton>
-            )}
-            {!isOwnProfile && !isFederated && (
-                <IconButton
-                    variant="icon"
-                    onPress={handleDM}
-                    accessibilityLabel={t('profile.actions.message', {
-                        handle,
-                        defaultValue: 'Message @{{handle}}',
-                    })}
-                >
-                    <MailIcon size={18} className="text-foreground" />
-                </IconButton>
-            )}
-            {isFederated && (
-                <IconButton
-                    variant="icon"
-                    onPress={handleOpenOnInstance}
-                    accessibilityLabel={t('profile.actions.openOnInstance', {
-                        handle,
-                        defaultValue: 'Open @{{handle}} on their home instance',
-                    })}
-                >
-                    <ExternalLinkIcon size={18} className="text-foreground" />
-                </IconButton>
-            )}
-            <IconButton
-                variant="icon"
-                onPress={handleShare}
-                accessibilityLabel={t('profile.actions.share', {
-                    handle,
-                    defaultValue: "Share @{{handle}}'s profile",
-                })}
-            >
-                <ShareIcon size={18} className="text-foreground" />
-            </IconButton>
-            {!isOwnProfile && (
-                <IconButton
-                    variant="icon"
-                    onPress={handleMoreOptions}
-                    accessibilityLabel={t('profile.actions.more', {
-                        handle,
-                        defaultValue: 'More options for @{{handle}}',
-                    })}
-                >
-                    <MoreIcon size={18} className="text-foreground" />
-                </IconButton>
-            )}
-        </>
-    );
-
-    return (
-        <>
-            {profileData ? (
-                <SEO
-                    title={t('seo.profile.title', {
-                        name: profileData.design.displayName,
-                        username,
-                        defaultValue: `${profileData.design.displayName} (@${username}) on Mention`,
-                    })}
-                    description={
-                        profileData.bio
-                            ? t('seo.profile.description', {
-                                name: profileData.design.displayName,
-                                bio: profileData.bio,
-                                defaultValue: `View ${profileData.design.displayName}'s profile on Mention. ${profileData.bio}`,
-                            })
-                            : t('seo.profile.description', {
-                                name: profileData.design.displayName,
-                                bio: '',
-                                defaultValue: `View ${profileData.design.displayName}'s profile on Mention.`,
-                            })
-                    }
-                    image={avatarUri || bannerUri}
-                    type="profile"
-                />
-            ) : null}
-            <ProfileShell
-                chrome={chrome}
-                loading={loading}
-                profileData={profileData}
-                banner={{ uri: bannerUri }}
-                headerActions={headerActions}
-                summary={summary}
-                tabBar={tabBar}
-                tabs={{
-                    tab: activeProfileTab,
-                    laneId: activeLaneId,
-                    profileId: profileData?.id,
-                    isPrivate,
-                    isOwnProfile,
-                    isFederated,
-                    actorUri: profileData?.actorUri,
-                }}
-            />
-        </>
-    );
-};
-
-const ProfileScreen: React.FC<ProfileScreenProps> = ({ tab = 'posts', laneId }) => {
-    const { username, handle, isFederated, profileData, loading, colorName, canonicalHref } =
-        useProfileAccount('person');
+    const view = usePersonProfileView({ activeKey: activeTabKey, onSelectTab });
 
     // A channel account's page is `/c/<handle>`. Sitting on `/@<handle>` for one
     // is a URL nobody should keep — a post row links every author to `/@`, since
     // the DTO says nothing about account kind, so this is how a reader reaches a
     // channel at all. The rule itself lives in `profileRoute.ts`, shared with the
     // channel screen so the two can never disagree about which way to send.
-    if (canonicalHref) {
-        return <Redirect href={canonicalHref} />;
+    if (view.canonicalHref) {
+        return <Redirect href={view.canonicalHref} />;
     }
 
+    const tabBar = (
+        <ProfileTabBarRow showLanes={view.isOwnProfile}>
+            <AnimatedTabBar
+                tabs={view.tabDescriptors.map((descriptor) => ({
+                    id: descriptor.key,
+                    label: descriptor.label,
+                }))}
+                activeTabId={view.activeDescriptor?.key ?? 'posts'}
+                onTabPress={view.selectTab}
+                scrollEnabled
+                instanceId={view.username || 'default'}
+            />
+        </ProfileTabBarRow>
+    );
+
     return (
-        <BloomColorScope colorPreset={colorName} asChild>
+        <BloomColorScope colorPreset={view.colorName} asChild>
             {/* `web:z-auto` so this profile wrapper does not become its own
                 stacking context and trap the sticky header chrome below the
                 panel's bleed-mask/border overlays (see ProfileShell's root for
                 the full rationale). No effect on native. */}
             <View className="flex-1 bg-background web:z-auto">
-                <PersonProfile
-                    tab={tab}
-                    laneId={laneId}
-                    username={username}
-                    handle={handle}
-                    isFederated={isFederated}
-                    profileData={profileData}
-                    loading={loading}
+                {view.seo}
+                <ProfileShell
+                    chrome={view.chrome}
+                    loading={view.loading}
+                    profileData={view.profileData}
+                    banner={{ uri: view.bannerUri }}
+                    headerActions={view.headerActions}
+                    summary={view.summary}
+                    tabBar={tabBar}
+                    tabs={view.tabs}
                 />
             </View>
         </BloomColorScope>

--- a/packages/frontend/components/ProfileScreen.web.tsx
+++ b/packages/frontend/components/ProfileScreen.web.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Redirect } from 'expo-router';
+import { useAuth } from '@oxyhq/services/ui/client';
+
+import {
+    ProfileTabs,
+    isProfilePrivate,
+    useProfileAccount,
+    viewerOwnsProfile,
+    type ProfileScreenProps,
+} from './Profile';
+
+/**
+ * ONE PERSON's profile TAB, at `/@<handle>` and its tab siblings — the WEB half.
+ *
+ * On web this component is the tab's CONTENT and nothing else. The banner, the
+ * identity summary, the action cluster and the tab strip are rendered by the
+ * `[username]` layout above it (`Profile/ProfileChromeFrame.web.tsx`), so that
+ * switching tabs swaps only this — the chrome is never unmounted, the strip's
+ * underline animates across instead of blanking, and Back returns to the tab the
+ * reader came from. `ProfileScreen.tsx` is the native half, where the whole page
+ * is still one screen; the seam between them is documented in
+ * `Profile/ProfileChromeFrame.tsx`.
+ *
+ * Nothing here is fetched twice. `useProfileAccount` is a React Query read under
+ * the same key the layout uses, so this asks the cache the layout has already
+ * filled; the two answer the same `isPrivate` / `isOwnProfile` because both go
+ * through `profileViewer.ts` rather than deriving them inline.
+ *
+ * The canonical-URL redirect stays HERE rather than moving up with the chrome.
+ * A layout must render its navigator unconditionally — a layout that swaps one
+ * for a plain screen (or for a `<Redirect/>`, which renders null) leaves the
+ * segment with no navigator in the navigation state, and on web, where every
+ * route is an async chunk, the remount that follows chases `usePathname()` until
+ * React aborts the render. `[username]/_layout.tsx` carries the full account.
+ * A screen has no such constraint.
+ */
+const ProfileScreen: React.FC<ProfileScreenProps> = ({ tab = 'posts', laneId }) => {
+    const { isFederated, profileData, canonicalHref } = useProfileAccount('person');
+    const { user: currentUser } = useAuth();
+
+    if (canonicalHref) {
+        return <Redirect href={canonicalHref} />;
+    }
+
+    return (
+        <ProfileTabs
+            tab={tab}
+            laneId={laneId}
+            profileId={profileData?.id}
+            isPrivate={isProfilePrivate(profileData)}
+            isOwnProfile={viewerOwnsProfile(profileData, currentUser?.id, isFederated)}
+            isFederated={isFederated}
+            actorUri={profileData?.actorUri}
+        />
+    );
+};
+
+export default ProfileScreen;

--- a/packages/frontend/components/__tests__/AccountBadge.test.tsx
+++ b/packages/frontend/components/__tests__/AccountBadge.test.tsx
@@ -397,7 +397,8 @@ describe('surfaces — only the profile arms the FEDIVERSE marker', () => {
     'components/AccountBadge.tsx': 'defines the opt-in',
     'components/Profile/types.ts': 'declares the prop on UserNameProps',
     'components/UserName.tsx': 'forwards its own prop through; opts nothing in itself',
-    'components/ProfileScreen.tsx': 'THE opt-in — the profile is where the explainer belongs',
+    'components/Profile/hooks/usePersonProfileView.tsx':
+      'THE opt-in — the profile is where the explainer belongs, and this is where the profile builds its identity block for both platforms',
     'components/__tests__/AccountBadge.test.tsx': 'this test',
   };
 
@@ -412,7 +413,9 @@ describe('surfaces — only the profile arms the FEDIVERSE marker', () => {
 
   it('the opt-in reaches the badge rather than only being mentioned', () => {
     // The rot check above is satisfied by a comment. This one is not.
-    const profile = sources.find((entry) => entry.rel === 'components/ProfileScreen.tsx');
+    const profile = sources.find(
+      (entry) => entry.rel === 'components/Profile/hooks/usePersonProfileView.tsx',
+    );
     expect(profile?.text).toMatch(/onExplainNetwork=\{/);
   });
 });


### PR DESCRIPTION
Second attempt at #649, in the flat shape the user chose. #649 shipped and was reverted by #651; `da4e2d8d` and `archive/profile-tab-navigator` are the durable handles for it.

## The bug

Switching profile tabs on web reads as a page reload. Measured on this branch's before/after builds, in a real foregrounded Chromium on a private Xvfb, sampling the DOM every 30ms across the transition:

| build | samples with NO tab strip on screen |
| --- | --- |
| `main` (857a7896) | **27 / 28** |
| this branch | **0 / 41** |

It is not a page load — the JS context survives and no `load` event fires. It is a remount, and the cause is placement: the strip was rendered INSIDE each tab screen, so the `<Slot/>` swapped it away and the incoming route's async chunk had to arrive before anything could replace it. `/explore` has the identical `<Slot/>` and has never had the problem, because it renders its strip in the LAYOUT.

Browser Back is fixed by the same move for a different reason. On `main` it left the profile entirely (measured: `pathname=blank`); here it returns to the tab the reader came from, because `RouterTabs` pushes and the strip now outlives the navigation.

## The shape, and why it is not the reverted one

The chrome — banner, identity summary, action cluster, tab strip — moves to `[username]/_layout.tsx`. Each tab screen becomes only its content (`ProfileScreen.web.tsx`).

The tab routes stay **FLAT**. #649 grouped them under a nested `(tabs)` segment so a layout could wrap exactly them; `router.push('/@handle')` from another profile then created a `[username]` entry carrying no nested state, its child navigator settled on `about`, and expo-router wrote `/@handle/about` into the URL. So a pushed entry's default child has to be a real route, and the boundary the group drew with a folder is drawn from the pathname instead — `profileTabSelectionFromPathname`, which answers `null` for `/followers`, `/following`, `/about`, `/connections`, `/in-common`, `/who-may-know` and for any child it has never heard of.

**Those six keep their own header and back arrow**, unchanged — the user's explicit choice. They get no banner and no strip. Verified with screenshots at 1440x1000: `/@nate`, `/@nate/followers` and `/@nate/about` are pixel-for-pixel the same in the centre column before and after.

`ProfileChromeFrame` renders the `<Slot/>` in every branch at ONE tree position, because it is the segment's navigator. React reconciles by position, so a conditional that moved it between two parents would destroy and rebuild it on every crossing into `/followers` and back, and a segment that loses its navigator is the "Maximum update depth exceeded" bug `[username]/_layout.tsx` already carries the account of. The chrome around it comes and goes; the navigator does not move. `usePersonProfileView` withholds the account when no tab is showing, which is what stops the profile's document-scroll pager paging a feed nobody is looking at while the reader scrolls a followers list.

Web only. Native is not simply behind — it has the same remount, invisible because bundled code has no chunk to fetch — and its chrome CANNOT move up: on the post and grid tabs the feed's own list is the scroll container and is handed the summary as its list header and the strip as its sticky row. `ProfileChromeFrame.tsx` carries that account. `usePersonProfileView` is the one implementation both compositions read and `ProfileChromeLayers` the one copy of the four pinned layers, so the account lookup, lane query, strip, summary, scroll chrome and z-index tuning cannot drift.

## Three gates, each mutation-tested

`profileTabRouteTargets.test.ts` asserts every tab has a route file, and **additionally that no group sits between the segment and its tabs**. Mutation-tested by moving `replies.tsx` into a `(tabs)` folder: every route path stays identical (a `(group)` segment is URL-transparent) and only the new assertion fails — which is exactly the gap that let the regression through the old gate unchanged.

`profileTabRoute.test.ts` classifies every real route file under `[username]` from the filesystem, so a route added later is judged the day it lands. Mutation-tested in both directions: loosening the named-tab branch fails 10 cases including all six siblings; loosening the fallback fails the unknown-child case.

`packages/e2e/tests/profile-tabs.spec.ts` asserts the RENDERED screen in a real browser. Mutation-tested against a real web export of `da4e2d8d`, three runs each:

| build | push target | landed on |
| --- | --- | --- |
| `da4e2d8d` (reverted) | federated | `/@aurius@mastodon.social/`**`about`** — 3/3 |
| `da4e2d8d` (reverted) | local | `/@lady` — 3/3, i.e. **does not reproduce** |
| this branch | federated | `/@aurius@mastodon.social` — 3/3 |
| `main` 857a7896 | federated | `/@aurius@mastodon.social` — 3/3 |

The target being FEDERATED is the whole flow, not a detail: a remote actor resolves slowly enough to flip the profile's loading state, which is the condition the reverted build's nested navigator was rebuilt under. A gate that pushed whichever card came first would have passed against the very build it exists to catch — the first version of this flow did exactly that, three times, before the discriminating input was found. On the reverted build the rewrite is in place 16-20ms after the key press, measured, so the settle window is not what makes the check work.

## Verification

`tsc --noEmit` (mutation-tested to confirm it covers `.web.tsx` — jest-expo never resolves them), 1589 frontend jest tests, `expo lint` (0 errors), `expo export --platform web` with bundle budgets passing, and the workspace validators. Browser: 10/11 checks on a production export, the one failure being 503s from an unrelated `api.mention.earth` outage during the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
