### PR TITLE
fix(polls): enforce owning post access for poll read/vote/results

### DIFF
--- a/packages/backend/src/__tests__/controllers/pollsControllerDetached.test.ts
+++ b/packages/backend/src/__tests__/controllers/pollsControllerDetached.test.ts
@@ -332,8 +332,14 @@ describe('getResults', () => {
       { pollId: poll.id, optionId: choices[1].id, userId: 'u3' },
     ]);
 
+    // Read as the CREATOR of a poll no post owns: that branch of the gate is
+    // decided from two columns, so this stays the percentages test rather than
+    // turning into an Oxy round trip nothing here can serve.
     const { getResults } = pollsController;
-    const { captured } = await call(getResults, { params: { id: poll.id } });
+    const { captured } = await call(getResults, {
+      params: { id: poll.id },
+      user: { id: author },
+    });
     const body = captured.body as {
       data: {
         id: string;
@@ -348,6 +354,40 @@ describe('getResults', () => {
     expect(body.data.isEnded).toBe(false);
     expect(body.data.results.map((r) => r.votes)).toEqual([2, 1]);
     expect(body.data.results[0].percentage).toBeCloseTo(66.67, 1);
+  });
+
+  it('conceals results when the owning post ACL refuses the viewer', async () => {
+    const author = `author-${randomUUID()}`;
+    const postId = await seedPost(author);
+    const { poll } = await seedPoll({ createdBy: author, postId });
+    vi.spyOn(postHydrationService, 'canViewerReadPostId').mockResolvedValueOnce(false);
+
+    const { getResults } = pollsController;
+    const { captured } = await call(getResults, {
+      params: { id: poll.id },
+      user: { id: 'intruder' },
+    });
+
+    expect(captured.status).toBe(404);
+    expect(captured.body).toEqual({ error: 'Not found', message: 'Poll not found' });
+  });
+
+  it('conceals results when the ACL cannot be answered at all', async () => {
+    const author = `author-${randomUUID()}`;
+    const postId = await seedPost(author);
+    const { poll } = await seedPoll({ createdBy: author, postId });
+    vi.spyOn(postHydrationService, 'canViewerReadPostId').mockRejectedValueOnce(
+      new Error('Oxy could not resolve the delegated blocked privacy context'),
+    );
+
+    const { getResults } = pollsController;
+    const { captured } = await call(getResults, {
+      params: { id: poll.id },
+      user: { id: 'intruder' },
+    });
+
+    // Fails closed rather than 500-ing: an unanswerable ACL is not a yes.
+    expect(captured.status).toBe(404);
   });
 });
 

--- a/packages/backend/src/__tests__/controllers/pollsControllerDetached.test.ts
+++ b/packages/backend/src/__tests__/controllers/pollsControllerDetached.test.ts
@@ -28,6 +28,7 @@ import { closePostgres, connectPostgres, type Database } from '../../db/postgres
 import { uuidv7 } from '../../db/schema/columns';
 import { pollOptions, pollVotes, polls } from '../../db/schema/polls';
 import { posts } from '../../db/schema/posts';
+import { postHydrationService } from '../../services/PostHydrationService';
 
 let db: Database;
 const createdPollIds: string[] = [];
@@ -103,6 +104,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   if (createdPollIds.length > 0) {
     await db.delete(polls).where(inArray(polls.id, createdPollIds.splice(0)));
   }
