### PR TITLE
fix(posts): a native post stops storing its trailing hashtag spam block

### DIFF
--- a/packages/backend/src/__tests__/services/postSpamHashtagStrip.test.ts
+++ b/packages/backend/src/__tests__/services/postSpamHashtagStrip.test.ts
@@ -1,0 +1,291 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A trailing block of 4+ hashtags is stripped from what a native post STORES.
+ *
+ * This behaviour used to live in the `Post` schema's Mongoose `pre('validate')`
+ * hook, which ran on `.save()` — and `.save()` is how both native write paths
+ * persisted a post until the Postgres cutover (`new Post(...).save()` in
+ * `PostCreationService`, `post.save()` in `updatePost`). So it fired on every
+ * native create and every native edit for as long as the store was Mongo; it is
+ * a behaviour that was LOST, not a validator that never ran. The federated
+ * ingest never went through the hook (`apPostContent.ts` calls
+ * `normalizePostHashtags` itself), which is why the gap presented as Mention
+ * cleaning other instances' bodies while storing its own users' verbatim.
+ *
+ * What is asserted here, and why each case earns its place:
+ *  - the CREATE half (`toStoredContent`) and the EDIT half (`updatePost`) are two
+ *    separate calls, so each needs its own case or half the surface is uncovered;
+ *  - the `hashtags` COLUMN keeps every tag the strip removed from view — losing a
+ *    tag would take the post out of its own hashtag feed, which is the failure
+ *    this normalization has always been careful to avoid;
+ *  - three consecutive hashtags stay VISIBLE (the threshold is a threshold, and a
+ *    test that only checks the stripping direction cannot tell a working rule from
+ *    one that eats every hashtag);
+ *  - an edit that does not touch the body rewrites NOTHING — the Mongoose hook was
+ *    guarded by `isModified('content.variants')` and dropping that guard would let
+ *    a media-only edit silently rewrite an author's words years later.
+ *
+ * Every assertion reads the row back through `readPost`, so it measures what the
+ * database HOLDS rather than what a service assembled.
+ */
+
+vi.mock('../../utils/notificationUtils', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  createMentionNotifications: vi.fn().mockResolvedValue(undefined),
+  createBatchNotifications: vi.fn().mockResolvedValue(undefined),
+  createPostAuthorNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/serviceRegistry', () => ({
+  getPostFederator: () => ({ federateNewPost: vi.fn().mockResolvedValue(undefined) }),
+  registerPostCreator: vi.fn(),
+}));
+
+const hoisted = vi.hoisted(() => ({
+  hydratePosts: vi.fn(),
+  resolveUserSummaries: vi.fn(),
+  resolveCollaboratorRefs: vi.fn(),
+  attachCollaborators: vi.fn(),
+  autoAcceptInvites: vi.fn(),
+  notifyPendingInvites: vi.fn(),
+}));
+
+vi.mock('../../services/PostHydrationService', () => ({
+  postHydrationService: { hydratePosts: hoisted.hydratePosts },
+  resolveUserSummaries: hoisted.resolveUserSummaries,
+  degradedActorSummary: (id: string) => ({ id, username: '', name: { displayName: 'Unknown user' } }),
+}));
+
+vi.mock('../../services/PostCollaborationService', () => ({
+  postCollaborationService: {
+    resolveCollaboratorRefs: hoisted.resolveCollaboratorRefs,
+    attachCollaborators: hoisted.attachCollaborators,
+    autoAcceptInvites: hoisted.autoAcceptInvites,
+    notifyPendingInvites: hoisted.notifyPendingInvites,
+    buildAuthorship: (ownerId: string) => [{ oxyUserId: ownerId, role: 'owner', status: 'accepted' }],
+  },
+  CollabValidationError: class extends Error {},
+  CollabStateError: class extends Error {},
+}));
+
+// The MTN dual-write is a best-effort side effect with a batched Oxy asset
+// lookup inside it. Nothing here is about the chain.
+vi.mock('../../services/mtn/MentionRecordEmitter', () => ({
+  emitPostCreated: vi.fn().mockResolvedValue(undefined),
+  emitTombstone: vi.fn().mockResolvedValue(undefined),
+  postRecordUri: () => 'at://test',
+}));
+
+vi.mock('../../runtime/socketServer', () => ({
+  getRuntimeSocketServer: () => undefined,
+}));
+
+// Spread the real module: `PostCreationService` and `posts.controller` need
+// three different helpers out of it, and other modules in this graph import
+// others still.
+vi.mock('../../utils/oxyHelpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/oxyHelpers')>()),
+  getServiceOxyClient: () => ({ getUsersByIds: vi.fn().mockResolvedValue([]) }),
+  createScopedOxyClient: () => undefined,
+  createUserScopedOxyServices: () => undefined,
+}));
+
+import { closePostgres, connectPostgres } from '../../db/postgres';
+import {
+  clearServiceScope,
+  readPost,
+  seedPost,
+  serviceScope,
+  trackPost,
+  withDeadlockRetry,
+} from '../helpers/serviceFixtures';
+import { postCreationService } from '../../services/PostCreationService';
+import { updatePost } from '../../controllers/posts.controller';
+import { stripSpamHashtagBlocks } from '../../services/postVariants';
+import type { PostRecord } from '../../db/posts/postRecord';
+
+const scope = serviceScope('post-spam-hashtag-strip');
+
+async function createAndReload(
+  params: Parameters<typeof postCreationService.create>[0],
+): Promise<PostRecord> {
+  const created = await withDeadlockRetry(() => postCreationService.create(params));
+  trackPost(scope, created.id);
+  const stored = await readPost(created.id);
+  if (!stored) throw new Error(`post ${created.id} was not readable after create`);
+  return stored;
+}
+
+function buildResponse() {
+  const captured: { status?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return this;
+    },
+  };
+  return { res, captured };
+}
+
+/** Edit an existing post through the real controller, inside the edit window. */
+async function edit(postId: string, userId: string, body: Record<string, unknown>) {
+  const { res, captured } = buildResponse();
+  hoisted.hydratePosts.mockImplementation(async () => [{ id: postId }]);
+  await updatePost(
+    {
+      params: { id: postId },
+      query: {},
+      headers: {},
+      acceptsLanguages: () => [] as string[],
+      body,
+      user: { id: userId },
+    } as never,
+    res as never,
+  );
+  return captured;
+}
+
+const bodyOf = (post: PostRecord | undefined, index = 0): string | undefined =>
+  post?.content.variants?.[index]?.text;
+
+beforeAll(async () => {
+  await connectPostgres();
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  hoisted.resolveCollaboratorRefs.mockResolvedValue(undefined);
+  await clearServiceScope(scope);
+});
+
+afterEach(async () => {
+  await clearServiceScope(scope);
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+describe('a native post is stored without its trailing hashtag block — CREATE', () => {
+  it('keeps the first tag of a block that follows real text, and drops the rest', async () => {
+    const post = await createAndReload({
+      oxyUserId: scope.user('author'),
+      content: { text: 'Shipping the new feed today. #startup #social #tech #ai #growth' },
+      hashtags: ['startup', 'social', 'tech', 'ai', 'growth'],
+      skipSocketEmit: true,
+    });
+
+    expect(bodyOf(post)).toBe('Shipping the new feed today. #startup');
+    // Every tag survives in the column even though four left the body: the post
+    // still belongs in all five hashtag feeds.
+    expect(post.hashtags).toEqual(['startup', 'social', 'tech', 'ai', 'growth']);
+  });
+
+  it('drops a block with nothing in front of it entirely', async () => {
+    const post = await createAndReload({
+      oxyUserId: scope.user('author'),
+      content: { text: '#startup #social #tech #ai #growth' },
+      hashtags: ['startup', 'social', 'tech', 'ai', 'growth'],
+      skipSocketEmit: true,
+    });
+
+    expect(bodyOf(post)).toBe('');
+    expect(post.hashtags).toEqual(['startup', 'social', 'tech', 'ai', 'growth']);
+  });
+
+  it('leaves THREE consecutive hashtags alone — the threshold is a threshold', async () => {
+    const post = await createAndReload({
+      oxyUserId: scope.user('author'),
+      content: { text: 'Testing categories #design #product #ux' },
+      hashtags: ['design', 'product', 'ux'],
+      skipSocketEmit: true,
+    });
+
+    expect(bodyOf(post)).toBe('Testing categories #design #product #ux');
+  });
+
+  it('cleans every author rendition, not just the primary', async () => {
+    const post = await createAndReload({
+      oxyUserId: scope.user('author'),
+      content: {
+        variants: [
+          { tag: 'en', source: 'author', text: 'Shipping today. #a #b #c #d' },
+          { tag: 'es', source: 'author', text: 'Lanzamos hoy. #uno #dos #tres #cuatro' },
+        ],
+      },
+      hashtags: [],
+      skipSocketEmit: true,
+    });
+
+    expect(bodyOf(post, 0)).toBe('Shipping today. #a');
+    expect(bodyOf(post, 1)).toBe('Lanzamos hoy. #uno');
+  });
+});
+
+describe('a native post is stored without its trailing hashtag block — EDIT', () => {
+  it('cleans a block the edit introduced', async () => {
+    const author = scope.user('editor');
+    const seeded = await seedPost(scope, {
+      oxyUserId: author,
+      status: 'published',
+      createdAt: new Date(),
+      content: { variants: [{ tag: 'en', source: 'author', text: 'original' }] },
+    });
+
+    const captured = await edit(seeded.id, author, {
+      content: { text: 'Shipping the new feed today. #startup #social #tech #ai #growth' },
+    });
+
+    expect(captured.status).toBeUndefined();
+    const stored = await readPost(seeded.id);
+    expect(bodyOf(stored)).toBe('Shipping the new feed today. #startup');
+    expect(stored?.hashtags).toEqual(['startup', 'social', 'tech', 'ai', 'growth']);
+  });
+
+  it('rewrites NOTHING when the edit did not touch the body', async () => {
+    // Seeded straight into the table with a block already in it — the shape a
+    // post written before this rule existed, or imported, actually has. The
+    // Mongoose hook was guarded by `isModified('content.variants')`; without the
+    // equivalent guard a settings-only edit would silently rewrite the author's
+    // words, so this is the case that pins the placement rather than the rule.
+    const author = scope.user('settings-editor');
+    const seeded = await seedPost(scope, {
+      oxyUserId: author,
+      status: 'published',
+      createdAt: new Date(),
+      content: { variants: [{ tag: 'en', source: 'author', text: 'Old post. #a #b #c #d' }] },
+    });
+
+    const captured = await edit(seeded.id, author, { reviewReplies: true });
+
+    expect(captured.status).toBeUndefined();
+    const stored = await readPost(seeded.id);
+    expect(bodyOf(stored)).toBe('Old post. #a #b #c #d');
+  });
+});
+
+describe('stripSpamHashtagBlocks', () => {
+  it('never touches a MACHINE rendition — a translation comes from the cleaned primary', () => {
+    const [author, machine] = stripSpamHashtagBlocks([
+      { source: 'author', text: 'Shipping today. #a #b #c #d' },
+      { source: 'machine', tag: 'es', text: 'Lanzamos hoy. #a #b #c #d' },
+    ]);
+
+    expect(author?.text).toBe('Shipping today. #a');
+    expect(machine?.text).toBe('Lanzamos hoy. #a #b #c #d');
+  });
+
+  it('is idempotent — a body already cleaned on ingest passes through unchanged', () => {
+    const once = stripSpamHashtagBlocks([{ source: 'author', text: 'Shipping today. #a #b #c #d' }]);
+    const twice = stripSpamHashtagBlocks(once);
+
+    expect(twice[0]?.text).toBe('Shipping today. #a');
+    // The same object, not an equal copy: an unchanged rendition is returned as-is.
+    expect(twice[0]).toBe(once[0]);
+  });
+});

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -75,7 +75,7 @@ import { getRuntimeSocketServer } from '../runtime/socketServer';
 import { emitPostEngagement, POST_ENGAGEMENT_EVENTS } from '../services/postEngagementBroadcast';
 import { normalizeMediaItems, type NormalizedMediaItem } from '../utils/mediaInput';
 import { warmLinkPreviewForText } from '../utils/linkPreviewWarm';
-import { authorVariants, buildPrimaryVariant, resolveVariant, validateAuthorVariants } from '../services/postVariants';
+import { authorVariants, buildPrimaryVariant, resolveVariant, stripSpamHashtagBlocks, validateAuthorVariants } from '../services/postVariants';
 import { postTranslationService, TranslationRequestError } from '../services/PostTranslationService';
 import { validatePublicShareTarget } from '../utils/postAccessControl';
 import { assertLaneAssignable, LaneAssignmentError } from '../utils/laneAssignment';
@@ -1971,12 +1971,20 @@ export const updatePost = async (req: AuthRequest, res: Response) => {
       // Rewrite the renditions. Every branch drops the machine translations: they
       // translate a body that no longer exists, and serving one would show a reader
       // the post as it used to be.
-      content.variants = rewriteEditedVariants({
+      //
+      // `stripSpamHashtagBlocks` is the edit half of the retired `pre('validate')`
+      // hook (`toStoredContent` is the create half). It sits INSIDE this branch on
+      // purpose: the branch condition — the edit supplied renditions, or the body
+      // changed — is what `isModified('content.variants')` used to answer, so a
+      // media-only or settings-only edit still rewrites nobody's words. The tags
+      // themselves survive the strip: `patch.hashtags` was taken from the RAW body
+      // above, before this runs.
+      content.variants = stripSpamHashtagBlocks(rewriteEditedVariants({
         authorLanguageVariants,
         existingAuthorVariants,
         text,
         detectedPrimary: primaryLanguage,
-      });
+      }));
     }
 
     // Handle content location updates (user's shared location)

--- a/packages/backend/src/services/postVariants.ts
+++ b/packages/backend/src/services/postVariants.ts
@@ -11,6 +11,7 @@ import {
 } from '@mention/shared-types';
 import { config } from '../config';
 import { normalizeAltInput, normalizeMediaItems } from '../utils/mediaInput';
+import { normalizePostHashtags } from '../utils/textProcessing';
 
 /**
  * Multilingual post content: the ONE place that knows how a localized rendition
@@ -142,6 +143,40 @@ export function applyDetectedPrimaryTag(
 }
 
 /**
+ * Remove a spammy 4+ consecutive-hashtag block from every AUTHOR rendition.
+ *
+ * This is the surviving half of the Mongoose `pre('validate')` hook that the
+ * Postgres cutover retired. The hook ran on `.save()`, which is how BOTH native
+ * write paths persisted a post (`new Post(...).save()` in `PostCreationService`,
+ * `post.save()` in `updatePost`), so it fired on every native create and every
+ * native edit right up to the cutover — it is a behaviour that was lost, not a
+ * validator that never ran. The federated ingest path never depended on it
+ * (`connectors/activitypub/apPostContent.ts` calls `normalizePostHashtags`
+ * directly), which is why the gap presented as Mention cleaning other instances'
+ * bodies while storing its own users' verbatim.
+ *
+ * MACHINE renditions are deliberately untouched: a translation is produced FROM
+ * the already-cleaned primary, so only the author's own words can carry a block
+ * of their own — the same predicate the hook used.
+ *
+ * The `hashtags` COLUMN is not this function's business and never loses a tag to
+ * the strip: both writers derive it with `mergeHashtags` over the RAW body before
+ * the clean, which is exactly what the hook did (`normalizePostHashtags` returns
+ * the full tag set alongside the cleaned text, from the same call).
+ *
+ * Idempotent — a cleaned block leaves at most one hashtag behind, which is no
+ * longer a block — so a body that already came through `normalizePostHashtags`
+ * on ingest passes through unchanged.
+ */
+export function stripSpamHashtagBlocks(variants: PostContentVariant[]): PostContentVariant[] {
+  return variants.map((variant) => {
+    if (variant.source !== 'author') return variant;
+    const cleaned = normalizePostHashtags(variant.text).content;
+    return cleaned === variant.text ? variant : { ...variant, text: cleaned };
+  });
+}
+
+/**
  * The API's content shape → the STORED one: renditions only.
  *
  * The single conversion, shared by every write path (`PostCreationService`, the
@@ -155,6 +190,11 @@ export function applyDetectedPrimaryTag(
  * becomes the primary variant. A post with no body at all — a boost — keeps no
  * variant.
  *
+ * Every rendition it produces goes through {@link stripSpamHashtagBlocks} on the
+ * way out — this conversion is the create/reply/boost half of the two native
+ * writers that the retired `pre('validate')` hook used to cover; `updatePost`
+ * calls it for itself on the edit half.
+ *
  * The post-level facts are copied by an explicit whitelist, not a spread of the
  * request: `text` (and the hydration-only `textLang`) must NOT reach storage,
  * and everything below is deliberately not per-language — a poll's votes must
@@ -167,9 +207,11 @@ export function toStoredContent(
 ): StoredPostContent {
   const declared = authorVariants(content);
   const primary = buildPrimaryVariant(content.text, primaryLanguage);
-  const variants = declared.length > 0
-    ? applyDetectedPrimaryTag(declared, primaryLanguage)
-    : (primary ? [primary] : []);
+  const variants = stripSpamHashtagBlocks(
+    declared.length > 0
+      ? applyDetectedPrimaryTag(declared, primaryLanguage)
+      : (primary ? [primary] : []),
+  );
 
   return {
     ...(variants.length > 0 ? { variants } : {}),

--- a/packages/backend/src/utils/textProcessing.ts
+++ b/packages/backend/src/utils/textProcessing.ts
@@ -187,9 +187,13 @@ export interface NormalizedPostHashtags {
  *   4. Hashtags used naturally inside sentence text (not part of a 4+ block)
  *      stay in `content` untouched.
  *
- * Pure and side-effect free so it is unit-testable in isolation; the persistence
- * layer (Post schema `pre('validate')` hook and the federated batch insert)
- * invokes it immediately before writing.
+ * Pure and side-effect free so it is unit-testable in isolation. The Mongoose
+ * `pre('validate')` hook that used to invoke it for every document write is
+ * gone with the model; its callers are now named individually — the federated
+ * ingest (`connectors/activitypub/apPostContent.ts`) reads both halves, and the
+ * native write paths read the cleaned `content` through
+ * `services/postVariants.ts`'s `stripSpamHashtagBlocks` while deriving the
+ * `hashtags` column with `mergeHashtags` over the RAW body.
  */
 export function normalizePostHashtags(text: string | undefined | null, userProvided?: string[]): NormalizedPostHashtags {
   const source = typeof text === 'string' ? text : '';


### PR DESCRIPTION
Closes #710. The issue asked for a DECISION — reimplement, or accept and document. The decision is **reimplement**, and here is what it rests on.

## The hook fired. It is a lost behaviour, not a validator that never ran.

`AGENTS.md` is explicit that a Mongoose validator which never ran must not become a constraint that does, because they do not run on `updateOne` / `findOneAndUpdate`. This one was a `pre('validate')`, which runs on `.save()` — and `.save()` is how **both** native write paths persisted a post until the Postgres cutover. Read out of `28f4c6bd^` (the commit before `feat(backend): port the posts write path and its readers to Postgres (batch 7)`, 2026-08-02):

- `PostCreationService`: `const post = new Post(postData); await post.save();`
- `posts.controller` `updatePost`: `await post.save();`

So it fired on every native create and every native edit, right up to the cutover.

## What the PG path stores today

Measured on `origin/main` against a real database, through `postCreationService.create`, reading the row back with `readPost`:

| body written | stored today | stored under Mongo |
|---|---|---|
| `Shipping the new feed today. #startup #social #tech #ai #growth` | verbatim | `Shipping the new feed today. #startup` |
| `#startup #social #tech #ai #growth` | verbatim | `` (empty) |
| two author renditions, a block in each | both verbatim | both cleaned |

And the asymmetry that makes it hard to defend as "accepted behaviour": the federated ingest still strips (`connectors/activitypub/apPostContent.ts` calls `normalizePostHashtags` directly), so Mention has been cleaning other instances' bodies while storing its own users' as sent.

## Where it went back

`stripSpamHashtagBlocks` in `services/postVariants.ts` — one implementation, called from the two native body writers and nowhere else:

- **`toStoredContent`** — create, reply and boost. That function's own docblock already calls it "the single conversion, shared by every write path".
- **`updatePost`**, *inside* the `authorLanguageVariants !== undefined || textChanged` branch. That branch condition is what `isModified('content.variants')` used to answer, so a media-only or settings-only edit still rewrites nobody's words.

**Deliberately not at the repository.** `replacePostContent` has eight callers, and four of them (`backfillMediaMetadata`, `mediaMetadataEnrichJob`, the two federated repair scripts) pass the existing variants straight through. Stripping there would have no equivalent of the `isModified` guard and would turn a media-metadata job into something that silently rewrites author bodies years after the fact.

## Two things the hook also did, and why neither needed porting

- **`orderContentVariants`** (author renditions before machine ones) is structural on the PG path: the only writers of author variants produce author-only sets, `rewriteEditedVariants` drops machine renditions on every edit, and `PostTranslationService.upsertMachineVariant` renumbers survivors and APPENDS. A machine rendition cannot precede an author one.
- **The `hashtags` column** never lost a tag to the strip, then or now. `normalizePostHashtags(text, userProvided).hashtags` *is* `mergeHashtags(text, userProvided)` — literally the same call inside it — and both writers already derive the column from the RAW body before the clean. A post whose block was removed from view still belongs to all five hashtag feeds, and the tests assert it.

## Mutation tests (each red, then restored from a pristine copy)

| mutation | result |
|---|---|
| create-half call removed from `toStoredContent` | 3 create cases fail |
| edit-half call removed from `updatePost` | the edit case fails |
| edit-half call moved OUTSIDE the changed-body guard | the "rewrites NOTHING when the edit did not touch the body" case fails |
| the `source === 'author'` predicate removed | the machine-rendition case fails |

The three-consecutive-hashtag case is the boundary control — a rule that ate every hashtag would pass every stripping assertion and fail that one.

## Also

`normalizePostHashtags`'s docblock still named the `pre('validate')` hook as its caller. Corrected to name the callers that exist.

## One thing left out, deliberately

The same dead hook also set `hasLinks`, and nothing on the native PG write path sets it now — `insertPostRecord` takes `input.hasLinks ?? false` and `PostCreationService` never passes it, so a native post with a link stores `false` (measured). `routes/search.ts` reads that column for the `filter:links` operator, so that operator currently matches no native post. It is a different behaviour with a different test and is not in this issue's scope; it needs its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification

`cd packages/backend && DATABASE_URL=... bunx vitest run`

| revision | result |
|---|---|
| `origin/main` (`c96c2764`), before any edit | **484 files / 5944 tests passed** |
| this branch (`e589115a`) | **485 files / 5952 tests passed** |

The delta is exactly the eight tests in the new `postSpamHashtagStrip.test.ts`. `bunx tsc --noEmit` in `packages/backend`: exit 0.

Note on how those were measured: this machine was under heavy load from sibling agents (load average 25-90 on 32 cores) and the shared Postgres on :5433 contends, which produces `FAIL <file>` with zero failing tests. `origin/main` itself goes red that way under load — 21 files at load ~30, 88 files at load ~65 — so both numbers above were taken with `--maxWorkers=4` to bound the concurrent client count and the baseline was re-measured under the same conditions. One earlier run of this branch reported a single failing test which did not reproduce in three consecutive full runs afterwards; its name was not captured.
