### PR TITLE
fix(theme): revoke a colour the viewer is no longer entitled to

### DIFF
--- a/packages/frontend/app/(app)/edit-profile.tsx
+++ b/packages/frontend/app/(app)/edit-profile.tsx
@@ -2,13 +2,7 @@ import React, { useMemo } from 'react';
 import { ScrollView, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useAuth, OxyAuthPrompt } from '@oxyhq/services/ui/client';
-import {
-  useBloomTheme,
-  useTheme,
-  FREE_COLOR_NAMES,
-  PREMIUM_COLOR_NAMES,
-  type AppColorName,
-} from '@oxyhq/bloom/theme';
+import { useBloomTheme, useTheme } from '@oxyhq/bloom/theme';
 import { SettingsListDivider } from '@oxyhq/bloom/settings-list';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { Loading } from '@oxyhq/bloom/loading';
@@ -19,6 +13,7 @@ import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { useSafeBack } from '@/hooks/useSafeBack';
 import { useProfileData } from '@/hooks/useProfileData';
 import { ColorSwatchPicker } from '@/components/settings/ColorSwatchPicker';
+import { entitledColorNames } from '@/lib/colorEntitlement';
 import { Icon } from '@/lib/icons';
 import { useAppColorSave } from '@/hooks/useAppColorSave';
 import { BannerSection } from '@/components/Profile/EditProfile/BannerSection';
