### PR TITLE
ci: give CI a manual dispatch, so a skipped run is recoverable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ on:
     branches: [main, drizzle/channels-plans]
   pull_request:
     branches: [main]
+  # The escape hatch the comment above is missing. A push that dispatches NO run
+  # is indistinguishable from one whose run passed, and the three deploy
+  # workflows key on `workflow_run` of this one — so a skipped dispatch is a
+  # release that silently never happens, with nothing red to notice. Measured on
+  # `ea100282`: the only run GitHub recorded for that commit was CodeQL, this
+  # workflow never dispatched, and the merge sat undeployed with `main` green.
+  # Without this, the only way to recover is to push another commit.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
`CI` **has not dispatched anywhere in this repo since 06:05 UTC (~13h)** — not for the pushes that merged #692 and #693, not for `main`. CodeQL, Socket and Cursor ran normally throughout, so Actions is healthy and this workflow specifically is not firing. `ci.yml` is unmodified, has no path filters, and closing/reopening a PR did not re-trigger it.

The three deploy workflows trigger on `workflow_run` of this one, so **`main` is currently accumulating unverified, undeployed commits** with nothing red to notice. That is exactly the failure this file's own header names: *"a gate whose absence is indistinguishable from its success"*.

Without `workflow_dispatch` the only recovery is to push another commit and hope — which is all this PR would otherwise be. With it, a skipped run is re-runnable deliberately and the deploys hanging off it can be released.

**This does not diagnose the cause.** It makes the failure recoverable instead of silent.