### PR TITLE
fix(dev): the local Compose stack ran Mongo and no Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,18 @@ bun run --cwd packages/frontend web
 
 <br>
 
-The Compose stack is a single node MongoDB replica set, Valkey, and a one shot migration container. The backend starts only once the replica set is writable, Valkey is healthy and migrations have finished:
+The Compose stack is PostGIS-flavoured PostgreSQL, Valkey, and a one shot migration container. The backend starts only once Postgres and Valkey are healthy and migrations have finished:
 
 ```bash
 docker compose up --build backend
 ```
 
-MongoDB and Valkey bind to loopback ports `27017` and `6379`, and their data lives in the named `mongo_data` and `valkey_data` volumes.
+Postgres and Valkey bind to loopback ports `5434` and `6379`, and their data lives in the named `postgres_data` and `valkey_data` volumes. Port `5434` rather than `5433` on purpose: `docker-compose.postgres.yml` binds `5433` for the database that sits beside the test suite, and both stacks are routinely up at once.
 
 For watch mode, start the dependencies only and run the backend on the host:
 
 ```bash
-docker compose up -d mongo valkey
-docker compose run --rm mongo-init
+docker compose up -d postgres valkey
 bun run dev:backend
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,52 +13,42 @@ x-backend-environment: &backend-environment
   # HOST side of the port mapping below uses; inside the container the two must
   # agree with the Dockerfile, so set it explicitly rather than inherit.
   PORT: "3000"
-  MONGODB_URI: mongodb://mongo:27017/mention?replicaSet=rs0&directConnection=true
+  # The backend opens Postgres and Redis. It does NOT open Mongo — the whole
+  # Mongo surface left in this package is the copier, which reads a PRODUCTION
+  # database named by its own `MONGODB_URI` and is never run from this stack.
+  DATABASE_URL: postgres://mention:mention@postgres:5432/mention
   REDIS_URL: redis://valkey:6379
 
 services:
-  mongo:
-    image: mongo:8.0.16@sha256:4b58ebcb1dc7a7b4e84cd8ce9098d48764ae4478876898ff9551acf2ac4a6a6d
-    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+  postgres:
+    # The SAME pinned image as `docker-compose.postgres.yml` and `ci.yml`, on
+    # purpose: a developer's database, CI's and this stack's must not disagree
+    # about what is installed. PostGIS rather than plain Postgres because
+    # `posts.geo`/`posts.content_geo` are generated `geography` columns, so
+    # `CREATE EXTENSION postgis` has to succeed before the migration naming the
+    # type; the major (17) is the one RDS runs, and both versions are pinned
+    # because a floating PostGIS minor is a floating set of function
+    # volatilities and a generated column requires IMMUTABLE.
+    image: postgis/postgis:17-3.5
     restart: unless-stopped
+    environment:
+      POSTGRES_USER: mention
+      POSTGRES_PASSWORD: mention
+      # `mention`, matching the `--target-database` the migrate step asserts.
+      POSTGRES_DB: mention
     ports:
-      - "127.0.0.1:27017:27017"
+      # 5434, deliberately NOT 5433: `docker-compose.postgres.yml` binds 5433 for
+      # the database that sits beside `bun run dev:backend` and the test suite,
+      # and both stacks are routinely up at once. Loopback only.
+      - "127.0.0.1:5434:5432"
     volumes:
-      - mongo_data:/data/db
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "mongosh --quiet --host 127.0.0.1:27017 --eval 'quit(db.adminCommand({ ping: 1 }).ok ? 0 : 1)'",
-        ]
+      test: ["CMD-SHELL", "pg_isready -U mention -d mention"]
       interval: 5s
       timeout: 5s
       retries: 20
       start_period: 10s
-
-  mongo-init:
-    image: mongo:8.0.16@sha256:4b58ebcb1dc7a7b4e84cd8ce9098d48764ae4478876898ff9551acf2ac4a6a6d
-    depends_on:
-      mongo:
-        condition: service_healthy
-    restart: "no"
-    entrypoint: ["/bin/bash", "-euc"]
-    command:
-      - |
-        mongosh --quiet --host mongo:27017 --eval '
-          try {
-            rs.status()
-          } catch (error) {
-            rs.initiate({
-              _id: "rs0",
-              members: [{ _id: 0, host: "mongo:27017" }]
-            })
-          }
-        '
-        until mongosh --quiet --host mongo:27017 --eval \
-          'quit(db.hello().isWritablePrimary ? 0 : 1)'; do
-          sleep 1
-        done
 
   valkey:
     image: valkey/valkey:8.1.9-alpine@sha256:a038175878d66b9d274fbf8be73c0305e93798b83917647f167e18cef3c71eec
@@ -75,11 +65,19 @@ services:
 
   migrate:
     <<: *backend-image
-    command: ["bun", "packages/backend/dist/scripts/migrate.js"]
+    # `dist/src/db/migrate.js`, not the top-level `dist/scripts/migrate.js` this
+    # used to run: that was the MONGO migration one-shot and it no longer exists.
+    # Until this line was fixed the stack failed before it could even reach a
+    # connection error, so the missing Postgres service below it was invisible.
+    #
+    # `--target-database` is required by the migrator and is not a formality: it
+    # asserts the URL still points where the caller thinks it does.
+    command:
+      ["bun", "packages/backend/dist/src/db/migrate.js", "--target-database=mention"]
     restart: "no"
     depends_on:
-      mongo-init:
-        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
       valkey:
         condition: service_healthy
     environment: *backend-environment
@@ -99,5 +97,5 @@ services:
       - "127.0.0.1:${MENTION_PORT:-4110}:3000"
 
 volumes:
-  mongo_data:
+  postgres_data:
   valkey_data:

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -9,10 +9,17 @@
 NODE_ENV=development
 PORT=4110
 LOG_LEVEL=debug
-# NOT required to boot: the server loads no Mongo. Set it only to run
-# `scripts/backfill-mongo-to-postgres.ts`, which names it as its SOURCE
-# database and asserts it itself.
-MONGODB_URI=mongodb://localhost:27017/mention?replicaSet=rs0
+# REQUIRED. The store the server actually opens. `docker-compose.yml` sets it to
+# its own `postgres` service; this value is the one that pairs with
+# `docker compose -f docker-compose.postgres.yml up -d postgres`, which is the
+# database that sits beside `bun run dev:backend` and the test suite.
+DATABASE_URL=postgres://mention:mention@127.0.0.1:5433/mention_dev
+
+# NOT required to boot, and not read by the server at all. Set it ONLY to run
+# `scripts/backfill-mongo-to-postgres.ts`, which names it as its SOURCE database
+# and asserts it itself — and point it at the database you mean to COPY FROM,
+# which is not a local one.
+MONGODB_URI=
 MONGODB_READ_PREFERENCE=primary
 FRONTEND_URL=http://localhost:8110
 MENTION_PUBLIC_API_URL=http://localhost:4110

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -17,11 +17,11 @@ backend. The production service listens on port 3000 and serves both
 - `src/connectors/` isolates ActivityPub and AT Protocol integrations.
 - `src/mtn/` contains the feed engine; `src/services/mtn/` contains Mention's
   signed-record integration.
-- `src/migrations/` contains versioned schema/data migrations.
+- `drizzle/` contains the versioned schema migrations, applied by `src/db/migrate.ts`.
 
-MongoDB must be a replica set or mongos because engagement writes use
-multi-document transactions. The deployment migration task verifies topology
-before changing schema or rolling out a new web task. Redis may degrade API
+Engagement writes use multi-statement transactions, which Postgres provides
+with no topology requirement — the replica-set/mongos constraint that used to
+sit here belonged to Mongo and no longer applies. Redis may degrade API
 features, but a process never assumes singleton leadership without a lock.
 
 ## Setup
@@ -35,8 +35,8 @@ bun run doctor
 bun run dev:backend
 ```
 
