### PR TITLE
A queued channel story answers to who runs the channel now, not to who wrote it

### DIFF
--- a/packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts
+++ b/packages/backend/src/__tests__/controllers/channelEditorialQueue.test.ts
@@ -121,7 +121,11 @@ import { closePostgres, connectPostgres, getDb } from '../../db/postgres';
 import { userSettings } from '../../db/schema/userProfile';
 import { clearServiceScope, seedPost, serviceScope } from '../helpers/serviceFixtures';
 import { PostHydrationService } from '../../services/PostHydrationService';
-import { getScheduledPosts, publishScheduledPostNow } from '../../controllers/posts.controller';
+import {
+  getPostById,
+  getScheduledPosts,
+  publishScheduledPostNow,
+} from '../../controllers/posts.controller';
 import { loadPostRecord } from '../../db/posts/postRepository';
 
 const scope = serviceScope('channel-editorial-queue');
@@ -561,30 +565,39 @@ describe('the shared editorial queue — publishing an entry early', () => {
 });
 
 /**
- * THE ACL UNDERNEATH, asked WITHOUT the operated-account set.
+ * THE ACL UNDERNEATH, on every surface that is NOT the queue endpoint.
  *
- * This block exists because a mutation SURVIVED without it. Every case above
- * reaches the queue through the endpoint, which resolves the caller's channels
- * and hands them to hydration — so the writer is admitted by `operatedAccountIds`
- * and the writer clause beside it never decides anything. Deleting
- * `canManagePostWithoutLookup` from the ACL left all twelve of them green.
+ * Every queue case above reaches hydration through a handler that resolves the
+ * caller's channels for its own query and hands the same list to the ACL. This
+ * block is the shape that handler can never produce: hydration asked by a
+ * surface holding only a post id — post detail, an article body, the response to
+ * an edit — where the only thing in hand is the post row itself.
  *
- * The distinguishing shape is the one the endpoint can never produce: hydration
- * asked with NO operated accounts, which is every other surface in the
- * application (post detail, a thread, a notification embed) because resolving
- * that set costs an Oxy round trip nothing else may pay. There the writer clause
- * is the only thing standing between a person and their OWN unpublished writing.
+ * That row used to be enough. `writtenByOxyUserId` names the human who wrote a
+ * channel post, is free to read, and the ACL admitted them on it alone. It is
+ * the wrong column for the question: it is written once at creation and never
+ * again, so it kept answering "yes" after the desk rewrote the post and after
+ * its writer left the channel. A removed member holding the id therefore kept a
+ * live read on the channel's embargoed queue.
  *
- * It also settles a real incoherence rather than adding a capability: `isOwner`
- * on the DTO already comes from `canManagePostWithoutLookup`, so before this the
- * two could disagree — the summary would have said "you own this post" about one
- * the same service refused to return.
+ * The replacement is not "refuse the writer" — that is a black hole, and it was
+ * measured as one: a channel AUTHORS its own posts, so the id comparison in the
+ * ACL answers "no" for every human alive, and with the writer clause gone and
+ * nothing put in its place, a queued story is readable by nobody. The
+ * replacement is to ASK, from `operatedAccountReader`, and the cases below pin
+ * both halves: that a current operator still reads the post, and that Oxy is not
+ * asked when the answer could not matter.
  */
 describe('the hydration ACL on an unpublished channel post', () => {
   const service = new PostHydrationService();
 
-  async function hydrateAs(viewerId: string | undefined) {
-    const post = await seedPost(scope, {
+  /** The reader an id-based surface hands over — the caller's own Oxy client. */
+  function readerFor(viewerId: string | undefined) {
+    return { listAccounts: async () => listAccounts(viewerId) as Promise<AccountNode[]> };
+  }
+
+  async function seedQueued(): Promise<Awaited<ReturnType<typeof seedPost>>> {
+    return seedPost(scope, {
       oxyUserId: CHANNEL,
       authorship: [{ oxyUserId: CHANNEL, role: 'owner', status: 'accepted' }],
       writtenByOxyUserId: WRITER,
@@ -592,25 +605,217 @@ describe('the hydration ACL on an unpublished channel post', () => {
       scheduledFor: later(60),
       content: { variants: [{ source: 'author', text: 'a queued story', tag: 'en' }] },
     });
-    // No `operatedAccountIds` — the defaults every other caller hydrates with.
-    return service.hydratePosts([post], { viewerId, maxDepth: 0 });
   }
 
-  it('lets the WRITER read their own unpublished channel post', async () => {
+  /** An id-based surface: no resolved set, but the capability to resolve one. */
+  async function hydrateAs(viewerId: string | undefined) {
+    const post = await seedQueued();
+    return service.hydratePosts([post], {
+      viewerId,
+      maxDepth: 0,
+      operatedAccountReader: readerFor(viewerId),
+    });
+  }
+
+  it('lets a current WRITER read their own unpublished channel post', async () => {
+    // THE BLACK-HOLE CONTROL. This is the case #737 broke and the reason that PR
+    // could not land as written: an id-based surface supplies no
+    // `operatedAccountIds`, so with the stored-writer clause removed and nothing
+    // resolving current authority, the person who queued the story cannot open
+    // it. Here the surface can ASK, so they can.
     expect(await hydrateAs(WRITER)).toHaveLength(1);
+    expect(listAccounts).toHaveBeenCalledWith(WRITER);
   });
 
-  it('refuses a colleague who operates the channel but did not write it', async () => {
-    // Not a permission judgement — they DO operate it. It is that this surface
-    // never asked Oxy, so it cannot know. The endpoint that does ask admits them
-    // (see the read cases above), which is what keeps affordance ⊆ permission:
-    // narrower without the answer, never wider.
-    expect(await hydrateAs(COLLEAGUE)).toHaveLength(0);
+  it('refuses a former WRITER whose channel membership was removed', async () => {
+    // THE DISCLOSURE. `writtenByOxyUserId` still names them — it is written once
+    // and never revised — but Oxy no longer does, and Oxy is now what decides.
+    // Before this, holding the post id was enough to keep reading the channel's
+    // queue, and to keep reading edits colleagues made after they left.
+    listAccounts.mockImplementation(async () => [node(WRITER, 'personal', null)]);
+
+    expect(await hydrateAs(WRITER)).toHaveLength(0);
   });
 
-  it('refuses an outsider and an anonymous reader', async () => {
+  it('lets a COLLEAGUE who operates the channel read it, though they did not write it', async () => {
+    // Widened deliberately, and it removes an incoherence rather than adding a
+    // capability: `postManagementRefusal` already lets any active member DELETE
+    // and EDIT this exact post. The question was never whether they may see it,
+    // only whether this surface could find out — and now it can.
+    expect(await hydrateAs(COLLEAGUE)).toHaveLength(1);
+  });
+
+  it('refuses an invited-but-not-accepted member, an outsider and an anonymous reader', async () => {
+    // The INVITEE is the discriminating case for the membership predicate: the
+    // channel IS in their forest, so anything that merely asked "is this account
+    // reachable" would admit them.
+    expect(await hydrateAs(INVITEE)).toHaveLength(0);
     expect(await hydrateAs(OUTSIDER)).toHaveLength(0);
     expect(await hydrateAs(undefined)).toHaveLength(0);
+    // ...and the anonymous read never even asked, since there is no viewer whose
+    // memberships could be resolved.
+    expect(listAccounts).not.toHaveBeenCalledWith(undefined);
+  });
+
+  it('refuses everyone when the surface supplies no reader at all', async () => {
+    // FAIL-CLOSED, pinned so the direction of the failure is a decision. A
+    // surface that can serve a withheld channel post and does not pass a reader
+    // refuses it to its own writer — recoverable and visible. The opposite
+    // default would serve it to someone who left.
+    const post = await seedQueued();
+
+    expect(await service.hydratePosts([post], { viewerId: WRITER, maxDepth: 0 })).toHaveLength(0);
+    expect(listAccounts).not.toHaveBeenCalled();
+  });
+
+  it('lets an explicitly supplied set win, even an empty one', async () => {
+    // `getScheduledPosts` scopes its QUERY with the list it resolved; a second,
+    // later resolution inside hydration could disagree with it. An explicit
+    // answer therefore suppresses the lazy one outright.
+    const post = await seedQueued();
+
+    const hydrated = await service.hydratePosts([post], {
+      viewerId: WRITER,
+      maxDepth: 0,
+      operatedAccountIds: [],
+      operatedAccountReader: readerFor(WRITER),
+    });
+
+    expect(hydrated).toHaveLength(0);
+    expect(listAccounts).not.toHaveBeenCalled();
+  });
+
+  /**
+   * THE COST, which is the half that decides whether this design is allowed to
+   * exist at all. Resolving current authority is an Oxy `GET /accounts`, and the
+   * reason the old code read a column instead is that this must never land on a
+   * feed. It does not: the trip is made only for a post that is WITHHELD from
+   * this viewer AND authored by an account on somebody's behalf.
+   *
+   * Each case below carries its own positive control — the same viewer, the same
+   * reader, one field different — because "Oxy was not called" is also what a
+   * hydration that silently did nothing would report.
+   */
+  describe('what does NOT cost an Oxy round trip', () => {
+    it('a PUBLISHED channel post, which is every channel post on every feed', async () => {
+      const published = await seedPost(scope, {
+        oxyUserId: CHANNEL,
+        authorship: [{ oxyUserId: CHANNEL, role: 'owner', status: 'accepted' }],
+        writtenByOxyUserId: WRITER,
+        status: 'published',
+        content: { variants: [{ source: 'author', text: 'a published story', tag: 'en' }] },
+      });
+
+      const hydrated = await service.hydratePosts([published], {
+        viewerId: COLLEAGUE,
+        maxDepth: 0,
+        operatedAccountReader: readerFor(COLLEAGUE),
+      });
+
+      expect(hydrated).toHaveLength(1);
+      expect(listAccounts).not.toHaveBeenCalled();
+
+      // POSITIVE CONTROL: the identical call over the identical fixture with the
+      // status withheld DOES ask, so the zero above is a decision and not a
+      // reader that was never wired up.
+      await service.hydratePosts([await seedQueued()], {
+        viewerId: COLLEAGUE,
+        maxDepth: 0,
+        operatedAccountReader: readerFor(COLLEAGUE),
+      });
+      expect(listAccounts).toHaveBeenCalledTimes(1);
+    });
+
+    it('an unpublished post NO account authored — an ordinary person’s own draft', async () => {
+      const draft = await seedPost(scope, {
+        oxyUserId: COLLEAGUE,
+        authorship: [{ oxyUserId: COLLEAGUE, role: 'owner', status: 'accepted' }],
+        status: 'draft',
+        content: { variants: [{ source: 'author', text: 'a private draft', tag: 'en' }] },
+      });
+
+      // Admitted for free by the id comparison, with nothing asked of Oxy.
+      expect(
+        await service.hydratePosts([draft], {
+          viewerId: COLLEAGUE,
+          maxDepth: 0,
+          operatedAccountReader: readerFor(COLLEAGUE),
+        }),
+      ).toHaveLength(1);
+      expect(listAccounts).not.toHaveBeenCalled();
+    });
+
+    it('and it asks ONCE for a whole page, not once per post', async () => {
+      const page = [await seedQueued(), await seedQueued(), await seedQueued()];
+
+      expect(
+        await service.hydratePosts(page, {
+          viewerId: COLLEAGUE,
+          maxDepth: 0,
+          operatedAccountReader: readerFor(COLLEAGUE),
+        }),
+      ).toHaveLength(3);
+      expect(listAccounts).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+/**
+ * THE SURFACES, asserted where the reader is actually wired — the half a service
+ * test cannot see.
+ *
+ * `hydratePosts` is honest about a missing reader: it refuses. So every test in
+ * the block above passes on a controller that forgot to pass one, and the
+ * symptom in production would be a writer unable to open their own queued story.
+ * These drive the real handler.
+ */
+describe('the id-based surfaces resolve current channel authority', () => {
+  async function seedQueuedEntry(): Promise<string> {
+    return seedScheduled({ owner: CHANNEL, writtenBy: WRITER });
+  }
+
+  async function fetchPost(viewerId: string | undefined, postId: string): Promise<Captured> {
+    const { res, captured } = buildResponse();
+    await getPostById(
+      { ...buildRequest(viewerId), params: { id: postId } } as never,
+      res as never,
+    );
+    return captured;
+  }
+
+  it('GET /posts/:id serves a queued channel post to a current operator', async () => {
+    const entry = await seedQueuedEntry();
+
+    // COLLEAGUE, not WRITER: nothing on the row names them, so this can only
+    // have come from the account graph.
+    const response = await fetchPost(COLLEAGUE, entry);
+
+    expect(response.status).toBeUndefined();
+    expect((response.body as unknown as HydratedPost | undefined)?.id).toBe(entry);
+    expect(listAccounts).toHaveBeenCalledWith(COLLEAGUE);
+  });
+
+  it('GET /posts/:id refuses the stored writer once their membership is gone', async () => {
+    const entry = await seedQueuedEntry();
+    listAccounts.mockImplementation(async () => [node(WRITER, 'personal', null)]);
+
+    expect((await fetchPost(WRITER, entry)).status).toBe(404);
+  });
+
+  it('CONTROL: an ordinary published post still costs no account lookup', async () => {
+    // Without this, both cases above would pass on a handler that had started
+    // resolving the account graph for every post-detail read in the app.
+    const ordinary = await seedPost(scope, {
+      oxyUserId: OUTSIDER,
+      authorship: [{ oxyUserId: OUTSIDER, role: 'owner', status: 'accepted' }],
+      status: 'published',
+      content: { variants: [{ source: 'author', text: 'an ordinary post', tag: 'en' }] },
+    });
+
+    const response = await fetchPost(COLLEAGUE, ordinary.id);
+
+    expect((response.body as unknown as HydratedPost | undefined)?.id).toBe(ordinary.id);
+    expect(listAccounts).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/src/__tests__/controllers/postLikesAndBookmarks.test.ts
+++ b/packages/backend/src/__tests__/controllers/postLikesAndBookmarks.test.ts
@@ -42,6 +42,11 @@ const hoisted = vi.hoisted(() => ({
 vi.mock('../../utils/oxyHelpers', () => ({
   createScopedOxyClient: hoisted.createScopedOxyClient,
   getServiceOxyClient: () => ({ getUserById: vi.fn(), getUsersByIds: vi.fn(async () => []) }),
+  // `getSavedPosts` hands hydration a way to resolve the viewer's channels,
+  // because bookmarks are selected by id alone and can therefore hold a post the
+  // ACL withholds. Irrelevant to the SELECTION this suite is about — hydration
+  // is a passthrough here — but the export has to exist or the route throws.
+  createUserScopedOxyServices: () => undefined,
 }));
 
 vi.mock('../../services/PostHydrationService', () => ({

--- a/packages/backend/src/controllers/articles.controller.ts
+++ b/packages/backend/src/controllers/articles.controller.ts
@@ -4,6 +4,7 @@ import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { getDb } from '../db/postgres';
 import { articles } from '../db/schema/articles';
 import { postHydrationService } from '../services/PostHydrationService';
+import { createUserScopedOxyServices } from '../utils/oxyHelpers';
 import { logger } from '../utils/logger';
 
 /**
@@ -59,7 +60,15 @@ export const getArticle = async (req: AuthRequest, res: Response) => {
     let canRead = false;
     try {
       canRead = article.postId
-        ? await postHydrationService.canViewerReadPostId(article.postId, viewerId)
+        ? await postHydrationService.canViewerReadPostId(article.postId, viewerId, {
+            // The docstring above names "a draft, a scheduled entry" as things
+            // this gate exists to withhold — which is also, for a CHANNEL's
+            // long-form piece, the state its editors most need to read it in.
+            // The gate can only tell the editors from a departed writer by
+            // asking Oxy who currently runs the channel, and it only asks when
+            // the post is withheld and an account authored it.
+            operatedAccountReader: createUserScopedOxyServices(req),
+          })
         : viewerId !== '' && viewerId === article.createdBy;
     } catch (error) {
       // Fails CLOSED, the same way `ContentRoomLifecycle` treats this gate. It

--- a/packages/backend/src/controllers/feed.controller.ts
+++ b/packages/backend/src/controllers/feed.controller.ts
@@ -44,7 +44,8 @@ import { validatePublicShareTarget } from '../utils/postAccessControl';
 import { postIsAuthoredByChannel } from '../utils/channelReplyGate';
 import { baselineContentClassifier } from '../services/BaselineContentClassifier';
 import { toStoredContent } from '../services/postVariants';
-import { createScopedOxyClient } from '../utils/oxyHelpers';
+import { createScopedOxyClient, createUserScopedOxyServices } from '../utils/oxyHelpers';
+import type { OperatedAccountReader } from '../services/publishAsAccount';
 import { federateAsResolvedActor } from '../connectors/outboundFederation';
 import {
   emitPostCreated,
@@ -133,8 +134,12 @@ class FeedController {
     currentUserId?: string,
     oxyClient?: OxyClient,
     // Only the single-item detail route asks for quote counts — see
-    // `HydrationOptions.includeQuoteCounts` for why the feed does not.
-    options: { includeQuoteCounts?: boolean } = {},
+    // `HydrationOptions.includeQuoteCounts` for why the feed does not. It is
+    // also the only caller that can be handed a WITHHELD post (it loads by id;
+    // the list timeline beside it filters on status), so it is the only one that
+    // supplies an operated-account reader — see `HydrationOptions` for what
+    // decides whether that reader is ever actually asked anything.
+    options: { includeQuoteCounts?: boolean; operatedAccountReader?: OperatedAccountReader } = {},
   ): Promise<HydratedPost[]> {
     try {
       if (!posts || posts.length === 0) {
@@ -151,6 +156,7 @@ class FeedController {
         includeFullArticleBody: false, // Don't include article bodies in feed
         includeFullMetadata: false, // Skip some metadata fields for performance
         includeQuoteCounts: options.includeQuoteCounts === true,
+        operatedAccountReader: options.operatedAccountReader,
       });
       
       // Ensure all posts have required fields
@@ -1142,7 +1148,10 @@ class FeedController {
         [post],
         currentUserId,
         createScopedOxyClient(req),
-        { includeQuoteCounts: true },
+        {
+          includeQuoteCounts: true,
+          operatedAccountReader: createUserScopedOxyServices(req),
+        },
       );
 
       return res.json(transformed);

--- a/packages/backend/src/controllers/posts.controller.ts
+++ b/packages/backend/src/controllers/posts.controller.ts
@@ -919,6 +919,12 @@ export const createPost = async (req: AuthRequest, res: Response) => {
       requestLanguages: requestLanguageCandidates(req),
       maxDepth: 1,
       includeLinkMetadata: true,
+      // A post scheduled or drafted AS A CHANNEL is withheld the instant it is
+      // written, and its author is the channel — so without current authority
+      // here the ACL refuses the response to the person who just created it, and
+      // the 500 below fires on a write that succeeded. Free for the ordinary
+      // case: a published post asks Oxy nothing.
+      operatedAccountReader: createUserScopedOxyServices(req),
     });
 
     if (!hydratedPost) {
@@ -1576,6 +1582,11 @@ export const createThread = async (req: AuthRequest, res: Response) => {
       requestLanguages: requestLanguageCandidates(req),
       maxDepth: 1,
       includeLinkMetadata: true,
+      // Same reason as `createPost`: a SCHEDULED batch is withheld from the
+      // moment it is written, and a batch published as a channel is authored by
+      // the channel — so the response would otherwise come back empty to the
+      // person who just wrote the thread.
+      operatedAccountReader: createUserScopedOxyServices(req),
     });
 
     logger.info(`Created ${createdPosts.length} posts in ${mode} mode`);
@@ -1672,6 +1683,13 @@ export const getPostById = async (req: AuthRequest, res: Response) => {
       includeLinkMetadata: true,
       // Single-post detail read — the surface that renders the quote count.
       includeQuoteCounts: true,
+      // The route loads by id with no status filter (above), so this is the
+      // surface where somebody asks for a post their feed would never have
+      // shown them — including a channel's queued story, asked for by one of
+      // the people who runs the channel. Hydration spends this only when the
+      // post is actually withheld AND an account authored it; an ordinary post
+      // detail read asks Oxy nothing extra.
+      operatedAccountReader: createUserScopedOxyServices(req),
     });
 
     const hydratedPost = hydrated[0];
@@ -1715,6 +1733,10 @@ export const getPostCorrections = async (req: AuthRequest, res: Response) => {
       viewerId: req.user?.id,
       oxyClient: createScopedOxyClient(req),
       requestLanguages: requestLanguageCandidates(req),
+      // The trail is exactly as readable as the post, so it has to be able to
+      // reach the same verdict — a channel's operators included, on a post
+      // moderation has since restricted.
+      operatedAccountReader: createUserScopedOxyServices(req),
     });
     if (hydrated.length === 0) {
       return res.status(404).json({ message: 'Post not available' });
@@ -2258,6 +2280,11 @@ export const updatePost = async (req: AuthRequest, res: Response) => {
       viewerId: userId,
       oxyClient: createScopedOxyClient(req),
       requestLanguages: requestLanguageCandidates(req),
+      // `postManagementRefusal` above already let this caller edit the post, and
+      // a scheduled one is still withheld after the edit — so without the same
+      // authority answer here the write succeeds and the response is a 500 to
+      // the person who made it.
+      operatedAccountReader: createUserScopedOxyServices(req),
     });
     if (hydrated.length === 0) {
       logger.error('Failed to hydrate edited post', { postId: edited.id, userId });
@@ -3064,6 +3091,12 @@ export const getSavedPosts = async (req: AuthRequest, res: Response) => {
       requestLanguages: requestLanguageCandidates(req),
       maxDepth: 1,
       includeLinkMetadata: true,
+      // Bookmarks are selected by id alone — deliberately, so saving something
+      // does not stop working when its visibility changes. That makes this one
+      // of the few list endpoints that can hold a withheld post, and dropping a
+      // channel operator's own saved entry out of their bookmarks would be a
+      // silent loss rather than a refusal they could act on.
+      operatedAccountReader: createUserScopedOxyServices(req),
     });
 
     res.json({
@@ -4015,6 +4048,10 @@ export const translatePost = async (req: AuthRequest, res: Response): Promise<vo
       includeLinkMetadata: false,
       includeFullArticleBody: false,
       includeFullMetadata: false,
+      // Loaded by id with no status filter, so a channel's operators must be
+      // able to translate a story before it publishes — which is when a
+      // translation is worth anything.
+      operatedAccountReader: createUserScopedOxyServices(req),
     });
     if (visiblePosts.length === 0) {
       res.status(404).json({ message: 'Post not found' });

--- a/packages/backend/src/routes/notifications.ts
+++ b/packages/backend/src/routes/notifications.ts
@@ -308,6 +308,16 @@ router.get("/", async (req: AuthRequest, res: Response) => {
         oxyClient: scopedOxyClient,
         maxDepth: 1,
         includeLinkMetadata: true,
+        // Already resolved above, for the recipient scope — so the ACL gets the
+        // SAME answer the inbox query was built from, and gets it for free. The
+        // rows come from `loadPostRecords`, which applies no status filter, so
+        // without this an operator's notification about their channel's own
+        // withheld post would arrive with the embed silently stripped: the one
+        // reader entitled to it, refused. `operatedAccountIds` rather than a
+        // reader precisely BECAUSE the answer is in hand — supplying it also
+        // suppresses hydration's own lazy lookup, which would be a second
+        // resolution free to disagree with the one that chose these rows.
+        operatedAccountIds: [...operatedChannelIds],
       });
 
       const compiledMuteWords = compileMuteWords(muteWords);

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -54,6 +54,7 @@ import {
   normalizeAuthorship,
 } from '../utils/postAuthorship';
 import { canManagePostWithoutLookup } from './postManagementAccess';
+import { listOperatedChannelIds, type OperatedAccountReader } from './publishAsAccount';
 import { normalizeMentionIds } from '../utils/textProcessing';
 import { degradedActorSummary } from '../utils/degradedActorSummary';
 import {
@@ -220,16 +221,42 @@ interface HydrationOptions {
    * author, so without this every unpublished channel post is unreadable by every
    * human alive — measured, including by the person who wrote it.
    *
-   * OPT-IN, and deliberately so: resolving it costs an Oxy `GET /accounts` round
-   * trip, which must never land on a feed hydration. Only a caller that is
-   * already asking an account-scoped question passes it (`getScheduledPosts`),
-   * and every other surface hydrates with an empty set and is bit-for-bit
-   * unchanged.
+   * Pass this when the caller has ALREADY resolved the set for its own reasons
+   * (`getScheduledPosts` scopes its query with it, and feeding the query and the
+   * ACL from one resolution is what keeps the two from disagreeing). Every other
+   * caller passes {@link operatedAccountReader} instead and lets hydration decide
+   * whether the round trip is worth making.
+   *
+   * Supplying it — even as an empty array — SUPPRESSES that decision: an explicit
+   * answer is never second-guessed by a lazy one.
    *
    * It widens READ only. What a member may DO with the post they can now see is
    * still `postManagementRefusal`'s answer, asked per action on the write routes.
    */
   operatedAccountIds?: readonly string[];
+  /**
+   * How to resolve {@link operatedAccountIds} IF a post in this batch turns out
+   * to need it — the caller's own Oxy client, since `GET /accounts` is anchored
+   * on the authenticated operator and honours no service delegation.
+   *
+   * A capability rather than a value, because the answer costs an Oxy round trip
+   * and almost nothing needs it. `mayNeedCurrentChannelAuthority` decides, off
+   * columns already in hand: the post must be withheld from this viewer AND
+   * authored by an account on somebody's behalf. A feed of published posts asks
+   * Oxy nothing, an ordinary post-detail read asks nothing, and a channel's own
+   * published posts ask nothing — the trip is made only for a withheld
+   * account-authored post, which is the one case where the answer can change the
+   * verdict.
+   *
+   * **Omitting it is fail-CLOSED, and that is the failure worth knowing about.**
+   * A surface that can serve a withheld channel post and does not pass this
+   * refuses that post to every human alive, including its own writer — the black
+   * hole the stored-writer clause used to paper over. Every id-based surface that
+   * can reach such a post passes it; the tests that pin this are behavioural, one
+   * per surface, so a new surface that forgets shows up as a person unable to read
+   * their own queued post rather than as a leak.
+   */
+  operatedAccountReader?: OperatedAccountReader;
 }
 
 interface HydratedGraphNode {
@@ -916,6 +943,127 @@ export async function resolveOrphanFederatedAuthors(
   return result;
 }
 
+/**
+ * Does this post's readability turn on whether the viewer OWNS it?
+ *
+ * The five gates below — unpublished, private, followers-only to a
+ * non-follower, an author the viewer is restricted by, an author behind a
+ * private profile — are exactly the states {@link viewerOwnsPost} overrides.
+ * `false` means every one of them passes on its own terms and the post is
+ * readable whoever is asking; `true` means ownership is the whole question.
+ *
+ * Split out of {@link PostHydrationService.canViewerReadPost} (whose verdict is
+ * unchanged — this is the same five conditions with the repeated
+ * `&& !viewerOwnsPost` factored out) so that {@link resolveCurrentChannelAuthority}
+ * can ask "could proving current authority change this answer?" without
+ * restating any of them. A second, hand-written copy of the gate conditions
+ * would decide when to pay for the proof, and drift from the gate that consumes
+ * it — the direction that drifts silently is a post nobody can read.
+ */
+function ownershipDecidesReadability(
+  post: RawPost,
+  authorId: string,
+  viewerContext: ViewerContext,
+): boolean {
+  if ((post.status ?? 'published') !== 'published') return true;
+
+  const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility;
+  if (visibility === PostVisibility.PRIVATE) return true;
+
+  const viewerFollowsAuthor =
+    Boolean(viewerContext.viewerId) && viewerContext.follows.has(authorId);
+  if (visibility === PostVisibility.FOLLOWERS_ONLY && !viewerFollowsAuthor) return true;
+
+  if (viewerContext.restrictedIds.has(authorId)) return true;
+
+  // A private / followers-only PROFILE, which is a separate setting from the
+  // post's own visibility. A follower passes; everyone else needs ownership.
+  if (viewerContext.privateProfileIds.has(authorId) && !viewerFollowsAuthor) return true;
+
+  return false;
+}
+
+/**
+ * May this viewer read a post that one of the gates above holds shut?
+ *
+ * Pending collaborators may PREVIEW the post they were invited to (so the
+ * collab-invite UI can render the actual content before they accept), alongside
+ * the owner and accepted collaborators.
+ *
+ * The last clause is the CHANNEL case, and it exists because the id comparison
+ * answers "no" for every human on a channel's post: a channel AUTHORS its own
+ * posts, and no session can ever have a channel as its subject. Without it a
+ * withheld channel post is readable by nobody at all — not a narrow gap, a black
+ * hole, and measured as one.
+ *
+ * **`writtenByOxyUserId` is deliberately NOT read here, and that is the whole
+ * point of this function's shape.** The stored writer used to be admitted
+ * through `canManagePostWithoutLookup`, off a column already in hand and with no
+ * lookup. But that column records who wrote the post, is written once at
+ * creation and never again — not when somebody else rewrites the post, and not
+ * when its writer leaves the channel. Treating it as authority let a removed
+ * member keep reading the channel's embargoed queue, and keep reading the
+ * DESK'S LATER EDITS to it, for as long as they held the post id. Historical
+ * authorship is not current authority, so the proof has to be current:
+ * `operatedAccountIds`, resolved per request from Oxy's account graph.
+ *
+ * It is `resolveCurrentChannelAuthority` that makes that affordable, and this
+ * function is meaningless without it — the two have to move together.
+ *
+ * **The same clause still grants WRITE, and that is a live gap, not a decision
+ * made here.** `postManagementRefusal` takes a free path on
+ * `canManagePostWithoutLookup` unless the caller passes `requireAuthorAuthority`,
+ * and only `publishScheduledPostNow` does. Delete, edit, settings, lane moves
+ * and insights therefore still answer to the stored writer alone, so a removed
+ * member can still destroy or rewrite the queued post this gate now refuses to
+ * show them. Closing that means making `requireAuthorAuthority` unconditional —
+ * a change to six routes' latency and to what `viewerState.isOwner` may promise,
+ * which is why it is named here rather than smuggled in.
+ *
+ * It takes no post, and that absence is the change: every remaining answer comes
+ * from the viewer's identity, the authorship rows and the account graph. Nothing
+ * a post row can carry decides this any more.
+ */
+function viewerOwnsPost(
+  authorId: string,
+  authorship: PostAuthorshipEntry[],
+  viewerContext: ViewerContext,
+): boolean {
+  const viewerEntry = getViewerEntry(authorship, viewerContext.viewerId);
+  return (
+    viewerContext.viewerId === authorId ||
+    (viewerEntry?.role === 'collaborator' &&
+      (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending')) ||
+    (Boolean(viewerContext.viewerId) && viewerContext.operatedAccountIds.has(authorId))
+  );
+}
+
+/**
+ * Is this a post where proving CURRENT authority over the authoring account
+ * could change the verdict — the only case worth an Oxy round trip for?
+ *
+ * Three conditions, and each one removes a case that could never be decided by
+ * the answer:
+ *
+ *  - `writtenByOxyUserId` is set. That column is written exactly when an ACCOUNT
+ *    authored the post on a human's behalf, so an absent one means there is no
+ *    account whose membership anybody could be a member of.
+ *  - the viewer is not themselves the author. If they were, the id comparison in
+ *    {@link viewerOwnsPost} has already admitted them for free.
+ *  - {@link ownershipDecidesReadability}. A published, public post from an
+ *    unrestricted account is readable without any of this — which is every
+ *    channel post on every feed, and why no feed pays for this.
+ */
+function mayNeedCurrentChannelAuthority(
+  post: RawPost,
+  viewerContext: ViewerContext,
+): boolean {
+  if (!post?.writtenByOxyUserId) return false;
+  const authorId = post.oxyUserId ? String(post.oxyUserId) : '';
+  if (!authorId || authorId === viewerContext.viewerId) return false;
+  return ownershipDecidesReadability(post, authorId, viewerContext);
+}
+
 export class PostHydrationService {
   async hydratePosts(rawPosts: object[], options: HydrationOptions = {}): Promise<HydratedPost[]> {
     if (!Array.isArray(rawPosts) || rawPosts.length === 0) {
@@ -1309,7 +1457,71 @@ export class PostHydrationService {
       }
     }
 
+    // LAST, because it reads the follow graph and the restriction/private-profile
+    // sets built above: whether a post is withheld from this viewer at all is
+    // what decides if the round trip is worth making.
+    await this.resolveCurrentChannelAuthority(posts, context, options);
+
     return context;
+  }
+
+  /**
+   * Ask Oxy which channels this viewer currently operates — but only if a post
+   * in this batch is one where the answer could change the verdict.
+   *
+   * ## Why the answer cannot simply be read off the post
+   *
+   * A channel post carries the human who wrote it in `writtenByOxyUserId`, free
+   * and already in hand, and the ACL used to admit them on that alone. It is the
+   * wrong column for the question. It is written once, at creation
+   * (`PostCreationService`), and never again — not when a colleague rewrites the
+   * post, and not when its writer leaves the channel. So it answered "yes" for a
+   * removed member for as long as they held the post id, over an editorial queue
+   * whose entire value is being embargoed, and over edits made after they left.
+   *
+   * Current membership lives in Oxy's account graph and nowhere else, so proving
+   * it costs a round trip. `GET /accounts` is anchored on the AUTHENTICATED
+   * OPERATOR — a service credential cannot ask it on someone's behalf — which is
+   * why the caller hands over its own client rather than hydration holding one.
+   *
+   * ## What stops this landing on a feed
+   *
+   * {@link mayNeedCurrentChannelAuthority}, evaluated over columns already
+   * fetched. A published, public post asks Oxy nothing however it was authored,
+   * which is every channel post on every feed, in search, and on the profile.
+   * What is left is a post WITHHELD from this viewer that an account authored on
+   * somebody's behalf — the exact set the departed-writer clause used to decide,
+   * and rare enough on the id-based surfaces to be worth one `GET /accounts`.
+   *
+   * ONE call for the whole batch, not one per post, and only ever after the free
+   * checks have failed to admit the viewer on their own.
+   *
+   * ## Two ways this deliberately does nothing
+   *
+   * An explicit `operatedAccountIds` wins outright, empty array included: a
+   * caller that resolved the set itself (`getScheduledPosts`, which scopes its
+   * query with the same list) must not have a second, later resolution disagree
+   * with the one its query used.
+   *
+   * No reader means no answer, and no answer means refusal — `listOperatedChannelIds`
+   * fail-softs to `[]` on an Oxy outage for the same reason. Both directions are
+   * narrow-not-wide: the cost is a member briefly unable to read their own queued
+   * post, never a stranger able to.
+   */
+  private async resolveCurrentChannelAuthority(
+    posts: object[],
+    context: ExtendedViewerContext,
+    options: HydrationOptions | undefined,
+  ): Promise<void> {
+    if (!context.viewerId) return;
+    if (options?.operatedAccountIds !== undefined) return;
+    const reader = options?.operatedAccountReader;
+    if (!reader) return;
+    if (!posts.some((post) => mayNeedCurrentChannelAuthority(post as RawPost, context))) return;
+
+    for (const accountId of await listOperatedChannelIds(reader)) {
+      context.operatedAccountIds.add(accountId);
+    }
   }
 
   // A boost-of-boost chain (Announce of an Announce) is collected one extra hop
@@ -2029,7 +2241,7 @@ export class PostHydrationService {
   async canViewerReadPostId(
     postId: string,
     viewerId: string,
-    options?: Pick<HydrationOptions, 'oxyClient'>,
+    options?: Pick<HydrationOptions, 'oxyClient' | 'operatedAccountReader'>,
   ): Promise<boolean> {
     const [post] = await loadReplyParents([postId]);
     if (!post) return false;
@@ -2068,6 +2280,12 @@ export class PostHydrationService {
    * which must not reveal the author — or the existence — of a post this viewer
    * would be refused. Answering that with a second, hand-rolled visibility check
    * is exactly how the two would drift apart; there is one gate and both call it.
+   *
+   * Two halves, and the split is what lets the cost of the second one be decided
+   * before it is paid: {@link ownershipDecidesReadability} says whether the post
+   * is withheld from this viewer at all, {@link viewerOwnsPost} says whether they
+   * override it. `resolveCurrentChannelAuthority` asks the first of those, in
+   * `buildViewerContext`, to decide whether the second is worth an Oxy round trip.
    */
   private canViewerReadPost(
     post: RawPost,
@@ -2075,65 +2293,8 @@ export class PostHydrationService {
     authorship: PostAuthorshipEntry[],
     viewerContext: ViewerContext,
   ): boolean {
-    const viewerEntry = getViewerEntry(authorship, viewerContext.viewerId);
-    // Pending collaborators may PREVIEW the post they were invited to (so the
-    // collab-invite UI can render the actual content before they accept),
-    // alongside the owner and accepted collaborators. All three bypass the
-    // unpublished/private/followers-only/restricted ACL checks below.
-    //
-    // The last two clauses are the CHANNEL cases, and they exist because the id
-    // comparison above answers "no" for every human on a channel's post: a
-    // channel AUTHORS its own posts, and no session can ever have a channel as
-    // its subject. Without them an unpublished channel post is readable by
-    // nobody at all — not a narrow gap, a black hole, and measured as one.
-    //
-    //  - `canManagePostWithoutLookup` covers the WRITER, off two columns already
-    //    in hand and with no lookup. It is the SAME predicate `buildViewerState`
-    //    uses for `isOwner`, which is what makes the two agree: the DTO used to
-    //    be able to say `isOwner: true` about a post this gate would refuse.
-    //  - `operatedAccountIds` covers the writer's CO-OPERATORS, and is empty
-    //    unless the caller opted in (see `HydrationOptions.operatedAccountIds`),
-    //    so no feed pays an Oxy round trip for it.
-    //
-    // Both are strictly narrower than what the write routes already permit:
-    // `postManagementRefusal` lets any active member DELETE and EDIT this exact
-    // post today. Granting them READ removes an inconsistency rather than
-    // creating one.
-    const viewerOwnsPost =
-      viewerContext.viewerId === authorId ||
-      (viewerEntry?.role === 'collaborator' &&
-        (viewerEntry.status === 'accepted' || viewerEntry.status === 'pending')) ||
-      canManagePostWithoutLookup(post, viewerContext.viewerId) ||
-      (Boolean(viewerContext.viewerId) && viewerContext.operatedAccountIds.has(authorId));
-
-    if ((post.status ?? 'published') !== 'published' && !viewerOwnsPost) {
-      return false;
-    }
-
-    const visibility = (post.visibility ?? PostVisibility.PUBLIC) as PostVisibility;
-    if (visibility === PostVisibility.PRIVATE && !viewerOwnsPost) {
-      return false;
-    }
-
-    if (visibility === PostVisibility.FOLLOWERS_ONLY && !viewerOwnsPost) {
-      if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
-        return false;
-      }
-    }
-
-    if (viewerContext.restrictedIds.has(authorId) && !viewerOwnsPost) {
-      return false;
-    }
-
-    // Filter posts from private/followers_only profiles. Own posts are always
-    // visible; public profiles pass through.
-    if (viewerContext.privateProfileIds.has(authorId) && !viewerOwnsPost) {
-      if (!viewerContext.viewerId || !viewerContext.follows.has(authorId)) {
-        return false;
-      }
-    }
-
-    return true;
+    if (!ownershipDecidesReadability(post, authorId, viewerContext)) return true;
+    return viewerOwnsPost(authorId, authorship, viewerContext);
   }
 
   /**


### PR DESCRIPTION
Closes #741. Takes option (a) from that issue: the id-based surfaces resolve current authority, so the disclosure closes without reopening the black hole.

## The exposure, re-derived

`posts.written_by_oxy_user_id` is written at exactly one place — `PostCreationService`, at creation — and never again. Not when a colleague rewrites the post (a channel post has no edit window at all), and not when its writer leaves the channel. The read ACL admitted them on that column alone, through `canManagePostWithoutLookup`.

So a removed member holding a post id kept reading the channel's embargoed queue, and kept reading edits the desk made after they left. `GET /posts/:id` loads by id with no status filter, so the id is the whole key.

## Why #737 could not land as written

It dropped the clause and required `operatedAccountIds`, which exactly one caller in `src` supplies (`getScheduledPosts`). A channel AUTHORS its own posts, so the ACL's id comparison answers "no" for every human alive — the queued story becomes unreadable by everybody, its writer included. The deleted comment recorded that as measured, and it was right.

## What this does instead

`viewerOwnsPost` no longer reads the post row at all. Current authority comes from `operatedAccountIds`, and `HydrationOptions.operatedAccountReader` is a new **capability** the caller hands over so hydration can resolve it *if* a post in the batch turns out to need one.

`mayNeedCurrentChannelAuthority` decides, off columns already fetched:

- `writtenByOxyUserId` is set (an account authored it on a human's behalf), **and**
- the viewer is not the author (or the free id comparison already admitted them), **and**
- `ownershipDecidesReadability` — the post is actually withheld from this viewer.

**A feed pays nothing.** A published, public channel post is readable on its own terms whoever asks, so the trigger is false for every channel post on every feed, in search, and on the profile. One `GET /accounts` per batch, never per post, and only for a withheld account-authored post — the exact set the removed clause used to decide.

`canViewerReadPost` is now two named halves (`ownershipDecidesReadability` + `viewerOwnsPost`) with the repeated `&& !viewerOwnsPost` factored out. Same five conditions, same verdict; the split is what lets the cost of the second half be decided before it is paid, without a second hand-written copy of the gate.

## Surfaces wired

Measured against every `hydratePosts` call site (37) and every `canViewerReadPostId` caller (3), asking which loader can hand over a non-published row:

| surface | why |
|---|---|
| `getPostById`, `getPostCorrections`, `translatePost`, `getFeedItemById` | load by id, no status filter |
| `updatePost` response | `postManagementRefusal` already allowed the edit; without this the write succeeds and returns a 500 |
| `createPost`, `createThread` | a draft/scheduled channel post is withheld the instant it is written |
| `getSavedPosts` | bookmarks are selected by id alone |
| `getArticle` (via `canViewerReadPostId`) | its own docstring names "a draft, a scheduled entry" |
| notifications | passes `operatedAccountIds` — **already resolved** for the recipient scope, so it costs nothing and cannot disagree with the query |

Deliberately not wired, each because the trip could not buy anything: `fetchPostOg` (anonymous, SWR-cached across viewers), `PostCollaborationService.emitPostUpdate` (broadcast, no viewer), the poll and live-counter gates (a withheld post takes no votes and has no live counters), and the AP actor-posts route (anonymous).

**A correction to the issue's premise:** "a thread" is not one of the affected surfaces. `getRepliesFeed`, `getThreadContinuations` and `getQuotesFeed`'s page all filter `eq(posts.status, 'published')`, so none can serve a withheld post.

## Mutation-tested

Five mutations, each diffed after editing to prove it applied, then run:

| mutation | tests killed |
|---|---|
| drop the `operatedAccountIds` clause from `viewerOwnsPost` | 11 |
| never call `resolveCurrentChannelAuthority` | 5 |
| **restore `canManagePostWithoutLookup` — the exact regression this closes** | 4 |
| `getPostById` forgets to pass the reader | 1 |
| make the trigger always true (the cost regression) | 3 |

The black hole has its own control — *"lets a current WRITER read their own unpublished channel post"* — hydrated with **no** `operatedAccountIds`, only a reader. That is the case #737 broke. The cost claims carry positive controls in the same currency: the same viewer, the same reader, one field different, asserting the trip IS made.

## Not fixed here, and it is bigger than what is

The same stored-writer clause still grants **write**. `postManagementRefusal` takes its free path on `canManagePostWithoutLookup` unless `requireAuthorAuthority` is passed, and grep says only `publishScheduledPostNow` passes it. So a removed member can still **delete**, **edit**, change settings on, move the lane of, and read the insights of the post this gate now refuses to show them — with no Oxy call anywhere.

Closing it means making `requireAuthorAuthority` unconditional: six routes gain one membership read on a user-initiated write, and `viewerState.isOwner` starts promising something the route may refuse for a departed writer. That is its own decision, so it is named in `viewerOwnsPost`'s docstring and here rather than smuggled in.

## Verification

- Full backend suite: **5953 passed, 0 failed** (baseline on this base: 5944 passed, 0 failed).
- 4 suites report `afterAll` hook timeouts under parallel load — Postgres connection contention on the shared local instance, not regressions: all 4 pass sequentially (96 tests), and the baseline showed 3 of the same kind. One parallel run surfaced `PostgresError: sorry, too many clients already` directly.
- `tsc --noEmit` clean.

## What a reviewer should check

1. That `mayNeedCurrentChannelAuthority` really cannot fire on a feed — it is the whole cost argument. The published-post case has a positive control beside it.
2. That `ownershipDecidesReadability` is verdict-identical to the five sequential `&& !viewerOwnsPost` checks it replaces, `followers_only` and `privateProfileIds` included (both admit a follower without ownership).
3. Whether the write-path gap above should land in this PR after all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)