### PR TITLE
fix(config): restore the boot fix #678 silently reverted

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -9,6 +9,9 @@
 NODE_ENV=development
 PORT=4110
 LOG_LEVEL=debug
+# NOT required to boot: the server loads no Mongo. Set it only to run
+# `scripts/backfill-mongo-to-postgres.ts`, which names it as its SOURCE
+# database and asserts it itself.
 MONGODB_URI=mongodb://localhost:27017/mention?replicaSet=rs0
 MONGODB_READ_PREFERENCE=primary
 FRONTEND_URL=http://localhost:8110

--- a/packages/backend/src/__tests__/config/bootDoesNotRequireMongo.test.ts
+++ b/packages/backend/src/__tests__/config/bootDoesNotRequireMongo.test.ts
@@ -1,0 +1,118 @@
+/**
+ * `validateEnvironment` must never demand `MONGODB_URI` again.
+ *
+ * The web service loads no Mongo — zero of the modules under `dist/` that
+ * require `mongoose`/`mongodb` are reachable from `dist/server.js` — yet
+ * `server.ts` called this function and it refused to boot without the variable.
+ * That is the shape this file exists to stop coming back: a required-variable
+ * list outliving the dependency it was written for, where the symptom is a
+ * refusal to start rather than anything a type or a build can see.
+ *
+ * ## Why the second case is the load-bearing one
+ *
+ * "It does not throw" is satisfied by a `validateEnvironment` that does nothing
+ * at all, so on its own it cannot tell a fixed validator from a broken one. The
+ * production case supplies the floor: it deliberately withholds a DIFFERENT
+ * required variable, asserts the error names THAT one, and only then asserts
+ * `MONGODB_URI` is absent from the same message. A validator that stopped
+ * collecting would fail the first assertion before it could pass the second.
+ *
+ * Mutation-tested both ways: restoring `if (!config.mongoUri)
+ * missing.push('MONGODB_URI')` turns both cases red, and emptying the `missing`
+ * list turns the production case red.
+ *
+ * `src/config/index.ts` snapshots `process.env` at MODULE scope
+ * (`const environment = parseRuntimeEnvironment(process.env)`), so each case has
+ * to set the environment BEFORE importing it and `vi.resetModules()` between
+ * cases. Importing it once and mutating `process.env` afterwards would measure
+ * the snapshot taken by whichever case ran first.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Enough of a production environment to reach the checks under test.
+ *
+ * The two secrets carry real length because the zod schema enforces a 32-char
+ * minimum on them; a short placeholder fails at `parseRuntimeEnvironment`, which
+ * is BEFORE `validateEnvironment` ever runs — so the case would go red for a
+ * reason that has nothing to do with what it asserts.
+ */
+const PRODUCTION_BASELINE = {
+  NODE_ENV: 'production',
+  MENTION_PUBLIC_API_URL: 'https://api.mention.earth',
+  MENTION_MCP_JWT_SECRET: 'mcp-jwt-secret-for-this-test-0123456789',
+  IP_HASH_SALT: 'ip-hash-salt-for-this-test-0123456789',
+} as const;
+
+const originalEnv = { ...process.env };
+
+async function loadValidator(
+  overrides: Record<string, string | undefined>,
+): Promise<() => void> {
+  vi.resetModules();
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  const { validateEnvironment } = await import('../../config');
+  return validateEnvironment;
+}
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, originalEnv);
+  vi.resetModules();
+});
+
+describe('validateEnvironment', () => {
+  it('boots without MONGODB_URI', async () => {
+    const validateEnvironment = await loadValidator({
+      NODE_ENV: 'test',
+      MONGODB_URI: undefined,
+    });
+    expect(() => validateEnvironment()).not.toThrow();
+  });
+
+  it('never names MONGODB_URI, even while reporting a variable that IS required', async () => {
+    const validateEnvironment = await loadValidator({
+      ...PRODUCTION_BASELINE,
+      FRONTEND_URL: undefined,
+      MONGODB_URI: undefined,
+    });
+
+    let message = '';
+    try {
+      validateEnvironment();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    // The floor: prove the validator is still collecting before reading the
+    // absence of anything from its output.
+    expect(message).toContain('FRONTEND_URL');
+    expect(message).not.toContain('MONGODB_URI');
+  });
+
+  it('does not name MONGODB_URI when it IS set either', async () => {
+    // The variable still reaches the process on a deployment that has not
+    // dropped it yet, and it must be as inert present as absent — otherwise the
+    // two cases above would pass on a validator that merely inverted the check.
+    const validateEnvironment = await loadValidator({
+      ...PRODUCTION_BASELINE,
+      FRONTEND_URL: undefined,
+      MONGODB_URI: 'mongodb://127.0.0.1:27017/mention',
+    });
+
+    let message = '';
+    try {
+      validateEnvironment();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('FRONTEND_URL');
+    expect(message).not.toContain('MONGODB_URI');
+  });
+});

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -867,9 +867,24 @@ export const config = {
   },
 } as const;
 
+/**
+ * The variables a task cannot boot without.
+ *
+ * **`MONGODB_URI` is deliberately NOT among them, and must not come back.** This
+ * function runs from `server.ts`, and the web service loads no Mongo at all —
+ * measured on the compiled artifact rather than argued from the source: zero of
+ * the 61 modules under `dist/` that require `mongoose`/`mongodb` are reachable
+ * from `dist/server.js`. Requiring the variable here was the last thing making
+ * "Mention needs MongoDB to start" true, months after it stopped being true in
+ * any other sense — a refusal to boot over a store the process never opens.
+ *
+ * It stays REQUIRED for the one entry point that genuinely reads Mongo:
+ * `scripts/backfill-mongo-to-postgres.ts` asserts it itself and names it as the
+ * SOURCE database, which is the right place for it — that check belongs to the
+ * consumer, not to every process that shares this config module.
+ */
 export function validateEnvironment(): void {
   const missing: string[] = [];
-  if (!config.mongoUri) missing.push('MONGODB_URI');
   if (config.runtime.isProduction && !config.frontendUrl) missing.push('FRONTEND_URL');
   if (config.runtime.isProduction && !environment.MENTION_PUBLIC_API_URL) {
     missing.push('MENTION_PUBLIC_API_URL');


### PR DESCRIPTION
`oxy-mention:219` — the first task definition without `MONGODB_URI` —
failed its health check three times with `Missing required runtime
configuration: MONGODB_URI` and the circuit breaker rolled back to
`:218`. #682's mechanism worked exactly as designed: the secret DID
leave the definition. The code had simply started demanding it again.

    0c6b5440  (#676)  missing.push('MONGODB_URI')  ->  0 occurrences
    5c561b53  (#678)  missing.push('MONGODB_URI')  ->  1 occurrence

#678's branch was created before #676 reached `main`, so its squash
carried an older copy of `config/index.ts` — and, because the file was
NEW on #676's branch, an absent `bootDoesNotRequireMongo.test.ts`. No
conflict: git had nothing to reconcile, since one side simply never knew
the change existed. The guard was deleted by the same commit that
reintroduced what it guarded, so #678's CI went green 13/13 with nothing
left to contradict it.

**The whole of #676 was reverted, not just the check** — the docblock
saying `MONGODB_URI` "must not come back", the `.env.example` note, and
the test, all three. That matters for what the restore had to be: this
takes the three files verbatim from `0c6b5440` rather than re-deriving
them, and `git log 0c6b5440..main` on each confirms `5c561b53` is the
ONLY commit that touched them since, so restoring them whole cannot
clobber anything later.

## The audit the incident demands

Every merge after #678 was checked for the same shape — a PR whose branch
predates its predecessor, deleting or reverting the predecessor's work:

    #678  deleted 44 files   <- 43 intended, plus this test
    #679  deleted  0 files
    #680  deleted  0 files
    #681  deleted 49 files   <- all its own migration surface, branched after #680
    #682  deleted  0 files

`bootDoesNotRequireMongo.test.ts` is the only casualty. Nothing else was
reverted.

The lesson is not "rebase before merging", which everyone already
believes. It is that **a stale branch reverting merged work produces no
conflict and no failing test when it takes the guard with it** — the two
signals that would normally catch it are exactly what the deletion
removes. The only thing that caught this was production refusing to boot.

Full suite: 528 files, 6329 tests, all passing.

---

**Deploy-blocking.** `oxy-mention:219` cannot boot without this; the service is holding on `:218` with the secret still present. Opened ready for review, not draft.

Restores `config/index.ts`, `.env.example` and `bootDoesNotRequireMongo.test.ts` verbatim from `0c6b5440` (#676).