### PR TITLE
fix(federation): an inbound Update from a Group or Organization applied nothing

### DIFF
--- a/packages/backend/src/__tests__/connectors/activitypub/inboundUpdateSecurity.test.ts
+++ b/packages/backend/src/__tests__/connectors/activitypub/inboundUpdateSecurity.test.ts
@@ -127,6 +127,7 @@ vi.mock('../../../connectors/activitypub/outbox.service', () => ({
 }));
 
 import { inboxProcessingService } from '../../../connectors/activitypub/inbox.service';
+import { actorService } from '../../../connectors/activitypub/actor.service';
 
 const EDITED_NOTE_ID = `${ACTOR_URI}/statuses/900`;
 
@@ -171,7 +172,17 @@ beforeEach(async () => {
   });
 });
 
+// The profile-update effect under test. Spying rather than mocking the module
+// keeps every OTHER actor-service path real — the owner-resolution fallback in
+// `handleUpdate` reads the seeded actor row through `getOrFetchActor`.
+let fetchRemoteActor: ReturnType<typeof vi.spyOn<typeof actorService, 'fetchRemoteActor'>>;
+
+beforeEach(() => {
+  fetchRemoteActor = vi.spyOn(actorService, 'fetchRemoteActor').mockResolvedValue(null);
+});
+
 afterEach(async () => {
+  fetchRemoteActor.mockRestore();
   await clearFederationScope(scope);
 });
 
@@ -210,6 +221,43 @@ describe('handleUpdate — NoSQL-injection safety + ownership scope', () => {
       .from(posts)
       .where(eq(posts.id, edited.id));
     expect(row.isEdited).toBe(false);
+  });
+
+  it('refetches the actor for EVERY AS2 actor type, not a hand-picked subset', async () => {
+    // This branch used to read `Person | Service | Application`, so a `Group`
+    // (every Lemmy community) or an `Organization` (every Mention channel, since
+    // channels federate as one) had its profile edits applied to NOTHING — no
+    // error, no log, the rename simply never landed. The predicate is now the
+    // engine's shared AS2 actor vocabulary.
+    for (const type of ['Person', 'Service', 'Application', 'Group', 'Organization']) {
+      fetchRemoteActor.mockClear();
+      await inboxProcessingService.processInboxActivity(
+        { id: `${ACTOR_URI}#update-${type}`, type: 'Update', actor: ACTOR_URI, object: { id: ACTOR_URI, type } },
+        ACTOR_URI,
+      );
+      expect(fetchRemoteActor).toHaveBeenCalledWith(ACTOR_URI);
+    }
+  });
+
+  it('does not treat a non-actor object as an actor', async () => {
+    // The other side of the branch, and it must be a type that actually REACHES
+    // it: a `Note` exits on the preceding `if`, so asserting on one cannot tell a
+    // real predicate from `else if (true)`.
+    for (const type of ['Video', 'Question', 'Tombstone', 'Event']) {
+      fetchRemoteActor.mockClear();
+      await inboxProcessingService.processInboxActivity(
+        { id: `${ACTOR_URI}#update-${type}`, type: 'Update', actor: ACTOR_URI, object: { id: `${ACTOR_URI}/x`, type } },
+        ACTOR_URI,
+      );
+      expect(fetchRemoteActor).not.toHaveBeenCalled();
+    }
+  });
+
+  it('still routes an edited Note down the content path, not the actor path', async () => {
+    await inboxProcessingService.processInboxActivity(updateActivity(), ACTOR_URI);
+
+    expect(fetchRemoteActor).not.toHaveBeenCalled();
+    expect(await storedVariants(edited.id)).toEqual([{ tag: 'es', body: 'texto editado' }]);
   });
 
   it('ignores an Update whose object.id is not a string (no updateOne, no injectable filter)', async () => {

--- a/packages/backend/src/connectors/activitypub/inbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/inbox.service.ts
@@ -1,4 +1,5 @@
 import { and, eq } from 'drizzle-orm';
+import { isApActorType } from '@oxyhq/federation';
 import { createInboundDispatcher } from '@oxyhq/federation/node';
 import { logger } from '../../utils/logger';
 import { findActorByUri } from '../../db/federation/actorRepository';
@@ -962,8 +963,16 @@ export class InboxProcessingService {
           );
         }
       }
-    } else if (object.type === 'Person' || object.type === 'Service' || object.type === 'Application') {
-      // Profile update — re-fetch the actor to get updated data
+    } else if (isApActorType(object.type)) {
+      // Profile update — re-fetch the actor to get updated data.
+      //
+      // Every AS2 actor type, not the `Person | Service | Application` subset
+      // this used to name: `Group` and `Organization` are ordinary actors that
+      // edit their profiles like any other, and dropping their Update applied
+      // NOTHING with no error — a Lemmy community's renames and avatar changes
+      // never landed here. It also became load-bearing the moment a channel
+      // started federating as `Organization`: without this, a Mention channel's
+      // profile edit would not propagate to another Mention instance.
       await actorService.fetchRemoteActor(actorUri);
       logger.debug('[Federation] updated federated actor');
     }


### PR DESCRIPTION
## What

`handleUpdate`'s actor branch read `Person | Service | Application`, so an `Update` whose object was a `Group` (every Lemmy community) or an `Organization` fell through **both** arms and applied to nothing — no error, no log. A community's rename or avatar change simply never landed; the only symptom was stale data nobody could attribute.

It is also load-bearing now that a channel federates as `Organization`: without this, a Mention channel's profile edit does not propagate to another Mention instance.

The predicate is now `isApActorType` from `@oxyhq/federation` — the engine's own AS2 actor vocabulary — rather than a subset restated here, so it cannot drift from the list the rest of the federation stack agrees on.

## Evidence

- `inboundUpdateSecurity.test.ts`: **6/6 pass** (3 new).
- `tsc --noEmit` on `packages/backend`: clean.
- **Mutation-tested, both directions.** Restoring the old subset predicate reds *"refetches the actor for EVERY AS2 actor type"*; `else if (true)` reds *"does not treat a non-actor object as an actor"*. Restored in place, green again.
- The negative case uses `Video`/`Question`/`Tombstone`/`Event` on purpose — a `Note` exits on the preceding `if`, so asserting on one cannot tell a real predicate from an always-true one.

## Provenance

Recovered from uncommitted work in a stale sibling worktree (`Mention-actor-type`, 442 commits behind `main`). The change was re-applied to current `main` by hand — the original patch predated the Mongo→Postgres port of this file's test — and the assertions were rewritten against the real Postgres fixtures, spying on `actorService.fetchRemoteActor` so every other actor-service path stays real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)