### PR TITLE
test(backend): point the MTN emitter mock at the module that exists, and gate the class

### DIFF
--- a/packages/backend/src/__tests__/controllers/updatePostScheduledWindow.test.ts
+++ b/packages/backend/src/__tests__/controllers/updatePostScheduledWindow.test.ts
@@ -76,7 +76,15 @@ vi.mock('../../services/PostCollaborationService', () => ({
   CollabStateError: class extends Error {},
 }));
 
-vi.mock('../../services/mtn/postRecords', () => ({
+// `MentionRecordEmitter`, the module the controller actually imports. This mock
+// named `services/mtn/postRecords`, the path the emitter was renamed AWAY from —
+// and `vi.mock` keys on a RESOLVED id, so a mock naming a module that does not
+// exist matches nothing and reports nothing. The real emitter ran on every edit
+// below (`resolvePostRecordEmbeds` batches an Oxy asset lookup before the
+// env gate can turn the write into a no-op), while `hoisted.emitPostCreated`
+// stayed permanently uncalled — which is indistinguishable from a stub that is
+// working. The assertions on that spy are what stop it going quiet again.
+vi.mock('../../services/mtn/MentionRecordEmitter', () => ({
   emitPostCreated: hoisted.emitPostCreated,
   emitTombstone: vi.fn(),
   postRecordUri: () => 'at://test',
@@ -179,6 +187,10 @@ describe('updatePost — the 30-minute window still binds a PUBLISHED post', () 
 
     expect(captured.status).toBe(403);
     expect(await storedText()).toBe('original');
+    // A refusal emits nothing. Its negative control is the INSIDE-the-window
+    // case below, which asserts the same spy DOES fire — without it, "never
+    // called" is also what an orphaned mock reports.
+    expect(hoisted.emitPostCreated).not.toHaveBeenCalled();
   });
 
   /**
@@ -205,6 +217,16 @@ describe('updatePost — the 30-minute window still binds a PUBLISHED post', () 
 
     expect(captured.status).toBeUndefined();
     expect(await storedText()).toBe('quick fix');
+    // The MTN dual-write re-emits the record under the SAME rkey, carrying the
+    // EDITED body — the chain is append-only and materialization is
+    // last-writer-wins, so an emit of the pre-edit record would silently
+    // publish the old text forever. Also the one assertion that fails when the
+    // emitter mock stops intercepting.
+    expect(hoisted.emitPostCreated).toHaveBeenCalledTimes(1);
+    expect(hoisted.emitPostCreated.mock.calls[0]?.[0]).toMatchObject({
+      id: POST_ID,
+      content: { variants: [expect.objectContaining({ text: 'quick fix' })] },
+    });
   });
 
   it('cannot be talked out of the window by the request body', async () => {

--- a/packages/backend/src/__tests__/userInvalidationSubscriber.test.ts
+++ b/packages/backend/src/__tests__/userInvalidationSubscriber.test.ts
@@ -62,7 +62,6 @@ vi.mock('../runtime/oxyClient', () => ({
   }),
 }));
 
-vi.mock('./userSummaryCache', () => ({}));
 vi.mock('../services/userSummaryCache', () => ({
   invalidate: mocks.invalidateUserSummaries,
 }));

--- a/packages/backend/src/__tests__/viMockPathsResolve.test.ts
+++ b/packages/backend/src/__tests__/viMockPathsResolve.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, normalize, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Every `vi.mock` in this package names a module that EXISTS.
+ *
+ * `vi.mock` keys on a RESOLVED module id. A mock whose specifier resolves to
+ * nothing therefore matches nothing — silently, with no warning from vitest and
+ * no failing assertion, because the spy it installs simply stays uncalled and an
+ * uncalled spy is indistinguishable from a stub that is working. The suite runs
+ * the REAL module while every comment in the file says it is stubbed.
+ *
+ * That failure mode has been paid for twice. #706 deleted the Mongoose models
+ * and left 151 mocks pointing at them, and every one of those suites stayed
+ * green; #712 swept them. #713 then found two more of a different origin — a
+ * module RENAMED out from under its mock, and a relative path written from the
+ * wrong directory — which is the shape that will keep recurring, because
+ * renaming a module does not touch the string that names it.
+ *
+ * So the sweep is not the fix; this is. It is worth having only because the
+ * thing it measures is invisible by construction.
+ *
+ * Bare specifiers (`@oxyhq/core/server`, `node:https`) are NOT checked — those
+ * resolve through package exports and conditions, and a wrong one fails loudly
+ * at import anyway. Only RELATIVE specifiers are in scope, which is where the
+ * silence lives.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = join(HERE, '..');
+
+/**
+ * Extension candidates, in the order a bundler would try them. `''` first so a
+ * specifier that already carries its extension resolves to itself.
+ */
+const CANDIDATES = ['', '.ts', '.tsx', '.js', '.mjs', '.cjs', '.json', '/index.ts', '/index.tsx', '/index.js'];
+
+/**
+ * Floors. A scanner that silently reads nothing reports the same clean zero as a
+ * repository with no dead mocks, so "found none" is only meaningful next to
+ * "and it looked at this much". Both are well under the current counts and are
+ * meant to catch a BROKEN scan, not to track growth.
+ */
+const MIN_FILES_WITH_MOCKS = 250;
+const MIN_RESOLVED_RELATIVE_MOCKS = 900;
+
+interface MockReference {
+  file: string;
+  spec: string;
+}
+
+/**
+ * Blank out comments and the insides of string literals, preserving offsets and
+ * line breaks.
+ *
+ * A census over source that counts comments is wrong in the direction that
+ * matters here: prose quoting `vi.mock('../models/Post')` to explain why it was
+ * REMOVED would be counted as the very thing it documents, and this file's own
+ * docblock does exactly that. Strings are blanked for the same reason — a
+ * fixture containing the text of a mock call is not a mock call.
+ */
+function blankNonCode(source: string): string {
+  const out: string[] = [];
+  let state: 'code' | 'line' | 'block' | "'" | '"' | '`' = 'code';
+  let index = 0;
+
+  while (index < source.length) {
+    const char = source[index];
+    const pair = source.slice(index, index + 2);
+
+    if (state === 'code') {
+      if (pair === '//') {
+        state = 'line';
+        out.push('  ');
+        index += 2;
+        continue;
+      }
+      if (pair === '/*') {
+        state = 'block';
+        out.push('  ');
+        index += 2;
+        continue;
+      }
+      if (char === "'" || char === '"' || char === '`') state = char;
+      out.push(char);
+      index += 1;
+      continue;
+    }
+
+    if (state === 'line' || state === 'block') {
+      if (state === 'line' && char === '\n') {
+        state = 'code';
+        out.push('\n');
+        index += 1;
+        continue;
+      }
+      if (state === 'block' && pair === '*/') {
+        state = 'code';
+        out.push('  ');
+        index += 2;
+        continue;
+      }
+      out.push(char === '\n' ? '\n' : ' ');
+      index += 1;
+      continue;
+    }
+
+    // Inside a string literal: keep the quotes (the extractor matches on them)
+    // and the length, blank the body.
+    if (char === '\\') {
+      out.push('  '.slice(0, Math.min(2, source.length - index)));
+      index += 2;
+      continue;
+    }
+    if (char === state) {
+      state = 'code';
+      out.push(char);
+      index += 1;
+      continue;
+    }
+    out.push(char === '\n' ? '\n' : ' ');
+    index += 1;
+  }
+
+  return out.join('');
+}
+
+/**
+ * The specifiers of every `vi.mock` / `vi.doMock` / `vi.unmock` in one file.
+ *
+ * Matched against the ORIGINAL source but positioned by the blanked copy, so a
+ * call inside a comment or a string contributes nothing while a real one keeps
+ * its literal specifier.
+ */
+function extractMockSpecs(source: string): string[] {
+  const blanked = blankNonCode(source);
+  const pattern = /vi\.(?:mock|doMock|unmock|doUnmock)\(\s*(['"])/g;
+  const specs: string[] = [];
+
+  for (const match of blanked.matchAll(pattern)) {
+    const quote = match[1];
+    const start = (match.index ?? 0) + match[0].length;
+    const end = source.indexOf(quote, start);
+    if (end === -1) continue;
+    specs.push(source.slice(start, end));
+  }
+  return specs;
+}
+
+/** Does this relative specifier, read from `fromFile`, name a file on disk? */
+function resolves(fromFile: string, spec: string): boolean {
+  const base = normalize(join(dirname(fromFile), spec));
+  return CANDIDATES.some((extension) => {
+    try {
+      return statSync(base + extension).isFile();
+    } catch {
+      return false;
+    }
+  });
+}
+
+function walk(directory: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const full = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      walk(full, found);
+      continue;
+    }
+    if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) found.push(full);
+  }
+  return found;
+}
+
+const scan = (() => {
+  const dead: MockReference[] = [];
+  let filesWithMocks = 0;
+  let resolvedRelative = 0;
+  let bare = 0;
+
+  for (const file of walk(SRC)) {
+    const source = readFileSync(file, 'utf8');
+    if (!source.includes('vi.mock') && !source.includes('vi.doMock') && !source.includes('vi.unmock')) continue;
+    const specs = extractMockSpecs(source);
+    if (specs.length > 0) filesWithMocks += 1;
+
+    for (const spec of specs) {
+      if (!spec.startsWith('.')) {
+        bare += 1;
+        continue;
+      }
+      if (resolves(file, spec)) resolvedRelative += 1;
+      else dead.push({ file: relative(SRC, file), spec });
+    }
+  }
+
+  return { dead, filesWithMocks, resolvedRelative, bare };
+})();
+
+describe('every vi.mock names a module that exists', () => {
+  it('finds no mock pointing at a path that resolves to nothing', () => {
+    expect(
+      scan.dead.map((reference) => `${reference.file} -> ${reference.spec}`),
+    ).toEqual([]);
+  });
+
+  it('actually looked at the tree it is reporting on', () => {
+    // Without these, a scanner that read zero files would pass the assertion
+    // above with the same output as a clean repository.
+    expect(scan.filesWithMocks).toBeGreaterThanOrEqual(MIN_FILES_WITH_MOCKS);
+    expect(scan.resolvedRelative).toBeGreaterThanOrEqual(MIN_RESOLVED_RELATIVE_MOCKS);
+    // Bare specifiers exist and are skipped on purpose; a zero here would mean
+    // the extractor stopped seeing a whole category.
+    expect(scan.bare).toBeGreaterThan(0);
+  });
+});
+
+describe('the scan itself', () => {
+  // The positive control, in the same currency as the measurement: a synthetic
+  // source attributed to a real directory, carrying one of every shape the scan
+  // claims to handle. If any counter here stops moving, the zero above stops
+  // meaning "none" and starts meaning "blind".
+  const synthetic = [
+    "import { vi } from 'vitest';",
+    "// vi.mock('../models/CommentedOut');",
+    "/* vi.mock('../models/BlockCommented'); */",
+    "const prose = \"vi.mock('../models/InAString')\";",
+    "vi.mock('../models/GoneForGood');",
+    "vi.mock('../utils/logger');",
+    "vi.mock('@oxyhq/core/server');",
+  ].join('\n');
+
+  const specs = extractMockSpecs(synthetic);
+
+  it('extracts a real call and ignores one in a comment or a string', () => {
+    expect(specs).toEqual(['../models/GoneForGood', '../utils/logger', '@oxyhq/core/server']);
+  });
+
+  it('classifies a missing module dead and a present one alive', () => {
+    const from = join(SRC, '__tests__', 'synthetic.test.ts');
+    expect(resolves(from, '../models/GoneForGood')).toBe(false);
+    expect(resolves(from, '../utils/logger')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #713, and carries the only piece of #709 that was still outstanding.

`packages/backend/src/__tests__/controllers/updatePostScheduledWindow.test.ts:79` mocked `services/mtn/postRecords` — the path the emitter was renamed **away** from. `vi.mock` keys on a RESOLVED module id, so a mock naming a module that does not exist matches nothing.

The consequence was not cosmetic: the real `emitPostCreated` ran on every edit in the file, reaching `resolvePostRecordEmbeds` (a batched Oxy asset-metadata lookup) before the unset-`MENTION_*` env gate turns the signing half into a logged no-op. Meanwhile `hoisted.emitPostCreated` was never called — and an uncalled spy is indistinguishable from a stub that is working, which is why it survived.

## Commit 1 — the fix

- Repointed the mock at `../../services/mtn/MentionRecordEmitter`.
- Gave the spy assertions, so it cannot silently go orphaned again:
  - the **in-window** edit asserts the record is re-emitted **carrying the edited body** (the chain is append-only, materialization is last-writer-wins under the same rkey, so emitting the pre-edit record would republish the old text forever);
  - the **out-of-window refusal** asserts nothing is emitted — a negative assertion whose control is the positive case beside it, on the same spy, under the same `beforeEach` clear.
- Deleted `vi.mock('./userSummaryCache')` in `userInvalidationSubscriber.test.ts` (the minor half of the issue). Resolved from `src/__tests__/` that path names nothing; the correct `../services/userSummaryCache` mock is on the very next line.

**Why repoint rather than delete** — the issue left this to the emitter's owner. Repointing, because the emitter is a real side effect with real I/O in it, and a controller test for the edit window should not be exercising the MTN dual-write. It is inert today only because `MENTION_PRIVATE_KEY` is unset; setting it in a test environment would make these tests write to the chain.

### Mutation tests (each RED, then restored from a pristine copy — not `git checkout`)

| mutation | result |
|---|---|
| mock repointed back to the orphaned `services/mtn/postRecords` | `expected "vi.fn()" to be called 1 times, but got 0 times` |
| `await emitPostCreated(edited)` deleted from `updatePost` | same, 0 calls |
| `emitPostCreated(post)` — the PRE-edit record | body `toMatchObject` fails on `'quick fix'` |

## Commit 2 — the gate (this is what remains of #709)

**#709's sweep was already done, and I re-measured rather than take the number.** A positive-controlled census over the whole backend tree finds **0** dead `vi.mock('.../models/*')` calls on `origin/main` — PR #712 removed exactly 151 of them — and `feedSafety.ts` no longer exports `SENSITIVE_EXCLUDE_MATCH` / `NSFW_HASHTAG_EXCLUDE_MATCH` / `DISCOVERY_SAFE_MATCH` (the only surviving mention anywhere is the `AGENTS.md` line recording their deletion). The census counted 1061 resolvable relative mocks and exactly **2** dead ones — both the ones named in #713, both fixed in commit 1.

So the sweep is not the fix; this is. `viMockPathsResolve.test.ts` resolves every RELATIVE `vi.mock`/`doMock`/`unmock` specifier in the package against the filesystem and fails naming any that resolve to nothing. Bare specifiers are out of scope on purpose: those go through package exports and a wrong one throws at import.

Written to the gate rules it is subject to:

- comments **and string literals are blanked** before extraction, so the file's own docblock — which quotes `vi.mock('../models/Post')` to explain the history — cannot inflate its own count;
- **three floors** (files with mocks >= 250, resolved relative specifiers >= 900, bare specifiers > 0), because a scan that reads nothing reports the same clean zero as a clean repository;
- a **positive control** over a synthetic source carrying one of every shape it claims to handle, asserting the extractor takes the real call and leaves the commented, block-commented and in-a-string ones, and that the resolver calls a missing module dead and a present one alive.

### Mutation tests

| mutation | result |
|---|---|
| reinstate the orphaned `services/mtn/postRecords` path | red, naming file and specifier — and counted **once**, though that string also appears in the prose above it, so the comment blanking is verified against real code and not only the synthetic fixture |
| `walk(SRC).slice(0, 0)` | the **floors** go red, not the emptiness assertion |

It lives here rather than in its own PR because this is the only base on which it is green: on `origin/main` the two mocks commit 1 fixes are exactly what it would fail on, and a PR stacked on this branch would report no real CI at all.

## Verification

`cd packages/backend && DATABASE_URL=... bunx vitest run`

| revision | result |
|---|---|
| `origin/main` (`c96c2764`), before any edit | **484 files / 5944 tests passed** |
| this branch (`2c82c5a9`) | **485 files / 5948 tests passed** |

The delta is exactly the new gate file and its four tests; commit 1 adds assertions to existing tests, not new ones. `bunx tsc --noEmit` in `packages/backend`: exit 0.

Note on how those were measured: this machine was under heavy load from sibling agents (load average 25-90 on 32 cores) and the shared Postgres on :5433 contends, which produces `FAIL <file>` with zero failing tests. `origin/main` itself goes red that way under load, so both numbers above were taken with `--maxWorkers=4` to bound the concurrent client count, and the baseline was re-measured under the same conditions rather than compared across them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
