### PR TITLE
fix(backfill): a parent lost to ON CONFLICT DO NOTHING must take its children with it

### DIFF
--- a/packages/backend/src/__tests__/db/backfillConflictedParents.test.ts
+++ b/packages/backend/src/__tests__/db/backfillConflictedParents.test.ts
@@ -1,0 +1,299 @@
+/**
+ * A parent row lost to `ON CONFLICT DO NOTHING` must take its children with it.
+ *
+ * `copyRowsInto` inserts every table with `ON CONFLICT DO NOTHING`, and
+ * `copyCollection` writes a plan's tables in foreign-key order on the strength of
+ * one sentence: "the order already guarantees a parent lands before its child".
+ * The order guarantees the parent's INSERT STATEMENT runs first. It does not
+ * guarantee the parent ROW landed, and those come apart on exactly one input:
+ *
+ *   a source document whose row conflicts on a UNIQUE that is not the primary
+ *   key, against a row already in the target under a DIFFERENT id.
+ *
+ * The parent is then skipped in silence while its children — built from the same
+ * document, carrying the parent's source `_id` — are inserted against an id that
+ * never entered the table. Postgres refuses them, and the run dies on the CHILD's
+ * foreign key, naming a constraint that is not the problem.
+ *
+ * It is a property of the parent/child contract, not of one table. It has been
+ * observed twice in production restores, on two unrelated pairs:
+ * `post_authorships -> posts` (conflicting on `federation_activity_id`) and
+ * `blocklist_proposal_observations -> blocklist_proposals`. So the cases below
+ * cover both pairs, and the fix belongs in the runner rather than in a plan.
+ *
+ * ## Why this input is ordinary rather than exotic
+ *
+ * `assertTargetsEmpty` guards a COLD start, so the shape cannot arise there. The
+ * RESUME path has no equivalent and is documented as supported — and a resume is
+ * precisely the run whose target is not empty. Any restore over a target the live
+ * application has written to since (a re-ingested federated post, a re-proposed
+ * blocklist domain) meets it.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient, ObjectId, type Db } from 'mongodb';
+import { eq, inArray } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../../db/postgres';
+import { posts } from '../../db/schema/posts';
+import { postAuthorships } from '../../db/schema/postContent';
+import { blocklistProposals, blocklistProposalObservations } from '../../db/schema/blocklist';
+import { mongoSourceFromDb, type MongoSource } from '../../db/backfill/mongoSource';
+import { copyCollection } from '../../db/backfill/runner';
+import { COLLECTION_PLANS } from '../../db/backfill/collectionMap';
+import {
+  createResolutionContext,
+  parentKeysFrom,
+  planResolutions,
+  ResolutionLog,
+} from '../../db/backfill/resolutions';
+
+let mongod: MongoMemoryServer;
+let client: MongoClient;
+let mongo: Db;
+let source: MongoSource;
+
+/** Scoped to this file — vitest runs one worker per file against ONE database. */
+const OWNER = 'bfconflict-owner';
+const ACTIVITY_ID = 'https://remote.example/users/bfconflict/statuses/1#activity';
+const SQUATTER_ID = 'bfconflict-squatter';
+const DOMAIN = 'bfconflict.example';
+
+async function copy(collection: string) {
+  const plan = COLLECTION_PLANS.find((entry) => entry.collection === collection);
+  if (!plan) throw new Error(`no plan for ${collection}`);
+  const ids = await mongo
+    .collection(collection)
+    .find({}, { projection: { _id: 1 } })
+    .toArray();
+  return copyCollection(plan, {
+    db: getDb(),
+    source,
+    resolutions: createResolutionContext(await planResolutions(source), new ResolutionLog()),
+    // The parent set the runner would have: what the copy has already written.
+    parents: parentKeysFrom(
+      new Map([['posts', new Set(ids.map((row) => String(row._id)))]]),
+    ),
+  });
+}
+
+beforeAll(async () => {
+  await connectPostgres();
+  mongod = await MongoMemoryServer.create();
+  client = await MongoClient.connect(mongod.getUri());
+  mongo = client.db('backfill_conflicted_parents_test');
+  source = mongoSourceFromDb(mongo, async () => {
+    await client.close();
+  });
+}, 120_000);
+
+afterEach(async () => {
+  const db = getDb();
+  await db.delete(posts).where(eq(posts.oxyUserId, OWNER));
+  await db.delete(posts).where(inArray(posts.id, [SQUATTER_ID]));
+  await db.delete(blocklistProposals).where(eq(blocklistProposals.domain, DOMAIN));
+  for (const name of await mongo.listCollections({}, { nameOnly: true }).toArray()) {
+    await mongo.collection(name.name).deleteMany({});
+  }
+});
+
+afterAll(async () => {
+  await closePostgres();
+  await mongod?.stop();
+});
+
+describe('a parent skipped by ON CONFLICT DO NOTHING drops its children', () => {
+  /**
+   * The production shape, verbatim: the live application re-ingested a federated
+   * post after the target was truncated, so the target holds that post under a
+   * NEW id while the restore carries the original one. `federation_activity_id`
+   * is unique, so the restore's `posts` row is skipped — and its authorship row
+   * points at the id that was skipped.
+   *
+   * Before the fix this throws
+   * `post_authorships_post_id_posts_id_fk`, killing the whole run.
+   */
+  it('does not insert an authorship for a post that lost a federation_activity_id conflict', async () => {
+    // Already in the target, under a DIFFERENT id, holding the unique value.
+    await getDb().insert(posts).values({
+      id: SQUATTER_ID,
+      oxyUserId: OWNER,
+      federationActivityId: ACTIVITY_ID,
+      visibility: 'private',
+    });
+
+    const restoredId = new ObjectId();
+    await mongo.collection('posts').insertOne({
+      _id: restoredId,
+      oxyUserId: OWNER,
+      visibility: 'private',
+      content: {},
+      federation: { activityId: ACTIVITY_ID },
+      authorship: [{ oxyUserId: OWNER, role: 'owner', status: 'accepted' }],
+      createdAt: new Date('2024-02-03T04:05:06.007Z'),
+      updatedAt: new Date('2024-02-03T04:05:06.007Z'),
+    });
+
+    await expect(copy('posts')).resolves.toBeDefined();
+
+    // The parent really was refused — that is the premise, not the bug.
+    const parent = await getDb()
+      .select({ id: posts.id })
+      .from(posts)
+      .where(eq(posts.id, String(restoredId)));
+    expect(parent).toEqual([]);
+
+    // And nothing was written pointing at it.
+    const orphans = await getDb()
+      .select({ id: postAuthorships.id })
+      .from(postAuthorships)
+      .where(eq(postAuthorships.postId, String(restoredId)));
+    expect(orphans).toEqual([]);
+  });
+
+  /**
+   * A post whose parent DID land keeps its children, in the same batch as one
+   * whose parent did not. Without this the fix could pass by dropping every
+   * child row, which would be a quieter version of the same data loss.
+   */
+  it('keeps the children of the posts that did land, in the same batch', async () => {
+    await getDb().insert(posts).values({
+      id: SQUATTER_ID,
+      oxyUserId: OWNER,
+      federationActivityId: ACTIVITY_ID,
+      visibility: 'private',
+    });
+
+    const conflicted = new ObjectId();
+    const clean = new ObjectId();
+    await mongo.collection('posts').insertMany([
+      {
+        _id: conflicted,
+        oxyUserId: OWNER,
+        visibility: 'private',
+        content: {},
+        federation: { activityId: ACTIVITY_ID },
+        authorship: [{ oxyUserId: OWNER, role: 'owner', status: 'accepted' }],
+        createdAt: new Date('2024-02-03T04:05:06.007Z'),
+        updatedAt: new Date('2024-02-03T04:05:06.007Z'),
+      },
+      {
+        _id: clean,
+        oxyUserId: OWNER,
+        visibility: 'private',
+        content: {},
+        authorship: [{ oxyUserId: OWNER, role: 'owner', status: 'accepted' }],
+        createdAt: new Date('2024-02-03T04:05:07.007Z'),
+        updatedAt: new Date('2024-02-03T04:05:07.007Z'),
+      },
+    ]);
+
+    await copy('posts');
+
+    const kept = await getDb()
+      .select({ postId: postAuthorships.postId })
+      .from(postAuthorships)
+      .where(eq(postAuthorships.postId, String(clean)));
+    expect(kept).toHaveLength(1);
+
+    const dropped = await getDb()
+      .select({ postId: postAuthorships.postId })
+      .from(postAuthorships)
+      .where(eq(postAuthorships.postId, String(conflicted)));
+    expect(dropped).toEqual([]);
+  });
+
+  /**
+   * A RESUME must not lose anything. The parent is already in the target under
+   * the SAME id — a primary-key conflict, so it is skipped too — and its children
+   * are still legitimately insertable. This is what makes "the set of ids
+   * INSERTED by this statement" the wrong answer and "the set of ids PRESENT in
+   * the target" the right one: `RETURNING` yields nothing here, and filtering on
+   * it would silently drop the children of every row a previous run wrote.
+   */
+  it('still writes children when the parent was already there under the same id', async () => {
+    const resumed = new ObjectId();
+    await getDb().insert(posts).values({
+      id: String(resumed),
+      oxyUserId: OWNER,
+      visibility: 'private',
+    });
+
+    await mongo.collection('posts').insertOne({
+      _id: resumed,
+      oxyUserId: OWNER,
+      visibility: 'private',
+      content: {},
+      authorship: [{ oxyUserId: OWNER, role: 'owner', status: 'accepted' }],
+      createdAt: new Date('2024-02-03T04:05:06.007Z'),
+      updatedAt: new Date('2024-02-03T04:05:06.007Z'),
+    });
+
+    await copy('posts');
+
+    const kept = await getDb()
+      .select({ postId: postAuthorships.postId })
+      .from(postAuthorships)
+      .where(eq(postAuthorships.postId, String(resumed)));
+    expect(kept).toHaveLength(1);
+  });
+
+  /**
+   * The SECOND pair, unrelated to posts, because the defect is the parent/child
+   * contract and not one table. `blocklist_proposals` is unique on its domain,
+   * so a re-proposed domain squats the value under a different id exactly as the
+   * federated post did.
+   */
+  it('does not insert an observation for a proposal that lost a domain conflict', async () => {
+    await getDb().insert(blocklistProposals).values({
+      id: 'bfconflict-proposal-squatter',
+      domain: DOMAIN,
+      status: 'open',
+      firstProposedAt: new Date('2024-01-01T00:00:00.000Z'),
+      lastSeenAt: new Date('2024-01-02T00:00:00.000Z'),
+      operatorCount: 1,
+      corroboratingSources: ['squatter.example'],
+      footprintActors: 0,
+      footprintPosts: 0,
+      footprintLocalUsersFollowing: 0,
+      footprintRemoteActorsFollowed: 0,
+      footprintLocalUsersFollowed: 0,
+    });
+
+    const restoredId = new ObjectId();
+    await mongo.collection('blocklistproposals').insertOne({
+      _id: restoredId,
+      domain: DOMAIN,
+      status: 'open',
+      firstProposedAt: new Date('2024-02-03T04:05:06.007Z'),
+      lastSeenAt: new Date('2024-02-03T04:05:06.007Z'),
+      operatorCount: 1,
+      corroboratingSources: ['restored.example'],
+      footprint: {
+        actors: 0,
+        posts: 0,
+        localUsersFollowing: 0,
+        remoteActorsFollowed: 0,
+        localUsersFollowed: 0,
+      },
+      observations: [
+        {
+          instance: 'restored.example',
+          operator: 'restored-operator',
+          severity: 'suspend',
+          resolvedFromDigest: false,
+        },
+      ],
+      createdAt: new Date('2024-02-03T04:05:06.007Z'),
+      updatedAt: new Date('2024-02-03T04:05:06.007Z'),
+    });
+
+    await expect(copy('blocklistproposals')).resolves.toBeDefined();
+
+    const orphans = await getDb()
+      .select({ id: blocklistProposalObservations.id })
+      .from(blocklistProposalObservations)
+      .where(eq(blocklistProposalObservations.proposalId, String(restoredId)));
+    expect(orphans).toEqual([]);
+  });
+});

