### PR TITLE
fix(purge): both blocked-domain purges opened Mongo for nothing

### DIFF
--- a/packages/backend/src/__tests__/scripts/purgesDoNotOpenMongo.test.ts
+++ b/packages/backend/src/__tests__/scripts/purgesDoNotOpenMongo.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The two blocked-domain purges must not reach MongoDB.
+ *
+ * ## Why this is a gate and not a note
+ *
+ * Both are run by GitHub workflows that derive their task definition from the
+ * LIVE SERVICE's (`run-blocked-domain-content-purge.yml`,
+ * `run-blocked-domain-purge.yml` — `describe-services` → `taskDefinition` → only
+ * the image replaced). So they inherit whatever secrets the web service carries,
+ * and the moment `MONGODB_URI` leaves that task definition, any Mongo connect
+ * left on these paths fails at startup — before either script does a single unit
+ * of the work it exists for. Nothing in either workflow would name Mongo as the
+ * cause.
+ *
+ * ## What was actually removed, and why the comments mattered more than the code
+ *
+ * Each script opened a Mongo connection it never used, and each carried a
+ * comment explaining why the connection was necessary. Both explanations were
+ * FALSE by the time they were read:
+ *
+ *  - `purgeBlockedDomainContent` said `feed_interactions` still had a live Mongo
+ *    writer. It does not — `purgeFeedInteractions` deletes through `getDb()`
+ *    against the Postgres table, and the Mongoose model was deleted once nothing
+ *    imported it.
+ *  - `purgeBlockedDomainPlatformData` said its cursor rows live in Mongo. They
+ *    live in Postgres; `lib/adminScriptCursor` reads and writes them through the
+ *    Postgres pool.
+ *
+ * A stale justification is worse than an unexplained line, because it reads as a
+ * decision somebody made on purpose — which is exactly why the removal is gated
+ * rather than left to the next reader to re-derive.
+ *
+ * ## Read on SOURCE, deliberately
+ *
+ * The property is "this file does not reach Mongo", which is a claim about what
+ * it IMPORTS. A runtime test cannot see an unused connection at all: the scripts
+ * behaved identically with and without it, for as long as `MONGODB_URI` happened
+ * to be present. The scan is floored on both files being found and non-trivial,
+ * so a moved or renamed file fails loudly instead of passing by matching nothing.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/** The scripts the two purge workflows invoke, by the path the workflows name. */
+const PURGE_SCRIPTS = [
+  'purgeBlockedDomainContent.ts',
+  'purgeBlockedDomainPlatformData.ts',
+] as const;
+
+/**
+ * Comments are stripped before matching. Both files legitimately DISCUSS Mongo —
+ * one records that a shape guard used to be `mongoose.isValidObjectId` — and a
+ * scan that counted prose would either fail on a correct file or force the
+ * explanation out of the code, which is the opposite of what is wanted here.
+ */
+function codeOf(script: string): string {
+  const source = readFileSync(path.resolve(__dirname, '../../scripts', script), 'utf8');
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+describe('the blocked-domain purges', () => {
+  it.each(PURGE_SCRIPTS)('%s reaches no Mongo store', (script) => {
+    const code = codeOf(script);
+
+    // Floor: the file was found and is the real one, so a rename cannot make
+    // this pass by matching an empty string.
+    expect(code.length).toBeGreaterThan(1_000);
+    expect(code).toContain('SCRIPT_NAME');
+
+    expect(code).not.toContain('mongoose');
+    expect(code).not.toContain('connectToDatabase');
+    expect(code).not.toContain('utils/database');
+  });
+
+  it('still opens the store it DOES use', () => {
+    // The mirror of the assertion above, and not redundant: "reaches no Mongo"
+    // is satisfied just as well by a script that opens nothing at all, which
+    // would be the same class of bug one store over — a one-shot gets none of
+    // `server.ts`'s startup, so the pool it needs is the pool it opens.
+    expect(codeOf('purgeBlockedDomainContent.ts')).toContain('connectPostgres');
+  });
+});

--- a/packages/backend/src/scripts/purgeBlockedDomainContent.ts
+++ b/packages/backend/src/scripts/purgeBlockedDomainContent.ts
@@ -147,7 +147,6 @@
  */
 
 import { createHash } from 'node:crypto';
-import mongoose from 'mongoose';
 import {
   and,
   asc,
@@ -164,7 +163,6 @@ import {
 import type { PgColumn, PgTable } from 'drizzle-orm/pg-core';
 import { PostType } from '@mention/shared-types';
 import { config } from '../config';
-import { connectToDatabase } from '../utils/database';
 import { connectPostgres, getDb } from '../db/postgres';
 import { bookmarks, entityFollows, likes, postSubscriptions } from '../db/schema/engagement';
 import { notifications } from '../db/schema/discovery';
@@ -2034,13 +2032,15 @@ async function main(): Promise<void> {
     );
 
     /**
-     * BOTH stores, and now for exactly ONE reason rather than because the script
-     * was half-ported: `feed_interactions` still has a live Mongo writer, so the
-     * cascade deletes that collection as well as its Postgres table (see
-     * {@link purgeFeedInteractions}). Everything else this run touches is
-     * Postgres. When that writer ports, the Mongo connection goes with it.
+     * POSTGRES ONLY. The comment that used to sit here justified a Mongo
+     * connection by saying `feed_interactions` still had a live Mongo writer —
+     * it does not: `purgeFeedInteractions` deletes through `getDb()` against the
+     * `feed_interactions` TABLE, and the Mongoose model was deleted once nothing
+     * imported it. The connection outlived its reason, and the reason outlived
+     * its truth, which is the more dangerous half: a stale justification reads as
+     * a decision somebody made.
      */
-    await Promise.all([connectToDatabase(), connectPostgres()]);
+    await connectPostgres();
     logger.info(`[${SCRIPT_NAME}] connected`, {
       dryRun: options.dryRun,
       domains: domains.size,
@@ -2078,7 +2078,6 @@ async function main(): Promise<void> {
     throw error;
   } finally {
     await closeAdminScriptResources();
-    await mongoose.disconnect();
   }
 }
 

--- a/packages/backend/src/scripts/purgeBlockedDomainPlatformData.ts
+++ b/packages/backend/src/scripts/purgeBlockedDomainPlatformData.ts
@@ -80,10 +80,8 @@
  *     bun packages/backend/dist/src/scripts/purgeBlockedDomainPlatformData.js
  */
 
-import mongoose from 'mongoose';
 import { canonicalFederationHost } from '@oxyhq/federation';
 import { getOxyServiceCredentials } from '../config';
-import { connectToDatabase } from '../utils/database';
 import { getServiceOxyClient } from '../utils/oxyHelpers';
 import { logger } from '../utils/logger';
 import { getBlockedDomainPolicy } from '../connectors/activitypub/federationBlockPolicy';
@@ -844,9 +842,11 @@ async function main(): Promise<void> {
 
     const domains = resolvePurgeTargets(options);
 
-    // The cursor rows live in Mongo; the purge itself happens entirely over the
-    // Oxy API.
-    await connectToDatabase();
+    // No store is opened here. The comment that used to sit here said the cursor
+    // rows live in Mongo; they live in POSTGRES — `lib/adminScriptCursor` reads
+    // and writes them through the Postgres pool — and the purge itself happens
+    // entirely over the Oxy API. Nothing on this path has needed Mongo since the
+    // cursor was ported.
     logger.info(`[${SCRIPT_NAME}] connected`, {
       dryRun: options.dryRun,
       domains: domains.size,
@@ -878,7 +878,6 @@ async function main(): Promise<void> {
     throw error;
   } finally {
     await closeAdminScriptResources();
-    await mongoose.disconnect();
   }
 }
 


### PR DESCRIPTION
Each script called `connectToDatabase()` and then never used the
connection: its only other mongoose reference was the
`mongoose.disconnect()` in its own `finally`, closing what nothing had
read. Neither imports a model; neither touches the driver.

This is not tidying. Both are run by workflows that derive their task
definition from the LIVE SERVICE's — `describe-services` ->
`taskDefinition` -> only the image replaced — so they inherit whatever
secrets the web service carries. The moment `MONGODB_URI` leaves that
task definition, a Mongo connect on these paths fails at startup, before
either script does a single unit of the work it exists for, and nothing
in either workflow names Mongo as the cause. That is what makes this a
prerequisite of removing the secret rather than a follow-up to it.

**The comments were the worse half, because both were false.**

- `purgeBlockedDomainContent` justified the connection by saying
  `feed_interactions` still had a live Mongo writer. It does not:
  `purgeFeedInteractions` deletes through `getDb()` against the Postgres
  table, and the Mongoose model was deleted once nothing imported it.
- `purgeBlockedDomainPlatformData` said its cursor rows live in Mongo.
  They live in Postgres — `lib/adminScriptCursor` reads and writes them
  through the Postgres pool — and the purge itself happens entirely over
  the Oxy API.

Both were verified against the code before deleting, not assumed from the
absence of a query. A stale justification is worse than an unexplained
line: it reads as a decision somebody made on purpose, so the next reader
leaves it alone. Both comments are replaced with what is actually true.

`__tests__/scripts/purgesDoNotOpenMongo.test.ts` gates it, on SOURCE
deliberately — the property is what the file imports, and a runtime test
cannot see an unused connection at all, which is exactly why these
survived: the scripts behaved identically with and without it for as long
as the variable happened to be present. Comments are stripped before
matching, because both files legitimately DISCUSS Mongo (one records that
a shape guard used to be `mongoose.isValidObjectId`) and a scan that
counted prose would force the explanation out of the code. Floored on
both files being found and non-trivial, plus a mirror case asserting the
content purge still opens the pool it DOES use — "reaches no Mongo" is
satisfied just as well by a script that opens nothing, which is the same
bug one store over.

Mutation-tested: reintroducing a `connectToDatabase()` call turns the
gate red, and the file was restored in place afterwards.

Full suite: 544 files, 6412 tests, all passing.

---

PR-5 of the Mongo cleanup, brought FORWARD of PR-4: `utils/database.ts` has four importers and PR-4 deletes only two of them, so removing the module while these two still import it does not compile. Follows #676, #678, #679.

It is also the prerequisite for taking `MONGODB_URI` out of the service task definition — until this lands, doing so breaks both purge workflows at the connect.