### PR TITLE
Enforce MCP scopes for pre-resolved MCP identities

### DIFF
--- a/packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts
+++ b/packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts
@@ -15,14 +15,15 @@ vi.mock('../../mcp/services/mcpRevocationService', () => ({
 // and every case times out rather than exercising the scope check.
 vi.mock('../../mcp/services/mcpBundleService', () => ({
   resolveBundleContext: vi.fn(async (jti: string, sub: string) => ({
-    connectionId: 'conn-1',
     bundleId: 'bundle-1',
-    activeOxyUserId: sub,
+    clientId: 'test-client',
+    primaryUserId: sub,
+    activeUserId: sub,
     jti,
   })),
 }));
 
-import { createRequireMcpOrOxyAuth } from '../../mcp/middleware/mcpAuth';
+import { createOptionalMcpAuth, createRequireMcpOrOxyAuth } from '../../mcp/middleware/mcpAuth';
 import { signAccessToken } from '../../mcp/services/mcpTokenService';
 
 function token(scopes: string[]): string {
@@ -46,8 +47,21 @@ function buildApp() {
   return app;
 }
 
+function buildProductionOrderedApp() {
+  const app = express();
+  app.use(express.json());
+  const fakeOxy = {
+    auth: () => (_req: express.Request, res: express.Response) => res.status(401).json({ error: 'oxy_required' }),
+  } as unknown as OxyServices;
+  app.use(createOptionalMcpAuth());
+  app.use(createRequireMcpOrOxyAuth(fakeOxy));
+  app.post('/resource', (_req, res) => res.status(201).json({ ok: true }));
+  return app;
+}
+
 describe('createRequireMcpOrOxyAuth MCP scope enforcement', () => {
   const app = buildApp();
+  const productionOrderedApp = buildProductionOrderedApp();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -77,6 +91,27 @@ describe('createRequireMcpOrOxyAuth MCP scope enforcement', () => {
 
   it('allows write-scoped MCP tokens on mutating requests', async () => {
     const res = await request(app).post('/resource').set('Authorization', `Bearer ${token(['mcp:read', 'mcp:write'])}`).send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('rejects read-only MCP tokens pre-resolved by optional auth on mutating requests', async () => {
+    const res = await request(productionOrderedApp)
+      .post('/resource')
+      .set('Authorization', `Bearer ${token(['mcp:read'])}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('insufficient_scope');
+    expect(res.body.required_scope).toBe('mcp:write');
+  });
+
+  it('allows write-scoped MCP tokens pre-resolved by optional auth on mutating requests', async () => {
+    const res = await request(productionOrderedApp)
+      .post('/resource')
+      .set('Authorization', `Bearer ${token(['mcp:read', 'mcp:write'])}`)
+      .send({});
 
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ ok: true });

--- a/packages/backend/src/mcp/middleware/mcpAuth.ts
+++ b/packages/backend/src/mcp/middleware/mcpAuth.ts
@@ -134,9 +134,9 @@ function requiredMcpScopeForRequest(req: Request): 'mcp:read' | 'mcp:write' {
   return ['GET', 'HEAD', 'OPTIONS'].includes(req.method.toUpperCase()) ? 'mcp:read' : 'mcp:write';
 }
 
-function enforceMcpRequestScope(req: Request, res: Response, outcome: Extract<McpAuthOutcome, { status: 'ok' }>): boolean {
+function enforceMcpRequestScope(req: Request, res: Response, scope: string): boolean {
   const requiredScope = requiredMcpScopeForRequest(req);
-  if (parseScopeSet(outcome.scope).has(requiredScope)) {
+  if (parseScopeSet(scope).has(requiredScope)) {
     return true;
   }
 
@@ -196,8 +196,13 @@ export function createRequireMcpOrOxyAuth(oxy: OxyServices): RequestHandler {
 
   return async (req: Request, res: Response, next: NextFunction) => {
     // An earlier pass (e.g. the global rate limiter's optional auth) may have
-    // already resolved an Oxy identity — honour it and skip re-verification.
+    // already resolved an identity. MCP identities still need the scope for
+    // this route enforced before their pre-resolved user can be trusted.
     if ((req as OxyAuthRequest).user?.id) {
+      const mcp = (req as OxyAuthRequestWithMcp).mcp;
+      if (mcp && !enforceMcpRequestScope(req, res, mcp.scope)) {
+        return;
+      }
       next();
       return;
     }
@@ -206,7 +211,7 @@ export function createRequireMcpOrOxyAuth(oxy: OxyServices): RequestHandler {
     if (token && looksLikeMcpToken(token)) {
       const outcome = await resolveMcpUser(token);
       if (outcome.status === 'ok') {
-        if (!enforceMcpRequestScope(req, res, outcome)) {
+        if (!enforceMcpRequestScope(req, res, outcome.scope)) {
           return;
         }
         attachMcpIdentity(req as OxyAuthRequest, outcome);


### PR DESCRIPTION
### Motivation

- Prevent MCP bearer tokens that were previously accepted by `createOptionalMcpAuth()` from bypassing request-level scope checks when the same request later reaches `createRequireMcpOrOxyAuth()` via the existing `req.user` shortcut.
- Ensure read/write scopes are enforced for MCP identities regardless of middleware ordering so read-scoped or `offline_access`-only tokens cannot perform mutating operations.

### Description

- Update `enforceMcpRequestScope` to accept a scope string and use it to validate the required per-request scope (`mcp:read` vs `mcp:write`).
- When `createRequireMcpOrOxyAuth()` observes a pre-resolved `req.user`, if an MCP identity is attached (`req.mcp`) it now enforces the MCP request scope before trusting the pre-resolved identity and returning early.
- Add regression coverage that reproduces the production middleware ordering by mounting `createOptionalMcpAuth()` before `createRequireMcpOrOxyAuth()` and asserting that read-only MCP tokens are rejected for mutating routes while write-scoped tokens remain accepted.
- Files changed: `packages/backend/src/mcp/middleware/mcpAuth.ts` and `packages/backend/src/__tests__/mcp/mcpAuthScope.test.ts` (test fixture adjusted to provide a complete bundle context for optional auth).

### Testing

- Ran `git diff --check` to verify no whitespace/patch issues, which produced no errors.
- Added unit tests exercising both direct and production-ordered middleware paths in `src/__tests__/mcp/mcpAuthScope.test.ts` but running `bun run test --run src/__tests__/mcp/mcpAuthScope.test.ts` was blocked because the test runner (`vitest`) was unavailable in the environment (`node_modules` missing).
- Attempted `bun install --frozen-lockfile` to install dependencies but it failed due to HTTP 403 responses from the configured registry, preventing local execution of the new tests; the tests are present and will validate the fix once CI or a developer environment with working dependency resolution runs them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7114e0f3f48323af93606266959bb2)