### PR TITLE
chore(boot): stop the web task connecting to Mongo, and take it out of readiness

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -1,15 +1,11 @@
 // --- Imports ---
 import http from "http";
-import mongoose from "mongoose";
 import { hostname } from 'os';
-import { connectToDatabase } from "./src/utils/database";
 import { Server as SocketIOServer, Namespace } from "socket.io";
 import { PUBLIC_REALTIME_NAMESPACE } from "@mention/shared-types";
 import { logger, sanitizeLogValue } from "./src/utils/logger";
 import { config, validateEnvironment } from './src/config';
 import { isAllowedOrigin } from "./src/utils/allowedOrigins";
-import { assertMigrationsApplied, runMigrations } from "./src/migrations/runner";
-import { assertMongoTransactionalTopology } from "./src/utils/mongoTopology";
 import { closePostgres, connectPostgres, getPostgresClient } from "./src/db/postgres";
 import { assertPostgresMigrationsCurrent } from "./src/db/migrationLedger";
 import { leaderElection } from "./src/services/LeaderElection";
@@ -539,32 +535,6 @@ app.set("io", io);
 app.set("notificationsNamespace", notificationsNamespace);
 app.set("postsNamespace", postsNamespace);
 
-// --- MongoDB Connection ---
-const db = mongoose.connection;
-let hasLoggedMongoError = false;
-db.on("error", (error: Error & { code?: string; syscall?: string }) => {
-  // Only log connection errors once to reduce spam
-  if (error.code === 'ECONNREFUSED' || error.syscall === 'querySrv') {
-    // Connection errors are already logged by connectToDatabase retry logic
-    // Don't log them again here to avoid duplicate messages
-    if (!hasLoggedMongoError) {
-      hasLoggedMongoError = true;
-      logger.debug("MongoDB connection error:", error.message);
-    }
-  } else {
-    logger.error("MongoDB connection error", error);
-  }
-});
-
-// Reset error flag and load models on successful connection.
-// Note: connectToDatabase() in src/utils/database.ts already logs the success message.
-db.once("open", () => {
-  hasLoggedMongoError = false;
-
-  // Load models
-  require("./src/models/Post");
-});
-
 /**
  * Start all in-process schedulers. Invoked by LeaderElection ONLY on the task
  * that holds the scheduler leadership lock. Redis failure pauses all singleton
@@ -634,8 +604,8 @@ function startSchedulers(): void {
 
   // CrowdSource reconciliation (leader-gated, env-gated on CROWDSOURCE_ENABLED):
   // finds reports whose durable delivery event is missing or dead-lettered. The
-  // outbox DISPATCHER runs on every task (Mongo-leased); this sweep scans the whole
-  // collection, so one task is enough.
+  // outbox DISPATCHER runs on every task (lease-claimed in Postgres); this sweep
+  // scans the whole table, so one task is enough.
   try {
     const { moderationReconciliationJob } = require("./src/services/moderation/ModerationReconciliationJob");
     moderationReconciliationJob.start();
@@ -736,33 +706,30 @@ const PORT = config.runtime.port;
 const bootServer = async () => {
   validateEnvironment();
   markRuntimeNotReady('booting');
-  await connectToDatabase();
-  // Both stores open before anything can be asked to serve. `getDb()` throws
-  // until this resolves, and the port has moved most reads onto Postgres — a
-  // task that skipped this would answer the health check and then fail every
-  // query that is no longer Mongo's.
+  // ONE store opens here, and it is Postgres. `getDb()` throws until this
+  // resolves, so a task that skipped it would answer the health check and then
+  // fail every query.
+  //
+  // Mongo used to open FIRST, on this line, on every task — so a web task could
+  // not boot without it even though no runtime read or write has gone to Mongo
+  // since the cutover. The connection is gone; what still uses Mongo is the
+  // DEPLOY ONE-SHOT (`scripts/migrate.ts`) and the restore/backfill tooling,
+  // neither of which is this process. See the PR that removed it for the full
+  // list of what was deliberately left in place.
   await connectPostgres();
 
   // Production migrations run as a deployment one-shot with the exact image
   // that will be rolled out. Web tasks never mutate schema during a scale-out;
-  // they only refuse readiness until that one-shot has completed. The one-shot
-  // is the primary topology barrier; this startup check is defense in depth if
-  // a task is launched outside the normal deployment workflow. It is not run in
-  // the readiness endpoint, avoiding a Mongo command on every health probe.
+  // they only refuse readiness until that one-shot has completed.
   //
-  // The Postgres half is the same posture against the same failure, and it is
-  // load-bearing during the cutover rather than defence in depth: the drizzle
+  // This assert is load-bearing rather than defence in depth: the drizzle
   // migrations are applied by the deploy's one-shot, and a task that boots
   // against a database that one-shot never reached becomes ready and then
   // fails every Postgres query — after traffic has been routed to it. Outside
   // production the migrator is a developer command (`bun run db:migrate`), so
   // there is nothing here to assert against.
   if (config.runtime.isProduction) {
-    await assertMongoTransactionalTopology();
-    await assertMigrationsApplied();
     await assertPostgresMigrationsCurrent(getPostgresClient());
-  } else {
-    await runMigrations();
   }
   markMigrationsComplete();
 
@@ -779,7 +746,8 @@ const bootServer = async () => {
   // Start BullMQ federation queue workers on EVERY task (inbox + delivery
   // throughput should scale with the fleet; BullMQ delivers each job to exactly
   // one worker). No-op when Redis is not configured — federation then falls
-  // back to inline inbox processing + the in-process Mongo delivery scheduler.
+  // back to inline inbox processing + the in-process delivery scheduler, which
+  // drains the Postgres `federation_delivery_queue` table.
   // Periodic repeatable-job REGISTRATION is leader-only (FederationJobScheduler,
   // driven by leaderElection); only the consuming workers run everywhere.
   try {
@@ -792,9 +760,9 @@ const bootServer = async () => {
   // Register MTN Protocol feed engine modules (sources / signals / filters)
   registerAllModules();
 
-  // Mongo-leased workers may run on every task: claims are atomic and do not
-  // depend on Redis leadership, so committed engagement effects keep draining
-  // even while Redis is degraded.
+  // Lease-claimed workers may run on every task: the claim is an atomic Postgres
+  // update and does not depend on Redis leadership, so committed engagement
+  // effects keep draining even while Redis is degraded.
   engagementOutboxDispatcher.start();
   // Same reasoning for moderation: a report and its delivery event committed
   // together, and the lease-based claim means every task can drain the queue.
@@ -815,7 +783,7 @@ const bootServer = async () => {
 // --- Graceful Shutdown ---
 // ECS sends SIGTERM on task stop (and again SIGKILL after the stop timeout).
 // Readiness is cleared and HTTP stops accepting immediately. Producers and
-// workers then drain while Mongo/Redis are still available, and the scheduler
+// workers then drain while Postgres/Redis are still available, and the scheduler
 // leadership lock is released only after singleton schedulers have stopped.
 let isShuttingDown = false;
 const gracefulShutdown = (signal: string): void => {
@@ -889,7 +857,7 @@ const gracefulShutdown = (signal: string): void => {
     };
 
     await presenceShutdown();
-    // Stop every producer/worker while Redis and Mongo are still available.
+    // Stop every producer/worker while Redis and Postgres are still available.
     // LeaderElection releases its owner-checked lock only after onLose has
     // stopped singleton schedulers.
     await Promise.allSettled([
@@ -905,12 +873,11 @@ const gracefulShutdown = (signal: string): void => {
       invalidationShutdown(),
       pubSubShutdown(),
       closeRedisConnection(),
-      mongoose.disconnect(),
       closePostgres(),
     ]);
 
     clearTimeout(hardTimeout);
-    logger.info('HTTP, sockets, queues, Redis, MongoDB and PostgreSQL closed');
+    logger.info('HTTP, sockets, queues, Redis and PostgreSQL closed');
     process.exit(0);
   })();
 };

--- a/packages/backend/src/__tests__/health.test.ts
+++ b/packages/backend/src/__tests__/health.test.ts
@@ -2,10 +2,6 @@ import express from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../utils/database', () => ({
-  isDatabaseConnected: vi.fn(),
-}));
-
 vi.mock('../db/postgres', () => ({
   checkPostgresHealth: vi.fn(),
 }));
@@ -17,7 +13,6 @@ vi.mock('../utils/redis', () => ({
 import healthRoutes from '../routes/health.routes';
 import { legacyApiRootReadiness } from '../routes/legacyRoot.routes';
 import { checkPostgresHealth } from '../db/postgres';
-import { isDatabaseConnected } from '../utils/database';
 import { getRedisStats } from '../utils/redis';
 import {
   markMigrationsComplete,
@@ -26,7 +21,6 @@ import {
   resetRuntimeHealthState,
 } from '../utils/runtimeHealth';
 
-const mockIsDatabaseConnected = isDatabaseConnected as unknown as ReturnType<typeof vi.fn>;
 const mockCheckPostgresHealth = checkPostgresHealth as unknown as ReturnType<typeof vi.fn>;
 const mockGetRedisStats = getRedisStats as unknown as ReturnType<typeof vi.fn>;
 
@@ -38,7 +32,6 @@ describe('health routes', () => {
 
   beforeEach(() => {
     resetRuntimeHealthState();
-    mockIsDatabaseConnected.mockReturnValue(false);
     // Healthy by default so each case states the ONE dependency it is about.
     mockCheckPostgresHealth.mockResolvedValue(true);
     mockGetRedisStats.mockReturnValue({
@@ -55,11 +48,16 @@ describe('health routes', () => {
   it('returns 503 readiness before boot and migrations complete', async () => {
     const response = await request(app).get('/health/ready').expect(503);
     expect(response.body.status).toBe('not_ready');
-    expect(response.body.dependencies.mongo).toBe('unavailable');
+    expect(response.body.dependencies.migrations).toBe('pending');
   });
 
-  it('becomes ready only after migrations and Mongo are ready', async () => {
-    mockIsDatabaseConnected.mockReturnValue(true);
+  /**
+   * The dependency list is asserted WHOLE, which is what makes this the
+   * regression test for the decommission: `mongo` is gone from the payload, and
+   * a `toEqual` fails if it comes back. The endpoint must not report a store
+   * this process never opens.
+   */
+  it('becomes ready on migrations and Postgres alone, with no Mongo dependency', async () => {
     mockGetRedisStats.mockReturnValue({
       connected: false,
       status: 'disconnected',
@@ -69,42 +67,50 @@ describe('health routes', () => {
 
     const response = await request(app).get('/health/ready').expect(200);
     expect(response.body.dependencies).toEqual({
-      mongo: 'ready',
       postgres: 'ready',
       migrations: 'ready',
       redis: 'degraded',
     });
   });
 
-  it('drops readiness immediately when Mongo disconnects', async () => {
+  /**
+   * THE case this change exists to make true, and the one that would have been
+   * an outage if the gate had been left behind when the boot connection went.
+   *
+   * `health.routes.ts` used to `&&` in `isDatabaseConnected()`, a read on the
+   * default mongoose connection `server.ts` opened at boot. With that connection
+   * gone the read is permanently false, so every task would answer 503 here for
+   * as long as it lived — the ALB drains the fleet, the deploy's smoke checks
+   * fail, over a store no request touches. Nothing in this suite is arranged to
+   * be Mongo-ready, because nothing can be any more: readiness is 200 anyway.
+   */
+  it('is ready with no Mongo connection in the process at all', async () => {
     markMigrationsComplete();
     markRuntimeReady();
 
-    await request(app).get('/health/ready').expect(503);
+    await request(app).get('/health/ready').expect(200);
   });
 
   it('drops readiness when POSTGRES stops answering', async () => {
     // The case this endpoint was blind to. Before the cutover it checked Mongo
     // and not Postgres at all, so a task whose Postgres had become unreachable
     // kept reporting ready and kept taking traffic while erroring on every
-    // request. Everything else here is healthy, so only the new gate can fail.
-    mockIsDatabaseConnected.mockReturnValue(true);
+    // request. Everything else here is healthy, so only this gate can fail.
     mockCheckPostgresHealth.mockResolvedValue(false);
     markMigrationsComplete();
     markRuntimeReady();
 
     const response = await request(app).get('/health/ready').expect(503);
+    // And it says WHICH one, because "not_ready" alone sends an operator to
+    // check every dependency in the list.
     expect(response.body.dependencies.postgres).toBe('unavailable');
-    // And it says which one, because "not_ready" alone sends an operator to
-    // check all four.
-    expect(response.body.dependencies.mongo).toBe('ready');
+    expect(response.body.dependencies.migrations).toBe('ready');
   });
 
   it('is a real query, not a pool-exists check', async () => {
     // `isPostgresConnected()` would answer "was a pool ever built", which is
     // TRUE of exactly the task that is failing every query. The endpoint has to
     // call the one that issues `select 1`.
-    mockIsDatabaseConnected.mockReturnValue(true);
     markMigrationsComplete();
     markRuntimeReady();
 
@@ -113,7 +119,6 @@ describe('health routes', () => {
   });
 
   it('keeps liveness but drops readiness while draining', async () => {
-    mockIsDatabaseConnected.mockReturnValue(true);
     markMigrationsComplete();
     markRuntimeReady();
     markRuntimeShuttingDown();
@@ -129,7 +134,6 @@ describe('health routes', () => {
       .expect(503);
     expect(starting.body.status).toBe('not_ready');
 
-    mockIsDatabaseConnected.mockReturnValue(true);
     markMigrationsComplete();
     markRuntimeReady();
 

--- a/packages/backend/src/__tests__/mongoOffTheBootPath.test.ts
+++ b/packages/backend/src/__tests__/mongoOffTheBootPath.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Mongo is not reachable from the web task's boot path — asserted on the module
+ * GRAPH, not on a grep.
+ *
+ * The property this defends was true by accident and is now depended on: no
+ * runtime read or write goes to Mongo, so `server.ts` no longer opens a
+ * connection to it and `/health/ready` no longer gates on one. Nothing about
+ * that survives a single `import mongoose` added to a controller — the process
+ * would start dialling a database nobody decommissioned yet, and the failure
+ * would surface as slow boots or a readiness flap rather than as an import.
+ *
+ * ## Why a graph walk rather than a grep
+ *
+ * A grep for `mongoose` over `src/` answers a much broader question than the one
+ * that matters and would fail today: ~60 model files, the migration runner, the
+ * restore tooling and a dozen scripts all import it legitimately, and every one
+ * of them is fine because nothing the SERVER loads reaches them. The question is
+ * reachability from one entry point, so the check has to be reachability.
+ *
+ * ## Three things the walk has to get right, each learned from a real shape
+ *
+ *  - **`require()` with a string literal counts.** The import this gate replaces
+ *    was `require("./src/models/Post")` inside a `db.once("open")` handler —
+ *    invisible to any scanner that only reads `import` declarations, and it is
+ *    exactly the shape a future one will take, because `server.ts` lazily
+ *    `require`s most of its schedulers.
+ *  - **`import type` does NOT count.** `db/feeds/customFeedRepository.ts` and
+ *    `routes/customFeedWrite.ts` both name a type from `models/CustomFeed`, and
+ *    both are erased at compile time — no module is loaded and no connection is
+ *    made. Counting them would make this gate red on arrival and it would be
+ *    wrong. Type-only named specifiers (`import { type X }`) are erased the same
+ *    way and are excluded per specifier, not per statement.
+ *  - **The floor.** `expect(offenders).toEqual([])` passes just as happily when
+ *    the traversal breaks and visits nothing. {@link REQUIRED_REACHABLE} names
+ *    modules the boot path certainly loads, so a walk that resolves nothing
+ *    fails on the floor instead of reporting success.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import type * as TypeScript from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const ts = createRequire(path.join(__dirname, 'mongoOffTheBootPath.test.ts'))(
+  'typescript',
+) as typeof TypeScript;
+
+const BACKEND_ROOT = path.resolve(__dirname, '../..');
+const BOOT_ENTRY = path.join(BACKEND_ROOT, 'server.ts');
+
+/** The packages a web task must never load. */
+const FORBIDDEN_PACKAGES = new Set(['mongoose', 'mongodb']);
+
+/**
+ * Modules the boot path certainly reaches, so a traversal that silently resolves
+ * nothing cannot pass. Deliberately spread across the graph's depth: the express
+ * app, a route module, and a service the feed depends on.
+ */
+const REQUIRED_REACHABLE = [
+  'src/app.ts',
+  'src/appRoutes.ts',
+  'src/routes/health.routes.ts',
+  'src/services/PostHydrationService.ts',
+];
+
+/** A module reached from the boot entry, with the chain that reached it. */
+interface Reached {
+  readonly file: string;
+  readonly chain: readonly string[];
+}
+
+/** Resolve a relative specifier to a real `.ts` file, or `undefined`. */
+function resolveRelative(fromFile: string, specifier: string): string | undefined {
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  for (const candidate of [`${base}.ts`, path.join(base, 'index.ts')]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Every specifier `file` loads AT RUNTIME: `import` declarations that are not
+ * type-only, `export ... from`, and `require('literal')` calls.
+ *
+ * A statement whose every named specifier is `type`-marked is erased entirely,
+ * so it is not a runtime load either — checked per specifier rather than
+ * assuming `importClause.isTypeOnly` covers it.
+ */
+function runtimeSpecifiers(file: string): string[] {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const specifiers: string[] = [];
+
+  const visit = (node: TypeScript.Node): void => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const clause = node.importClause;
+      // `import './x'` for side effects has no clause and IS a runtime load.
+      const typeOnlyStatement = clause?.isTypeOnly === true;
+      const bindings = clause?.namedBindings;
+      const everyNamedIsType =
+        bindings !== undefined &&
+        ts.isNamedImports(bindings) &&
+        clause?.name === undefined &&
+        bindings.elements.length > 0 &&
+        bindings.elements.every((element) => element.isTypeOnly);
+      if (!typeOnlyStatement && !everyNamedIsType) {
+        specifiers.push(node.moduleSpecifier.text);
+      }
+    }
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      !node.isTypeOnly
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.Identifier &&
+      node.expression.getText(source) === 'require' &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      specifiers.push((node.arguments[0] as TypeScript.StringLiteral).text);
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+  return specifiers;
+}
+
+/** Walk the runtime module graph from the boot entry. */
+function walkBootGraph(): { reached: Map<string, Reached>; offenders: string[] } {
+  const reached = new Map<string, Reached>();
+  const offenders: string[] = [];
+  const queue: Reached[] = [{ file: BOOT_ENTRY, chain: ['server.ts'] }];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || reached.has(current.file)) continue;
+    reached.set(current.file, current);
+
+    for (const specifier of runtimeSpecifiers(current.file)) {
+      if (specifier.startsWith('.')) {
+        const resolved = resolveRelative(current.file, specifier);
+        if (resolved && !reached.has(resolved)) {
+          queue.push({
+            file: resolved,
+            chain: [...current.chain, path.relative(BACKEND_ROOT, resolved)],
+          });
+        }
+        continue;
+      }
+      // A bare specifier is a package. Only the forbidden ones are interesting;
+      // the walk does not descend into `node_modules`.
+      const packageName = specifier.startsWith('@')
+        ? specifier.split('/').slice(0, 2).join('/')
+        : specifier.split('/')[0];
+      if (FORBIDDEN_PACKAGES.has(packageName)) {
+        offenders.push(`${packageName} <- ${current.chain.join(' -> ')}`);
+      }
+    }
+  }
+
+  return { reached, offenders };
+}
+
+describe('the web task boot path does not reach Mongo', () => {
+  const { reached, offenders } = walkBootGraph();
+
+  /**
+   * The floor, asserted FIRST so a broken traversal reports itself rather than
+   * being reported as a clean result by the check below.
+   */
+  it('reaches the modules the server certainly loads', () => {
+    const relative = new Set(
+      [...reached.keys()].map((file) => path.relative(BACKEND_ROOT, file)),
+    );
+    for (const required of REQUIRED_REACHABLE) {
+      expect(relative.has(required), `${required} was not reached — the walk is broken`).toBe(true);
+    }
+    // A boot graph this small would mean resolution silently failed.
+    expect(reached.size).toBeGreaterThan(100);
+  });
+
+  /**
+   * THE case. Each offender is reported with the chain that reached it, because
+   * "mongoose is on the boot path" is not actionable and
+   * "server.ts -> src/app.ts -> ... -> src/models/Post.ts" is.
+   *
+   * Mutation: restore `require("./src/models/Post")` to `server.ts` and this
+   * goes red naming that chain — verified, including through the `require`,
+   * which is the form the deleted import actually took.
+   */
+  it('loads neither mongoose nor the mongodb driver, by any route', () => {
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/backend/src/routes/health.routes.ts
+++ b/packages/backend/src/routes/health.routes.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import { checkPostgresHealth } from '../db/postgres';
-import { isDatabaseConnected } from '../utils/database';
 import { getRedisStats } from '../utils/redis';
 import { getRuntimeHealthState } from '../utils/runtimeHealth';
 
@@ -15,36 +14,37 @@ router.get('/health/live', (_req, res) => {
 });
 
 /**
- * Readiness gates on POSTGRES, and the asymmetry with Mongo below is deliberate.
+ * Readiness gates on POSTGRES, and on nothing else that is a data store.
  *
- * Mongo is checked with `isDatabaseConnected()` — a synchronous `readyState`
- * read, no command, because a probe must not cost a round trip per call.
  * Postgres is checked with `checkPostgresHealth()`, which issues a real
- * `select 1`, and the difference is the whole point: the failure this exists to
+ * `select 1` rather than reading a connection flag: the failure this exists to
  * catch is a task whose database has become UNREACHABLE, and a pool object
  * survives that. `isPostgresConnected()` would answer "was a pool ever built",
- * which is true of exactly the task that is failing every query.
+ * which is true of exactly the task that is failing every request.
  *
- * Before the Mongo→Postgres cutover this endpoint checked Mongo and not
- * Postgres at all. That matched which store was authoritative, and it inverts
- * the moment the data moves: a task with no Postgres connection kept reporting
- * ready and kept taking traffic while erroring on every request. `postgres.ts`
- * already said the health endpoint was the caller `checkPostgresHealth` existed
- * for; it simply was not wired.
+ * ## Mongo was removed from this gate, and it had to be removed WITH the boot
  *
- * Mongo stays in the gate while Mongo is still running. Removing it is
- * decommission work, and it must be removed rather than left: once Mongo is off,
- * `isDatabaseConnected()` pins readiness false forever.
+ * The gate used to `&&` in `isDatabaseConnected()`, a synchronous `readyState`
+ * read on the default mongoose connection that `server.ts` opened at boot. The
+ * previous version of this comment stated the consequence exactly — "once Mongo
+ * is off, `isDatabaseConnected()` pins readiness false forever" — and it is
+ * why this file is part of the same change that stopped the web task connecting
+ * to Mongo. Dropping the connection alone would leave every task answering 503
+ * on `/health/ready` for as long as it lived: the ALB would drain the fleet and
+ * the deploy's own smoke checks would fail, on a store no request touches.
+ *
+ * `dependencies.mongo` is gone from the payload for the same reason it is gone
+ * from the gate — reporting a store this process never opens would be inventing
+ * a status. What still uses Mongo is the deploy one-shot and the restore
+ * tooling, and neither is a web task whose readiness this answers.
  */
 router.get('/health/ready', async (_req, res) => {
   const runtime = getRuntimeHealthState();
-  const mongoReady = isDatabaseConnected();
   const postgresReady = await checkPostgresHealth();
   const redis = getRedisStats();
   const ready =
     runtime.phase === 'ready' &&
     runtime.migrationsComplete &&
-    mongoReady &&
     postgresReady;
 
   res.setHeader('Cache-Control', 'no-store');
@@ -52,7 +52,6 @@ router.get('/health/ready', async (_req, res) => {
     status: ready ? 'ready' : 'not_ready',
     phase: runtime.phase,
     dependencies: {
-      mongo: mongoReady ? 'ready' : 'unavailable',
       postgres: postgresReady ? 'ready' : 'unavailable',
       migrations: runtime.migrationsComplete ? 'ready' : 'pending',
       // Redis is intentionally non-blocking for HTTP readiness. Singleton jobs

--- a/packages/backend/src/routes/legacyRoot.routes.ts
+++ b/packages/backend/src/routes/legacyRoot.routes.ts
@@ -1,7 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import { checkPostgresHealth } from '../db/postgres';
 import { isApexHost } from '../middleware/apexFrontendProxy';
-import { isDatabaseConnected } from '../utils/database';
 import { getRuntimeHealthState } from '../utils/runtimeHealth';
 
 /**
@@ -25,7 +24,6 @@ export async function legacyApiRootReadiness(
   const ready =
     runtime.phase === 'ready' &&
     runtime.migrationsComplete &&
-    isDatabaseConnected() &&
     (await checkPostgresHealth());
 
   res.setHeader('Cache-Control', 'no-store');


### PR DESCRIPTION
> **Do not merge.** Not until the Postgres restore is **complete _and verified_** — complete is not enough. Mongo is currently the only intact copy of Mention's data and the live source of that restore. Based on `main`, independent of #665/#666.

Takes Mongo off the web task's boot path. Scoped to exactly that: the deploy one-shot and the restore tooling still use Mongo and are deliberately untouched.

Full backend suite: **538 files, 6,402 tests, all passing.** `tsc` clean.

## The part that would have been an outage

`/health/ready` and the legacy `/` handler both `&&`-ed in `isDatabaseConnected()` — a `readyState` read on the default mongoose connection that `server.ts` opened at boot. **With that connection gone, the read is permanently false**, so every task would answer 503 for as long as it lived: the ALB drains the fleet, and the deploy's own smoke checks fail, over a store no request touches.

`health.routes.ts` predicted this in so many words:

> *Mongo stays in the gate while Mongo is still running. Removing it is decommission work, and it must be removed rather than left: once Mongo is off, `isDatabaseConnected()` pins readiness false forever.*

So the gate moves in this commit, not a later one. `dependencies.mongo` leaves the payload with it — reporting a store the process never opens is inventing a status. The readiness test now asserts the dependency list **whole**, so it fails if `mongo` comes back.

## What was removed

From `server.ts`: the `mongoose` import, `connectToDatabase()`, the connection error/open handlers, `require("./src/models/Post")`, `assertMongoTransactionalTopology()`, `assertMigrationsApplied()`, `runMigrations()`, `mongoose.disconnect()`. From the two readiness paths: `isDatabaseConnected()`.

Four comments were corrected rather than left: two called the engagement/moderation outbox workers "Mongo-leased" and one called the federation delivery fallback an "in-process Mongo delivery scheduler". Both drain Postgres tables now (`EngagementOutboxDispatcher` uses `getDb()`; the fallback drains `federation_delivery_queue` via `deliveryQueueRepository`). A comment naming the wrong store is how the next reader re-adds the dependency.

## What was deliberately NOT removed — and why

Each of these is load-bearing **right now**. If a future cleanup deletes one without checking, it breaks either the restore or the deploy.

| kept | why |
|---|---|
| `mongoose` in `package.json` | `db/backfill/mongoSource.ts` opens a **dedicated** connection with it (`mongoose.createConnection`, raw `db.collection()` — never the models, never the default connection). **This is the only restore path we have.** |
| `src/db/backfill/**` | The restore itself. Untouched, not read, not moved. |
| `src/models/` (37 files) | Imported by ~15 scripts, plus two runtime `import type`s (`db/feeds/customFeedRepository.ts`, `routes/customFeedWrite.ts`) that are erased at compile time. |
| `src/migrations/**`, `scripts/migrate.ts`, `src/utils/database.ts`, `src/utils/mongoTopology.ts` | The deploy one-shot. `.github/scripts/deploy-ecs-image.sh` runs `dist/scripts/migrate.js` under `RUN_MIGRATIONS=true`, and that task also carries **`BlockedDomainPurgeReconciler`** — deleting these drops a reconciler from every deploy. |

Deleting any of the above is separate work for after Mongo is actually decommissioned, and it needs the restore to be finished and verified first.

## The gate

`src/__tests__/mongoOffTheBootPath.test.ts` walks the runtime module graph from `server.ts` and fails if `mongoose` or `mongodb` is reachable, reporting the **import chain** rather than just the fact:

```
mongoose <- server.ts -> src/runtimeApp.ts -> src/appRoutes.ts -> src/routes/lists.ts -> src/controllers/feed.controller.ts
```

A grep would not do here — it answers a much broader question and would fail on arrival, since ~60 files import mongoose legitimately. The question is *reachability from one entry point*, so the check is reachability. Three details it has to get right, each from a real shape in this repo:

- **`require('literal')` counts.** The import this replaces was `require("./src/models/Post")` inside a `db.once("open")` handler — invisible to a scanner that only reads `import` declarations, and it is the shape a future one will take, because `server.ts` lazily `require`s most of its schedulers.
- **`import type` does not count**, per specifier, not per statement. Two live runtime modules name a type from `models/CustomFeed`; counting them would make the gate red on arrival and wrong.
- **A reachability floor**, so a traversal that breaks and visits nothing fails loudly instead of reporting `[]`.

Mutation-tested, all three verified:

| mutation | result |
|---|---|
| restore `require("./src/models/Post")` in `server.ts` | red — `mongoose <- server.ts -> src/models/Post.ts` |
| `import mongoose` in `feed.controller.ts` | red — full 5-hop chain |
| `import type { Types } from 'mongoose'` in the same file | **passes** (correct — no false positive) |

## Merge order

Independent of #665 and #666 — different files, no conflict. But it should land **last** of the three, and only once the restore is verified.

Refs #664.
