### PR TITLE
Claim the marks in the web footer

### DIFF
--- a/packages/frontend/components/RightBar.tsx
+++ b/packages/frontend/components/RightBar.tsx
@@ -101,7 +101,11 @@ function RightBarFooter() {
                     <FooterLink key={link.label} label={link.label} url={link.url} />
                 ))}
             </View>
-            <Text className="text-muted-foreground text-[12.5px] pt-0.5">Made with ❤️ in the 🌎 by Oxy.</Text>
+            <Text className="text-muted-foreground text-[12.5px] pt-0.5">Made with ❤️ in the 🌎 by Oxy&trade;.</Text>
+            {/* Mention and Oxy are unregistered marks, so the symbol is (TM) and never (R):
+                using (R) before a registration is granted is unlawful in several
+                jurisdictions. Swap it only once a registration actually issues. */}
+            <Text className="text-muted-foreground text-[12.5px] pt-0.5">Mention&trade; is a trademark of The Oxy Collective Inc.</Text>
         </View>
     );
 }


### PR DESCRIPTION
The web footer read `Made with ❤️ in the 🌎 by Oxy.` and nothing anywhere in the product identified Mention or Oxy as trademarks.

That matters because trademark rights in the United States arise from **use in commerce**, not from registration, and the `™` symbol is the cheapest thing that turns "a name we use" into "a mark we claim". It requires no registration, no filing and no money.

`™` and deliberately never `®`: neither mark is registered yet, and using `®` before a registration actually issues is unlawful in several jurisdictions. The comment in the source says so, so the next person to touch that line does not upgrade it by instinct.

Org-wide policy: https://github.com/OxyHQ/.github/blob/main/TRADEMARK.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)