### PR TITLE
docs: correct four claims about a store the service no longer opens

### DIFF
--- a/docs/AWS_DEPLOYMENT.md
+++ b/docs/AWS_DEPLOYMENT.md
@@ -40,7 +40,10 @@ a failed production smoke rolls back to the previously captured deployment.
 ## Health and secrets
 
 - Liveness: `GET /health/live`.
-- Readiness: `GET /health/ready`; Mongo and the expected schema are mandatory.
+- Readiness: `GET /health/ready`; it checks `postgres`, `migrations` and `redis`.
+  Mongo is NOT among them and has not been since the cutover — a task that fails
+  readiness is failing one of those three, so debugging the store this line used
+  to name would be debugging a store the service no longer opens.
 - Redis degradation does not fail HTTP readiness, but singleton workers never
   claim leadership without their distributed lock.
 - GitHub authenticates to AWS with OIDC. Runtime secrets are stored in SSM and

--- a/docs/mentions.md
+++ b/docs/mentions.md
@@ -80,7 +80,7 @@ invented handle.
 
 `Post.content` stores the placeholder text and `Post.mentions` stores the
 identity references used by queries and readers. Readers normalize and
-deduplicate this array. MongoDB indexes `mentions` together with `createdAt`.
+deduplicate this array. `mentions` is indexed together with `created_at`.
 
 All post DTOs go through `PostHydrationService`. For each post it:
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -1,6 +1,6 @@
 # @mention/backend
 
-Mention's Express, MongoDB, Redis/Valkey, Socket.IO, federation, and MTN
+Mention's Express, PostgreSQL, Redis/Valkey, Socket.IO, federation, and MTN
 backend. The production service listens on port 3000 and serves both
 `api.mention.earth` and the `mention.earth` web/federation surface.
 
@@ -66,7 +66,8 @@ Production migrations run only as the deployment one-shot. Do not run
 ## Operational endpoints
 
 - `GET /health/live` checks that the process can answer.
-- `GET /health/ready` requires completed startup, Mongo connectivity, and the
+- `GET /health/ready` requires completed startup, Postgres connectivity, applied
+  migrations, Redis, and the
   expected migration version.
 - `GET /internal/metrics` is disabled unless configured and additionally
   requires an allowed network source plus a service bearer token.


### PR DESCRIPTION
Docs-only. Each line said something that WAS true and stopped being true
at the cutover, and each is replaced with what is true rather than
deleted — an emptied sentence leaves the reader to re-derive it, and the
next person writes the old thing back.

The one that mattered most is a single line. `docs/AWS_DEPLOYMENT.md`
said readiness required "Mongo and the expected schema"; the live gate
checks `postgres`, `migrations` and `redis`. That is the page somebody
opens during an incident, and it sent them to debug a store the service
does not open. `packages/backend/README.md` carried the same claim and
listed MongoDB as the stack.

## Two files were RECLASSIFIED after checking, not edited

Both were on my correct-these list, and both would have been made FALSE
by the edit. They are left alone:

- **`README.md`'s Compose section.** `docker-compose.yml` still defines
  `mongo` and `mongo-init` and defines no Postgres service, so "the
  Compose stack is a single node MongoDB replica set" is ACCURATE. The
  local dev stack genuinely has not been ported; the documentation is
  correct and the compose file is what is out of step. Rewriting the
  prose would have described a stack that does not exist and hidden a
  real gap behind a green-looking docs PR.
- **`docs/handoff/userbehavior-inventory.md`** opens by stating it was
  measured against a pinned snapshot of `41deedbd` rather than the live
  tree. It is historical by construction; "correcting" a document that
  declares its own as-of is falsifying it.

`packages/mcp/README.md` came up in the scan on a long line that does not
mention Mongo at all — a substring match, not a claim.

Deliberately untouched, per the classification: the cutover narrative,
the superpowers plans, and the two NORMATIVE documents
(`MIGRATION-CONTRACT.md`, `schema/CONVENTIONS.md`). `CONVENTIONS.md` in
particular has the second-highest Mongo count in the repo and every
mention is of the form "no Mongo baggage" / "not Mongoose's" — it defines
the Postgres schema by contrast with the shape it came from, so removing
Mongo would not update it, it would disarm the argument.

---

Docs-only; no code, no tests, no workflows. The two `AGENTS.md` files go through docs-keeper separately, per the house rule.