-The root `docker-compose.yml` starts a local single-node Mongo replica set,
-Valkey, a one-shot migration task, and then the backend.
+The root `docker-compose.yml` starts Postgres, Valkey, a one-shot migration
+task, and then the backend.
 
 ## Commands
 


### PR DESCRIPTION
`docker compose up` has been broken since the cutover. The stack defined
`mongo`, `mongo-init`, `valkey`, `migrate` and `backend`, with zero
occurrences of `postgres` or `DATABASE_URL` — so a fresh clone brought up
a store the backend does not open and none of the store it does.

It failed EARLIER than that, and the earlier failure hid the later one:
the `migrate` service ran `dist/scripts/migrate.js`, the Mongo migration
one-shot deleted in #681. The stack died there, before anything could
reach a connection error, so "no Postgres service" was never reachable as
a symptom.

This was found by NOT editing a README. `README.md` said the Compose
stack is a single-node MongoDB replica set, which was on a list of stale
Mongo claims to correct — and it was accurate. The documentation and the
code disagreed, and the code was the wrong one. Rewriting the prose would
have buried a broken developer environment under a docs PR and left it
for whoever cloned the repo next, with no clue where to start.

## What changed

- `postgres` service, on the SAME pinned image as
  `docker-compose.postgres.yml` and `ci.yml` (`postgis/postgis:17-3.5`) —
  a developer's database, CI's and this stack's must not disagree about
  what is installed. PostGIS rather than plain Postgres because
  `posts.geo`/`posts.content_geo` are generated `geography` columns.
  Bound to 5434, deliberately not the 5433 the test-suite database uses,
  because both stacks are routinely up at once.
- `migrate` now runs `dist/src/db/migrate.js --target-database=mention`
  and waits on Postgres instead of a replica set.
- `DATABASE_URL` in the shared backend environment; `MONGODB_URI` out of
  it, because the backend does not read it.
- `mongo`, `mongo-init` and `mongo_data` REMOVED rather than kept. The
  only Mongo consumer left in the package is the copier, and it reads a
  PRODUCTION database named by its own `MONGODB_URI` — a local Mongo
  serves nothing it does, so keeping one would only invite the next
  person to conclude the backend needs it.
- `.env.example` gains `DATABASE_URL` as required, and `MONGODB_URI`
  becomes empty with a note that it is not read by the server and should
  point at the database you mean to COPY FROM, which is not a local one.
- `README.md` and `packages/backend/README.md` now describe the stack
  that exists, including the removed `docker compose run --rm mongo-init`
  step and the replica-set/mongos requirement that belonged to Mongo.

## Verified by running it

    docker compose up -d postgres        -> healthy in 12s
    select version()                     -> PostgreSQL 17.5, the major RDS runs
    postgis_version()                    -> 3.5
    db:migrate --target-database=mention -> applied through 0019
    tables in public                     -> 93

Torn down afterwards with `down -v`, and the teardown VERIFIED (0
containers, 0 volumes) rather than assumed.

**Not verified in execution:** `docker compose up --build backend`. That
needs a full image build, and the Docker daemon here is shared with other
sessions. The migrate service's exact command was run against the compose
database and applied the whole schema, so the step that was broken is
proven fixed; the backend container reaching `ready` on top of it is not.