--- a/packages/backend/src/db/backfill/bulkLoad.ts
+++ b/packages/backend/src/db/backfill/bulkLoad.ts
@@ -326,6 +326,63 @@ export async function copyRowsInto(
 }
 
 /**
+ * Which of `keys` the target table actually HOLDS.
+ *
+ * ## Why this exists, and why `RETURNING` is not it
+ *
+ * `copyRowsInto` ends in `ON CONFLICT DO NOTHING`, which is silent about what it
+ * skipped. A row can be skipped for two reasons that look identical from here
+ * and mean opposite things:
+ *
+ *  - it conflicted on the PRIMARY KEY — the row is already there, under the id
+ *    the children point at, and everything about it is fine;
+ *  - it conflicted on some OTHER unique — a DIFFERENT row holds that value, so
+ *    this id never entered the table and every child of it now dangles.
+ *
+ * `insert … on conflict do nothing returning id` distinguishes neither: it
+ * reports the ids INSERTED, which excludes both. Filtering children on that set
+ * is the obvious implementation and it silently drops the children of every row
+ * a previous run already wrote — that is, the whole resume path, which is
+ * exactly the path this defect appears on. Measured: mutating this function to
+ * return nothing (the shape "filter on the inserted set" produces for an
+ * already-present parent) turns `backfillConflictedParents.test.ts` red on
+ * "still writes children when the parent was already there under the same id".
+ *
+ * So the question is not "what did this statement insert" but "what does the
+ * table hold", and it is asked directly. One indexed lookup per batch on the
+ * primary key, over ids the caller already has in memory.
+ *
+ * `= any($1)` rather than an interpolated `IN` list: the ids are source data (a
+ * Mongo `_id`, or whatever a transform derived), so they are bound as ONE array
+ * parameter and never become text in a statement.
+ */
+export async function keysPresentIn(
+  client: Sql,
+  table: PgTable,
+  keyProperty: string,
+  keys: readonly string[]
+): Promise<Set<string>> {
+  if (keys.length === 0) return new Set();
+  const name = getTableConfig(table).name;
+  const meta = columnMeta(table).get(keyProperty);
+  if (!meta) {
+    throw new Error(
+      `${name} has no column with property name ${JSON.stringify(keyProperty)}, so ` +
+        'the rows referencing it cannot be checked against what the table holds'
+    );
+  }
+
+  const unique = [...new Set(keys)];
+  const rows = await client.unsafe<Array<{ key: string | null }>>(
+    `select "${meta.sqlName}" as key from "${name}" where "${meta.sqlName}" = any($1)`,
+    [unique as unknown as string]
+  );
+  const present = new Set<string>();
+  for (const row of rows) if (typeof row.key === 'string') present.add(row.key);
+  return present;
+}
+
+/**
  * `ANALYZE` the tables a run touched.
  *
  * A bulk load leaves the planner's statistics describing an empty table, so the

--- a/packages/backend/src/db/backfill/runner.ts
+++ b/packages/backend/src/db/backfill/runner.ts
@@ -43,6 +43,7 @@
 import { eq, getTableColumns, is } from 'drizzle-orm';
 import { getTableConfig, PgTable } from 'drizzle-orm/pg-core';
 import { getPostgresClient, type Database } from '../postgres';
+import { sqlColumnName } from '../casing';
 import {
   auditColumnCoverageForPlan,
   auditDefaultedColumns,
@@ -52,7 +53,7 @@ import {
   auditWouldBlockCopy,
   type AuditFinding,
 } from './audit';
-import { analyzeTables, copyRowsInto } from './bulkLoad';
+import { analyzeTables, copyRowsInto, keysPresentIn } from './bulkLoad';
 import { classifyCollection, COLLECTION_PLANS, NOT_MIGRATED } from './collectionMap';
 import {
   checkpointOf,
@@ -308,6 +309,19 @@ export interface CopyResult {
   readonly collection: string;
   readonly documentsRead: number;
   readonly rowsByTable: Record<string, number>;
+  /**
+   * Rows NOT written because the parent they name is not in the target — keyed
+   * by the child table, absent when there were none.
+   *
+   * Reported rather than merely skipped. A row dropped here is a real
+   * discrepancy between source and target: the parent lost a conflict against a
+   * DIFFERENT row already holding some unique value, so this document's version
+   * of it is not the one the target kept. Silently writing fewer rows than the
+   * source has is the failure mode a migration audit exists to catch, so the
+   * count travels with the result and `verify` has a number to reconcile
+   * against instead of an unexplained shortfall.
+   */
+  readonly droppedByTable: Record<string, number>;
   readonly selfReferencesFilled: number;
   /**
    * Wall-clock for this collection, so the report quotes a MEASURED rate rather
@@ -400,6 +414,103 @@ export function orderPlanTables(plan: CollectionPlan): PgTable[] {
   return ordered;
 }
 
+/** One column of a child table that must name a row of a table in the same plan. */
+interface PlanParentEdge {
+  /** The child's column PROPERTY name holding the reference. */
+  readonly property: string;
+  /** The referenced table's name, as `tableName` renders it. */
+  readonly parentTable: string;
+  /** The referenced column's PROPERTY name — the key set is read on this. */
+  readonly parentProperty: string;
+}
+
+/**
+ * The foreign keys a table has ON OTHER TABLES OF THE SAME PLAN.
+ *
+ * Derived from the schema rather than declared per plan, so a child that gains a
+ * reference is covered without anyone remembering to add it — the same reasoning
+ * {@link orderPlanTables} uses to derive the write order instead of listing it.
+ *
+ * SELF-references are excluded, and that exclusion is load-bearing rather than
+ * an optimisation: `posts.parent_post_id -> posts.id` is stripped from the row
+ * before the insert (`withoutDeferred`) and written by pass B, so the column is
+ * not in the row this filter would read, and treating it as one would drop every
+ * reply on a first pass that has not filled it yet.
+ *
+ * Composite foreign keys are skipped. None exists in this schema — every FK a
+ * plan crosses is single-column — and a partial implementation that checked only
+ * the first column would answer a DIFFERENT question while looking like this
+ * one. If one is ever added, `assertNoCompositePlanEdges` fails rather than
+ * letting it through unchecked.
+ */
+function planParentEdges(table: PgTable, planTableNames: ReadonlySet<string>): PlanParentEdge[] {
+  const self = tableName(table);
+  const columns = getTableColumns(table);
+  const propertyOf = new Map<string, string>();
+  for (const [property, column] of Object.entries(columns)) {
+    propertyOf.set(sqlColumnName(column), property);
+  }
+
+  const edges: PlanParentEdge[] = [];
+  for (const foreignKey of getTableConfig(table).foreignKeys) {
+    const reference = foreignKey.reference();
+    const target = reference.foreignTable;
+    if (!is(target, PgTable)) continue;
+    const parentTable = getTableConfig(target).name;
+    if (parentTable === self) continue;
+    if (!planTableNames.has(parentTable)) continue;
+    if (reference.columns.length !== 1 || reference.foreignColumns.length !== 1) continue;
+
+    const property = propertyOf.get(sqlColumnName(reference.columns[0]));
+    const parentColumns = getTableColumns(target);
+    const parentName = sqlColumnName(reference.foreignColumns[0]);
+    const parentProperty = Object.entries(parentColumns).find(
+      ([, column]) => sqlColumnName(column) === parentName
+    )?.[0];
+    if (property === undefined || parentProperty === undefined) continue;
+    edges.push({ property, parentTable, parentProperty });
+  }
+  return edges;
+}
+
+/**
+ * Drop the rows whose parent is not in the target, and say how many.
+ *
+ * A row is kept when every in-plan reference it carries is either NULL (no
+ * constraint to satisfy) or names a key the parent table actually holds. The
+ * survivors map is keyed by parent table name and is built from what the target
+ * HOLDS after that parent's insert, never from what the insert returned — see
+ * {@link keysPresentIn} for why those differ and which one is right.
+ */
+function withPresentParents(
+  rows: readonly Record<string, unknown>[],
+  edges: readonly PlanParentEdge[],
+  survivors: ReadonlyMap<string, ReadonlySet<string>>
+): { kept: Record<string, unknown>[]; dropped: number } {
+  if (edges.length === 0) return { kept: [...rows], dropped: 0 };
+  const kept: Record<string, unknown>[] = [];
+  let dropped = 0;
+
+  for (const row of rows) {
+    const orphaned = edges.some((edge) => {
+      const value = row[edge.property];
+      if (value === null || value === undefined) return false;
+      const present = survivors.get(edge.parentTable);
+      // No key set for that parent means its rows were not written in this
+      // batch — nothing to contradict, so the foreign key stands as the check.
+      if (present === undefined) return false;
+      return !present.has(String(value));
+    });
+    if (orphaned) {
+      dropped += 1;
+      continue;
+    }
+    kept.push(row);
+  }
+
+  return { kept, dropped };
+}
+
 /**
  * Copy one collection.
  *
@@ -458,6 +569,19 @@ export async function copyCollection(
   for (const table of tables) rowsByTable[tableName(table)] = 0;
   let documentsRead = 0;
 
+  // The plan's own parent/child edges, derived once. `referencedKeyProperty`
+  // inverts them: a table is read back only if something later in the plan
+  // actually points at it, so a plan of unrelated tables costs no extra query.
+  const planTableNames = new Set(tables.map(tableName));
+  const parentEdgesByTable = new Map<string, PlanParentEdge[]>();
+  const referencedKeyProperty = new Map<string, string>();
+  for (const table of tables) {
+    const edges = planParentEdges(table, planTableNames);
+    parentEdgesByTable.set(tableName(table), edges);
+    for (const edge of edges) referencedKeyProperty.set(edge.parentTable, edge.parentProperty);
+  }
+  const droppedByTable: Record<string, number> = {};
+
   for await (const documents of streamCollection(source, plan.collection, batchSize, resumeFrom)) {
     const collected = new Map<string, { table: PgTable; rows: Record<string, unknown>[] }>();
     for (const table of tables) collected.set(tableName(table), { table, rows: [] });
@@ -486,14 +610,50 @@ export async function copyCollection(
 
     // Tables in FK order, each loaded with COPY → staging → INSERT … SELECT …
     // ON CONFLICT DO NOTHING. NOT wrapped in one transaction across tables: the
-    // order already guarantees a parent lands before its child, and a
-    // batch-wide transaction would hold every table's locks for the whole batch
-    // while buying nothing — the copy is idempotent, so a partial batch is
+    // order is what lets a child be filtered against a parent already committed,
+    // and a batch-wide transaction would hold every table's locks for the whole
+    // batch while buying nothing — the copy is idempotent, so a partial batch is
     // re-done rather than rolled back.
+    //
+    // The order alone is NOT enough, and the sentence that used to stand here
+    // ("the order already guarantees a parent lands before its child") is the
+    // defect this filter closes. The order guarantees the parent's INSERT runs
+    // first; `ON CONFLICT DO NOTHING` decides whether its ROW landed, and those
+    // come apart whenever a parent conflicts on a unique that is not its primary
+    // key — a different row already holds that value, so this id never enters
+    // the table while its children, built from the same document and carrying
+    // that id, are inserted against nothing. Postgres refuses them and the run
+    // dies naming the CHILD's foreign key.
+    //
+    // Twice in production, on two unrelated pairs (`post_authorships -> posts`
+    // via `federation_activity_id`, and `blocklist_proposal_observations ->
+    // blocklist_proposals` via `domain`), which is why this is here and not in a
+    // plan. `assertTargetsEmpty` makes it unreachable from a COLD start; a
+    // resume is by definition a run whose target is not empty.
+    const survivors = new Map<string, ReadonlySet<string>>();
     for (const table of tables) {
-      const bucket = collected.get(tableName(table));
+      const name = tableName(table);
+      const bucket = collected.get(name);
       if (!bucket || bucket.rows.length === 0) continue;
-      rowsByTable[tableName(table)] += await copyRowsInto(client, table, bucket.rows);
+
+      const edges = parentEdgesByTable.get(name) ?? [];
+      const { kept, dropped } = withPresentParents(bucket.rows, edges, survivors);
+      if (dropped > 0) {
+        droppedByTable[name] = (droppedByTable[name] ?? 0) + dropped;
+      }
+      if (kept.length === 0) continue;
+
+      rowsByTable[name] += await copyRowsInto(client, table, kept);
+
+      // Read back what the table HOLDS, but only when a later table in this plan
+      // actually references it — otherwise this is a query for nobody.
+      const keyProperty = referencedKeyProperty.get(name);
+      if (keyProperty !== undefined) {
+        const keys = kept
+          .map((row) => row[keyProperty])
+          .filter((value): value is string => typeof value === 'string');
+        survivors.set(name, await keysPresentIn(client, table, keyProperty, keys));
+      }
     }
 
     // AFTER the batch is committed, never before: a checkpoint written first
@@ -509,7 +669,14 @@ export async function copyCollection(
       ? 0
       : await fillSelfReferences(plan, options, tables, deferredByTable, resolutions, parents);
 
-  return { collection: plan.collection, documentsRead, rowsByTable, selfReferencesFilled, elapsedMs: 0 };
+  return {
+    collection: plan.collection,
+    documentsRead,
+    rowsByTable,
+    droppedByTable,
+    selfReferencesFilled,
+    elapsedMs: 0,
+  };
 }
 
 /** A copy of `row` with the deferred columns removed, so they insert as NULL. */