@@ -33,26 +28,16 @@ export default function EditProfileScreen() {
   const { colors } = useTheme();
   const { saveColor } = useAppColorSave();
 
-  const normalizedUsername = authUser?.username?.toLowerCase();
   const authUserRecord = authUser as { premium?: { isPremium?: boolean } } | null;
   const isPremium = authUserRecord?.premium?.isPremium ?? false;
-  const isOxyUser = normalizedUsername === 'oxy';
-  const isFaircoinUser = normalizedUsername === 'faircoin';
 
-  // The full list this viewer may pick, built UP from the free presets rather
-  // than down from all of them. Two different gates, and they are not
-  // interchangeable: `oxy` and `faircoin` belong to those accounts and cannot be
-  // bought, while `mono` — black on white and white on black — is what a
-  // subscription buys.
-  const visibleColors = useMemo<readonly AppColorName[]>(
-    () => [
-      ...FREE_COLOR_NAMES,
-      ...(isOxyUser ? (['oxy'] as const) : []),
-      ...(isFaircoinUser ? (['faircoin'] as const) : []),
-      ...(isPremium ? PREMIUM_COLOR_NAMES : []),
-    ],
-    [isPremium, isOxyUser, isFaircoinUser],
-  );
+  // Which presets this viewer may pick — answered by the one authority that also
+  // guards an already-stored preference, so the picker and the applier cannot
+  // disagree about who is entitled to what.
+  const visibleColors = useMemo(
+    () => entitledColorNames({ username: authUser?.username, isPremium }),
+    [authUser?.username, isPremium],
+  )
 
   if (!isAuthenticated) {
     return (

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -8,6 +8,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import React, { useCallback, useEffect, useState } from "react";
 import { AppState, Platform, type AppStateStatus } from "react-native";
 import { BloomProvider } from '@oxyhq/bloom/provider';
+import { APP_DEFAULT_COLOR_PRESET } from '@/lib/colorEntitlement';
 
 // Components
 import AppSplashScreen from '@/components/AppSplashScreen';
@@ -176,7 +177,7 @@ export default function RootLayout() {
         imageResolver={resolveImageSource}
         haptics={!hapticsDisabled}
         defaultMode="system"
-        defaultColorPreset="blue"
+        defaultColorPreset={APP_DEFAULT_COLOR_PRESET}
         persistKey={BLOOM_THEME_PERSIST_KEY}
         storage={BLOOM_THEME_STORAGE}
         // WEB shows the custom splash while fonts load; NATIVE shows nothing here

--- a/packages/frontend/hooks/useAccountTheme.ts
+++ b/packages/frontend/hooks/useAccountTheme.ts
@@ -8,6 +8,7 @@ import {
   type ThemeMode,
 } from '@oxyhq/bloom/theme';
 import { useThemeSourceStore, type ThemeSource } from '@/stores/themeSourceStore';
+import { APP_DEFAULT_COLOR_PRESET, isColorEntitled } from '@/lib/colorEntitlement';
 
 /**
  * The portable account theme value that rides the Oxy user DTO
@@ -46,7 +47,7 @@ export function useAccountThemeSync(): void {
   const source = useThemeSourceStore((state) => state.source);
   const hydrated = useThemeSourceStore((state) => state.hydrated);
   const hydrate = useThemeSourceStore((state) => state.hydrate);
-  const { setMode, setColorPreset } = useBloomTheme();
+  const { colorPreset, setMode, setColorPreset } = useBloomTheme();
 
   // Resolve the persisted source once (async on native; already resolved on web).
   useEffect(() => {
@@ -67,6 +68,34 @@ export function useAccountThemeSync(): void {
       setColorPreset(themePreference.colorPreset);
     }
   }, [hydrated, isAuthenticated, source, themePreference, setMode, setColorPreset]);
+
+  // REVOKE a preset the viewer is no longer entitled to.
+  //
+  // Gating the picker only stops someone CHOOSING a colour; it does nothing about
+  // one already chosen. A subscriber who picked the colourless theme and then
+  // lapsed kept rendering it indefinitely, because both the account preference
+  // and Bloom's own local persistence store a preset NAME and validate only that
+  // the name exists. So the paywall held on one screen and nowhere else.
+  //
+  // Deliberately NOT inside the effect above: that one is scoped to the `account`
+  // theme source, while a stale entitlement can arrive by either route — Bloom's
+  // local storage paints on cold boot before any account theme lands, and under
+  // the `app` source it is the only thing that ever paints.
+  //
+  // Guarded on the resolved user object rather than on `isAuthenticated` alone,
+  // because entitlement is READ FROM IT: acting while it is still undefined would
+  // read `isPremium` as false and strip a paying subscriber's theme on every cold
+  // boot, in the window before the session resolves.
+  useEffect(() => {
+    if (!isAuthenticated || !user) return;
+    const viewer = {
+      username: user.username,
+      isPremium: (user as { premium?: { isPremium?: boolean } }).premium?.isPremium ?? false,
+    };
+    if (!isColorEntitled(colorPreset, viewer)) {
+      setColorPreset(APP_DEFAULT_COLOR_PRESET);
+    }
+  }, [isAuthenticated, user, colorPreset, setColorPreset]);
 }
 
 interface ThemeControls {

--- a/packages/frontend/lib/__tests__/colorEntitlement.test.ts
+++ b/packages/frontend/lib/__tests__/colorEntitlement.test.ts
@@ -1,0 +1,63 @@
+import {
+  APP_DEFAULT_COLOR_PRESET,
+  entitledColorNames,
+  isColorEntitled,
+} from '@/lib/colorEntitlement';
+
+/**
+ * Two gates, and they are not interchangeable: `oxy` and `faircoin` belong to
+ * those accounts and cannot be bought, while `mono` is what a subscription buys.
+ * Everything else is everyone's.
+ *
+ * The preset table is MOCKED so these cases state the rule directly instead of
+ * restating whatever Bloom currently ships (which is asserted in Bloom's own
+ * `theme/__tests__/color-preset-gates.test.ts`, and which jest cannot import
+ * here anyway — Bloom's `react-native` export condition resolves to source).
+ * That split is deliberate: Bloom owns WHAT is gated, this owns WHETHER a given
+ * viewer clears it.
+ */
+jest.mock('@oxyhq/bloom/theme', () => ({
+  FREE_COLOR_NAMES: ['teal', 'blue', 'red'],
+  HANDLE_COLOR_NAMES: ['oxy', 'faircoin'],
+  PREMIUM_COLOR_NAMES: ['mono'],
+}));
+
+const NOBODY = { username: undefined, isPremium: false };
+
+describe('colour entitlement', () => {
+  it('gives the free presets to everyone, including a signed-out viewer', () => {
+    expect(entitledColorNames(NOBODY)).toEqual(['teal', 'blue', 'red']);
+  });
+
+  it('never sells a reserved brand colour', () => {
+    const richStranger = { username: 'someone', isPremium: true };
+    expect(isColorEntitled('oxy', richStranger)).toBe(false);
+    expect(isColorEntitled('faircoin', richStranger)).toBe(false);
+    // ...and paying still buys the one that IS for sale.
+    expect(isColorEntitled('mono', richStranger)).toBe(true);
+  });
+
+  it('gives a reserved colour only to the account that owns the handle', () => {
+    expect(isColorEntitled('oxy', { username: 'oxy', isPremium: false })).toBe(true);
+    // ...and only that one — owning a handle is not a subscription.
+    expect(isColorEntitled('faircoin', { username: 'oxy', isPremium: false })).toBe(false);
+    expect(isColorEntitled('mono', { username: 'oxy', isPremium: false })).toBe(false);
+  });
+
+  it('matches the handle regardless of case or padding', () => {
+    expect(isColorEntitled('faircoin', { username: '  FairCoin ', isPremium: false })).toBe(true);
+  });
+
+  it('withholds the sold preset from a viewer who is not paying', () => {
+    expect(isColorEntitled('mono', NOBODY)).toBe(false);
+    expect(entitledColorNames(NOBODY)).not.toContain('mono');
+  });
+
+  // The revocation target has to be something the lapsed viewer may actually
+  // have: falling back to a gated preset would hand out on revocation exactly
+  // what the revocation exists to take away. Bloom's own built-in default is
+  // `oxy`, which is handle-gated — hence a Mention-side constant.
+  it('falls back to a preset every viewer is entitled to', () => {
+    expect(isColorEntitled(APP_DEFAULT_COLOR_PRESET, NOBODY)).toBe(true);
+  });
+});

--- a/packages/frontend/lib/colorEntitlement.ts
+++ b/packages/frontend/lib/colorEntitlement.ts
@@ -1,0 +1,57 @@
+import {
+  FREE_COLOR_NAMES,
+  HANDLE_COLOR_NAMES,
+  PREMIUM_COLOR_NAMES,
+  type AppColorName,
+} from '@oxyhq/bloom/theme';
+
+/**
+ * WHO MAY WEAR WHICH COLOUR — the one authority, used by the picker AND by the
+ * code that applies a stored preference.
+ *
+ * Those two must never answer differently. When only the picker knew the rule, a
+ * preset it refused to offer was still applied on the next cold boot, so the
+ * paywall held for exactly as long as the user stayed on that screen. Splitting
+ * the answer across two call sites is the same shape as the bug that let the
+ * picker give the gated presets away in the first place.
+ *
+ * Bloom declares WHAT is gated (`FREE_`/`HANDLE_`/`PREMIUM_COLOR_NAMES`); this
+ * decides WHETHER a given viewer clears it, because only the app knows who is
+ * signed in and what they pay for.
+ */
+export interface ColorViewer {
+  /** The viewer's handle, in any case. Absent for a signed-out viewer. */
+  username?: string | null;
+  isPremium: boolean;
+}
+
+/**
+ * Mention's baseline preset — what the app paints before anyone chooses, and
+ * what an unentitled preference falls back to. Declared here rather than at the
+ * provider so the revocation path cannot drift from the provider's default and
+ * "revoke" some third colour nobody picked.
+ *
+ * It must be a FREE preset: Bloom's own built-in default is `oxy`, which is
+ * handle-gated, and falling back to that would hand out a reserved brand colour
+ * as a consolation prize.
+ */
+export const APP_DEFAULT_COLOR_PRESET: AppColorName = 'blue';
+
+/**
+ * A handle-gated preset is owned by the account whose handle matches its NAME —
+ * `oxy` belongs to @oxy, `faircoin` to @faircoin. Deriving the owner from the
+ * name rather than listing pairs means a new reserved colour is gated the moment
+ * Bloom declares it, with nothing to update here.
+ */
+export function entitledColorNames(viewer: ColorViewer): readonly AppColorName[] {
+  const handle = viewer.username?.trim().toLowerCase();
+  return [
+    ...FREE_COLOR_NAMES,
+    ...HANDLE_COLOR_NAMES.filter((name) => name === handle),
+    ...(viewer.isPremium ? PREMIUM_COLOR_NAMES : []),
+  ];
+}
+
+export function isColorEntitled(name: AppColorName, viewer: ColorViewer): boolean {
+  return entitledColorNames(viewer).includes(name);
+}


### PR DESCRIPTION
Follow-up to #657, closing the half of the paywall that PR left open.

## The gap

Gating the picker only stops someone **choosing** a colour. It does nothing about one already chosen. A subscriber who picked the colourless theme and then lapsed kept rendering it indefinitely — both the account preference and Bloom's own local persistence store a preset **name** and validate only that the name exists.

So the paywall held on one screen and nowhere else.

## One authority

The rule now lives in `lib/colorEntitlement.ts`, because the picker and the applier answering differently **is** the bug — the same shape as the one #657 fixed. Bloom declares *what* is gated; this decides *whether* a given viewer clears it, and both call sites read it.

A handle-gated preset is matched to the account whose handle equals its **name**, so a new reserved colour is gated the moment Bloom declares one, with nothing to update here.

## Two design points worth stating

- **Not folded into the existing account-theme effect.** That one is scoped to the `account` theme source, while a stale entitlement arrives by either route — Bloom's local storage paints on cold boot before any account theme lands, and under the `app` source it is the only thing that ever paints.
- **Guarded on the resolved user object**, not on `isAuthenticated`. Entitlement is read from that object; acting while it is undefined would read `isPremium` as false and strip a paying subscriber's theme on every cold boot.

The fallback target is a Mention-side constant that now also feeds the provider, so the two cannot drift. It must be a **free** preset — Bloom's built-in default is `oxy`, which is handle-gated, so falling back to it would hand out a reserved brand colour as a consolation prize for losing one.

## Known and accepted

A **signed-out** viewer keeps whatever is in local storage. The guard needs a resolved user to read entitlement from, and revoking on sign-out would strip a legitimate subscriber's theme every time the session lapses. The effect is local and cosmetic — nothing server-side treats the preset as proof of anything.

## Verification

- `lib/__tests__/colorEntitlement.test.ts` — mutation-checked three ways: letting premium unlock the reserved colours, pointing the fallback at a gated preset, and dropping the handle normalisation each turn exactly one case red.
- `typecheck:frontend` 0 errors · `test:frontend` 1595 passed (165 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)