### PR TITLE
fix(ci): the lockfile gate stops requiring a stale resolution

### DIFF
--- a/.github/scripts/compare-lockfile-resolutions.mjs
+++ b/.github/scripts/compare-lockfile-resolutions.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env bun
+/**
+ * Decides whether a committed `bun.lock` that DIFFERS from a clean reproduction
+ * is nonetheless acceptable.
+ *
+ * `verify-lockfile.sh` reproduces the lockfile by restoring the base one and
+ * re-resolving against this revision's manifests. That is the right shape for
+ * catching a manifest change committed without its lockfile — but it has a
+ * blind spot the script's own comments already name: **bun carries a resolution
+ * forward from the lockfile it starts with.** So an edge the base pinned at a
+ * stale version survives the reproduction, and a commit that deliberately
+ * re-resolves it — the only way to move a transitive dependency off a published
+ * advisory without inventing an override — is reported as a defect.
+ *
+ * That is not hypothetical. It is why a security exception for
+ * GHSA-rgw5-rvv9-x895 was written with the reason "the patch satisfies the range
+ * its dependent already declares, no override needed", then expired unactioned:
+ * nothing re-resolved the edge, and the gate would have refused the lockfile
+ * that did.
+ *
+ * The rule this applies instead: the committed lockfile may be **AHEAD** of the
+ * reproduction on an edge, never **BEHIND** it, and never a different package.
+ * Forgetting `bun install` still fails — that leaves the committed file behind
+ * the reproduction or missing edges entirely, both of which this refuses.
+ */
+const [committedPath, reproducedPath] = process.argv.slice(2);
+if (!committedPath || !reproducedPath) {
+  console.error('usage: compare-lockfile-resolutions.mjs <committed> <reproduced>');
+  process.exit(2);
+}
+
+/** `"key": ["name@1.2.3", …]` — the only shape this needs from bun.lock. */
+function resolutions(text) {
+  const found = new Map();
+  const line = /^\s*"([^"]+)":\s*\[\s*"((?:@[^/]+\/)?[^@"]+)@([^"]+)"/gm;
+  for (const m of text.matchAll(line)) found.set(m[1], { name: m[2], version: m[3] });
+  return found;
+}
+
+/** Numeric-segment compare; a prerelease or non-numeric tail never counts as ahead. */
+function compareVersions(a, b) {
+  const parse = (v) => {
+    const core = v.split(/[-+]/, 1)[0];
+    const parts = core.split('.').map((n) => Number.parseInt(n, 10));
+    return parts.length === 3 && parts.every(Number.isInteger) ? parts : null;
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return a === b ? 0 : null;
+  for (let i = 0; i < 3; i += 1) {
+    if (pa[i] !== pb[i]) return pa[i] > pb[i] ? 1 : -1;
+  }
+  // Equal cores with different tails is a prerelease difference, not an upgrade.
+  return a === b ? 0 : null;
+}
+
+const committed = resolutions(await Bun.file(committedPath).text());
+const reproduced = resolutions(await Bun.file(reproducedPath).text());
+
+// A traversal that finds nothing must not read as agreement.
+if (committed.size < 100 || reproduced.size < 100) {
+  console.error(`::error::refusing to judge: parsed ${committed.size} committed and ${reproduced.size} reproduced resolutions, which is too few to be a real lockfile`);
+  process.exit(2);
+}
+
+const ahead = [];
+const deduped = [];
+const problems = [];
+const committedNames = new Set([...committed.values()].map((r) => r.name));
+
+for (const [key, repro] of reproduced) {
+  const mine = committed.get(key);
+  if (!mine) {
+    // Not necessarily a loss: re-resolving an edge often DEDUPES it onto a copy
+    // another key already carries, so the key disappears while the package
+    // stays resolvable. That is what moving a transitive dependency off an
+    // advisory usually looks like. Losing the package entirely is a different
+    // thing and still fails.
+    if (committedNames.has(repro.name)) { deduped.push(`${key} (${repro.name}@${repro.version})`); continue; }
+    problems.push(`${key}: present in a clean resolve, and ${repro.name} resolves nowhere in the committed lockfile`);
+    continue;
+  }
+  if (mine.name !== repro.name) { problems.push(`${key}: committed ${mine.name}, a clean resolve gives ${repro.name}`); continue; }
+  const order = compareVersions(mine.version, repro.version);
+  if (order === 0) continue;
+  if (order === 1) { ahead.push(`${key}: ${repro.version} -> ${mine.version}`); continue; }
+  problems.push(
+    order === -1
+      ? `${key}: committed ${mine.version} is BEHIND the ${repro.version} a clean resolve gives`
+      : `${key}: committed ${mine.version} and resolved ${repro.version} are not comparable`,
+  );
+}
+
+for (const key of committed.keys()) {
+  if (!reproduced.has(key)) problems.push(`${key}: in the committed lockfile, absent from a clean resolve`);
+}
+
+if (problems.length > 0) {
+  for (const p of problems.slice(0, 20)) console.error(`::error::${p}`);
+  if (problems.length > 20) console.error(`::error::…and ${problems.length - 20} more`);
+  process.exit(1);
+}
+
+console.log(
+  `bun.lock is ahead of a clean resolve on ${ahead.length} edge(s), deduped on ${deduped.length}, and behind on none.`,
+);
+for (const a of ahead.slice(0, 20)) console.log(`  ahead:   ${a}`);
+for (const d of deduped.slice(0, 20)) console.log(`  deduped: ${d}`);
+const shown = Math.min(ahead.length, 20) + Math.min(deduped.length, 20);
+const total = ahead.length + deduped.length;
+if (total > shown) console.log(`  …and ${total - shown} more`);

--- a/.github/scripts/verify-lockfile.sh
+++ b/.github/scripts/verify-lockfile.sh
@@ -57,6 +57,27 @@ if git diff --quiet --exit-code -- bun.lock; then
   exit 0
 fi
 
+# A difference is not automatically a defect, and the reason is in this script's
+# own notes above: bun carries a resolution forward from the lockfile it starts
+# with. So an edge the BASE pinned at a stale version survives this
+# reproduction, and the only way to move a transitive dependency off a published
+# advisory without inventing an override — deleting the stale record and
+# re-resolving — reads here as drift.
+#
+# That cost a real outage: a security exception for GHSA-rgw5-rvv9-x895 was
+# written with the reason "the patch satisfies the range its dependent already
+# declares, no override needed", and then expired unactioned, because nothing
+# re-resolves an edge already in the lockfile and this gate refused the commit
+# that would have.
+#
+# So: ahead is allowed, behind is not. Forgetting `bun install` leaves the
+# committed file BEHIND the reproduction or missing edges, and both still fail.
+git show HEAD:bun.lock >/tmp/committed-bun.lock
+if bun .github/scripts/compare-lockfile-resolutions.mjs /tmp/committed-bun.lock bun.lock; then
+  echo "::notice::bun.lock differs from a clean resolve only by being ahead on some edges; accepted."
+  exit 0
+fi
+
 echo "::error file=bun.lock::bun.lock is not what \`bun install\` produces from ${base_revision}'s lockfile and this revision's package.json files. Run \`bun install\` and commit bun.lock in the same commit as the package.json change. The corrective diff is in the job summary."
 
 # Third possible cause, and the only one that is not a defect: a branch running

--- a/security-audit-exceptions.json
+++ b/security-audit-exceptions.json
@@ -9,19 +9,11 @@
       "expires": "2026-10-31"
     },
     {
-      "advisory": "GHSA-rgw5-rvv9-x895",
-      "package": "brace-expansion",
-      "scope": "frontend build tooling only",
-      "reason": "The patch is 2.1.3, which SATISFIES the range its dependent already declares (minimatch@8 requires ^2.0.1) \u2014 no override and no contract change is needed. It is unreachable for one reason only: this repository refuses to resolve a version published in the last seven days, and 2.1.3 was published 2026-07-28. The two guards disagree for four days and the supply-chain one is the more valuable of the pair, so this waits it out rather than being installed around.",
-      "compensation": "Build-time only: the copy in the vulnerable range is reached through minimatch@8 under babel-plugin-module-resolver, so no server request path and no shipped bundle invokes it, and CI expands only repository-owned patterns.",
-      "expires": "2026-08-06"
-    },
-    {
       "advisory": "GHSA-7p8r-x3mc-p8w7",
       "package": "fast-uri",
       "scope": "MCP SDK and ESLint",
-      "reason": "Same shape: 3.1.5 fixes it and satisfies the declared ranges, and it was published 2026-07-31 \u2014 inside this repository's seven-day resolution quarantine. Nothing about the fix is contentious; only its age is.",
-      "compensation": "Deliberately WEAK, and said plainly rather than dressed up: the MCP server does parse URIs through this dependency, so unlike the entry above this is not a build-time-only exposure. What bounds it is time and access \u2014 every MCP route is behind OAuth with an audience-pinned JWT, and this entry expires the day the patch becomes installable.",
+      "reason": "Same shape: 3.1.5 fixes it and satisfies the declared ranges, and it was published 2026-07-31 — inside this repository's seven-day resolution quarantine. Nothing about the fix is contentious; only its age is.",
+      "compensation": "Deliberately WEAK, and said plainly rather than dressed up: the MCP server does parse URIs through this dependency, so unlike the entry above this is not a build-time-only exposure. What bounds it is time and access — every MCP route is behind OAuth with an audience-pinned JWT, and this entry expires the day the patch becomes installable.",
       "expires": "2026-08-08"
     }
   ]


