### PR TITLE
fix(backfill): a checkpoint of the wrong KIND silently copies nothing

### DIFF
--- a/packages/backend/src/__tests__/db/backfillCheckpointKind.test.ts
+++ b/packages/backend/src/__tests__/db/backfillCheckpointKind.test.ts
@@ -1,0 +1,153 @@
+/**
+ * A checkpoint whose `kind` does not describe the collection must FAIL, not
+ * silently select nothing.
+ *
+ * This reproduces a production cutover failure exactly. `engagement_outbox` (25
+ * documents) and `moderation_outbox` (1) key their documents by a
+ * caller-supplied STRING (`plans/timestamps.ts` names both), and both were given
+ * a hand-written `objectId` checkpoint while another collection was being
+ * rewound. MongoDB orders BSON types before values and **String sorts before
+ * ObjectId**, so `{_id: {$gt: ObjectId("000…0")}}` matched no document at all.
+ *
+ * The copy then did the worst possible thing: it read zero, reached the end of
+ * its sweep, marked the collection COMPLETE and exited 0 — with every row still
+ * in the source. The only symptom was a source/target count somebody compared
+ * by hand.
+ *
+ * ## What was already right, and what was missing
+ *
+ * `checkpointOf` and `reviveCheckpoint` handle both id kinds correctly; the
+ * consuming code was never the problem, and checking it was what made this
+ * defect look ruled out. The gap is that nothing verified the kind it was
+ * HANDED against the collection it was about to filter — "can it do this?"
+ * against "is what it was given coherent?".
+ *
+ * The check is local to the source: one sampled `_id`, no target query.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient, ObjectId, type Db } from 'mongodb';
+import {
+  CheckpointKindMismatchError,
+  mongoSourceFromDb,
+  streamCollection,
+  type MongoSource,
+} from '../../db/backfill/mongoSource';
+
+let mongod: MongoMemoryServer;
+let client: MongoClient;
+let mongo: Db;
+let source: MongoSource;
+
+/** The shape of a real `engagement_outbox` key. */
+const STRING_IDS = [
+  'engagement:post.unsave:6a6e8db8cf216b1a1a9885e3:v2',
+  'engagement:post.save:6a6e8db8cf216b1a1a9885e4:v1',
+];
+
+/** The value a hand-rewound checkpoint was set to in production. */
+const ZERO_OBJECT_ID = '000000000000000000000000';
+
+async function drain(name: string, after?: { value: string; kind: 'objectId' | 'string' }) {
+  const documents: unknown[] = [];
+  for await (const batch of streamCollection(source, name, 100, after)) {
+    documents.push(...batch);
+  }
+  return documents;
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  client = await MongoClient.connect(mongod.getUri());
+  mongo = client.db('backfill_checkpoint_kind_test');
+  source = mongoSourceFromDb(mongo, async () => {
+    await client.close();
+  });
+}, 120_000);
+
+afterEach(async () => {
+  for (const name of await mongo.listCollections({}, { nameOnly: true }).toArray()) {
+    await mongo.collection(name.name).deleteMany({});
+  }
+});
+
+afterAll(async () => {
+  await mongod?.stop();
+});
+
+describe('a checkpoint whose kind does not match the collection', () => {
+  /**
+   * THE case, and the production failure verbatim.
+   *
+   * Mutation: remove the kind check from `streamCollection` and this stops
+   * throwing — it returns an EMPTY array instead, which is precisely the silent
+   * failure being guarded. So the assertion is on the throw, and the case below
+   * pins the empty-read consequence separately.
+   */
+  it('refuses an objectId checkpoint over a string-keyed collection', async () => {
+    await mongo.collection('engagement_outbox').insertMany(
+      STRING_IDS.map((id) => ({ _id: id, kind: 'post.save' })) as never,
+    );
+
+    await expect(
+      drain('engagement_outbox', { value: ZERO_OBJECT_ID, kind: 'objectId' }),
+    ).rejects.toThrow(CheckpointKindMismatchError);
+  });
+
+  /**
+   * The consequence the refusal exists to prevent, asserted directly against
+   * MongoDB rather than described: the cross-type filter really does select
+   * nothing. Without this the test above could pass against a check that
+   * refuses something harmless.
+   */
+  it('would otherwise read ZERO of the documents that are there', async () => {
+    await mongo.collection('engagement_outbox').insertMany(
+      STRING_IDS.map((id) => ({ _id: id, kind: 'post.save' })) as never,
+    );
+
+    // The filter `streamCollection` would have built, issued directly.
+    const selected = await mongo
+      .collection('engagement_outbox')
+      .find({ _id: { $gt: new ObjectId(ZERO_OBJECT_ID) } } as never)
+      .toArray();
+    const present = await mongo.collection('engagement_outbox').countDocuments({});
+
+    expect(present).toBe(2);
+    expect(selected).toHaveLength(0);
+  });
+
+  /** The matching kind still resumes, so the guard has not simply broken resume. */
+  it('resumes normally when the kind matches', async () => {
+    await mongo.collection('engagement_outbox').insertMany(
+      STRING_IDS.map((id) => ({ _id: id, kind: 'post.save' })) as never,
+    );
+
+    const documents = await drain('engagement_outbox', {
+      value: 'engagement:post.save:6a6e8db8cf216b1a1a9885e4:v1',
+      kind: 'string',
+    });
+    expect(documents).toHaveLength(1);
+  });
+
+  /** And an ObjectId collection with an ObjectId checkpoint is untouched. */
+  it('leaves an ObjectId-keyed collection alone', async () => {
+    const older = new ObjectId('6a3480c3cd38eea5e9312c6a');
+    const newer = new ObjectId();
+    await mongo.collection('posts').insertMany([{ _id: older }, { _id: newer }] as never);
+
+    const documents = await drain('posts', { value: older.toHexString(), kind: 'objectId' });
+    expect(documents).toHaveLength(1);
+  });
+
+  /**
+   * An EMPTY collection cannot hide anything behind a mismatched checkpoint, so
+   * refusing there would be a false alarm on a legitimately empty source — and a
+   * gate that cries wolf gets removed by whoever hits it next.
+   */
+  it('does not refuse when the collection is empty', async () => {
+    await expect(
+      drain('never_written', { value: ZERO_OBJECT_ID, kind: 'objectId' }),
+    ).resolves.toEqual([]);
+  });
+});

