### PR TITLE
refactor(deploy): the blocked-domain purge stops riding the Mongo one-shot

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -114,6 +114,14 @@ fi
 # smoke checks because a failure here has routed nothing; a smoke failure rolls
 # back after the image has already served.
 #
+# THE FOURTH ENTRY PURGES NEWLY BLOCKED DOMAINS, and it is last because it is
+# the only one that DELETES: the schema has to be current and the store has to be
+# populated before content is removed from it. It was the tail of the MONGO
+# migration one-shot until it was split out — it is Postgres-only, so carrying it
+# inside a step named after Mongo meant removing Mongo from the deploy would have
+# removed the purge with it, silently. It exits 0 even when it fails (fail-soft
+# by design), so it cannot roll a healthy release back over a cleanup.
+#
 # ITS LIFETIME IS THE CUTOVER'S. It asserts that Postgres is authoritative,
 # which is false before the cutover and false again after a rollback to Mongo —
 # the planned contingency. It therefore ships INSIDE the cutover commit, so
@@ -132,6 +140,10 @@ MIGRATION_TASK_COMMANDS_JSON='[
   {
     "label": "Postgres population floor",
     "command": ["bun", "packages/backend/dist/src/scripts/assertPostgresPopulated.js"]
+  },
+  {
+    "label": "Blocked-domain reconciliation",
+    "command": ["bun", "packages/backend/dist/src/scripts/reconcileBlockedDomains.js"]
   }
 ]'
 # Exit code a smoke script uses to say "this failed, and rolling back cannot fix

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -446,13 +446,17 @@ fi
 # Both stores migrate on one release, and the ORDER is the assertion: Postgres
 # first, because a task that boots without its schema becomes ready and then
 # fails every query, while a missed Mongo data migration leaves the previous
-# release's behaviour standing. A `diff` of the whole log is what notices a
-# reordering -- grepping for both entries would pass either way round.
+# release's behaviour standing. The blocked-domain reconciliation is LAST of the
+# pre-rollout steps because it is the only one that deletes rows, so it must not
+# run before the schema is current and the store is known to be populated. A
+# `diff` of the whole log is what notices a reordering -- grepping for the
+# entries would pass in any order.
 run_release migration-order true true false 0
 printf '%s\n' \
   'task:bun packages/backend/dist/src/db/migrate.js --target-database=mention' \
   'task:bun packages/backend/dist/scripts/migrate.js' \
   'task:bun packages/backend/dist/src/scripts/assertPostgresPopulated.js' \
+  'task:bun packages/backend/dist/src/scripts/reconcileBlockedDomains.js' \
   'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
   smoke \
   task:reconcile \

