### PR TITLE
fix(connectors): the duplicate-key guards still tested for MongoDB's error code

### DIFF
--- a/packages/backend/src/connectors/activitypub/helpers.ts
+++ b/packages/backend/src/connectors/activitypub/helpers.ts
@@ -474,17 +474,6 @@ export async function runWithTimeout<T>(work: Promise<T>, timeoutMs: number): Pr
 }
 
 /**
- * Whether an error is a MongoDB duplicate-key error (code 11000), including
- * Mongoose `MongoServerError` and bulk write error shapes.
- */
-export function isDuplicateKeyError(err: unknown): boolean {
-  if (err && typeof err === 'object' && 'code' in err) {
-    return (err as { code?: unknown }).code === 11000;
-  }
-  return false;
-}
-
-/**
  * Extract the announced object URI from an Announce activity's `object`,
  * which may be a plain URI string or an embedded object with an `id`.
  */

--- a/packages/backend/src/connectors/activitypub/outbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/outbox.service.ts
@@ -53,7 +53,6 @@ import {
   fetchActivityPubObject,
   fetchVerifiedAnnouncedNote,
   runWithTimeout,
-  isDuplicateKeyError,
   extractAnnouncedObjectUri,
   extractActorUri,
   extractInReplyToUri,
@@ -1375,9 +1374,9 @@ export class OutboxSyncService {
         ...(published ? { createdAt: published, updatedAt: published } : {}),
       });
     } catch (err) {
-      // A duplicate-key error means a concurrent import already created the
+      // A unique violation means a concurrent import already created the
       // boost — treat as already-imported, not a failure.
-      if (isDuplicateKeyError(err)) return false;
+      if (isUniqueViolation(err)) return false;
       const message = err instanceof Error ? err.message : String(err);
       logger.warn('[FedSync] failed to create boost', {
         error: message,
@@ -1629,7 +1628,7 @@ export class OutboxSyncService {
       return created.id;
     } catch (err) {
       // Concurrent import may have created it — re-read to return the id.
-      if (isDuplicateKeyError(err)) {
+      if (isUniqueViolation(err)) {
         const [raced] = await getDb()
           .select({ id: posts.id })
           .from(posts)

--- a/packages/backend/src/connectors/atproto/post.mapper.ts
+++ b/packages/backend/src/connectors/atproto/post.mapper.ts
@@ -3,6 +3,7 @@ import { normalizeMultilineText } from '@oxyhq/core';
 import { logger } from '../../utils/logger';
 import { inArray } from 'drizzle-orm';
 import { getDb } from '../../db/postgres';
+import { isUniqueViolation } from '../../db/pgErrors';
 import { posts } from '../../db/schema/posts';
 import { findActorByUri } from '../../db/federation/actorRepository';
 import { normalizeAlt } from '../../services/MediaMetadataService';
@@ -395,11 +396,6 @@ export function mapPostViewToNormalizedPost(
   };
 }
 
-/** True for a MongoDB duplicate-key (E11000) error — a concurrent import race. */
-function isDuplicateKeyError(err: unknown): boolean {
-  return Boolean(err && typeof err === 'object' && (err as { code?: number }).code === 11000);
-}
-
 /**
  * Resolve a mentioned atproto DID to its Oxy user id. Prefers an already-synced
  * `federated_actors` row (no network round trip); otherwise resolves + mints the actor
@@ -556,7 +552,7 @@ async function createPostFromNormalized(
     });
     return true;
   } catch (err) {
-    if (isDuplicateKeyError(err)) return false;
+    if (isUniqueViolation(err)) return false;
     logger.warn('[atproto] failed to import post', err);
     return false;
   }

--- a/packages/backend/src/connectors/atproto/starterpack.mapper.ts
+++ b/packages/backend/src/connectors/atproto/starterpack.mapper.ts
@@ -219,8 +219,9 @@ async function upsertMirroredPack(
     });
     return true;
   } catch (err) {
-    // A concurrent sync of the same pack can race the upsert to an E11000; that is
-    // benign (the other writer landed the same mirror), so it is not re-thrown.
+    // A concurrent sync of the same pack can race the upsert to a unique
+    // violation; that is benign (the other writer landed the same mirror), so it
+    // is not re-thrown.
     logger.warn('[atproto] failed to upsert mirrored starter pack', err);
     return false;
   }

--- a/packages/backend/src/utils/push.ts
+++ b/packages/backend/src/utils/push.ts
@@ -167,9 +167,8 @@ export async function formatPushForNotification(n: PushNotificationSource) {
   let f = map[n.type] || { title: 'Notification', body: 'You have a new notification' };
   let preview: string | undefined;
   // For post notifications, try to include a short preview in the push body.
-  // The POST row is deliberately still read from Mongo: `posts` and
-  // `resolveVariant`'s content shape belong to the posts batch, and reading a
-  // half-migrated table here would produce an empty preview rather than an error.
+  // Best-effort: a preview is a nicety, so every failure below is swallowed and
+  // logged at debug. A push with a generic body is better than no push.
   try {
     if (n.type === 'post' && n.entityType === 'post' && n.entityId) {
       const post = await loadPostRecord(String(n.entityId));


### PR DESCRIPTION
## Not a prose cleanup

`validate:no-mongo` passes and there is no `mongoose` anywhere, so this started as
a docs sweep. It isn't: **two live guards were still classifying failures by
MongoDB's duplicate-key code**, which no Postgres error carries.

`db/pgErrors.ts` says in its own first line that the port replaces
`error.code === 11000` **"at every call site"** with a SQLSTATE check. Two were
missed — and `outbox.service.ts` is the evidence that this was an oversight, not a
decision: it **already imports `isUniqueViolation`** and uses it at line 969,
while importing and using the broken predicate at 1379 and 1631.

## Why it can never fire

```ts
// connectors/activitypub/helpers.ts — deleted here
export function isDuplicateKeyError(err: unknown): boolean {
  return (err as { code?: unknown }).code === 11000;   // MongoDB
}
```

Postgres reports a unique violation as SQLSTATE **`23505`**. It is wrong twice
over: `pgErrors.ts` also documents that **drizzle wraps the driver failure**, so
the SQLSTATE lives on `cause` and a predicate reading `error.code` directly
*"matches NOTHING"*.

## What it costs, per site

| Site | Effect |
|---|---|
| **`outbox.service.ts:1631`** | **Loses data.** On a concurrent import race it should re-read `posts` by `federationActivityId` and return the winner's id; instead it logged a warning and returned `null`, dropping the Announce that depended on it. `pgErrors.ts` explicitly names "`federation.activityId` dedup" as a branch relying on this predicate. |
| `outbox.service.ts:1379` | Same return value (`false`) either way — cost is a spurious warning |
| `atproto/post.mapper.ts:555` | Same |

All three are **concurrency-only**, which is why nothing surfaced them.

## The change

A clean cut rather than a translation: the exported helper and the private copy in
`atproto/post.mapper.ts` are both **deleted**, and all three call sites use
`isUniqueViolation` from `db/pgErrors`.

The **unnamed** form matches the existing precedent one file over
(`atproto/profile.mapper.ts:236`). `pgErrors.ts` argues a handler mapping a
duplicate onto a *retry* should name its constraint — none of these three retries
(they return "already imported" or re-read one specific row), so naming them is a
separate hardening call, not part of de-Mongo-ing. Flagging it rather than doing
it.

## Two stale comments

`utils/push.ts` claimed "The POST row is deliberately still read from Mongo" —
`loadPostRecord` is `db/posts/postRepository.ts`. `starterpack.mapper.ts`
described a benign race as reaching "an E11000"; that path catches everything and
was never broken.

## Deliberately kept

The `11000` references in `db/pgErrors.ts`, `db/moderation/moderationEventRepository.ts`
and `services/moderation/moderationEventStore.ts` explain why the current shape is
what it is. `moderationEventStore` is the **better** pattern and says so — it
removed the classifier entirely in favour of `ON CONFLICT DO NOTHING … RETURNING`,
making "somebody else has this" a *value* rather than an exception to inspect. The
three sites here still catch because their inserts go through a shared
post-creation path; converting them is a larger change than this PR should carry.

## Verification

- backend `tsc` clean; lint clean
- connectors — **81 files / 885 tests** green
- **full backend suite — 483 files / 5928 tests, 0 failures**
- `validate:no-mongo` — 33/33 guard self-test cases
- `bun.lock` **byte-unchanged**

Run on a dedicated `postgis/postgis:17-3.5` container rather than the shared one,
so the file-level contention failures `AGENTS.md` warns about could not be
confused with real red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)