### PR TITLE
cutover: flip Mention to PostgreSQL

### DIFF
--- a/.github/scripts/smoke-mention.sh
+++ b/.github/scripts/smoke-mention.sh
@@ -157,6 +157,62 @@ expect_status() {
   fail_check "$name" "$name returned HTTP $actual (expected $expected)"
 }
 
+# `expect_nonempty_collection <name> <jq-path> <what>` — the VACUITY FLOOR.
+#
+# A 200 says the process answered. It does not say the process has a database
+# behind it: an empty store answers the anonymous feed with `{"data":{"items":
+# []}}` and HTTP 200, so `expect_status` alone cannot tell a healthy deployment
+# from one pointed at nothing. That is not hypothetical — a trunk image went
+# live against an empty Postgres on 2026-08-04, these checks passed, and the
+# rollback came from an unrelated post-deploy task crashing.
+#
+# It needs no "we are mid-migration" escape hatch, and that is a property of the
+# runbook rather than luck: `docs/MONGO-TO-POSTGRES-CUTOVER.md` §3.4 deploys
+# AFTER §3.3 copies, and the service sits at desired count 0 in between, so the
+# only moment the store is legitimately empty is a moment this script does not
+# run. If that ORDER ever changes, this check is what will notice.
+#
+# Prints what it counted and what it required on SUCCESS too. A check that says
+# only "passed" leaves nobody able to tell later whether it looked at anything —
+# which is how a capped or empty result becomes a fact about the system rather
+# than a fact about the measurement.
+expect_nonempty_collection() {
+  local name="$1"
+  local path="$2"
+  local what="$3"
+
+  if [[ -n "${check_failed[$name]:-}" ]]; then
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    # A missing tool says nothing about the deployed image, so it must not
+    # revert one — the same rule the ERR trap follows.
+    echo "::error::jq is not installed, so $name's population floor could not be evaluated. Refusing to attribute that to the deployed image."
+    exit "$NO_ROLLBACK_EXIT"
+  fi
+
+  # TYPE first, then length, and the order is the check. `jq` answers
+  # `null | length` with 0, so counting straight away reports a response whose
+  # SHAPE changed — a missing key, a renamed field, an error object — as "the
+  # store is empty". Both end in a rollback, but they send whoever reads the log
+  # to different places, and a floor that cannot tell them apart is a floor that
+  # states a fact about the data on the strength of a fact about the parser.
+  local kind count
+  kind="$(jq -r "$path | type" "$smoke_dir/$name.body" 2>/dev/null || true)"
+  if [[ "$kind" != "array" ]]; then
+    fail_check "$name" \
+      "$name returned a body with no \`$path\` array at all (found: ${kind:-unparseable}), so $what could not be counted. This is a response SHAPE change, not an empty store"
+    return 0
+  fi
+  count="$(jq -r "$path | length" "$smoke_dir/$name.body")"
+  if (( count < 1 )); then
+    fail_check "$name" \
+      "$name returned 0 $what (\`$path\` is empty). The process answered, so this is not a dead task — it is a LIVE task whose store has nothing in it. Check that the image is pointed at the populated database"
+    return 0
+  fi
+  echo "::notice::$name: $count $what (floor 1, from \`$path\`)."
+}
+
 expect_json_response() {
   local name="$1"
 
@@ -182,8 +238,14 @@ expect_status readiness "$http_status" 200
 # The anonymous feed is the widest read path in the app. It is hermetic despite
 # touching Oxy: author hydration soft-fails to a degraded summary rather than
 # throwing, so an oxy-api outage costs display names here, not a 5xx.
-request hermetic anonymous-feed "$API_ORIGIN/feed/mtn?descriptor=for_you&limit=1"
+#
+# `limit=8` rather than 1: the floor asks whether the store has content, and a
+# single-item page can be emptied by one ranking decision about one post, which
+# would make this fire on a healthy deployment. A for-you page that yields
+# nothing at all across eight is a store answer, not a ranking answer.
+request hermetic anonymous-feed "$API_ORIGIN/feed/mtn?descriptor=for_you&limit=8"
 expect_status anonymous-feed "$http_status" 200
+expect_nonempty_collection anonymous-feed '.data.items' 'feed item(s)'
 
 # --- dependent: mention.earth, a Cloudflare-proxied record -------------------
 

--- a/.github/scripts/test-smoke-mention.sh
+++ b/.github/scripts/test-smoke-mention.sh
@@ -60,9 +60,14 @@ curl() {
   local status_variable="SMOKE_TEST_STATUS_${key}"
   local content_type_variable="SMOKE_TEST_CT_${key}"
   local curl_exit_variable="SMOKE_TEST_CURL_EXIT_${key}"
+  # The BODY matters now, not just the status: an empty store answers the
+  # anonymous feed with HTTP 200 and no items, so a scenario that cannot vary
+  # the body cannot express the failure the population floor exists for.
+  local body_variable="SMOKE_TEST_BODY_${key}"
   status="${!status_variable:-}"
   content_type="${!content_type_variable:-application/json; charset=utf-8}"
   curl_exit="${!curl_exit_variable:-0}"
+  local body="${!body_variable:-\{\}}"
 
   if [[ -z "$status" ]]; then
     echo "Stubbed curl has no configured status for check $name." >&2
@@ -79,7 +84,7 @@ curl() {
   fi
 
   printf 'HTTP/2 %s\r\ncontent-type: %s\r\n\r\n' "$status" "$content_type" >"$dump_header"
-  [[ -n "$output" ]] && printf '{}' >"$output"
+  [[ -n "$output" ]] && printf '%s' "$body" >"$output"
   printf '%s\n' "$status"
 }
 export -f curl
@@ -100,6 +105,11 @@ run_scenario() {
     SMOKE_TEST_STATUS_webfinger=404
     SMOKE_TEST_STATUS_actor=404
     SMOKE_TEST_STATUS_inbox=404
+    # A healthy production answers the anonymous feed with POSTS. Defaulted here
+    # rather than per scenario so every existing scenario keeps describing a
+    # populated store, and only a scenario that says otherwise is testing the
+    # empty case.
+    'SMOKE_TEST_BODY_anonymous_feed={"success":true,"data":{"items":[{"id":"p1"},{"id":"p2"}]}}'
     "$@"
   )
 
@@ -210,5 +220,34 @@ expect_output hermetic-outranks-dependent "readiness returned HTTP 503 (expected
 expect_output hermetic-outranks-dependent "webfinger returned HTTP 500 (expected 404)"
 expect_output hermetic-outranks-dependent "rolling the deployment back"
 refute_output hermetic-outranks-dependent "will NOT be rolled back"
+
+# --- the population floor ----------------------------------------------------
+#
+# On 2026-08-04 a trunk image went live against an EMPTY Postgres, every check
+# here passed, and the rollback came from an unrelated post-deploy task
+# crashing. A 200 says the process answered; it says nothing about whether the
+# process has a database behind it.
+
+# The case the floor exists for: HTTP 200, valid JSON, zero content. Hermetic,
+# because only the deployed image decides which store it reads.
+run_scenario feed-empty-store 1 \
+  'SMOKE_TEST_BODY_anonymous_feed={"success":true,"data":{"items":[]}}'
+expect_output feed-empty-store "anonymous-feed returned 0 feed item(s)"
+expect_output feed-empty-store "it is a LIVE task whose store has nothing in it"
+expect_output feed-empty-store "This check is hermetic"
+expect_output feed-empty-store "rolling the deployment back"
+
+# A shape change must not read as "no data" — nor pass silently. Both readings
+# are wrong in the same direction: they would let an unrecognisable response
+# through as if it had been counted.
+run_scenario feed-missing-items 1 \
+  'SMOKE_TEST_BODY_anonymous_feed={"success":true,"data":{}}'
+expect_output feed-missing-items "no \`.data.items\` array at all"
+expect_output feed-missing-items "rolling the deployment back"
+
+# The CONTROL, and it is what stops the two scenarios above from passing under a
+# floor that fails on everything: a populated store still passes, and says what
+# it counted rather than only that it passed.
+expect_output healthy "anonymous-feed: 2 feed item(s) (floor 1, from \`.data.items\`)"
 
 echo "Mention smoke check classification tests passed."

--- a/bun.lock
+++ b/bun.lock
@@ -3324,7 +3324,6 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
-
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -3512,7 +3511,6 @@
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "@redis/client/cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
-
 
     "@syra.fm/sdk/expo-audio": ["expo-audio@56.0.12", "", { "peerDependencies": { "expo": "*", "expo-asset": "*", "react": "*", "react-native": "*" } }, "sha512-ne2UIO/HsQoBL9e+tGs5N9Sf3NyW5sJMm4sDkexbSJRc2IchLDG+9Msu/+l5N4RlZ8SiF42wRyWsh/Usg+SwOw=="],
 

--- a/packages/backend/scripts/migrate.ts
+++ b/packages/backend/scripts/migrate.ts
@@ -9,20 +9,46 @@
 
 import mongoose from 'mongoose';
 import { logger } from '../src/utils/logger';
+import { closePostgres, connectPostgres } from '../src/db/postgres';
 import { runMigrationTask } from '../src/migrations/task';
 
+/**
+ * BOTH stores, and Postgres is not optional here despite this being the MONGO
+ * migration one-shot.
+ *
+ * A one-shot entry point gets none of `server.ts`'s startup, so whatever it
+ * reaches must be opened here. `runMigrationTask`'s own docblock says the only
+ * live payload left is `reconcileBlockedDomains` and that it "is Postgres-only"
+ * — and that payload runs `purgeBlockedDomainContent`, whose own
+ * `connectPostgres` lives inside a `require.main === module` block and therefore
+ * does NOT run for an importer. Without this the first `getDb()` throws
+ * `PostgreSQL is not connected`, which `reconcileBlockedDomains` catches and
+ * logs as fail-soft — so blocking a domain silently stops purging its content
+ * while the deploy reports success.
+ *
+ * Nothing went red when the purge was ported (2026-08-02, `cd122151`) because
+ * the link between an entry point and the store its callee reads is a RUNTIME
+ * CONNECTION, not a symbol: `tsc` cannot see it and no test runs this file.
+ */
 async function main(): Promise<void> {
+  await connectPostgres();
   await runMigrationTask();
 }
 
 void main()
   .then(async () => {
-    await mongoose.disconnect();
+    await Promise.all([mongoose.disconnect(), closePostgres()]);
     logger.info('[migration] all migrations are current');
     process.exit(0);
   })
   .catch(async (error) => {
     logger.error('[migration] migration task failed', error);
-    await mongoose.disconnect().catch(() => undefined);
+    // Both, and both tolerant: a failure BEFORE either connect must still reach
+    // `process.exit(1)` rather than dying in its own cleanup. `closePostgres`
+    // is already a no-op when the pool was never opened.
+    await Promise.all([
+      mongoose.disconnect().catch(() => undefined),
+      closePostgres().catch(() => undefined),
+    ]);
     process.exit(1);
   });

--- a/packages/backend/scripts/reconcile-engagement-projections.ts
+++ b/packages/backend/scripts/reconcile-engagement-projections.ts
@@ -4,25 +4,30 @@
  * This runs only after the new transactional writers have fully replaced the
  * legacy ECS tasks. It closes the narrow pre-rollout migration window without
  * putting reconciliation into request latency.
+ *
+ * Postgres-only, because `reconcileEngagementProjections` reads and writes
+ * exclusively through Drizzle. A one-shot gets none of `server.ts`'s startup,
+ * so it must open the pool itself: without `connectPostgres()` the service's
+ * first `getDb()` throws `PostgreSQL is not connected`, this task exits 1, and
+ * `deploy-aws.yml` rolls the whole service back on every deploy.
  */
 
-import mongoose from 'mongoose';
-import { connectToDatabase } from '../src/utils/database';
+import { closePostgres, connectPostgres } from '../src/db/postgres';
 import { reconcileEngagementProjections } from '../src/services/EngagementProjectionReconciliationService';
 import { logger } from '../src/utils/logger';
 
 async function main(): Promise<void> {
-  await connectToDatabase();
+  await connectPostgres();
   await reconcileEngagementProjections();
 }
 
 void main()
   .then(async () => {
-    await mongoose.disconnect();
+    await closePostgres();
     process.exit(0);
   })
   .catch(async (error) => {
     logger.error('[EngagementProjectionReconciliation] task failed', error);
-    await mongoose.disconnect().catch(() => undefined);
+    await closePostgres().catch(() => undefined);
     process.exit(1);
   });

--- a/packages/backend/src/__tests__/db/backfillFederationPlans.test.ts
+++ b/packages/backend/src/__tests__/db/backfillFederationPlans.test.ts
@@ -845,6 +845,39 @@ describe('duplicate federated actors', () => {
     expect(plan.actedOn.get(KEEP_FRESHEST_FEDERATED_ACTOR.id)?.size).toBe(2);
   });
 
+  it('re-keys a lone sentinel row whose acct is padded with whitespace MONGO does not trim', async () => {
+    // `isUnresolvedAtprotoHandle` trims with JavaScript, which strips all
+    // Unicode whitespace; Mongo's `$trim` strips a fixed set that does NOT
+    // include U+3000. So a pipeline arm written as "equals after trimming" is
+    // NARROWER than the predicate it stands in for, and this row would keep the
+    // sentinel — silently, and only when it is alone, since a colliding group
+    // arrives through `count > 1` instead. Measured on a real mongod: `$trim`
+    // handles NBSP but not U+2028, U+FEFF or U+3000.
+    const did = 'did:plc:bffpaddedsentinel00000000';
+    await mongo.collection('federatedactors').insertOne({
+      _id: oid(66),
+      uri: did,
+      protocol: 'atproto',
+      username: 'handle.invalid',
+      domain: 'bsky.social',
+      acct: '　handle.invalid',
+      lastFetchedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+
+    const plan = await planResolutions(source);
+    expect(plan.rekeyedActorIdentities.has(oid(66).toHexString())).toBe(true);
+
+    await copy('federatedactors');
+    const [row] = await getDb()
+      .select()
+      .from(federatedActors)
+      .where(eq(federatedActors.uri, did));
+    // The sentinel survives nowhere — a copy left in one column is a copy the
+    // next collision is built from.
+    expect(row?.acct).toBe(did);
+    expect(row?.username).toBe(did);
+  });
+
   it('re-keys a LONE sentinel row, which no collision would ever reach', async () => {
     // `handle.invalid` identifies nobody whether or not a second row carries
     // it, so a `count > 1` pre-pass would leave this row holding a value that

--- a/packages/backend/src/__tests__/scripts/oneShotPoolCoverage.test.ts
+++ b/packages/backend/src/__tests__/scripts/oneShotPoolCoverage.test.ts
@@ -1,0 +1,397 @@
+/**
+ * A one-shot entry point that reaches the Postgres pool must OPEN it.
+ *
+ * ## The defect this exists for leaves nothing to go red
+ *
+ * `scripts/reconcile-engagement-projections.ts` opened only Mongo while
+ * `EngagementProjectionReconciliationService` had been ported to Drizzle. Its
+ * first `getDb()` threw `PostgreSQL is not connected`, the task exited 1, and
+ * every deploy rolled back. `scripts/migrate.ts` had the same shape through
+ * `runMigrationTask` → `reconcileBlockedDomains` → `purgeBlockedDomainContent`,
+ * where the throw is caught as fail-soft — so blocking a domain silently
+ * stopped purging its content while the deploy reported success.
+ *
+ * **Nothing went red either time, and nothing could have.** The link between an
+ * entry point and the store its callee reads is a RUNTIME CONNECTION, not a
+ * symbol: `tsc` sees a valid import graph, and no test executes these files. A
+ * clean cut gives TS2307; this gives a green build and a container that dies on
+ * its first query. So the property has to be checked STATICALLY, from the
+ * module graph, which is what this does.
+ *
+ * ## Why a graph and not a grep
+ *
+ * `reconcile-engagement-projections.ts` imports zero Drizzle. It needs the pool
+ * because a service two hops away calls `getDb()`. A grep for `drizzle` or
+ * `getDb` in the entry point finds nothing in either of the two real cases.
+ *
+ * ## The over-approximation, and how the exemption stays honest
+ *
+ * Module reachability is not call reachability: an entry that imports one PURE
+ * function from a module which ALSO calls `getDb()` elsewhere is flagged
+ * although no call path reaches the pool. That is the safe direction (it asks
+ * for a connect that is not strictly needed) but it is also how a gate starts
+ * crying wolf, so {@link PURE_IMPORT_EXEMPTIONS} records those — and each entry
+ * NAMES the symbols it may import from the offending module. Import anything
+ * else from it and the exemption stops applying, so the escape hatch cannot
+ * quietly widen into "this script is allowed to skip the pool".
+ *
+ * A stale exemption is also a failure: if an exempted entry stops reaching the
+ * module at all, the declaration has to go rather than sit there looking like
+ * it protects something.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+
+/** `packages/backend`. */
+const BACKEND = resolve(__dirname, '../../..');
+const POSTGRES_MODULE = resolve(BACKEND, 'src/db/postgres.ts');
+
+/** Calling either of these requires a pool that someone already opened. */
+const POOL_READERS = new Set(['getDb', 'getPostgresClient']);
+const OPENER = 'connectPostgres';
+
+/** Where a Fargate one-shot's `command` can point. */
+const ENTRY_DIRS = ['scripts', 'src/scripts'];
+
+/**
+ * The FLOOR. A traversal that silently stopped finding entry points would pass
+ * every assertion below while checking nothing, so the count is asserted first.
+ * Deliberately a floor and not an equality: adding a script must not fail this.
+ */
+const MIN_ENTRY_POINTS = 30;
+
+/**
+ * Entries whose only route into a pool-using module is through symbols that
+ * cannot reach the pool.
+ *
+ * `symbols` is the whole point: it is re-checked against the file's real
+ * imports on every run, so this cannot decay into a blanket exemption.
+ */
+const PURE_IMPORT_EXEMPTIONS: ReadonlyArray<{
+  readonly entry: string;
+  readonly module: string;
+  readonly symbols: readonly string[];
+  readonly reason: string;
+}> = [
+  {
+    entry: 'src/scripts/purgeBlockedDomainPlatformData.ts',
+    module: 'src/scripts/purgeBlockedDomainContent.ts',
+    symbols: ['buildBlockedContentDomains'],
+    reason:
+      'It purges a domain on the PLATFORM (Oxy), not in our stores, and calls ' +
+      '`getDb` nowhere itself. Its one edge into the content purge is ' +
+      '`buildBlockedContentDomains`, which folds a blocklist and our own ' +
+      'domains into a set of targets and touches no store — the module around ' +
+      'it is what reads Postgres.',
+  },
+];
+
+interface ImportRecord {
+  readonly spec: string;
+  readonly names: ReadonlyArray<{ imported: string; local: string }>;
+}
+
+/**
+ * Every VALUE import, static or dynamic.
+ *
+ * `import type` and per-specifier `type` are excluded because a type cannot
+ * call anything; dynamic `await import(...)` is INCLUDED because
+ * `evalFeedQuality.ts` reaches the pool that way and a static-only reader
+ * called it pool-free.
+ */
+function valueImports(src: string): ImportRecord[] {
+  const out: ImportRecord[] = [];
+  const destructured = /(?:const|let|var)\s*(\{[\s\S]*?\})\s*=\s*await\s+import\(\s*['"]([^'"]+)['"]\s*\)/g;
+  for (const match of src.matchAll(destructured)) {
+    out.push({ spec: match[2] ?? '', names: readBindings(match[1] ?? '', ':') });
+  }
+  for (const match of src.matchAll(/await\s+import\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+    out.push({ spec: match[1] ?? '', names: [] });
+  }
+  for (const match of src.matchAll(/import\s+(type\s+)?([\s\S]*?)\s*from\s*['"]([^'"]+)['"]/g)) {
+    if (match[1]) continue;
+    const braces = /\{([\s\S]*?)\}/.exec(match[2] ?? '');
+    out.push({ spec: match[3] ?? '', names: braces ? readBindings(braces[1] ?? '', ' as ') : [] });
+  }
+  return out;
+}
+
+/** `{ a, b as c }` / `{ a, b: c }` → the imported name and the local one. */
+function readBindings(clause: string, separator: string): Array<{ imported: string; local: string }> {
+  const out: Array<{ imported: string; local: string }> = [];
+  for (const part of clause.replace(/[{}]/g, '').split(',')) {
+    const trimmed = part.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('type ')) continue;
+    const [imported, local] = trimmed.split(separator === ':' ? /\s*:\s*/ : /\s+as\s+/);
+    out.push({ imported: (imported ?? '').trim(), local: (local ?? imported ?? '').trim() });
+  }
+  return out;
+}
+
+function resolveImport(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith('.')) return null;
+  const base = resolve(dirname(fromFile), spec);
+  for (const candidate of [`${base}.ts`, `${base}/index.ts`, base]) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) return resolve(candidate);
+  }
+  return null;
+}
+
+/**
+ * The source with comments and string bodies blanked out, for CALL detection.
+ *
+ * Not a nicety. Every file that fixes this bug explains itself in a docblock,
+ * and those docblocks say `connectPostgres()` — with parentheses. Against the
+ * raw text the call check therefore matched the PROSE, so deleting the real
+ * call from `reconcile-engagement-projections.ts` (the defect that rolled back
+ * every deploy) left this gate green. A gate that a comment can satisfy is
+ * worse than no gate.
+ *
+ * Written as ONE pass over the characters rather than chained replaces: a
+ * comment strip followed by a string strip desynchronises on the first
+ * apostrophe in prose (`server.ts's startup`), and the failure mode is a file
+ * that reports NO matches, which reads exactly like success.
+ *
+ * Lengths are preserved so nothing else has to care that this happened.
+ */
+function stripCommentsAndStrings(src: string): string {
+  let out = '';
+  let state: 'code' | 'line' | 'block' | '"' | "'" | '`' = 'code';
+  for (let index = 0; index < src.length; index += 1) {
+    const char = src[index] ?? '';
+    const next = src[index + 1] ?? '';
+    if (state === 'code') {
+      if (char === '/' && next === '/') { state = 'line'; out += '  '; index += 1; continue; }
+      if (char === '/' && next === '*') { state = 'block'; out += '  '; index += 1; continue; }
+      if (char === '"' || char === "'" || char === '`') { state = char; out += ' '; continue; }
+      out += char;
+      continue;
+    }
+    if (state === 'line') {
+      if (char === '\n') { state = 'code'; out += '\n'; continue; }
+      out += ' ';
+      continue;
+    }
+    if (state === 'block') {
+      if (char === '*' && next === '/') { state = 'code'; out += '  '; index += 1; continue; }
+      out += char === '\n' ? '\n' : ' ';
+      continue;
+    }
+    // Inside a string: an escape consumes the next character, so a `\'` cannot
+    // close it and a `\\` cannot escape the quote that follows.
+    if (char === '\\') { out += '  '; index += 1; continue; }
+    if (char === state) { state = 'code'; out += ' '; continue; }
+    out += char === '\n' ? '\n' : ' ';
+  }
+  return out;
+}
+
+interface Module {
+  readonly file: string;
+  readonly src: string;
+  /** {@link src} with comments and string bodies blanked — see the function. */
+  readonly code: string;
+  readonly imports: readonly ImportRecord[];
+}
+
+const modules = new Map<string, Module>();
+function readModule(file: string): Module | null {
+  const cached = modules.get(file);
+  if (cached) return cached;
+  let src: string;
+  try {
+    src = readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  // Imports are parsed from the RAW source — the specifier lives INSIDE a
+  // string, so a stripped copy has no module paths left to resolve. Calls are
+  // detected from the stripped copy. The two reads want opposite things.
+  const mod: Module = { file, src, code: stripCommentsAndStrings(src), imports: valueImports(src) };
+  modules.set(file, mod);
+  return mod;
+}
+
+/**
+ * Does this module CALL one of the pool readers?
+ *
+ * Keyed on the LOCAL name the file bound, not on the exported one — an aliased
+ * import is still a call, and a name-only grep would miss it.
+ */
+function callsPoolReader(mod: Module): boolean {
+  return bindsAndCalls(mod, (imported) => POOL_READERS.has(imported));
+}
+
+function callsOpener(mod: Module): boolean {
+  return bindsAndCalls(mod, (imported) => imported === OPENER);
+}
+
+function bindsAndCalls(mod: Module, wanted: (imported: string) => boolean): boolean {
+  for (const record of mod.imports) {
+    if (resolveImport(mod.file, record.spec) !== POSTGRES_MODULE) continue;
+    for (const { imported, local } of record.names) {
+      if (wanted(imported) && new RegExp(`\\b${local}\\s*\\(`).test(mod.code)) return true;
+    }
+  }
+  return false;
+}
+
+/** Every module transitively imported, with the edge each was first reached by. */
+function graphOf(entry: string): { reached: Set<string>; via: Map<string, string> } {
+  const reached = new Set<string>();
+  const via = new Map<string, string>();
+  const stack = [entry];
+  while (stack.length > 0) {
+    const file = stack.pop();
+    if (file === undefined || reached.has(file)) continue;
+    reached.add(file);
+    const mod = readModule(file);
+    if (!mod) continue;
+    for (const record of mod.imports) {
+      const target = resolveImport(file, record.spec);
+      if (target === null || reached.has(target)) continue;
+      if (!via.has(target)) via.set(target, file);
+      stack.push(target);
+    }
+  }
+  return { reached, via };
+}
+
+function chainTo(via: Map<string, string>, entry: string, file: string): string[] {
+  const out: string[] = [];
+  let cursor: string | undefined = file;
+  while (cursor !== undefined && cursor !== entry) {
+    out.unshift(relative(BACKEND, cursor));
+    cursor = via.get(cursor);
+  }
+  return out;
+}
+
+const entryPoints = ENTRY_DIRS.flatMap((dir) => {
+  const absolute = resolve(BACKEND, dir);
+  if (!existsSync(absolute)) return [];
+  return readdirSync(absolute)
+    .filter((name) => name.endsWith('.ts') && !name.endsWith('.d.ts'))
+    .map((name) => resolve(absolute, name))
+    .filter((file) => statSync(file).isFile());
+});
+
+interface Verdict {
+  readonly entry: string;
+  readonly rel: string;
+  readonly opens: boolean;
+  /** Pool-using modules in the graph, each with the chain that reached it. */
+  readonly reachedPoolVia: ReadonlyArray<{ module: string; chain: readonly string[] }>;
+}
+
+const verdicts: Verdict[] = entryPoints.map((entry) => {
+  const { reached, via } = graphOf(entry);
+  const reachedPoolVia: Array<{ module: string; chain: readonly string[] }> = [];
+  for (const file of reached) {
+    const mod = modules.get(file);
+    if (mod && callsPoolReader(mod)) {
+      reachedPoolVia.push({ module: relative(BACKEND, file), chain: chainTo(via, entry, file) });
+    }
+  }
+  const own = readModule(entry);
+  return {
+    entry,
+    rel: relative(BACKEND, entry),
+    opens: own !== null && callsOpener(own),
+    reachedPoolVia,
+  };
+});
+
+/** The exemption applies only while the entry imports NOTHING ELSE from the module. */
+function exemptionFor(verdict: Verdict) {
+  const declared = PURE_IMPORT_EXEMPTIONS.find((entry) => entry.entry === verdict.rel);
+  if (!declared) return null;
+  const own = readModule(verdict.entry);
+  if (!own) return null;
+  const target = resolve(BACKEND, declared.module);
+  const imported = own.imports
+    .filter((record) => resolveImport(verdict.entry, record.spec) === target)
+    .flatMap((record) => record.names.map((name) => name.imported));
+  return { declared, imported };
+}
+
+describe('one-shot entry points and the Postgres pool', () => {
+  it(`scans at least ${MIN_ENTRY_POINTS} entry points`, () => {
+    // The vacuity floor. Every assertion below is over `verdicts`, so a
+    // traversal that found nothing would pass all of them.
+    expect(entryPoints.length).toBeGreaterThanOrEqual(MIN_ENTRY_POINTS);
+  });
+
+  it('finds entry points that DO reach the pool, so the check is not inert', () => {
+    // The second floor: if the import walker broke, every entry would read as
+    // pool-free and the real assertion would pass vacuously.
+    expect(verdicts.filter((verdict) => verdict.reachedPoolVia.length > 0).length).toBeGreaterThan(20);
+  });
+
+  it('opens the pool in every entry point whose import graph reaches it', () => {
+    const offenders = verdicts
+      .filter((verdict) => verdict.reachedPoolVia.length > 0 && !verdict.opens)
+      .filter((verdict) => exemptionFor(verdict) === null)
+      .map((verdict) => {
+        const first = verdict.reachedPoolVia[0];
+        return `${verdict.rel}\n      reaches ${first?.module} via ${first?.chain.join(' -> ')}`;
+      });
+
+    // Named, not counted: "3 scripts are wrong" sends whoever reads it looking.
+    expect(
+      offenders,
+      `These one-shots reach getDb()/getPostgresClient() but never call ${OPENER}(). ` +
+        'A one-shot gets none of server.ts\'s startup, so the first query throws ' +
+        '"PostgreSQL is not connected" — as a hard exit if nothing catches it, or ' +
+        'silently if something does.'
+    ).toEqual([]);
+  });
+
+  it('does not read a function NAMED in a comment as a call to it', () => {
+    // The fixture in the gap, and it is the exact shape that made this gate
+    // vacuous: every file that fixes the bug explains itself in a docblock, and
+    // the docblock says `connectPostgres()`.
+    const prose = [
+      '/**',
+      " * A one-shot gets none of server.ts's startup, so it must call",
+      ' * `connectPostgres()` itself or the first `getDb()` throws.',
+      ' */',
+      "import { connectPostgres } from '../src/db/postgres';",
+      'async function main() { await runIt(); }',
+    ].join('\n');
+    const stripped = stripCommentsAndStrings(prose);
+    expect(/\bconnectPostgres\s*\(/.test(prose)).toBe(true);
+    expect(/\bconnectPostgres\s*\(/.test(stripped)).toBe(false);
+    // And the strip must not eat the code around it — an over-eager stripper
+    // would make every call invisible and this gate green forever.
+    expect(stripped).toContain('async function main');
+    expect(stripped).toContain('await runIt(');
+    expect(stripped.length).toBe(prose.length);
+  });
+
+  it('keeps every pure-import exemption honest and current', () => {
+    for (const declared of PURE_IMPORT_EXEMPTIONS) {
+      const verdict = verdicts.find((entry) => entry.rel === declared.entry);
+      expect(verdict, `${declared.entry} is exempted but is not an entry point`).toBeDefined();
+      if (!verdict) continue;
+
+      // STALE: it no longer reaches a pool-using module, so the exemption is
+      // claiming to protect something that is not happening.
+      expect(
+        verdict.reachedPoolVia.length,
+        `${declared.entry} no longer reaches the pool — delete its exemption`
+      ).toBeGreaterThan(0);
+
+      // WIDENED: it now imports something else from the module it was exempted
+      // for, and that something may well read the pool.
+      const resolved = exemptionFor(verdict);
+      expect(resolved?.imported.length ?? 0).toBeGreaterThan(0);
+      expect(
+        [...(resolved?.imported ?? [])].sort(),
+        `${declared.entry} imports more from ${declared.module} than the exemption allows`
+      ).toEqual([...declared.symbols].sort());
+    }
+  });
+});

--- a/packages/backend/src/__tests__/scripts/oneShotPoolCoverage.test.ts
+++ b/packages/backend/src/__tests__/scripts/oneShotPoolCoverage.test.ts
@@ -56,6 +56,22 @@ const OPENER = 'connectPostgres';
 const ENTRY_DIRS = ['scripts', 'src/scripts'];
 
 /**
+ * One-shots that do NOT live in an entry directory.
+ *
+ * Enumerating by DIRECTORY is a guess about where entry points live, and it is
+ * wrong for at least one: `.github/scripts/deploy-ecs-image.sh` runs
+ * `packages/backend/dist/src/db/migrate.js` as the FIRST migration one-shot of
+ * every deploy — the step whose own comment calls Postgres "the store that can
+ * invalidate the whole rollout". A directory scan would have left the most
+ * consequential entry point in the deploy unchecked.
+ *
+ * It passes today for a reason that does not generalise: it builds its own
+ * `postgres(url, …)` client rather than going through `connectPostgres`. The
+ * day it imports a service instead, this is what notices.
+ */
+const EXTRA_ENTRY_POINTS = ['src/db/migrate.ts'];
+
+/**
  * The FLOOR. A traversal that silently stopped finding entry points would pass
  * every assertion below while checking nothing, so the count is asserted first.
  * Deliberately a floor and not an equality: adding a script must not fail this.
@@ -269,14 +285,17 @@ function chainTo(via: Map<string, string>, entry: string, file: string): string[
   return out;
 }
 
-const entryPoints = ENTRY_DIRS.flatMap((dir) => {
-  const absolute = resolve(BACKEND, dir);
-  if (!existsSync(absolute)) return [];
-  return readdirSync(absolute)
-    .filter((name) => name.endsWith('.ts') && !name.endsWith('.d.ts'))
-    .map((name) => resolve(absolute, name))
-    .filter((file) => statSync(file).isFile());
-});
+const entryPoints = [
+  ...ENTRY_DIRS.flatMap((dir) => {
+    const absolute = resolve(BACKEND, dir);
+    if (!existsSync(absolute)) return [];
+    return readdirSync(absolute)
+      .filter((name) => name.endsWith('.ts') && !name.endsWith('.d.ts'))
+      .map((name) => resolve(absolute, name))
+      .filter((file) => statSync(file).isFile());
+  }),
+  ...EXTRA_ENTRY_POINTS.map((entry) => resolve(BACKEND, entry)),
+];
 
 interface Verdict {
   readonly entry: string;
@@ -318,6 +337,15 @@ function exemptionFor(verdict: Verdict) {
 }
 
 describe('one-shot entry points and the Postgres pool', () => {
+  it('scans every declared out-of-directory entry point', () => {
+    // A path that stopped existing would silently drop out of the scan and take
+    // its coverage with it, which is the same failure the directory walk has —
+    // one file at a time instead of a whole directory.
+    for (const entry of EXTRA_ENTRY_POINTS) {
+      expect(existsSync(resolve(BACKEND, entry)), `${entry} is declared but missing`).toBe(true);
+    }
+  });
+
   it(`scans at least ${MIN_ENTRY_POINTS} entry points`, () => {
     // The vacuity floor. Every assertion below is over `verdicts`, so a
     // traversal that found nothing would pass all of them.

--- a/packages/backend/src/db/backfill/resolutions.ts
+++ b/packages/backend/src/db/backfill/resolutions.ts
@@ -1081,14 +1081,26 @@ async function planActorIdentityRekeys(source: MongoSource): Promise<{
               { count: { $gt: 1 } },
               // The sentinel identifies nobody even when it appears ONCE, so a
               // lone row carrying it is re-keyed too — which `count > 1` alone
-              // would never reach. Trimmed and lower-cased for the same reason
-              // `isUnresolvedAtprotoHandle` does it, and built from the shared
-              // constant rather than a second copy of the literal. That
-              // function stays the AUTHORITY and is re-applied below; this only
-              // decides what leaves Mongo, and must never be narrower than it.
+              // would never reach.
+              //
+              // CONTAINS, not equals-after-trimming, and the difference is
+              // measured rather than stylistic. `isUnresolvedAtprotoHandle`
+              // stays the AUTHORITY and is re-applied below, so this arm only
+              // has to be a SUPERSET of it — and `$trim` is not one. Mongo's
+              // `$trim` strips a fixed ASCII whitespace set plus NBSP, while
+              // JavaScript's `.trim()` strips all Unicode whitespace, so an
+              // `acct` padded with U+2028, U+FEFF or U+3000 satisfies the
+              // predicate and NOT the pipeline: a lone row carrying one would
+              // have kept the sentinel, silently, where the pre-unification
+              // transform re-keyed it. Containment cannot have that gap —
+              // trimming only removes leading and trailing characters, so any
+              // value whose trimmed lower-case IS the sentinel still contains
+              // it — and it needs no belief about either whitespace set.
+              // Returning a few extra groups (`xhandle.invalidy`) costs one
+              // rejected group in TypeScript.
               {
                 $expr: {
-                  $eq: [{ $toLower: { $trim: { input: '$_id' } } }, UNRESOLVED_HANDLE],
+                  $ne: [{ $indexOfCP: [{ $toLower: '$_id' }, UNRESOLVED_HANDLE] }, -1],
                 },
               },
             ],


### PR DESCRIPTION
Las tres ramas retenidas del cutover, combinadas para que la ventana sea **un solo merge y un solo deploy**.

| rama | qué aporta |
|---|---|
| `fix/reconcile-connect-postgres` | la tarea post-deploy abre el pool de Postgres — sin esto todo deploy hacía rollback |
| `feat/smoke-population-floor` | suelo post-deploy: el smoke deja de reportar sana una base vacía |
| `drizzle/actor-acct-collision` | superset de whitespace en el re-key + el agujero del gate de one-shots |

**MERGEAR SOLO DENTRO DE LA VENTANA.** Al mergear, `main` va verde, dispara deploy, y el suelo pre-rollout ya pasa (Postgres poblado) — o sea que **este merge ES el flip a PostgreSQL**.

Verificado en local: `tsc` 0, 6.407 tests, suite completa del backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)