--- a/packages/backend/src/__tests__/adminScriptSafety.test.ts
+++ b/packages/backend/src/__tests__/adminScriptSafety.test.ts
@@ -37,6 +37,20 @@ const READ_ONLY_SCRIPTS = new Set([
  * offenders. These are the destructive ones; requiring that they are FOUND, and
  * found guarded, is a floor a broken traversal cannot meet.
  */
+/**
+ * Scripts the DEPLOY invokes unattended, which therefore cannot require
+ * `CONFIRM_ADMIN_MUTATION` — there is no operator present to set it, and a guard
+ * that would refuse every run is not a guard.
+ *
+ * They are not `READ_ONLY_SCRIPTS`: this one deletes rows. What replaces the
+ * confirmation is that its INPUT is not operator-supplied — the domains come from
+ * a committed policy file that reaches production through review and a deploy, so
+ * the decision was already made in the place this guard exists to force it to be
+ * made. Anything added here must have that same property; a script taking a
+ * domain or an id from the environment does not.
+ */
+const DEPLOY_INVOKED_SCRIPTS = new Set(['reconcileBlockedDomains.ts']);
+
 const REQUIRED_GUARDED_SCRIPTS = [
   'purgeBlockedDomainContent.ts',
   'purgeBlockedDomainPlatformData.ts',
@@ -151,8 +165,16 @@ describe('assertAdminMutationAllowed', () => {
     // exemption written for a different one.
     expect([...READ_ONLY_SCRIPTS].filter((name) => !scripts.includes(name)).map(at)).toEqual([]);
 
+    // FLOOR — the deploy-invoked exemptions must name real scripts too.
+    expect([...DEPLOY_INVOKED_SCRIPTS].filter((name) => !scripts.includes(name)).map(at)).toEqual([]);
+
     const unguarded = scripts
-      .filter((name) => !READ_ONLY_SCRIPTS.has(name) && !guarded.has(name))
+      .filter(
+        (name) =>
+          !READ_ONLY_SCRIPTS.has(name) &&
+          !DEPLOY_INVOKED_SCRIPTS.has(name) &&
+          !guarded.has(name),
+      )
       .map(at);
     expect(unguarded).toEqual([]);
   });

--- a/packages/backend/src/__tests__/isolatedDatabaseCoverage.test.ts
+++ b/packages/backend/src/__tests__/isolatedDatabaseCoverage.test.ts
@@ -140,6 +140,10 @@ const JOB_ENTRY_POINTS: readonly JobEntryPoint[] = [
    */
   { name: 'backfillFederatedThreadLinks', call: /\bbackfillFederatedThreadLinks\s*\(/ },
   { name: 'normalizeStoredText', call: /\bnormalizeStoredText\s*\(/ },
+  // Keyed on the FILE, not on a call: its suite runs the entry point as a
+  // subprocess rather than importing it, which is the only way to exercise the
+  // `require.main === module` block where the pool is opened.
+  { name: 'reconcileBlockedDomains', call: /'scripts',\s*'reconcileBlockedDomains\.ts'/ },
   { name: 'repairFederatedMentions', call: /\brepairFederatedMentions\s*\(/ },
   { name: 'backfillThreadRootThreadId', call: /\bbackfillThreadRootThreadId\s*\(/ },
   { name: 'migrateThreadFanToChain', call: /\bmigrateThreadFanToChain\s*\(/ },

--- a/packages/backend/src/__tests__/isolatedDatabaseFiles.ts
+++ b/packages/backend/src/__tests__/isolatedDatabaseFiles.ts
@@ -224,6 +224,14 @@ export const ISOLATED_DATABASE_FILES: readonly IsolatedDatabaseFile[] = [
       'text. The suite calls it with `dryRun: false`.',
   },
   {
+    path: 'src/__tests__/scripts/reconcileBlockedDomains.test.ts',
+    jobEntryPoint: 'reconcileBlockedDomains',
+    reason:
+      'Its candidate set is every domain in the COMMITTED blocklist policy, and for each it ' +
+      'deletes that domain\'s posts and actor rows. Another file\'s federated post from a ' +
+      'blocked domain is a candidate, and the run also writes the shared purge ledger.',
+  },
+  {
     path: 'src/__tests__/scripts/repairFederatedMentions.test.ts',
     jobEntryPoint: 'repairFederatedMentions',
     reason:

--- a/packages/backend/src/__tests__/migrations/migrationTask.test.ts
+++ b/packages/backend/src/__tests__/migrations/migrationTask.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
 const mocks = vi.hoisted(() => ({
   connectToDatabase: vi.fn(),
@@ -113,49 +115,25 @@ describe('migration task database isolation', () => {
     expect(mocks.runMigrations).not.toHaveBeenCalled();
   });
 
-  it('does not reconcile blocked domains when the policy names none', async () => {
-    mocks.loadBlockedDomainPolicy.mockReturnValue([]);
-
-    await runMigrationTask();
-
-    // The branch that hid this whole path from the suite until the blocklist
-    // gained entries. Asserted deliberately now, rather than relied upon.
-    expect(mocks.reconcileBlockedDomainPurges).not.toHaveBeenCalled();
-  });
-
-  it('reconciles blocked domains once the policy names some', async () => {
-    mocks.loadBlockedDomainPolicy.mockReturnValue([{
-  domain: 'spam.example',
-  severity: 'suspend' as const,
-  category: 'spam' as const,
-  reason: 'test',
-  since: '2026-01-01',
-  corroboratingSources: [] as readonly string[],
-}]);
-
-    await runMigrationTask();
-
-    expect(mocks.reconcileBlockedDomainPurges).toHaveBeenCalledOnce();
-    const input = mocks.reconcileBlockedDomainPurges.mock.calls[0][0];
-    expect(input.policyEntries).toHaveLength(1);
-    expect(input.policyEntries[0].domain).toBe('spam.example');
-  });
-
-  it('completes the migration task even when reconciliation throws', async () => {
-    mocks.loadBlockedDomainPolicy.mockReturnValue([{
-  domain: 'spam.example',
-  severity: 'suspend' as const,
-  category: 'spam' as const,
-  reason: 'test',
-  since: '2026-01-01',
-  corroboratingSources: [] as readonly string[],
-}]);
-    mocks.reconcileBlockedDomainPurges.mockRejectedValue(new Error('reconcile exploded'));
-
-    // Fail-soft on purpose: this runs inside the deploy one-shot, and a content
-    // cleanup problem must never stop a release from shipping. Failing to delete
-    // is the safe direction; blocking the deploy is not.
-    await expect(runMigrationTask()).resolves.toBeUndefined();
-    expect(mocks.runMigrations).toHaveBeenCalledOnce();
+  it('no longer reconciles blocked domains at all', () => {
+    // The payload MOVED to `scripts/reconcileBlockedDomains.ts`, its own deploy
+    // step, because it is Postgres-only and carrying it inside the MONGO
+    // migration one-shot meant removing Mongo from the deploy would have removed
+    // the purge with it. This asserts the departure rather than the behaviour:
+    // whether the purge still works is `__tests__/scripts/reconcileBlockedDomains.test.ts`,
+    // which runs the real entry point against a real database instead of
+    // asserting a mock was called.
+    //
+    // Read on SOURCE, not through a spy, because a spy can only observe a symbol
+    // this module still imports — and the point is that it imports none of them.
+    const source = readFileSync(
+      path.resolve(__dirname, '../../migrations/task.ts'),
+      'utf8',
+    );
+    expect(source).not.toContain('reconcileBlockedDomainPurges');
+    expect(source).not.toContain('purgeBlockedDomainContent');
+    expect(source).not.toContain('loadBlockedDomainPolicy');
+    // Floor: the file was actually read and is the one under test.
+    expect(source).toContain('export async function runMigrationTask');
   });
 });

--- a/packages/backend/src/__tests__/scripts/reconcileBlockedDomains.test.ts
+++ b/packages/backend/src/__tests__/scripts/reconcileBlockedDomains.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The blocked-domain reconciliation, driven END TO END against a real database.
+ *
+ * ## What this file exists to catch, and why a mock cannot
+ *
+ * This work used to be the tail of `runMigrationTask`. It is Postgres-only, and
+ * when the purge was ported (2026-08-02, `cd122151`) the entry point stopped
+ * opening a Postgres pool while every symbol stayed exactly where it was: the
+ * callee's own `connectPostgres` lives inside a `require.main === module` block,
+ * which does not run for an importer. The result was `PostgreSQL is not
+ * connected` thrown on the first `getDb()`, caught by the deliberate fail-soft,
+ * and a deploy that reported success while blocking a domain purged nothing.
+ * Nothing went red — `tsc` cannot see a runtime connection, and a test that
+ * substitutes `runPurge` or asserts a spy was called would still pass with no
+ * pool open at all.
+ *
+ * So this file substitutes NOTHING, and it does not IMPORT the entry point
+ * either — it runs the file as a process, with the real committed policy and the
+ * real purge, and reads the database afterwards. Importing it would execute the
+ * exported function while the TEST held the pool open, which passes just as well
+ * against an entry point that opens none.
+ * `blockedDomainPurgeReconciler.test.ts` covers the reconciler's own decisions
+ * (batching, ceilings, holds) with injected inputs; that is the right shape for
+ * those, and it is why they are not repeated here.
+ *
+ * ## The two assertions, and why the second one is not redundant
+ *
+ * The FIRST is the wiring: the ledger goes from empty to non-empty. That is
+ * precisely what the historical bug would have failed — with no pool, the
+ * reconciler never writes a row and the fail-soft hides it — and it cannot pass
+ * vacuously, because the table is asserted empty first.
+ *
+ * The SECOND is that the purge reached ROWS: for every domain the ledger records
+ * as `purged`, no post from that domain survives. A run that wrote its ledger and
+ * then failed to delete anything satisfies the first assertion and fails this
+ * one. It is floored on the purged set being non-empty, so a run that purged
+ * nothing cannot pass it by having nothing to check.
+ *
+ * This file needs its OWN database (see `isolatedDatabaseFiles.ts`): the sweep is
+ * unscoped by construction — its candidate set is every domain in the committed
+ * policy — so another file's federated post from a blocked domain is a candidate.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { eq, inArray } from 'drizzle-orm';
+
+import { closePostgres, connectPostgres, getDb } from '../../db/postgres';
+import { blockedDomainPurges } from '../../db/schema/blocklist';
+import { posts } from '../../db/schema/posts';
+import { loadBlockedDomainPolicy } from '../../services/federation/blockedDomainPolicySource';
+
+const run = promisify(execFile);
+
+/** The entry point, run the way ECS runs it. */
+const ENTRY_POINT = join(__dirname, '..', '..', 'scripts', 'reconcileBlockedDomains.ts');
+
+/**
+ * A federated post attributed to `domain`, in the shape the purge selects on:
+ * `federation_activity_id` carries the origin host, which is what
+ * `purgeBlockedDomainContent` matches.
+ */
+async function seedFederatedPost(domain: string, suffix: string): Promise<string> {
+  const id = `blocked-${suffix}`;
+  await getDb()
+    .insert(posts)
+    .values({
+      id,
+      oxyUserId: `actor-${suffix}`,
+      visibility: 'public',
+      status: 'published',
+      federationActivityId: `https://${domain}/activities/${suffix}`,
+      federationActorUri: `https://${domain}/users/${suffix}`,
+    });
+  return id;
+}
+
+/** Domains the committed policy blocks, in the order the reconciler sees them. */
+const POLICY_DOMAINS = loadBlockedDomainPolicy().map((entry) => entry.domain);
+
+describe('the blocked-domain reconciliation entry point', () => {
+  const seeded = new Map<string, string>();
+
+  beforeAll(async () => {
+    await connectPostgres();
+
+    // The floor for the whole file: a committed policy that names nothing would
+    // make `reconcileBlockedDomains` a documented no-op and every assertion
+    // below vacuously true.
+    expect(POLICY_DOMAINS.length).toBeGreaterThan(0);
+
+    // One post per blocked domain, so whichever domains this run reaches, there
+    // is content for them to remove. Seeding only a guessed subset would make the
+    // second assertion depend on the reconciler's batching, which is another
+    // file's subject.
+    for (const [index, domain] of POLICY_DOMAINS.entries()) {
+      seeded.set(domain, await seedFederatedPost(domain, String(index)));
+    }
+    expect(seeded.size).toBe(POLICY_DOMAINS.length);
+
+    const before = await getDb().select({ domain: blockedDomainPurges.domain }).from(blockedDomainPurges);
+    expect(before, 'the ledger must start empty, or the first assertion proves nothing').toEqual([]);
+
+    // RUN IT AS A PROCESS, not as an imported function. That is the whole point:
+    // the bug this file exists for lived in the `require.main === module` block,
+    // which an importer never executes — so a test that called the exported
+    // function would open the pool ITSELF and pass against an entry point that
+    // opens none. Mutation-tested: deleting `connectPostgres()` from that block
+    // turns both cases below red, and no in-process call can do that.
+    await run('bun', [ENTRY_POINT], {
+      env: { ...process.env, DATABASE_URL: process.env.DATABASE_URL },
+      timeout: 120_000,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    await closePostgres().catch(() => undefined);
+  });
+
+  it('writes its ledger, which it can only do with a pool this entry point opened', async () => {
+    const rows = await getDb()
+      .select({ domain: blockedDomainPurges.domain, state: blockedDomainPurges.state })
+      .from(blockedDomainPurges);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('removes the content of every domain it recorded as purged', async () => {
+    const purgedDomains = (
+      await getDb()
+        .select({ domain: blockedDomainPurges.domain })
+        .from(blockedDomainPurges)
+        .where(eq(blockedDomainPurges.state, 'purged'))
+    ).map((row) => row.domain);
+
+    // Floor: "no surviving post among an empty set" is true of a run that
+    // deleted nothing at all.
+    expect(purgedDomains.length).toBeGreaterThan(0);
+
+    const shouldBeGone = purgedDomains
+      .map((domain) => seeded.get(domain))
+      .filter((id): id is string => id !== undefined);
+    expect(shouldBeGone.length).toBe(purgedDomains.length);
+
+    const survivors = await getDb()
+      .select({ id: posts.id })
+      .from(posts)
+      .where(inArray(posts.id, shouldBeGone));
+    expect(survivors.map((row) => row.id)).toEqual([]);
+  });
+});

--- a/packages/backend/src/migrations/task.ts
+++ b/packages/backend/src/migrations/task.ts
@@ -3,11 +3,7 @@ import {
   type DatabaseConnectionOptions,
 } from '../utils/database';
 import { assertMongoTransactionalTopology } from '../utils/mongoTopology';
-import { logger } from '../utils/logger';
 import { runMigrations } from './runner';
-import { loadBlockedDomainPolicy } from '../services/federation/blockedDomainPolicySource';
-import { reconcileBlockedDomainPurges } from '../services/federation/BlockedDomainPurgeReconciler';
-import purgeBlockedDomainContent from '../scripts/purgeBlockedDomainContent';
 
 /**
  * A minute, not fifteen — and the reduction is a CUTOVER risk control rather
@@ -15,10 +11,11 @@ import purgeBlockedDomainContent from '../scripts/purgeBlockedDomainContent';
  *
  * The 15 minutes existed because index builds and bounded backfills legitimately
  * outlive the web runtime's 45-second socket timeout. That is no longer what
- * this task does: all 25 Mongo migrations are recorded applied and skip, and the
- * only live payload (`reconcileBlockedDomains`) is Postgres-only. The entire
- * remaining Mongo surface here is a connect, one `hello`, a ledger read, and the
- * lease `findOneAndUpdate` — none of which legitimately takes a minute.
+ * this task does: every Mongo migration is recorded applied and skips, and the
+ * one live payload it used to carry (`reconcileBlockedDomains`) has moved to its
+ * own entry point. The entire remaining Mongo surface here is a connect, one
+ * `hello`, a ledger read, and the lease `findOneAndUpdate` — none of which
+ * legitimately takes a minute.
  *
  * Why it matters at all: this task runs inside the Mongo→Postgres cutover
  * window, in the deploy that follows the copy, with the service already stopped.
@@ -47,37 +44,17 @@ export const MIGRATION_DATABASE_CONNECTION_OPTIONS = Object.freeze({
 }) satisfies DatabaseConnectionOptions;
 
 /**
- * Purge the content of any domain the committed blocklist policy has newly
- * blocked, so blocking is one action with a complete effect.
+ * The Mongo half of the deploy, and ONLY the Mongo half.
  *
- * Runs AFTER the schema migrations, in the same deploy one-shot: once per
- * deploy, on the exact image being rolled out, at the only moment a committed
- * policy file can have changed. See `BlockedDomainPurgeReconciler` for why that
- * beats a startup reconciliation (N tasks on a scale-out) or a scheduled job (a
- * window where the domain is blocked but its content is still served).
- *
- * Deliberately fail-soft: a cleanup problem must never block shipping. The
- * failure is recorded per domain and logged at error level, and the content
- * stays until the next reconciliation — failing to delete is the safe direction,
- * and it is the direction a bug here should always fall in.
+ * `reconcileBlockedDomains` used to run here as a fourth step. It is
+ * Postgres-only, so carrying it inside the MONGO migration one-shot meant the
+ * deploy step that performed it was named after a store it does not touch —
+ * which would have made removing Mongo from the deploy remove the purge with it,
+ * silently. It is now its own entry point, `scripts/reconcileBlockedDomains.ts`,
+ * invoked as its own step by `deploy-ecs-image.sh`.
  */
-async function reconcileBlockedDomains(): Promise<void> {
-  const policyEntries = loadBlockedDomainPolicy();
-  if (policyEntries.length === 0) return;
-
-  try {
-    await reconcileBlockedDomainPurges({
-      policyEntries,
-      runPurge: (domains, options) => purgeBlockedDomainContent(domains, options),
-    });
-  } catch (error) {
-    logger.error('[migration] blocked-domain reconciliation failed; deploy continues', error);
-  }
-}
-
 export async function runMigrationTask(): Promise<void> {
   await connectToDatabase(MIGRATION_DATABASE_CONNECTION_OPTIONS);
   await assertMongoTransactionalTopology();
   await runMigrations();
-  await reconcileBlockedDomains();
 }

--- a/packages/backend/src/scripts/reconcileBlockedDomains.ts
+++ b/packages/backend/src/scripts/reconcileBlockedDomains.ts
@@ -1,0 +1,88 @@
+/**
+ * Purge the content of any domain the committed blocklist policy has newly
+ * blocked, so blocking is ONE action with a complete effect.
+ *
+ * ## Why this is its own entry point
+ *
+ * It used to be the tail of `runMigrationTask` — the MONGO migration one-shot —
+ * and it is Postgres-only. That pairing is what made the coupling invisible: the
+ * deploy step that carried this work was named after a store it no longer
+ * touches, so removing Mongo from the deploy would have removed the purge with
+ * it, silently and for a reason nothing in the diff would name.
+ *
+ * The placement rationale is unchanged and still belongs to a DEPLOY step rather
+ * than a scheduled job or a startup hook: it runs once per deploy, on the exact
+ * image being rolled out, at the only moment a committed policy file can have
+ * changed. A startup reconciliation would run N times on a scale-out; a
+ * scheduled job would leave a window where a domain is blocked but its content
+ * is still served. See `BlockedDomainPurgeReconciler`.
+ *
+ * ## It must open the pool itself, and that is not boilerplate
+ *
+ * A one-shot gets none of `server.ts`'s startup. `purgeBlockedDomainContent`
+ * connects inside its own `require.main === module` block, which does NOT run
+ * for an importer — so without `connectPostgres()` here the first `getDb()`
+ * throws `PostgreSQL is not connected`, `reconcile` catches it as fail-soft, and
+ * blocking a domain silently stops purging its content while the deploy reports
+ * success. That happened once already (2026-08-02, `cd122151`, when the purge was
+ * ported): nothing went red, because the link between an entry point and the
+ * store its callee reads is a RUNTIME CONNECTION, not a symbol. `tsc` cannot see
+ * it, and neither can a test that only imports this file.
+ *
+ * That is why `__tests__/scripts/reconcileBlockedDomains.test.ts` runs the whole
+ * path against a real database and asserts the ROWS are gone, rather than
+ * asserting that a mock was called.
+ *
+ * ## Fail-soft, deliberately
+ *
+ * A cleanup problem must never block shipping. Failures are recorded per domain
+ * by the reconciler and logged at error level here, and the content stays until
+ * the next reconciliation — failing to delete is the safe direction, and it is
+ * the direction a bug here should always fall in. The process still exits 0, so
+ * `deploy-ecs-image.sh` does not roll a healthy release back over a purge.
+ */
+
+import { closePostgres, connectPostgres } from '../db/postgres';
+import { loadBlockedDomainPolicy } from '../services/federation/blockedDomainPolicySource';
+import { reconcileBlockedDomainPurges } from '../services/federation/BlockedDomainPurgeReconciler';
+import purgeBlockedDomainContent from './purgeBlockedDomainContent';
+import { logger } from '../utils/logger';
+
+/**
+ * Exported so the test can drive the real path with a pool it opened itself.
+ * Takes no arguments: the policy is a committed file and the purge is the one
+ * implementation, so there is nothing here a caller should be able to substitute.
+ */
+export async function reconcileBlockedDomains(): Promise<void> {
+  const policyEntries = loadBlockedDomainPolicy();
+  if (policyEntries.length === 0) return;
+
+  try {
+    await reconcileBlockedDomainPurges({
+      policyEntries,
+      runPurge: (domains, options) => purgeBlockedDomainContent(domains, options),
+    });
+  } catch (error) {
+    logger.error('[reconcileBlockedDomains] reconciliation failed; deploy continues', error);
+  }
+}
+
+if (require.main === module) {
+  void (async () => {
+    try {
+      await connectPostgres();
+      await reconcileBlockedDomains();
+    } catch (error) {
+      // Reaching here means the POOL could not be opened, which the fail-soft
+      // above cannot absorb because it never ran. Still exit 0: a deploy must not
+      // be rolled back over a cleanup step.
+      logger.error('[reconcileBlockedDomains] could not open the database', error);
+    } finally {
+      await closePostgres().catch(() => undefined);
+      // Imported singletons (BullMQ Redis handles, the media cache worker) keep
+      // the event loop alive, so a Fargate one-shot would sit RUNNING after the
+      // work completed. Mirrors the other one-shots.
+      process.exit(0);
+    }
+  })();
+}


### PR DESCRIPTION
`reconcileBlockedDomains` was the tail of `runMigrationTask` — the MONGO
migration one-shot — and it is Postgres-only. That pairing is what made
the coupling invisible: the deploy step performing the purge was named
after a store it does not touch, so removing Mongo from the deploy would
have removed the purge with it, silently, for a reason nothing in the
diff would name.

It is now `src/scripts/reconcileBlockedDomains.ts`, its own entry in
`MIGRATION_TASK_COMMANDS_JSON`, ordered LAST of the pre-rollout steps
because it is the only one that deletes: the schema must be current and
the store known to be populated before content is removed from it. It
exits 0 even when it fails, so a cleanup cannot roll back a healthy
release.

The placement rationale is unchanged — once per deploy, on the image
being rolled out, at the only moment a committed policy file can have
changed.

## The test runs the file as a PROCESS, and that is the whole point

When the purge was ported (2026-08-02, `cd122151`) the entry point
stopped opening a Postgres pool while every symbol stayed where it was:
the callee's `connectPostgres` lives inside `require.main === module`,
which an importer never executes. First `getDb()` threw, the deliberate
fail-soft swallowed it, and the deploy reported success while blocking a
domain purged nothing. Nothing went red — a runtime connection is not a
symbol.

A test that imported the entry point would open the pool ITSELF and pass
against an entry point that opens none, so this one spawns the file the
way ECS does and reads the database afterwards. Two assertions, each
floored: the purge ledger goes from empty to non-empty (the wiring), and
no post survives for any domain the ledger records as `purged`, floored
on that set being non-empty (the rows). Mutation-tested: deleting
`connectPostgres()` from the entry point turns both red, and no
in-process call can do that.

Four gates moved with it, each for a stated reason rather than to pass:

- `migrationTask.test.ts` asserts the DEPARTURE by reading source, not
  through a spy — a spy can only observe a symbol the module still
  imports, and the point is that it imports none of them.
- `adminScriptSafety` gains `DEPLOY_INVOKED_SCRIPTS`. This script deletes
  rows, so `READ_ONLY_SCRIPTS` would be a lie, and it runs unattended, so
  requiring `CONFIRM_ADMIN_MUTATION` would refuse every run. What
  replaces the confirmation is that its input is a committed policy file,
  not an operator argument — the decision was already made where this
  guard exists to force it.
- `isolatedDatabaseFiles` gains an entry: the sweep's candidate set is
  every domain in the policy, so another file's federated post is a
  candidate. Its coverage pattern is keyed on the FILE rather than a
  call, since the suite spawns rather than imports.
- The `scriptScope` declaration is dropped rather than kept — that list
  requires a test that imports the script, and by design none does.

Full suite: 543 files, 6409 tests, all passing.

---

PR-3 of the Mongo cleanup. Follows #676 and #678. Unblocks PR-4 (retiring the Mongo migration one-shot), which is still gated on confirming in production's ledger that every id in `MIGRATION_IDS` is recorded applied — by set inclusion, not by count.