### PR TITLE
fix(federation): the orphan backfill already held 257 of these authors locally

### DIFF
--- a/packages/backend/src/__tests__/scripts/backfillFederatedPostAuthors.test.ts
+++ b/packages/backend/src/__tests__/scripts/backfillFederatedPostAuthors.test.ts
@@ -8,12 +8,14 @@ import {
 } from '../helpers/federationFixtures';
 
 const scope = federationScope('backfill-federated-post-authors');
+const posts = postScope('backfill-federated-post-authors');
 
 beforeAll(async () => {
   await connectPostgres();
 });
 
 afterEach(async () => {
+  await clearPostScope(posts);
   await clearFederationScope(scope);
 });
 
@@ -55,7 +57,13 @@ vi.mock('@oxyhq/core/server', async (importOriginal) => ({
   assertSafePublicUrl: vi.fn(),
 }));
 
-import { resolveAuthorOxyUserId } from '../../scripts/backfillFederatedPostAuthors';
+import {
+  resolveAuthorOxyUserId,
+  resolveOrphanAuthorUri,
+} from '../../scripts/backfillFederatedPostAuthors';
+import { extractActorUri, signedFetch, asRecord } from '../../connectors/activitypub/helpers';
+import { assertSafePublicUrl } from '@oxyhq/core/server';
+import { clearPostScope, postScope, seedPost } from '../helpers/postFixtures';
 
 /** A promise plus its externally-callable resolver, for holding a resolve in-flight. */
 function deferred<T>() {
@@ -114,5 +122,112 @@ describe('backfillFederatedPostAuthors — resolveAuthorOxyUserId in-flight dedu
     // Lookup-only: the row answered, and neither resolver was reached.
     expect(getOrFetchActor).not.toHaveBeenCalled();
     expect(fetchRemoteActor).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The orphan cohort this script exists for carries NO stored `federation.actorUri`
+ * — measured over all 578 rows on production, 2026-08-15. What 509 of them DO
+ * carry is a Bridgy Fed object URL, and an AT-URI's authority is by protocol
+ * definition the repo holding the record, i.e. the author. So the author is
+ * knowable locally, and the script must take that route before the network one.
+ *
+ * These tests pin the ORDER of the three sources and, in the last case, the
+ * correctness consequence: without the derivation a bridged post whose author
+ * deleted it upstream answers 410 and becomes a deletion candidate, even though
+ * its author was never in doubt.
+ */
+describe('backfillFederatedPostAuthors — resolveOrphanAuthorUri source order', () => {
+  const DID = 'did:plc:b7kamuwqipovlbz2l5vhe2tb';
+  const BRIDGY_OBJECT = `https://bsky.brid.gy/convert/ap/at://${DID}/app.bsky.feed.post/3mocp2h5ijs2n`;
+  const BRIDGY_ACTOR = `https://bsky.brid.gy/ap/${DID}`;
+
+  beforeEach(() => {
+    vi.mocked(signedFetch).mockReset();
+    vi.mocked(extractActorUri).mockReset();
+    vi.mocked(asRecord).mockReset();
+    vi.mocked(assertSafePublicUrl).mockReset();
+  });
+
+  it('derives the bridged author from the activity id with NO network call', async () => {
+    const orphan = await seedPost(posts, {
+      oxyUserId: null,
+      authorship: [],
+      federation: { activityId: BRIDGY_OBJECT, url: BRIDGY_OBJECT },
+    });
+
+    await expect(resolveOrphanAuthorUri(orphan)).resolves.toEqual({
+      kind: 'ok',
+      authorUri: BRIDGY_ACTOR,
+      actorUriWasMissing: true,
+    });
+
+    // The whole point: the repair costs nothing at the network layer.
+    expect(signedFetch).not.toHaveBeenCalled();
+    expect(assertSafePublicUrl).not.toHaveBeenCalled();
+  });
+
+  it('still prefers a STORED actor uri over the derivation', async () => {
+    const stored = 'https://mastodon.social/users/gargron';
+    const orphan = await seedPost(posts, {
+      oxyUserId: null,
+      authorship: [],
+      federation: { activityId: BRIDGY_OBJECT, url: BRIDGY_OBJECT, actorUri: stored },
+    });
+
+    await expect(resolveOrphanAuthorUri(orphan)).resolves.toEqual({
+      kind: 'ok',
+      authorUri: stored,
+      actorUriWasMissing: false,
+    });
+    expect(signedFetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The negative control for the test above. A branch that answered every orphan
+   * locally would pass "no network call" while quietly breaking the 69 posts that
+   * genuinely need the fetch — so one ordinary Mastodon orphan must still reach it.
+   */
+  it('falls through to the network fetch for a NON-bridged orphan', async () => {
+    const objectUrl = 'https://toot.community/users/someone/statuses/110';
+    const authorUri = 'https://toot.community/users/someone';
+    const orphan = await seedPost(posts, {
+      oxyUserId: null,
+      authorship: [],
+      federation: { activityId: objectUrl, url: objectUrl },
+    });
+
+    vi.mocked(assertSafePublicUrl).mockResolvedValue({ ok: true });
+    vi.mocked(signedFetch).mockResolvedValue(
+      new Response(JSON.stringify({ attributedTo: authorUri }), { status: 200 }),
+    );
+    vi.mocked(asRecord).mockReturnValue({ attributedTo: authorUri });
+    vi.mocked(extractActorUri).mockReturnValue(authorUri);
+
+    await expect(resolveOrphanAuthorUri(orphan)).resolves.toEqual({
+      kind: 'ok',
+      authorUri,
+      actorUriWasMissing: true,
+    });
+    expect(signedFetch).toHaveBeenCalledWith(objectUrl, expect.any(String));
+  });
+
+  it('repairs a bridged post whose upstream object is GONE, instead of marking it deletable', async () => {
+    const orphan = await seedPost(posts, {
+      oxyUserId: null,
+      authorship: [],
+      federation: { activityId: BRIDGY_OBJECT, url: BRIDGY_OBJECT },
+    });
+
+    // The author deleted the post on Bluesky: the object 410s, but the ACTOR is
+    // unaffected. Before the derivation this fell into `gone` and, with
+    // BACKFILL_DELETE_GONE, would have been deleted.
+    vi.mocked(assertSafePublicUrl).mockResolvedValue({ ok: true });
+    vi.mocked(signedFetch).mockResolvedValue(new Response(null, { status: 410 }));
+
+    const result = await resolveOrphanAuthorUri(orphan);
+
+    expect(result).toEqual({ kind: 'ok', authorUri: BRIDGY_ACTOR, actorUriWasMissing: true });
+    expect(result.kind).not.toBe('gone');
   });
 });

--- a/packages/backend/src/scripts/backfillFederatedPostAuthors.ts
+++ b/packages/backend/src/scripts/backfillFederatedPostAuthors.ts
@@ -17,28 +17,44 @@
  * PER-ORPHAN ALGORITHM
  * --------------------
  * For each post with `federation.activityId` set and `oxyUserId == null`:
- *   1. Determine the author actor URI:
+ *   1. Determine the author actor URI, cheapest source first:
  *        - use `federation.actorUri` when present (no network); else
+ *        - DERIVE the bridged actor URI from the atproto DID embedded in a Bridgy
+ *          Fed object URL (`deriveBridgyActorUri`, no network) — the same
+ *          derivation hydration applies to these very posts; else
  *        - re-fetch the AP object by `federation.activityId` (falling back to
- *          `federation.url`) and read `attributedTo`. This covers brid.gy /
- *          Bluesky-bridged notes, which arrive over ActivityPub (brid.gy is an AP
- *          bridge) and whose actor is a normal AP actor — so the SAME
- *          `actorService` path resolves them; the atproto connector is NOT
- *          involved (that is READ/discovery of NATIVE bsky, and our own outbound
- *          be-discovered bridge — both unrelated to inbound bridged content).
+ *          `federation.url`) and read `attributedTo`. brid.gy / Bluesky-bridged
+ *          notes arrive over ActivityPub (brid.gy is an AP bridge) and their actor
+ *          is a normal AP actor — so the SAME `actorService` path resolves them;
+ *          the atproto connector is NOT involved (that is READ/discovery of NATIVE
+ *          bsky, and our own outbound be-discovered bridge — both unrelated to
+ *          inbound bridged content).
+ *
+ *      Why the middle step earns its place, measured against production on
+ *      2026-08-15 over the whole 578-post orphan cohort: NONE carries a stored
+ *      `actorUri`, but 509 are Bridgy Fed objects whose DID yields an actor URI
+ *      locally, and 257 of those already resolve against a `federated_actors` row
+ *      we hold — repaired with ZERO network calls. The remaining 252 need one
+ *      ACTOR fetch per distinct DID (170 of them), not one OBJECT fetch per post.
+ *      Only 69 posts have no derivable DID and reach the fetch below.
  *   2. Resolve the actor URI → `oxyUserId` via `actorService.getOrFetchActor`,
  *      forcing a full `fetchRemoteActor` (which mints/refreshes the Oxy user via
  *      the shared `resolveOxyExternalUser` identity bridge) when a cached actor
  *      row exists but was never linked. Repeated actors are resolved once
- *      (in-memory cache) — the 11,967 orphans come from far fewer actors.
- *   3. On success: set the post's `oxyUserId` + `authorship` (`buildAuthorship`)
- *      and backfill `federation.actorUri` when it was missing. `updateOne` does
- *      NOT run the Post pre-save hook, so BOTH fields are written explicitly and
- *      stay in lockstep (the same shape the hook would produce).
+ *      (in-memory cache) — the orphans come from far fewer actors than posts:
+ *      measured 2026-08-15, 578 posts over 295 distinct DIDs plus 69 non-bridged.
+ *   3. On success: `replacePostAuthorship` writes the authorship rows and the
+ *      denormalized `posts.oxy_user_id` they project in ONE transaction, and
+ *      `federation.actorUri` is backfilled when it was missing — so a repaired
+ *      post never has an owner column naming a user with no authorship row.
  *   4. DELETE the post ONLY when its source is definitively gone (HTTP 404/410)
  *      AND no author could be resolved. A transient failure (timeout, 5xx, 401/403
  *      signature rejection, SSRF-blocked, no `attributedTo`) is LEFT UNTOUCHED for
- *      a later re-run — never deleted.
+ *      a later re-run — never deleted. Note that step 1's derivation shrinks this
+ *      bucket on purpose: a bridged post whose author DELETED it on Bluesky answers
+ *      404/410 at the object URL while its author stays perfectly knowable, so
+ *      without the derivation it would be a deletion candidate under
+ *      `BACKFILL_DELETE_GONE` despite a repair being available.
  *
  * SAFETY / OPERATION
  * ------------------
@@ -67,6 +83,7 @@ import type { PostRecord } from '../db/posts/postRecord';
 import { findActorByUri } from '../db/federation/actorRepository';
 import { actorService } from '../connectors/activitypub/actor.service';
 import { extractActorUri, signedFetch, asRecord } from '../connectors/activitypub/helpers';
+import { deriveBridgyActorUri } from '../connectors/activitypub/bridgy';
 import { AP_CONTENT_TYPE } from '../connectors/activitypub/constants';
 import { assertSafePublicUrl } from '@oxyhq/core/server';
 import { buildAuthorship } from '../utils/postAuthorship';
@@ -169,15 +186,38 @@ export async function resolveAuthorOxyUserId(
 }
 
 /**
- * Determine the author actor URI for an orphan: prefer the stored
- * `federation.actorUri`, otherwise re-fetch the AP object and read `attributedTo`.
+ * Determine the author actor URI for an orphan, cheapest source first: the stored
+ * `federation.actorUri`, then the actor URI DERIVED from a Bridgy Fed object URL,
+ * and only then a re-fetch of the AP object to read `attributedTo`.
  * Distinguishes a definitively-gone source (404/410) from a transient failure so
  * only truly-dead posts become deletion candidates.
  */
-async function resolveOrphanAuthorUri(orphan: OrphanRow): Promise<AuthorUriResult> {
+export async function resolveOrphanAuthorUri(orphan: OrphanRow): Promise<AuthorUriResult> {
   const storedActorUri = orphan.federation?.actorUri;
   if (storedActorUri) {
     return { kind: 'ok', authorUri: storedActorUri, actorUriWasMissing: false };
+  }
+
+  // A Bridgy Fed object URL embeds the author's atproto DID
+  // (`.../convert/ap/at://<did>/app.bsky.feed.post/<rkey>`), and an AT-URI's
+  // authority IS the repo holding the record — the author, by protocol
+  // definition rather than by pattern guess. The bridged actor URI is a pure
+  // function of that DID, so the author is knowable with NO network round trip.
+  // This is the SAME derivation hydration already applies to these very posts
+  // (`resolveOrphanFederatedAuthors`); both call one helper on purpose.
+  //
+  // It is not only cheaper, it is STRICTLY MORE CORRECT than the fetch below.
+  // The object URL 404s once the author deletes the post on Bluesky, which sends
+  // the orphan to the `gone` bucket — so without this branch, a post whose author
+  // was locally knowable all along becomes a deletion candidate under
+  // `BACKFILL_DELETE_GONE`. An actor also outlives any single post, so the
+  // derived URI resolves in cases where the object fetch cannot.
+  const derivedActorUri = deriveBridgyActorUri(
+    orphan.federation?.activityId,
+    orphan.federation?.url,
+  );
+  if (derivedActorUri) {
+    return { kind: 'ok', authorUri: derivedActorUri, actorUriWasMissing: true };
   }
 
   const objectUrl = orphan.federation?.activityId || orphan.federation?.url;


### PR DESCRIPTION
Closes nothing on its own — this is the code half of the #672 investigation. The evidence half is [a comment on #672](https://github.com/OxyHQ/Mention/issues/672).

## What was wrong

`scripts/backfillFederatedPostAuthors.ts` resolves an orphan's author from `federation.actorUri`, and goes straight to a **signed remote object fetch** when that is absent. Measured against production on **2026-08-15**, it is absent on **all 578** posts in the cohort — so the script always took the network path, and its own header concluded:

> So the network is not the cheapest route. It is the only route.

That is false, and the helper disproving it was already in the repo.

## The local route

A Bridgy Fed activity id embeds the author's atproto DID:

```
https://bsky.brid.gy/convert/ap/at://did:plc:b7kamuwqipovlbz2l5vhe2tb/app.bsky.feed.post/3mocp2h5ijs2n
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the author
```

An AT-URI's authority component **is** the repository holding the record — the author by protocol definition, not by pattern guess — and Bridgy Fed's actor URI is a pure function of it. `deriveBridgyActorUri` (`connectors/activitypub/bridgy.ts`) already does this conversion, and `PostHydrationService.resolveOrphanFederatedAuthors` already applies it **to these very posts** on the read path. The repair script was the only place that did not.

The fix is the ordering: stored actor uri → derivation → network.

## Measured over the cohort (production, 2026-08-15)

| | posts | repair cost |
|---|---|---|
| DID derivable **and** actor already held & linked | **257** | **zero network** |
| DID derivable, actor not held yet | **252** | one **actor** fetch per distinct DID (**170**) |
| no DID (ordinary AP instances) | **69** | one object fetch, as before |

509 of 578 yield a DID (295 distinct). The actor-URI shape was confirmed against **1,057 `federated_actors` rows we already hold, 1,053 of them linked**. Control: **0 of the 69** non-Bridgy orphans yield a DID, so the extraction is not matching blindly.

So the cost drops from *578 signed requests against third-party servers* to *257 free, then at most 239*.

## It is also more correct, not just cheaper

A bridged post whose author **deleted it on Bluesky** answers 404/410 at the object URL while the author remains perfectly knowable. Under the old ordering those landed in the `gone` bucket and, with `BACKFILL_DELETE_GONE=true`, **would have been deleted despite a repair being available.** There is a test for exactly that.

## Tests

Four added to the existing file, covering the source ORDER rather than just the happy path:

- derives the bridged author with **no** network call (asserts `signedFetch` and `assertSafePublicUrl` are never reached);
- a **stored** actor uri still wins over the derivation;
- **negative control** — an ordinary Mastodon orphan still falls through to the fetch, so the new branch cannot be silently answering everything locally;
- a **gone** bridged object is repaired rather than marked deletable.

They use real seeded `PostRecord`s via `postFixtures`, so the federation fields round-trip through the actual schema (no casts).

**Mutation-tested.** Disabling the new branch (`if (false && derivedActorUri)`) turns the first and fourth red while the negative control and the stored-uri test stay green — which is the correct signature, since only those two depend on the branch. The mutation was diffed on disk before running, and the file byte-compared against a pristine copy after restoring.

## Verification

Full backend suite, against a dedicated Postgres on an isolated high port (the shared dev instance on 5433 was saturated by other sessions — `53300 too many clients`, which is what produced the first, misleading red run).

At CI-like concurrency (`--maxWorkers=4`):

| | tests passed | tests failed |
|---|---|---|
| `origin/main` baseline | 5944 | **0** |
| this branch | 5948 (+4) | **0** |

The handful of *file*-level failures in both columns are the same pre-existing `afterAll` teardown timeout at `src/__tests__/setup.ts:72`; they vary run to run in both directions and there are fewer of them on this branch. `tsc --noEmit` and `lint` are clean.

## Not fixed here

`ensureFederatedNote` (`connectors/activitypub/outbox.service.ts`) has `authorUri` in scope but omits `actorUri` from the `federation` literal it writes, so boosted originals, reply ancestors and quoted notes are **still** stored today with an activity id and no actor uri. Those rows are not orphans — the author guard above them is a real early-exit, and the re-measurement confirms zero new orphans in 30 days against 9,801 federated posts ingested in the last 7 — so it is a latent data-completeness gap, not a live bug. It wants its own issue rather than a drive-by here.

## Nothing has been run against production

The two measurement tasks were read-only (`SELECT` only). **The backfill itself has not been run** and should be a deliberate decision: dry run first (`bun packages/backend/dist/src/scripts/backfillFederatedPostAuthors.js`, writes off by default), read the plan, then `BACKFILL_APPLY=true`. Leave `BACKFILL_DELETE_GONE` off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