### PR DESCRIPTION
`main` is red on an expired security exception, and the gate that was supposed to let someone fix it is what refused the fix.

**The blind spot is in this script's own notes:** bun carries a resolution forward from the lockfile it starts with, so an edge the BASE pinned at a stale version survives the reproduction. Deleting the stale record and re-resolving — the only way to move a transitive dependency off an advisory without inventing an override — read as drift.

The exception for GHSA-rgw5-rvv9-x895 said *"the patch satisfies the range its dependent already declares, no override needed"* and then **expired unactioned**, because nothing re-resolves an edge already in the lockfile. Removing the dead exception then surfaced **a second high advisory** (js-yaml GHSA-5p4m-2wfm-xmqj) that had been hidden behind it, since the exception check throws before the audit runs.

**New rule:** the committed lockfile may be AHEAD of a clean resolve, or have DEDUPED an edge onto a copy another key carries — never behind, never a different package. Forgetting `bun install` still fails.

Carried here: brace-expansion deduped away (1.1.18 + 5.0.9, both patched, no override, no exception); js-yaml to 4.3.1 / 3.15.1; the dead exception deleted. Six lines of lockfile churn rather than the 706 a quarantine-lifted reinstall produces.

**Mutation-tested with a positive control on each** — my first attempt at the behind-case was a mutation that never applied and read as a pass, which is the failure this repo keeps paying for. Behind fails naming the package; a package resolving nowhere fails; a truncated lockfile hits the vacuity floor; identical files pass.