### PR TITLE
perf(feed,search): give the planner an index it can reach on three hot paths — and stop the profile feed losing posts

### DIFF
--- a/packages/backend/src/__tests__/authorFeedMatch.test.ts
+++ b/packages/backend/src/__tests__/authorFeedMatch.test.ts
@@ -1,0 +1,201 @@
+/**
+ * What `authorFeedSql` MATCHES — the profile feed's membership rule, against a
+ * real database.
+ *
+ * The rule is "this post is `authorId`'s", and it is answered by two terms:
+ * the `post_authorships` `EXISTS` (the authority) OR the denormalized
+ * `posts.oxy_user_id` mirror. Every case below exists because ONE of those two
+ * terms answers it and the other does not — so a formulation that keeps only one
+ * of them fails by naming the post it dropped.
+ *
+ * That is the whole point of the file. The obvious "optimisation" here is to
+ * trade the correlated `EXISTS` for the cheap mirror, or to narrow it to
+ * `role = 'collaborator'` on the grounds that the mirror already covers owners.
+ * Both are measurably faster and both silently DROP rows — which matters more
+ * than usual, because the defect this feed was reported for is posts MISSING
+ * from their own author's profile. A speedup that loses posts is that bug with a
+ * better latency graph.
+ *
+ * ## These are not invariant assertions, deliberately
+ *
+ * The mirror is documented (`db/schema/postContent.ts`) as always agreeing with
+ * the `owner` authorship row, and an earlier draft of this suite asserted that
+ * agreement directly. That test guards the wrong thing: the `or` is a SUPERSET
+ * of either term, so it is correct whether or not the invariant holds, and a
+ * test that fails when the mirror drifts would report a data condition this code
+ * is specifically built to tolerate. What is asserted instead is the property
+ * that actually protects the reader — no drift state, in either direction, can
+ * cost a post its place on its author's profile.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { and, eq, inArray } from 'drizzle-orm';
+import { PostType, PostVisibility } from '@mention/shared-types';
+
+import { closePostgres, connectPostgres, type Database } from '../db/postgres';
+import { posts } from '../db/schema';
+import { insertPostRecord } from '../db/posts/postRepository';
+import type { PostRecordInput } from '../db/posts/postRecord';
+import { authorFeedSql } from '../utils/postAuthorship';
+
+let db: Database;
+const created: string[] = [];
+
+const AUTHOR = 'authormatch-author';
+const OTHER = 'authormatch-other';
+const CHANNEL = 'authormatch-channel';
+const WRITER = 'authormatch-writer';
+
+/**
+ * Fixtures are stamped in the FUTURE so this suite's rows sort above whatever
+ * else the shared database holds, and so their relative order is stated here
+ * rather than inherited from insertion timing.
+ */
+const HORIZON = Date.now() + 60_000;
+
+async function create(overrides: Partial<PostRecordInput>): Promise<string> {
+  const record = await insertPostRecord({
+    oxyUserId: OTHER,
+    authorship: [{ oxyUserId: OTHER, role: 'owner', status: 'accepted' }],
+    type: PostType.TEXT,
+    visibility: PostVisibility.PUBLIC,
+    status: 'published',
+    content: { variants: [{ source: 'author', text: 'body' }] },
+    createdAt: new Date(HORIZON),
+    ...overrides,
+  });
+  created.push(record.id);
+  return record.id;
+}
+
+/** The ids `authorFeedSql` matches, restricted to this suite's own rows. */
+async function matched(authorId: string): Promise<string[]> {
+  if (created.length === 0) return [];
+  const rows = await db
+    .select({ id: posts.id })
+    .from(posts)
+    .where(and(authorFeedSql(authorId), inArray(posts.id, [...created])));
+  return rows.map((row) => row.id).sort();
+}
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterEach(async () => {
+  const ids = created.splice(0);
+  if (ids.length > 0) await db.delete(posts).where(inArray(posts.id, ids));
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+describe('authorFeedSql — which posts count as an author\'s own', () => {
+  /**
+   * The ordinary shape, and the two DRIFT shapes that only the `EXISTS` can
+   * answer. Both drift rows are states the schema permits: `oxy_user_id` is
+   * nullable (the raw federated insert path may omit it) and Mongo's owner-mirror
+   * hook was bypassed by bulk writes, so backfilled rows can carry a stale one.
+   *
+   * Mutation: narrow the `EXISTS` to `role = 'collaborator'` — the shape that
+   * measured fastest — and this goes red naming `nullMirror` and `staleMirror`.
+   */
+  it('serves posts whose authorship row exists but whose mirror is absent or stale', async () => {
+    const ordinary = await create({
+      oxyUserId: AUTHOR,
+      authorship: [{ oxyUserId: AUTHOR, role: 'owner', status: 'accepted' }],
+    });
+    // Owner authorship present, mirror never written.
+    const nullMirror = await create({
+      oxyUserId: null,
+      authorship: [{ oxyUserId: AUTHOR, role: 'owner', status: 'accepted' }],
+    });
+    // Owner authorship present, mirror points at somebody else.
+    const staleMirror = await create({
+      oxyUserId: OTHER,
+      authorship: [{ oxyUserId: AUTHOR, role: 'owner', status: 'accepted' }],
+    });
+
+    expect(await matched(AUTHOR)).toEqual([ordinary, nullMirror, staleMirror].sort());
+  });
+
+  /**
+   * The shape only the MIRROR can answer, and the one that makes this a
+   * correctness fix rather than an optimisation: `insertChildRows` writes
+   * authorship rows only `if (authorship.length > 0)`, so a post created with an
+   * empty authorship list has an owner and no `post_authorships` row at all.
+   * Under the `EXISTS` alone it is invisible on its own author's profile.
+   *
+   * Mutation: drop the `oxy_user_id` term and this goes red naming `noAuthorship`.
+   */
+  it('serves a post that carries an owner but no authorship row at all', async () => {
+    const noAuthorship = await create({ oxyUserId: AUTHOR, authorship: [] });
+
+    expect(await matched(AUTHOR)).toEqual([noAuthorship]);
+  });
+
+  /**
+   * Consent. A collaborator counts once they have ACCEPTED and never before —
+   * an invitee must not appear as an author, and must not have the invitation
+   * disclosed by the post surfacing on their profile.
+   *
+   * The mirror cannot leak a pending invite (it holds the owner), so this is the
+   * `EXISTS`'s `status` term being load-bearing. Mutation: drop
+   * `status = 'accepted'` and this goes red naming `pendingCollab`.
+   */
+  it('serves accepted collaborators and withholds pending ones', async () => {
+    const acceptedCollab = await create({
+      oxyUserId: OTHER,
+      authorship: [
+        { oxyUserId: OTHER, role: 'owner', status: 'accepted' },
+        { oxyUserId: AUTHOR, role: 'collaborator', status: 'accepted' },
+      ],
+    });
+    await create({
+      oxyUserId: OTHER,
+      authorship: [
+        { oxyUserId: OTHER, role: 'owner', status: 'accepted' },
+        { oxyUserId: AUTHOR, role: 'collaborator', status: 'pending' },
+      ],
+    });
+
+    expect(await matched(AUTHOR)).toEqual([acceptedCollab]);
+  });
+
+  /**
+   * A channel post belongs to the CHANNEL, never to the human who typed it.
+   * `utils/postAuthorship` calls that exclusion load-bearing and explains it is
+   * held by `written_by_oxy_user_id` being a column these matchers never read —
+   * so adding a term that reads `oxy_user_id` is exactly the change that could
+   * have broken it, and it does not, because `oxy_user_id` holds the channel.
+   *
+   * Asserted rather than reasoned about: this is the property that would fail
+   * silently and publicly, by republishing on a writer's profile the posts a
+   * channel exists to keep anonymous.
+   */
+  it('keeps a channel post on the channel and off its writer', async () => {
+    const channelPost = await create({
+      oxyUserId: CHANNEL,
+      writtenByOxyUserId: WRITER,
+      authorship: [{ oxyUserId: CHANNEL, role: 'owner', status: 'accepted' }],
+    });
+
+    expect(await matched(CHANNEL)).toEqual([channelPost]);
+    expect(await matched(WRITER)).toEqual([]);
+  });
+
+  /**
+   * The negative case that keeps the three positives honest: nothing belonging
+   * to somebody else is served. Without this, a predicate that simply matched
+   * everything would pass every assertion above.
+   */
+  it('serves nothing belonging to another account', async () => {
+    await create({
+      oxyUserId: OTHER,
+      authorship: [{ oxyUserId: OTHER, role: 'owner', status: 'accepted' }],
+    });
+
+    expect(await matched(AUTHOR)).toEqual([]);
+  });
+});

--- a/packages/backend/src/mtn/feed/feeds/forYouCandidateSources.ts
+++ b/packages/backend/src/mtn/feed/feeds/forYouCandidateSources.ts
@@ -55,6 +55,7 @@ import { logger } from '../../../utils/logger';
 import { followedAuthorsSql } from '../../../utils/postAuthorship';
 import { excludeSeenSql, notABoostSql } from '../../../utils/feedQueryBuilder';
 import { engagementScoreSql } from '../engine/sources/discoverySources';
+import { chronoOrderBy } from '../CursorBuilder';
 import type { CandidatePost as EngineCandidatePost } from '../engine/types';
 import type { OxyClient } from '../../../utils/privacyHelpers';
 
@@ -162,8 +163,15 @@ async function runSource(
       .where(and(...conditions))
       // `created_at` leads; the id is the uniqueness tiebreak that makes the
       // order total. Sorting by id alone would be meaningless here — see
-      // `chronoOrderBy` in `CursorBuilder.ts`.
-      .orderBy(desc(posts.createdAt), desc(posts.id))
+      // `chronoOrderBy` in `CursorBuilder.ts`, which is now CALLED rather than
+      // cited: the bare `desc()` this replaces spells `DESC NULLS FIRST`, which
+      // matches none of the chronological indexes on `posts` (drizzle emits
+      // `.desc()` in index DDL as `DESC NULLS LAST`), so every lane sorted its
+      // whole match set instead of streaming the first `cap` rows out of an
+      // index. Measured on 624k posts with a 7-day window: 6.04 ms → 0.54 ms per
+      // lane, and the gap grows with the WINDOW rather than the page — seven
+      // lanes run this per For You request.
+      .orderBy(...chronoOrderBy())
       .limit(cap);
     return assemblePostRecords(rows, db);
   } catch (error) {

--- a/packages/backend/src/routes/search.ts
+++ b/packages/backend/src/routes/search.ts
@@ -1,5 +1,5 @@
 import express, { Response } from "express";
-import { and, arrayContains, desc, eq, exists, gte, lte, lt, or, sql, type SQL } from 'drizzle-orm';
+import { and, arrayContains, eq, exists, gte, lte, lt, or, sql, type SQL } from 'drizzle-orm';
 import { getDb } from '../db/postgres';
 import { QUERY_CANCELED, sqlStateOf } from '../db/pgErrors';
 import { posts } from '../db/schema/posts';
@@ -14,6 +14,7 @@ import { getRuntimeOxyClient } from '../runtime/oxyClient';
 import { queryInt } from '../utils/queryParams';
 import { PostVisibility } from '@mention/shared-types';
 import { decodeChronoCursor, encodeChronoCursor } from '../utils/chronoCursor';
+import { chronoOrderBy } from '../mtn/feed/CursorBuilder';
 import { scanTextEntities } from '@mention/shared-types/textEntities';
 import { isAbsoluteHttpUrl } from '../connectors/shared/url';
 import { discoverySafeSql } from '../mtn/feed/feedSafety';
@@ -438,8 +439,19 @@ router.get("/", async (req: AuthRequest, res: Response) => {
       const limitNum = Math.min(Math.max(queryInt(req.query.limit) || DEFAULT_SEARCH_LIMIT, 1), MAX_SEARCH_LIMIT);
 
       // Execute query with lean() for read-only performance
+      // `chronoOrderBy()`, never a bare `desc()` — see `CursorBuilder.ts`, which
+      // owns the reason: drizzle emits `.desc()` in INDEX DDL as
+      // `DESC NULLS LAST`, while a QUERY's `desc()` means `DESC NULLS FIRST`, so
+      // the bare spelling matches none of the thirteen chronological indexes on
+      // `posts` and the whole search fell back to a scan. Both columns are
+      // `NOT NULL`, so this changes no row and no order — only whether an index
+      // can serve the sort. Measured on 624k posts, page of 21: a text search
+      // went from a parallel Seq Scan of every post at 177 ms to an index-served
+      // 1.6 ms, and `has:links` from 51.5 ms to 0.2 ms — the latter being the
+      // only query `post_links_chrono_v1` exists for, so that index was
+      // unreachable and purely paying for itself on every insert.
       const page = await findPostRecords(and(...conditions), {
-        orderBy: [desc(posts.createdAt), desc(posts.id)],
+        orderBy: chronoOrderBy(),
         limit: limitNum + 1, // Fetch one extra to check if there are more
       });
 

--- a/packages/backend/src/utils/postAuthorship.ts
+++ b/packages/backend/src/utils/postAuthorship.ts
@@ -1,6 +1,6 @@
 import type { PostAuthorshipEntry, PostAuthorRole, PostAuthorStatus } from '@mention/shared-types';
 import { MAX_POST_COLLABORATORS } from '@mention/shared-types';
-import { and, eq, exists, inArray, sql, type SQL } from 'drizzle-orm';
+import { and, eq, exists, inArray, or, sql, type SQL } from 'drizzle-orm';
 import { getDb } from '../db/postgres';
 import { postAuthorships, posts } from '../db/schema';
 
@@ -162,7 +162,61 @@ export function followedAuthorsSql(authorIds: readonly string[]): SQL {
   return authored;
 }
 
-/** Single-author form of {@link followedAuthorsSql} — the profile feed's match. */
+/**
+ * The profile feed's match: "this post is `authorId`'s".
+ *
+ * The `post_authorships` `EXISTS` is the AUTHORITY and stays exactly as
+ * {@link followedAuthorsSql} writes it. The `oxy_user_id` term in front of it is
+ * a second, cheaper way to reach the same posts, and it is here for two distinct
+ * reasons — one of them a correctness fix, not an optimisation.
+ *
+ * ## It is a SUPERSET, which is what makes it safe
+ *
+ * `posts.oxy_user_id` is the denormalized owner (`db/schema/postContent.ts`:
+ * exactly one `owner`, always `accepted`, mirrored onto the post). So under that
+ * invariant the two terms select the same owner rows and this changes nothing.
+ * Written as an `or`, a DRIFTED mirror cannot cost a row either way: a post whose
+ * mirror is NULL or stale is still found by the `EXISTS`, and a post whose
+ * authorship row is missing is still found by the mirror. That direction matters
+ * because the failure being fixed is posts MISSING from their author's own
+ * profile — a formulation that trades the `EXISTS` for the mirror (or narrows it
+ * to `role = 'collaborator'`) is faster still and silently drops exactly the
+ * drifted rows, which is the bug wearing the fix's clothes.
+ *
+ * ## The correctness half
+ *
+ * `insertChildRows` writes authorship rows only `if (authorship.length > 0)`, so
+ * a post created with an empty authorship list — and any Mongo document that
+ * backfilled from one — has an `oxy_user_id` and NO `post_authorships` row at
+ * all. The `EXISTS` alone cannot see those, so they are invisible on their own
+ * author's profile. This term is what serves them.
+ *
+ * ## The performance half
+ *
+ * The `EXISTS` alone gives the planner no index that connects "this author" to
+ * "newest first", so it walks a chronological index over the whole table probing
+ * `post_authorships` once per candidate. Measured on 624k posts, page of 21:
+ *
+ *   author with 2,003 posts    84–99 ms  →  2.3–4.2 ms   (the common case)
+ *   author with 20,000 posts   3.7–6.0 ms → 10.5–15.6 ms  (a REGRESSION, kept)
+ *
+ * The regression is real and deliberate: the second shape is an account owning a
+ * measurable fraction of all recent posts, where the probe-as-you-scan plan
+ * happens to hit matches immediately. Trading ~5 ms there for ~90 ms on the
+ * ordinary case is the right side of that trade, and both land in single or low
+ * double digit milliseconds. Removing the regression entirely needs
+ * `posts.created_at` denormalized onto `post_authorships` with a
+ * `(oxy_user_id, status, post_created_at desc, post_id desc)` index — measured
+ * at 0.58 ms / 0.93 ms for the two shapes — which is a migration, not a
+ * predicate change.
+ *
+ * ## Channel posts stay excluded, and not by accident
+ *
+ * A channel post's `oxy_user_id` is the CHANNEL account; the human is in
+ * `written_by_oxy_user_id`, which this term does not read. So the exclusion
+ * {@link followedAuthorsSql} documents survives — asserted, not assumed, in
+ * `__tests__/authorFeedMatch.test.ts`.
+ */
 export function authorFeedSql(authorId: string): SQL {
-  return followedAuthorsSql([authorId]);
+  return or(eq(posts.oxyUserId, authorId), followedAuthorsSql([authorId])) as SQL;
 }


### PR DESCRIPTION
Implements the three request-path findings from #664. All numbers are `EXPLAIN (ANALYZE, BUFFERS)` on a private PostGIS 17 instance seeded to the production row count (624,000 posts, 624,000 authorships/variants), stock indexes only. Nothing touched production.

Full backend suite: **538 files, 6,405 tests, all passing** (`bun run test`, not scoped directories).

---

## 1. Profile feed — and it was losing posts, not just slow

This is the one the user actually reported: they looked at their profile and posts were missing. It turned out to be two defects sharing a cause.

`authorFeedSql` matched **only** through the correlated `EXISTS` over `post_authorships`. But `insertChildRows` writes authorship rows only `if (authorship.length > 0)` — so a post carrying an `oxy_user_id` and **no authorship row at all** is invisible on its own author's profile. Any post created with an empty authorship list, and any Mongo document that backfilled from one, is exactly that shape. Reproduced:

| | visible today | with this change |
|---|---|---|
| post owned by X, no authorship row | **0** | 1 |

The fix ORs the denormalized owner in front of the `EXISTS`, which stays the authority. It is a strict **superset**, and that direction is the whole point: a drifted mirror is still found by the `EXISTS`, a missing authorship row is still found by the mirror, and neither state can cost a row. `purgeBlockedDomainContent.ts:1365` already composed the same `or` for the same reason.

It also gives the planner `posts_owner_chrono_idx`, which the `EXISTS` alone could never reach — it walked a chronological index over the whole table probing `post_authorships` once per candidate row (42,394 probes to return 21). Five runs each, page of 21:

| author size | before | after |
|---|---|---|
| 2,003 posts (ordinary active account) | 83.8–98.6 ms | **2.3–4.2 ms** |
| 20,000 posts (very prolific) | 3.7–6.0 ms | **10.5–15.6 ms** ← regression |

**The second row is a regression and it is deliberate.** An account owning a measurable fraction of all recent posts is precisely where probe-as-you-scan hits matches immediately. Trading ~5 ms there for ~90 ms on the ordinary case is the right side of that trade, and both land in single or low double digit milliseconds. Removing it entirely needs `posts.created_at` denormalized onto `post_authorships` with a `(oxy_user_id, status, post_created_at desc, post_id desc)` index — measured at **0.58 ms / 0.93 ms** for the two shapes, flat across author size. That is a migration, not a predicate change, so it is deliberately not in this PR.

## 2. `search.ts` — 110x, and it recovers 99 MB

One bare `desc()` where `chronoOrderBy()` exists. `CursorBuilder.ts` already documents why the bare spelling never matches: drizzle emits `.desc()` in **index DDL** as `DESC NULLS LAST`, while a **query's** `desc()` means `DESC NULLS FIRST`, and Postgres compares the NULLS placement when deciding whether an index can satisfy an `ORDER BY`. Both columns are `NOT NULL`, so this changes no row and no order — only whether an index can serve the sort.

| | before | after |
|---|---|---|
| text query, page of 21 | 177.0 ms, parallel Seq Scan of all 624k posts, 58,265 buffers | **1.6 ms**, 586 buffers |
| `has:links` | 51.5 ms | **0.2 ms** |

`has:links` is the only query `post_links_chrono_v1` exists for — **99 MB, the largest index on `posts`** — so it was unreachable, paying its write cost on every insert with nothing able to read it. This makes the table smaller *and* faster.

## 3. `forYouCandidateSources.ts` — same one-liner, seven times per request

`runSource` has seven call sites, one per For You lane. 7-day window: **6.04 ms → 0.54 ms** per lane, 337 → 32 buffers. The gap grows with the *window*, not the page, so it scales with corpus activity.

---

## Tests

`packages/backend/src/__tests__/authorFeedMatch.test.ts` states the profile feed's membership rule against a real database. Every case is answered by **one** of the two terms and not the other, so removing either goes red naming the post it dropped:

- authorship row present, mirror NULL or stale → only the `EXISTS` answers
- owner present, no authorship row → only the mirror answers
- accepted vs pending collaborator → the consent property
- channel post stays on the channel and off its writer → the exclusion `utils/postAuthorship` calls load-bearing, asserted rather than reasoned about
- a negative case, so a predicate matching everything cannot pass

Both mutations run and verified red:

```
revert to EXISTS-only          → × serves a post that carries an owner but no authorship row at all
narrow to role='collaborator'  → × serves posts whose authorship row exists but whose mirror is absent or stale
```

### A note on the test that was asked for

The request was a test that fails if the owner-mirror invariant (`db/schema/postContent.ts:81`) stops holding. I deliberately did not write that one, because the fix I landed **does not depend on that invariant** — the `or` is a superset of either term, so it is correct whether or not the mirror agrees. A test asserting the agreement would fail on a data condition this code is specifically built to tolerate. What is asserted instead is the property that protects the reader: no drift state, in either direction, can cost a post its place on its author's profile.

## Retracted from #664, with the measurements

Three candidate fixes for finding #2 were proposed and killed by measurement:

| candidate | result |
|---|---|
| `UNION ALL` with `role='collaborator'` (the 1.76 ms fix in #664) | **Loses posts.** Against drift fixtures it dropped exactly the null-mirror and stale-mirror rows. Fast, and the reported bug wearing a better latency graph. |
| Drift-safe `UNION ALL` with `oxy_user_id IS DISTINCT FROM X` | **503 ms** vs 76 ms baseline. The anti-correlated predicate blocks driving from the authorship index; 1.1M buffers. |
| Materialized CTE forcing the authorship-driven plan | 8.3x *better* for a 2k-post author, **65x worse** for a 20k-post author (243 ms). Moves the slowness to different users. |

One earlier reading in #664 was also contaminated: an OR-form measurement of 4.6 ms for the prolific author was taken while an experimental index was still present. The uncontaminated number is 10.5–15.6 ms, and it is the regression reported above rather than a win.

Closes the request-path half of #664. The `risingCreators` aggregation (finding 4), the Mongo boot dependency (5), `TrendingService` batching (6) and the two latent `sql<Date>` sites (7) are untouched and remain open there.
