### PR TITLE
chore(deploy): a maintenance sweep may not roll back a healthy release

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -222,22 +222,39 @@ jobs:
           # rollout. `deploy-ecs-image.sh` still supports it; nothing here needs
           # it. Reasons, in the order that matters:
           #
-          # 1. A FAILING ONE-SHOT ROLLS THE SERVICE BACK (`:689`). On 2026-08-05
+          # 1. IT NEVER FIT, not even with the table empty — AND THE REASON
+          #    GENERALISES TO EVERY POST-DEPLOY ONE-SHOT. `deploy-ecs-image.sh`
+          #    passes `--task-definition "$new_task_definition"` to `run-task`
+          #    (`:593`), and that revision is registered from the LIVE SERVICE's
+          #    own definition (`:515`, `:577`) with only `image`, `secrets` and
+          #    `environment` rewritten. `cpu` and `memory` are copied verbatim,
+          #    and nothing here can override them. So the one-shot runs on the
+          #    WEB CONTAINER's sizing — `oxy-mention:211` is 512 CPU / 1024 MiB,
+          #    against 8192 CPU / 61440 MiB for the sizing this sweep was timed
+          #    on. 16x the CPU. The 12-minute measurement extrapolates to roughly
+          #    3 HOURS inside a 20-minute deadline. **Any post-deploy one-shot
+          #    doing heavy work inherits a container sized to serve HTTP
+          #    requests.** Whatever gets coupled here next hits this too, and it
+          #    is invisible from the workflow — the sizing is never named in this
+          #    file.
+          # 2. A FAILING ONE-SHOT ROLLS THE SERVICE BACK (`:689`). On 2026-08-05
           #    a healthy release that had already reached steady state and passed
           #    its smoke checks was reverted because this sweep did not finish
           #    inside MAX_WAIT_SECS. Release health and maintenance work are
           #    different questions, and only one of them may cancel a deploy.
-          # 2. IT IS NOT INCREMENTAL, so the cost is paid in full every time.
+          # 3. IT IS NOT INCREMENTAL, so the cost is paid in full every time.
           #    Measured against a 624,116-post copy of production's shape: a
           #    second run over already-converged data still processed 300,000
           #    posts in 210s, deleting and reinserting 300,000 rows to produce a
           #    byte-identical result. Converging beforehand shortens it by
-          #    nothing.
-          # 3. THE COST GROWS WITH THE TABLE, so no timeout survives. Work is
+          #    nothing — which is also why converging out of band did not rescue
+          #    the deploy that this removal follows.
+          # 4. THE COST GROWS WITH THE TABLE, so no timeout survives. Work is
           #    O(distinct reply parents), which grows with content — production
           #    was at 156,945 of them, reconciled twice per run. Raising
-          #    MAX_WAIT_SECS buys months, not a fix.
-          # 4. IT IS A MIGRATION-WINDOW CLOSER, not a release step — its own
+          #    MAX_WAIT_SECS would not have bought months even before (1); with
+          #    it, there was never a value that worked.
+          # 5. IT IS A MIGRATION-WINDOW CLOSER, not a release step — its own
           #    docblock says so. It repairs what the pre-cutover Mongo writers
           #    left wrong: a fixed, historical set. Today's writers maintain both
           #    projections transactionally (`PostEngagementCommandService`,

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -217,8 +217,37 @@ jobs:
           TASK_SECRET_OVERRIDES_JSON: >-
             {"MENTION_MCP_JWT_SECRET":"arn:aws:ssm:us-west-2:237343248947:parameter/oxy/mention/MENTION_MCP_JWT_SECRET",
              "DATABASE_URL":"arn:aws:ssm:us-west-2:237343248947:parameter/oxy/mention/DATABASE_URL"}
-          POST_DEPLOY_TASK_COMMAND_JSON: >-
-            ["bun","packages/backend/dist/scripts/reconcile-engagement-projections.js"]
+          # DELIBERATELY UNSET, and it must stay that way — this is the variable
+          # that used to run `reconcile-engagement-projections.js` after every
+          # rollout. `deploy-ecs-image.sh` still supports it; nothing here needs
+          # it. Reasons, in the order that matters:
+          #
+          # 1. A FAILING ONE-SHOT ROLLS THE SERVICE BACK (`:689`). On 2026-08-05
+          #    a healthy release that had already reached steady state and passed
+          #    its smoke checks was reverted because this sweep did not finish
+          #    inside MAX_WAIT_SECS. Release health and maintenance work are
+          #    different questions, and only one of them may cancel a deploy.
+          # 2. IT IS NOT INCREMENTAL, so the cost is paid in full every time.
+          #    Measured against a 624,116-post copy of production's shape: a
+          #    second run over already-converged data still processed 300,000
+          #    posts in 210s, deleting and reinserting 300,000 rows to produce a
+          #    byte-identical result. Converging beforehand shortens it by
+          #    nothing.
+          # 3. THE COST GROWS WITH THE TABLE, so no timeout survives. Work is
+          #    O(distinct reply parents), which grows with content — production
+          #    was at 156,945 of them, reconciled twice per run. Raising
+          #    MAX_WAIT_SECS buys months, not a fix.
+          # 4. IT IS A MIGRATION-WINDOW CLOSER, not a release step — its own
+          #    docblock says so. It repairs what the pre-cutover Mongo writers
+          #    left wrong: a fixed, historical set. Today's writers maintain both
+          #    projections transactionally (`PostEngagementCommandService`,
+          #    `recordRecentReplierForPost`) and the backfill loads both, so on
+          #    an ordinary deploy it recomputes correct values into themselves.
+          #
+          # It now runs BY HAND when there is a reason to — after a restore, or
+          # after any window where those writers were not the only ones writing.
+          # `packages/backend/scripts/reconcile-engagement-projections.ts` holds
+          # the command and how to launch it.
           POST_DEPLOY_SMOKE_SCRIPT: .github/scripts/smoke-mention.sh
         # The existing target group remains on `/`, which server.ts now serves
         # as the same readiness gate as `/health/ready`. ELB mutations belong

