### PR TITLE
Require current channel authority before publishing or hydrating scheduled channel posts

### DIFF
--- a/packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts
+++ b/packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts
@@ -514,6 +514,18 @@ describe('the shared editorial queue — publishing an entry early', () => {
     expect(claim).not.toHaveBeenCalled();
   });
 
+  it('refuses a former WRITER whose channel membership was removed', async () => {
+    const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+    listAccountMembers.mockResolvedValue([
+      membership(CHANNEL, WRITER, 'removed'),
+      membership(CHANNEL, COLLEAGUE),
+    ]);
+
+    expect((await publishAs(WRITER, entry)).status).toBe(404);
+    expect(listAccountMembers).toHaveBeenCalledWith(CHANNEL);
+    expect(claim).not.toHaveBeenCalled();
+  });
+
   it('refuses a member whose invitation is not yet ACCEPTED', async () => {
     const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
 
@@ -547,22 +559,17 @@ describe('the shared editorial queue — publishing an entry early', () => {
 /**
  * THE ACL UNDERNEATH, asked WITHOUT the operated-account set.
  *
- * This block exists because a mutation SURVIVED without it. Every case above
- * reaches the queue through the endpoint, which resolves the caller's channels
- * and hands them to hydration — so the writer is admitted by `operatedAccountIds`
- * and the writer clause beside it never decides anything. Deleting
- * `canManagePostWithoutLookup` from the ACL left all twelve of them green.
+ * Every queue case above reaches hydration through an endpoint that resolves the
+ * caller's channels and supplies `operatedAccountIds`. This block exercises the
+ * other id-based surfaces that do not make that current-authority lookup.
  *
  * The distinguishing shape is the one the endpoint can never produce: hydration
  * asked with NO operated accounts, which is every other surface in the
  * application (post detail, a thread, a notification embed) because resolving
- * that set costs an Oxy round trip nothing else may pay. There the writer clause
- * is the only thing standing between a person and their OWN unpublished writing.
- *
- * It also settles a real incoherence rather than adding a capability: `isOwner`
- * on the DTO already comes from `canManagePostWithoutLookup`, so before this the
- * two could disagree — the summary would have said "you own this post" about one
- * the same service refused to return.
+ * that set costs an Oxy round trip nothing else may pay. There, a stored writer
+ * id cannot establish whether that person STILL operates the channel. Treating
+ * it as authority would disclose queued content to a former member who retained
+ * the post id.
  */
 describe('the hydration ACL on an unpublished channel post', () => {
   const service = new PostHydrationService();
@@ -580,8 +587,27 @@ describe('the hydration ACL on an unpublished channel post', () => {
     return service.hydratePosts([post], { viewerId, maxDepth: 0 });
   }
 
-  it('lets the WRITER read their own unpublished channel post', async () => {
-    expect(await hydrateAs(WRITER)).toHaveLength(1);
+  it('refuses the stored WRITER without proof they still operate the channel', async () => {
+    expect(await hydrateAs(WRITER)).toHaveLength(0);
+  });
+
+  it('lets the WRITER read after current channel authority is supplied', async () => {
+    const post = await seedPost(scope, {
+      oxyUserId: CHANNEL,
+      authorship: [{ oxyUserId: CHANNEL, role: 'owner', status: 'accepted' }],
+      writtenByOxyUserId: WRITER,
+      status: 'scheduled',
+      scheduledFor: later(60),
+      content: { variants: [{ source: 'author', text: 'a queued story', tag: 'en' }] },
+    });
+
+    expect(
+      await service.hydratePosts([post], {
+        viewerId: WRITER,
+        operatedAccountIds: [CHANNEL],
+        maxDepth: 0,
+      }),
+    ).toHaveLength(1);
   });
 
   it('refuses a colleague who operates the channel but did not write it', async () => {

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -3253,6 +3253,10 @@ export const publishScheduledPostNow = async (req: AuthRequest, res: Response) =
       post: target,
       callerId: userId,
       memberReader: createUserScopedOxyServices(req),
+      // Publishing is irreversible and acts under the author's identity. A
+      // stored writer may have left the channel since scheduling, so unlike
+      // ordinary management actions this must prove their authority now.
+      requireAuthorAuthority: true,
     });
     if (publishRefusal) {
       return res.status(publishRefusal.status).json({ message: publishRefusal.message });

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -2078,32 +2078,37 @@ export class PostHydrationService {
     // alongside the owner and accepted collaborators. All three bypass the
     // unpublished/private/followers-only/restricted ACL checks below.
     //
-    // The last two clauses are the CHANNEL cases, and they exist because the id
-    // comparison above answers "no" for every human on a channel's post: a
-    // channel AUTHORS its own posts, and no session can ever have a channel as
-    // its subject. Without them an unpublished channel post is readable by
-    // nobody at all — not a narrow gap, a black hole, and measured as one.
+    // The channel cases exist because the id comparison answers "no" for every
+    // human on a channel's post: a channel AUTHORS its own posts, and no session
+    // can ever have a channel as its subject.
     //
-    //  - `canManagePostWithoutLookup` covers the WRITER, off two columns already
-    //    in hand and with no lookup. It is the SAME predicate `buildViewerState`
-    //    uses for `isOwner`, which is what makes the two agree: the DTO used to
-    //    be able to say `isOwner: true` about a post this gate would refuse.
-    //  - `operatedAccountIds` covers the writer's CO-OPERATORS, and is empty
-    //    unless the caller opted in (see `HydrationOptions.operatedAccountIds`),
-    //    so no feed pays an Oxy round trip for it.
+    //  - `canManagePostWithoutLookup` remains the published-post affordance for
+    //    its stored WRITER, off two columns already in hand and with no lookup.
+    //  - `operatedAccountIds` proves CURRENT authority for unpublished channel
+    //    posts. It is empty unless the caller opted in (see
+    //    `HydrationOptions.operatedAccountIds`), so no feed pays an Oxy round
+    //    trip for it.
     //
-    // Both are strictly narrower than what the write routes already permit:
-    // `postManagementRefusal` lets any active member DELETE and EDIT this exact
-    // post today. Granting them READ removes an inconsistency rather than
-    // creating one.
-    const viewerOwnsPost =
+    // The stored writer alone cannot grant unpublished access: membership can
+    // be revoked after the post was written, while the stored id does not change.
+    const viewerOperatesAuthor =
       viewerContext.viewerId === authorId ||
+      (Boolean(viewerContext.viewerId) && viewerContext.operatedAccountIds.has(authorId));
+    const viewerOwnsPost =
+      viewerOperatesAuthor ||
       (viewerEntry?.role === 'collaborator' &&
         (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending')) ||
-      canManagePostWithoutLookup(post, viewerContext.viewerId) ||
-      (Boolean(viewerContext.viewerId) && viewerContext.operatedAccountIds.has(authorId));
+      canManagePostWithoutLookup(post, viewerContext.viewerId);
 
-    if ((post.status ?? 'published') !== 'published' && !viewerOwnsPost) {
+    // A stored channel writer is historical authorship, not proof they still
+    // operate the channel. Unpublished content therefore requires current
+    // authority supplied by the caller, rather than the lookup-free management
+    // affordance used for already-published posts.
+    const viewerOwnsUnpublishedPost =
+      viewerOperatesAuthor ||
+      (viewerEntry?.role === 'collaborator' &&
+        (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending'));
+    if ((post.status ?? 'published') !== 'published' && !viewerOwnsUnpublishedPost) {
       return false;
     }
 

--- a/packages/backend/src/services/postManagementAccess.ts
+++ b/packages/backend/src/services/postManagementAccess.ts
@@ -81,8 +81,17 @@ export async function postManagementRefusal(params: {
   post: ManageablePost;
   callerId: string;
   memberReader: AccountMemberReader | undefined;
+  /** Require current authority over the authoring account, even for its stored writer. */
+  requireAuthorAuthority?: boolean;
 }): Promise<PostManagementRefusal | null> {
-  if (canManagePostWithoutLookup(params.post, params.callerId)) return null;
+  const isAuthor =
+    Boolean(params.post.oxyUserId) && String(params.post.oxyUserId) === params.callerId;
+  if (
+    isAuthor ||
+    (!params.requireAuthorAuthority && canManagePostWithoutLookup(params.post, params.callerId))
+  ) {
+    return null;
+  }
 
   const authorId = params.post.oxyUserId ? String(params.post.oxyUserId) : '';
   if (!authorId) return NOT_FOUND;


### PR DESCRIPTION
### Motivation
- A stored-writer shortcut allowed a former channel writer to publish a queued channel post or hydrate unpublished channel content using the historical `writtenByOxyUserId` value without proving current membership, which can prematurely disclose or publish embargoed channel content under an account the caller no longer operates. 

### Description
- Add a `requireAuthorAuthority` option to `postManagementRefusal` and make the scheduled-publish handler enforce it so early publication must revalidate current authority for the authoring account (backend service change: `packages/backend/src/services/postManagementAccess.ts`, handler: `packages/backend/src/controllers/posts.controller.ts`).
- Harden hydration ACLs so a stored writer id alone no longer grants unread/unpublished access; unpublished channel posts require current operated-account authority (service change: `packages/backend/src/services/PostHydrationService.ts`).
- Add regression tests that cover a removed/former writer being refused for early publish and refused for id-based hydration unless current operated-account authority is supplied (tests: `packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts`).
- Clarified and tightened comments around channel authorship vs current membership to explain the rationale and prevent regression.

### Testing
- Ran `git diff --check` and repository checks to validate the workspace changes (succeeded). 
- Attempted to run the affected backend test file (`bun run test src/__tests__/controllers/channelEditorialQueue.test.ts`) but execution was blocked because dependency installation failed in this environment (`bun install --frozen-lockfile` encountered registry 403 responses), so the test suite could not be executed here. 
- The new regression tests exercise the removed-writer and operated-account authority paths and are expected to pass in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74e4c9aa3c8323a8a8e1f00242b2b4)