### PR TITLE
fix(backfill): staging table names collide between concurrent tasks

### DIFF
--- a/packages/backend/src/__tests__/db/backfillBulkLoad.test.ts
+++ b/packages/backend/src/__tests__/db/backfillBulkLoad.test.ts
@@ -19,7 +19,7 @@
  * GENERATED `tsvector` that must never be written.
  */
 
-import { afterAll, beforeAll, afterEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { eq, inArray } from 'drizzle-orm';
 import { closePostgres, connectPostgres, getDb, getPostgresClient } from '../../db/postgres';
 import { gifs } from '../../db/schema/discovery';
@@ -29,6 +29,7 @@ import {
   encodeCopyValue,
   groupByColumnSet,
   peekNextStagingName,
+  STAGING_TABLE_PREFIX,
 } from '../../db/backfill/bulkLoad';
 import { buildRow, BackfillRowError } from '../../db/backfill/rowBuilder';
 
@@ -166,6 +167,52 @@ describe('COPY encoder vs drizzle parameter binding', () => {
 
     const rows = await getDb().select().from(gifs).where(eq(gifs.id, id));
     expect(rows).toHaveLength(1);
+  });
+});
+
+/**
+ * Staging table names must differ BETWEEN PROCESSES.
+ *
+ * They used to be `pid + counter`, and the pid is 1 in every container — so two
+ * backfill tasks generated identical names and, because `copyRowsInto` drops
+ * before it creates, each dropped the other's staging table mid-`COPY`. With
+ * matching column shapes that silently inserts one task's rows into the other
+ * task's target.
+ *
+ * The property is per-PROCESS, so a single module instance cannot demonstrate
+ * it: the token is bound once at module load. `vi.resetModules()` gives a
+ * genuinely fresh instance, which is the closest thing in-process to a second
+ * task and exercises the same binding a second container would perform.
+ */
+describe('staging table names', () => {
+  async function freshStagingName(): Promise<string> {
+    vi.resetModules();
+    const module = await import('../../db/backfill/bulkLoad');
+    return module.peekNextStagingName();
+  }
+
+  it('differ between independently loaded instances', async () => {
+    const first = await freshStagingName();
+    const second = await freshStagingName();
+
+    expect(first).not.toBe(second);
+    // Both are still recognisable as staging tables, so the invariant sweep in
+    // `schemaInvariants.test.ts` keeps excluding them.
+    expect(first.startsWith(STAGING_TABLE_PREFIX)).toBe(true);
+    expect(second.startsWith(STAGING_TABLE_PREFIX)).toBe(true);
+  });
+
+  it('stays within Postgres\' 63-byte identifier limit', async () => {
+    // The counter is unbounded in principle; a wide margin is what keeps a long
+    // run from silently truncating into a COLLIDING name.
+    expect((await freshStagingName()).length).toBeLessThan(50);
+  });
+
+  it('does not derive from the pid, which is constant in a container', async () => {
+    // The specific regression, named: the old scheme embedded `process.pid`, so
+    // this asserts the pid is not what makes one name differ from another.
+    const name = await freshStagingName();
+    expect(name).not.toContain(`${STAGING_TABLE_PREFIX}${process.pid}_`);
   });
 });
 

--- a/packages/backend/src/db/backfill/bulkLoad.ts
+++ b/packages/backend/src/db/backfill/bulkLoad.ts
@@ -42,6 +42,7 @@
  * values are identical. A divergence fails the build naming the column.
  */
 
+import { randomBytes } from 'node:crypto';
 import { getTableColumns } from 'drizzle-orm';
 import { getTableConfig, type PgTable } from 'drizzle-orm/pg-core';
 import type { Sql } from 'postgres';
@@ -211,6 +212,51 @@ export function applyDefaultFns(table: PgTable, rows: readonly BuiltRow[]): Buil
  */
 export const STAGING_TABLE_PREFIX = 'mention_backfill_stage_';
 
