### PR TITLE
fix(backend): enforce article read authorization

### DIFF
--- a/packages/backend/src/__tests__/controllers/articlesController.test.ts
+++ b/packages/backend/src/__tests__/controllers/articlesController.test.ts
@@ -31,7 +31,7 @@ interface CapturedResponse {
   body: unknown;
 }
 
-async function call(id: string): Promise<CapturedResponse> {
+async function call(id: string, viewerId?: string): Promise<CapturedResponse> {
   const captured: CapturedResponse = { status: 200, body: undefined };
   const res = {
     status(code: number) {
@@ -43,7 +43,10 @@ async function call(id: string): Promise<CapturedResponse> {
       return res;
     },
   };
-  await getArticle({ params: { id } } as never, res as never);
+  await getArticle(
+    { params: { id }, user: viewerId ? { id: viewerId } : undefined } as never,
+    res as never,
+  );
   return captured;
 }
 
@@ -88,7 +91,7 @@ describe('getArticle', () => {
     expect((res.body as { updatedAt: Date }).updatedAt).toBeInstanceOf(Date);
   });
 
-  it('OMITS an absent optional rather than sending null', async () => {
+  it('returns an unlinked draft only to its creator and omits absent optionals', async () => {
     const author = `article-author-${randomUUID()}`;
     const [article] = await db
       .insert(articles)
@@ -96,7 +99,11 @@ describe('getArticle', () => {
       .returning({ id: articles.id });
     createdArticleIds.push(article.id);
 
-    const res = await call(article.id);
+    const anonymous = await call(article.id);
+    expect(anonymous.status).toBe(404);
+    expect(anonymous.body).toEqual({ message: 'Article not found' });
+
+    const res = await call(article.id, author);
     expect(res.status).toBe(200);
     expect(res.body).not.toHaveProperty('postId');
     expect(res.body).not.toHaveProperty('title');

--- a/packages/backend/src/appRoutes.ts
+++ b/packages/backend/src/appRoutes.ts
@@ -106,7 +106,9 @@ export function createAppRoutes({
   publicApi.use('/feed', optionalAuth, feedRoutes);
   publicApi.use('/posts', optionalAuth, publicPostsRouter);
   publicApi.use('/profile/design', profileDesignRoutes);
-  publicApi.use('/articles', articlesRoutes);
+  // Article reads are public only after the controller applies the linked
+  // post's ACL; optional auth lets owners/followers supply that viewer context.
+  publicApi.use('/articles', optionalAuth, articlesRoutes);
   publicApi.use('/trending', trendingRoutes);
   publicApi.use('/topics', topicsRoutes);
   publicApi.use('/federation', optionalAuth, federationApiRoutes);

--- a/packages/backend/src/controllers/articles.controller.ts
+++ b/packages/backend/src/controllers/articles.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { eq } from 'drizzle-orm';
 import { getDb } from '../db/postgres';
 import { articles } from '../db/schema/articles';
+import { postHydrationService } from '../services/PostHydrationService';
 import { logger } from '../utils/logger';
 
 /**
@@ -35,6 +36,18 @@ export const getArticle = async (req: Request, res: Response) => {
       .limit(1);
 
     if (!article) {
+      return res.status(404).json({ message: 'Article not found' });
+    }
+
+    const viewerId = req.user?.id;
+    const canRead = article.postId
+      ? await postHydrationService.canViewerReadPostId(article.postId, viewerId)
+      : viewerId === article.createdBy;
+
+    // Do not reveal whether an inaccessible article id exists. An unlinked
+    // article is a draft and is readable only by its creator; linked articles
+    // inherit the canonical post ACL (status, visibility, profile and graph).
+    if (!canRead) {
       return res.status(404).json({ message: 'Article not found' });
     }
 

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -1998,7 +1998,7 @@ export class PostHydrationService {
    */
   async canViewerReadPostId(
     postId: string,
-    viewerId: string,
+    viewerId: string | undefined,
     options?: Pick<HydrationOptions, 'oxyClient'>,
   ): Promise<boolean> {
     const [post] = await loadReplyParents([postId]);


### PR DESCRIPTION
### Motivation

- The articles backfill populated a Postgres `articles` table that the public `GET /articles/:id` route read without enforcing the parent post's visibility, enabling disclosure of draft or private article bodies. 
- Article reads must respect the same post ACLs (status, visibility, profile/follower gating, and block rules) as post-detail reads. 
- Unlinked articles (drafts with `postId === null`) must remain accessible only to their creator.

### Description

- Require optional authentication for the public articles router by mounting it with `optionalAuth` in `packages/backend/src/appRoutes.ts`. 
- Enforce access control in `packages/backend/src/controllers/articles.controller.ts` by consulting `postHydrationService.canViewerReadPostId` for linked articles and restricting unlinked drafts to the article `createdBy` value, returning a 404 for unauthorized requests to avoid id enumeration. 
- Make the `PostHydrationService.canViewerReadPostId` signature accept an optional `viewerId: string | undefined` so anonymous callers can be evaluated using the canonical post ACL. 
- Update `packages/backend/src/__tests__/controllers/articlesController.test.ts` to assert that anonymous requests cannot read an unlinked draft while its creator can, and to propagate an optional `user` on the test request helper.

### Testing

- Ran `git diff --check` and local workspace status checks which reported no whitespace/patch issues. (succeeded)
- Attempted `bun run --cwd packages/shared-types build` but the environment returned a TypeScript configuration deprecation error (`moduleResolution=node10`) that prevented a full build in this runner. (blocked)
- Attempted to run the backend unit test `packages/backend` test for `articlesController.test.ts` via `bun run test ...`, but the test runner failed because `node_modules/vitest` is not present in the environment, so the test could not be executed here. (blocked)
- The unit test file was updated to cover anonymous denial and owner access for unlinked drafts and is ready to run in CI or a developer environment with dependencies installed. (not executed here)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71b37fb1b4832382be63e1a28f5614)