--- a/packages/backend/scripts/reconcile-engagement-projections.ts
+++ b/packages/backend/scripts/reconcile-engagement-projections.ts
@@ -1,15 +1,58 @@
 /**
- * Post-deploy convergence task for engagement-derived read models.
+ * MANUAL convergence task for engagement-derived read models.
  *
- * This runs only after the new transactional writers have fully replaced the
- * legacy ECS tasks. It closes the narrow pre-rollout migration window without
- * putting reconciliation into request latency.
+ * It closes a migration window: it repairs what writers OTHER than today's
+ * transactional ones left behind in `posts.stats_saves_count` and
+ * `post_recent_repliers`. On an ordinary day there is no such window —
+ * `PostEngagementCommandService` and `recordRecentReplierForPost` maintain both
+ * projections inside the same transaction as the write they derive from, and the
+ * backfill loads both — so this recomputes correct values into themselves.
+ *
+ * ## Run it when a window actually opened, not on a schedule
+ *
+ * After a restore, after a bulk import that bypassed the writers, or after any
+ * incident where something else wrote `posts` or `bookmarks`. Two properties make
+ * that safe: it derives everything from the authoritative rows (`bookmarks`, and
+ * the replies themselves), and each batch of `RECONCILIATION_BATCH_SIZE` posts is
+ * one transaction, so an interrupted run leaves every post either fully repaired
+ * or untouched and a re-run converges.
+ *
+ * **It must not run against a half-restored database.** "Authoritative" is read
+ * as of NOW: if a post's replies or a post's bookmarks have not been copied back
+ * yet, the authoritative answer is "none", and this task will faithfully delete
+ * the correct projection rows and zero the correct counters. Measured: with
+ * `bookmarks` empty, 500 posts carrying a total of 3,500 saves went to 0. A later
+ * run over the complete data repairs it, but nothing else will.
+ *
+ * ## It is NOT wired into the deploy, on purpose
+ *
+ * `deploy-aws.yml` used to pass this file as `POST_DEPLOY_TASK_COMMAND_JSON`.
+ * That variable is now deliberately unset, and the removal site there carries the
+ * four reasons. The short one: a failing post-deploy one-shot rolls the service
+ * back, and this task's cost is O(distinct reply parents) with no watermark and
+ * no incremental mode, so it grows with the table until it outlives any timeout —
+ * which is what rolled back a healthy release on 2026-08-05.
+ *
+ * ## Launching it
+ *
+ * A Fargate one-shot on the live service's own task definition, network
+ * configuration and secrets. Take all of them from the RUNNING service rather
+ * than naming a task definition here: a pinned name is a claim about
+ * infrastructure this repo does not own, and it goes stale silently.
+ * `.github/workflows/run-federated-text-backfill.yml` is the worked example —
+ * `describe-services` -> `taskDefinition` + `networkConfiguration` -> `run-task`
+ * with a container override whose command is:
+ *
+ *     bun packages/backend/dist/scripts/reconcile-engagement-projections.js
+ *
+ * `dist/scripts/`, not `dist/src/scripts/`: `tsconfig.json` sets `rootDir: ./`,
+ * so this file (outside `src/`) compiles to a sibling of it. The runtime image is
+ * `oven/bun:*-alpine` and has no `node`.
  *
  * Postgres-only, because `reconcileEngagementProjections` reads and writes
  * exclusively through Drizzle. A one-shot gets none of `server.ts`'s startup,
  * so it must open the pool itself: without `connectPostgres()` the service's
- * first `getDb()` throws `PostgreSQL is not connected`, this task exits 1, and
- * `deploy-aws.yml` rolls the whole service back on every deploy.
+ * first `getDb()` throws `PostgreSQL is not connected` and this task exits 1.
  */
 
 import { closePostgres, connectPostgres } from '../src/db/postgres';

--- a/packages/backend/scripts/reconcile-engagement-projections.ts
+++ b/packages/backend/scripts/reconcile-engagement-projections.ts
@@ -28,26 +28,32 @@
  *
  * `deploy-aws.yml` used to pass this file as `POST_DEPLOY_TASK_COMMAND_JSON`.
  * That variable is now deliberately unset, and the removal site there carries the
