### PR TITLE
feat(channel): a channel's queue stops being invisible to the people who fill it

### DIFF
--- a/packages/backend/drizzle/0022_a_channel_queue_is_shared.sql
+++ b/packages/backend/drizzle/0022_a_channel_queue_is_shared.sql
@@ -1,0 +1,36 @@
+-- A CHANNEL'S SCHEDULED QUEUE IS READ BY ITS MEMBERS, NOT BY ITS OWNER.
+--
+-- `GET /posts/scheduled` used to read one account's pending posts. It now reads
+-- the caller's own UNION those of every channel they operate, because a channel
+-- AUTHORS its own posts and no session can ever have a channel as its subject —
+-- so a scheduled channel post was returned to nobody at all, the person who
+-- wrote it included.
+--
+-- WHY A SECOND SCHEDULED INDEX. `posts_scheduled_idx` (on `scheduled_for`,
+-- partial) serves the 60-second publisher sweep, which wants every DUE post
+-- regardless of owner. It cannot serve a per-account read: with only that index
+-- the planner walks the whole site-wide scheduled set in `scheduled_for` order
+-- and filters on the owner, so one member's queue costs a scan proportional to
+-- what EVERYBODY ELSE has scheduled. Measured on 403,000 posts of which 3,000
+-- scheduled, reading 20 accounts' entries:
+--
+--   posts_scheduled_idx only  200 rows returned, 2,800 removed by filter, 0.407 ms
+--   post_owner_scheduled_v1   200 rows returned,     0 removed by filter, 0.125 ms
+--
+-- The absolute numbers are small. The COUPLING is the defect: it grows with
+-- global scheduled volume rather than with the caller's own queue.
+--
+-- PARTIAL on `status = 'scheduled'` is what makes this nearly free, and it is the
+-- Postgres spelling of the rule the Mongo schema stated as
+-- `partialFilterExpression` (never `sparse`, which indexes a document when ANY
+-- indexed key exists and would therefore have indexed the whole table here). A
+-- post enters this index when it is scheduled and leaves when it publishes, so
+-- it covers a set that drains every 60 seconds. The reading query carries
+-- `status = 'scheduled'` as a literal term so the planner can prove eligibility.
+--
+-- NOT ONLINE, matching `0021`, `0004` and `0003`: `CREATE INDEX CONCURRENTLY`
+-- cannot run inside the migrator's transaction. The argument is stronger here
+-- than in any of those — this indexes only unpublished, not-yet-due posts, a set
+-- bounded by how much is scheduled at that instant rather than by the table, so
+-- the build is short. There is no table rewrite and no column change.
+CREATE INDEX "post_owner_scheduled_v1" ON "posts" USING btree ("oxy_user_id","scheduled_for") WHERE "posts"."status" = 'scheduled';

