### PR TITLE
fix(e2e): wait for the followers list, not for the app chrome around it

### DIFF
--- a/packages/e2e/tests/profile-tabs.spec.ts
+++ b/packages/e2e/tests/profile-tabs.spec.ts
@@ -144,23 +144,44 @@ test('a profile pushed from another profile still opens on the default tab', asy
   // thing that has broken, and each row is a `ProfileCard`, i.e. a literal
   // `router.push('/@handle')`.
   await page.goto(`/@${PROFILE_HANDLE}/followers`);
-  await expect(page.locator('[role="button"]').first()).toBeVisible();
 
-  const pushed = await page.evaluate((here: string) => {
-    const cards = Array.from(document.querySelectorAll('[role="button"]')).filter((element) => {
+  // Find the first federated row and focus it. ONE function, used to wait AND to
+  // pick, so what is waited for cannot drift from what is pressed. Focusing while
+  // polling is harmless: it runs only once a match exists, and the same call
+  // below leaves the focus this test's Enter needs.
+  const focusFederatedCard = (here: string): boolean => {
+    const first = Array.from(document.querySelectorAll('[role="button"]')).filter((element) => {
       const text = (element.textContent || '').replace(/\s+/g, ' ').trim();
       if (text.length > 200 || text.includes('·')) return false;
       const match = text.match(/@([a-z0-9_.@-]+)/i);
       // An instance suffix is what makes the actor remote, and therefore cold.
       return Boolean(match) && match?.[1] !== here && Boolean(match?.[1]?.includes('@'));
-    });
-    const first = cards[0];
+    })[0];
     if (!first) return false;
     // Focus + Enter: `mention.earth` renders zero anchors, and a real mouse
     // click on an RNW `Pressable` is a measured no-op.
     (first as HTMLElement).focus();
     return true;
-  }, PROFILE_HANDLE);
+  };
+
+  // Waiting for the first `[role="button"]` was NOT waiting for the list, and
+  // that is what made this gate unpassable. Measured against production: at the
+  // moment that condition is satisfied the page holds TWO buttons — both app
+  // chrome — and ZERO follower rows; the rows arrive ~1.5s later, at which point
+  // there are twenty buttons and seven federated actors. So the gate evaluated an
+  // empty list every time and reported it as "no federated account exists" — a
+  // verdict about the fixture rather than about the candidate, which is what sent
+  // an earlier investigation to the followers API hunting for data that was there
+  // all along.
+  //
+  // A timeout is deliberately NOT an error here: it falls through to the
+  // assertion below, so a fixture that genuinely has no federated follower still
+  // reports exactly as it did before.
+  await page
+    .waitForFunction(focusFederatedCard, PROFILE_HANDLE, { timeout: 20_000 })
+    .catch(() => undefined);
+
+  const pushed = await page.evaluate(focusFederatedCard, PROFILE_HANDLE);
 
   // Not a skip. A skip is indistinguishable from a pass in a report, and this
   // flow exists to block a promotion. If no federated card rendered, the gate


### PR DESCRIPTION
Every Mention frontend deploy is currently blocked by this gate — including the Bloom 0.84.0 bump, which is merged but not live.

## The message sent the investigation the wrong way

The gate reports:

> GATE COULD NOT EVALUATE THIS CANDIDATE: no FEDERATED account appeared in @nate's followers... Set `MENTION_E2E_PROFILE_HANDLE` to an account with at least one remote follower.

@nate **has** seven federated followers and the page renders them (`@rober@masto.es`, `@bagder@mastodon.social`, `@ronimia@mastodon.social`, …). The fixture was never the problem.

## What is actually wrong

`expect(page.locator('[role="button"]').first()).toBeVisible()` does not wait for the list. Measured against production:

| moment | `[role="button"]` | federated rows |
|---|---|---|
| when the wait resolves | **2** (app chrome) | **0** |
| +500ms | 3 | 0 |
| +1500ms | 20 | 7 |

The first button is a nav control, so the gate evaluated an empty document every time and attributed it to the data.

## The fix

The wait polls for a federated row using the **same function** that focuses it, so what is waited for cannot drift from what is pressed. A timeout deliberately does not throw — it falls through to the existing assertion, so a fixture that genuinely has no federated follower still reports exactly as before. The gate keeps refusing to reach a verdict rather than passing vacuously.

**Verified against production**, not reasoned: the flow pushes `/@bagder@mastodon.social` and lands on the default tab, from `@nate` (2.6s) and from `@mention` (2.0s).

## One thing found and deliberately not changed

It predates this fix and is your call. The predicate scans the whole document, so it also matches the **"Who May Know" rail**. Against a profile that does not exist — no followers list at all — it still finds four federated cards and would pass:

```
daniel stenberg@bagder@mastodon.social
Signal@signalapp@mastodon.world
J L Westover@mrlovenstein@mastodon.social
Max Leibman@maxleibman@beige.party
```

So the fixture is less independent than its comment claims ("the followers list is the origin"), and the assertion message names a cause it has not established. Scoping the query to the list would fix both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)