### PR TITLE
ci(deploy): remove MONGODB_URI from the service, keep the parameter

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -17,6 +17,20 @@ POLL_INTERVAL="${POLL_INTERVAL:-15}"
 RUN_MIGRATIONS="${RUN_MIGRATIONS:-false}"
 INTERNAL_METRICS_PARAMETER="${INTERNAL_METRICS_PARAMETER:-}"
 TASK_SECRET_OVERRIDES_JSON="${TASK_SECRET_OVERRIDES_JSON:-}"
+# Secret NAMES to REMOVE from the rendered task definition, space-separated.
+#
+# The script derives each release's definition from the LIVE one and rewrites
+# only what it is told about, so a secret nobody names survives indefinitely —
+# which is how `MONGODB_URI` outlived the store it pointed at. Removal has to be
+# expressible, and it has to be a STANDING assertion rather than a one-off manual
+# registration: the definition is also recorded in Terraform, so an apply or a
+# hand-registered revision can reintroduce a secret that was deleted once. Naming
+# it here re-asserts its absence on every deploy.
+#
+# Removing the secret does NOT delete its SSM parameter. That is deliberate and
+# is the whole safety margin: the parameter stays for one-shots that still need
+# it.
+TASK_SECRET_REMOVALS="${TASK_SECRET_REMOVALS:-}"
 AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-}"
 AWS_PARTITION="${AWS_PARTITION:-aws}"
 POST_DEPLOY_SMOKE_SCRIPT="${POST_DEPLOY_SMOKE_SCRIPT:-}"
@@ -187,6 +201,21 @@ fi
 if [[ -z "$TASK_SECRET_OVERRIDES_JSON" ]]; then
   TASK_SECRET_OVERRIDES_JSON='{}'
 fi
+for removal_name in $TASK_SECRET_REMOVALS; do
+  if ! [[ "$removal_name" =~ ^[A-Z][A-Z0-9_]{0,127}$ ]]; then
+    echo "::error::TASK_SECRET_REMOVALS must be space-separated environment variable names; got '$removal_name'."
+    exit 1
+  fi
+  # A name in BOTH lists is refused rather than resolved. The render filters by
+  # name and then concatenates the overrides, so such a name would be dropped and
+  # immediately re-added — the outcome would depend on the order of two
+  # operations nobody is reading, in a render of SECRETS. Whoever wrote both
+  # entries meant one of them; the script must not pick.
+  if jq -e --arg name "$removal_name" 'has($name)' <<<"$TASK_SECRET_OVERRIDES_JSON" >/dev/null; then
+    echo "::error::$removal_name is in both TASK_SECRET_OVERRIDES_JSON and TASK_SECRET_REMOVALS. Remove it from one."
+    exit 1
+  fi
+done
 if ! jq -e '
   type == "object" and
   length <= 20 and
@@ -521,6 +550,10 @@ task_secret_overrides="$(jq -c '
   ]
 ' <<<"$TASK_SECRET_OVERRIDES_JSON")"
 
+# The removals ride the SAME filter as the overrides — both are "drop any secret
+# with this name" — and only the overrides are concatenated back afterwards.
+task_secret_removals="$(jq -cRn '[inputs | select(length > 0)]' <<<"$(printf '%s\n' $TASK_SECRET_REMOVALS)")"
+
 aws ecs describe-task-definition \
   --task-definition "$current_task_definition" \
   --query taskDefinition \
@@ -538,6 +571,7 @@ jq \
   --arg image "$IMAGE_URI" \
   --arg internalMetricsSecretArn "$internal_metrics_secret_arn" \
   --argjson taskSecretOverrides "$task_secret_overrides" \
+  --argjson taskSecretRemovals "$task_secret_removals" \
   '
     del(
       .taskDefinitionArn,
@@ -548,7 +582,7 @@ jq \
       .registeredAt,
       .registeredBy
     )
