### PR TITLE
perf(shell): the layout's widths are CSS, not a re-render

### DIFF
--- a/.github/workflows/run-blocked-domain-purge.yml
+++ b/.github/workflows/run-blocked-domain-purge.yml
@@ -28,7 +28,7 @@ name: Purge blocked-domain data from the platform
 # TWO GATES, AND THE SECOND ONE IS NOT IN THIS REPO
 #   A real run needs `confirm_write` here AND `FEDERATION_DOMAIN_PURGE_ENABLED=true`
 #   on the oxy-api deployment, which answers 409 otherwise. Arming the endpoint is
-#   an operator decision made over in OxyHQServices, on purpose — this workflow
+#   an operator decision made over in the oxy repo, on purpose — this workflow
 #   cannot talk itself into a deletion.
 #
 # ALWAYS PLAN FIRST (`dry_run=true`, the default). `dryRun` is the ONLY field the

--- a/packages/frontend/app/(app)/_layout.tsx
+++ b/packages/frontend/app/(app)/_layout.tsx
@@ -23,7 +23,6 @@ import { useKeyboardVisibility } from "@/hooks/useKeyboardVisibility";
 import { useIsScreenNotMobile } from "@/hooks/useOptimizedMediaQuery";
 import { useScreenColor } from '@/context/ScreenColorContext';
 import { APP_COLOR_PRESETS, BloomColorScope, useTheme, type AppColorName } from '@oxyhq/bloom/theme';
-import { cn } from '@/lib/utils';
 
 const IS_WEB = Platform.OS === 'web';
 
@@ -132,30 +131,19 @@ export default function AppLayout() {
           for signed-out visitors, who cannot connect to the two above at all. */}
       <PublicRealtimeBridge />
       {/* ── visual shell (was MainLayout): SideBar + gutter/ContentPanel + RightBar ── */}
-      <View
-        className={cn(
-          "flex-1 w-full bg-background",
-          isScreenNotMobile ? "flex-row justify-center" : "flex-col"
-        )}
-      >
+      {/* Every width decision below is a CLASS, not a measured boolean. The
+          shell used to read `isScreenNotMobile` for its direction, its cap and
+          its gutter — pure styling, which `useOptimizedMediaQuery`'s own docs
+          send to NativeWind — so dragging a window re-rendered this subtree on
+          every frame to pick between two strings. The hook stays for what it is
+          actually for: the mount gates below. */}
+      <View className="flex-1 w-full flex-col shell:flex-row shell:justify-center bg-background">
         <SideBar />
-        <View
-          className={cn(
-            "flex-1 justify-between bg-background",
-            isScreenNotMobile ? "flex-row" : "flex-col"
-          )}
-          style={isScreenNotMobile ? { maxWidth: 950, flexShrink: 1 } : undefined}
-        >
+        <View className="flex-1 justify-between flex-col shell:flex-row shell:max-w-[950px] shell:shrink bg-background">
           {/* Desktop-web gutter: the `bg-background` band around the floating panel
               (`p-2 pl-0` so the panel meets the rail flush). Gated to the same
               >=500px breakpoint as the sidebar; full-bleed once the sidebar hides. */}
-          <View
-            className={cn(
-              "bg-background",
-              IS_WEB && isScreenNotMobile && "p-2 pl-0",
-            )}
-            style={{ flex: isScreenNotMobile ? 2.2 : 1 }}
-          >
+          <View className="flex-1 shell:flex-[2.2] bg-background web:shell:p-2 web:shell:pl-0">
             <BloomColorScope colorPreset={activeScreenColor} asChild>
               <ContentPanel
                 framedFrom={500}

--- a/packages/frontend/global.css
+++ b/packages/frontend/global.css
@@ -26,6 +26,17 @@
    drift to `var(--surface)` (card === surface no longer holds: card is the
    lightest surface). */
 @theme {
+  /* Shell breakpoints, as CSS.
+
+     `hooks/useOptimizedMediaQuery.ts` already draws the line: a JS width read is
+     for MOUNT gates and data-level decisions, and "pure show/hide and pure
+     styling differences use NativeWind responsive classes — NOT these hooks".
+     Naming the widths here is what lets the shell keep that rule instead of
+     re-rendering on every resize frame to pick a class name.
+
+     The numbers are the hook's, unchanged. */
+  --breakpoint-shell: 500px;
+
   --font-sans: Inter, sans-serif;
 
   --radius-lg: var(--radius);


### PR DESCRIPTION
`hooks/useOptimizedMediaQuery.ts` already draws the line:

> Pure show/hide and pure styling differences use NativeWind responsive classes (`md:`, `max-md:`, …) directly — **NOT these hooks**.

The shell did not follow its own rule. It read `isScreenNotMobile` to pick:

- the flex direction (`flex-row` vs `flex-col`), twice
- `justify-center`
- the 950px cap and its `flexShrink`
- `flex: 2.2` vs `flex: 1`
- the desktop gutter (`p-2 pl-0`)

Six pure-styling decisions, so dragging a window re-rendered this subtree on every resize frame just to choose between two strings. On web the browser does all six for free.

They are now classes over `--breakpoint-shell: 500px` — **the hook's own number**, named once so the shell and the hook cannot drift apart.

## What deliberately stays in JavaScript

Everything the hook's docs say it is for:

- `mobileWebBottomInset` — arithmetic feeding a style, which no class expresses
- `{isAuthenticated && !isScreenNotMobile && <BottomBarHost />}` and `{!isScreenNotMobile && <DrawerOverlay />}` — **mount gates**. An unmounted `BottomBarHost` is the whole point: it owns a keyboard-visibility subscription that desktop should never run. `hidden` would mount it and subscribe anyway.

## Verified, not assumed

The emitted stylesheet carries the same values the inline styles set, inside `@media (…500px)`:

```css
.shell\:max-w-\[950px\]{max-width:950px}
.shell\:flex-\[2\.2\]{flex:2.2}
.shell\:shrink{flex-shrink:1}
.shell\:flex-row{flex-direction:row}
```

`flex-[2.2]` was the one I did not want to take on faith — react-native-web's `flex: 2.2` and CSS's resolve to the same `flex-grow:2.2; flex-shrink:1; flex-basis:0%`, and the class emits exactly `flex:2.2`.

`tsc --noEmit` clean, `expo export --platform web` clean.

Found while building Atlas (the Oxy App Store), which had the same mistake copied from here and now has neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)