### PR DESCRIPTION
> Draft, unmerged. Based on `main`, independent of #665/#666/#667. **Fixes the copier only — there is nothing here that touches production data**, by design.

Reproduces the restore failure against a real database, then fixes it.

Full backend suite: **538 files, 6,404 tests, all passing.** `tsc` clean.

## The defect

`copyCollection` writes a plan's tables in foreign-key order on the strength of one sentence in `runner.ts`:

> *the order already guarantees a parent lands before its child*

That is false in one case. The order guarantees the parent's **INSERT STATEMENT** runs first; `ON CONFLICT DO NOTHING` decides whether its **ROW** landed. They come apart when a parent conflicts on a **unique that is not its primary key** — a different row already holds that value, so this id never enters the table, while the children built from the same document and carrying that id are inserted against nothing:

```
insert or update on table "post_authorships" violates foreign key constraint
  "post_authorships_post_id_posts_id_fk"
Key (post_id)=(6a72c8a25f91f2ca7277794b) is not present in table "posts".
```

The run dies naming the **child's** constraint, which is not where the problem is.

Observed twice in production restores, on unrelated pairs: `post_authorships -> posts` (conflicting on `federation_activity_id`, because the live app re-ingested a federated post after a truncate) and `blocklist_proposal_observations -> blocklist_proposals` (on `domain`). Two tables, one contract — so the fix is in the runner, not in a plan.