- * four reasons. The short one: a failing post-deploy one-shot rolls the service
- * back, and this task's cost is O(distinct reply parents) with no watermark and
- * no incremental mode, so it grows with the table until it outlives any timeout —
- * which is what rolled back a healthy release on 2026-08-05.
+ * five reasons. The short one: a failing post-deploy one-shot rolls the service
+ * back, and that one-shot runs on the WEB SERVICE's task definition — 512 CPU,
+ * against the 8192 this sweep was timed on — so it never fit the deploy's
+ * deadline, at any table size. It rolled back a healthy release on 2026-08-05.
  *
  * ## Launching it
  *
- * A Fargate one-shot on the live service's own task definition, network
- * configuration and secrets. Take all of them from the RUNNING service rather
- * than naming a task definition here: a pinned name is a claim about
- * infrastructure this repo does not own, and it goes stale silently.
+ * A Fargate one-shot taking its network configuration and secrets from the LIVE
+ * service, rather than naming a task definition here: a pinned name is a claim
+ * about infrastructure this repo does not own, and it goes stale silently.
  * `.github/workflows/run-federated-text-backfill.yml` is the worked example —
- * `describe-services` -> `taskDefinition` + `networkConfiguration` -> `run-task`
- * with a container override whose command is:
+ * `describe-services` -> `taskDefinition` + `networkConfiguration` -> register a
+ * throwaway revision -> `run-task` with a container override whose command is:
  *
  *     bun packages/backend/dist/scripts/reconcile-engagement-projections.js
  *
  * `dist/scripts/`, not `dist/src/scripts/`: `tsconfig.json` sets `rootDir: ./`,
  * so this file (outside `src/`) compiles to a sibling of it. The runtime image is
  * `oven/bun:*-alpine` and has no `node`.
+ *
+ * **Raise `cpu`/`memory` on that throwaway revision — do not inherit the web
+ * service's.** The service is sized to answer HTTP requests (512 CPU / 1024 MiB
+ * on `oxy-mention:211`); this sweep's only published timing, ~12 minutes over
+ * production's data, was taken at 8192 CPU / 61440 MiB. Sixteen times the CPU,
+ * so a run left on the service's sizing is a different job with the same name. A
+ * duration quoted without the sizing it was measured at is not a number.
  *
  * Postgres-only, because `reconcileEngagementProjections` reads and writes
  * exclusively through Drizzle. A one-shot gets none of `server.ts`'s startup,


### PR DESCRIPTION
## Summary

`POST_DEPLOY_TASK_COMMAND_JSON` ran `reconcile-engagement-projections.js` as a one-shot after every ECS rollout. On 2026-08-05 that task did not finish inside `MAX_WAIT_SECS`, `deploy-ecs-image.sh` treated the timeout as a release failure, and production was rolled back from `:210` to `:208` — after the service had already reached steady state and passed its smoke checks. Nothing was wrong with the release.

This removes `POST_DEPLOY_TASK_COMMAND_JSON` from `deploy-aws.yml` (replaced with a comment explaining why it must stay unset) and rewrites the script's docblock into a manual runbook. Four reasons this belongs outside the deploy path, not behind a bigger timeout:

1. **A failing post-deploy one-shot rolls the service back.** Release health and maintenance work are different questions, and only one of them may cancel a deploy.
2. **It is not incremental.** Measured against a local copy of production's shape (624,116 posts, 150,000 distinct reply parents): a second run over already-converged data still processed 300,000 posts in 210s and produced a byte-identical result, deleting and reinserting 300,000 rows to do it. Converging out of band beforehand shortens the deploy's run by nothing.
3. **The cost grows with the table, so no timeout survives.** Work is O(distinct reply parents) with no watermark — production has 156,945, reconciled twice per run. Today it is ~20 minutes; the number only goes up.
4. **It is a migration-window closer, not a release step**, as its own docblock says. It repairs what writers other than today's transactional ones left behind; on an ordinary deploy those writers already keep both projections correct, so the sweep just recomputes correct values into themselves.

It now runs by hand when a window actually opens. The script's docblock carries the exact command and derives the task definition from the running service rather than pinning a name this repo does not own.

`deploy-ecs-image.sh` is **unchanged** and still supports the variable: it defaults to empty, validates only when non-empty, and its `one_shot_run_task_args` block stays live because `RUN_MIGRATIONS` is `true` and the migration one-shots use it.

## Test plan

- [x] `bash .github/scripts/test-deploy-ecs-image.sh` — "Deployment script transaction tests passed."
- [x] `node scripts/validate-workflows.mjs` — "Validated 7 GitHub Actions workflow file(s)."
- [x] `bun run build:backend` — clean
- [x] `bun run --cwd packages/backend test` — 540 files / 6416 tests passed
- [x] Lockfile gate (plain `bun install` + `git diff --exit-code -- bun.lock`) — clean, no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)