+/**
+ * A token unique to this PROCESS, and the reason it is not `process.pid`.
+ *
+ * The name used to be `pid + counter`. **In a container the pid is 1**, always,
+ * and the counter starts at 0 — so two backfill tasks running at the same time
+ * generate byte-identical staging names. Since {@link copyRowsInto} issues
+ * `drop table if exists` BEFORE creating, the second task drops the first task's
+ * staging table out from under an in-flight `COPY`.
+ *
+ * That is not merely a crash. The staging table is created
+ * `as select <columns> from "<target>" with no data`, so its SHAPE comes from
+ * whichever target that task is loading. Two tasks copying different
+ * collections therefore create same-named tables with different columns: the
+ * loud outcome is a column-mismatch error, and the quiet one — when the two
+ * shapes happen to agree — is one task's rows being inserted into the other
+ * task's target. Silent cross-contamination between two tables is the worst
+ * failure this module can produce, and a name derived from a constant is all it
+ * takes.
+ *
+ * Sixteen hex characters from a CSPRNG, so the names cannot collide across
+ * processes on any host, in any container, however the scheduler assigns pids.
+ * Well inside Postgres' 63-byte identifier limit with the prefix and counter.
+ *
+ * ## What this gives up, stated rather than discovered later
+ *
+ * Deterministic names meant the NEXT run reclaimed a dead run's leftovers, since
+ * it generated the same names and dropped them first. Random names do not: a run
+ * that dies hard now leaves its staging tables behind for good. They are
+ * `UNLOGGED` and empty-to-small, so the cost is catalogue clutter rather than
+ * storage, and reclaiming them is one statement an operator can run when no
+ * backfill is in flight:
+ *
+ * ```sql
+ * -- ONLY with no backfill running: this cannot tell a dead run's tables from a live one's.
+ * select format('drop table if exists %I', c.relname)
+ * from pg_class c join pg_namespace n on n.oid = c.relnamespace
+ * where n.nspname = 'public' and c.relname like 'mention_backfill_stage_%';
+ * ```
+ *
+ * An automatic sweep is deliberately NOT done here: nothing in the catalogue
+ * distinguishes a crashed run's staging table from a concurrent run's, so a
+ * sweeper would reintroduce exactly the cross-task destruction this fixes.
+ */
+const STAGING_PROCESS_TOKEN = randomBytes(8).toString('hex');
+
 /** A staging table name unique to one load, safe to interpolate. */
 let stagingCounter = 0;
 function nextStagingName(): string {
@@ -219,7 +265,7 @@ function nextStagingName(): string {
 }
 
 function stagingNameFor(counter: number): string {
-  return `${STAGING_TABLE_PREFIX}${process.pid}_${counter}`;
+  return `${STAGING_TABLE_PREFIX}${STAGING_PROCESS_TOKEN}_${counter}`;
 }
 
 /**
@@ -276,14 +322,11 @@ export async function copyRowsInto(
     // pure cost. `on commit drop` is not used because the copy runs outside a
     // transaction block here; the explicit drop below is the pair.
     //
-    // Dropped FIRST as well, and that is what makes the run genuinely
-    // re-runnable rather than only claiming to be. The name is
-    // `pid + counter`, and in a container the pid is 1 and the counter restarts
-    // at 0 — so every run generates the SAME names. A run that dies hard skips
-    // the drop below, and the next run then fails on
-    // `relation "mention_backfill_stage_1_51" already exists` — nowhere near
-    // the collection at fault, and with the previous failure's cause long since
-    // scrolled away.
+    // Dropped FIRST, which is now belt-and-braces rather than the load-bearing
+    // step it once was: the name carries a per-process random token
+    // (STAGING_PROCESS_TOKEN), so no other run — concurrent or dead — can be
+    // holding this name. It stays because a name is only unique per PROCESS, and
+    // a retry inside one process must not meet its own leftovers.
     //
     // TEMP would drop itself, and is wrong here: the COPY and the INSERT can
     // land on different pooled connections, and a temporary table is invisible


### PR DESCRIPTION
> Draft, unmerged. Based on `main`, independent of the queue. Goes in **behind #668**, after the window.

Staging table names collide between concurrent backfill tasks.

Full backend suite: **537 files, 6,403 tests, all passing.** `tsc` clean.

## The defect

`nextStagingName()` built `mention_backfill_stage_<pid>_<counter>`. **In a container the pid is `1`**, always, and the counter starts at 0 — so two backfill tasks running at the same time generate byte-identical names.

The file already knew the pid was constant. It says so, as the reason a crashed run's leftovers could be reclaimed by the next run. The same fact makes the name a guaranteed collider the moment two tasks overlap.

`copyRowsInto` issues `drop table if exists` **before** creating, so task B's 5th batch drops the staging table task A is mid-`COPY` into.

**And the worst case isn't a crash.** Staging is created `as select <columns> from "<target>" with no data`, so its shape is inherited from whichever target that task is loading. Two tasks copying different collections make same-named tables with different columns:

- shapes differ → column-mismatch error (loud, recoverable)
- shapes agree → **one task's rows are inserted into the other task's target** (silent, permanent)

Silent cross-contamination between two tables is the worst thing this module can produce, and a name derived from a constant is all it takes.

## The fix

Sixteen hex characters from a CSPRNG, bound once per process, in place of the pid. Well inside Postgres' 63-byte identifier limit.

`peekNextStagingName()` still predicts correctly **within** a process, so the existing crashed-leftover regression test keeps testing exactly what it always did — a retry meeting its own leftovers — rather than quietly becoming vacuous.

## What this gives up

Stated here rather than discovered later. Deterministic names meant the next run reclaimed a dead run's leftovers, by generating the same names and dropping them first. Random names do not: a run that dies hard now leaves its staging tables behind for good.

They are `UNLOGGED` and empty-to-small, so the cost is catalogue clutter rather than storage. The docblock carries the one-statement reclaim, for an operator to run when no backfill is in flight.

**An automatic sweep is deliberately not added.** Nothing in the catalogue distinguishes a crashed run's staging table from a concurrent run's — so a sweeper would reintroduce precisely the cross-task destruction this commit removes. That trade is the whole point of the change, and it would be self-defeating to hand it back.

## Tests

The property is per-**process**, so a single module instance cannot demonstrate it — the token binds once at load. `vi.resetModules()` gives a genuinely fresh binding, which is the closest in-process equivalent of a second container performing the same load.

- names differ between independently loaded instances
- names stay well inside the 63-byte identifier limit, so a long run cannot truncate into a *colliding* name
- the name does not derive from `process.pid` — the specific regression, named

Mutation verified: restoring `process.pid` fails two of the three, one of them naming the identical pair —

```
AssertionError: expected 'mention_backfill_stage_102487_1' not to be 'mention_backfill_stage_102487_1'
```

## Why now, given we are running in series

Not for parallelism. A table name derived from a value that is *always* 1 is a collider sitting in the copier, and the next person to launch two backfills at once will not have read the thread where we decided not to.

Refs #664.
