### PR TITLE
db: a date a raw sql template only claims to be

### DIFF
--- a/packages/backend/src/__tests__/classificationSources.test.ts
+++ b/packages/backend/src/__tests__/classificationSources.test.ts
@@ -312,6 +312,37 @@ describe('the newVoices source', () => {
     // never the one returned, because replies are excluded from the grouping.
     expect(suiteIdsOf(gathered)).toEqual([quiet.id, root.id]);
   });
+
+  /**
+   * The ORDER is `min(created_at) DESC` — "earliest-arriving first" — and it was
+   * NOT pinned by anything until this test.
+   *
+   * Every other fixture in this describe gives its authors a single post, and
+   * for a one-post author `min(created_at)` and `max(created_at)` are the same
+   * value. Mutation-tested: rewriting the `ORDER BY` from `min` to `max`
+   * SURVIVED the rest of this file. That matters now because the selected
+   * `min(created_at)` column — an unread bare date assertion — was deleted, and
+   * the `min` left in the `ORDER BY` reads like its orphan. It is the ordering
+   * itself, and this is what says so.
+   *
+   * The discriminator is an author whose two posts straddle another author's
+   * one: `veteran` ARRIVED first (older `min`) but posted most recently (newer
+   * `max`), so the two aggregates rank the pair in opposite orders.
+   */
+  it('orders by each author\'s FIRST post, not their latest', async () => {
+    const veteranFirst = await create({ oxyUserId: 'classsrc-veteran', createdAt: at(-30_000) });
+    const veteranLatest = await create({ oxyUserId: 'classsrc-veteran', createdAt: at(0) });
+    const newcomer = await create({ oxyUserId: 'classsrc-latecomer', createdAt: at(-15_000) });
+
+    const gathered = await newVoicesSource.gather({}, {}, WIDE_CAP);
+
+    // `min DESC`: latecomer (-15s) before veteran (-30s). Under `max DESC` the
+    // veteran's 0s would come first, which is the mutation this refuses.
+    // Each author contributes their LATEST post, so the veteran's row is
+    // `veteranLatest` and never `veteranFirst`.
+    expect(suiteIdsOf(gathered)).toEqual([newcomer.id, veteranLatest.id]);
+    expect(suiteIdsOf(gathered)).not.toContain(veteranFirst.id);
+  });
 });
 
 describe('the topReplies source', () => {

--- a/packages/backend/src/__tests__/db/bareSqlDate.test.ts
+++ b/packages/backend/src/__tests__/db/bareSqlDate.test.ts
@@ -1,0 +1,211 @@
+/**
+ * No raw `sql` template may be annotated with `Date`, anywhere in
+ * `packages/backend/src`.
+ *
+ * Such an annotation is a TYPE ASSERTION over a raw expression, never a
+ * conversion. `drizzle-orm/postgres-js` installs a transparent parser for every
+ * timestamp OID so that DRIZZLE owns the conversion, and drizzle then applies it
+ * per DECLARED COLUMN — a raw `sql` expression has no column behind it, so the
+ * value arrives as the driver's string (`'2026-08-15 17:01:48.833+00'`) while
+ * `tsc` believes it is a `Date`. Measured against a real server before this gate
+ * was written: `typeof` `string`, `instanceof Date` false, `.getTime` undefined.
+ *
+ * The trap is that the natural thing to write against the DECLARED type —
+ * `row.lastPostAt.toISOString()` — is a 500 with nothing anywhere to warn you.
+ * It happened once already, in `routes/channelWriters.routes.ts`, whose comment
+ * is the precedent this rule generalizes: `.mapWith(<column>)` borrows the
+ * column's own decoder, so the type is DERIVED from what runs rather than
+ * asserted over it.
+ *
+ * ## Why the rule is total rather than scoped to SELECT lists
+ *
+ * One site was write-only (`postRepository`'s `postCreatedAtSql`, an
+ * `INSERT ... (select ...)` whose value never comes back), where the annotation
+ * was harmless. Exempting it would mean a check that must classify each
+ * occurrence by POSITION — and a rule with a judgement call in it is a rule that
+ * grows an exemption list, one defensible entry at a time, until it cannot fail.
+ * A bare `SQL` costs that call site nothing, so the rule is "never" and there is
+ * no list.
+ *
+ * ## Why the scan strips comments, which is normally the wrong thing to do
+ *
+ * The first version of this gate did NOT, and went red on three occurrences that
+ * were all PROSE — including the `channelWriters` comment that is the best
+ * explanation of this trap in the repository, and the two written by the change
+ * that added this file. A census over source normally must exclude nothing,
+ * because a comment quoting a call verbatim is how a count gets inflated; here
+ * the inflation is the whole population, and the cheapest way to green a
+ * prose-sensitive gate is to delete the prose that explains the rule. A gate
+ * whose cheapest green destroys documentation is the wrong gate.
+ *
+ * So: comments are stripped, and the two ways THAT can go wrong are both
+ * controlled below — a code occurrence must still be FOUND (positive control),
+ * and a commented one must be ignored while the scan can still see the file
+ * (negative control with its own floor).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const SOURCE_ROOT = join(__dirname, '..', '..');
+
+/**
+ * The forbidden sequence, assembled from two halves so that this file does not
+ * match itself and need an exemption.
+ *
+ * The trailing backtick is part of it: `sql` is a template TAG, so the tagged
+ * template is the only shape that can construct one, and requiring the backtick
+ * costs nothing while narrowing the match to real code.
+ */
+const PATTERN_SOURCE = 'sql<' + 'Date>' + '`';
+
+/**
+ * A scan that read nothing reports the same clean ZERO as a scan that read
+ * everything and found nothing, so the file count carries a floor. 400 is well
+ * under the number of TypeScript files in `src` and well over anything a broken
+ * walk would return.
+ */
+const MIN_SCANNED_FILES = 400;
+
+/**
+ * The file both controls inject into. Named explicitly rather than found by
+ * search: a control that PICKS its own subject can keep passing for the wrong
+ * reason once that subject moves. This one is retired when
+ * `db/posts/postRepository.ts` is.
+ */
+const CONTROL_FILE = join('db', 'posts', 'postRepository.ts');
+
+async function typescriptFiles(directory: string): Promise<string[]> {
+  const found: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) found.push(...(await typescriptFiles(path)));
+    else if (entry.name.endsWith('.ts')) found.push(path);
+  }
+  return found;
+}
+
+/**
+ * Blank out `//` and block comments, preserving line structure so reported line
+ * numbers stay true.
+ *
+ * Deliberately NOT a TypeScript parser. The one thing a naive stripper can get
+ * wrong in the permissive direction is a `//` inside a string literal earlier on
+ * the same line as a real tagged template, which would hide it — a line that
+ * would have to read `f('http://x'); const q = <tag>...` to occur at all. The
+ * positive control is what stands behind that judgement; if this ever needs to
+ * be smarter, make it a parser rather than adding cases.
+ */
+function stripComments(source: string): string[] {
+  const out: string[] = [];
+  let inBlock = false;
+
+  for (const line of source.split('\n')) {
+    let result = '';
+    let index = 0;
+    while (index < line.length) {
+      if (inBlock) {
+        const end = line.indexOf('*/', index);
+        if (end === -1) { index = line.length; break; }
+        inBlock = false;
+        index = end + 2;
+        continue;
+      }
+      const block = line.indexOf('/*', index);
+      const lineComment = line.indexOf('//', index);
+      if (lineComment !== -1 && (block === -1 || lineComment < block)) {
+        result += line.slice(index, lineComment);
+        index = line.length;
+        break;
+      }
+      if (block !== -1) {
+        result += line.slice(index, block);
+        inBlock = true;
+        index = block + 2;
+        continue;
+      }
+      result += line.slice(index);
+      index = line.length;
+    }
+    out.push(result);
+  }
+  return out;
+}
+
+/**
+ * Every `file:line` carrying the annotation in CODE.
+ *
+ * `inject` replaces one file's content IN MEMORY, which is how both controls
+ * exercise this exact reader, this exact stripper and this exact matcher rather
+ * than a re-implementation of them beside it.
+ */
+async function findOccurrences(
+  files: readonly string[],
+  inject?: { file: string; content: string },
+): Promise<string[]> {
+  const hits: string[] = [];
+  for (const file of files) {
+    const content = inject && file === inject.file ? inject.content : await readFile(file, 'utf8');
+    for (const [index, line] of stripComments(content).entries()) {
+      if (line.includes(PATTERN_SOURCE)) {
+        hits.push(`${file.slice(SOURCE_ROOT.length + 1)}:${index + 1}`);
+      }
+    }
+  }
+  return hits;
+}
+
+describe('a raw sql template annotated as a date', () => {
+  it('appears nowhere in packages/backend/src', async () => {
+    const files = await typescriptFiles(SOURCE_ROOT);
+
+    // VACUITY FLOOR: without this, a walk that returned `[]` would pass.
+    expect(files.length).toBeGreaterThan(MIN_SCANNED_FILES);
+
+    expect(await findOccurrences(files)).toEqual([]);
+  });
+
+  it('is FOUND when it is real code — positive control', async () => {
+    const files = await typescriptFiles(SOURCE_ROOT);
+    expect(files.length).toBeGreaterThan(MIN_SCANNED_FILES);
+
+    const control = join(SOURCE_ROOT, CONTROL_FILE);
+    expect(files).toContain(control);
+
+    const hits = await findOccurrences(files, {
+      file: control,
+      content: [
+        '// a line comment above it',
+        `const probe = ${PATTERN_SOURCE}max(created_at)\`;`,
+      ].join('\n'),
+    });
+
+    expect(hits).toEqual([`${CONTROL_FILE}:2`]);
+  });
+
+  it('is IGNORED when it is only prose — negative control, with a floor', async () => {
+    const files = await typescriptFiles(SOURCE_ROOT);
+    expect(files.length).toBeGreaterThan(MIN_SCANNED_FILES);
+
+    const control = join(SOURCE_ROOT, CONTROL_FILE);
+    expect(files).toContain(control);
+
+    // Every shape the real comments use: a block comment, a doc line, and a
+    // trailing comment on a line that also carries live code.
+    const prose = [
+      '/**',
+      ` * A bare ${PATTERN_SOURCE}...\` is an assertion, not a conversion.`,
+      ' */',
+      `// never write ${PATTERN_SOURCE}...\``,
+      `const real = 1; // ${PATTERN_SOURCE}max(created_at)\``,
+    ].join('\n');
+
+    const hits = await findOccurrences(files, { file: control, content: prose });
+
+    // The FLOOR that makes this negative control non-vacuous: the injected file
+    // really was read, and really did contain the sequence.
+    expect(prose).toContain(PATTERN_SOURCE);
+    expect(hits).toEqual([]);
+  });
+});

