### PR TITLE
docs: rebuild the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,170 @@
-# Mention
+<p align="center">
+  <b>Mention is a social network for iOS, Android and the web, connected to the Fediverse.</b><br>
+  Posts are signed records on a chain the author owns, not rows we can quietly rewrite.
+</p>
 
-Mention is a social app for iOS, Android, and the web. It combines an Expo
-client, an Express API, a signed-record layer (MTN), ActivityPub federation,
-and a remote MCP server in one Bun workspace.
+<p align="center">
+  <a href="https://mention.earth"><img alt="mention.earth" src="https://img.shields.io/badge/mention.earth-440151?style=flat-square"></a>
+  <a href="./LICENSE"><img alt="License MIT" src="https://img.shields.io/badge/license-MIT-informational?style=flat-square"></a>
+  <img alt="Expo SDK 57" src="https://img.shields.io/badge/Expo-SDK%2057-000020?style=flat-square&logo=expo&logoColor=white">
+  <img alt="React Native 0.86" src="https://img.shields.io/badge/React%20Native-0.86-61DAFB?style=flat-square&logo=react&logoColor=black">
+  <img alt="TypeScript 5.9" src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white">
+  <img alt="Bun 1.3.14" src="https://img.shields.io/badge/Bun-1.3.14-000000?style=flat-square&logo=bun&logoColor=white">
+</p>
 
-## Repository
+---
 
-| Workspace | Purpose |
-| --- | --- |
-| `packages/frontend` | Expo 56 / React Native 0.85 / React 19 app |
-| `packages/backend` | Express 5 API, Socket.IO, workers, federation, and MTN |
-| `packages/shared-types` | Shared TypeScript contracts |
-| `packages/mcp` | Remote and local Model Context Protocol server |
+<table>
+<tr>
+<td valign="top" width="50%">
 
-Oxy owns account identity and the social graph. Mention owns posts, feeds,
-engagement, notifications, Mention-specific settings, and federation state.
-Live rooms use `@syra.fm/sdk` and load only when needed.
+### What is in this repository
 
-## Requirements
+One Bun workspace holding the whole product: an Expo client that ships to iOS, Android and the web from a single codebase, an Express API that also serves the web shell and the federation endpoints, the shared type contracts both sides compile against, and a remote MCP server so an AI assistant can read and post with your permission.
 
-- Bun 1.3.14
-- Node.js 22.17.0
-- Docker with Compose for the local data plane
-- Xcode or Android Studio only when running the corresponding native target
+Mention owns posts, feeds, engagement, notifications, its own mutes and its federation state. It does not own you.
 
-Install exactly from the lockfile, then validate the toolchain:
+</td>
+<td valign="top" width="50%">
 
-```sh
+### How it fits the Oxy platform
+
+Identity, sessions and the social graph come from [**oxy**](https://github.com/OxyHQ/oxy), the platform every Oxy app stands on. The client mounts one `OxyProvider` from `@oxyhq/services`, the backend verifies requests with `@oxyhq/core/server`, and neither side hand rolls a token parser.
+
+The interface is built with [**Bloom**](https://github.com/OxyHQ/Bloom). Live audio rooms come from `@syra.fm/sdk`, the engine behind [**Syra**](https://github.com/OxyHQ/Syra), and load only when a room is opened.
+
+</td>
+</tr>
+</table>
+
+## Workspaces
+
+| Package | Path | What it holds |
+|---|---|---|
+| `@mention/frontend` | [`packages/frontend`](./packages/frontend) | Expo Router app for iOS, Android and web. Expo 57, React Native 0.86, React 19, NativeWind, TanStack Query, Zustand |
+| `@mention/backend` | [`packages/backend`](./packages/backend) | Express 5 API, Socket.IO, background workers, ActivityPub federation, the MTN signed record layer and the web shell |
+| `@mention/shared-types` | [`packages/shared-types`](./packages/shared-types) | The request and response contracts, plus the MTN record schemas, that both sides compile against |
+| `@mention/mcp` | [`packages/mcp`](./packages/mcp) | Model Context Protocol server, remote over HTTP and local over stdio |
+| `@mention/e2e` | [`packages/e2e`](./packages/e2e) | Real browser release gate that exercises a candidate web build before it is promoted |
+
+## Quick start
+
+You need [Bun](https://bun.sh) 1.3.14, Node.js 22.17.0 for the Expo and Jest toolchains, and Docker with Compose for the local data plane. Xcode or Android Studio are needed only when you run the matching native target.
+
+```bash
 bun install --frozen-lockfile
 bun run doctor
 ```
 
-`doctor` checks the runtime, workspace links, and the pinned Expo, React,
-React Native, Bloom, and shared-types versions.
+`doctor` checks the runtime, the workspace links and the pinned Expo, React, React Native, Bloom and shared types versions. It is worth running before you believe any other failure.
 
-## Local development
+```bash
+bun run dev              # every workspace
+bun run dev:frontend     # Expo dev server
+bun run dev:backend      # API in watch mode
+bun run dev:mcp          # MCP over stdio
+bun run dev:mcp:http     # MCP over streamable HTTP, as production runs it
+```
 
-The local Compose stack uses a single-node MongoDB replica set, Valkey, and a
-one-shot migration container. The backend starts only after the replica set is
-writable, Valkey is healthy, and migrations have completed:
+Run a specific native target from the frontend workspace:
 
-```sh
+```bash
+bun run --cwd packages/frontend ios
+bun run --cwd packages/frontend android
+bun run --cwd packages/frontend web
+```
+
+<details>
+<summary><b>Local data plane</b></summary>
+
+<br>
+
+The Compose stack is a single node MongoDB replica set, Valkey, and a one shot migration container. The backend starts only once the replica set is writable, Valkey is healthy and migrations have finished:
+
+```bash
 docker compose up --build backend
 ```
 