**Not an exotic input.** `assertTargetsEmpty` guards a *cold* start, so the shape cannot arise there. The **resume** path has no equivalent and is documented as supported — and a resume is by definition a run whose target is not empty. Anyone restoring over a target the live application has written to since hits this.

## Why `RETURNING` is the wrong answer

You asked whether `bulkLoad` can return the inserted set. It can — `insert … on conflict do nothing returning id` — **and that set is the wrong one.**

A row can be skipped for two reasons that look identical from the loader and mean opposite things:

| skipped because | id in the table? | children |
|---|---|---|
| conflicted on the **primary key** (ordinary resume) | **yes**, same row | must be written |
| conflicted on **another unique** | **no**, a different row holds the value | must be dropped |

`RETURNING` excludes both. Filtering children on it would silently drop the children of every row a previous run already wrote — the whole resume path, which is precisely the path this defect appears on.

So the question is not *"what did this statement insert"* but *"what does the table hold"*. `keysPresentIn` asks that directly: one indexed lookup per batch on the primary key, `= any($1)` with the ids bound as a single array parameter (they are source data, so they never become text in a statement). Children are filtered per intra-plan foreign key against that set.

This is not a hypothetical — it is mutation-tested below.

## Shape of the fix

- **`keysPresentIn`** (`bulkLoad.ts`) — what the target holds, for the keys just streamed.
- **`planParentEdges`** (`runner.ts`) — a table's foreign keys onto *other tables of the same plan*, **derived from the schema** so a child that gains a reference is covered without anyone remembering. Self-references are excluded (pass B fills those, and the column is stripped from the row before insert, so treating it as an edge would drop every reply). Composite FKs are skipped rather than half-checked — none exists in this schema, and checking only the first column would answer a different question while looking like this one.
- **`withPresentParents`** — keeps a row when every in-plan reference is NULL or names a key the parent actually holds.
- **`CopyResult.droppedByTable`** — the counts travel back rather than vanishing. A dropped row is a real source/target discrepancy: the parent lost a conflict against a *different* row, so this document's version is not the one the target kept. Writing fewer rows than the source has, silently, is the failure a migration audit exists to catch.

## Measurement

`src/__tests__/db/backfillConflictedParents.test.ts`, against a real Postgres with `MongoMemoryServer` as the source. It fails on today's `main` with the exact production error before the fix, and passes after.

Four cases:

1. the production shape — a post losing a `federation_activity_id` conflict
2. a **mixed batch**: one parent lands, one does not — so a fix that passes by dropping *every* child (a quieter version of the same data loss) cannot pass
3. **resume**: the parent is already there under the *same* id, and its children must still be written
4. the second production pair, `blocklist_proposal_observations -> blocklist_proposals`

Two mutations, both verified:

| mutation | result |
|---|---|
| neutralise the filter (keep every row) | **3 red**, with the exact production FK error and `Key (post_id)=(…) is not present` |
| make the presence lookup return nothing — the shape *"filter on the inserted set"* produces for an already-present parent | **2 red, including the RESUME case** |

That second one is the evidence for the `RETURNING` argument above, rather than an assertion of it.

## Scope

Copier only. Nothing here reads or writes production, and nothing here is a data-repair step — the point is that the copier stops needing one.

Refs #664.