--- a/packages/backend/src/__tests__/services/interestScoreService.test.ts
+++ b/packages/backend/src/__tests__/services/interestScoreService.test.ts
@@ -136,6 +136,39 @@ describe('aggregateAuthors — the numbers come back as NUMBERS', () => {
     expect(row.lastPostMs).toBe(newer.getTime());
   });
 
+  /**
+   * The DATE half of the same trap, and it needs its own test because the two
+   * fail in opposite ways.
+   *
+   * `sum()` returning a string is silent: `Math.log1p('45')` scores an author 0
+   * and nothing complains. `max(created_at)` returning a string was silent too,
+   * but only because the consumer laundered it — `new Date(r.lastPost)` parses
+   * the driver's `'2026-08-15 17:01:48.833+00'` correctly in V8, so the VALUE
+   * was right and no assertion on it could ever have distinguished the two.
+   *
+   * `.mapWith(posts.createdAt)` made it a real `Date`, and the consumer now
+   * calls `.getTime()` on it directly. That is what turns the property into
+   * something a test can see: delete the `.mapWith` and this throws
+   * `r.lastPost.getTime is not a function` — the same shape of 500 that the
+   * channel-writers route once shipped — where before it would have passed.
+   * `tsc` cannot catch that mutation; the declared type is `Date` either way.
+   *
+   * Mutation-tested by removing the `.mapWith` and confirming this test, and
+   * only this family of tests, goes red.
+   */
+  it('hands the consumer a real Date, not the driver string that parses like one', async () => {
+    const author = authorId('date-shape');
+    const at = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+    await seedPost(author, { createdAt: at });
+
+    const [row] = await aggregateMine();
+
+    // Exact, not approximate: a string that reparsed to a DIFFERENT instant
+    // would be a second, quieter bug this also refuses.
+    expect(row.lastPostMs).toBe(at.getTime());
+    expect(new Date(row.lastPostMs).toISOString()).toBe(at.toISOString());
+  });
+
   it('excludes boosts, drafts, private posts, and posts outside the 30-day window', async () => {
     const counted = authorId('counted');
     const boostOnly = authorId('boost-only');

--- a/packages/backend/src/db/posts/postRepository.ts
+++ b/packages/backend/src/db/posts/postRepository.ts
@@ -868,9 +868,17 @@ function toPostInsert(input: PostRecordInput, id: string): PostInsert {
  * {@link insertChildRows}, and `replacePostAuthorship` only ever runs against a
  * post that already exists. A subquery on the primary key costs a single index
  * lookup per statement.
+ *
+ * Returns a bare `SQL`, deliberately NOT `SQL<Date>`. A type argument on a raw
+ * expression describes how the value DECODES, and this one is never decoded —
+ * it goes out in an `INSERT` and never comes back. Annotating it `Date` would be
+ * the same unfalsifiable assertion the SELECT-side sites carried, differing only
+ * in that nothing here could ever contradict it; `src/__tests__/db/bareSqlDate.test.ts`
+ * refuses the annotation everywhere rather than maintaining a list of the
+ * positions where it happens to be harmless.
  */
-function postCreatedAtSql(postId: string): SQL<Date> {
-  return sql<Date>`(select ${posts.createdAt} from ${posts} where ${posts.id} = ${postId})`;
+function postCreatedAtSql(postId: string): SQL {
+  return sql`(select ${posts.createdAt} from ${posts} where ${posts.id} = ${postId})`;
 }
 
 /**

--- a/packages/backend/src/mtn/feed/engine/sources/socialSources.ts
+++ b/packages/backend/src/mtn/feed/engine/sources/socialSources.ts
@@ -597,6 +597,12 @@ export const linksSource: SourceModule = {
  * with `DISTINCT ON` over the real `(created_at DESC, id DESC)` order — which is
  * also strictly more correct for federated posts, whose import-time id bears no
  * relation to when they were written.
+ *
+ * "Earliest-arriving first" is the `ORDER BY min(created_at) DESC` below and
+ * nothing else. `min(created_at)` was ALSO selected, as a bare `sql<Date>` no
+ * caller ever read — a false assertion (the value arrives as the driver's
+ * string) sitting on a column with no consumer, so it was deleted rather than
+ * mapped. The ordering is a separate expression and is untouched.
  */
 export const newVoicesSource: SourceModule = {
   id: 'newVoices',
@@ -611,7 +617,6 @@ export const newVoicesSource: SourceModule = {
         oxyUserId: posts.oxyUserId,
         latestPostId: sql<string>`(array_agg(${posts.id} order by ${posts.createdAt} desc, ${posts.id} desc))[1]`,
         recentCount: sql<number>`count(*)::int`,
-        firstPostAt: sql<Date>`min(${posts.createdAt})`,
       })
       .from(posts)
       .where(

--- a/packages/backend/src/services/InterestScoreService.ts
+++ b/packages/backend/src/services/InterestScoreService.ts
@@ -79,6 +79,16 @@ export class InterestScoreService {
      * The five `stats_*` columns are `NOT NULL DEFAULT 0`, so Mongo's `$ifNull`
      * wrappers have nothing left to guard and are dropped rather than ported as
      * `coalesce` noise.
+     *
+     * `lastPost` carries the SAME trap in its date-shaped form, and the fix is
+     * the same one `routes/channelWriters.routes.ts` documents: a bare
+     * `sql<Date>` is an ASSERTION over a raw expression, not a conversion.
+     * Drizzle owns timestamp decoding per DECLARED COLUMN and a raw `sql`
+     * expression has no column behind it, so `max(created_at)` came back as the
+     * driver's string — measured, `'2026-08-15 17:01:48.833+00'`, with
+     * `.getTime` undefined. `.mapWith(posts.createdAt)` borrows the column's own
+     * decoder, so the annotation is DERIVED from what actually runs and cannot
+     * drift from it.
      */
     const rows = await getDb()
       .select({
@@ -88,7 +98,7 @@ export class InterestScoreService {
           + ${posts.statsViewsCount} + ${posts.statsSharesCount}
         )`.mapWith(Number),
         postCount: sql`count(*)`.mapWith(Number),
-        lastPost: sql<Date>`max(${posts.createdAt})`,
+        lastPost: sql`max(${posts.createdAt})`.mapWith(posts.createdAt),
       })
       .from(posts)
       .where(
@@ -106,6 +116,12 @@ export class InterestScoreService {
     // `flatMap` rather than `filter`+`map`: it narrows `oxy_user_id` from
     // `string | null` to `string` without a cast. The empty-string check stays —
     // the column is nullable and the WHERE only excludes NULL.
+    //
+    // `r.lastPost.getTime()` directly: a group exists only because it has at
+    // least one row, and `created_at` is `NOT NULL`, so `max()` over it cannot
+    // be NULL. The `now` fallback that stood here guarded a state the grouping
+    // cannot produce, and it read as though `lastPost` might be absent when the
+    // real hazard was that it was a STRING.
     return rows.flatMap((r) => {
       const oxyUserId = r.oxyUserId;
       if (typeof oxyUserId !== 'string' || oxyUserId.length === 0) return [];
@@ -113,7 +129,7 @@ export class InterestScoreService {
         oxyUserId,
         raw: r.raw,
         postCount: r.postCount,
-        lastPostMs: r.lastPost ? new Date(r.lastPost).getTime() : now,
+        lastPostMs: r.lastPost.getTime(),
       }];
     });
   }


### PR DESCRIPTION
Closes #752

`sql<Date>` over a raw aggregate is a **type assertion, not a conversion**. `drizzle-orm/postgres-js` installs a transparent parser for every timestamp OID so that *drizzle* owns the conversion, and drizzle applies it per DECLARED COLUMN — a raw `sql` expression has no column behind it.

## Measured before touching anything

Against a real Postgres 17, one seeded post, the exact `InterestScoreService` query shape:

```
BARE sql<Date>   typeof=string  instanceof Date=false  value=2026-08-15 17:01:48.833+00
mapWith(column)  typeof=object  instanceof Date=true   value=2026-08-15T17:01:48.833Z
BARE .getTime is a function? undefined
```

That is the "before" — without it a fix is indistinguishable from a no-op, because the *value* was right either way (V8 parses the driver string correctly, which is exactly why this survived).

## The three sites

| site | change | why |
|---|---|---|
| `services/InterestScoreService.ts` | `.mapWith(posts.createdAt)`, and the consumer now calls `.getTime()` directly | The `new Date(...)` laundering is what made the bug invisible. Removing it makes the `Date` **load-bearing** rather than merely true. |
| `mtn/feed/engine/sources/socialSources.ts` (`newVoices`) | deleted the selected `min(created_at)` | Nothing has ever read it (`grep firstPostAt` → that one line). The identical expression in the `ORDER BY` is what makes the source "earliest-arriving first" and is **untouched**. |
| `db/posts/postRepository.ts` (`postCreatedAtSql`) | `SQL<Date>` → `SQL` | Write-only (`INSERT ... (select ...)`), so the annotation was harmless — but exempting it means a gate that classifies each occurrence by position, and a rule with a judgement call grows an exemption list until it cannot fail. A bare `SQL` costs the call site nothing. |

## The gate strips comments, which is normally the wrong thing to do

Its first version did not, and went red on three occurrences that were **all prose** — including the `channelWriters` comment that is the best explanation of this trap in the repo, and the two written by this very change. The cheapest way to green a prose-sensitive gate is to delete the prose explaining the rule, so that gate was wrong.

Both directions are controlled:
- **positive control** — a code occurrence injected into the same walk, read by the same reader, through the same stripper, must be FOUND;
- **negative control with its own floor** — a commented occurrence must be IGNORED while the scan can still see the file;
- **vacuity floor** — >400 files scanned, or the walk returning `[]` would pass.

## Mutation tests

| mutation | result |
|---|---|
| remove `.mapWith(posts.createdAt)` | **11 tests red** across `interestScoreService` (TypeError: `.getTime` is not a function) and the source gate |
| re-introduce the annotation as real code | gate red, naming the file:line |
| re-introduce it as a comment | gate stays green (correct) |
| `ORDER BY min(created_at)` → `max(...)` in `newVoices` | **SURVIVED** the whole file — see below |

## A finding: the `newVoices` ordering was pinned by nothing

Every existing fixture in `classificationSources.test.ts` gives its author a single post, and for a one-post author `min(created_at)` and `max(created_at)` are the same value. So the `min`→`max` mutant passed 11/11.

That matters *because of this PR*: with the selected `min(created_at)` gone, the `min` left in the `ORDER BY` reads like its orphan. A new fixture straddles two authors — one that arrived first but posted most recently — so the two aggregates rank them in opposite orders. It kills the mutant.

## Verification

- `tsc --noEmit` clean.
- `classificationSources` + `interestScoreService` + `postRepository` + the new gate: 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)