@@ -118,7 +120,9 @@ afterAll(async () => {
 describe('polls controller called the way Express calls it', () => {
   it('GET /polls/:id answers with the sanitized poll', async () => {
     const author = `author-${randomUUID()}`;
-    const { poll, choices } = await seedPoll({ createdBy: author, isAnonymous: true });
+    const postId = await seedPost(author);
+    const acl = vi.spyOn(postHydrationService, 'canViewerReadPostId').mockResolvedValueOnce(true);
+    const { poll, choices } = await seedPoll({ createdBy: author, isAnonymous: true, postId });
     await db.insert(pollVotes).values([
       { pollId: poll.id, optionId: choices[0].id, userId: 'u1' },
       { pollId: poll.id, optionId: choices[0].id, userId: 'u2' },
@@ -126,7 +130,7 @@ describe('polls controller called the way Express calls it', () => {
 
     // Detached on purpose — this is the registration the router uses.
     const { getPoll } = pollsController;
-    const { captured, next } = await call(getPoll, { params: { id: poll.id } });
+    const { captured, next } = await call(getPoll, { params: { id: poll.id }, user: { id: 'u1' } });
 
     expect(next).not.toHaveBeenCalled();
     const body = captured.body as { success: boolean; data: Record<string, unknown> };
@@ -137,11 +141,14 @@ describe('polls controller called the way Express calls it', () => {
       { _id: choices[0].id, text: 'yes', votes: 2 },
       { _id: choices[1].id, text: 'no', votes: 0 },
     ]);
+    expect(acl).toHaveBeenCalledWith(postId, 'u1');
   });
 
   it('POST /polls/:id/vote answers instead of 500-ing after recording the vote', async () => {
     const author = `author-${randomUUID()}`;
-    const { poll, choices } = await seedPoll({ createdBy: author });
+    const postId = await seedPost(author);
+    vi.spyOn(postHydrationService, 'canViewerReadPostId').mockResolvedValueOnce(true);
+    const { poll, choices } = await seedPoll({ createdBy: author, postId });
 
     const { vote } = pollsController;
     const { captured, next } = await call(vote, {
@@ -156,6 +163,39 @@ describe('polls controller called the way Express calls it', () => {
     // Not anonymous, so the voter ids come back as the array the client expects.
     expect(body.data.options[0].votes).toEqual(['u1']);
     expect(await db.select().from(pollVotes).where(eq(pollVotes.pollId, poll.id))).toHaveLength(1);
+  });
+
+  it('conceals an attached poll when the owning post ACL refuses the viewer', async () => {
+    const author = `author-${randomUUID()}`;
+    const postId = await seedPost(author);
+    const { poll } = await seedPoll({ createdBy: author, postId });
+    vi.spyOn(postHydrationService, 'canViewerReadPostId').mockResolvedValueOnce(false);
+
+    const { getPoll } = pollsController;
+    const { captured } = await call(getPoll, {
+      params: { id: poll.id },
+      user: { id: 'intruder' },
+    });
+
+    expect(captured.status).toBe(404);
+    expect(captured.body).toEqual({ error: 'Not found', message: 'Poll not found' });
+  });
+
+  it('refuses voting before writing when the owning post ACL refuses the viewer', async () => {
+    const author = `author-${randomUUID()}`;
+    const postId = await seedPost(author);
+    const { poll, choices } = await seedPoll({ createdBy: author, postId });
+    vi.spyOn(postHydrationService, 'canViewerReadPostId').mockResolvedValueOnce(false);
+
+    const { vote } = pollsController;
+    const { captured } = await call(vote, {
+      params: { id: poll.id },
+      body: { optionId: choices[0].id },
+      user: { id: 'intruder' },
+    });
+
+    expect(captured.status).toBe(404);
+    expect(await db.select().from(pollVotes).where(eq(pollVotes.pollId, poll.id))).toHaveLength(0);
   });
 });
 
@@ -178,7 +218,7 @@ describe('the id guards — a documented 400, widened to both live shapes', () =
     // created after the cutover carries a uuid v7 and must not be rejected as
     // malformed.
     const { getPoll } = pollsController;
-    const { captured } = await call(getPoll, { params: { id: uuidv7() } });
+    const { captured } = await call(getPoll, { params: { id: uuidv7() }, user: { id: 'u1' } });
     expect(captured.status).toBe(404);
   });
 });

--- a/packages/backend/src/controllers/polls.controller.ts
+++ b/packages/backend/src/controllers/polls.controller.ts
@@ -97,7 +97,21 @@ function validationError(res: Response, message: string) {
  */
 async function canViewerAccessPoll(poll: PollRecord, viewerId: string): Promise<boolean> {
   if (poll.postId === null) return poll.createdBy === viewerId;
-  return postHydrationService.canViewerReadPostId(poll.postId, viewerId);
+  try {
+    return await postHydrationService.canViewerReadPostId(poll.postId, viewerId);
+  } catch (error) {
+    // Fails CLOSED, the same way `ContentRoomLifecycle` treats this gate: it
+    // needs the viewer's blocks from Oxy, so an Oxy outage makes the question
+    // unanswerable, and an unanswerable ACL is not a yes. Caught HERE rather
+    // than at the three call sites so a refusal cannot become a 500 at one of
+    // them and a 404 at the others — and, on the vote path, so the throw
+    // cannot escape before the write is refused.
+    logger.warn('Refusing poll access: visibility check failed', {
+      pollId: poll.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
 }
 
 function pollNotFound(res: Response) {

--- a/packages/backend/src/controllers/polls.controller.ts
+++ b/packages/backend/src/controllers/polls.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express';
+import { Response, NextFunction } from 'express';
 import { eq } from 'drizzle-orm';
 import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { isLiveEntityId } from '../db/ids';
@@ -13,6 +13,7 @@ import {
   pollVoteService,
   type PollRecord,
 } from '../services/PollVoteService';
+import { postHydrationService } from '../services/PostHydrationService';
 
 /** Default poll lifetime when the client does not supply `endsAt`. */
 const DEFAULT_POLL_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
@@ -86,6 +87,22 @@ function isTemporaryPostId(value: string): boolean {
  */
 function validationError(res: Response, message: string) {
   return res.status(400).json({ error: 'Validation Error', message });
+}
+
+/**
+ * Apply the owning post's canonical read ACL before exposing a poll subresource.
+ * An unattached poll is a composer intermediate and is visible only to its
+ * creator; once attached, the post gate covers status, visibility, follows,
+ * blocks, profile privacy, and collaborators in one place.
+ */
+async function canViewerAccessPoll(poll: PollRecord, viewerId: string): Promise<boolean> {
+  if (poll.postId === null) return poll.createdBy === viewerId;
+  return postHydrationService.canViewerReadPostId(poll.postId, viewerId);
+}
+
+function pollNotFound(res: Response) {
+  // Do not disclose whether a poll exists behind an inaccessible post.
+  return res.status(404).json({ error: 'Not found', message: 'Poll not found' });
 }
 
 class PollsController {
@@ -242,7 +259,7 @@ class PollsController {
     }
   }
 
-  async getPoll(req: Request, res: Response, next: NextFunction) {
+  async getPoll(req: AuthRequest, res: Response, next: NextFunction) {
     try {
       const id = req.params.id as string;
 
@@ -257,12 +274,8 @@ class PollsController {
       }
 
       const poll = await loadPollRecord(getDb(), id);
-      if (!poll) {
-        return res.status(404).json({
-          error: 'Not found',
-          message: 'Poll not found'
-        });
-      }
+      const viewerId = req.user?.id;
+      if (!poll || !viewerId || !(await canViewerAccessPoll(poll, viewerId))) return pollNotFound(res);
 
       res.json({
         success: true,
@@ -294,6 +307,9 @@ class PollsController {
         });
       }
 
+      const poll = await loadPollRecord(getDb(), id);
+      if (!poll || !(await canViewerAccessPoll(poll, userId))) return pollNotFound(res);
+
       // Record the vote through the shared service (the SAME atomic dedup path the
       // inbound ActivityPub poll-vote handler uses), then map its result to HTTP.
       const result = await pollVoteService.recordVoteByOptionId(id, String(optionId), userId);
@@ -317,7 +333,7 @@ class PollsController {
     }
   }
 
-  async getResults(req: Request, res: Response, next: NextFunction) {
+  async getResults(req: AuthRequest, res: Response, next: NextFunction) {
     try {
       const id = req.params.id as string;
 
@@ -329,12 +345,8 @@ class PollsController {
       }
 
       const poll = await loadPollRecord(getDb(), id);
-      if (!poll) {
-        return res.status(404).json({
-          error: 'Not found',
-          message: 'Poll not found'
-        });
-      }
+      const viewerId = req.user?.id;
+      if (!poll || !viewerId || !(await canViewerAccessPoll(poll, viewerId))) return pollNotFound(res);
 
       // Calculate results
       const totalVotes = poll.options.reduce((sum, option) => sum + option.votes.length, 0);

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -879,7 +879,7 @@ export const createPost = async (req: AuthRequest, res: Response) => {
       }
     }
 
-    if (!isScheduled && pollId) {
+    if (pollId) {
       try {
         await attachPollToPost(pollId, post.id);
       } catch (pollUpdateError) {

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -786,8 +786,6 @@ export const createPost = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'scheduledFor is required when scheduling a post' });
     }
 
-    const isScheduled = postStatus === 'scheduled';
-
     const postMetadata = buildPostMetadata(req.body.metadata);
 
     if (quoted_post_id) {


### PR DESCRIPTION
### Motivation

- Composer-created polls were migrated to Postgres and became discoverable by poll ID, but the poll API endpoints (`GET /polls/:id`, `POST /polls/:id/vote`, `GET /polls/:id/results`) did not check the owning post's visibility or ACLs, enabling an authenticated IDOR.
- Scheduled polls remained un-attached (`post_id` NULL) in some flows, preventing post-based ACLs and cascade cleanup from applying.

### Description

- Added a shared access guard `canViewerAccessPoll` that restricts unattached composer polls to their creator and delegates access for attached polls to the canonical post gate via `postHydrationService.canViewerReadPostId`.
- Applied the guard to poll details, voting, and results endpoints so requests are rejected with a non-disclosing `404` when the viewer cannot access the owning post.
- Changed post creation behavior to attach polls (`attachPollToPost`) whenever a poll id exists so scheduled polls no longer remain indefinitely unattached and are subject to the same post-based ACLs and cascade semantics.
- Extended `pollsController` tests (`pollsControllerDetached.test.ts`) to mock `postHydrationService.canViewerReadPostId`, assert the ACL is consulted, and add regression cases ensuring inaccessible polls are concealed and that denied voters do not persist votes; also restored test mocks after each test.

### Testing

- Ran the shared-types build with `bun run --cwd packages/shared-types build`, which completed successfully.
- Attempted lint/type-check with `bun run --cwd packages/backend lint` but the environment reported missing ambient types (`bun`/`node`) and TypeScript deprecation diagnostics, preventing completion of that check in this container.
- Attempted to run the backend poll controller test file with `bun run test` / Vitest, but the environment lacks the test runner dependencies (`vitest`/`node_modules`), so the unit tests could not be executed here; the repository test harnesss should pass in CI where dependencies and DB are available.
- Ran repository sanity checks (`git diff --check`) and code diffs locally to verify the intended changes were applied without accidental whitespace/errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71b3578c208323a0426e29949e3762)