### PR TITLE
fix(deps): fast-uri 3.1.5 — retire the audit exception that expires today

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -226,7 +226,7 @@
     "expo-file-system": "57.0.1",
     "expo-modules-core": "57.0.7",
     "expo-secure-store": "57.0.1",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "fast-xml-parser": "5.10.1",
     "ioredis": "5.11.1",
     "ip-address": "10.3.1",
@@ -1893,7 +1893,7 @@
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@oxyhq/bloom": "catalog:",
     "@oxyhq/core": "catalog:",
     "@oxyhq/services": "catalog:",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "fast-xml-parser": "5.10.1",
     "linkify-it": "5.0.2",
     "ioredis": "5.11.1",

--- a/security-audit-exceptions.json
+++ b/security-audit-exceptions.json
@@ -9,14 +9,6 @@
       "expires": "2026-10-31"
     },
     {
-      "advisory": "GHSA-7p8r-x3mc-p8w7",
-      "package": "fast-uri",
-      "scope": "MCP SDK and ESLint",
-      "reason": "Same shape: 3.1.5 fixes it and satisfies the declared ranges, and it was published 2026-07-31 — inside this repository's seven-day resolution quarantine. Nothing about the fix is contentious; only its age is.",
-      "compensation": "Deliberately WEAK, and said plainly rather than dressed up: the MCP server does parse URIs through this dependency, so unlike the entry above this is not a build-time-only exposure. What bounds it is time and access — every MCP route is behind OAuth with an audience-pinned JWT, and this entry expires the day the patch becomes installable.",
-      "expires": "2026-08-08"
-    },
-    {
       "advisory": "GHSA-w3rx-r6r6-pgpr",
       "package": "image-size",
       "scope": "Metro bundler, build time only",


### PR DESCRIPTION
`security-audit-exceptions.json`'s fast-uri GHSA-7p8r-x3mc-p8w7 entry carries `expires: 2026-08-08` — today. `scripts/audit-security.mjs` THROWS on an expired exception before it reaches the advisory check, so from 2026-08-09T00:00Z every branch's quality job hard-errors (same failure shape the a5790511 history records for brace-expansion).

The entry's own stated fix condition is now met: fast-uri 3.1.5 (published 2026-07-31) is past the 7-day quarantine and satisfies both real dependents' `^3.0.1`. Root override moves 3.1.4 → 3.1.5, lockfile follows, exception retired.

Verified: `bun install` no-changes; `audit:security` green (3 reviewed exceptions remain); `validate:lockfile` green; `verify-lockfile.sh origin/main` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)