### PR TITLE
ci(no-mongo): match MONGO_URI too — the narrow pattern IS the bug

### DIFF
--- a/scripts/test-validate-no-mongo.mjs
+++ b/scripts/test-validate-no-mongo.mjs
@@ -488,6 +488,21 @@ const cases = [
     expectOutput: "tracked by git but could not be read",
   },
 
+  {
+    // Not this repository's own spelling, and included for exactly that reason:
+    // with nothing here matching either form, `/\\bMONGODB_URI/i` and
+    // `/\\bMONGO(?:DB)?_URI/i` are indistinguishable, and the broader pattern
+    // would be an untested claim. A sibling Oxy service carries `MONGO_URI` on
+    // its live task definition, and a guard written for the other spelling
+    // called that repository clean while the secret was still there.
+    name: "the no-DB spelling MONGO_URI is caught too, and reported as itself",
+    files: filler({
+      "packages/backend/src/config/legacy.ts": "export const uri = process.env.MONGO_URI;\n",
+    }),
+    expectFailure: true,
+    expectOutput: "names MONGO_URI",
+  },
+
   // ------------------------------------------------------- self-protection ---
   {
     name: "a broken file listing cannot pass silently (vacuity floors)",

--- a/scripts/validate-no-mongo.mjs
+++ b/scripts/validate-no-mongo.mjs
@@ -189,8 +189,19 @@ const BANNED_IMPORT = new RegExp(
  * and a lowercased `mongodb_uri` config key are both the same reference. No
  * trailing word boundary, deliberately: a suffixed spelling is the likeliest way
  * one comes back, and nothing benign is spelled this way.
+ *
+ * `MONGO_URI` — no DB — is matched too, and the reason is worth keeping. A
+ * sibling Oxy service spells it that way on its LIVE task definition and in its
+ * SSM parameter, and `MONGODB_URI` appears nowhere in that repository. A check
+ * written for one spelling reported it clean while a live secret named a
+ * database that was about to be dropped, and the mistake surfaced sideways
+ * rather than by anyone re-reading the pattern.
+ *
+ * So a guard that catches one spelling and certifies the other is not a weaker
+ * guard — it is an instance of the failure it exists to prevent. Matching both
+ * costs nothing.
  */
-const MONGO_ENV_VARIABLE = /\bMONGODB_URI/i;
+const MONGO_ENV_VARIABLE = /\bMONGO(?:DB)?_URI/i;
 
 /** A live connection string. Escaped regex SOURCE containing `:\/\/` cannot match. */
 const MONGO_CONNECTION_STRING = /\bmongodb(?:\+srv)?:\/\//i;
@@ -363,8 +374,14 @@ for (const path of [...sources, ...configs]) {
     if (isSource && BANNED_IMPORT.test(line)) {
       record(path, index + 1, line.trim(), "imports a Mongo driver");
     }
-    if (MONGO_ENV_VARIABLE.test(line)) {
-      record(path, index + 1, line.trim(), "names MONGODB_URI");
+    const envMatch = MONGO_ENV_VARIABLE.exec(line);
+    if (envMatch) {
+      // Reports the spelling it actually MATCHED, not the one this guard is
+      // named after. Same principle as printing the whole matched line instead
+      // of a capture group: an operator reading "names MONGODB_URI" under a line
+      // that says MONGO_URI would reasonably doubt the tool, and doubting the
+      // tool is how a real finding gets dismissed.
+      record(path, index + 1, line.trim(), `names ${envMatch[0].toUpperCase()}`);
     }
     if (MONGO_CONNECTION_STRING.test(line)) {
       record(path, index + 1, line.trim(), "carries a mongodb:// connection string");


### PR DESCRIPTION
The env check matched `MONGODB_URI` only. A sibling Oxy service spells it **without the DB** — `MONGO_URI` on its live task definition, in its SSM parameter and in its deploy workflow, with `MONGODB_URI` appearing nowhere — so this guard would have reported that repository **clean while a live secret named a database about to be dropped**.

That is not a weaker guard. **It is an instance of the exact failure the guard exists to prevent:** a spelling substitution producing a false "clean" is the whole finding, so a check that catches one spelling and certifies the other is the bug, not a smaller version of the protection.

It surfaced **sideways** — while porting this guard to the repo that happens to use the other spelling — rather than by anyone re-reading the pattern. Nobody would have found it by inspection, which is why it belongs in every copy and not just the one where it bit.

### Why there is a fixture for a spelling this repo does not use

With nothing in this tree matching either form, `/\bMONGODB_URI/i` and `/\bMONGO(?:DB)?_URI/i` are **indistinguishable** — the change would otherwise be an untested claim.

### Findings now report the spelling they matched

Same principle as printing the full matched line instead of a capture group: an operator reading *"names MONGODB_URI"* under a line that says `MONGO_URI` would reasonably doubt the tool, and doubting the tool is how a real finding gets dismissed.

### Verification

Mutation-tested with the probe file **staged** — the guard reads `git ls-files`, not the filesystem, so an unstaged probe is never scanned and the run passes for the wrong reason (measured: exit 0 until it was `git add`ed). Staged, the guard exits 1 naming the file and line; removed, exit 0. Self-test **32 → 33**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)