-    | ($taskSecretOverrides | map(.name)) as $taskSecretNames
+    | (($taskSecretOverrides | map(.name)) + $taskSecretRemovals) as $taskSecretNames
     | .containerDefinitions |= map(
         if .name == $name then
           .image = $image

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -25,6 +25,7 @@ export DEPLOY_TEST_EXPECT_METRICS_ARN=false
 export DEPLOY_TEST_METRICS_PARAMETER=/oxy/sampleapp/INTERNAL_METRICS_TOKEN
 export DEPLOY_TEST_TASK_EXIT_CODE=0
 export DEPLOY_TEST_EXPECT_TASK_SECRET_ARN=false
+export DEPLOY_TEST_EXPECT_SECRET_REMOVED=
 export DEPLOY_TEST_SERVICE_DESIRED_COUNT=1
 export DEPLOY_TEST_ROLLOUT_SCENARIO=healthy
 # The `lastStatus` a mocked one-shot reports. `RUNNING` never resolves, which is
@@ -126,6 +127,16 @@ aws() {
           "name": "deploy-test",
           "image": "example.invalid/deploy-test:old",
           "essential": true,
+          "secrets": [
+            {
+              "name": "DOOMED_TASK_SECRET",
+              "valueFrom": "arn:aws:ssm:test:123456789012:parameter/oxy/sample-app/DOOMED_TASK_SECRET"
+            },
+            {
+              "name": "KEPT_TASK_SECRET",
+              "valueFrom": "arn:aws:ssm:test:123456789012:parameter/oxy/sample-app/KEPT_TASK_SECRET"
+            }
+          ],
           "logConfiguration": {
             "logDriver": "awslogs",
             "options": {
@@ -172,6 +183,32 @@ aws() {
           printf 'metrics:arn\n' >>"$DEPLOY_TEST_LOG"
         else
           printf 'metrics:arn:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
+        fi
+      fi
+      if [[ "$DEPLOY_TEST_EXPECT_SECRET_REMOVED" != "" ]]; then
+        local previous_argument=""
+        local input_json=""
+        local argument
+        for argument in "$@"; do
+          if [[ "$previous_argument" == "--cli-input-json" ]]; then
+            input_json="${argument#file://}"
+            break
+          fi
+          previous_argument="$argument"
+        done
+        # Two verdicts, not one. Asserting only the ABSENCE of the removed name
+        # passes just as well against a render that dropped every secret, or
+        # against a definition that never carried it -- so the surviving secret
+        # is asserted in the same breath. Both are logged, so a wrong answer
+        # names itself in the expected.log diff rather than vanishing into an
+        # exit status.
+        if jq -e --arg name "$DEPLOY_TEST_EXPECT_SECRET_REMOVED" '
+          [.containerDefinitions[] | select(.name == "deploy-test") | .secrets[] | .name]
+          | (index($name) | not) and (index("KEPT_TASK_SECRET") != null)
+        ' "$input_json" >/dev/null; then
+          printf 'secret-removed\n' >>"$DEPLOY_TEST_LOG"
+        else
+          printf 'secret-removed:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
         fi
       fi
       if [[ "$DEPLOY_TEST_EXPECT_TASK_SECRET_ARN" == "true" ]]; then
@@ -671,5 +708,31 @@ if grep -qF "refusing to accept a zero-task steady state" \
   echo "The exemption was applied to the pre-check only; both zero-checks need it." >&2
   exit 1
 fi
+
+# A secret NAMED in TASK_SECRET_REMOVALS must leave the registered definition,
+# and the one beside it must stay. The live definition the script derives from
+# carries both, so this cannot pass by removing a secret that was never there --
+# the mirror assertion on KEPT_TASK_SECRET is what rules out a render that simply
+# dropped them all.
+DEPLOY_TEST_EXPECT_SECRET_REMOVED=DOOMED_TASK_SECRET \
+  TASK_SECRET_REMOVALS=DOOMED_TASK_SECRET \
+  run_release secret-removal true false false 0
+grep -qx 'secret-removed' "$test_directory/secret-removal/aws.log" || {
+  echo "TASK_SECRET_REMOVALS did not remove the secret from the registered definition." >&2
+  grep -n 'secret-removed' "$test_directory/secret-removal/aws.log" >&2 || true
+  exit 1
+}
+
+# A name in BOTH lists is refused rather than resolved: the render filters by
+# name and then concatenates the overrides, so the outcome would depend on the
+# order of two operations nobody reads.
+TASK_SECRET_REMOVALS=EXTRA_TASK_SECRET \
+  TASK_SECRET_OVERRIDES_JSON='{"EXTRA_TASK_SECRET":"arn:aws:ssm:test:123456789012:parameter/oxy/sample-app/EXTRA_TASK_SECRET"}' \
+  run_release secret-conflict false false false 0
+grep -q 'in both TASK_SECRET_OVERRIDES_JSON and TASK_SECRET_REMOVALS' \
+  "$test_directory/secret-conflict/output.log" || {
+  echo "The conflicting-name refusal must name BOTH lists, or it is indistinguishable from any other failure." >&2
+  exit 1
+}
 
 echo "Deployment script transaction tests passed."

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -114,7 +114,6 @@ jobs:
           MENTION_OXY_CLIENT_ID: ${{ secrets.MENTION_OXY_CLIENT_ID }}
           MENTION_PRIVATE_KEY: ${{ secrets.MENTION_PRIVATE_KEY }}
           MENTION_PUBLIC_KEY: ${{ secrets.MENTION_PUBLIC_KEY }}
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
           OXY_SERVICE_API_KEY: ${{ secrets.OXY_SERVICE_API_KEY }}
           OXY_SERVICE_API_SECRET: ${{ secrets.OXY_SERVICE_API_SECRET }}
           OXY_SERVICE_TOKEN: ${{ secrets.OXY_SERVICE_TOKEN }}
@@ -122,10 +121,22 @@ jobs:
           REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
           REDIS_URI: ${{ secrets.REDIS_URI }}
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # MONGODB_URI is deliberately ABSENT. The sync loop only ever calls
+          # `put-parameter --overwrite`, so dropping the name stops UPDATING
+          # `/oxy/mention/MONGODB_URI` and leaves the parameter itself in place —
+          # which is the point: its one remaining consumer is the Mongo->Postgres
+          # copier (`packages/backend/scripts/backfill-mongo-to-postgres.ts`),
+          # which runs as its own one-shot and names it as the SOURCE database.
+          # Deleting the parameter is a separate, irreversible decision.
+          #
+          # The cost, accepted knowingly: the parameter is now FROZEN at its last
+          # synced value. If the Mongo endpoint or its credentials ever rotate,
+          # the copier will start with a stale URI and fail to connect — update
+          # it by hand at that point. It is not synced from here any more.
           SSM_SECRET_ALLOWLIST: >-
             ALIA_API_KEY DATABASE_URL FIREBASE_SERVICE_ACCOUNT_BASE64 FIREBASE_PROJECT_ID
             INTERNAL_METRICS_TOKEN KLIPY_APP_KEY MENTION_OXY_CLIENT_ID
-            MENTION_DID MENTION_PRIVATE_KEY MENTION_PUBLIC_KEY MONGODB_URI
+            MENTION_DID MENTION_PRIVATE_KEY MENTION_PUBLIC_KEY
             OXY_SERVICE_API_KEY OXY_SERVICE_API_SECRET OXY_SERVICE_TOKEN
             REDIS_URL REDIS_URI
             REDIS_HOST REDIS_PASSWORD
@@ -265,6 +276,17 @@ jobs:
           # after any window where those writers were not the only ones writing.
           # `packages/backend/scripts/reconcile-engagement-projections.ts` holds
           # the command and how to launch it.
+          # The web service loads NO Mongo — measured on the compiled artefact,
+          # zero of the modules under `dist/` that require mongoose are reachable
+          # from `dist/server.js` — and since #676 it no longer demands the
+          # variable to boot. Nothing on this task reads it.
+          #
+          # It is REMOVED rather than merely unnamed because the definition is
+          # derived from the LIVE one: a secret nobody names survives every
+          # deploy, which is exactly how this one outlived its store. Naming it
+          # here re-asserts the absence each time, so a Terraform apply or a
+          # hand-registered revision cannot quietly put it back.
+          TASK_SECRET_REMOVALS: MONGODB_URI
           POST_DEPLOY_SMOKE_SCRIPT: .github/scripts/smoke-mention.sh
         # The existing target group remains on `/`, which server.ts now serves
         # as the same readiness gate as `/health/ready`. ELB mutations belong


### PR DESCRIPTION
Nate asked to take Mention off MongoDB. With #676 the web task stopped
DEMANDING the variable to boot, and #681 took the last Mongo step out of
the deploy; this removes the secret itself from the service's task
definition and stops syncing it.

## Removal had to be expressible, because absence is not inherited

`deploy-ecs-image.sh` derives each release's definition from the LIVE one
and rewrites only what it is told about: `TASK_SECRET_OVERRIDES_JSON`
replaces a named secret, and anything unnamed is carried forward
verbatim. There was no way to say "drop this" — the validation demands a
complete SSM ARN, so an empty value is refused. That is precisely how
`MONGODB_URI` outlived the store it pointed at.

The alternative was registering one revision by hand. Rejected: the
definition is also recorded in Terraform (many revisions behind, as
`deploy-aws.yml` already warns), so an apply or a hand-registered
revision reintroduces the secret and nothing notices. A manual delete is
a one-off assertion about a value the system propagates by construction.
`TASK_SECRET_REMOVALS` is a STANDING one — re-asserted every deploy,
reviewable, with the reason beside it.

## Two validations, each for a failure that would otherwise be silent

A name in BOTH lists is REFUSED rather than resolved. The render filters
by name and then concatenates the overrides, so such a name would be
dropped and immediately re-added: the outcome depends on the order of two
operations nobody is reading, in a render of secrets. Whoever wrote both
entries meant one of them, and the script must not pick.

The test asserts the secret DISAPPEARS from the registered definition,
not that the script exits 0 — a case that only checks for the absence of
an exception passes just as well against a capability that does nothing.
The mocked live definition now carries two secrets so the case cannot
pass by removing one that was never there, and the assertion pairs the
absence of the removed name with the PRESENCE of its neighbour, which is
what rules out a render that dropped them all. Mutation-tested: making
the removals stop filtering turns it red with `secret-removed:MISMATCH`.
The conflict case additionally greps for a message naming both lists, so
it cannot be satisfied by any other failure.

## The parameter STAYS, and the cost of that is stated

`MONGODB_URI` also leaves `SSM_SECRET_ALLOWLIST`. The sync loop only ever
calls `put-parameter --overwrite`, so dropping the name stops UPDATING
`/oxy/mention/MONGODB_URI` and leaves the parameter in place — which is
the point: its one remaining consumer is the Mongo->Postgres copier,
which runs as its own one-shot and names it as the SOURCE database.
Deleting the parameter is a separate, irreversible decision and is not
this commit's.

Accepted knowingly, and written into the workflow: the parameter is now
frozen at its last synced value, so a rotation of the Mongo endpoint or
its credentials leaves the copier with a stale URI until somebody updates
it by hand.

Deploy script tests pass, including the two new cases. Workflows validate.

---

The AWS half of the Mongo cleanup. Follows #676, #678, #679, #680, #681. Takes effect on the next deploy — no manual AWS action, no `run-task`, nothing registered by hand.

Deliberately NOT here: deleting the SSM parameter, and dropping `mongoose` from the manifest. Both are the same decision — giving up rebuilding Postgres from Mongo — and both wait for an explicit call.