### PR TITLE
fix: enforce post ACLs for article reads

### DIFF
--- a/packages/backend/src/__tests__/controllers/articlesController.test.ts
+++ b/packages/backend/src/__tests__/controllers/articlesController.test.ts
@@ -15,6 +15,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { inArray } from 'drizzle-orm';
+import { PostVisibility } from '@mention/shared-types';
 
 import { getArticle } from '../../controllers/articles.controller';
 import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
@@ -31,7 +32,7 @@ interface CapturedResponse {
   body: unknown;
 }
 
-async function call(id: string): Promise<CapturedResponse> {
+async function call(id: string, userId?: string): Promise<CapturedResponse> {
   const captured: CapturedResponse = { status: 200, body: undefined };
   const res = {
     status(code: number) {
@@ -43,7 +44,10 @@ async function call(id: string): Promise<CapturedResponse> {
       return res;
     },
   };
-  await getArticle({ params: { id } } as never, res as never);
+  await getArticle(
+    { params: { id }, user: userId ? { id: userId } : undefined } as never,
+    res as never,
+  );
   return captured;
 }
 
@@ -102,6 +106,29 @@ describe('getArticle', () => {
     expect(res.body).not.toHaveProperty('title');
     expect(res.body).not.toHaveProperty('body');
     expect(JSON.parse(JSON.stringify(res.body))).not.toHaveProperty('title');
+  });
+
+  it.each([
+    ['a private post', { visibility: PostVisibility.PRIVATE, status: 'published' as const }],
+    ['a followers-only post', { visibility: PostVisibility.FOLLOWERS_ONLY, status: 'published' as const }],
+    ['a draft post', { visibility: PostVisibility.PUBLIC, status: 'draft' as const }],
+    ['a scheduled post', { visibility: PostVisibility.PUBLIC, status: 'scheduled' as const }],
+  ])('does not expose an article linked to %s to an anonymous viewer', async (_label, restricted)) => {
+    const author = `article-author-${randomUUID()}`;
+    const [post] = await db
+      .insert(posts)
+      .values({ oxyUserId: author, ...restricted })
+      .returning({ id: posts.id });
+    createdPostIds.push(post.id);
+    const [article] = await db
+      .insert(articles)
+      .values({ postId: post.id, createdBy: author, body: 'private body' })
+      .returning({ id: articles.id });
+    createdArticleIds.push(article.id);
+
+    const res = await call(article.id);
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: 'Article not found' });
   });
 
   it.each([

--- a/packages/backend/src/appRoutes.ts
+++ b/packages/backend/src/appRoutes.ts
@@ -106,7 +106,10 @@ export function createAppRoutes({
   publicApi.use('/feed', optionalAuth, feedRoutes);
   publicApi.use('/posts', optionalAuth, publicPostsRouter);
   publicApi.use('/profile/design', profileDesignRoutes);
-  publicApi.use('/articles', articlesRoutes);
+  // Article bodies inherit the linked post's ACL. Authentication remains
+  // optional so public articles are readable anonymously while owners,
+  // collaborators, and followers can be recognized by the controller.
+  publicApi.use('/articles', optionalAuth, articlesRoutes);
   publicApi.use('/trending', trendingRoutes);
   publicApi.use('/topics', topicsRoutes);
   publicApi.use('/federation', optionalAuth, federationApiRoutes);

--- a/packages/backend/src/controllers/articles.controller.ts
+++ b/packages/backend/src/controllers/articles.controller.ts
@@ -1,7 +1,10 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { eq } from 'drizzle-orm';
+import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { getDb } from '../db/postgres';
 import { articles } from '../db/schema/articles';
+import { postHydrationService } from '../services/PostHydrationService';
+import { createScopedOxyClient } from '../utils/oxyHelpers';
 import { logger } from '../utils/logger';
 
 /**
@@ -25,7 +28,7 @@ import { logger } from '../utils/logger';
  * application behaviour with no Postgres counterpart, but it belongs to the
  * WRITE path (`controllers/posts.controller.ts`), not here.
  */
-export const getArticle = async (req: Request, res: Response) => {
+export const getArticle = async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;
     const [article] = await getDb()
@@ -35,6 +38,22 @@ export const getArticle = async (req: Request, res: Response) => {
       .limit(1);
 
     if (!article) {
+      return res.status(404).json({ message: 'Article not found' });
+    }
+
+    // The article id is included in hydrated post content, but it is not a
+    // bearer credential. Apply the exact same status, visibility, relationship,
+    // profile-privacy, collaboration, restriction, and block checks as post
+    // detail before returning the long-form body. Keep a 404 response so this
+    // endpoint does not disclose whether a forbidden article exists.
+    if (
+      article.postId !== null &&
+      !(await postHydrationService.canViewerReadPostId(
+        article.postId,
+        req.user?.id,
+        { oxyClient: createScopedOxyClient(req) },
+      ))
+    ) {
       return res.status(404).json({ message: 'Article not found' });
     }
 

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1998,7 +1998,7 @@ export class PostHydrationService {
    */
   async canViewerReadPostId(
     postId: string,
-    viewerId: string,
+    viewerId?: string,
     options?: Pick<HydrationOptions, 'oxyClient'>,
   ): Promise<boolean> {
     const [post] = await loadReplyParents([postId]);


### PR DESCRIPTION
### Motivation

- Close a confidentiality bypass where `GET /articles/:id` returned long-form article bodies by ID without enforcing the linked post's visibility, status, or relationship checks after article bodies were moved into Postgres.

### Description

- Apply the existing optional auth middleware to the articles route so the controller can observe the viewer identity while preserving anonymous reads for public articles by mounting `articlesRoutes` with `optionalAuth` (`appRoutes.ts`).
- Require the same canonical post-level ACL used for post detail reads before returning an article body by calling `postHydrationService.canViewerReadPostId(...)` from `getArticle`; anonymous or unauthorized viewers now get a non-disclosing `404` (`controllers/articles.controller.ts`).
- Broaden `PostHydrationService.canViewerReadPostId` to accept an optional `viewerId` so callers that may be anonymous can reuse the same single ACL implementation (`services/PostHydrationService.ts`).
- Add regression coverage to verify anonymous requests do not receive article bodies linked to `private`, `followers_only`, `draft`, or `scheduled` posts and update the test harness to exercise `getArticle` with or without a user (`__tests__/controllers/articlesController.test.ts`).

### Testing

- Ran `git diff --check` to validate whitespace / patch sanity and it passed locally.
- Attempted to build shared types with `bun run --cwd packages/shared-types build`, but the local TypeScript tooling raised a `TS5107` deprecation check for `moduleResolution=node10` and blocked the build in this environment.
- Attempted to run the backend test target `bun run test -- src/__tests__/controllers/articlesController.test.ts`, but `vitest` was not present in the checkout's `node_modules`, so the test run could not be executed here; the new tests were added in the patch but were not run successfully in this environment.
- The change is intentionally implemented by reusing the existing, well-tested post hydration ACL rather than adding a separate article-specific gate to avoid policy drift. Please run the backend test suite and the project build in CI (or locally with dependencies installed) to validate the added tests and end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71b738ffb0832395d4ca7bfb2bad16)