--- a/packages/backend/drizzle/meta/0022_snapshot.json
+++ b/packages/backend/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,12399 @@
+{
+  "id": "c9b005b0-946a-4822-bf9d-1e658ea69324",
+  "prevId": "29f31e26-fd9b-45ff-b1ad-a85a95bc268e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_script_cursors": {
+      "name": "admin_script_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "admin_script_cursors_script_scope_key": {
+          "name": "admin_script_cursors_script_scope_key",
+          "columns": [
+            {
+              "expression": "script",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_script_cursors_scanned_check": {
+          "name": "admin_script_cursors_scanned_check",
+          "value": "\"admin_script_cursors\".\"scanned\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.repair_fetch_failures": {
+      "name": "repair_fetch_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "repair_fetch_failures_script_post_id_key": {
+          "name": "repair_fetch_failures_script_post_id_key",
+          "columns": [
+            {
+              "expression": "script",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repair_fetch_failures_script_reason_idx": {
+          "name": "repair_fetch_failures_script_reason_idx",
+          "columns": [
+            {
+              "expression": "script",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "repair_fetch_failures_status_check": {
+          "name": "repair_fetch_failures_status_check",
+          "value": "\"repair_fetch_failures\".\"status\" is null or (\"repair_fetch_failures\".\"status\" >= 100 and \"repair_fetch_failures\".\"status\" <= 599)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "articles_post_id_idx": {
+          "name": "articles_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"articles\".\"post_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_created_by_idx": {
+          "name": "articles_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_post_id_posts_id_fk": {
+          "name": "articles_post_id_posts_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_domain_purge_runs": {
+      "name": "blocked_domain_purge_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_posts": {
+          "name": "removed_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_actors": {
+          "name": "removed_actors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_boosts": {
+          "name": "removed_boosts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_likes": {
+          "name": "removed_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_notifications": {
+          "name": "removed_notifications",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_media_cache_rows": {
+          "name": "removed_media_cache_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_local_content_kept": {
+          "name": "removed_local_content_kept",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_local_follows_removed": {
+          "name": "removed_local_follows_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corroborating_sources": {
+          "name": "corroborating_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocked_domain_purge_runs_domain_run_id_key": {
+          "name": "blocked_domain_purge_runs_domain_run_id_key",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocked_domain_purge_runs_domain_chrono_idx": {
+          "name": "blocked_domain_purge_runs_domain_chrono_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocked_domain_purge_runs_trigger_check": {
+          "name": "blocked_domain_purge_runs_trigger_check",
+          "value": "\"blocked_domain_purge_runs\".\"trigger\" in ('policy_added', 'manual')"
+        },
+        "blocked_domain_purge_runs_removed_check": {
+          "name": "blocked_domain_purge_runs_removed_check",
+          "value": "\"blocked_domain_purge_runs\".\"removed_posts\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_actors\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_boosts\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_likes\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_notifications\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_media_cache_rows\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_local_content_kept\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_local_follows_removed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocked_domain_purges": {
+      "name": "blocked_domain_purges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_policy": {
+          "name": "in_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purged_at": {
+          "name": "purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "held_reason": {
+          "name": "held_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_posts": {
+          "name": "measured_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_actors": {
+          "name": "measured_actors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_boosts": {
+          "name": "measured_boosts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_likes": {
+          "name": "measured_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_notifications": {
+          "name": "measured_notifications",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_media_cache_rows": {
+          "name": "measured_media_cache_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_local_content_kept": {
+          "name": "measured_local_content_kept",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_local_follows_removed": {
+          "name": "measured_local_follows_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocked_domain_purges_domain_key": {
+          "name": "blocked_domain_purges_domain_key",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocked_domain_purges_state_claimed_idx": {
+          "name": "blocked_domain_purges_state_claimed_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocked_domain_purges_state_check": {
+          "name": "blocked_domain_purges_state_check",
+          "value": "\"blocked_domain_purges\".\"state\" in ('pending', 'in_progress', 'purged', 'held', 'failed')"
+        },
+        "blocked_domain_purges_measured_check": {
+          "name": "blocked_domain_purges_measured_check",
+          "value": "(\"blocked_domain_purges\".\"measured_posts\" is null\n          and \"blocked_domain_purges\".\"measured_actors\" is null\n          and \"blocked_domain_purges\".\"measured_boosts\" is null\n          and \"blocked_domain_purges\".\"measured_likes\" is null\n          and \"blocked_domain_purges\".\"measured_notifications\" is null\n          and \"blocked_domain_purges\".\"measured_media_cache_rows\" is null\n          and \"blocked_domain_purges\".\"measured_local_content_kept\" is null\n          and \"blocked_domain_purges\".\"measured_local_follows_removed\" is null)\n        or (\"blocked_domain_purges\".\"measured_posts\" >= 0\n          and \"blocked_domain_purges\".\"measured_actors\" >= 0\n          and \"blocked_domain_purges\".\"measured_boosts\" >= 0\n          and \"blocked_domain_purges\".\"measured_likes\" >= 0\n          and \"blocked_domain_purges\".\"measured_notifications\" >= 0\n          and \"blocked_domain_purges\".\"measured_media_cache_rows\" >= 0\n          and \"blocked_domain_purges\".\"measured_local_content_kept\" >= 0\n          and \"blocked_domain_purges\".\"measured_local_follows_removed\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocklist_proposal_observations": {
+      "name": "blocklist_proposal_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance": {
+          "name": "instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_from_digest": {
+          "name": "resolved_from_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blocklist_proposal_observations_proposal_id_instance_key": {
+          "name": "blocklist_proposal_observations_proposal_id_instance_key",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_proposal_observations_proposal_idx": {
+          "name": "blocklist_proposal_observations_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_proposal_observations_proposal_id_blocklist_proposals_id_fk": {
+          "name": "blocklist_proposal_observations_proposal_id_blocklist_proposals_id_fk",
+          "tableFrom": "blocklist_proposal_observations",
+          "tableTo": "blocklist_proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocklist_proposal_observations_severity_check": {
+          "name": "blocklist_proposal_observations_severity_check",
+          "value": "\"blocklist_proposal_observations\".\"severity\" in ('suspend', 'silence', 'noop')"
+        },
+        "blocklist_proposal_observations_position_check": {
+          "name": "blocklist_proposal_observations_position_check",
+          "value": "\"blocklist_proposal_observations\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocklist_proposal_run_sources": {
+      "name": "blocklist_proposal_run_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_row_id": {
+          "name": "run_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance": {
+          "name": "instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blocklist_proposal_run_sources_run_row_id_instance_key": {
+          "name": "blocklist_proposal_run_sources_run_row_id_instance_key",
+          "columns": [
+            {
+              "expression": "run_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_proposal_run_sources_run_row_id_blocklist_proposal_runs_id_fk": {
+          "name": "blocklist_proposal_run_sources_run_row_id_blocklist_proposal_runs_id_fk",
+          "tableFrom": "blocklist_proposal_run_sources",
+          "tableTo": "blocklist_proposal_runs",
+          "columnsFrom": [
+            "run_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocklist_proposal_run_sources_outcome_check": {
+          "name": "blocklist_proposal_run_sources_outcome_check",
+          "value": "\"blocklist_proposal_run_sources\".\"outcome\" in ('published', 'not-published', 'failed')"
+        },
+        "blocklist_proposal_run_sources_counts_check": {
+          "name": "blocklist_proposal_run_sources_counts_check",
+          "value": "\"blocklist_proposal_run_sources\".\"entries\" >= 0 and \"blocklist_proposal_run_sources\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocklist_proposal_runs": {
+      "name": "blocklist_proposal_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_operators": {
+          "name": "min_operators",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_domains_observed": {
+          "name": "counts_domains_observed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_cleared_operator_threshold": {
+          "name": "counts_cleared_operator_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_opened": {
+          "name": "counts_opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_pending": {
+          "name": "counts_pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_suppressed_declined": {
+          "name": "counts_suppressed_declined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_suppressed_blocked": {
+          "name": "counts_suppressed_blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_lapsed": {
+          "name": "counts_lapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_adopted": {
+          "name": "counts_adopted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocklist_proposal_runs_run_id_key": {
+          "name": "blocklist_proposal_runs_run_id_key",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_proposal_runs_started_at_idx": {
+          "name": "blocklist_proposal_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocklist_proposal_runs_trigger_check": {
+          "name": "blocklist_proposal_runs_trigger_check",
+          "value": "\"blocklist_proposal_runs\".\"trigger\" in ('scheduled', 'manual')"
+        },
+        "blocklist_proposal_runs_counts_check": {
+          "name": "blocklist_proposal_runs_counts_check",
+          "value": "\"blocklist_proposal_runs\".\"min_operators\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_domains_observed\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_cleared_operator_threshold\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_opened\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_pending\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_suppressed_declined\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_suppressed_blocked\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_lapsed\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_adopted\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocklist_proposals": {
+      "name": "blocklist_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "first_proposed_at": {
+          "name": "first_proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_count": {
+          "name": "operator_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corroborating_sources": {
+          "name": "corroborating_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_actors": {
+          "name": "footprint_actors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_posts": {
+          "name": "footprint_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_local_users_following": {
+          "name": "footprint_local_users_following",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_remote_actors_followed": {
+          "name": "footprint_remote_actors_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_local_users_followed": {
+          "name": "footprint_local_users_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocklist_proposals_domain_key": {
+          "name": "blocklist_proposals_domain_key",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_proposals_status_chrono_idx": {
+          "name": "blocklist_proposals_status_chrono_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocklist_proposals_status_check": {
+          "name": "blocklist_proposals_status_check",
+          "value": "\"blocklist_proposals\".\"status\" in ('open', 'declined', 'adopted', 'lapsed')"
+        },
+        "blocklist_proposals_counts_check": {
+          "name": "blocklist_proposals_counts_check",
+          "value": "\"blocklist_proposals\".\"operator_count\" >= 0\n        and \"blocklist_proposals\".\"footprint_actors\" >= 0\n        and \"blocklist_proposals\".\"footprint_posts\" >= 0\n        and \"blocklist_proposals\".\"footprint_local_users_following\" >= 0\n        and \"blocklist_proposals\".\"footprint_remote_actors_followed\" >= 0\n        and \"blocklist_proposals\".\"footprint_local_users_followed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lane_mutes": {
+      "name": "lane_mutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_oxy_user_id": {
+          "name": "viewer_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lane_id": {
+          "name": "lane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lane_owner_oxy_user_id": {
+          "name": "lane_owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "lane_mutes_viewer_chrono_idx": {
+          "name": "lane_mutes_viewer_chrono_idx",
+          "columns": [
+            {
+              "expression": "viewer_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lane_mutes_lane_id_lanes_id_fk": {
+          "name": "lane_mutes_lane_id_lanes_id_fk",
+          "tableFrom": "lane_mutes",
+          "tableTo": "lanes",
+          "columnsFrom": [
+            "lane_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lane_mutes_viewer_lane_key": {
+          "name": "lane_mutes_viewer_lane_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "viewer_oxy_user_id",
+            "lane_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lanes": {
+      "name": "lanes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_lower": {
+          "name": "name_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_mode": {
+          "name": "display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mixed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "lanes_owner_idx": {
+          "name": "lanes_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lanes_owner_name_lower_key": {
+          "name": "lanes_owner_name_lower_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner_id",
+            "name_lower"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lanes_display_mode_check": {
+          "name": "lanes_display_mode_check",
+          "value": "\"lanes\".\"display_mode\" in ('mixed', 'tab', 'hidden')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.author_follower_snapshots": {
+      "name": "author_follower_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follower_count": {
+          "name": "follower_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "author_follower_snapshots_owner_chrono_idx": {
+          "name": "author_follower_snapshots_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "author_follower_snapshots_at_idx": {
+          "name": "author_follower_snapshots_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "author_follower_snapshots_follower_count_check": {
+          "name": "author_follower_snapshots_follower_count_check",
+          "value": "\"author_follower_snapshots\".\"follower_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gifs": {
+      "name": "gifs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "klipy_id": {
+          "name": "klipy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'klipy'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "search_terms": {
+          "name": "search_terms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::text[]"
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mp4_file_id": {
+          "name": "mp4_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_file_id": {
+          "name": "preview_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_hit_count": {
+          "name": "search_hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(array_to_tsvector(search_terms), 'A')\n        || setweight(to_tsvector('simple', title), 'B')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "gifs_search_gin": {
+          "name": "gifs_search_gin",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "gifs_use_count_idx": {
+          "name": "gifs_use_count_idx",
+          "columns": [
+            {
+              "expression": "use_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gifs_last_used_at_idx": {
+          "name": "gifs_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gifs_klipy_id_key": {
+          "name": "gifs_klipy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "klipy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "gifs_source_check": {
+          "name": "gifs_source_check",
+          "value": "\"gifs\".\"source\" in ('klipy')"
+        },
+        "gifs_dimensions_check": {
+          "name": "gifs_dimensions_check",
+          "value": "\"gifs\".\"width\" > 0 and \"gifs\".\"height\" > 0"
+        },
+        "gifs_counts_check": {
+          "name": "gifs_counts_check",
+          "value": "\"gifs\".\"use_count\" >= 0 and \"gifs\".\"search_hit_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_keyset_idx": {
+          "name": "notifications_recipient_keyset_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_dedup_key": {
+          "name": "notifications_dedup_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_id",
+            "actor_id",
+            "type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "notifications_type_check": {
+          "name": "notifications_type_check",
+          "value": "\"notifications\".\"type\" in ('like', 'reply', 'mention', 'follow', 'boost', 'quote', 'welcome', 'post', 'poke', 'collab_invite', 'collab_accepted', 'collab_declined')"
+        },
+        "notifications_entity_type_check": {
+          "name": "notifications_entity_type_check",
+          "value": "\"notifications\".\"entity_type\" in ('post', 'reply', 'profile')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "push_tokens_user_enabled_idx": {
+          "name": "push_tokens_user_enabled_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"push_tokens\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_tokens_token_key": {
+          "name": "push_tokens_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_type_check": {
+          "name": "push_tokens_type_check",
+          "value": "\"push_tokens\".\"type\" in ('fcm', 'apns', 'unknown')"
+        },
+        "push_tokens_platform_check": {
+          "name": "push_tokens_platform_check",
+          "value": "\"push_tokens\".\"platform\" in ('android', 'ios', 'unknown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.topic_stats": {
+      "name": "topic_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "topic_stats_popularity_idx": {
+          "name": "topic_stats_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_stats_topic_id_key": {
+          "name": "topic_stats_topic_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "topic_stats_post_count_check": {
+          "name": "topic_stats_post_count_check",
+          "value": "\"topic_stats\".\"post_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.trend_batches": {
+      "name": "trend_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trend_batches_calculated_at_key": {
+          "name": "trend_batches_calculated_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calculated_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trend_graphs": {
+      "name": "trend_graphs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "edges": {
+          "name": "edges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "dropped_edges": {
+          "name": "dropped_edges",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trend_graphs_calculated_at_key": {
+          "name": "trend_graphs_calculated_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calculated_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "trend_graphs_dropped_edges_check": {
+          "name": "trend_graphs_dropped_edges_check",
+          "value": "\"trend_graphs\".\"dropped_edges\" is null or \"trend_graphs\".\"dropped_edges\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.trend_summaries": {
+      "name": "trend_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_started_at": {
+          "name": "run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trend_summaries_generated_at_idx": {
+          "name": "trend_summaries_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trend_summaries_term_run_started_at_key": {
+          "name": "trend_summaries_term_run_started_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term",
+            "run_started_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trending": {
+      "name": "trending",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_version": {
+          "name": "label_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "burst_score": {
+          "name": "burst_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "momentum": {
+          "name": "momentum",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_ids": {
+          "name": "actor_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "trending_batch_idx": {
+          "name": "trending_batch_idx",
+          "columns": [
+            {
+              "expression": "calculated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trending_calculated_at_idx": {
+          "name": "trending_calculated_at_idx",
+          "columns": [
+            {
+              "expression": "calculated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trending_topic_id_idx": {
+          "name": "trending_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"trending\".\"topic_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trending_name_calculated_at_type_key": {
+          "name": "trending_name_calculated_at_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "calculated_at",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "trending_type_check": {
+          "name": "trending_type_check",
+          "value": "\"trending\".\"type\" in ('hashtag', 'topic', 'entity')"
+        },
+        "trending_category_check": {
+          "name": "trending_category_check",
+          "value": "\"trending\".\"category\" is null or \"trending\".\"category\" in ('news', 'politics', 'sports', 'pop-culture', 'video-games', 'tech', 'science', 'other')"
+        },
+        "trending_status_check": {
+          "name": "trending_status_check",
+          "value": "\"trending\".\"status\" is null or \"trending\".\"status\" in ('hot')"
+        },
+        "trending_volume_check": {
+          "name": "trending_volume_check",
+          "value": "\"trending\".\"volume\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_id_created_at_idx": {
+          "name": "bookmarks_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_post_id_idx": {
+          "name": "bookmarks_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_id_folder_idx": {
+          "name": "bookmarks_user_id_folder_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"bookmarks\".\"folder\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_post_id_posts_id_fk": {
+          "name": "bookmarks_post_id_posts_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_id_post_id_key": {
+          "name": "bookmarks_user_id_post_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_follows": {
+      "name": "entity_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "entity_follows_entity_idx": {
+          "name": "entity_follows_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_follows_user_type_idx": {
+          "name": "entity_follows_user_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_follows_user_id_entity_type_entity_id_key": {
+          "name": "entity_follows_user_id_entity_type_entity_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "entity_follows_entity_type_check": {
+          "name": "entity_follows_entity_type_check",
+          "value": "\"entity_follows\".\"entity_type\" in ('hashtag', 'list')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "likes_post_id_idx": {
+          "name": "likes_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "likes_user_id_created_at_idx": {
+          "name": "likes_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "likes_post_id_posts_id_fk": {
+          "name": "likes_post_id_posts_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "likes_user_id_post_id_key": {
+          "name": "likes_user_id_post_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "likes_value_check": {
+          "name": "likes_value_check",
+          "value": "\"likes\".\"value\" in (1, -1)"
+        },
+        "likes_revision_check": {
+          "name": "likes_revision_check",
+          "value": "\"likes\".\"revision\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mute_words": {
+      "name": "mute_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targets": {
+          "name": "targets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::text[]"
+        },
+        "actor_target": {
+          "name": "actor_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mute_words_user_id_value_key": {
+          "name": "mute_words_user_id_value_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mute_words_actor_target_check": {
+          "name": "mute_words_actor_target_check",
+          "value": "\"mute_words\".\"actor_target\" in ('all', 'exclude-following')"
+        },
+        "mute_words_targets_check": {
+          "name": "mute_words_targets_check",
+          "value": "\"mute_words\".\"targets\" <@ array['content', 'tag']::text[]"
+        },
+        "mute_words_value_length_check": {
+          "name": "mute_words_value_length_check",
+          "value": "length(\"mute_words\".\"value\") <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mutes": {
+      "name": "mutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_id": {
+          "name": "muted_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mutes_muted_id_idx": {
+          "name": "mutes_muted_id_idx",
+          "columns": [
+            {
+              "expression": "muted_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mutes_user_id_muted_id_key": {
+          "name": "mutes_user_id_muted_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "muted_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pokes": {
+      "name": "pokes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poker_id": {
+          "name": "poker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poked_id": {
+          "name": "poked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "pokes_poked_id_created_at_idx": {
+          "name": "pokes_poked_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "poked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pokes_poker_id_poked_id_key": {
+          "name": "pokes_poker_id_poked_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poker_id",
+            "poked_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_subscriptions": {
+      "name": "post_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "post_subscriptions_author_id_idx": {
+          "name": "post_subscriptions_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_subscriptions_subscriber_id_author_id_key": {
+          "name": "post_subscriptions_subscriber_id_author_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subscriber_id",
+            "author_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor_key_pairs": {
+      "name": "actor_key_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_pem": {
+          "name": "private_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "actor_key_pairs_oxy_user_id_key": {
+          "name": "actor_key_pairs_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federated_actor_fields": {
+      "name": "federated_actor_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federated_actor_fields_actor_id_federated_actors_id_fk": {
+          "name": "federated_actor_fields_actor_id_federated_actors_id_fk",
+          "tableFrom": "federated_actor_fields",
+          "tableTo": "federated_actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federated_actor_fields_actor_id_position_key": {
+          "name": "federated_actor_fields_actor_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "federated_actor_fields_position_check": {
+          "name": "federated_actor_fields_position_check",
+          "value": "\"federated_actor_fields\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.federated_actors": {
+      "name": "federated_actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'activitypub'"
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acct": {
+          "name": "acct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_acct": {
+          "name": "network_acct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_url": {
+          "name": "header_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_url": {
+          "name": "outbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_url": {
+          "name": "followers_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following_url": {
+          "name": "following_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key_id": {
+          "name": "public_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Person'"
+        },
+        "manually_approves_followers": {
+          "name": "manually_approves_followers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "memorial": {
+          "name": "memorial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured_url": {
+          "name": "featured_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_tags_url": {
+          "name": "featured_tags_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "also_known_as": {
+          "name": "also_known_as",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_created_at": {
+          "name": "remote_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "following_count": {
+          "name": "following_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "posts_count": {
+          "name": "posts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_outbox_sync_at": {
+          "name": "last_outbox_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_status": {
+          "name": "outbox_backfill_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_outbox_url": {
+          "name": "outbox_backfill_outbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_cursor_url": {
+          "name": "outbox_backfill_cursor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_cursor_item_offset": {
+          "name": "outbox_backfill_cursor_item_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_processed_count": {
+          "name": "outbox_backfill_processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_imported_count": {
+          "name": "outbox_backfill_imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_existing_count": {
+          "name": "outbox_backfill_existing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_page_count": {
+          "name": "outbox_backfill_page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_locked_until": {
+          "name": "outbox_backfill_locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_last_run_at": {
+          "name": "outbox_backfill_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_completed_at": {
+          "name": "outbox_backfill_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_last_error": {
+          "name": "outbox_backfill_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_atproto_graph_sync_at": {
+          "name": "last_atproto_graph_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atproto_graph_sync_started_at": {
+          "name": "atproto_graph_sync_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "federated_actors_protocol_idx": {
+          "name": "federated_actors_protocol_idx",
+          "columns": [
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_domain_idx": {
+          "name": "federated_actors_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_public_key_id_idx": {
+          "name": "federated_actors_public_key_id_idx",
+          "columns": [
+            {
+              "expression": "public_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"federated_actors\".\"public_key_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_last_fetched_at_idx": {
+          "name": "federated_actors_last_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "last_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_backfill_claim_idx": {
+          "name": "federated_actors_backfill_claim_idx",
+          "columns": [
+            {
+              "expression": "outbox_backfill_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outbox_backfill_locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_oxy_user_id_idx": {
+          "name": "federated_actors_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"federated_actors\".\"oxy_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_network_acct_idx": {
+          "name": "federated_actors_network_acct_idx",
+          "columns": [
+            {
+              "expression": "network_acct",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"federated_actors\".\"network_acct\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federated_actors_uri_key": {
+          "name": "federated_actors_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        },
+        "federated_actors_acct_key": {
+          "name": "federated_actors_acct_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "acct"
+          ]
+        },
+        "federated_actors_domain_username_key": {
+          "name": "federated_actors_domain_username_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain",
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "federated_actors_protocol_check": {
+          "name": "federated_actors_protocol_check",
+          "value": "\"federated_actors\".\"protocol\" in ('activitypub', 'atproto')"
+        },
+        "federated_actors_type_check": {
+          "name": "federated_actors_type_check",
+          "value": "\"federated_actors\".\"type\" in ('Person', 'Service', 'Application', 'Group', 'Organization')"
+        },
+        "federated_actors_outbox_backfill_status_check": {
+          "name": "federated_actors_outbox_backfill_status_check",
+          "value": "\"federated_actors\".\"outbox_backfill_status\" is null or \"federated_actors\".\"outbox_backfill_status\" in ('pending', 'complete', 'unavailable', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.federated_follows": {
+      "name": "federated_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "local_user_id": {
+          "name": "local_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_actor_uri": {
+          "name": "remote_actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'activitypub'"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "federated_follows_local_direction_status_idx": {
+          "name": "federated_follows_local_direction_status_idx",
+          "columns": [
+            {
+              "expression": "local_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_follows_remote_direction_idx": {
+          "name": "federated_follows_remote_direction_idx",
+          "columns": [
+            {
+              "expression": "remote_actor_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federated_follows_local_remote_direction_key": {
+          "name": "federated_follows_local_remote_direction_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "local_user_id",
+            "remote_actor_uri",
+            "direction"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "federated_follows_direction_check": {
+          "name": "federated_follows_direction_check",
+          "value": "\"federated_follows\".\"direction\" in ('outbound', 'inbound')"
+        },
+        "federated_follows_status_check": {
+          "name": "federated_follows_status_check",
+          "value": "\"federated_follows\".\"status\" in ('pending', 'accepted', 'rejected')"
+        },
+        "federated_follows_network_check": {
+          "name": "federated_follows_network_check",
+          "value": "\"federated_follows\".\"network\" in ('activitypub', 'atproto')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.federated_media_cache": {
+      "name": "federated_media_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_file_id": {
+          "name": "oxy_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_file_id": {
+          "name": "poster_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fail_count": {
+          "name": "fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "federated_media_cache_state_accessed_idx": {
+          "name": "federated_media_cache_state_accessed_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_media_cache_state_next_attempt_idx": {
+          "name": "federated_media_cache_state_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federated_media_cache_remote_url_key": {
+          "name": "federated_media_cache_remote_url_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "remote_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "federated_media_cache_state_check": {
+          "name": "federated_media_cache_state_check",
+          "value": "\"federated_media_cache\".\"state\" in ('pending', 'cached', 'evicted', 'failed')"
+        },
+        "federated_media_cache_fail_count_check": {
+          "name": "federated_media_cache_fail_count_check",
+          "value": "\"federated_media_cache\".\"fail_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.federation_delivery_queue": {
+      "name": "federation_delivery_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_json": {
+          "name": "activity_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_inbox": {
+          "name": "target_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_oxy_user_id": {
+          "name": "sender_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_to_bullmq": {
+          "name": "migrated_to_bullmq",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "federation_delivery_queue_drain_idx": {
+          "name": "federation_delivery_queue_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "federation_delivery_queue_status_check": {
+          "name": "federation_delivery_queue_status_check",
+          "value": "\"federation_delivery_queue\".\"status\" in ('pending', 'delivered', 'failed')"
+        },
+        "federation_delivery_queue_attempts_check": {
+          "name": "federation_delivery_queue_attempts_check",
+          "value": "\"federation_delivery_queue\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_feed_definition_modules": {
+      "name": "custom_feed_definition_modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_feed_definition_modules_feed_id_custom_feeds_id_fk": {
+          "name": "custom_feed_definition_modules_feed_id_custom_feeds_id_fk",
+          "tableFrom": "custom_feed_definition_modules",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_feed_definition_modules_feed_kind_position_key": {
+          "name": "custom_feed_definition_modules_feed_kind_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "kind",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "custom_feed_definition_modules_kind_check": {
+          "name": "custom_feed_definition_modules_kind_check",
+          "value": "\"custom_feed_definition_modules\".\"kind\" in ('source', 'signal', 'filter')"
+        },
+        "custom_feed_definition_modules_position_check": {
+          "name": "custom_feed_definition_modules_position_check",
+          "value": "\"custom_feed_definition_modules\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_feed_members": {
+      "name": "custom_feed_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "custom_feed_members_oxy_user_id_idx": {
+          "name": "custom_feed_members_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_feed_members_feed_id_custom_feeds_id_fk": {
+          "name": "custom_feed_members_feed_id_custom_feeds_id_fk",
+          "tableFrom": "custom_feed_members",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_feed_members_feed_id_oxy_user_id_key": {
+          "name": "custom_feed_members_feed_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "oxy_user_id"
+          ]
+        },
+        "custom_feed_members_feed_id_position_key": {
+          "name": "custom_feed_members_feed_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "custom_feed_members_position_check": {
+          "name": "custom_feed_members_position_check",
+          "value": "\"custom_feed_members\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_feed_source_lists": {
+      "name": "custom_feed_source_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "custom_feed_source_lists_list_id_idx": {
+          "name": "custom_feed_source_lists_list_id_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_feed_source_lists_feed_id_custom_feeds_id_fk": {
+          "name": "custom_feed_source_lists_feed_id_custom_feeds_id_fk",
+          "tableFrom": "custom_feed_source_lists",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_feed_source_lists_list_id_account_lists_id_fk": {
+          "name": "custom_feed_source_lists_list_id_account_lists_id_fk",
+          "tableFrom": "custom_feed_source_lists",
+          "tableTo": "account_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_feed_source_lists_feed_id_list_id_key": {
+          "name": "custom_feed_source_lists_feed_id_list_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "list_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_feed_topics": {
+      "name": "custom_feed_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_feed_topics_feed_id_custom_feeds_id_fk": {
+          "name": "custom_feed_topics_feed_id_custom_feeds_id_fk",
+          "tableFrom": "custom_feed_topics",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_feed_topics_feed_id_topic_id_key": {
+          "name": "custom_feed_topics_feed_id_topic_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_feeds": {
+      "name": "custom_feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_mode": {
+          "name": "definition_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "include_replies": {
+          "name": "include_replies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_boosts": {
+          "name": "include_boosts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_media": {
+          "name": "include_media",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "average_rating": {
+          "name": "average_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ratings_count": {
+          "name": "ratings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "custom_feeds_owner_chrono_idx": {
+          "name": "custom_feeds_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_feeds_public_chrono_idx": {
+          "name": "custom_feeds_public_chrono_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"custom_feeds\".\"is_public\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_feeds_marketplace_idx": {
+          "name": "custom_feeds_marketplace_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"custom_feeds\".\"is_public\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_feeds_definition_mode_check": {
+          "name": "custom_feeds_definition_mode_check",
+          "value": "\"custom_feeds\".\"definition_mode\" is null or \"custom_feeds\".\"definition_mode\" in ('ranked', 'chronological')"
+        },
+        "custom_feeds_category_check": {
+          "name": "custom_feeds_category_check",
+          "value": "\"custom_feeds\".\"category\" is null or \"custom_feeds\".\"category\" in ('news', 'tech', 'culture', 'finance', 'health', 'sports', 'entertainment', 'other')"
+        },
+        "custom_feeds_counts_check": {
+          "name": "custom_feeds_counts_check",
+          "value": "\"custom_feeds\".\"subscriber_count\" >= 0 and \"custom_feeds\".\"ratings_count\" >= 0"
+        },
+        "custom_feeds_average_rating_check": {
+          "name": "custom_feeds_average_rating_check",
+          "value": "\"custom_feeds\".\"average_rating\" between 0 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_generators": {
+      "name": "feed_generators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_network": {
+          "name": "source_network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_service_did": {
+          "name": "source_service_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_synced_at": {
+          "name": "source_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "feed_generators_created_by_idx": {
+          "name": "feed_generators_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_generators_uri_key": {
+          "name": "feed_generators_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feed_generators_source_network_check": {
+          "name": "feed_generators_source_network_check",
+          "value": "\"feed_generators\".\"source_network\" is null or \"feed_generators\".\"source_network\" in ('atproto')"
+        },
+        "feed_generators_source_complete_check": {
+          "name": "feed_generators_source_complete_check",
+          "value": "(\"feed_generators\".\"source_network\" is null and \"feed_generators\".\"source_service_did\" is null and \"feed_generators\".\"source_synced_at\" is null)\n        or (\"feed_generators\".\"source_network\" is not null and \"feed_generators\".\"source_service_did\" is not null and \"feed_generators\".\"source_synced_at\" is not null)"
+        },
+        "feed_generators_counts_check": {
+          "name": "feed_generators_counts_check",
+          "value": "\"feed_generators\".\"like_count\" >= 0 and \"feed_generators\".\"subscriber_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_interactions": {
+      "name": "feed_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_descriptor": {
+          "name": "feed_descriptor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_uri": {
+          "name": "post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "feed_interactions_user_chrono_idx": {
+          "name": "feed_interactions_user_chrono_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_interactions_post_event_idx": {
+          "name": "feed_interactions_post_event_idx",
+          "columns": [
+            {
+              "expression": "post_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_interactions_created_at_idx": {
+          "name": "feed_interactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_interactions_event_check": {
+          "name": "feed_interactions_event_check",
+          "value": "\"feed_interactions\".\"event\" in ('impression', 'click', 'like', 'reply', 'boost', 'save', 'report')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_likes": {
+      "name": "feed_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "feed_likes_feed_id_idx": {
+          "name": "feed_likes_feed_id_idx",
+          "columns": [
+            {
+              "expression": "feed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_likes_user_id_idx": {
+          "name": "feed_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_likes_feed_id_custom_feeds_id_fk": {
+          "name": "feed_likes_feed_id_custom_feeds_id_fk",
+          "tableFrom": "feed_likes",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_likes_user_id_feed_id_key": {
+          "name": "feed_likes_user_id_feed_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "feed_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_reviews": {
+      "name": "feed_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_text": {
+          "name": "review_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "feed_reviews_reviewer_id_idx": {
+          "name": "feed_reviews_reviewer_id_idx",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_reviews_feed_id_custom_feeds_id_fk": {
+          "name": "feed_reviews_feed_id_custom_feeds_id_fk",
+          "tableFrom": "feed_reviews",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_reviews_feed_id_reviewer_id_key": {
+          "name": "feed_reviews_feed_id_reviewer_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "reviewer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feed_reviews_rating_check": {
+          "name": "feed_reviews_rating_check",
+          "value": "\"feed_reviews\".\"rating\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_feed_preferences": {
+      "name": "user_feed_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_feed_preferences_oxy_user_id_key": {
+          "name": "user_feed_preferences_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_saved_feeds": {
+      "name": "user_saved_feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preference_id": {
+          "name": "preference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descriptor": {
+          "name": "descriptor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_saved_feeds_preference_order_idx": {
+          "name": "user_saved_feeds_preference_order_idx",
+          "columns": [
+            {
+              "expression": "preference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_feeds_preference_id_user_feed_preferences_id_fk": {
+          "name": "user_saved_feeds_preference_id_user_feed_preferences_id_fk",
+          "tableFrom": "user_saved_feeds",
+          "tableTo": "user_feed_preferences",
+          "columnsFrom": [
+            "preference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_saved_feeds_preference_id_key_key": {
+          "name": "user_saved_feeds_preference_id_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "preference_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postgates": {
+      "name": "postgates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_uri": {
+          "name": "post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disable_quotes": {
+          "name": "disable_quotes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "detached_quote_uris": {
+          "name": "detached_quote_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "postgates_post_id_idx": {
+          "name": "postgates_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postgates_created_by_idx": {
+          "name": "postgates_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "postgates_post_uri_key": {
+          "name": "postgates_post_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threadgate_allow_rules": {
+      "name": "threadgate_allow_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadgate_id": {
+          "name": "threadgate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threadgate_allow_rules_threadgate_id_threadgates_id_fk": {
+          "name": "threadgate_allow_rules_threadgate_id_threadgates_id_fk",
+          "tableFrom": "threadgate_allow_rules",
+          "tableTo": "threadgates",
+          "columnsFrom": [
+            "threadgate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "threadgate_allow_rules_threadgate_id_position_key": {
+          "name": "threadgate_allow_rules_threadgate_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadgate_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "threadgate_allow_rules_type_check": {
+          "name": "threadgate_allow_rules_type_check",
+          "value": "\"threadgate_allow_rules\".\"type\" in ('mentionedOnly', 'followingOnly', 'followerOnly', 'listOnly')"
+        },
+        "threadgate_allow_rules_list_id_check": {
+          "name": "threadgate_allow_rules_list_id_check",
+          "value": "(\"threadgate_allow_rules\".\"type\" = 'listOnly') = (\"threadgate_allow_rules\".\"list_id\" is not null)"
+        },
+        "threadgate_allow_rules_position_check": {
+          "name": "threadgate_allow_rules_position_check",
+          "value": "\"threadgate_allow_rules\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.threadgates": {
+      "name": "threadgates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_uri": {
+          "name": "post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "threadgates_post_id_idx": {
+          "name": "threadgates_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threadgates_created_by_idx": {
+          "name": "threadgates_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "threadgates_post_uri_key": {
+          "name": "threadgates_post_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_list_members": {
+      "name": "account_list_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_list_members_oxy_user_id_idx": {
+          "name": "account_list_members_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_list_members_list_id_account_lists_id_fk": {
+          "name": "account_list_members_list_id_account_lists_id_fk",
+          "tableFrom": "account_list_members",
+          "tableTo": "account_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_list_members_list_id_oxy_user_id_key": {
+          "name": "account_list_members_list_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "list_id",
+            "oxy_user_id"
+          ]
+        },
+        "account_list_members_list_id_position_key": {
+          "name": "account_list_members_list_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "list_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_list_members_position_check": {
+          "name": "account_list_members_position_check",
+          "value": "\"account_list_members\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_lists": {
+      "name": "account_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "account_lists_owner_chrono_idx": {
+          "name": "account_lists_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_lists_public_chrono_idx": {
+          "name": "account_lists_public_chrono_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"account_lists\".\"is_public\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_lists_subscriber_count_check": {
+          "name": "account_lists_subscriber_count_check",
+          "value": "\"account_lists\".\"subscriber_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.starter_pack_members": {
+      "name": "starter_pack_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "starter_pack_members_oxy_user_id_idx": {
+          "name": "starter_pack_members_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "starter_pack_members_pack_id_starter_packs_id_fk": {
+          "name": "starter_pack_members_pack_id_starter_packs_id_fk",
+          "tableFrom": "starter_pack_members",
+          "tableTo": "starter_packs",
+          "columnsFrom": [
+            "pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "starter_pack_members_pack_id_oxy_user_id_key": {
+          "name": "starter_pack_members_pack_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pack_id",
+            "oxy_user_id"
+          ]
+        },
+        "starter_pack_members_pack_id_position_key": {
+          "name": "starter_pack_members_pack_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pack_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "starter_pack_members_position_check": {
+          "name": "starter_pack_members_position_check",
+          "value": "\"starter_pack_members\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.starter_pack_uses": {
+      "name": "starter_pack_uses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "starter_pack_uses_oxy_user_id_idx": {
+          "name": "starter_pack_uses_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "starter_pack_uses_pack_id_starter_packs_id_fk": {
+          "name": "starter_pack_uses_pack_id_starter_packs_id_fk",
+          "tableFrom": "starter_pack_uses",
+          "tableTo": "starter_packs",
+          "columnsFrom": [
+            "pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "starter_pack_uses_pack_id_oxy_user_id_key": {
+          "name": "starter_pack_uses_pack_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pack_id",
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.starter_packs": {
+      "name": "starter_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_network": {
+          "name": "source_network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_uri": {
+          "name": "source_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_synced_at": {
+          "name": "source_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "starter_packs_source_uri_key": {
+          "name": "starter_packs_source_uri_key",
+          "columns": [
+            {
+              "expression": "source_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"starter_packs\".\"source_uri\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "starter_packs_owner_chrono_idx": {
+          "name": "starter_packs_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "starter_packs_use_count_idx": {
+          "name": "starter_packs_use_count_idx",
+          "columns": [
+            {
+              "expression": "use_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "starter_packs_use_count_check": {
+          "name": "starter_packs_use_count_check",
+          "value": "\"starter_packs\".\"use_count\" >= 0"
+        },
+        "starter_packs_source_network_check": {
+          "name": "starter_packs_source_network_check",
+          "value": "\"starter_packs\".\"source_network\" is null or \"starter_packs\".\"source_network\" in ('atproto')"
+        },
+        "starter_packs_source_complete_check": {
+          "name": "starter_packs_source_complete_check",
+          "value": "(\"starter_packs\".\"source_network\" is null and \"starter_packs\".\"source_uri\" is null and \"starter_packs\".\"source_synced_at\" is null)\n        or (\"starter_packs\".\"source_network\" is not null and \"starter_packs\".\"source_uri\" is not null and \"starter_packs\".\"source_synced_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_codes": {
+      "name": "mcp_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mcp_auth_codes_code_key": {
+          "name": "mcp_auth_codes_code_key",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_auth_codes_expires_at_idx": {
+          "name": "mcp_auth_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_connections": {
+      "name": "mcp_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bundle_primary": {
+          "name": "is_bundle_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active_oxy_user_id": {
+          "name": "active_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_connections_refresh_token_hash_key": {
+          "name": "mcp_connections_refresh_token_hash_key",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_bundle_id_oxy_user_id_key": {
+          "name": "mcp_connections_bundle_id_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mcp_connections\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_oxy_user_id_idx": {
+          "name": "mcp_connections_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_bundle_id_idx": {
+          "name": "mcp_connections_bundle_id_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_jti_idx": {
+          "name": "mcp_connections_jti_idx",
+          "columns": [
+            {
+              "expression": "jti",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_registered_clients": {
+      "name": "mcp_registered_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mcp_registered_clients_client_id_key": {
+          "name": "mcp_registered_clients_client_id_key",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_labels": {
+      "name": "content_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "labeler_id": {
+          "name": "labeler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_slug": {
+          "name": "label_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "content_labels_target_idx": {
+          "name": "content_labels_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_labels_labeler_slug_idx": {
+          "name": "content_labels_labeler_slug_idx",
+          "columns": [
+            {
+              "expression": "labeler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_labels_labeler_id_labelers_id_fk": {
+          "name": "content_labels_labeler_id_labelers_id_fk",
+          "tableFrom": "content_labels",
+          "tableTo": "labelers",
+          "columnsFrom": [
+            "labeler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_labels_labeler_target_slug_key": {
+          "name": "content_labels_labeler_target_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "labeler_id",
+            "target_type",
+            "target_id",
+            "label_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "content_labels_target_type_check": {
+          "name": "content_labels_target_type_check",
+          "value": "\"content_labels\".\"target_type\" in ('post', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labeler_label_definitions": {
+      "name": "labeler_label_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "labeler_id": {
+          "name": "labeler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_action": {
+          "name": "default_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labeler_label_definitions_labeler_id_labelers_id_fk": {
+          "name": "labeler_label_definitions_labeler_id_labelers_id_fk",
+          "tableFrom": "labeler_label_definitions",
+          "tableTo": "labelers",
+          "columnsFrom": [
+            "labeler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labeler_label_definitions_labeler_id_slug_key": {
+          "name": "labeler_label_definitions_labeler_id_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "labeler_id",
+            "slug"
+          ]
+        },
+        "labeler_label_definitions_labeler_id_position_key": {
+          "name": "labeler_label_definitions_labeler_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "labeler_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "labeler_label_definitions_severity_check": {
+          "name": "labeler_label_definitions_severity_check",
+          "value": "\"labeler_label_definitions\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "labeler_label_definitions_default_action_check": {
+          "name": "labeler_label_definitions_default_action_check",
+          "value": "\"labeler_label_definitions\".\"default_action\" in ('show', 'warn', 'blur', 'hide')"
+        },
+        "labeler_label_definitions_position_check": {
+          "name": "labeler_label_definitions_position_check",
+          "value": "\"labeler_label_definitions\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labelers": {
+      "name": "labelers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_official": {
+          "name": "is_official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "labelers_creator_id_idx": {
+          "name": "labelers_creator_id_idx",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "labelers_subscriber_count_check": {
+          "name": "labelers_subscriber_count_check",
+          "value": "\"labelers\".\"subscriber_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_enforcements": {
+      "name": "moderation_enforcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_action": {
+          "name": "recommended_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_reason": {
+          "name": "skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_post_status": {
+          "name": "previous_state_post_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_metadata_is_sensitive": {
+          "name": "previous_state_metadata_is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_enforcements_case_id_idx": {
+          "name": "moderation_enforcements_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_enforcements_subject_idx": {
+          "name": "moderation_enforcements_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_enforcements_idempotency_key": {
+          "name": "moderation_enforcements_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "decision_id",
+            "decision_revision",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_enforcements_action_check": {
+          "name": "moderation_enforcements_action_check",
+          "value": "\"moderation_enforcements\".\"action\" in ('none', 'restrict', 'restore', 'label_sensitive', 'unlabel_sensitive', 'manual_review')"
+        },
+        "moderation_enforcements_mode_check": {
+          "name": "moderation_enforcements_mode_check",
+          "value": "\"moderation_enforcements\".\"mode\" in ('observe', 'manual', 'automatic')"
+        },
+        "moderation_enforcements_revision_check": {
+          "name": "moderation_enforcements_revision_check",
+          "value": "\"moderation_enforcements\".\"decision_revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_events": {
+      "name": "moderation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claimed'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_events_case_id_idx": {
+          "name": "moderation_events_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"moderation_events\".\"case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_state_received_idx": {
+          "name": "moderation_events_state_received_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_expires_at_idx": {
+          "name": "moderation_events_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_events_state_check": {
+          "name": "moderation_events_state_check",
+          "value": "\"moderation_events\".\"state\" in ('claimed', 'queued', 'ignored')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_outbox": {
+      "name": "moderation_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_report_id": {
+          "name": "payload_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_event_id": {
+          "name": "payload_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_case_id": {
+          "name": "payload_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_decision": {
+          "name": "payload_decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_urgency": {
+          "name": "payload_urgency",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_outbox_due_idx": {
+          "name": "moderation_outbox_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_lease_idx": {
+          "name": "moderation_outbox_lease_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_expires_at_idx": {
+          "name": "moderation_outbox_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_outbox_payload_report_id_reports_id_fk": {
+          "name": "moderation_outbox_payload_report_id_reports_id_fk",
+          "tableFrom": "moderation_outbox",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "payload_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_outbox_kind_check": {
+          "name": "moderation_outbox_kind_check",
+          "value": "\"moderation_outbox\".\"kind\" in ('report.submit', 'decision.apply')"
+        },
+        "moderation_outbox_status_check": {
+          "name": "moderation_outbox_status_check",
+          "value": "\"moderation_outbox\".\"status\" in ('pending', 'processing', 'processed', 'dead_letter')"
+        },
+        "moderation_outbox_attempts_check": {
+          "name": "moderation_outbox_attempts_check",
+          "value": "\"moderation_outbox\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reported_type": {
+          "name": "reported_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter": {
+          "name": "reporter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "local_status": {
+          "name": "local_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "local_status_reason": {
+          "name": "local_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_report_id": {
+          "name": "crowd_source_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_case_id": {
+          "name": "crowd_source_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_merged": {
+          "name": "crowd_source_merged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_outcome": {
+          "name": "decision_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_action": {
+          "name": "enforced_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_snapshot_hash": {
+          "name": "content_snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_error": {
+          "name": "last_delivery_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reports_reported_id_idx": {
+          "name": "reports_reported_id_idx",
+          "columns": [
+            {
+              "expression": "reported_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_reporter_idx": {
+          "name": "reports_reporter_idx",
+          "columns": [
+            {
+              "expression": "reporter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_case_id_idx": {
+          "name": "reports_case_id_idx",
+          "columns": [
+            {
+              "expression": "crowd_source_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reports\".\"crowd_source_case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_local_status_chrono_idx": {
+          "name": "reports_local_status_chrono_idx",
+          "columns": [
+            {
+              "expression": "local_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reports_reporter_reported_key": {
+          "name": "reports_reporter_reported_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reporter",
+            "reported_id",
+            "reported_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reports_reported_type_check": {
+          "name": "reports_reported_type_check",
+          "value": "\"reports\".\"reported_type\" in ('post', 'user', 'comment', 'message', 'room')"
+        },
+        "reports_status_check": {
+          "name": "reports_status_check",
+          "value": "\"reports\".\"status\" in ('pending', 'reviewed', 'resolved', 'dismissed')"
+        },
+        "reports_local_status_check": {
+          "name": "reports_local_status_check",
+          "value": "\"reports\".\"local_status\" in ('received', 'queued', 'submitted', 'delivery_failed', 'closed')"
+        },
+        "reports_enforced_action_check": {
+          "name": "reports_enforced_action_check",
+          "value": "\"reports\".\"enforced_action\" is null or \"reports\".\"enforced_action\" in ('none', 'restrict', 'restore', 'label_sensitive', 'unlabel_sensitive', 'manual_review')"
+        },
+        "reports_categories_check": {
+          "name": "reports_categories_check",
+          "value": "array_length(\"reports\".\"categories\", 1) >= 1\n        and \"reports\".\"categories\" <@ array['spam', 'hate_speech', 'harassment', 'misinformation', 'explicit_content', 'other']::text[]"
+        },
+        "reports_decision_revision_check": {
+          "name": "reports_decision_revision_check",
+          "value": "\"reports\".\"decision_revision\" is null or \"reports\".\"decision_revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mention_node_ingest_witnesses": {
+      "name": "mention_node_ingest_witnesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witness_signature": {
+          "name": "witness_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mention_node_ingest_witnesses_owner_chrono_idx": {
+          "name": "mention_node_ingest_witnesses_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mention_node_ingest_witnesses_record_id_key": {
+          "name": "mention_node_ingest_witnesses_record_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mention_node_ingest_witnesses_ingested_at_check": {
+          "name": "mention_node_ingest_witnesses_ingested_at_check",
+          "value": "\"mention_node_ingest_witnesses\".\"ingested_at\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mention_repo_heads": {
+      "name": "mention_repo_heads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_record_id": {
+          "name": "head_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mention_repo_heads_oxy_user_id_key": {
+          "name": "mention_repo_heads_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mention_repo_heads_seq_check": {
+          "name": "mention_repo_heads_seq_check",
+          "value": "\"mention_repo_heads\".\"seq\" >= 0"
+        },
+        "mention_repo_heads_record_count_check": {
+          "name": "mention_repo_heads_record_count_check",
+          "value": "\"mention_repo_heads\".\"record_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mention_signed_records": {
+      "name": "mention_signed_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_status": {
+          "name": "chain_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nsid": {
+          "name": "nsid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mention_signed_records_record_id_key": {
+          "name": "mention_signed_records_record_id_key",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mention_signed_records\".\"record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_signed_records_oxy_user_id_seq_key": {
+          "name": "mention_signed_records_oxy_user_id_seq_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mention_signed_records\".\"seq\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_signed_records_idempotency_key": {
+          "name": "mention_signed_records_idempotency_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mention_signed_records\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_signed_records_materialize_idx": {
+          "name": "mention_signed_records_materialize_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nsid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mention_signed_records\".\"nsid\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_signed_records_subject_did_idx": {
+          "name": "mention_signed_records_subject_did_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mention_signed_records_chain_status_check": {
+          "name": "mention_signed_records_chain_status_check",
+          "value": "\"mention_signed_records\".\"chain_status\" is null or \"mention_signed_records\".\"chain_status\" in ('canonical', 'conflict')"
+        },
+        "mention_signed_records_seq_check": {
+          "name": "mention_signed_records_seq_check",
+          "value": "\"mention_signed_records\".\"seq\" is null or \"mention_signed_records\".\"seq\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mention_user_nodes": {
+      "name": "mention_user_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_did": {
+          "name": "node_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_public_key": {
+          "name": "node_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pull'"
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controller": {
+          "name": "controller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_at": {
+          "name": "last_probe_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mention_user_nodes_status_idx": {
+          "name": "mention_user_nodes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_user_nodes_ingest_sweep_idx": {
+          "name": "mention_user_nodes_ingest_sweep_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mention_user_nodes_oxy_user_id_key": {
+          "name": "mention_user_nodes_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mention_user_nodes_mode_check": {
+          "name": "mention_user_nodes_mode_check",
+          "value": "\"mention_user_nodes\".\"mode\" in ('pull', 'push')"
+        },
+        "mention_user_nodes_controller_check": {
+          "name": "mention_user_nodes_controller_check",
+          "value": "\"mention_user_nodes\".\"controller\" in ('self', 'oxy')"
+        },
+        "mention_user_nodes_status_check": {
+          "name": "mention_user_nodes_status_check",
+          "value": "\"mention_user_nodes\".\"status\" in ('active', 'unreachable', 'revoked')"
+        },
+        "mention_user_nodes_cursor_check": {
+          "name": "mention_user_nodes_cursor_check",
+          "value": "\"mention_user_nodes\".\"cursor\" is null or \"mention_user_nodes\".\"cursor\" >= 0"
+        },
+        "mention_user_nodes_managed_controller_check": {
+          "name": "mention_user_nodes_managed_controller_check",
+          "value": "\"mention_user_nodes\".\"managed\" = (\"mention_user_nodes\".\"controller\" = 'oxy')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.endorsement_outbox": {
+      "name": "endorsement_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_remove_owner_id": {
+          "name": "pending_remove_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_remove_member_ids": {
+          "name": "pending_remove_member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "endorsement_outbox_drain_idx": {
+          "name": "endorsement_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "endorsement_outbox_source_source_id_key": {
+          "name": "endorsement_outbox_source_source_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "endorsement_outbox_source_check": {
+          "name": "endorsement_outbox_source_check",
+          "value": "\"endorsement_outbox\".\"source\" in ('starterPack', 'accountList')"
+        },
+        "endorsement_outbox_status_check": {
+          "name": "endorsement_outbox_status_check",
+          "value": "\"endorsement_outbox\".\"status\" in ('pending', 'sent')"
+        },
+        "endorsement_outbox_attempts_check": {
+          "name": "endorsement_outbox_attempts_check",
+          "value": "\"endorsement_outbox\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.engagement_outbox": {
+      "name": "engagement_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_actor_oxy_user_id": {
+          "name": "payload_actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_post_id": {
+          "name": "payload_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_relationship_id": {
+          "name": "payload_relationship_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_post_owner_oxy_user_id": {
+          "name": "payload_post_owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_federation_activity_id": {
+          "name": "payload_federation_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_previous_value": {
+          "name": "payload_previous_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_value": {
+          "name": "payload_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "engagement_outbox_due_idx": {
+          "name": "engagement_outbox_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "engagement_outbox_lease_idx": {
+          "name": "engagement_outbox_lease_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "engagement_outbox_relationship_order_idx": {
+          "name": "engagement_outbox_relationship_order_idx",
+          "columns": [
+            {
+              "expression": "payload_relationship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "engagement_outbox_expires_at_idx": {
+          "name": "engagement_outbox_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "engagement_outbox_payload_post_id_posts_id_fk": {
+          "name": "engagement_outbox_payload_post_id_posts_id_fk",
+          "tableFrom": "engagement_outbox",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "payload_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "engagement_outbox_kind_check": {
+          "name": "engagement_outbox_kind_check",
+          "value": "\"engagement_outbox\".\"kind\" in ('post.like', 'post.unlike', 'post.downvote', 'post.undownvote', 'post.save', 'post.unsave')"
+        },
+        "engagement_outbox_status_check": {
+          "name": "engagement_outbox_status_check",
+          "value": "\"engagement_outbox\".\"status\" in ('pending', 'processing', 'processed')"
+        },
+        "engagement_outbox_revision_check": {
+          "name": "engagement_outbox_revision_check",
+          "value": "\"engagement_outbox\".\"revision\" >= 1"
+        },
+        "engagement_outbox_attempts_check": {
+          "name": "engagement_outbox_attempts_check",
+          "value": "\"engagement_outbox\".\"attempts\" >= 0"
+        },
+        "engagement_outbox_values_check": {
+          "name": "engagement_outbox_values_check",
+          "value": "(\"engagement_outbox\".\"payload_previous_value\" is null or \"engagement_outbox\".\"payload_previous_value\" in (1, -1))\n        and (\"engagement_outbox\".\"payload_value\" is null or \"engagement_outbox\".\"payload_value\" in (1, -1))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_attachments": {
+      "name": "post_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_attachments_post_id_posts_id_fk": {
+          "name": "post_attachments_post_id_posts_id_fk",
+          "tableFrom": "post_attachments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_attachments_post_id_position_key": {
+          "name": "post_attachments_post_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_attachments_type_check": {
+          "name": "post_attachments_type_check",
+          "value": "\"post_attachments\".\"type\" in ('media', 'poll', 'article', 'event', 'location', 'sources', 'room', 'podcast')"
+        },
+        "post_attachments_media_type_check": {
+          "name": "post_attachments_media_type_check",
+          "value": "\"post_attachments\".\"media_type\" is null or \"post_attachments\".\"media_type\" in ('image', 'video', 'gif')"
+        },
+        "post_attachments_media_fields_check": {
+          "name": "post_attachments_media_fields_check",
+          "value": "\"post_attachments\".\"type\" <> 'media' or (\"post_attachments\".\"attachment_id\" is not null and \"post_attachments\".\"media_type\" is not null)"
+        },
+        "post_attachments_position_check": {
+          "name": "post_attachments_position_check",
+          "value": "\"post_attachments\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_authorships": {
+      "name": "post_authorships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_created_at": {
+          "name": "post_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_authorships_one_owner_per_post": {
+          "name": "post_authorships_one_owner_per_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"post_authorships\".\"role\" = 'owner'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_authorships_author_idx": {
+          "name": "post_authorships_author_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_authorships_author_chrono_idx": {
+          "name": "post_authorships_author_chrono_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_authorships_post_id_posts_id_fk": {
+          "name": "post_authorships_post_id_posts_id_fk",
+          "tableFrom": "post_authorships",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_authorships_post_id_oxy_user_id_key": {
+          "name": "post_authorships_post_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_authorships_role_check": {
+          "name": "post_authorships_role_check",
+          "value": "\"post_authorships\".\"role\" in ('owner', 'collaborator')"
+        },
+        "post_authorships_status_check": {
+          "name": "post_authorships_status_check",
+          "value": "\"post_authorships\".\"status\" in ('accepted', 'pending', 'declined', 'stopped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_classification_topic_refs": {
+      "name": "post_classification_topic_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_classification_topic_refs_name_idx": {
+          "name": "post_classification_topic_refs_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_classification_topic_refs_topic_id_idx": {
+          "name": "post_classification_topic_refs_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"post_classification_topic_refs\".\"topic_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_classification_topic_refs_post_id_posts_id_fk": {
+          "name": "post_classification_topic_refs_post_id_posts_id_fk",
+          "tableFrom": "post_classification_topic_refs",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_classification_topic_refs_post_id_name_key": {
+          "name": "post_classification_topic_refs_post_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_classification_topic_refs_type_check": {
+          "name": "post_classification_topic_refs_type_check",
+          "value": "\"post_classification_topic_refs\".\"type\" is null or \"post_classification_topic_refs\".\"type\" in ('topic', 'entity')"
+        },
+        "post_classification_topic_refs_relevance_check": {
+          "name": "post_classification_topic_refs_relevance_check",
+          "value": "\"post_classification_topic_refs\".\"relevance\" is null or \"post_classification_topic_refs\".\"relevance\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_content_variants": {
+      "name": "post_content_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "article_title": {
+          "name": "article_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_body": {
+          "name": "article_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_excerpt": {
+          "name": "article_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_created_at": {
+          "name": "variant_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(body, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "post_content_variants_post_id_tag_key": {
+          "name": "post_content_variants_post_id_tag_key",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"post_content_variants\".\"tag\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_content_variants_search_gin": {
+          "name": "post_content_variants_search_gin",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "post_content_variants_primary_idx": {
+          "name": "post_content_variants_primary_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"post_content_variants\".\"position\" = 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_content_variants_post_id_posts_id_fk": {
+          "name": "post_content_variants_post_id_posts_id_fk",
+          "tableFrom": "post_content_variants",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_content_variants_post_id_position_key": {
+          "name": "post_content_variants_post_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_content_variants_source_check": {
+          "name": "post_content_variants_source_check",
+          "value": "\"post_content_variants\".\"source\" in ('author', 'machine')"
+        },
+        "post_content_variants_position_check": {
+          "name": "post_content_variants_position_check",
+          "value": "\"post_content_variants\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_media": {
+      "name": "post_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_from_federation": {
+          "name": "cached_from_federation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_media_video_idx": {
+          "name": "post_media_video_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orientation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "duration_sec",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_media_media_id_idx": {
+          "name": "post_media_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_media_post_id_posts_id_fk": {
+          "name": "post_media_post_id_posts_id_fk",
+          "tableFrom": "post_media",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_media_post_id_position_key": {
+          "name": "post_media_post_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_media_type_check": {
+          "name": "post_media_type_check",
+          "value": "\"post_media\".\"type\" in ('image', 'video', 'gif')"
+        },
+        "post_media_orientation_check": {
+          "name": "post_media_orientation_check",
+          "value": "\"post_media\".\"orientation\" is null or \"post_media\".\"orientation\" in ('portrait', 'landscape', 'square')"
+        },
+        "post_media_positive_dimensions_check": {
+          "name": "post_media_positive_dimensions_check",
+          "value": "(\"post_media\".\"width\" is null or \"post_media\".\"width\" > 0)\n        and (\"post_media\".\"height\" is null or \"post_media\".\"height\" > 0)\n        and (\"post_media\".\"duration_sec\" is null or \"post_media\".\"duration_sec\" > 0)\n        and (\"post_media\".\"size_bytes\" is null or \"post_media\".\"size_bytes\" > 0)\n        and (\"post_media\".\"aspect_ratio\" is null or \"post_media\".\"aspect_ratio\" > 0)"
+        },
+        "post_media_position_check": {
+          "name": "post_media_position_check",
+          "value": "\"post_media\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_mentions": {
+      "name": "post_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "post_mentions_oxy_user_id_idx": {
+          "name": "post_mentions_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_mentions_post_id_posts_id_fk": {
+          "name": "post_mentions_post_id_posts_id_fk",
+          "tableFrom": "post_mentions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_mentions_post_id_oxy_user_id_key": {
+          "name": "post_mentions_post_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_recent_repliers": {
+      "name": "post_recent_repliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "post_recent_repliers_post_idx": {
+          "name": "post_recent_repliers_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replied_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_recent_repliers_post_id_posts_id_fk": {
+          "name": "post_recent_repliers_post_id_posts_id_fk",
+          "tableFrom": "post_recent_repliers",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_recent_repliers_post_id_oxy_user_id_key": {
+          "name": "post_recent_repliers_post_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_sources": {
+      "name": "post_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_sources_post_id_posts_id_fk": {
+          "name": "post_sources_post_id_posts_id_fk",
+          "tableFrom": "post_sources",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_sources_post_id_position_key": {
+          "name": "post_sources_post_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_sources_position_check": {
+          "name": "post_sources_position_check",
+          "value": "\"post_sources\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_variant_alt_texts": {
+      "name": "post_variant_alt_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_variant_alt_texts_variant_id_post_content_variants_id_fk": {
+          "name": "post_variant_alt_texts_variant_id_post_content_variants_id_fk",
+          "tableFrom": "post_variant_alt_texts",
+          "tableTo": "post_content_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_variant_alt_texts_variant_id_media_id_key": {
+          "name": "post_variant_alt_texts_variant_id_media_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_id",
+            "media_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_variant_media": {
+      "name": "post_variant_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_from_federation": {
+          "name": "cached_from_federation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_variant_media_variant_id_post_content_variants_id_fk": {
+          "name": "post_variant_media_variant_id_post_content_variants_id_fk",
+          "tableFrom": "post_variant_media",
+          "tableTo": "post_content_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_variant_media_variant_id_position_key": {
+          "name": "post_variant_media_variant_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_variant_media_type_check": {
+          "name": "post_variant_media_type_check",
+          "value": "\"post_variant_media\".\"type\" in ('image', 'video', 'gif')"
+        },
+        "post_variant_media_orientation_check": {
+          "name": "post_variant_media_orientation_check",
+          "value": "\"post_variant_media\".\"orientation\" is null or \"post_variant_media\".\"orientation\" in ('portrait', 'landscape', 'square')"
+        },
+        "post_variant_media_positive_dimensions_check": {
+          "name": "post_variant_media_positive_dimensions_check",
+          "value": "(\"post_variant_media\".\"width\" is null or \"post_variant_media\".\"width\" > 0)\n        and (\"post_variant_media\".\"height\" is null or \"post_variant_media\".\"height\" > 0)\n        and (\"post_variant_media\".\"duration_sec\" is null or \"post_variant_media\".\"duration_sec\" > 0)\n        and (\"post_variant_media\".\"size_bytes\" is null or \"post_variant_media\".\"size_bytes\" > 0)\n        and (\"post_variant_media\".\"aspect_ratio\" is null or \"post_variant_media\".\"aspect_ratio\" > 0)"
+        },
+        "post_variant_media_position_check": {
+          "name": "post_variant_media_position_check",
+          "value": "\"post_variant_media\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "written_by_oxy_user_id": {
+          "name": "written_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "has_links": {
+          "name": "has_links",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curated": {
+          "name": "curated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edit_history": {
+          "name": "edit_history",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_permission": {
+          "name": "reply_permission",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array['anyone']::text[]"
+        },
+        "review_replies": {
+          "name": "review_replies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quotes_disabled": {
+          "name": "quotes_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "boost_of": {
+          "name": "boost_of",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_of": {
+          "name": "quote_of",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lane_id": {
+          "name": "lane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_post_id": {
+          "name": "parent_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_reply": {
+          "name": "is_reply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_likes_count": {
+          "name": "stats_likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_downvotes_count": {
+          "name": "stats_downvotes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_boosts_count": {
+          "name": "stats_boosts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_federated_boosts_count": {
+          "name": "stats_federated_boosts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_comments_count": {
+          "name": "stats_comments_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_views_count": {
+          "name": "stats_views_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_shares_count": {
+          "name": "stats_shares_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_saves_count": {
+          "name": "stats_saves_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata_is_sensitive": {
+          "name": "metadata_is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_is_pinned": {
+          "name": "metadata_is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_is_boosted": {
+          "name": "metadata_is_boosted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_is_commented": {
+          "name": "metadata_is_commented",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_is_following_author": {
+          "name": "metadata_is_following_author",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_author_blocked": {
+          "name": "metadata_author_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_author_muted": {
+          "name": "metadata_author_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_hide_engagement_counts": {
+          "name": "metadata_hide_engagement_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_collab_federation_deferred": {
+          "name": "metadata_collab_federation_deferred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_federation_delivered": {
+          "name": "metadata_federation_delivered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "federation_activity_id": {
+          "name": "federation_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_actor_uri": {
+          "name": "federation_actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_in_reply_to": {
+          "name": "federation_in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_url": {
+          "name": "federation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_sensitive": {
+          "name": "federation_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_spoiler_text": {
+          "name": "federation_spoiler_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_poll_id": {
+          "name": "content_poll_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_article_id": {
+          "name": "content_article_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_article_title": {
+          "name": "content_article_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_article_excerpt": {
+          "name": "content_article_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_id": {
+          "name": "content_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_name": {
+          "name": "content_event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_date": {
+          "name": "content_event_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_location": {
+          "name": "content_event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_description": {
+          "name": "content_event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_id": {
+          "name": "content_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_title": {
+          "name": "content_room_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_status": {
+          "name": "content_room_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_topic": {
+          "name": "content_room_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_host": {
+          "name": "content_room_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_syra_id": {
+          "name": "content_podcast_syra_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_title": {
+          "name": "content_podcast_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_author": {
+          "name": "content_podcast_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_artwork_url": {
+          "name": "content_podcast_artwork_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_show_url": {
+          "name": "content_podcast_show_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_location_latitude": {
+          "name": "content_location_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_location_longitude": {
+          "name": "content_location_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_location_address": {
+          "name": "content_location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_geo": {
+          "name": "content_geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(content_location_longitude, content_location_latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "location_latitude": {
+          "name": "location_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_longitude": {
+          "name": "location_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_address": {
+          "name": "location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(location_longitude, location_latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "classification_topics": {
+          "name": "classification_topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_languages": {
+          "name": "classification_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_region": {
+          "name": "classification_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_hashtags_norm": {
+          "name": "classification_hashtags_norm",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_trend_terms": {
+          "name": "classification_trend_terms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_sensitive": {
+          "name": "classification_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_version": {
+          "name": "classification_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_sentiment": {
+          "name": "classification_sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'neutral'"
+        },
+        "classification_intent": {
+          "name": "classification_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "classification_score_toxicity": {
+          "name": "classification_score_toxicity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_constructiveness": {
+          "name": "classification_score_constructiveness",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_spam": {
+          "name": "classification_score_spam",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_quality": {
+          "name": "classification_score_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_controversy": {
+          "name": "classification_score_controversy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_negativity": {
+          "name": "classification_score_negativity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_status": {
+          "name": "classification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification_attempts": {
+          "name": "classification_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_classified_at": {
+          "name": "classification_classified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "posts_federation_activity_id_key": {
+          "name": "posts_federation_activity_id_key",
+          "columns": [
+            {
+              "expression": "federation_activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"federation_activity_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_public_chrono_v1": {
+          "name": "post_public_chrono_v1",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_roots_chrono_idx": {
+          "name": "posts_roots_chrono_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"is_reply\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_replies_chrono_v1": {
+          "name": "post_replies_chrono_v1",
+          "columns": [
+            {
+              "expression": "parent_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_links_chrono_v1": {
+          "name": "post_links_chrono_v1",
+          "columns": [
+            {
+              "expression": "has_links",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_owner_chrono_idx": {
+          "name": "posts_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_type_chrono_idx": {
+          "name": "posts_type_chrono_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_thread_idx": {
+          "name": "posts_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_boost_of_idx": {
+          "name": "posts_boost_of_idx",
+          "columns": [
+            {
+              "expression": "boost_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_one_boost_per_account_key": {
+          "name": "posts_one_boost_per_account_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "boost_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"type\" = 'boost' and \"posts\".\"boost_of\" is not null and \"posts\".\"federation_activity_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_quote_of_idx": {
+          "name": "posts_quote_of_idx",
+          "columns": [
+            {
+              "expression": "quote_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_scheduled_idx": {
+          "name": "posts_scheduled_idx",
+          "columns": [
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"status\" = 'scheduled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_owner_scheduled_v1": {
+          "name": "post_owner_scheduled_v1",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"status\" = 'scheduled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_lane_chrono_v1": {
+          "name": "post_lane_chrono_v1",
+          "columns": [
+            {
+              "expression": "lane_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"lane_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_hashtags_gin": {
+          "name": "posts_hashtags_gin",
+          "columns": [
+            {
+              "expression": "hashtags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_classification_topics_gin": {
+          "name": "posts_classification_topics_gin",
+          "columns": [
+            {
+              "expression": "classification_topics",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_classification_languages_gin": {
+          "name": "posts_classification_languages_gin",
+          "columns": [
+            {
+              "expression": "classification_languages",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_classification_trend_terms_gin": {
+          "name": "posts_classification_trend_terms_gin",
+          "columns": [
+            {
+              "expression": "classification_trend_terms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_classification_region_idx": {
+          "name": "posts_classification_region_idx",
+          "columns": [
+            {
+              "expression": "classification_region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_classification_queue_idx": {
+          "name": "posts_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_curated_idx": {
+          "name": "posts_curated_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"curated\" is true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_geo_gist": {
+          "name": "posts_geo_gist",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "posts_content_geo_gist": {
+          "name": "posts_content_geo_gist",
+          "columns": [
+            {
+              "expression": "content_geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_boost_of_posts_id_fk": {
+          "name": "posts_boost_of_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "boost_of"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_quote_of_posts_id_fk": {
+          "name": "posts_quote_of_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "quote_of"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_lane_id_lanes_id_fk": {
+          "name": "posts_lane_id_lanes_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "lanes",
+          "columnsFrom": [
+            "lane_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_parent_post_id_posts_id_fk": {
+          "name": "posts_parent_post_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "parent_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_thread_id_posts_id_fk": {
+          "name": "posts_thread_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "posts_created_at_ms_precision_check": {
+          "name": "posts_created_at_ms_precision_check",
+          "value": "\"posts\".\"created_at\" = date_trunc('milliseconds', \"posts\".\"created_at\")"
+        },
+        "posts_type_check": {
+          "name": "posts_type_check",
+          "value": "\"posts\".\"type\" in ('text', 'image', 'video', 'poll', 'boost', 'quote')"
+        },
+        "posts_visibility_check": {
+          "name": "posts_visibility_check",
+          "value": "\"posts\".\"visibility\" in ('public', 'followers_only', 'private')"
+        },
+        "posts_status_check": {
+          "name": "posts_status_check",
+          "value": "\"posts\".\"status\" in ('draft', 'published', 'scheduled', 'restricted')"
+        },
+        "posts_room_status_check": {
+          "name": "posts_room_status_check",
+          "value": "\"posts\".\"content_room_status\" is null or \"posts\".\"content_room_status\" in ('scheduled', 'live', 'ended')"
+        },
+        "posts_classification_status_check": {
+          "name": "posts_classification_status_check",
+          "value": "\"posts\".\"classification_status\" in ('pending', 'baseline', 'classified', 'failed')"
+        },
+        "posts_classification_sentiment_check": {
+          "name": "posts_classification_sentiment_check",
+          "value": "\"posts\".\"classification_sentiment\" in ('positive', 'neutral', 'negative', 'mixed')"
+        },
+        "posts_classification_intent_check": {
+          "name": "posts_classification_intent_check",
+          "value": "\"posts\".\"classification_intent\" in ('question', 'announcement', 'feedback', 'opinion', 'complaint', 'joke', 'news', 'personal_update', 'other')"
+        },
+        "posts_reply_permission_check": {
+          "name": "posts_reply_permission_check",
+          "value": "\"posts\".\"reply_permission\" <@ array['anyone', 'followers', 'following', 'mentioned', 'nobody']::text[]"
+        },
+        "posts_classification_scores_check": {
+          "name": "posts_classification_scores_check",
+          "value": "\"posts\".\"classification_score_toxicity\" between 0 and 1\n        and \"posts\".\"classification_score_constructiveness\" between 0 and 1\n        and \"posts\".\"classification_score_spam\" between 0 and 1\n        and \"posts\".\"classification_score_quality\" between 0 and 1\n        and \"posts\".\"classification_score_controversy\" between 0 and 1\n        and \"posts\".\"classification_score_negativity\" between 0 and 1\n        and \"posts\".\"classification_confidence\" between 0 and 1"
+        },
+        "posts_content_location_pair_check": {
+          "name": "posts_content_location_pair_check",
+          "value": "(\"posts\".\"content_location_latitude\" is null) = (\"posts\".\"content_location_longitude\" is null)"
+        },
+        "posts_location_pair_check": {
+          "name": "posts_location_pair_check",
+          "value": "(\"posts\".\"location_latitude\" is null) = (\"posts\".\"location_longitude\" is null)"
+        },
+        "posts_content_location_range_check": {
+          "name": "posts_content_location_range_check",
+          "value": "\"posts\".\"content_location_latitude\" is null or (\n        \"posts\".\"content_location_latitude\" between -90 and 90\n        and \"posts\".\"content_location_longitude\" between -180 and 180)"
+        },
+        "posts_location_range_check": {
+          "name": "posts_location_range_check",
+          "value": "\"posts\".\"location_latitude\" is null or (\n        \"posts\".\"location_latitude\" between -90 and 90\n        and \"posts\".\"location_longitude\" between -180 and 180)"
+        },
+        "posts_reply_discriminator_check": {
+          "name": "posts_reply_discriminator_check",
+          "value": "\"posts\".\"parent_post_id\" is null or \"posts\".\"is_reply\""
+        },
+        "posts_federated_reply_discriminator_check": {
+          "name": "posts_federated_reply_discriminator_check",
+          "value": "\"posts\".\"federation_in_reply_to\" is null or \"posts\".\"is_reply\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.poll_options": {
+      "name": "poll_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_options_poll_id_polls_id_fk": {
+          "name": "poll_options_poll_id_polls_id_fk",
+          "tableFrom": "poll_options",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_options_poll_id_position_key": {
+          "name": "poll_options_poll_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poll_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "poll_options_position_check": {
+          "name": "poll_options_position_check",
+          "value": "\"poll_options\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.poll_votes": {
+      "name": "poll_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "poll_votes_poll_id_idx": {
+          "name": "poll_votes_poll_id_idx",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "poll_votes_poll_id_user_id_idx": {
+          "name": "poll_votes_poll_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "poll_votes_option_id_poll_options_id_fk": {
+          "name": "poll_votes_option_id_poll_options_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "poll_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_votes_poll_id_polls_id_fk": {
+          "name": "poll_votes_poll_id_polls_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_votes_option_id_user_id_key": {
+          "name": "poll_votes_option_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "option_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_multiple_choice": {
+          "name": "is_multiple_choice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "polls_created_by_idx": {
+          "name": "polls_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "polls_ends_at_idx": {
+          "name": "polls_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "polls_post_id_idx": {
+          "name": "polls_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"polls\".\"post_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "polls_post_id_posts_id_fk": {
+          "name": "polls_post_id_posts_id_fk",
+          "tableFrom": "polls",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_authors": {
+      "name": "user_behavior_authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interaction_count": {
+          "name": "interaction_count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_interaction_at": {
+          "name": "last_interaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "boosts": {
+          "name": "boosts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "saves": {
+          "name": "saves",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shares": {
+          "name": "shares",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_behavior_authors_author_id_idx": {
+          "name": "user_behavior_authors_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_behavior_authors_behavior_id_user_behaviors_id_fk": {
+          "name": "user_behavior_authors_behavior_id_user_behaviors_id_fk",
+          "tableFrom": "user_behavior_authors",
+          "tableTo": "user_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_behavior_authors_behavior_id_author_id_key": {
+          "name": "user_behavior_authors_behavior_id_author_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "author_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_behavior_authors_weight_check": {
+          "name": "user_behavior_authors_weight_check",
+          "value": "\"user_behavior_authors\".\"weight\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_regions": {
+      "name": "user_behavior_regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_interaction_at": {
+          "name": "last_interaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_behavior_regions_behavior_id_user_behaviors_id_fk": {
+          "name": "user_behavior_regions_behavior_id_user_behaviors_id_fk",
+          "tableFrom": "user_behavior_regions",
+          "tableTo": "user_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_behavior_regions_behavior_id_region_key": {
+          "name": "user_behavior_regions_behavior_id_region_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "region"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_behavior_regions_count_check": {
+          "name": "user_behavior_regions_count_check",
+          "value": "\"user_behavior_regions\".\"count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_topics": {
+      "name": "user_behavior_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interaction_count": {
+          "name": "interaction_count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_interaction_at": {
+          "name": "last_interaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_behavior_topics_behavior_id_user_behaviors_id_fk": {
+          "name": "user_behavior_topics_behavior_id_user_behaviors_id_fk",
+          "tableFrom": "user_behavior_topics",
+          "tableTo": "user_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_behavior_topics_behavior_id_topic_key": {
+          "name": "user_behavior_topics_behavior_id_topic_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "topic"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_behavior_topics_weight_check": {
+          "name": "user_behavior_topics_weight_check",
+          "value": "\"user_behavior_topics\".\"weight\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_behaviors": {
+      "name": "user_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_post_type_text": {
+          "name": "preferred_post_type_text",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_post_type_image": {
+          "name": "preferred_post_type_image",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_post_type_video": {
+          "name": "preferred_post_type_video",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_post_type_poll": {
+          "name": "preferred_post_type_poll",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_hours": {
+          "name": "active_hours",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_languages": {
+          "name": "preferred_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_engagement_time": {
+          "name": "average_engagement_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skip_rate": {
+          "name": "skip_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completion_rate": {
+          "name": "completion_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hidden_authors": {
+          "name": "hidden_authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_authors": {
+          "name": "muted_authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_authors": {
+          "name": "blocked_authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden_topics": {
+          "name": "hidden_topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_behaviors_oxy_user_id_key": {
+          "name": "user_behaviors_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_behaviors_rates_check": {
+          "name": "user_behaviors_rates_check",
+          "value": "\"user_behaviors\".\"skip_rate\" between 0 and 1 and \"user_behaviors\".\"completion_rate\" between 0 and 1"
+        },
+        "user_behaviors_active_hours_check": {
+          "name": "user_behaviors_active_hours_check",
+          "value": "\"user_behaviors\".\"active_hours\" <@ array[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]::integer[]"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appearance_theme_mode": {
+          "name": "appearance_theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "appearance_primary_color": {
+          "name": "appearance_primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance_post_text_expand": {
+          "name": "appearance_post_text_expand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "appearance_post_read_more_action": {
+          "name": "appearance_post_read_more_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openPost'"
+        },
+        "appearance_collapse_long_bio": {
+          "name": "appearance_collapse_long_bio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "profile_header_image": {
+          "name": "profile_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_profile_visibility": {
+          "name": "privacy_profile_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "privacy_show_contact_info": {
+          "name": "privacy_show_contact_info",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_tags": {
+          "name": "privacy_allow_tags",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_mentions": {
+          "name": "privacy_allow_mentions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_show_online_status": {
+          "name": "privacy_show_online_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_hide_like_counts": {
+          "name": "privacy_hide_like_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_share_counts": {
+          "name": "privacy_hide_share_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_reply_counts": {
+          "name": "privacy_hide_reply_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_save_counts": {
+          "name": "privacy_hide_save_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_show_sensitive_content": {
+          "name": "privacy_show_sensitive_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hidden_words": {
+          "name": "privacy_hidden_words",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_restricted_users": {
+          "name": "privacy_restricted_users",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_subscribed_labelers": {
+          "name": "privacy_subscribed_labelers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_account_sign_posts": {
+          "name": "channel_account_sign_posts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_cover_photo_enabled": {
+          "name": "profile_cover_photo_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "profile_minimalist_mode": {
+          "name": "profile_minimalist_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_media_type": {
+          "name": "profile_media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_title": {
+          "name": "profile_media_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_artwork_url": {
+          "name": "profile_media_artwork_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_syra_track_id": {
+          "name": "profile_media_syra_track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_artist": {
+          "name": "profile_media_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_preview_url": {
+          "name": "profile_media_preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_start_sec": {
+          "name": "profile_media_start_sec",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_duration_sec": {
+          "name": "profile_media_duration_sec",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_syra_podcast_id": {
+          "name": "profile_media_syra_podcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_author": {
+          "name": "profile_media_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_show_url": {
+          "name": "profile_media_show_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interest_tags": {
+          "name": "interest_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_diversity_enabled": {
+          "name": "feed_diversity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "feed_same_author_penalty": {
+          "name": "feed_same_author_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.95
+        },
+        "feed_same_topic_penalty": {
+          "name": "feed_same_topic_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.92
+        },
+        "feed_max_consecutive_same_author": {
+          "name": "feed_max_consecutive_same_author",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_recency_half_life_hours": {
+          "name": "feed_recency_half_life_hours",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "feed_recency_max_age_hours": {
+          "name": "feed_recency_max_age_hours",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 168
+        },
+        "feed_min_engagement_rate": {
+          "name": "feed_min_engagement_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_boost_high_quality": {
+          "name": "feed_boost_high_quality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tuning_min_length_enabled": {
+          "name": "tuning_min_length_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_length": {
+          "name": "tuning_min_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_low_effort_gate_enabled": {
+          "name": "tuning_low_effort_gate_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_meaningful_text_length": {
+          "name": "tuning_min_meaningful_text_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_native_engagement_enabled": {
+          "name": "tuning_native_engagement_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_native_engagement": {
+          "name": "tuning_min_native_engagement",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_quality_enabled": {
+          "name": "tuning_min_quality_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_quality": {
+          "name": "tuning_min_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_push_enabled": {
+          "name": "notify_push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_email_enabled": {
+          "name": "notify_email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_likes": {
+          "name": "notify_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_boosts": {
+          "name": "notify_boosts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_follows": {
+          "name": "notify_follows",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_mentions": {
+          "name": "notify_mentions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_replies": {
+          "name": "notify_replies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_quotes": {
+          "name": "notify_quotes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "embed_youtube": {
+          "name": "embed_youtube",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_youtube_shorts": {
+          "name": "embed_youtube_shorts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_vimeo": {
+          "name": "embed_vimeo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_twitch": {
+          "name": "embed_twitch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_giphy": {
+          "name": "embed_giphy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_spotify": {
+          "name": "embed_spotify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_apple_music": {
+          "name": "embed_apple_music",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_soundcloud": {
+          "name": "embed_soundcloud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_flickr": {
+          "name": "embed_flickr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_bandcamp": {
+          "name": "embed_bandcamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fediverse_preferred_language": {
+          "name": "fediverse_preferred_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_oxy_user_id_key": {
+          "name": "user_settings_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_settings_theme_mode_check": {
+          "name": "user_settings_theme_mode_check",
+          "value": "\"user_settings\".\"appearance_theme_mode\" in ('light', 'dark', 'system', 'adaptive')"
+        },
+        "user_settings_post_text_expand_check": {
+          "name": "user_settings_post_text_expand_check",
+          "value": "\"user_settings\".\"appearance_post_text_expand\" in ('default', 'more', 'muchMore', 'all')"
+        },
+        "user_settings_post_read_more_action_check": {
+          "name": "user_settings_post_read_more_action_check",
+          "value": "\"user_settings\".\"appearance_post_read_more_action\" in ('openPost', 'expandInline')"
+        },
+        "user_settings_profile_visibility_check": {
+          "name": "user_settings_profile_visibility_check",
+          "value": "\"user_settings\".\"privacy_profile_visibility\" in ('public', 'private', 'followers_only')"
+        },
+        "user_settings_profile_media_type_check": {
+          "name": "user_settings_profile_media_type_check",
+          "value": "\"user_settings\".\"profile_media_type\" is null or \"user_settings\".\"profile_media_type\" in ('song', 'podcast')"
+        },
+        "user_settings_profile_media_shape_check": {
+          "name": "user_settings_profile_media_shape_check",
+          "value": "(\"user_settings\".\"profile_media_type\" is null\n          and \"user_settings\".\"profile_media_syra_track_id\" is null\n          and \"user_settings\".\"profile_media_syra_podcast_id\" is null)\n        or (\"user_settings\".\"profile_media_type\" = 'song'\n          and \"user_settings\".\"profile_media_syra_track_id\" is not null\n          and \"user_settings\".\"profile_media_preview_url\" is not null\n          and \"user_settings\".\"profile_media_syra_podcast_id\" is null)\n        or (\"user_settings\".\"profile_media_type\" = 'podcast'\n          and \"user_settings\".\"profile_media_syra_podcast_id\" is not null\n          and \"user_settings\".\"profile_media_show_url\" is not null\n          and \"user_settings\".\"profile_media_syra_track_id\" is null)"
+        },
+        "user_settings_feed_penalties_check": {
+          "name": "user_settings_feed_penalties_check",
+          "value": "\"user_settings\".\"feed_same_author_penalty\" between 0.5 and 1.0\n        and \"user_settings\".\"feed_same_topic_penalty\" between 0.5 and 1.0"
+        },
+        "user_settings_feed_recency_check": {
+          "name": "user_settings_feed_recency_check",
+          "value": "\"user_settings\".\"feed_recency_half_life_hours\" between 6 and 72\n        and \"user_settings\".\"feed_recency_max_age_hours\" between 24 and 336"
+        },
+        "user_settings_feed_min_engagement_check": {
+          "name": "user_settings_feed_min_engagement_check",
+          "value": "\"user_settings\".\"feed_min_engagement_rate\" is null or \"user_settings\".\"feed_min_engagement_rate\" between 0 and 1"
+        },
+        "user_settings_max_consecutive_same_author_check": {
+          "name": "user_settings_max_consecutive_same_author_check",
+          "value": "\"user_settings\".\"feed_max_consecutive_same_author\" is null\n        or \"user_settings\".\"feed_max_consecutive_same_author\" between 1 and 10"
+        },
+        "user_settings_external_embeds_check": {
+          "name": "user_settings_external_embeds_check",
+          "value": "(\"user_settings\".\"embed_youtube\" is null or \"user_settings\".\"embed_youtube\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_youtube_shorts\" is null or \"user_settings\".\"embed_youtube_shorts\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_vimeo\" is null or \"user_settings\".\"embed_vimeo\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_twitch\" is null or \"user_settings\".\"embed_twitch\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_giphy\" is null or \"user_settings\".\"embed_giphy\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_spotify\" is null or \"user_settings\".\"embed_spotify\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_apple_music\" is null or \"user_settings\".\"embed_apple_music\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_soundcloud\" is null or \"user_settings\".\"embed_soundcloud\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_flickr\" is null or \"user_settings\".\"embed_flickr\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_bandcamp\" is null or \"user_settings\".\"embed_bandcamp\" in ('show', 'hide'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_settings_label_actions": {
+      "name": "user_settings_label_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "settings_id": {
+          "name": "settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_id": {
+          "name": "labeler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_slug": {
+          "name": "label_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_label_actions_settings_id_user_settings_id_fk": {
+          "name": "user_settings_label_actions_settings_id_user_settings_id_fk",
+          "tableFrom": "user_settings_label_actions",
+          "tableTo": "user_settings",
+          "columnsFrom": [
+            "settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_label_actions_settings_labeler_slug_key": {
+          "name": "user_settings_label_actions_settings_labeler_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "settings_id",
+            "labeler_id",
+            "label_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_settings_label_actions_action_check": {
+          "name": "user_settings_label_actions_action_check",
+          "value": "\"user_settings_label_actions\".\"action\" in ('hide', 'warn', 'blur', 'show')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/meta/_journal.json
+++ b/packages/backend/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1785903871646,
       "tag": "0021_faithful_bloodstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1786042468188,
+      "tag": "0022_a_channel_queue_is_shared",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts
+++ b/packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts
@@ -1,0 +1,711 @@
+/**
+ * THE SHARED EDITORIAL QUEUE — `GET /posts/scheduled` for a channel's members.
+ *
+ * Several people publish under one channel's byline, so a queue only one of them
+ * can see is a queue two of them schedule into for the same Tuesday. This suite
+ * pins the two questions that feature turns on, and they have DIFFERENT answers:
+ *
+ *  - **Who may see the queue** — an ACTIVE member of the channel, and nobody
+ *    else. Answered by the one gate the write routes already use, never by a
+ *    second membership reader.
+ *  - **Who may see WHO QUEUED each entry** — exactly whoever the published post
+ *    would have named, which is `channel.signPosts`' decision and no new one.
+ *    A member of a channel that does not sign learns WHAT is queued and WHEN,
+ *    and nothing about the person who queued it.
+ *
+ * The second is the one that is easy to get wrong by accident, because the
+ * obvious implementation ("show the team who scheduled what") reads as helpful
+ * and quietly ends the anonymity of every channel that never opted in. It is
+ * also the direction that cannot be walked back: a name shown to colleagues has
+ * been shown.
+ *
+ * ## Everything Mention owns is REAL here
+ *
+ * The posts, the `user_settings` row carrying the consent flag, the query, the
+ * hydration ACL and the byline are all real; `listOperatedChannelIds` runs for
+ * real over a stubbed account forest, so the membership PREDICATE
+ * (`membershipAuthorizesActingFor`) is exercised rather than assumed. Only Oxy —
+ * a remote service — is mocked.
+ *
+ * That division matters for a consent gate. Stubbing the settings read would
+ * make the disclosure cases a test of the stub: the gate asks `user_settings` a
+ * question, and a mock answers it whether or not the query would have found the
+ * row — and "found nothing" is exactly what a broken consent read looks like
+ * from outside, while reading as ANONYMOUS and therefore passing.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AccountMember, AccountNode, User } from '@oxyhq/core';
+import type { CachedUserSummary } from '../../services/userSummaryCache';
+
+const { getUsersByIds, cacheStore, listAccounts, listAccountMembers, claim } = vi.hoisted(() => ({
+  getUsersByIds: vi.fn(),
+  cacheStore: new Map<string, CachedUserSummary>(),
+  listAccounts: vi.fn(),
+  listAccountMembers: vi.fn(),
+  claim: vi.fn(),
+}));
+
+// The publish PIPELINE (MTN record, federation fan-out, notifications) is the
+// subject of its own suites; what matters here is WHO may start it and WHICH
+// account it is claimed for, so the claim is observed rather than executed.
+vi.mock('../../services/PostCreationService', () => ({
+  postCreationService: { claimAndPublishScheduledPost: claim },
+}));
+
+vi.mock('../../runtime/socketServer', () => ({
+  getRuntimeSocketServer: () => undefined,
+}));
+
+// Oxy owns identity and the account graph, and is a remote service, so it stays
+// mocked. Everything Mention stores is real.
+vi.mock('../../runtime/oxyClient', () => ({
+  getRuntimeOxyClient: () => ({
+    getUserById: vi.fn(),
+    getUserFollowing: vi.fn(async () => []),
+    getUserFollowers: vi.fn(async () => []),
+  }),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    getUsersByIds,
+    getLinkPreviews: vi.fn(async () => ({})),
+    getFileDownloadUrl: (id: string) => `https://cdn.test/${id}`,
+  }),
+  // Hydration falls back to the service client when this is undefined, which is
+  // what keeps the identity batch on one stub.
+  createScopedOxyClient: () => undefined,
+  // The caller's own Oxy client. It carries BOTH account reads, because the two
+  // halves of this feature ask different questions of the account graph and a
+  // stub offering only one silently turns the other's refusals into 503s:
+  //
+  //  - `listAccounts` (the caller's forest) answers `listOperatedChannelIds`,
+  //    which is how the READ decides which queues to merge in;
+  //  - `listAccountMembers` (one account's roster) answers
+  //    `assertCanPublishAsAccount` behind `postManagementRefusal`, which is how
+  //    every WRITE decides.
+  //
+  // Both are derived from ONE fixture below, so the test cannot accidentally
+  // describe someone who reads a queue they may not act on, or the reverse.
+  createUserScopedOxyServices: (req: { user?: { id?: string } }) => ({
+    listAccounts: async () => listAccounts(req.user?.id),
+    listAccountMembers: async (accountId: string) => listAccountMembers(accountId),
+  }),
+}));
+
+vi.mock('../../utils/privacyHelpers', () => ({
+  getBlockedUserIds: vi.fn(async () => []),
+  getRestrictedUserIds: vi.fn(async () => []),
+  extractFollowingIds: vi.fn(() => []),
+  extractFollowersIds: vi.fn(() => []),
+}));
+
+vi.mock('../../services/userSummaryCache', () => ({
+  mget: vi.fn(async (ids: string[]) => {
+    const hits = new Map<string, CachedUserSummary>();
+    for (const id of ids) {
+      const hit = cacheStore.get(id);
+      if (hit) hits.set(id, hit);
+    }
+    return hits;
+  }),
+  mset: vi.fn(async (entries: Map<string, CachedUserSummary>) => {
+    for (const [id, value] of entries) cacheStore.set(id, value);
+  }),
+}));
+
+import { eq } from 'drizzle-orm';
+import type { HydratedPost } from '@mention/shared-types';
+import { closePostgres, connectPostgres, getDb } from '../../db/postgres';
+import { userSettings } from '../../db/schema/userProfile';
+import { clearServiceScope, seedPost, serviceScope } from '../helpers/serviceFixtures';
+import { PostHydrationService } from '../../services/PostHydrationService';
+import { getScheduledPosts, publishScheduledPostNow } from '../../controllers/posts.controller';
+import { loadPostRecord } from '../../db/posts/postRepository';
+
+const scope = serviceScope('channel-editorial-queue');
+const CHANNEL = scope.user('channel');
+/** The member who wrote the queued post. */
+const WRITER = scope.user('writer');
+/** A second member of the same channel, who wrote nothing. */
+const COLLEAGUE = scope.user('colleague');
+/** Not a member of anything. */
+const OUTSIDER = scope.user('outsider');
+/** A member whose invitation has not been accepted. */
+const INVITEE = scope.user('invitee');
+/** An account the caller operates that is NOT a channel. */
+const ORGANIZATION = scope.user('organization');
+
+const OPERATOR_PERMISSIONS = ['account:read', 'account:update', 'account:act_as', 'members:read'];
+
+function membership(
+  accountId: string,
+  memberUserId: string,
+  status: AccountMember['status'] = 'active',
+): AccountMember {
+  return {
+    _id: `member-${accountId}-${memberUserId}`,
+    accountId,
+    memberUserId,
+    role: 'owner',
+    permissions: OPERATOR_PERMISSIONS,
+    inherit: true,
+    status,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+/** A whole `User`, so no field has to be asserted into existence. */
+function account(accountId: string): User {
+  return {
+    id: accountId,
+    publicKey: `pk-${accountId}`,
+    username: accountId,
+    name: { displayName: accountId },
+  };
+}
+
+function node(
+  accountId: string,
+  kind: AccountNode['kind'],
+  callerMembership: AccountMember | null,
+): AccountNode {
+  return {
+    accountId,
+    kind,
+    parentAccountId: null,
+    account: account(accountId),
+    relationship: callerMembership ? 'member' : 'self',
+    callerMembership,
+  };
+}
+
+/**
+ * THE ONE ROSTER both account reads are derived from.
+ *
+ * WRITER and COLLEAGUE are active members of the channel; INVITEE has been asked
+ * and has not accepted. Deriving the forest AND the member list from this single
+ * fixture is what stops the suite describing an impossible person — someone the
+ * read admits and the write refuses, or the reverse — which is exactly the
+ * inconsistency this change exists to remove.
+ */
+const CHANNEL_ROSTER: ReadonlyArray<{ member: string; status: AccountMember['status'] }> = [
+  { member: WRITER, status: 'active' },
+  { member: COLLEAGUE, status: 'active' },
+  { member: INVITEE, status: 'invited' },
+];
+
+function membersOf(accountId: string): AccountMember[] {
+  if (accountId === CHANNEL) {
+    return CHANNEL_ROSTER.map((row) => membership(CHANNEL, row.member, row.status));
+  }
+  if (accountId === ORGANIZATION) {
+    return [membership(ORGANIZATION, WRITER), membership(ORGANIZATION, COLLEAGUE)];
+  }
+  return [];
+}
+
+/**
+ * What Oxy answers about one viewer's forest — the same roster, seen from the
+ * caller's side.
+ *
+ * The INVITEE is the discriminating fixture for the membership predicate: the
+ * channel IS in their forest, so a check that merely asked "is this account
+ * reachable" would admit them. Only the `status === 'active'` clause keeps them
+ * out. The ORGANIZATION is the same for the KIND clause — the caller may
+ * genuinely act for it, so only the `kind === 'channel'` filter excludes it.
+ */
+function forestFor(viewerId: string | undefined): AccountNode[] {
+  const own = node(viewerId ?? '', 'personal', null);
+  const channelRow = CHANNEL_ROSTER.find((row) => row.member === viewerId);
+  if (!channelRow) return [own];
+  const forest = [own, node(CHANNEL, 'channel', membership(CHANNEL, viewerId ?? '', channelRow.status))];
+  if (channelRow.status === 'active') {
+    forest.push(node(ORGANIZATION, 'organization', membership(ORGANIZATION, viewerId ?? '')));
+  }
+  return forest;
+}
+
+const IDENTITIES: Record<string, { kind: string }> = {
+  [CHANNEL]: { kind: 'channel' },
+  [WRITER]: { kind: 'personal' },
+  [COLLEAGUE]: { kind: 'personal' },
+  [OUTSIDER]: { kind: 'personal' },
+  [INVITEE]: { kind: 'personal' },
+  [ORGANIZATION]: { kind: 'organization' },
+};
+
+function later(minutes: number): Date {
+  return new Date(Date.now() + minutes * 60 * 1000);
+}
+
+/** One scheduled post owned by `owner`, optionally written by a human. */
+async function seedScheduled(options: {
+  owner: string;
+  writtenBy?: string;
+  inMinutes?: number;
+  text?: string;
+}): Promise<string> {
+  const record = await seedPost(scope, {
+    oxyUserId: options.owner,
+    authorship: [{ oxyUserId: options.owner, role: 'owner', status: 'accepted' }],
+    ...(options.writtenBy ? { writtenByOxyUserId: options.writtenBy } : {}),
+    status: 'scheduled',
+    scheduledFor: later(options.inMinutes ?? 60),
+    content: { variants: [{ source: 'author', text: options.text ?? 'a queued story', tag: 'en' }] },
+  });
+  return record.id;
+}
+
+/** Turn a channel's writer disclosure on, off, or to a hostile value. */
+async function setSignPosts(value: boolean | null): Promise<void> {
+  await getDb()
+    .insert(userSettings)
+    .values({ oxyUserId: CHANNEL, channelAccountSignPosts: value })
+    .onConflictDoUpdate({
+      target: userSettings.oxyUserId,
+      set: { channelAccountSignPosts: value },
+    });
+}
+
+function buildRequest(viewerId?: string) {
+  return {
+    params: {},
+    query: {},
+    headers: {},
+    acceptsLanguages: () => [] as string[],
+    ...(viewerId ? { user: { id: viewerId } } : {}),
+  };
+}
+
+interface Captured {
+  status?: number;
+  body?: { posts?: HydratedPost[]; message?: string };
+}
+
+function buildResponse(): { res: unknown; captured: Captured } {
+  const captured: Captured = {};
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return this;
+    },
+    json(body: Captured['body']) {
+      captured.body = body;
+      return this;
+    },
+  };
+  return { res, captured };
+}
+
+/** Drive the real handler and answer with the hydrated page. */
+async function fetchQueue(viewerId?: string): Promise<Captured> {
+  const { res, captured } = buildResponse();
+  await getScheduledPosts(buildRequest(viewerId) as never, res as never);
+  return captured;
+}
+
+function idsOf(captured: Captured): string[] {
+  return (captured.body?.posts ?? []).map((post) => post.id);
+}
+
+beforeAll(async () => {
+  await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+beforeEach(() => {
+  cacheStore.clear();
+  getUsersByIds.mockReset();
+  listAccounts.mockReset();
+  claim.mockReset();
+  listAccountMembers.mockReset();
+  listAccounts.mockImplementation(async (viewerId: string | undefined) => forestFor(viewerId));
+  listAccountMembers.mockImplementation(async (accountId: string) => membersOf(accountId));
+  getUsersByIds.mockImplementation(async (ids: string[]) =>
+    ids
+      .filter((id) => IDENTITIES[id])
+      .map((id) => ({
+        id,
+        username: id,
+        name: { displayName: id },
+        kind: IDENTITIES[id].kind,
+        verified: false,
+      })),
+  );
+});
+
+afterEach(async () => {
+  await getDb().delete(userSettings).where(eq(userSettings.oxyUserId, CHANNEL));
+  await clearServiceScope(scope);
+});
+
+describe('the shared editorial queue — who may READ it', () => {
+  it('gives a member the channel’s queue alongside their own posts', async () => {
+    const channelEntry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER, inMinutes: 30 });
+    const ownEntry = await seedScheduled({ owner: COLLEAGUE, inMinutes: 90 });
+
+    const page = await fetchQueue(COLLEAGUE);
+
+    // Soonest first, and the channel's entry is there even though COLLEAGUE did
+    // not write it — that is the whole feature.
+    expect(idsOf(page)).toEqual([channelEntry, ownEntry]);
+  });
+
+  it('names the CHANNEL as the author, so the client knows whose queue an entry is in', async () => {
+    await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    const page = await fetchQueue(COLLEAGUE);
+
+    // No separate `channel` field and no parallel notion of "queue": the post
+    // says which account it belongs to, because the channel IS its author.
+    expect(page.body?.posts?.[0]?.user.id).toBe(CHANNEL);
+  });
+
+  it('gives the WRITER their own channel post back', async () => {
+    // The bug this feature had to fix first, and it is not a narrow one. A
+    // channel AUTHORS its post, so `oxy_user_id` is an account nobody can sign in
+    // as — and the owner-scoped read returned this post to NOBODY, including the
+    // person who scheduled it. It could only ever leave the queue via the sweep.
+    const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    expect(idsOf(await fetchQueue(WRITER))).toEqual([entry]);
+  });
+
+  it('gives an OUTSIDER nothing of the channel’s', async () => {
+    await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+    const ownEntry = await seedScheduled({ owner: OUTSIDER });
+
+    const page = await fetchQueue(OUTSIDER);
+
+    expect(idsOf(page)).toEqual([ownEntry]);
+  });
+
+  it('refuses a member whose invitation is not yet ACCEPTED', async () => {
+    // The discriminating fixture for the membership predicate: the channel IS in
+    // this caller's forest, so anything that merely asked "can you reach this
+    // account" would admit them. Only `status === 'active'` keeps them out.
+    await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    expect(idsOf(await fetchQueue(INVITEE))).toEqual([]);
+  });
+
+  it('does NOT fold in an organization the caller may act for', async () => {
+    // The kind clause on its own. A channel's queue is shared because a channel
+    // cannot be acted as, so its members have no other way in. An organization
+    // CAN be acted as, and widening this to it would be a decision nobody made.
+    await seedScheduled({ owner: ORGANIZATION });
+    const ownEntry = await seedScheduled({ owner: COLLEAGUE });
+
+    expect(idsOf(await fetchQueue(COLLEAGUE))).toEqual([ownEntry]);
+  });
+
+  it('degrades to the personal queue when Oxy cannot answer', async () => {
+    // `listOperatedChannelIds` fails soft, so an account-graph outage costs a
+    // member the shared half rather than 500-ing the composer. It can never ADD
+    // an account, which is the direction that would matter.
+    listAccounts.mockRejectedValue(new Error('oxy is down'));
+    await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+    const ownEntry = await seedScheduled({ owner: COLLEAGUE });
+
+    const page = await fetchQueue(COLLEAGUE);
+
+    expect(idsOf(page)).toEqual([ownEntry]);
+    expect(page.status).toBeUndefined();
+  });
+
+  it('still refuses an unauthenticated caller with a 401', async () => {
+    await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    const page = await fetchQueue(undefined);
+
+    expect(page.status).toBe(401);
+    expect(listAccounts).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * PUBLISHING AN ENTRY EARLY — the write half, which had to be decided in the
+ * same change as the read.
+ *
+ * Widening one alone breaks `affordance ⊆ permission` in whichever direction it
+ * is left, so this pins that seeing and acting are the SAME right. They can be,
+ * and should be, because membership is the strongest right that exists over a
+ * channel — it can never be acted as, so there is nothing stronger to demand of
+ * whoever sends an entry early than of whoever reads it.
+ *
+ * The read was in fact the NARROW half before this: `DELETE /posts/:id` already
+ * let any active member CANCEL a channel's scheduled post, through the same
+ * `postManagementRefusal` used here. So this endpoint was the one management
+ * action still keyed on the caller, and a member could destroy a queued post
+ * they were unable to see or send.
+ *
+ * The load-bearing assertion is WHICH ACCOUNT the claim names. The claim is an
+ * atomic `status = 'scheduled' AND oxy_user_id = ?` update, and that owner is the
+ * CHANNEL — passing the caller (as this did) matched no row, so the post was
+ * unpublishable by everybody while the 409/404 told them it did not exist.
+ */
+describe('the shared editorial queue — publishing an entry early', () => {
+  async function publishAs(viewerId: string | undefined, postId: string): Promise<Captured> {
+    const { res, captured } = buildResponse();
+    const req = { ...buildRequest(viewerId), params: { id: postId } };
+    await publishScheduledPostNow(req as never, res as never);
+    return captured;
+  }
+
+  it('lets a member send a channel’s entry early, claimed AS THE CHANNEL', async () => {
+    const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+    claim.mockImplementation(async ({ postId }: { postId: string }) => {
+      const record = await loadPostRecord(postId);
+      return record ? { ...record, status: 'published' } : null;
+    });
+
+    // COLLEAGUE did not write it — they are simply on the team.
+    const response = await publishAs(COLLEAGUE, entry);
+
+    expect(response.status).toBeUndefined();
+    expect(claim).toHaveBeenCalledWith({ postId: entry, ownerId: CHANNEL });
+  });
+
+  it('publishes a channel’s whole scheduled THREAD, root first', async () => {
+    // The fixture that tells the chain walk's owner apart, and without it a
+    // mutation survives: a LONE scheduled post walks to itself whatever account
+    // the walk is scoped to (no parent to climb, no children to match), so every
+    // other case here is blind to that argument. Scoped to the caller instead of
+    // the channel, the descendant query matches nothing and only the root goes
+    // out — a thread published half-way, stopping mid-sentence until the
+    // continuation's own time comes round.
+    const root = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER, text: 'part one' });
+    const continuation = await seedPost(scope, {
+      oxyUserId: CHANNEL,
+      authorship: [{ oxyUserId: CHANNEL, role: 'owner', status: 'accepted' }],
+      writtenByOxyUserId: WRITER,
+      status: 'scheduled',
+      scheduledFor: later(60),
+      parentPostId: root,
+      content: { variants: [{ source: 'author', text: 'part two', tag: 'en' }] },
+    });
+    claim.mockImplementation(async ({ postId }: { postId: string }) => {
+      const record = await loadPostRecord(postId);
+      return record ? { ...record, status: 'published' } : null;
+    });
+
+    await publishAs(COLLEAGUE, root);
+
+    expect(claim.mock.calls.map((call) => call[0])).toEqual([
+      { postId: root, ownerId: CHANNEL },
+      { postId: continuation.id, ownerId: CHANNEL },
+    ]);
+  });
+
+  it('refuses an OUTSIDER with a 404 and never reaches the claim', async () => {
+    const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    const response = await publishAs(OUTSIDER, entry);
+
+    expect(response.status).toBe(404);
+    // The refusal is a 404 rather than a 403 precisely so it cannot be used to
+    // confirm that somebody else's unpublished post exists.
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  it('refuses a member whose invitation is not yet ACCEPTED', async () => {
+    const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    expect((await publishAs(INVITEE, entry)).status).toBe(404);
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  it('still refuses an unauthenticated caller with a 401', async () => {
+    const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    expect((await publishAs(undefined, entry)).status).toBe(401);
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: an ordinary author still publishes their OWN post, claimed as themselves', async () => {
+    // Without this, every assertion above would pass on a handler that had
+    // stopped letting anybody publish anything.
+    const entry = await seedScheduled({ owner: OUTSIDER });
+    claim.mockImplementation(async ({ postId }: { postId: string }) => {
+      const record = await loadPostRecord(postId);
+      return record ? { ...record, status: 'published' } : null;
+    });
+
+    const response = await publishAs(OUTSIDER, entry);
+
+    expect(response.status).toBeUndefined();
+    expect(claim).toHaveBeenCalledWith({ postId: entry, ownerId: OUTSIDER });
+  });
+});
+
+/**
+ * THE ACL UNDERNEATH, asked WITHOUT the operated-account set.
+ *
+ * This block exists because a mutation SURVIVED without it. Every case above
+ * reaches the queue through the endpoint, which resolves the caller's channels
+ * and hands them to hydration — so the writer is admitted by `operatedAccountIds`
+ * and the writer clause beside it never decides anything. Deleting
+ * `canManagePostWithoutLookup` from the ACL left all twelve of them green.
+ *
+ * The distinguishing shape is the one the endpoint can never produce: hydration
+ * asked with NO operated accounts, which is every other surface in the
+ * application (post detail, a thread, a notification embed) because resolving
+ * that set costs an Oxy round trip nothing else may pay. There the writer clause
+ * is the only thing standing between a person and their OWN unpublished writing.
+ *
+ * It also settles a real incoherence rather than adding a capability: `isOwner`
+ * on the DTO already comes from `canManagePostWithoutLookup`, so before this the
+ * two could disagree — the summary would have said "you own this post" about one
+ * the same service refused to return.
+ */
+describe('the hydration ACL on an unpublished channel post', () => {
+  const service = new PostHydrationService();
+
+  async function hydrateAs(viewerId: string | undefined) {
+    const post = await seedPost(scope, {
+      oxyUserId: CHANNEL,
+      authorship: [{ oxyUserId: CHANNEL, role: 'owner', status: 'accepted' }],
+      writtenByOxyUserId: WRITER,
+      status: 'scheduled',
+      scheduledFor: later(60),
+      content: { variants: [{ source: 'author', text: 'a queued story', tag: 'en' }] },
+    });
+    // No `operatedAccountIds` — the defaults every other caller hydrates with.
+    return service.hydratePosts([post], { viewerId, maxDepth: 0 });
+  }
+
+  it('lets the WRITER read their own unpublished channel post', async () => {
+    expect(await hydrateAs(WRITER)).toHaveLength(1);
+  });
+
+  it('refuses a colleague who operates the channel but did not write it', async () => {
+    // Not a permission judgement — they DO operate it. It is that this surface
+    // never asked Oxy, so it cannot know. The endpoint that does ask admits them
+    // (see the read cases above), which is what keeps affordance ⊆ permission:
+    // narrower without the answer, never wider.
+    expect(await hydrateAs(COLLEAGUE)).toHaveLength(0);
+  });
+
+  it('refuses an outsider and an anonymous reader', async () => {
+    expect(await hydrateAs(OUTSIDER)).toHaveLength(0);
+    expect(await hydrateAs(undefined)).toHaveLength(0);
+  });
+});
+
+/**
+ * WHO QUEUED IT.
+ *
+ * The queue makes NO new disclosure: an entry names its writer exactly when the
+ * published post would have, which is `channel.signPosts`. The mechanism is the
+ * same one — these posts go through `PostHydrationService` like every other
+ * listing — so there is no second consent gate here to drift from the first.
+ *
+ * Each case below asserts BOTH halves, because either alone is satisfiable by a
+ * broken implementation: that the entry is present (so a suite cannot pass by
+ * returning nothing) and that the writer is or is not named.
+ */
+describe('the shared editorial queue — who may see WHO QUEUED an entry', () => {
+  it('names the writer to the team when the channel signs its posts', async () => {
+    await setSignPosts(true);
+    await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    const page = await fetchQueue(COLLEAGUE);
+    const entry = page.body?.posts?.[0];
+
+    // The channel stays the signature; the writer is a SECOND author, drawn by
+    // the byline the collaborative header already knows how to render.
+    expect(entry?.user.id).toBe(CHANNEL);
+    expect(entry?.authors.map((author) => [author.id, author.role])).toEqual([
+      [CHANNEL, 'owner'],
+      [WRITER, 'writer'],
+    ]);
+  });
+
+  it('tells a member WHAT is queued and WHEN, but not WHO, when the channel does not sign', async () => {
+    // THE CASE THE FEATURE LIVES OR DIES ON.
+    //
+    // A queue that says "scheduled by Ana" discloses authorship for a post that
+    // has not published, and would do it for a channel that deliberately never
+    // names anybody. `signPosts` protects anonymity FROM READERS — and a channel's
+    // own members are readers of this surface, which is why the notification
+    // inbox refuses the same disclosure to the same audience. So the shared queue
+    // is genuinely shared, and genuinely anonymous, at the same time: the
+    // collision this feature exists to prevent is answered by the CONTENT and the
+    // TIME, neither of which is a name.
+    await setSignPosts(false);
+    const entry = await seedScheduled({
+      owner: CHANNEL,
+      writtenBy: WRITER,
+      text: 'the Tuesday story',
+    });
+
+    const page = await fetchQueue(COLLEAGUE);
+
+    // The entry IS there — the queue is shared. Without this the assertion below
+    // would pass on a handler that had simply stopped returning anything.
+    expect(idsOf(page)).toEqual([entry]);
+    expect(page.body?.posts?.[0]?.authors.map((author) => author.id)).toEqual([CHANNEL]);
+    // And the writer is nowhere in the payload, under any key. `writtenByOxyUserId`
+    // is deliberately absent from every DTO; a queue must not be the exception.
+    expect(JSON.stringify(page.body)).not.toContain(WRITER);
+  });
+
+  it('withholds the writer from a channel with no settings row at all', async () => {
+    const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+
+    const page = await fetchQueue(COLLEAGUE);
+
+    expect(idsOf(page)).toEqual([entry]);
+    expect(JSON.stringify(page.body)).not.toContain(WRITER);
+  });
+
+  /**
+   * THE TRUTHY-NON-BOOLEAN FIXTURE IS DELIBERATELY NOT HERE, and it is worth
+   * saying why rather than leaving a reader to notice the gap.
+   *
+   * The ecosystem rule asks any `x === true` check for a fixture in the one shape
+   * that tells it from `Boolean(x)` — a truthy non-boolean like `'false'` — since
+   * `true`, `false` and absent all agree. `disclosesWriters` reads exactly that
+   * way, and the fixture exists: `services/postHydrationChannelWriter.test.ts`
+   * stages it and is mutation-tested on it.
+   *
+   * It cannot be reproduced HERE, because this suite's whole value is that the
+   * settings row is REAL — and `user_settings.channel_account_sign_posts` is a
+   * Postgres `boolean`, so the column itself refuses every value that would make
+   * the strict and loose reads disagree. Writing one would mean going around the
+   * schema, which would be testing a state the database cannot hold.
+   *
+   * The two suites are therefore doing different jobs on purpose: that one owns
+   * the DECISION against arbitrary staged values, this one owns the QUERY that
+   * fetches the real row and the SURFACE that honours it. Do not "complete" this
+   * file by adding a fake row — it would make the settings read a stub again, and
+   * a consent read that silently finds nothing reads as anonymous and passes.
+   */
+
+  it('does not name a non-signing channel’s writer even when they are already resolved', async () => {
+    // Withholding the id from the identity batch is what usually makes disclosure
+    // impossible, which leaves the byline's own check unfalsifiable. It stops
+    // being unfalsifiable the moment the writer is in the batch for another
+    // reason — and the most ordinary reason there is, on THIS surface, is that
+    // they have a scheduled post of their own in the same queue.
+    await setSignPosts(false);
+    const channelEntry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER, inMinutes: 30 });
+    const ownEntry = await seedScheduled({ owner: WRITER, inMinutes: 90 });
+
+    const page = await fetchQueue(WRITER);
+
+    expect(idsOf(page)).toEqual([channelEntry, ownEntry]);
+    const channelPost = page.body?.posts?.find((post) => post.user.id === CHANNEL);
+    expect(channelPost?.authors.map((author) => author.id)).toEqual([CHANNEL]);
+    // Vacuity floor: the writer really was resolved in this batch (their own post
+    // names them), so the assertion above is the byline refusing to name them and
+    // not an identity that was merely unavailable.
+    expect(page.body?.posts?.find((post) => post.user.id === WRITER)?.user.username).toBe(WRITER);
+  });
+});

--- a/packages/backend/src/__tests__/controllers/getScheduledPosts.test.ts
+++ b/packages/backend/src/__tests__/controllers/getScheduledPosts.test.ts
@@ -33,10 +33,18 @@ const hoisted = vi.hoisted(() => ({
   hydratePosts: vi.fn(),
   createScopedOxyClient: vi.fn(),
   resolveUserSummaries: vi.fn(),
+  listAccounts: vi.fn(),
 }));
 
 vi.mock('../../utils/oxyHelpers', () => ({
   createScopedOxyClient: hoisted.createScopedOxyClient,
+  // The reader `listOperatedChannelIds` is asked with. This file is about the
+  // PERSONAL half of the read, so the forest is empty by default and the union
+  // below collapses to the caller — the shared editorial queue is the subject of
+  // `channelEditorialQueue.test.ts`, which drives the real membership predicate.
+  createUserScopedOxyServices: () => ({
+    listAccounts: async () => hoisted.listAccounts(),
+  }),
 }));
 
 vi.mock('../../services/PostHydrationService', () => ({
@@ -118,6 +126,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   hoisted.createScopedOxyClient.mockReturnValue(undefined);
   hoisted.hydratePosts.mockResolvedValue([]);
+  hoisted.listAccounts.mockResolvedValue([]);
 });
 
 afterEach(async () => {

--- a/packages/backend/src/__tests__/controllers/updatePostScheduledWindow.test.ts
+++ b/packages/backend/src/__tests__/controllers/updatePostScheduledWindow.test.ts
@@ -31,6 +31,7 @@ const hoisted = vi.hoisted(() => ({
   autoAcceptInvites: vi.fn(),
   notifyPendingInvites: vi.fn(),
   emitPostCreated: vi.fn(),
+  listAccountMembers: vi.fn(),
 }));
 
 /**
@@ -45,7 +46,13 @@ const hoisted = vi.hoisted(() => ({
  */
 vi.mock('../../utils/oxyHelpers', () => ({
   createScopedOxyClient: hoisted.createScopedOxyClient,
-  createUserScopedOxyServices: vi.fn(() => undefined),
+  // A real member reader, because the CHANNEL case below is authorized through
+  // `postManagementRefusal` rather than by owning the row. Every other case in
+  // this file edits its own post, which `canManagePostWithoutLookup` settles
+  // before any account read — so none of them reaches this.
+  createUserScopedOxyServices: vi.fn(() => ({
+    listAccountMembers: (accountId: string) => hoisted.listAccountMembers(accountId),
+  })),
 }));
 
 vi.mock('../../services/PostHydrationService', () => ({
@@ -386,5 +393,66 @@ describe('updatePost — rescheduling moves the whole thread', () => {
 
     expect(await scheduledTimes()).toEqual(before);
     expect(await storedText()).toBe('reworded');
+  });
+
+  /**
+   * A CHANNEL'S thread, moved by a member who is not its owner.
+   *
+   * The chain is walked as the post's OWNER, never as the caller, and a channel
+   * is the one case where those differ: a channel AUTHORS its own posts and no
+   * session can ever be one. Scoped to the caller, the descendant query matched
+   * nothing, so the edited post moved alone and its continuations stayed where
+   * they were — silently producing the exact split queue this whole block exists
+   * to prevent, with no error and nothing in the response to suggest it.
+   *
+   * The caller's RIGHT to be here is a separate question, already settled by
+   * `postManagementRefusal` above; this is only about which account's chain the
+   * walk names.
+   */
+  it('carries a CHANNEL’s continuations, walked as the channel and not the caller', async () => {
+    const channel = scope.user('channel');
+    const member = scope.user('channel-member');
+    hoisted.resolveUserSummaries.mockResolvedValue(
+      new Map([[channel, { user: { id: channel, username: 'thechannel', kind: 'channel' } }]]),
+    );
+    hoisted.listAccountMembers.mockResolvedValue([
+      {
+        _id: `member-${channel}-${member}`,
+        accountId: channel,
+        memberUserId: member,
+        role: 'editor',
+        permissions: ['account:read', 'account:act_as'],
+        inherit: true,
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    await seedTarget({
+      oxyUserId: channel,
+      writtenByOxyUserId: scope.user('some-writer'),
+      status: 'scheduled',
+      scheduledFor: ORIGINAL_TIME(),
+    });
+    const continuation = await seedPost(scope, {
+      oxyUserId: channel,
+      status: 'scheduled',
+      scheduledFor: ORIGINAL_TIME(),
+      parentPostId: POST_ID,
+    });
+    continuationIds = [continuation.id];
+
+    const later = new Date(Date.now() + 4 * HOUR_MS);
+    const { res, captured } = buildResponse();
+
+    await updatePost(
+      buildRequest({ scheduledFor: later.toISOString() }, { id: member }) as never,
+      res as never,
+    );
+
+    expect(captured.status).toBeUndefined();
+    expect((await stored())?.scheduledFor?.toISOString()).toBe(later.toISOString());
+    expect(await scheduledTimes()).toEqual([later.toISOString()]);
   });
 });

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -87,6 +87,7 @@ import type { AccountKind } from '@oxyhq/contracts';
 import {
   assertCanPublishAsAccount,
   cacheAccountMemberReads,
+  listOperatedChannelIds,
   PublishAsAccessError,
 } from '../services/publishAsAccount';
 import { postManagementRefusal } from '../services/postManagementAccess';
@@ -2067,8 +2068,16 @@ export const updatePost = async (req: AuthRequest, res: Response) => {
     // parent is still scheduled simply waits — but it would show the author a
     // queue with three different times for one thread and publish it in dribs.
     // After the write, so a failed edit cannot move anything.
+    //
+    // Scoped to the post's OWNER, never the caller. A channel's thread is owned
+    // by the channel, so walking it as the caller matched nothing and moved the
+    // edited post alone — silently producing the exact split queue this block
+    // exists to prevent, with no error anywhere. The caller's right to be here at
+    // all was settled by `postManagementRefusal` above; this only has to name the
+    // account whose chain it is.
     if (rescheduledTo) {
-      const chain = await loadScheduledChain(post.id, userId);
+      const chainOwnerId = post.oxyUserId ? String(post.oxyUserId) : userId;
+      const chain = await loadScheduledChain(post.id, chainOwnerId);
       if (chain.ok) {
         const others = chain.postIds.filter((id) => id !== post.id);
         if (others.length > 0) {
@@ -2077,7 +2086,7 @@ export const updatePost = async (req: AuthRequest, res: Response) => {
             .set({ scheduledFor: rescheduledTo })
             .where(and(
               inArray(postsTable.id, others),
-              eq(postsTable.oxyUserId, userId),
+              eq(postsTable.oxyUserId, chainOwnerId),
               eq(postsTable.status, 'scheduled'),
             ));
         }
@@ -3197,10 +3206,18 @@ export const getDrafts = async (req: AuthRequest, res: Response) => {
  * exact method rather than reimplementing publishing in a controller; the post
  * takes the identical pipeline, only sooner.
  *
- * Ownership and the publish decision are both server-side and both inside ONE
- * atomic claim: the update filters on `oxyUserId` AND `status: 'scheduled'`, so a
- * non-owner cannot publish someone else's post, and nothing can publish twice —
- * not even the sweep running concurrently, which selects on the same filter.
+ * The publish decision stays inside ONE atomic claim: the update filters on the
+ * post's OWNER and `status: 'scheduled'`, so nothing can publish twice — not even
+ * the sweep running concurrently, which selects on the same filter.
+ *
+ * **The owner is the post's `oxyUserId`, which is NOT the caller.** For a channel
+ * post it is the channel — an account nobody can be signed in as — so passing the
+ * caller here (as this did) made every channel's scheduled post unpublishable by
+ * everybody, the writer included, while `DELETE /posts/:id` had already been
+ * widened to let any member CANCEL that same post. Authorization is therefore
+ * asked SEPARATELY, of `postManagementRefusal` — the one authority the other six
+ * management routes use — and the owner it resolves is what scopes the claim. The
+ * claim is no weaker for it: it still names one exact account, just the right one.
  *
  * **Publishing one post of a scheduled THREAD publishes the thread.** Its posts
  * are replies to one another, so there is no coherent way to send just one:
@@ -3216,7 +3233,37 @@ export const publishScheduledPostNow = async (req: AuthRequest, res: Response) =
     }
 
     const targetId = String(req.params.id);
-    const chain = await loadScheduledChain(targetId, userId);
+
+    // Two columns, not a whole `PostRecord`: this read only has to answer "may
+    // the caller manage this post, and whose queue is it in". Assembling the
+    // content graph for that would be nine joins on the way to a decision that
+    // reads neither. Same shape, and the same order, as `deletePost`.
+    const [target] = await getDb()
+      .select({
+        oxyUserId: postsTable.oxyUserId,
+        writtenByOxyUserId: postsTable.writtenByOxyUserId,
+      })
+      .from(postsTable)
+      .where(eq(postsTable.id, targetId))
+      .limit(1);
+    if (!target) {
+      return res.status(404).json({ message: 'Post not found' });
+    }
+    const publishRefusal = await postManagementRefusal({
+      post: target,
+      callerId: userId,
+      memberReader: createUserScopedOxyServices(req),
+    });
+    if (publishRefusal) {
+      return res.status(publishRefusal.status).json({ message: publishRefusal.message });
+    }
+    // The account the chain and the claim are scoped to. Falls back to the caller
+    // only for a post with no owner at all, which is a federated row — one that
+    // `postManagementRefusal` has already refused above, so this is a total
+    // function rather than a reachable branch.
+    const ownerId = target.oxyUserId ? String(target.oxyUserId) : userId;
+
+    const chain = await loadScheduledChain(targetId, ownerId);
     if (!chain.ok) {
       return res.status(409).json({
         message: 'This post continues a thread that has not been published yet.',
@@ -3228,7 +3275,7 @@ export const publishScheduledPostNow = async (req: AuthRequest, res: Response) =
     // scheduled and publishes at its own time, still in order.
     let published: PostRecord | null = null;
     for (const postId of chain.postIds) {
-      const result = await postCreationService.claimAndPublishScheduledPost({ postId, ownerId: userId });
+      const result = await postCreationService.claimAndPublishScheduledPost({ postId, ownerId });
       if (postId === targetId) {
         published = result;
       }
@@ -3238,16 +3285,17 @@ export const publishScheduledPostNow = async (req: AuthRequest, res: Response) =
     }
 
     if (!published) {
-      // The claim missed. Tell the OWNER why — a post of theirs that already
-      // went out is a different situation from one that never existed — but only
-      // after proving ownership, so this can never confirm the existence of
-      // someone else's post.
+      // The claim missed. Tell the caller why — a post that already went out is a
+      // different situation from one that never existed — which is safe to
+      // distinguish here because `postManagementRefusal` above has already
+      // established they may manage this post. Scoped to the resolved OWNER, so
+      // it still reports on the row the claim actually tried.
       const [own] = await getDb()
         .select({ status: postsTable.status })
         .from(postsTable)
         .where(and(
-          eq(postsTable.id, String(req.params.id)),
-          eq(postsTable.oxyUserId, userId),
+          eq(postsTable.id, targetId),
+          eq(postsTable.oxyUserId, ownerId),
         ))
         .limit(1);
       if (own && own.status === 'published') {
@@ -3279,19 +3327,54 @@ export const publishScheduledPostNow = async (req: AuthRequest, res: Response) =
 };
 
 /**
- * The caller's own pending scheduled posts, soonest first.
+ * The pending scheduled posts this caller can act on, soonest first: their own,
+ * plus the SHARED EDITORIAL QUEUE of every channel they operate.
  *
- * Hydrated like every other post listing, so the composer can PREVIEW one
- * through the same renderer the feed uses — media resolved to display URLs,
- * author, poll, quote and language variants all built by the one service that
- * knows how. Serving raw lean documents here (as this did) forced the client to
- * reimplement a slice of hydration, which drifts the moment either side changes.
+ * ## Why the channel half exists
  *
- * Access control is enforced TWICE, both server-side: the query is scoped to
- * `oxyUserId`, and `PostHydrationService` — the single ACL authority — drops any
- * post whose `status` is not `published` for a viewer who does not own it. A
- * non-owner therefore cannot obtain a scheduled post here even if the query
- * scoping were ever loosened.
+ * Several people publish under one channel's byline, and scheduling was private
+ * to each author — so two writers could schedule a story for the same Tuesday and
+ * neither would know. Worse, and measured rather than inferred: a channel AUTHORS
+ * its own posts, so a scheduled channel post carries the CHANNEL as `oxy_user_id`
+ * — an account nobody can sign in as — and the owner-scoped query below returned
+ * it to NOBODY, *including the person who scheduled it*. It could only ever leave
+ * the queue via the 60-second sweep.
+ *
+ * ## Whose queue an entry belongs to is already in the DTO
+ *
+ * Each post's `user` IS its authoring account, so the client groups by
+ * `post.user.id` with no extra field, no second request and no parallel notion of
+ * "queue" to keep in sync with the posts themselves.
+ *
+ * ## Access control, still enforced twice and now agreeing
+ *
+ * The query admits an account only after {@link listOperatedChannelIds} confirms
+ * an ACTIVE membership through the caller's OWN bearer, and hydration — the
+ * single ACL authority — is told the same set, so a post reaches the response
+ * only if BOTH agree. The two gates are fed from one resolution, so they cannot
+ * drift; loosening the query alone would still return nothing.
+ *
+ * Fail-soft to `[]` (that resolver's own contract), so an Oxy outage degrades
+ * this to the personal queue it has always been rather than 500-ing the
+ * composer. It can never ADD an account, which is the direction that would
+ * matter.
+ *
+ * ## Seeing and acting are the SAME right here, deliberately
+ *
+ * Membership is the strongest right that exists over a channel — it can never be
+ * acted as — so there is nothing stronger to demand of someone publishing an
+ * entry early than of someone reading it. `postManagementRefusal` already lets
+ * any active member DELETE and EDIT these exact posts, so this restores
+ * `affordance ⊆ permission` rather than stretching it: the read had been the
+ * narrow half, not the wide one.
+ *
+ * ## WHO QUEUED IT is `signPosts`' decision, and is not made here
+ *
+ * These are hydrated by the same `PostHydrationService` as every other listing,
+ * so an entry names its writer in `authors[]` exactly when the channel signs its
+ * posts, and `writtenByOxyUserId` never crosses the wire either way. This surface
+ * therefore makes NO new disclosure: it shows a member precisely what the
+ * published post would have shown them.
  */
 export const getScheduledPosts = async (req: AuthRequest, res: Response) => {
   try {
@@ -3300,8 +3383,16 @@ export const getScheduledPosts = async (req: AuthRequest, res: Response) => {
       return res.status(401).json({ message: 'Unauthorized' });
     }
 
+    // ONE resolution feeding both gates below. Asked with the caller's own client
+    // because `GET /accounts` is anchored on the authenticated operator — a
+    // service credential cannot ask "which accounts does person X operate" at all.
+    const operatedChannelIds = await listOperatedChannelIds(createUserScopedOxyServices(req));
+
     const scheduledPosts = await findPostRecords(
-      and(eq(postsTable.oxyUserId, userId), eq(postsTable.status, 'scheduled')),
+      and(
+        inArray(postsTable.oxyUserId, [userId, ...operatedChannelIds]),
+        eq(postsTable.status, 'scheduled'),
+      ),
       { orderBy: [asc(postsTable.scheduledFor), asc(postsTable.id)] },
     );
 
@@ -3311,6 +3402,7 @@ export const getScheduledPosts = async (req: AuthRequest, res: Response) => {
       requestLanguages: requestLanguageCandidates(req),
       maxDepth: 1,
       includeLinkMetadata: true,
+      operatedAccountIds: operatedChannelIds,
     });
 
     res.json({ posts: hydratedPosts });

--- a/packages/backend/src/db/schema/posts.ts
+++ b/packages/backend/src/db/schema/posts.ts
@@ -662,6 +662,35 @@ export const posts = pgTable(
       .where(sql`${t.status} = 'scheduled'`),
 
     /**
+     * ONE ACCOUNT'S QUEUE — `GET /posts/scheduled`, which reads the caller's own
+     * pending posts UNION those of every channel they operate.
+     *
+     * `posts_scheduled_idx` above serves the SWEEP, which wants every due post
+     * regardless of owner, and it cannot serve this: with only that index the
+     * planner walks the entire site-wide scheduled set in `scheduled_for` order
+     * and filters by owner, so one member's queue read costs a scan proportional
+     * to how much EVERYBODY ELSE has scheduled. Measured on 403k posts of which
+     * 3k scheduled, reading 20 accounts' entries: 200 rows returned, **2,800
+     * removed by filter**, 0.407 ms — against 0.125 ms and no wasted rows here.
+     * The absolute numbers are small; the coupling is the defect, because it
+     * grows with global scheduled volume rather than with the caller's own.
+     *
+     * PARTIAL on `status = 'scheduled'`, which is what makes it nearly free: a
+     * post enters the index when it is scheduled and leaves when it publishes, so
+     * this indexes a set that drains every 60 seconds rather than the table. The
+     * query carries `status = 'scheduled'` as a literal term, so the planner can
+     * prove eligibility.
+     *
+     * `scheduled_for` second gives the ORDER BY for free per account; `id` is
+     * deliberately NOT a third column — it is the sort's tie-break only, and it
+     * holds both pre-cutover ObjectId hex and post-cutover uuid v7, so it is not
+     * a chronological axis worth widening every index entry for.
+     */
+    index('post_owner_scheduled_v1')
+      .on(t.oxyUserId, t.scheduledFor)
+      .where(sql`${t.status} = 'scheduled'`),
+
+    /**
      * The lane tab's keyset — `laneSource` pages ONE lane on `(created_at, id)`,
      * and this serves the predicate and the order end to end.
      *

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -207,6 +207,26 @@ interface HydrationOptions {
    * number, wasted on every feed request that does not.
    */
   includeQuoteCounts?: boolean;
+  /**
+   * Accounts this viewer OPERATES — today, the channels they are an active member
+   * of, as resolved by `listOperatedChannelIds`.
+   *
+   * A channel AUTHORS its own posts, so `oxyUserId` on a channel post is an
+   * account NOBODY can be signed in as (`isActAsEligibleKind` refuses a channel as
+   * a session subject). The ACL's ownership test is an id comparison against that
+   * author, so without this every unpublished channel post is unreadable by every
+   * human alive — measured, including by the person who wrote it.
+   *
+   * OPT-IN, and deliberately so: resolving it costs an Oxy `GET /accounts` round
+   * trip, which must never land on a feed hydration. Only a caller that is
+   * already asking an account-scoped question passes it (`getScheduledPosts`),
+   * and every other surface hydrates with an empty set and is bit-for-bit
+   * unchanged.
+   *
+   * It widens READ only. What a member may DO with the post they can now see is
+   * still `postManagementRefusal`'s answer, asked per action on the write routes.
+   */
+  operatedAccountIds?: readonly string[];
 }
 
 interface HydratedGraphNode {
@@ -240,6 +260,12 @@ interface ViewerContext {
   boostedPosts: Set<string>;
   /** Author IDs with private or followers_only profile visibility */
   privateProfileIds: Set<string>;
+  /**
+   * Accounts the viewer operates, from {@link HydrationOptions.operatedAccountIds}.
+   * EMPTY on every caller that does not opt in, which is every caller but the
+   * scheduled queue — see that option for why this is not resolved here.
+   */
+  operatedAccountIds: Set<string>;
 }
 
 interface ExtendedViewerContext extends ViewerContext {
@@ -1178,6 +1204,7 @@ export class PostHydrationService {
       savedPosts: new Set<string>(),
       boostedPosts: new Set<string>(),
       privateProfileIds: new Set<string>(),
+      operatedAccountIds: new Set<string>(options?.operatedAccountIds ?? []),
       includeFullArticleBody: options?.includeFullArticleBody ?? true,
       includeFullMetadata: options?.includeFullMetadata ?? true,
     };
@@ -2050,10 +2077,31 @@ export class PostHydrationService {
     // collab-invite UI can render the actual content before they accept),
     // alongside the owner and accepted collaborators. All three bypass the
     // unpublished/private/followers-only/restricted ACL checks below.
+    //
+    // The last two clauses are the CHANNEL cases, and they exist because the id
+    // comparison above answers "no" for every human on a channel's post: a
+    // channel AUTHORS its own posts, and no session can ever have a channel as
+    // its subject. Without them an unpublished channel post is readable by
+    // nobody at all — not a narrow gap, a black hole, and measured as one.
+    //
+    //  - `canManagePostWithoutLookup` covers the WRITER, off two columns already
+    //    in hand and with no lookup. It is the SAME predicate `buildViewerState`
+    //    uses for `isOwner`, which is what makes the two agree: the DTO used to
+    //    be able to say `isOwner: true` about a post this gate would refuse.
+    //  - `operatedAccountIds` covers the writer's CO-OPERATORS, and is empty
+    //    unless the caller opted in (see `HydrationOptions.operatedAccountIds`),
+    //    so no feed pays an Oxy round trip for it.
+    //
+    // Both are strictly narrower than what the write routes already permit:
+    // `postManagementRefusal` lets any active member DELETE and EDIT this exact
+    // post today. Granting them READ removes an inconsistency rather than
+    // creating one.
     const viewerOwnsPost =
       viewerContext.viewerId === authorId ||
       (viewerEntry?.role === 'collaborator' &&
-        (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending'));
+        (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending')) ||
+      canManagePostWithoutLookup(post, viewerContext.viewerId) ||
+      (Boolean(viewerContext.viewerId) && viewerContext.operatedAccountIds.has(authorId));
 
     if ((post.status ?? 'published') !== 'published' && !viewerOwnsPost) {
       return false;

--- a/packages/frontend/components/Compose/ScheduledPostsList.tsx
+++ b/packages/frontend/components/Compose/ScheduledPostsList.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@oxyhq/bloom/toast';
+import { getNormalizedUserHandle } from '@oxyhq/core';
 import type { HydratedPost } from '@mention/shared-types';
 import { CalendarIcon } from '@/assets/icons/calendar-icon';
 import { isPastDue, scheduledDate } from '@/utils/postSchedule';
@@ -20,6 +21,20 @@ export interface ScheduledPostsListProps {
   isLoading: boolean;
   isError: boolean;
   onRetry: () => void;
+  /**
+   * The signed-in reader, so a row can say whose queue it is in.
+   *
+   * This list is no longer only the reader's own: `GET /posts/scheduled` returns
+   * the shared editorial queue of every CHANNEL they operate, so that two people
+   * publishing under one byline can see each other's plans instead of both
+   * booking Tuesday. Every entry names its authoring account (`post.user`, which
+   * IS the channel — a channel authors its own posts), and the id is what tells
+   * "mine" from "the channel's".
+   *
+   * Optional because the sheet can render for a split second before the session
+   * lands; an absent viewer labels nothing rather than labelling everything.
+   */
+  viewerId?: string;
   /** Open the full preview for one post. */
   onPreview: (post: HydratedPost) => void;
   /** Load one post back into the composer to rewrite or reschedule it. */
@@ -90,6 +105,7 @@ const ScheduledPostsList: React.FC<ScheduledPostsListProps> = ({
   onPreview,
   onEdit,
   onCancel,
+  viewerId,
 }) => {
   const theme = useTheme();
   const { t } = useTranslation();
@@ -139,6 +155,25 @@ const ScheduledPostsList: React.FC<ScheduledPostsListProps> = ({
         ? t('compose.scheduled.publishing', { defaultValue: 'Publishing now…' })
         : formatScheduledLabel(publishAt);
 
+    // Whose queue this entry is in. Only shown for an account that is NOT the
+    // reader — labelling their own posts "you" on every row would be noise, and
+    // the absence of a label is already the clearest possible "mine".
+    //
+    // It deliberately names the ACCOUNT and never the person who queued it: a
+    // channel's writers are anonymous unless it signs its posts, and that
+    // decision is made on the server. When a channel DOES sign, the writer is
+    // already in `authors[]` and the preview's byline draws them — so this row
+    // never has to make a disclosure judgement of its own.
+    // `viewerId` is checked FIRST and not merely compared: it is absent for the
+    // moment between mount and the session landing, and `author.id !== undefined`
+    // is true of every row — so comparing alone labels the reader's own posts as
+    // somebody else's during exactly the window nobody watches.
+    const author = item.user;
+    const queuedFor =
+      author !== undefined && viewerId !== undefined && author.id !== viewerId
+        ? author.name?.displayName?.trim() || getNormalizedUserHandle(author) || undefined
+        : undefined;
+
     return (
       <View className="flex-row items-center px-4 py-3 bg-background border-b border-border">
         <TouchableOpacity
@@ -155,6 +190,18 @@ const ScheduledPostsList: React.FC<ScheduledPostsListProps> = ({
               <Text className="text-xs font-semibold" style={{ color: theme.colors.primary }}>
                 {timeLabel}
               </Text>
+              {queuedFor !== undefined && (
+                <Text
+                  className="text-xs text-muted-foreground flex-shrink"
+                  numberOfLines={1}
+                  accessibilityLabel={t('compose.scheduled.queuedForA11y', {
+                    defaultValue: 'Queued for {{account}}',
+                    account: queuedFor,
+                  })}
+                >
+                  {queuedFor}
+                </Text>
+              )}
             </View>
             <Text className="text-sm text-foreground mb-1" numberOfLines={2}>
               {getPreview(item)}
@@ -205,7 +252,7 @@ const ScheduledPostsList: React.FC<ScheduledPostsListProps> = ({
         </TouchableOpacity>
       </View>
     );
-  }, [cancellingId, getPreview, handleCancel, onEdit, onPreview, t, theme]);
+  }, [cancellingId, getPreview, handleCancel, onEdit, onPreview, t, theme, viewerId]);
 
   if (isLoading) {
     return (

--- a/packages/frontend/components/Compose/UnpublishedSheet.tsx
+++ b/packages/frontend/components/Compose/UnpublishedSheet.tsx
@@ -99,6 +99,7 @@ const UnpublishedSheet: React.FC<UnpublishedSheetProps> = ({
     refetch,
     cancelScheduledPost,
     publishScheduledPostNow,
+    viewerId,
   } = useScheduledPosts();
 
   const showDrafts = useCallback(() => setActiveTab('drafts'), []);
@@ -203,6 +204,7 @@ const UnpublishedSheet: React.FC<UnpublishedSheetProps> = ({
           onPreview={openPreview}
           onEdit={editPost}
           onCancel={cancelScheduledPost}
+          viewerId={viewerId}
         />
       )}
     </View>

--- a/packages/frontend/components/Compose/__tests__/ScheduledPostPreview.test.tsx
+++ b/packages/frontend/components/Compose/__tests__/ScheduledPostPreview.test.tsx
@@ -55,6 +55,11 @@ jest.mock('@/utils/alerts', () => ({ confirmDialog: (...args: unknown[]) => mock
 jest.mock('@oxyhq/core/logger', () => ({
   createLogger: () => ({ error: jest.fn(), warn: jest.fn(), debug: jest.fn(), info: jest.fn() }),
 }));
+// Reached through `ScheduledPostsList`, which this screen shares its cancel
+// helper with. `@oxyhq/core` ships ESM jest does not transform.
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user?: { username?: string }) => user?.username,
+}));
 
 jest.mock('@/components/Feed/PostItem', () => {
   const react = jest.requireActual('react');

--- a/packages/frontend/components/Compose/__tests__/ScheduledPostsList.test.tsx
+++ b/packages/frontend/components/Compose/__tests__/ScheduledPostsList.test.tsx
@@ -46,6 +46,13 @@ jest.mock('@/utils/alerts', () => ({ confirmDialog: (...args: unknown[]) => mock
 jest.mock('@oxyhq/core/logger', () => ({
   createLogger: () => ({ error: jest.fn(), warn: jest.fn(), debug: jest.fn(), info: jest.fn() }),
 }));
+// `@oxyhq/core` ships ESM that jest does not transform, so it is stubbed at the
+// one symbol this component uses — the same shape `CollaboratorsList.test.tsx`
+// takes. Returning the username IS the real behaviour for a local account, which
+// is what every channel is.
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user?: { username?: string }) => user?.username,
+}));
 
 /** Far enough ahead that the row is never accidentally past due. */
 const SCHEDULED_AT = new Date(Date.now() + 24 * 60 * 60 * 1000);
@@ -250,5 +257,77 @@ describe('ScheduledPostsList', () => {
     expect(textContent(tree)).toContain('No scheduled posts');
 
     act(() => tree.unmount());
+  });
+
+  /**
+   * WHOSE QUEUE AN ENTRY IS IN.
+   *
+   * This list stopped being only the reader's own: `GET /posts/scheduled` merges
+   * in the shared editorial queue of every channel they operate, so two people
+   * publishing under one byline can see each other's plans. Unlabelled, a
+   * channel's entry is indistinguishable from your own — which is the confusion
+   * the feature exists to remove, reintroduced one layer up.
+   *
+   * It names the ACCOUNT and never the person who queued it. A channel's writers
+   * are anonymous unless the channel signs its posts, and that decision is made
+   * on the server — when it says yes, the writer already arrives in `authors[]`
+   * and the preview's byline draws them. This row therefore has no disclosure
+   * judgement of its own to get wrong.
+   */
+  describe('attribution', () => {
+    const CHANNEL = {
+      id: 'channel-1',
+      username: 'techweekly',
+      name: { displayName: 'Tech Weekly' },
+    };
+
+    function channelEntry(user: HydratedPost['user']): HydratedPost {
+      return { ...post(), user };
+    }
+
+    it('names the account when the entry is not the reader’s own', () => {
+      const tree = renderList({
+        posts: [channelEntry(CHANNEL)],
+        viewerId: 'viewer-1',
+      });
+
+      expect(textContent(tree)).toContain('Tech Weekly');
+
+      act(() => tree.unmount());
+    });
+
+    it('says nothing on the reader’s OWN entry', () => {
+      // The fixture's author IS `viewer-1`. Labelling every personal row "you"
+      // would be noise on the common case, and its absence already reads as mine.
+      const tree = renderList({ posts: [post()], viewerId: 'viewer-1' });
+
+      expect(textContent(tree)).not.toContain('Author');
+
+      act(() => tree.unmount());
+    });
+
+    it('falls back to the handle when the account has no display name', () => {
+      // `name` itself is REQUIRED on a user DTO; it is `name.displayName` that is
+      // optional, and absent is the ordinary shape for an unresolved account.
+      const tree = renderList({
+        posts: [channelEntry({ ...CHANNEL, name: {} })],
+        viewerId: 'viewer-1',
+      });
+
+      expect(textContent(tree)).toContain('techweekly');
+
+      act(() => tree.unmount());
+    });
+
+    it('labels nothing at all while the session is still restoring', () => {
+      // `viewerId` is absent for the moment between mount and the session
+      // landing. Labelling then would mark the reader's OWN posts as somebody
+      // else's, which is worse than labelling nothing.
+      const tree = renderList({ posts: [channelEntry(CHANNEL)] });
+
+      expect(textContent(tree)).not.toContain('Tech Weekly');
+
+      act(() => tree.unmount());
+    });
   });
 });

--- a/packages/frontend/hooks/useScheduledPosts.ts
+++ b/packages/frontend/hooks/useScheduledPosts.ts
@@ -10,17 +10,31 @@ const SCHEDULED_STALE_TIME = 30_000;
 /**
  * `GET /posts/scheduled` serves the same hydrated DTO every other post listing
  * serves, so a scheduled post can be PREVIEWED through the feed's own renderer
- * rather than a client-side approximation that drifts from it. The server
- * enforces the ACL twice: the query is scoped to the caller's `oxyUserId`, and
- * `PostHydrationService` drops any non-`published` post for a viewer who does
- * not own it.
+ * rather than a client-side approximation that drifts from it.
+ *
+ * It answers with the caller's own pending posts AND the shared editorial queue
+ * of every CHANNEL they are an active member of — so two people publishing under
+ * one byline can see each other's plans. The server still enforces the ACL twice
+ * and both halves are fed from ONE membership resolution: the query admits only
+ * accounts Oxy confirmed, and `PostHydrationService` is told the same set, so a
+ * post survives only if both agree.
+ *
+ * WHO QUEUED an entry is not this surface's decision and is not always answered:
+ * a channel's writer is named only when the channel signs its posts, in which
+ * case they arrive in `authors[]` like any other byline. The raw writer id is
+ * never on the DTO.
  */
 interface ScheduledPostsResponse {
   posts?: HydratedPost[];
 }
 
 export interface UseScheduledPostsResult {
-  /** The viewer's pending scheduled posts, soonest first (the server's order). */
+  /**
+   * Every pending scheduled post this viewer can act on, soonest first (the
+   * server's order) — their own, PLUS the shared editorial queue of each channel
+   * they operate. Group by `post.user.id` to tell them apart; a channel authors
+   * its own posts, so that field IS the account an entry is queued for.
+   */
   scheduledPosts: HydratedPost[];
   /** True only while the first authenticated fetch is in flight. */
   isLoading: boolean;
@@ -30,6 +44,12 @@ export interface UseScheduledPostsResult {
   cancelScheduledPost: (postId: string) => Promise<void>;
   /** Publish one scheduled post immediately, ahead of its time. */
   publishScheduledPostNow: (postId: string) => Promise<void>;
+  /**
+   * The signed-in reader, so a list row can say whose queue an entry is in. The
+   * hook already resolves it to key its cache; returning it saves the sheet a
+   * second `useAuth` that could disagree with this one mid-restore.
+   */
+  viewerId?: string;
 }
 
 /**
@@ -105,5 +125,6 @@ export function useScheduledPosts(): UseScheduledPostsResult {
     refetch: query.refetch,
     cancelScheduledPost,
     publishScheduledPostNow,
+    viewerId,
   };
 }

--- a/packages/frontend/lib/viewerQueryKeys.ts
+++ b/packages/frontend/lib/viewerQueryKeys.ts
@@ -91,9 +91,15 @@ export const viewerQueryKeys = {
     profileId,
   ] as const,
   /**
-   * The viewer's own not-yet-published scheduled posts. Strictly private: the
-   * list is the caller's alone, so it can never be shared across viewers the way
-   * a public post detail can.
+   * The not-yet-published posts this viewer can act on — their own, plus the
+   * shared editorial queue of every channel they operate.
+   *
+   * Still strictly VIEWER-scoped, and the distinction matters: the entries are no
+   * longer the caller's alone, but WHICH entries they are depends on the caller's
+   * channel memberships, so this response can never be shared across viewers the
+   * way a public post detail can. Two members of one channel see overlapping
+   * lists that are not equal — each also holds their own posts — so keying on the
+   * channel instead would serve one member the other's personal queue.
    */
   scheduledPosts: (viewerId: ViewerId) => [
     ...viewerQueryKeys.postsRoot(viewerId),

--- a/packages/frontend/stores/bylineInvalidation.ts
+++ b/packages/frontend/stores/bylineInvalidation.ts
@@ -119,11 +119,14 @@ export function noteChannelBylineChanged(channelOxyUserId: string): void {
       // byline the server has just rewritten:
       //   `posts`       — the post detail behind a notification, and a profile's
       //                   pinned post, which on a channel's page is the channel's
-      //                   own. `scheduledPosts` rides in the same family and is
-      //                   collateral rather than a target: `GET /posts/scheduled`
-      //                   matches `oxyUserId: <caller>`, and a post published as a
-      //                   channel carries the CHANNEL's id, so an operator's
-      //                   scheduled list cannot hold one.
+      //                   own. `scheduledPosts` rides in the same family and IS a
+      //                   target: `GET /posts/scheduled` now returns the shared
+      //                   editorial queue of every channel the caller operates, so
+      //                   an operator's scheduled list holds channel posts whose
+      //                   byline this change rewrites. (It used to be collateral —
+      //                   the read was owner-scoped and a channel's post reached
+      //                   nobody's queue. The invalidation was already correct;
+      //                   only the reason it fires has changed.)
       //   `saved-posts` — the saved screen, React Query's own post list.
       //   `search`      — the posts tab.
       //   `notifications` — rows embed the post they are about, and the server


### PR DESCRIPTION
Scheduling already existed, but it was private to whoever wrote the post — which for a channel meant private to **nobody**.

## What was measured first

A channel AUTHORS its own posts, so a scheduled channel post carries the CHANNEL as `oxy_user_id`, an account no session can ever have as its subject (`isActAsEligibleKind` refuses it). Every scheduling surface was keyed on the caller:

| surface | before | evidence |
|---|---|---|
| `GET /posts/scheduled` | returned it to **nobody**, the writer included | probe against real Postgres: writer's page `[]` |
| hydration ACL | dropped it for every human | real `hydratePosts`: writer 0, stranger 0, channel 1 — and the channel cannot log in |
| `POST /posts/:id/publish` | claimed as the caller → matched no row → 404 for everyone | read of `claimScheduledPost`'s filter |
| `PUT /posts/:id` reschedule cascade | walked the chain as the caller → a channel's scheduled **thread** moved its edited post alone and silently left the continuations behind | the split queue that block exists to prevent |

Meanwhile `DELETE /posts/:id` had **already** been widened through `postManagementRefusal`. So a member could CANCEL a queued post they could neither see nor send. This makes the other three agree with it rather than inventing a fourth authority.

## Authority

One gate, the existing one. `listOperatedChannelIds` for the read, `postManagementRefusal` for each write — no second membership reader.

Seeing and acting are deliberately the **same** right. Membership is the strongest right that exists over a channel, so there is nothing stronger to demand of whoever publishes an entry early than of whoever reads it. `affordance ⊆ permission` is restored, not stretched — the read had been the narrow half.

The read's two gates are fed from **one** resolution, so they cannot drift: the query admits only accounts Oxy confirmed and hydration is told the same set. Fails soft — an account-graph outage costs a member the shared half, never the composer.

## Writer disclosure — the question this lives or dies on

**A member sees WHAT is queued and WHEN. They see WHO only when the channel already says who.**

The queue hydrates through `PostHydrationService` like every other listing, so an entry names its writer exactly when `channel.signPosts` names them on the published post, and `writtenByOxyUserId` never reaches the wire either way. **No new disclosure decision exists in this change.**

`signPosts` protects anonymity from READERS, and a channel's own members are readers of this surface — which is why the notification inbox already refuses the same disclosure to the same audience. The collision this feature exists to prevent ("two writers book Tuesday") is answered by the content and the time, neither of which is a name.

Scoped to `channel` on purpose: an organization CAN be acted as, so its members reach its queue by switching into it, gated on `account:act_as`. Widening to it would hand that view to `viewer`/`billing` members through a door the switch keeps shut.

## Index

`post_owner_scheduled_v1` (migration `0022`), partial on `status = 'scheduled'`. Without it the planner walks the site-wide scheduled set and filters by owner — measured on 403k posts / 3k scheduled, reading 20 accounts:

```
posts_scheduled_idx only  200 rows returned, 2,800 removed by filter, 0.407 ms
post_owner_scheduled_v1   200 rows returned,     0 removed by filter, 0.125 ms
```

The absolute numbers are small; the coupling to *global* scheduled volume is the defect. Migration verified by applying the full 23-migration chain to a scratch database.

## Verification

- Full backend suite **530 files / 6354 tests green**; coverage 76.31% statements against the 69.13 floor.
- Frontend **165 suites / 1599 tests green**; `check:types` clean; lint 0 errors (10 warnings, all pre-existing files untouched here).
- Posts, `user_settings` (the consent row), the query, the ACL and the byline are all **real** in the new suite — only Oxy is mocked, and `listOperatedChannelIds` runs for real over a stubbed account forest so the membership predicate is exercised rather than assumed.
- **Ten mutations run, ten killed.** Two survived first and are the reason two fixtures exist:
  - a **lone** scheduled post cannot tell the chain walk's owner apart (no parent to climb, no children to match) → added a channel **thread**;
  - a writer who is also a **member** cannot tell the ACL's two clauses apart → added a hydration case asked with **no** operated accounts.
  - The disclosure mutation (byline discloses unconditionally) is killed by the `signPosts: false` case.

## Known gaps, stated rather than hidden

- The truthy-non-boolean `signPosts` fixture is **not** in the new suite and cannot be: the column is a Postgres `boolean`, so it refuses the only value that tells `=== true` from `Boolean(...)`. That fixture lives in `postHydrationChannelWriter.test.ts`, which fakes the DB for exactly this reason. The two suites own different halves on purpose.
- A **former** writer (removed from the channel) no longer sees their queued post, because the query gates on current membership before the ACL runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)