--- a/packages/backend/src/db/backfill/mongoSource.ts
+++ b/packages/backend/src/db/backfill/mongoSource.ts
@@ -251,6 +251,66 @@ export function reviveCheckpoint(checkpoint: Checkpoint): mongo.ObjectId | strin
 }
 
 /**
+ * Raised when a stored checkpoint's `kind` does not match the `_id` type the
+ * collection actually uses.
+ *
+ * This exists because the failure it replaces is SILENT and total. MongoDB
+ * compares across BSON types by a canonical type order in which **String sorts
+ * before ObjectId**, so `{_id: {$gt: ObjectId("000…0")}}` over a collection of
+ * STRING ids excludes every document. The stream then yields nothing, the copy
+ * reports `0 document(s) read`, the sweep reaches the end and the collection is
+ * marked COMPLETE — with an exit code of 0 and every row still in the source.
+ *
+ * Observed in production during the cutover on `engagement_outbox` (25
+ * documents) and `moderation_outbox` (1): both key their documents by a
+ * caller-supplied string (`timestamps.ts` says so), and both had been given a
+ * hand-written `objectId` checkpoint while rewinding another collection. The
+ * only symptom was a source/target count that somebody happened to compare.
+ *
+ * The code that CONSUMES a checkpoint already handles both kinds correctly
+ * ({@link checkpointOf}, {@link reviveCheckpoint}) — that is not the gap. The
+ * gap is that nothing checked whether the kind it was HANDED describes the
+ * collection it is about to filter, which is a different question: "can it do
+ * this?" versus "is what it was given coherent?".
+ */
+export class CheckpointKindMismatchError extends Error {
+  constructor(collection: string, stored: Checkpoint['kind'], actual: string) {
+    super(
+      `Checkpoint for ${collection} says kind ${JSON.stringify(stored)}, but its ` +
+        `documents are keyed by ${actual}. Resuming would build ` +
+        `{_id: {$gt: <${stored}>}}, and MongoDB orders BSON types before values — ` +
+        `so that filter selects NO ${actual} document and the copy would report ` +
+        'zero rows read, mark the collection complete and exit 0 with every row ' +
+        'still in the source. Clear this checkpoint (or re-run with --restart) ' +
+        'rather than resuming from it.'
+    );
+    this.name = 'CheckpointKindMismatchError';
+  }
+}
+
+/**
+ * The `_id` kind a collection actually uses, sampled from one document.
+ *
+ * `null` when the collection is empty — there is nothing to read, so a
+ * mismatched checkpoint cannot hide anything and refusing would be a false
+ * alarm on a legitimately empty source.
+ */
+async function sampledIdKind(
+  source: MongoSource,
+  name: string
+): Promise<Checkpoint['kind'] | 'an unsupported type' | null> {
+  const [doc] = await source
+    .collection(name)
+    .find({}, { projection: { _id: 1 }, limit: 1 })
+    .toArray();
+  if (!doc) return null;
+  const raw = (doc as MongoDocument)._id;
+  if (isObjectId(raw)) return 'objectId';
+  if (typeof raw === 'string') return 'string';
+  return 'an unsupported type';
+}
+
+/**
  * Stream a collection in `_id` order, in batches, from an optional checkpoint.
  *
  * `after` is the last `_id` a previous run committed. Restarting from
@@ -277,7 +337,15 @@ export async function* streamCollection(
   upTo?: unknown
 ): AsyncGenerator<MongoDocument[]> {
   const bounds: Record<string, unknown> = {};
-  if (after !== undefined) bounds.$gt = reviveCheckpoint(after);
+  if (after !== undefined) {
+    // BEFORE the cursor, because a mismatch here does not fail — it silently
+    // matches nothing. See {@link CheckpointKindMismatchError}.
+    const actual = await sampledIdKind(source, name);
+    if (actual !== null && actual !== after.kind) {
+      throw new CheckpointKindMismatchError(name, after.kind, actual);
+    }
+    bounds.$gt = reviveCheckpoint(after);
+  }
   if (upTo !== undefined) bounds.$lte = upTo;
   const filter = Object.keys(bounds).length === 0 ? {} : { _id: bounds };
   const cursor = source


### PR DESCRIPTION
> Draft, unmerged. Based on `main`, behind #669 and #670. Fixes a defect that hit the cutover.

A resume checkpoint whose `kind` does not match the collection's `_id` type makes the copy read **nothing**, report success, and mark the collection complete.

Full backend suite: **541 files, 6,421 tests, all passing.** `tsc` clean.

## The defect

`streamCollection` resumes with `{_id: {$gt: reviveCheckpoint(after)}}` and never checked that the checkpoint's `kind` describes the collection it is filtering.

**MongoDB orders BSON types before values, and String sorts before ObjectId.** So `{_id: {$gt: ObjectId("000…0")}}` over a STRING-keyed collection matches no document whatsoever.

What follows is silent and total:

```
migrate  engagement_outbox   25 document(s)      ← discovery counts 25
engagement_outbox: copying
engagement_outbox: 0 document(s) read in 0.2s    ← the copy reads 0
  → engagement_outbox   0 row(s)                 ← marked COMPLETE, exit 0
```

Nothing errors. Nothing warns. The collection is recorded as done with every row still in the source.

## Where it was found

Production, during the cutover: `engagement_outbox` (25 documents) and `moderation_outbox` (1). Both key their documents by a **caller-supplied string** — `plans/timestamps.ts` names exactly these two — and both had been handed a hand-written `{value: '000000000000000000000000', kind: 'objectId'}` checkpoint while a different collection was being rewound.

26 rows in transient queues, so the impact was nil. **The same condition on `posts` would have produced zero rows copied, `completed = true`, and exit 0** — with a source/target count as the only symptom. It was caught by a count comparison somebody ran by hand, not by anything in the pipeline.

## What was already correct — and why that made it look ruled out

`checkpointOf` and `reviveCheckpoint` handle **both** id kinds properly. The consuming code was never the problem, and verifying that is exactly what made this defect appear eliminated during the investigation.

The gap is elsewhere: nothing verified the kind it was **handed** against the collection it was about to filter. *"Can it do this?"* and *"is what it was given coherent?"* are different questions, and only the first one had an answer.

## The check

One sampled `_id` from the collection, compared against the checkpoint's kind, before the cursor is built. Local to the source — **no target query**. On mismatch it throws `CheckpointKindMismatchError`, whose message names both kinds and says what to do (clear the checkpoint, or `--restart`).

An **empty** collection is exempt. There is nothing to hide behind a mismatched checkpoint there, so refusing would be a false alarm on a legitimately empty source — and a gate that cries wolf gets removed by whoever hits it next.

## Tests

`src/__tests__/db/backfillCheckpointKind.test.ts`, against a real MongoDB:

- refuses an `objectId` checkpoint over a string-keyed collection
- **pins the consequence separately** — issues the cross-type filter directly against MongoDB and asserts it selects **0 of 2** documents that are present, so the refusal above cannot pass by refusing something harmless
- a matching kind still resumes (the guard has not broken resume)
- an ObjectId collection with an ObjectId checkpoint is untouched
- an empty collection is not refused

**Mutation verified**, and it reproduces the incident rather than a proxy for it: with the check removed, `streamCollection` returns **zero of two** present documents and **raises nothing** — precisely what production did — and the guarding case goes red.

## Scope note

A second, looser check was considered and deliberately not built: contradicting "complete" against an empty target table. It is a net further from the failure and cannot distinguish a legitimately empty collection. If wanted, it belongs as a second layer, not the first.

Refs #664, #671.