-MongoDB and Valkey bind to loopback ports `27017` and `6379`. Their data lives
-in the named `mongo_data` and `valkey_data` volumes.
+MongoDB and Valkey bind to loopback ports `27017` and `6379`, and their data lives in the named `mongo_data` and `valkey_data` volumes.
 
-For watch mode, start only the dependencies and run the workspace process on
-the host:
+For watch mode, start the dependencies only and run the backend on the host:
 
-```sh
+```bash
 docker compose up -d mongo valkey
 docker compose run --rm mongo-init
 bun run dev:backend
 ```
 
-The non-production backend runs its migrations before it marks itself ready.
+Outside production the backend runs its own migrations before it reports ready.
 
-Other development entry points:
+</details>
 
-```sh
-bun run dev              # all workspaces
-bun run dev:frontend     # Expo; run from the frontend workspace
-bun run dev:mcp          # local stdio transport
-bun run dev:mcp:http     # local Streamable HTTP transport
-```
+<details>
+<summary><b>Checks, builds and tests</b></summary>
 
-Metro must run from `packages/frontend`, which the root frontend script does.
+<br>
 
-## Checks and builds
-
-```sh
-bun run doctor
-bun run check
-bun run build            # shared-types, backend, and MCP
+```bash
+bun run check            # workspace validators, then build, then type checks
+bun run build            # shared-types, backend, MCP
 bun run build:frontend   # static Expo web export
-bun run test
-bun run lint             # all workspaces
+bun run test             # every workspace
+bun run lint             # every workspace
 ```
 
-Run backend tests from their package root to avoid stale compiled test copies:
+Two things save time here. Rebuild `shared-types` before you trust a red type check, because every other package compiles against its built output and reports newly landed symbols as missing. And run backend tests from their own package root, `cd packages/backend && bun run test`, so stale compiled copies cannot be picked up.
 
-```sh
-cd packages/backend
-bun run test
-```
+</details>
 
-## Runtime surfaces
+## What the platform does
 
-| Host | Runtime |
-| --- | --- |
-| `api.mention.earth` | Mention API on AWS ECS |
-| `mention.earth` | The same backend for federation, OG shells, and the web proxy |
-| `mcp.mention.earth` | Separate MCP service on AWS ECS |
-| `mention-frontend.pages.dev` | Static Expo web origin, reached through the apex proxy |
+<table>
+<tr>
+<td valign="top" width="50%">
 
-The backend serves protocol routes before the apex web proxy. ActivityPub
-endpoint paths must never redirect. Hashed web assets are immutable; HTML is
-served with revalidation.
+**Signed records (MTN)**
 
-Production deployments are CI-gated. Workflows publish immutable images or
-static artifacts from the successful `main` SHA. Backend migrations run as a
-one-shot task before the ECS rollout.
+Local posts are dual written to a per user hash chain built on `@oxyhq/protocol`. MongoDB stays authoritative for reads while the chain gives an author a verifiable, portable history. Native writes are signed on the device, web writes are signed custodially by the service, and a user can run their own node to hold their own chain.
 
-## Operational contracts
+**Federation**
 
-- `GET /health/live` reports process liveness.
-- `GET /health/ready` requires startup, migrations, and MongoDB to be ready.
-- Redis/Valkey failure degrades optional API capabilities but never grants
-  singleton leadership without a lock.
-- `GET /internal/metrics` is service-only and requires both network policy and
-  a bearer token.
-- `POST /telemetry/web` accepts bounded browser vitals and runtime events.
+External networks are a pluggable connector module rather than a hardcoded assumption. ActivityPub reaches Mastodon and the wider Fediverse. AT Protocol is read and discovery only, for resolving handles and mirroring profiles and posts. The core never knows a network exists.
 
