### PR TITLE
test(backend): retire the "uuid v7 is monotonic" assumption from six suites

### DIFF
--- a/packages/backend/src/__tests__/exploreFeed.test.ts
+++ b/packages/backend/src/__tests__/exploreFeed.test.ts
@@ -53,6 +53,7 @@ import type { PostRecordInput } from '../db/posts/postRecord';
 import { exploreSource } from '../mtn/feed/engine/sources/discoverySources';
 import { ScoreCursor } from '../mtn/feed/CursorBuilder';
 import type { CandidatePost, FeedEngineContext } from '../mtn/feed/engine/types';
+import { sameMillisecondIds } from './helpers/tiedIds';
 
 let db: Database;
 
@@ -392,18 +393,25 @@ describe('a pagination session is a frozen snapshot', () => {
    */
   async function pool(): Promise<string[]> {
     const tiedAt = new Date(AS_OF - 3 * 60 * 60 * 1000);
-    const ids = [
+
+    // The tied pair's ids are SUPPLIED rather than minted. `uuidv7()` has no
+    // monotonic counter, so two rows written back to back order on their random
+    // tail whenever they share a millisecond — "the later insert leads" was a
+    // coin flip that a database round trip usually, but not reliably, hid.
+    // `sameMillisecondIds` states the tie instead of hoping for it.
+    const [tiedLower, tiedHigher] = sameMillisecondIds(2);
+
+    const [a, b, c, d] = [
       await create({ createdAt: tiedAt }, { likes: 50 }),
       await create({ createdAt: tiedAt }, { likes: 40 }),
       await create({ createdAt: tiedAt }, { likes: 30 }),
       await create({ createdAt: tiedAt }, { likes: 20 }),
-      await create({ createdAt: tiedAt }, { likes: 10 }),
-      await create({ createdAt: tiedAt }, { likes: 10 }),
     ];
-    // The two tied posts sort by DESCENDING id, and uuid v7 is monotonic, so the
-    // later insert leads.
-    const [a, b, c, d, tiedFirst, tiedSecond] = ids;
-    return [a, b, c, d, tiedSecond, tiedFirst];
+    await create({ id: tiedLower, createdAt: tiedAt }, { likes: 10 });
+    await create({ id: tiedHigher, createdAt: tiedAt }, { likes: 10 });
+
+    // The tied pair sorts by DESCENDING id, so the higher id leads.
+    return [a, b, c, d, tiedHigher, tiedLower];
   }
 
   it('walks adjacent pages that neither overlap nor gap, across a score tie', async () => {

--- a/packages/backend/src/__tests__/fallbackCursorRegime.test.ts
+++ b/packages/backend/src/__tests__/fallbackCursorRegime.test.ts
@@ -125,6 +125,7 @@ import type {
   FeedEngineContext,
   SourceModule,
 } from '../mtn/feed/engine/types';
+import { sameMillisecondIds } from './helpers/tiedIds';
 
 let db: Database;
 const created: string[] = [];
@@ -206,15 +207,21 @@ async function fallbackLane(): Promise<string[]> {
     content: { variants: [{ source: 'author', text: 'clip' }], media: [PORTRAIT_VIDEO] },
   };
 
+  // The pair tied on BOTH keys carries SUPPLIED ids. `uuidv7()` has no monotonic
+  // counter, so two rows written back to back order on their random tail
+  // whenever they share a millisecond; asserting that the later insert leads was
+  // a coin flip that a database round trip usually, but not reliably, hid.
+  const [tiedLower, tiedHigher] = sameMillisecondIds(2);
+
   const top = await create(author, 50_000, RECENT, video);
   const second = await create(author, 40_000, RECENT, video);
   const sameScoreNewer = await create(author, 30_000, RECENT, video);
   const sameScoreOlder = await create(author, 30_000, OLDER, video);
-  const tiedEarlier = await create(author, 20_000, RECENT, video);
-  const tiedLater = await create(author, 20_000, RECENT, video);
+  await create(author, 20_000, RECENT, { ...video, id: tiedLower });
+  await create(author, 20_000, RECENT, { ...video, id: tiedHigher });
 
-  // uuid v7 is monotonic, so the later insert leads the pair tied on both keys.
-  return [top, second, sameScoreNewer, sameScoreOlder, tiedLater, tiedEarlier];
+  // That pair is split by id DESCENDING, so the higher id leads.
+  return [top, second, sameScoreNewer, sameScoreOlder, tiedHigher, tiedLower];
 }
 
 /**

--- a/packages/backend/src/__tests__/helpers/tiedIds.test.ts
+++ b/packages/backend/src/__tests__/helpers/tiedIds.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The tied-id helper, and the fact it exists because of.
+ *
+ * Five ranking/pagination suites now state their id ties through
+ * `sameMillisecondIds` instead of assuming `uuidv7()` orders two back-to-back
+ * inserts. If this helper silently stopped producing TIED ids, or stopped
+ * ascending, those suites would keep passing while no longer pinning the case
+ * they are written for — so the properties they lean on are asserted here, once.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { uuidv7 } from '../../db/schema/columns';
+import { sameMillisecondIds } from './tiedIds';
+
+/** The 48-bit timestamp is the first 12 hex characters, i.e. `xxxxxxxx-xxxx`. */
+const timestampOf = (id: string): string => id.slice(0, 13);
+
+describe('sameMillisecondIds', () => {
+  it('returns ids that are strictly ascending, so the caller names the winner', () => {
+    const ids = sameMillisecondIds(6);
+
+    expect(ids).toHaveLength(6);
+    expect([...ids].sort()).toEqual(ids);
+    expect(new Set(ids).size).toBe(6);
+  });
+
+  it('ties every id to ONE millisecond — the case the production tiebreak is for', () => {
+    // The vacuity floor. Ids spread across milliseconds would order correctly
+    // for the wrong reason, and the suites consuming this would no longer be
+    // exercising a tie at all.
+    const stamps = new Set(sameMillisecondIds(8).map(timestampOf));
+
+    expect(stamps.size).toBe(1);
+  });
+
+  it('mints real uuid v7 values, so post-cutover id checks still classify them', () => {
+    for (const id of sameMillisecondIds(4)) {
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    }
+  });
+
+  it('keeps the random tail random, so parallel suites cannot collide', () => {
+    // `rand_b` is the last 12 hex characters. Two calls asking for the same
+    // ordinals must not produce the same ids: vitest runs these files in
+    // parallel against ONE database.
+    const first = sameMillisecondIds(4);
+    const second = sameMillisecondIds(4);
+
+    expect(new Set([...first, ...second]).size).toBe(8);
+  });
+
+  it('refuses a count it cannot represent rather than silently repeating an id', () => {
+    expect(() => sameMillisecondIds(1)).toThrow(RangeError);
+    expect(() => sameMillisecondIds(4097)).toThrow(RangeError);
+    expect(() => sameMillisecondIds(2.5)).toThrow(RangeError);
+  });
+});
+
+describe('uuidv7 — the property the fixtures used to assume', () => {
+  it('does NOT order two ids minted in the same millisecond by mint order', () => {
+    /*
+     * This is the claim four suites carried in comments ("uuid v7 is monotonic,
+     * so the later insert leads") and it is false: `uuidv7()` is a millisecond
+     * timestamp plus `randomFillSync`, with none of RFC 9562's optional
+     * monotonic counter. Same-millisecond pairs therefore order on randomness.
+     *
+     * Asserted as "at least one inversion in a large sample" rather than a rate,
+     * so it cannot flake: the measured inversion rate is ~49.3%, so a run of
+     * PAIRS same-millisecond comparisons all landing the same way has
+     * probability about 2^-PAIRS. The sample is verified to be genuinely tied
+     * first, so a future implementation that spaced ids across milliseconds
+     * would fail the floor rather than read as "monotonic".
+     */
+    const SAMPLES = 500;
+    let tied = 0;
+    let inverted = 0;
+
+    for (let i = 0; i < SAMPLES; i += 1) {
+      const earlier = uuidv7();
+      const later = uuidv7();
+      if (timestampOf(earlier) !== timestampOf(later)) continue;
+      tied += 1;
+      if (later < earlier) inverted += 1;
+    }
+
+    expect(tied).toBeGreaterThan(100);
+    expect(inverted).toBeGreaterThan(0);
+  });
+});

--- a/packages/backend/src/__tests__/helpers/tiedIds.ts
+++ b/packages/backend/src/__tests__/helpers/tiedIds.ts
@@ -1,0 +1,98 @@
+/**
+ * Ids that SHARE a millisecond and whose relative order is fixed by
+ * construction.
+ *
+ * ## The belief this exists to retire
+ *
+ * Several ranking and pagination suites created two rows back to back and then
+ * asserted which one led, justified by a comment saying "uuid v7 is monotonic,
+ * so the later insert leads". **It is not.** `uuidv7()` in
+ * `db/schema/columns.ts` is 48 bits of `Date.now()` followed by
+ * `randomFillSync` — RFC 9562's optional monotonic counter (the `rand_a`
+ * "method 2" sub-millisecond sequence) is NOT implemented, and
+ * `db/posts/postRepository.ts` already says so where it explains why an
+ * authorship byline cannot be recovered from id order.
+ *
+ * Two ids minted in the same millisecond therefore order on their RANDOM tail.
+ * Measured on this implementation: 19,967 of 20,000 back-to-back in-process
+ * pairs shared a millisecond, and 49.3% of those put the EARLIER id first — a
+ * coin flip, not a rare edge. A sibling suite
+ * (`services/profileLinkMentionWrites.test.ts`) had already measured the same
+ * thing the hard way, at 4 passes to 6 failures over ten runs of one file.
+ *
+ * Those suites passed only because a database round trip usually pushes two
+ * inserts into different milliseconds. That is latency, not a guarantee: it
+ * makes the assertion a coin flip exactly when the round trip is fast, so the
+ * failure arrives at random, months later, looking like a ranking or pagination
+ * regression rather than a fixture.
+ *
+ * ## What this does instead
+ *
+ * `posts.id` is supplied by the caller when `PostRecordInput.id` is set, so a
+ * fixture can state the tie rather than hope for it. Every id from ONE call
+ * carries the same 48-bit timestamp and differs only in `rand_a`, which sits
+ * immediately after it — so the ids are strictly ascending with their index,
+ * and the pair is a genuine same-millisecond tie of exactly the kind the
+ * production tiebreak exists to resolve. Spacing the writes across milliseconds
+ * would have been the other way to make the fixture deterministic, but it
+ * removes the very case under test.
+ *
+ * `rand_b` (bytes 9-15) stays random, because vitest runs these files in
+ * parallel against ONE database and a fixed tail would collide between suites.
+ *
+ * The ids are real uuid v7 values — correct version nibble and RFC 9562
+ * variant — so every shape check that tells a post-cutover id from a 24-char
+ * ObjectId hex still classifies them correctly.
+ */
+
+import { randomFillSync } from 'node:crypto';
+
+const UUID_BYTES = 16;
+const UUID_V7_TIMESTAMP_BYTES = 6;
+
+/**
+ * `rand_a` is 12 bits — byte 6's low nibble plus byte 7 — so it addresses 4096
+ * ids within one millisecond. Every fixture here wants a handful.
+ */
+const MAX_ORDINAL = 0x0fff;
+
+/**
+ * `count` uuid v7 ids sharing one millisecond, strictly ascending.
+ *
+ * Index 0 is the LOWEST id, so a `desc(id)` tiebreak puts the LAST element
+ * first. Callers name the two ends rather than relying on insertion order.
+ */
+export function sameMillisecondIds(count: number): string[] {
+  if (!Number.isInteger(count) || count < 2 || count > MAX_ORDINAL + 1) {
+    throw new RangeError(`sameMillisecondIds needs an integer 2..${MAX_ORDINAL + 1}, got ${count}`);
+  }
+
+  // ONE clock reading for the whole run: two readings could straddle a
+  // millisecond boundary and the ids would no longer be tied.
+  const milliseconds = Date.now();
+  return Array.from({ length: count }, (_, ordinal) => mintTiedId(milliseconds, ordinal));
+}
+
+function mintTiedId(milliseconds: number, ordinal: number): string {
+  const bytes = new Uint8Array(UUID_BYTES);
+  randomFillSync(bytes);
+
+  // Big-endian 48-bit millisecond timestamp, exactly as `uuidv7()` writes it.
+  let remaining = milliseconds;
+  for (let index = UUID_V7_TIMESTAMP_BYTES - 1; index >= 0; index -= 1) {
+    bytes[index] = remaining & 0xff;
+    remaining = Math.floor(remaining / 256);
+  }
+
+  // Version 7 in the high nibble of octet 6, and the ordinal across the 12 bits
+  // of `rand_a`. Placing it HERE rather than in the tail is what makes the order
+  // deterministic: `rand_a` is the most significant field after the timestamp,
+  // so it decides the comparison before any random byte is reached.
+  bytes[6] = 0x70 | ((ordinal >>> 8) & 0x0f);
+  bytes[7] = ordinal & 0xff;
+  // RFC 9562 variant `10` in the top two bits of octet 8; the rest stays random.
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Buffer.from(bytes).toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/backend/src/__tests__/popularFallbackPagination.test.ts
+++ b/packages/backend/src/__tests__/popularFallbackPagination.test.ts
@@ -78,6 +78,7 @@ import {
 import { FeedEngine } from '../mtn/feed/engine/FeedEngine';
 import { FeedModuleRegistry } from '../mtn/feed/engine/FeedModuleRegistry';
 import type { FeedDefinition, FeedEngineContext, SourceModule } from '../mtn/feed/engine/types';
+import { sameMillisecondIds } from './helpers/tiedIds';
 
 let db: Database;
 const created: string[] = [];
@@ -156,17 +157,23 @@ async function create(
  *
  * - `top` / `second`: distinct engagement.
  * - `sameScoreNewer` / `sameScoreOlder`: TIED on engagement, split by `created_at`.
- * - `tiedLater` / `tiedEarlier`: tied on engagement AND `created_at`, split by id
- *   descending (uuid v7 is monotonic, so the later insert leads).
+ * - `tiedHigher` / `tiedLower`: tied on engagement AND `created_at`, split by id
+ *   descending — so the HIGHER id leads.
+ *
+ * That last pair's ids are SUPPLIED rather than minted. `uuidv7()` has no
+ * monotonic counter, so two rows written back to back order on their random tail
+ * whenever they share a millisecond; asserting that the later insert leads was a
+ * coin flip that a database round trip usually, but not reliably, hid.
  */
 async function pool(content: Partial<PostRecordInput>): Promise<string[]> {
+  const [tiedLower, tiedHigher] = sameMillisecondIds(2);
   const top = await create(50, RECENT, content);
   const second = await create(40, RECENT, content);
   const sameScoreOlder = await create(30, OLDER, content);
   const sameScoreNewer = await create(30, RECENT, content);
-  const tiedEarlier = await create(10, RECENT, content);
-  const tiedLater = await create(10, RECENT, content);
-  return [top, second, sameScoreNewer, sameScoreOlder, tiedLater, tiedEarlier];
+  await create(10, RECENT, { ...content, id: tiedLower });
+  await create(10, RECENT, { ...content, id: tiedHigher });
+  return [top, second, sameScoreNewer, sameScoreOlder, tiedHigher, tiedLower];
 }
 
 function definitionFor(sourceId: string): FeedDefinition {

--- a/packages/backend/src/__tests__/rankedSourceCandidateWindow.test.ts
+++ b/packages/backend/src/__tests__/rankedSourceCandidateWindow.test.ts
@@ -118,6 +118,7 @@ import type {
   FeedEngineContext,
   SourceModule,
 } from '../mtn/feed/engine/types';
+import { sameMillisecondIds } from './helpers/tiedIds';
 
 let db: Database;
 const created: string[] = [];
@@ -150,9 +151,10 @@ function authorFor(index: number): string {
   return `ranked-window-author-${index}`;
 }
 
-async function create(index: number, likes: number): Promise<string> {
+async function create(index: number, likes: number, id?: string): Promise<string> {
   const author = authorFor(index);
   const input: PostRecordInput = {
+    id,
     oxyUserId: author,
     authorship: [{ oxyUserId: author, role: 'owner', status: 'accepted' }],
     type: PostType.VIDEO,
@@ -199,8 +201,12 @@ describe.each([
   ['media', mediaSource],
 ])('the %s candidate window', (_name, source: SourceModule) => {
   /**
-   * Five posts, created oldest-first, so ids ascend with insertion (uuid v7 is
-   * monotonic).
+   * Five posts whose ids ASCEND, because they are supplied that way.
+   *
+   * They are not left to `uuidv7()`: it has no monotonic counter, so five rows
+   * written back to back do not ascend at all once any two share a millisecond —
+   * their order is decided by the random tail. The vacuity floor below would then
+   * fail at random and name the candidate window for what is really a fixture.
    *
    * The ANCHOR is the middle row and carries the HIGHEST engagement — a page-one
    * cursor anchor is the lowest-scoring slice of the page, and its position in id
@@ -208,12 +214,13 @@ describe.each([
    * id order and two below, so an id bound in EITHER direction is visible here.
    */
   async function fixtures(): Promise<{ ids: string[]; anchor: string; pageTwoCandidate: string }> {
+    const ascending = sameMillisecondIds(5);
     const ids = [
-      await create(0, 4),
-      await create(1, 3),
-      await create(2, 9),
-      await create(3, 2),
-      await create(4, 1),
+      await create(0, 4, ascending[0]),
+      await create(1, 3, ascending[1]),
+      await create(2, 9, ascending[2]),
+      await create(3, 2, ascending[3]),
+      await create(4, 1, ascending[4]),
     ];
     return { ids, anchor: ids[2], pageTwoCandidate: ids[4] };
   }

--- a/packages/backend/src/__tests__/utils/mentionNotificationCap.test.ts
+++ b/packages/backend/src/__tests__/utils/mentionNotificationCap.test.ts
@@ -46,7 +46,7 @@ vi.mock('../../utils/push', () => ({
   sendPushToUser: mocks.sendPushToUser,
 }));
 
-import { asc, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import {
   MAX_MENTION_NOTIFICATIONS_PER_POST as CAP,
   isMentionBroadcast,
@@ -69,21 +69,34 @@ const mentionIds = (count: number): string[] =>
   Array.from({ length: count }, (_, i) => `${RUN}_mentioned_${i}`);
 
 /**
- * The recipient ids that actually have a row, in insertion order.
+ * The recipient ids that actually have a row, SORTED — the set, not a sequence.
  *
- * Ordered by `id` rather than by `created_at`: every row of one fan-out is
- * written inside the same statement burst, and `now()` is
- * `transaction_timestamp()`, so `created_at` is a tie. The ids are uuid v7,
- * which is monotonic — and every row here is post-cutover, so ordering by id is
- * meaningful in exactly this narrow case.
+ * This used to order by `id` and call the result insertion order, on the grounds
+ * that uuid v7 is monotonic. It is NOT: `uuidv7()` (`db/schema/columns.ts`) is 48
+ * bits of `Date.now()` followed by `randomFillSync`, with none of RFC 9562's
+ * optional monotonic counter, so two rows sharing a millisecond order on their
+ * random tail — measured at a ~50/50 split, the same coin flip
+ * `services/profileLinkMentionWrites.test.ts` records having hit for real.
+ * `db/posts/postRepository.ts` states the rule.
+ *
+ * `createMentionNotifications` fans out in a sequential loop of separate round
+ * trips, so the rows usually — never reliably — land in distinct milliseconds.
+ * Every collision was a 50% chance of transposing two names inside an ordered
+ * `toEqual`, which is a red failure arriving at random, with no code change, and
+ * reading as a cap regression.
+ *
+ * Sorting is the right answer here rather than pinning the ids, because ORDER
+ * CARRIES NO MEANING: every case below asks who was notified and how many — the
+ * cap's decision — and nothing reads notifications in id sequence. The
+ * assertions keep their full force; a truncated prefix, a missing recipient, an
+ * extra one or a wrongly suppressed fan-out all still fail.
  */
 const notifiedRecipients = async (): Promise<string[]> => {
   const rows = await getDb()
     .select({ recipientId: notifications.recipientId })
     .from(notifications)
-    .where(eq(notifications.entityId, POST_ID))
-    .orderBy(asc(notifications.id));
-  return rows.map((row) => row.recipientId);
+    .where(eq(notifications.entityId, POST_ID));
+  return rows.map((row) => row.recipientId).sort();
 };
 
 beforeAll(async () => {
@@ -125,7 +138,7 @@ describe('createMentionNotifications — fan-out cap boundary', () => {
   it(`notifies every mentioned user AT the cap (${CAP})`, async () => {
     await createMentionNotifications(mentionIds(CAP), POST_ID, AUTHOR, 'post');
 
-    expect(await notifiedRecipients()).toEqual(mentionIds(CAP));
+    expect(await notifiedRecipients()).toEqual([...mentionIds(CAP)].sort());
     expect(mocks.loggerWarn).not.toHaveBeenCalled();
   });
 
@@ -152,7 +165,7 @@ describe('createMentionNotifications — fan-out cap boundary', () => {
 
     await createMentionNotifications(duplicated, POST_ID, AUTHOR, 'post');
 
-    expect(await notifiedRecipients()).toEqual(mentionIds(CAP));
+    expect(await notifiedRecipients()).toEqual([...mentionIds(CAP)].sort());
   });
 });
 
@@ -177,6 +190,6 @@ describe('createMentionNotifications — suppression is observable', () => {
     );
 
     expect(mocks.loggerWarn).not.toHaveBeenCalled();
-    expect(await notifiedRecipients()).toEqual([`${RUN}_mentioned_0`, `${RUN}_mentioned_1`]);
+    expect(await notifiedRecipients()).toEqual([`${RUN}_mentioned_0`, `${RUN}_mentioned_1`].sort());
   });
 });

--- a/packages/backend/src/__tests__/videosFeedMetadata.test.ts
+++ b/packages/backend/src/__tests__/videosFeedMetadata.test.ts
@@ -75,6 +75,7 @@ import { videosSource } from '../mtn/feed/engine/sources/discoverySources';
 import { FeedEngine } from '../mtn/feed/engine/FeedEngine';
 import { FeedModuleRegistry } from '../mtn/feed/engine/FeedModuleRegistry';
 import type { FeedDefinition, FeedEngineContext } from '../mtn/feed/engine/types';
+import { sameMillisecondIds } from './helpers/tiedIds';
 
 let db: Database;
 
@@ -262,25 +263,44 @@ describe('portrait-first ordering on the served page', () => {
   }
 
   /**
-   * THE PORTRAIT POST IS INSERTED FIRST, AND THAT ORDER IS THE ENTIRE TEST.
+   * THE LANDSCAPE POST CARRIES THE HIGHER ID, AND THAT IS THE ENTIRE TEST.
    *
    * On a ranking tie `finalizeRanked` falls through to
-   * `readCandidateId(b).localeCompare(readCandidateId(a))` — DESCENDING id — and
-   * ids are uuid v7, so the later insert wins. Insert the portrait clip last and
-   * the id tiebreak alone produces `[portrait, landscape]`: the assertion passes
-   * whether or not the portrait preference exists, which is worth nothing.
+   * `readCandidateId(b).localeCompare(readCandidateId(a))` — DESCENDING id — so
+   * giving the landscape clip the higher id makes the tiebreak alone produce
+   * `[landscape, portrait]`. The assertion is the OPPOSITE order, so it can only
+   * pass if the portrait preference did the work.
+   *
+   * The ids are SUPPLIED rather than left to insertion order, and that is a
+   * correctness fix rather than tidying. `uuidv7()` has no monotonic counter, so
+   * two rows written back to back share a millisecond and order on their RANDOM
+   * tail — "insert the portrait first" therefore bought this control only about
+   * half the time, and the other half the id tiebreak agreed with the assertion
+   * and it passed whether or not the preference existed. That failure mode is
+   * GREEN, not red: nothing reports a check that has stopped discriminating.
+   *
    * Mutation-tested — renaming the definition away from `videos` (the id the
-   * preference is keyed on) had to make this go RED, and with the fixtures in
-   * this order it does.
+   * preference is keyed on) had to make this go RED, and with the ids pinned this
+   * way it does on every run rather than half of them.
    */
   it('emits a portrait clip before a landscape one when ranking ties', async () => {
-    const portrait = await create([video({ id: 'm-port', orientation: 'portrait', durationSec: 30 })]);
+    const [portraitId, landscapeId] = sameMillisecondIds(2);
+    const portrait = await create([video({ id: 'm-port', orientation: 'portrait', durationSec: 30 })], {
+      id: portraitId,
+    });
     const landscape = await create(
       [video({ id: 'm-land', width: 1920, height: 1080, orientation: 'landscape', durationSec: 30 })],
-      { oxyUserId: OTHER_AUTHOR, authorship: [{ oxyUserId: OTHER_AUTHOR, role: 'owner', status: 'accepted' }] },
+      {
+        id: landscapeId,
+        oxyUserId: OTHER_AUTHOR,
+        authorship: [{ oxyUserId: OTHER_AUTHOR, role: 'owner', status: 'accepted' }],
+      },
     );
 
-    // The id tiebreak alone would say `[landscape, portrait]`.
+    // The control, stated rather than assumed: the id tiebreak alone would say
+    // `[landscape, portrait]`, so the expected order below is the one only the
+    // portrait preference can produce.
+    expect(landscape > portrait).toBe(true);
     expect(await emittedIds([portrait, landscape])).toEqual([portrait, landscape]);
     expect(rankPosts).toHaveBeenCalled();
   });
@@ -289,16 +309,27 @@ describe('portrait-first ordering on the served page', () => {
     // `hasPortraitVideo` requires BOTH `type: 'video'` and the orientation. A
     // post carrying a portrait image alongside a landscape clip is landscape as
     // far as the Reels surface is concerned — so the genuinely portrait clip
-    // still leads despite being the OLDER id.
-    const trulyPortrait = await create([video({ id: 'm-tall-video', orientation: 'portrait', durationSec: 30 })]);
+    // still leads despite carrying the LOWER id, which the descending-id tiebreak
+    // would otherwise place second. Supplied for the same reason as the case
+    // above: minting order does not decide id order.
+    const [portraitId, landscapeId] = sameMillisecondIds(2);
+    const trulyPortrait = await create(
+      [video({ id: 'm-tall-video', orientation: 'portrait', durationSec: 30 })],
+      { id: portraitId },
+    );
     const imagePlusLandscape = await create(
       [
         video({ id: 'm-wide', width: 1920, height: 1080, orientation: 'landscape', durationSec: 30 }),
         { id: 'm-tall-photo', type: 'image', width: 1080, height: 1920, orientation: 'portrait' },
       ],
-      { oxyUserId: OTHER_AUTHOR, authorship: [{ oxyUserId: OTHER_AUTHOR, role: 'owner', status: 'accepted' }] },
+      {
+        id: landscapeId,
+        oxyUserId: OTHER_AUTHOR,
+        authorship: [{ oxyUserId: OTHER_AUTHOR, role: 'owner', status: 'accepted' }],
+      },
     );
 
+    expect(imagePlusLandscape > trulyPortrait).toBe(true);
     expect(await emittedIds([trulyPortrait, imagePlusLandscape])).toEqual([
       trulyPortrait,
       imagePlusLandscape,

--- a/packages/backend/src/db/schema/CONVENTIONS.md
+++ b/packages/backend/src/db/schema/CONVENTIONS.md
@@ -107,6 +107,28 @@ measured reason: `uuid@14` is ESM-only under the node condition and this package
 emits CommonJS, while `uuid@11` would collide with the transitive `uuid@3.4.0`
 already hoisted at the workspace root.
 
+**It carries NO monotonic counter, so id order is not insertion order within a
+millisecond.** `uuidv7()` is 48 bits of `Date.now()` followed by
+`randomFillSync`; RFC 9562's optional `rand_a` sub-millisecond sequence is not
+implemented. Two rows minted in the same millisecond therefore order on their
+random tail — measured at 49.3% inversion over 20,000 pairs, a coin flip rather
+than an edge case. The id is still a UNIQUE and STABLE total order, which is
+exactly what the keyset pagination in `mtn/feed/CursorBuilder.ts` needs from it:
+every feed sort spells the id LAST, after `score` and/or `created_at`, so
+chronology is carried by `created_at` and the id only breaks the remaining ties.
+
+Two consequences, both of which have already cost real debugging time:
+
+- **Never assert which of two rows written back to back leads.** A database round
+  trip usually spreads inserts across milliseconds, so such an assertion passes
+  for months and then fails at random, reading as a ranking or pagination
+  regression. Test fixtures state the tie instead —
+  `__tests__/helpers/tiedIds.ts`.
+- **If true insertion order is ever load-bearing, it needs a `position` column
+  and a migration, not a different sort.** `post_content_variants` and
+  `post_sources` already have one; `db/posts/postRepository.ts` records where the
+  absence of one is deliberate.
+
 **Two exceptions, both caller-supplied ids with no generator:**
 `moderation_outbox.id` (deterministic, so a retry re-derives the same row) and
 `moderation_events.id` (the CrowdSource event id — the primary key IS the §10.8


### PR DESCRIPTION
## The false belief

Six backend test files asserted which of two rows created back-to-back sorts
first. Four justified it in a comment: *"uuid v7 is monotonic, so the later
insert leads."*

It is false. `uuidv7()` (`packages/backend/src/db/schema/columns.ts`) is 48 bits
of `Date.now()` followed by `randomFillSync`; RFC 9562's optional monotonic
counter is not implemented. Measured on this exact implementation:

| back-to-back mints | shared a millisecond | earlier id sorted higher |
|---|---|---|
| 20,000 | 19,967 | 9,839 (**49.3%**) |

A coin flip, not a rare edge.

**The repository already knew.** `db/posts/postRepository.ts:264`,
`__tests__/db/customFeedRelationWriters.test.ts:25` and `AGENTS.md:156`
("`ORDER BY id DESC` is not a time order") all state it correctly, so the right
and wrong beliefs were coexisting in one codebase.
`services/profileLinkMentionWrites.test.ts:198` records having hit the flake for
real — *4 passes to 6 failures over ten runs of one file*.

These passed only because a database round trip usually pushes two inserts into
different milliseconds. That is latency, not a guarantee, and it makes the
assertion fail exactly when the round trip is fast — at random, months later,
looking like a ranking or pagination regression.

## Two files the four-file list missed

Grepping the **claim** rather than the known files found two more:

- `videosFeedMetadata.test.ts` — phrases it as *"ids are uuid v7, so the later insert wins"*
- `utils/mentionNotificationCap.test.ts` — *"the ids are uuid v7, which is monotonic"*, over a sequential fan-out asserted as an **ordered 8-element array**

`videosFeedMetadata` is the one that mattered most, and it failed **green, not
red**. It inserts the portrait clip first precisely so the descending-id
tiebreak *opposes* the assertion — that opposition is what makes the test
discriminate. When the two ids shared a millisecond, the tiebreak agreed with
the assertion about half the time and the case passed whether or not the
portrait preference existed, *including under the mutation its own docblock
cites as proof it works*. A check that silently stops distinguishing is worse
than a flaky one.

## Is this a schema gap? No.

Every feed sort spells `desc(posts.id)` **last**, after `score` and/or
`created_at` — `discoverySources.ts`, `forYouCandidateSources.ts`,
`socialSources.ts`, `FeedEngine.finalizeRanked`. The id is the final tiebreaker
that makes a keyset **total and stable**; uniqueness and stability are all it
needs, and uuid v7 supplies both. Chronology is already carried by `created_at`,
one key above. No `position` column or explicit sequence would buy anything
here — `postRepository.ts` records where that conclusion *does* apply, and this
is not it.

So the tests were over-specifying a property production neither has nor needs.

## The fix

Fixtures **state** the tie instead of hoping for it.

`__tests__/helpers/tiedIds.ts` mints ids sharing one millisecond whose relative
order is fixed in `rand_a` — the field immediately after the timestamp, so it
decides the comparison before any random byte — with `rand_b` left random so
suites running in parallel against one database cannot collide. The five post
suites pass them through the existing `PostRecordInput.id`.

This deliberately keeps the **same-millisecond tie** the production tiebreak
exists to resolve; spacing the writes across milliseconds would have made the
fixture deterministic by removing the case under test.

`mentionNotificationCap` cannot supply ids (they are minted inside
`createNotification`), so it compares the recipient **set**. Order carries no
meaning there — every case asks who was notified and how many — and nothing
reads notifications in id sequence. Same conclusion, same reasoning, as the
sibling suite that hit this before.

## Mutation testing

Each mutation restored from a pristine copy rather than `git restore` (which
would have reverted the uncommitted fix along with the mutation), with an edit
marker re-asserted after each restore.

| mutation | result |
|---|---|
| explore tie-break `desc(posts.id)` → `asc` | `exploreFeed` **1 failed** |
| `popularOrder` `desc(posts.id)` → `asc` | popular + fallback **20 failed** |
| `FeedEngine` id tiebreak reversed | `rankedSourceCandidateWindow` **2 failed** |
| portrait preference disabled | `videosFeedMetadata` **2 failed** |
| cap notifies a truncated prefix | `mentionNotificationCap` **2 failed** |
| cap notifies one fewer recipient | `mentionNotificationCap` **3 failed** |

The failure diffs show the supplied ids transposed with a shared timestamp
prefix (`019fe66d-34e0-7000…` / `019fe66d-34e0-7001…`), confirming the tie is
genuine and the ordinal lands where intended.

`helpers/tiedIds.test.ts` is the vacuity floor: if the helper stopped producing
tied or ascending ids, the five suites would keep passing while no longer
pinning anything. It also records the motivating fact as an executable
assertion.

## Gates

- `tsc --noEmit` clean
- Full backend suite **483 files / 5928 tests passed**
- The seven affected files green **10 runs out of 10**
- Run on a dedicated Postgres container, not the shared local one, to avoid
  known cross-agent contention
- `bun.lock` byte-unchanged

## Comments and docs

Every comment asserting the false property is rewritten to state the true one —
a comment asserting a false property is worse than none, because the next person
reasons from it. `db/schema/CONVENTIONS.md` gains the property and its two
consequences, since package `files` excludes docs and a wrong statement there is
the one that survives longest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
