### PR TITLE
chore(licensing): apply the Breathe License

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mention/shared-types",
   "version": "1.0.0",
+  "private": true,
   "description": "Shared TypeScript types for Mention frontend and backend",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
`OxyHQ/Mention` moves to the **Breathe License 1.0** (`LicenseRef-Breathe-1.0`), from **MIT**.

This was blocked until now for one reason, and the reason is gone. Every Parameters table in the org named **The Oxy Foundation, Inc.**, an entity that is not registered, and a licence granted by an entity that does not exist grants nothing. The licensor is now **The Oxy Collective, Inc.**, which exists today.

## What the licence does

| | |
| --- | --- |
| Non commercial use | Free, perpetual, irrevocable while you comply |
| Commercial use | **Requires a paid licence.** The trigger is revenue, and it includes purely internal use inside a business that earns revenue |
| Deploying it, or a modified version | **You publish the corresponding source.** Binds everyone, paying customers included. Cannot be bought out of |
| Attribution | **Required of everyone**, cannot be waived by agreement or by payment |
| Cooperatives, nonprofits, education, public bodies, worker owned businesses | **No fee.** They publish source and give credit like anyone else |

**This is source available, not open source**, and it is worth being precise about why, because the obvious guess is wrong. It is not the copyleft: the AGPL is copyleft and is OSI approved. It fails **clause 6 of the Open Source Definition**, no discrimination against fields of endeavour, because commercial use is conditional on payment. Automated scanners will report it as unknown and GitHub shows it as "Other". Nobody should call this repository open source.

## It is not retroactive, and it could not be

Every version of this work already published under MIT **stays MIT permanently** for anyone who has it. They may keep using it commercially, for free, indefinitely, and may fork it. A licence change binds future versions only.

This is worth stating plainly in the announcement too, because a narrowing like this is easy to misread as a revocation. It is not one, and it could not be one.


## The outside contributor question, closed on evidence

This repository holds the organisation's only outside human contributor,
`alexlab84`, so it is the one where a relicence could genuinely have been
blocked. It is not. The working, so a reviewer can check it rather than take it
on trust:

- `afb4f4f` is their only non-merge commit. It changes **four lines of
  `package.json`** (bump `react-native-svg`, drop `react-native-svg-charts`) and
  replaces `yarn.lock` with `package-lock.json`. Both lockfiles are machine
  generated.
- `2beb4d4` is a **merge commit**. Its own contribution is a three line conflict
  resolution in `package.json`. The 355-line `CreatePoll/index.tsx` and the rest
  of the feature work that `git show --stat` prints against it came in through
  its **second parent** and is authored by Nate Isern. Reading that stat as
  theirs is the easy mistake, and it inverts the conclusion.

Those three files are the only ones they ever touched. Both lockfiles are
**deleted** from `main`, and `git blame` attributes **zero** lines of the
surviving `package.json` to them.

So there are two independent reasons this does not block, and only one has to
hold: dependency version strings in a manifest are facts and formatting, below
the threshold of originality in both US and EU law; and in any case **none of
their expression is in the work being relicensed.** The email the migration
analysis recommended is no longer worth sending.


## Files

- `LICENSE`: the full Breathe License text with its Parameters filled in. The operative text from Section 1 onward is asserted byte identical to the org template at `OxyHQ/.github`; only the Parameters, the Section 3.1 attribution example, and the header comment differ. The header no longer says "this is a template and licenses nothing", because in this file it does.
- `NOTICE`: attribution, copyright **The Oxy Collective, Inc.**, and the standing rule that this work must never take a GPL or AGPL dependency linked in process.
- `package.json`: `"license": "SEE LICENSE IN LICENSE"`.
## What is still outstanding

**Three Parameters are visible placeholders, not guesses:** jurisdiction of
incorporation, registration number, and governing law. They read
`NOT YET SUPPLIED` in the licence. The licence grant itself works without them,
because the Licensor is now a real entity, but **the commercial arm cannot
invoice until they are filled in.**

**No CLA is switched on.** The agreement text is settled and now names
The Oxy Collective, Inc., with a successor clause so that moving the work to a
foundation later does not force every signatory to sign again
([OxyHQ/.github#7](https://github.com/OxyHQ/.github/pull/7)). But no bot is
installed and no signature has been taken, and that is deliberate: it changes
the contribution flow on every pull request. **Until it is on, one merged
outside contribution to this repository permanently breaks its commercial arm**,
because Oxy cannot offer commercial terms over somebody else's copyright.

## Merge order matters

**This must not merge before the Apache-2.0 SDK pull requests land and
publish.** The Breathe License is not compatible with the AGPL in either
direction, and this repository depends on `@oxyhq/*` packages that are
AGPL-3.0-only on npm today. Merging this first produces an application that
cannot lawfully be distributed under the licence it now declares. The SDK move
is [OxyHQ/oxy#844](https://github.com/OxyHQ/oxy/pull/844) and
[OxyHQ/Bloom#32](https://github.com/OxyHQ/Bloom/pull/32).

**Opened as a draft on purpose.** The org convention is that green CI means
merge; this one needs a decision and an ordering, not an automatic merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