-Post API responses are produced by `PostHydrationService`; Oxy's user shape is
-the canonical identity shape. The MTN record chain is best-effort for native
-writes, while MongoDB remains authoritative for application reads. External
-networks are isolated behind the connector registry.
+</td>
+<td valign="top" width="50%">
+
+**Feeds and social surfaces**
+
+Following and For You feeds, custom feeds, lanes, channels, lists, starter packs, hashtags, topics, trending, polls, articles and collaborative posts. Ranking, classification and read surface safety gating live in the backend rather than in the client.
+
+**Moderation and AI access**
+
+Reports go to [**CrowdSource**](https://github.com/OxyHQ/CrowdSource), which draws an independent jury, publishes a versioned decision and returns it by webhook. Mention decides what to enforce and nothing else. The MCP server lets Claude and other assistants act as you, with OAuth and per account linking.
+
+</td>
+</tr>
+</table>
 
 ## Documentation
 
-- [Documentation index](./docs/index.mdx)
-- [Architecture](./docs/architecture.mdx)
-- [API surface](./docs/api.mdx)
-- [Compatibility retirement](./docs/COMPATIBILITY_RETIREMENT.md)
-- [Fediverse integration](./docs/fediverse.mdx)
-- [User mentions](./docs/mentions.md)
-- [MCP server](./packages/mcp/README.md)
-- [AWS deployment](./docs/AWS_DEPLOYMENT.md)
-- [Theming](./docs/THEMING.md)
+| Document | Covers |
+|---|---|
+| [Overview](./docs/index.mdx) | Entry point, workspace responsibilities, data ownership |
+| [Architecture](./docs/architecture.mdx) | How the pieces fit together |
+| [API](./docs/api.mdx) | The HTTP surface |
+| [Fediverse](./docs/fediverse.mdx) | ActivityPub integration and discovery |
+| [Compose intent URLs](./docs/compose-intent.mdx) | Linking into the composer from outside the app |
+| [User mentions](./docs/mentions.md) | How handles resolve, local and federated |
+| [Theming](./docs/THEMING.md) | Bloom and NativeWind in this app |
+| [MCP server](./packages/mcp/README.md) | Connecting Claude, linking accounts, the tool list |
+| [Compatibility retirement](./docs/COMPATIBILITY_RETIREMENT.md) | What we removed and why |
 
-Repository-specific agent instructions live in `AGENTS.md`. Parent instructions
-referenced there also apply.
+Instructions for AI coding agents live in [`AGENTS.md`](./AGENTS.md). The parent files it references apply as well.
+
+## Contributing
+
+Issues and pull requests are welcome. Please run `bun run check` and `bun run test` before opening one. Org wide [contributing notes](https://github.com/OxyHQ/.github/blob/main/CONTRIBUTING.md), the [security policy](https://github.com/OxyHQ/.github/blob/main/SECURITY.md) and the [code of conduct](https://github.com/OxyHQ/.github/blob/main/CODE_OF_CONDUCT.md) live in the organisation profile.
 
 ## License
 
-See [LICENSE](./LICENSE).
+MIT. See [LICENSE](./LICENSE).


### PR DESCRIPTION
Rewrites `README.md` only. No code, no config, no other docs.

## What was wrong

| Problem | Detail |
|---|---|
| Wrong stack | Claimed **Expo 56 / React Native 0.85**. `packages/frontend/package.json` pins `expo ~57.0.8` and the root override pins `react-native 0.86.0`. Anyone matching their toolchain to the README got the wrong one. |
| Missing workspace | The table listed four packages. There are five: `packages/e2e` (`@mention/e2e`, the real-browser release gate) was absent. |
| No orientation | Nothing said what Mention is to a reader arriving from the org profile, or how it relates to the platform. The page opened on runtime hosts and Compose commands. |
| Buried product | MTN, the connector model for ActivityPub and AT Protocol, the CrowdSource moderation path and the MCP server were absent or reduced to operational bullets. |

## What it is now

House style from [OxyHQ/oxy](https://github.com/OxyHQ/oxy) and the org profile: centered intro, badges, two column sections, `<details>` for the long material, tables for the inventories. No em dashes or en dashes.

## Verification

- Every relative link resolves on disk (all nine docs, all five package paths, `packages/mcp/README.md`, `AGENTS.md`, `LICENSE`).
- Every `github.com/OxyHQ/...` link resolves to a public repo (`oxy`, `Bloom`, `Syra`, `CrowdSource`, `.github` policy files).
- Badge values checked against the tree: MIT from `LICENSE` and `package.json`, Expo 57 and RN 0.86 from `packages/frontend`, TypeScript 5.9 from the workspace catalog, Bun 1.3.14 from `packageManager`.
- Every quick-start command exists as a script in the relevant `package.json`; the Compose service names (`mongo`, `mongo-init`, `valkey`, `backend`) are the real ones.
- Platform claims checked in the tree: `@oxyhq/services` and `OxyProvider` in the frontend, `@oxyhq/core/server` in the backend, `@oxyhq/protocol` for MTN, `@oxyhq/crowdsource*` for moderation, `@syra.fm/sdk` for live rooms.
- Grepped for `—` and `–`: zero.

Deployment plumbing (ECR, SSM, ALB) was deliberately dropped from the public README. It stays in `docs/` and `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)