### PR TITLE
fix(security): restrict production purge dispatches to operators

### DIFF
--- a/.github/workflows/run-blocked-domain-purge.yml
+++ b/.github/workflows/run-blocked-domain-purge.yml
@@ -25,11 +25,13 @@ name: Purge blocked-domain data from the platform
 #   but erasing an instance's history from a shared platform waits for a reviewed
 #   entry with an author and a diff.
 #
-# TWO GATES, AND THE SECOND ONE IS NOT IN THIS REPO
-#   A real run needs `confirm_write` here AND `FEDERATION_DOMAIN_PURGE_ENABLED=true`
-#   on the oxy-api deployment, which answers 409 otherwise. Arming the endpoint is
-#   an operator decision made over in the oxy repo, on purpose — this workflow
-#   cannot talk itself into a deletion.
+# AUTHORIZATION PLUS TWO SAFETY GATES
+#   Dispatches are accepted only from an actor in the repository-administered
+#   `BLOCKED_DOMAIN_PURGE_OPERATORS` variable. A real run then needs
+#   `confirm_write` here AND `FEDERATION_DOMAIN_PURGE_ENABLED=true` on the oxy-api
+#   deployment, which answers 409 otherwise. Arming the endpoint is an operator
+#   decision made over in the oxy repo, on purpose — this workflow cannot talk
+#   itself into a deletion.
 #
 # ALWAYS PLAN FIRST (`dry_run=true`, the default). `dryRun` is the ONLY field the
 # script derives from the mode, so the numbers a plan reports are the numbers the
@@ -90,7 +92,15 @@ permissions:
 
 jobs:
   purge:
-    if: github.ref == 'refs/heads/main'
+    # This is authorization, not another typo guard: Actions dispatch access is
+    # broader than permission to delete production data. Repository admins own
+    # this comma-separated, no-spaces allowlist outside the workflow, so changing
+    # a public confirmation phrase cannot grant an operator capability. Re-runs
+    # must also be initiated by the original authorized dispatcher.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      contains(format(',{0},', vars.BLOCKED_DOMAIN_PURGE_OPERATORS), format(',{0},', github.actor)) &&
+      github.triggering_actor == github.actor
     # Same arch as the deployed image — the service runs linux/arm64.
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90


### PR DESCRIPTION
### Motivation

- The manually-dispatchable purge workflow exposed a path to run a destructive production ECS one-shot with only a public confirmation phrase as an in-repo gate. 
- The goal is to add an authorization check so only repository-designated operators can run the production purge and to prevent someone else from re-running an authorized dispatch.

### Description

- Updated `.github/workflows/run-blocked-domain-purge.yml` to gate the `purge` job on an administrator-managed allowlist variable `BLOCKED_DOMAIN_PURGE_OPERATORS` so only listed actors may dispatch the job. 
- Added a requirement that `github.triggering_actor == github.actor` so re-runs must be initiated by the same authorized dispatcher. 
- Clarified the workflow comments to state that the confirmation phrase and the external `FEDERATION_DOMAIN_PURGE_ENABLED` feature flag are safety gates, not substitutes for authorization.

### Testing

- YAML syntax was validated via a Ruby parse (`YAML.parse_file`) and returned valid. 
- Basic repository checks passed (`git diff --check`).
- The workflow validator (`bun run validate:workflows`) could not be completed in this environment because `bun install` could not fetch registry packages (HTTP 403), so full workflow linting was blocked by missing dependencies. 
- File-level diff/stat showed the edited workflow and no YAML syntax issues after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6efe27da108323a22c2b16931a1f94)