### PR TITLE
fix(config): the server refused to boot over a store it never opens

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -9,6 +9,9 @@
 NODE_ENV=development
 PORT=4110
 LOG_LEVEL=debug
+# NOT required to boot: the server loads no Mongo. Set it only to run
+# `scripts/backfill-mongo-to-postgres.ts`, which names it as its SOURCE
+# database and asserts it itself.
 MONGODB_URI=mongodb://localhost:27017/mention?replicaSet=rs0
 MONGODB_READ_PREFERENCE=primary
 FRONTEND_URL=http://localhost:8110

--- a/packages/backend/src/__tests__/config/bootDoesNotRequireMongo.test.ts
+++ b/packages/backend/src/__tests__/config/bootDoesNotRequireMongo.test.ts
@@ -1,0 +1,118 @@
+/**
+ * `validateEnvironment` must never demand `MONGODB_URI` again.
+ *
+ * The web service loads no Mongo — zero of the modules under `dist/` that
+ * require `mongoose`/`mongodb` are reachable from `dist/server.js` — yet
+ * `server.ts` called this function and it refused to boot without the variable.
+ * That is the shape this file exists to stop coming back: a required-variable
+ * list outliving the dependency it was written for, where the symptom is a
+ * refusal to start rather than anything a type or a build can see.
+ *
+ * ## Why the second case is the load-bearing one
+ *
+ * "It does not throw" is satisfied by a `validateEnvironment` that does nothing
+ * at all, so on its own it cannot tell a fixed validator from a broken one. The
+ * production case supplies the floor: it deliberately withholds a DIFFERENT
+ * required variable, asserts the error names THAT one, and only then asserts
+ * `MONGODB_URI` is absent from the same message. A validator that stopped
+ * collecting would fail the first assertion before it could pass the second.
+ *
+ * Mutation-tested both ways: restoring `if (!config.mongoUri)
+ * missing.push('MONGODB_URI')` turns both cases red, and emptying the `missing`
+ * list turns the production case red.
+ *
+ * `src/config/index.ts` snapshots `process.env` at MODULE scope
+ * (`const environment = parseRuntimeEnvironment(process.env)`), so each case has
+ * to set the environment BEFORE importing it and `vi.resetModules()` between
+ * cases. Importing it once and mutating `process.env` afterwards would measure
+ * the snapshot taken by whichever case ran first.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Enough of a production environment to reach the checks under test.
+ *
+ * The two secrets carry real length because the zod schema enforces a 32-char
+ * minimum on them; a short placeholder fails at `parseRuntimeEnvironment`, which
+ * is BEFORE `validateEnvironment` ever runs — so the case would go red for a
+ * reason that has nothing to do with what it asserts.
+ */
+const PRODUCTION_BASELINE = {
+  NODE_ENV: 'production',
+  MENTION_PUBLIC_API_URL: 'https://api.mention.earth',
+  MENTION_MCP_JWT_SECRET: 'mcp-jwt-secret-for-this-test-0123456789',
+  IP_HASH_SALT: 'ip-hash-salt-for-this-test-0123456789',
+} as const;
+
+const originalEnv = { ...process.env };
+
+async function loadValidator(
+  overrides: Record<string, string | undefined>,
+): Promise<() => void> {
+  vi.resetModules();
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  const { validateEnvironment } = await import('../../config');
+  return validateEnvironment;
+}
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+  vi.resetModules();
+});
+
+describe('validateEnvironment', () => {
+  it('boots without MONGODB_URI', async () => {
+    const validateEnvironment = await loadValidator({
+      NODE_ENV: 'test',
+      MONGODB_URI: undefined,
+    });
+    expect(() => validateEnvironment()).not.toThrow();
+  });
+
+  it('never names MONGODB_URI, even while reporting a variable that IS required', async () => {
+    const validateEnvironment = await loadValidator({
+      ...PRODUCTION_BASELINE,
+      FRONTEND_URL: undefined,
+      MONGODB_URI: undefined,
+    });
+
+    let message = '';
+    try {
+      validateEnvironment();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    // The floor: prove the validator is still collecting before reading the
+    // absence of anything from its output.
+    expect(message).toContain('FRONTEND_URL');
+    expect(message).not.toContain('MONGODB_URI');
+  });
+
+  it('does not name MONGODB_URI when it IS set either', async () => {
+    // The variable still reaches the process on a deployment that has not
+    // dropped it yet, and it must be as inert present as absent — otherwise the
+    // two cases above would pass on a validator that merely inverted the check.
+    const validateEnvironment = await loadValidator({
+      ...PRODUCTION_BASELINE,
+      FRONTEND_URL: undefined,
+      MONGODB_URI: 'mongodb://127.0.0.1:27017/mention',
+    });
+
+    let message = '';
+    try {
+      validateEnvironment();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('FRONTEND_URL');
+    expect(message).not.toContain('MONGODB_URI');
+  });
+});

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -867,9 +867,24 @@ export const config = {
   },
 } as const;
 
+/**
+ * The variables a task cannot boot without.
+ *
+ * **`MONGODB_URI` is deliberately NOT among them, and must not come back.** This
+ * function runs from `server.ts`, and the web service loads no Mongo at all —
+ * measured on the compiled artifact rather than argued from the source: zero of
+ * the 61 modules under `dist/` that require `mongoose`/`mongodb` are reachable
+ * from `dist/server.js`. Requiring the variable here was the last thing making
+ * "Mention needs MongoDB to start" true, months after it stopped being true in
+ * any other sense — a refusal to boot over a store the process never opens.
+ *
+ * It stays REQUIRED for the one entry point that genuinely reads Mongo:
+ * `scripts/backfill-mongo-to-postgres.ts` asserts it itself and names it as the
+ * SOURCE database, which is the right place for it — that check belongs to the
+ * consumer, not to every process that shares this config module.
+ */
 export function validateEnvironment(): void {
   const missing: string[] = [];
-  if (!config.mongoUri) missing.push('MONGODB_URI');
   if (config.runtime.isProduction && !config.frontendUrl) missing.push('FRONTEND_URL');
   if (config.runtime.isProduction && !environment.MENTION_PUBLIC_API_URL) {
     missing.push('MENTION_PUBLIC_API_URL');


### PR DESCRIPTION
`validateEnvironment` listed `MONGODB_URI` as required — unconditionally, not even gated on production — and `server.ts:707` calls it. So the web task refused to start without a Mongo connection string while loading no Mongo at all. This was the last thing making "Mention needs MongoDB to boot" true, and the only item in the Mongo inventory that blocked anything today.

## The evidence

Measured on the compiled artefact, not argued from the source: of the **61 modules under `packages/backend/dist` that require `mongoose`/`mongodb`, zero are reachable from `dist/server.js`.**

Two scanner corrections were needed before that number could be trusted, and both cut the other way at first:

- **`tsc` keeps comments in the emitted `.js`**, so a docblock containing `require('mongoose')` as an example reads as a live import to any grep — on `dist` exactly as on the source. That alone mis-reported `src/scripts/reportFederationBlocklistCandidates.ts` as a live Mongo consumer inside the web service; it imports no Mongo anywhere.
- **`import { type X } from '...'` is elided by `tsc`**, so a type-only edge looks like a value import in the source and does not exist at runtime.

The comment stripper used for the corrected scan is a single-pass state machine, mutation-tested on 7 cases (apostrophes inside template literals, `//` inside quoted strings, adjacent block comments) before being trusted, with a vacuity floor on the file count.

## What still requires it

`scripts/backfill-mongo-to-postgres.ts` — the one entry point that genuinely reads Mongo. It asserts the variable itself and names it as the SOURCE database. That check belongs to the consumer, not to every process that shares this config module, which is precisely how this one outlived its reason.

`.env.example` now says so beside the variable.

## The test

`src/__tests__/config/bootDoesNotRequireMongo.test.ts`. The second and third cases are the load-bearing ones — *"it does not throw"* is satisfied by a validator that does nothing at all, so it cannot tell a fixed validator from a broken one:

- **case 2** withholds a DIFFERENT required variable (`FRONTEND_URL`), asserts the error names *that* one, and only then asserts `MONGODB_URI` is absent from the same message. A validator that stopped collecting fails the first assertion before it can reach the second.
- **case 3** SUPPLIES `MONGODB_URI` rather than withholding it, so the pair cannot pass on a check that was merely inverted.

Mutation-tested three ways, each restored in place afterwards:

| mutation | result |
|---|---|
| reinstate `if (!config.mongoUri) missing.push('MONGODB_URI')` | cases 1 and 2 red |
| make the `missing.length` guard unreachable | cases 2 and 3 red |
| (control) unmutated | 3 passed |

## Scope

Part 1 of the Mongo cleanup. Nothing is deleted here — the 28 orphan models, the 13 orphan scripts and the migration one-shot come in their own PRs, and `mongoose` stays in the manifest for the copier. No AWS change: the secret can only leave the task definition once this is deployed, since until then the boot demands it.
