### PR TITLE
fix(channels): publishing a queued entry proves current channel authority

### DIFF
--- a/packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts
+++ b/packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts
@@ -514,6 +514,22 @@ describe('the shared editorial queue — publishing an entry early', () => {
     expect(claim).not.toHaveBeenCalled();
   });
 
+  it('refuses a former WRITER whose channel membership was removed', async () => {
+    // `writtenByOxyUserId` records who wrote the entry and never changes; it is
+    // not evidence they still operate the channel. Every OTHER management action
+    // may still ride that stored id, but publishing acts under the channel's
+    // identity and cannot be undone, so this one asks the roster.
+    const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+    listAccountMembers.mockResolvedValue([
+      membership(CHANNEL, WRITER, 'removed'),
+      membership(CHANNEL, COLLEAGUE),
+    ]);
+
+    expect((await publishAs(WRITER, entry)).status).toBe(404);
+    expect(listAccountMembers).toHaveBeenCalledWith(CHANNEL);
+    expect(claim).not.toHaveBeenCalled();
+  });
+
   it('refuses a member whose invitation is not yet ACCEPTED', async () => {
     const entry = await seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
 

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -3347,6 +3347,10 @@ export const publishScheduledPostNow = async (req: AuthRequest, res: Response) =
       post: target,
       callerId: userId,
       memberReader: createUserScopedOxyServices(req),
+      // Publishing is irreversible and acts under the author's identity. A
+      // stored writer may have left the channel since scheduling, so unlike
+      // ordinary management actions this must prove their authority now.
+      requireAuthorAuthority: true,
     });
     if (publishRefusal) {
       return res.status(publishRefusal.status).json({ message: publishRefusal.message });

--- a/packages/backend/src/services/postManagementAccess.ts
+++ b/packages/backend/src/services/postManagementAccess.ts
@@ -81,8 +81,17 @@ export async function postManagementRefusal(params: {
   post: ManageablePost;
   callerId: string;
   memberReader: AccountMemberReader | undefined;
+  /** Require current authority over the authoring account, even for its stored writer. */
+  requireAuthorAuthority?: boolean;
 }): Promise<PostManagementRefusal | null> {
-  if (canManagePostWithoutLookup(params.post, params.callerId)) return null;
+  const isAuthor =
+    Boolean(params.post.oxyUserId) && String(params.post.oxyUserId) === params.callerId;
+  if (
+    isAuthor ||
+    (!params.requireAuthorAuthority && canManagePostWithoutLookup(params.post, params.callerId))
+  ) {
+    return null;
+  }
 
   const authorId = params.post.oxyUserId ? String(params.post.oxyUserId) : '';
   if (!authorId) return NOT_FOUND;


### PR DESCRIPTION
`writtenByOxyUserId` records who wrote a scheduled channel entry and never changes, so it is not evidence that person still operates the channel. Every management action rode that stored id with no lookup — publishing included. Publishing is irreversible and speaks under the channel's own identity, so a writer who had left the channel could still push their queued entry live.

`postManagementRefusal` grows `requireAuthorAuthority`, set only by `publishScheduledPostNow`. Under it the lookup-free affordance stops applying to the stored writer; the authoring **account** still short-circuits, since a caller who IS the author needs no roster. Ordinary management (edit, delete) is untouched.

## This is the publish half of #737, and the other half is deliberately left out

#737 also drops the stored-writer clause from the unpublished-post read ACL, requiring `operatedAccountIds` instead. The measurement against current `main`:

```
$ grep -rn "operatedAccountIds" packages --include=*.ts
controllers/posts.controller.ts:3499:      operatedAccountIds: operatedChannelIds,
services/PostHydrationService.ts: (the option and its own comments)
__tests__/controllers/channelEditorialQueue.test.ts:579: // No `operatedAccountIds` — the defaults every other caller hydrates with.
```

Exactly one production caller supplies it — the editorial queue endpoint — and a test on `main` states the general case outright. So requiring that set for unpublished channel posts does not narrow reads on the surfaces #737 describes; it removes them everywhere else (post detail, a thread, a notification embed). That is the "black hole … measured as one" recorded in the comment #737 deletes. Tracked in #741.

## Verified

- 22/22 on `channelEditorialQueue.test.ts`, typecheck clean
- Mutation test: removing `requireAuthorAuthority: true` fails exactly the new case and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)