### PR TITLE
db(posts): stop indexing absence, and classify all 24 indexes so it stays true

### DIFF
--- a/packages/backend/drizzle/0025_posts_indexes_stop_indexing_absence.sql
+++ b/packages/backend/drizzle/0025_posts_indexes_stop_indexing_absence.sql
@@ -1,0 +1,8 @@
+DROP INDEX "posts_thread_idx";--> statement-breakpoint
+DROP INDEX "posts_classification_region_idx";--> statement-breakpoint
+DROP INDEX "posts_geo_gist";--> statement-breakpoint
+DROP INDEX "posts_content_geo_gist";--> statement-breakpoint
+CREATE INDEX "posts_thread_idx" ON "posts" USING btree ("thread_id","oxy_user_id","parent_post_id","created_at") WHERE "posts"."thread_id" is not null;--> statement-breakpoint
+CREATE INDEX "posts_classification_region_idx" ON "posts" USING btree ("classification_region","created_at" DESC NULLS LAST) WHERE "posts"."classification_region" is not null;--> statement-breakpoint
+CREATE INDEX "posts_geo_gist" ON "posts" USING gist ("geo") WHERE "posts"."geo" is not null;--> statement-breakpoint
+CREATE INDEX "posts_content_geo_gist" ON "posts" USING gist ("content_geo") WHERE "posts"."content_geo" is not null;

--- a/packages/backend/drizzle/meta/0025_snapshot.json
+++ b/packages/backend/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,12494 @@
+{
+  "id": "b607fa3b-46c6-492f-a434-aa2c5eb34513",
+  "prevId": "805a2030-564d-4bfe-9432-d89c72216c54",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_script_cursors": {
+      "name": "admin_script_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "admin_script_cursors_script_scope_key": {
+          "name": "admin_script_cursors_script_scope_key",
+          "columns": [
+            {
+              "expression": "script",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "admin_script_cursors_scanned_check": {
+          "name": "admin_script_cursors_scanned_check",
+          "value": "\"admin_script_cursors\".\"scanned\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.repair_fetch_failures": {
+      "name": "repair_fetch_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "repair_fetch_failures_script_post_id_key": {
+          "name": "repair_fetch_failures_script_post_id_key",
+          "columns": [
+            {
+              "expression": "script",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repair_fetch_failures_script_reason_idx": {
+          "name": "repair_fetch_failures_script_reason_idx",
+          "columns": [
+            {
+              "expression": "script",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "repair_fetch_failures_status_check": {
+          "name": "repair_fetch_failures_status_check",
+          "value": "\"repair_fetch_failures\".\"status\" is null or (\"repair_fetch_failures\".\"status\" >= 100 and \"repair_fetch_failures\".\"status\" <= 599)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "articles_post_id_idx": {
+          "name": "articles_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"articles\".\"post_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_created_by_idx": {
+          "name": "articles_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_post_id_posts_id_fk": {
+          "name": "articles_post_id_posts_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_domain_purge_runs": {
+      "name": "blocked_domain_purge_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_posts": {
+          "name": "removed_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_actors": {
+          "name": "removed_actors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_boosts": {
+          "name": "removed_boosts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_likes": {
+          "name": "removed_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_notifications": {
+          "name": "removed_notifications",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_media_cache_rows": {
+          "name": "removed_media_cache_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_local_content_kept": {
+          "name": "removed_local_content_kept",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_local_follows_removed": {
+          "name": "removed_local_follows_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corroborating_sources": {
+          "name": "corroborating_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocked_domain_purge_runs_domain_run_id_key": {
+          "name": "blocked_domain_purge_runs_domain_run_id_key",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocked_domain_purge_runs_domain_chrono_idx": {
+          "name": "blocked_domain_purge_runs_domain_chrono_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocked_domain_purge_runs_trigger_check": {
+          "name": "blocked_domain_purge_runs_trigger_check",
+          "value": "\"blocked_domain_purge_runs\".\"trigger\" in ('policy_added', 'manual')"
+        },
+        "blocked_domain_purge_runs_removed_check": {
+          "name": "blocked_domain_purge_runs_removed_check",
+          "value": "\"blocked_domain_purge_runs\".\"removed_posts\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_actors\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_boosts\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_likes\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_notifications\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_media_cache_rows\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_local_content_kept\" >= 0\n        and \"blocked_domain_purge_runs\".\"removed_local_follows_removed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocked_domain_purges": {
+      "name": "blocked_domain_purges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_policy": {
+          "name": "in_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purged_at": {
+          "name": "purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "held_reason": {
+          "name": "held_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_posts": {
+          "name": "measured_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_actors": {
+          "name": "measured_actors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_boosts": {
+          "name": "measured_boosts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_likes": {
+          "name": "measured_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_notifications": {
+          "name": "measured_notifications",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_media_cache_rows": {
+          "name": "measured_media_cache_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_local_content_kept": {
+          "name": "measured_local_content_kept",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_local_follows_removed": {
+          "name": "measured_local_follows_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocked_domain_purges_domain_key": {
+          "name": "blocked_domain_purges_domain_key",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocked_domain_purges_state_claimed_idx": {
+          "name": "blocked_domain_purges_state_claimed_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocked_domain_purges_state_check": {
+          "name": "blocked_domain_purges_state_check",
+          "value": "\"blocked_domain_purges\".\"state\" in ('pending', 'in_progress', 'purged', 'held', 'failed')"
+        },
+        "blocked_domain_purges_measured_check": {
+          "name": "blocked_domain_purges_measured_check",
+          "value": "(\"blocked_domain_purges\".\"measured_posts\" is null\n          and \"blocked_domain_purges\".\"measured_actors\" is null\n          and \"blocked_domain_purges\".\"measured_boosts\" is null\n          and \"blocked_domain_purges\".\"measured_likes\" is null\n          and \"blocked_domain_purges\".\"measured_notifications\" is null\n          and \"blocked_domain_purges\".\"measured_media_cache_rows\" is null\n          and \"blocked_domain_purges\".\"measured_local_content_kept\" is null\n          and \"blocked_domain_purges\".\"measured_local_follows_removed\" is null)\n        or (\"blocked_domain_purges\".\"measured_posts\" >= 0\n          and \"blocked_domain_purges\".\"measured_actors\" >= 0\n          and \"blocked_domain_purges\".\"measured_boosts\" >= 0\n          and \"blocked_domain_purges\".\"measured_likes\" >= 0\n          and \"blocked_domain_purges\".\"measured_notifications\" >= 0\n          and \"blocked_domain_purges\".\"measured_media_cache_rows\" >= 0\n          and \"blocked_domain_purges\".\"measured_local_content_kept\" >= 0\n          and \"blocked_domain_purges\".\"measured_local_follows_removed\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocklist_proposal_observations": {
+      "name": "blocklist_proposal_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance": {
+          "name": "instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_from_digest": {
+          "name": "resolved_from_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blocklist_proposal_observations_proposal_id_instance_key": {
+          "name": "blocklist_proposal_observations_proposal_id_instance_key",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_proposal_observations_proposal_idx": {
+          "name": "blocklist_proposal_observations_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_proposal_observations_proposal_id_blocklist_proposals_id_fk": {
+          "name": "blocklist_proposal_observations_proposal_id_blocklist_proposals_id_fk",
+          "tableFrom": "blocklist_proposal_observations",
+          "tableTo": "blocklist_proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocklist_proposal_observations_severity_check": {
+          "name": "blocklist_proposal_observations_severity_check",
+          "value": "\"blocklist_proposal_observations\".\"severity\" in ('suspend', 'silence', 'noop')"
+        },
+        "blocklist_proposal_observations_position_check": {
+          "name": "blocklist_proposal_observations_position_check",
+          "value": "\"blocklist_proposal_observations\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocklist_proposal_run_sources": {
+      "name": "blocklist_proposal_run_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_row_id": {
+          "name": "run_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance": {
+          "name": "instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blocklist_proposal_run_sources_run_row_id_instance_key": {
+          "name": "blocklist_proposal_run_sources_run_row_id_instance_key",
+          "columns": [
+            {
+              "expression": "run_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_proposal_run_sources_run_row_id_blocklist_proposal_runs_id_fk": {
+          "name": "blocklist_proposal_run_sources_run_row_id_blocklist_proposal_runs_id_fk",
+          "tableFrom": "blocklist_proposal_run_sources",
+          "tableTo": "blocklist_proposal_runs",
+          "columnsFrom": [
+            "run_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocklist_proposal_run_sources_outcome_check": {
+          "name": "blocklist_proposal_run_sources_outcome_check",
+          "value": "\"blocklist_proposal_run_sources\".\"outcome\" in ('published', 'not-published', 'failed')"
+        },
+        "blocklist_proposal_run_sources_counts_check": {
+          "name": "blocklist_proposal_run_sources_counts_check",
+          "value": "\"blocklist_proposal_run_sources\".\"entries\" >= 0 and \"blocklist_proposal_run_sources\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocklist_proposal_runs": {
+      "name": "blocklist_proposal_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_operators": {
+          "name": "min_operators",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_domains_observed": {
+          "name": "counts_domains_observed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_cleared_operator_threshold": {
+          "name": "counts_cleared_operator_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_opened": {
+          "name": "counts_opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_pending": {
+          "name": "counts_pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_suppressed_declined": {
+          "name": "counts_suppressed_declined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_suppressed_blocked": {
+          "name": "counts_suppressed_blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_lapsed": {
+          "name": "counts_lapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts_adopted": {
+          "name": "counts_adopted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocklist_proposal_runs_run_id_key": {
+          "name": "blocklist_proposal_runs_run_id_key",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_proposal_runs_started_at_idx": {
+          "name": "blocklist_proposal_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocklist_proposal_runs_trigger_check": {
+          "name": "blocklist_proposal_runs_trigger_check",
+          "value": "\"blocklist_proposal_runs\".\"trigger\" in ('scheduled', 'manual')"
+        },
+        "blocklist_proposal_runs_counts_check": {
+          "name": "blocklist_proposal_runs_counts_check",
+          "value": "\"blocklist_proposal_runs\".\"min_operators\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_domains_observed\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_cleared_operator_threshold\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_opened\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_pending\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_suppressed_declined\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_suppressed_blocked\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_lapsed\" >= 0\n        and \"blocklist_proposal_runs\".\"counts_adopted\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocklist_proposals": {
+      "name": "blocklist_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "first_proposed_at": {
+          "name": "first_proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_count": {
+          "name": "operator_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corroborating_sources": {
+          "name": "corroborating_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_actors": {
+          "name": "footprint_actors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_posts": {
+          "name": "footprint_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_local_users_following": {
+          "name": "footprint_local_users_following",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_remote_actors_followed": {
+          "name": "footprint_remote_actors_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footprint_local_users_followed": {
+          "name": "footprint_local_users_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocklist_proposals_domain_key": {
+          "name": "blocklist_proposals_domain_key",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_proposals_status_chrono_idx": {
+          "name": "blocklist_proposals_status_chrono_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocklist_proposals_status_check": {
+          "name": "blocklist_proposals_status_check",
+          "value": "\"blocklist_proposals\".\"status\" in ('open', 'declined', 'adopted', 'lapsed')"
+        },
+        "blocklist_proposals_counts_check": {
+          "name": "blocklist_proposals_counts_check",
+          "value": "\"blocklist_proposals\".\"operator_count\" >= 0\n        and \"blocklist_proposals\".\"footprint_actors\" >= 0\n        and \"blocklist_proposals\".\"footprint_posts\" >= 0\n        and \"blocklist_proposals\".\"footprint_local_users_following\" >= 0\n        and \"blocklist_proposals\".\"footprint_remote_actors_followed\" >= 0\n        and \"blocklist_proposals\".\"footprint_local_users_followed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lane_mutes": {
+      "name": "lane_mutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_oxy_user_id": {
+          "name": "viewer_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lane_id": {
+          "name": "lane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lane_owner_oxy_user_id": {
+          "name": "lane_owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "lane_mutes_viewer_chrono_idx": {
+          "name": "lane_mutes_viewer_chrono_idx",
+          "columns": [
+            {
+              "expression": "viewer_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lane_mutes_lane_id_lanes_id_fk": {
+          "name": "lane_mutes_lane_id_lanes_id_fk",
+          "tableFrom": "lane_mutes",
+          "tableTo": "lanes",
+          "columnsFrom": [
+            "lane_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lane_mutes_viewer_lane_key": {
+          "name": "lane_mutes_viewer_lane_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "viewer_oxy_user_id",
+            "lane_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lanes": {
+      "name": "lanes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_lower": {
+          "name": "name_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_mode": {
+          "name": "display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mixed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "lanes_owner_idx": {
+          "name": "lanes_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lanes_owner_name_lower_key": {
+          "name": "lanes_owner_name_lower_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner_id",
+            "name_lower"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lanes_display_mode_check": {
+          "name": "lanes_display_mode_check",
+          "value": "\"lanes\".\"display_mode\" in ('mixed', 'tab', 'hidden')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.author_follower_snapshots": {
+      "name": "author_follower_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follower_count": {
+          "name": "follower_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "author_follower_snapshots_owner_chrono_idx": {
+          "name": "author_follower_snapshots_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "author_follower_snapshots_at_idx": {
+          "name": "author_follower_snapshots_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "author_follower_snapshots_follower_count_check": {
+          "name": "author_follower_snapshots_follower_count_check",
+          "value": "\"author_follower_snapshots\".\"follower_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gifs": {
+      "name": "gifs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "klipy_id": {
+          "name": "klipy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'klipy'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "search_terms": {
+          "name": "search_terms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::text[]"
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mp4_file_id": {
+          "name": "mp4_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_file_id": {
+          "name": "preview_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_hit_count": {
+          "name": "search_hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(array_to_tsvector(search_terms), 'A')\n        || setweight(to_tsvector('simple', title), 'B')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "gifs_search_gin": {
+          "name": "gifs_search_gin",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "gifs_use_count_idx": {
+          "name": "gifs_use_count_idx",
+          "columns": [
+            {
+              "expression": "use_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gifs_last_used_at_idx": {
+          "name": "gifs_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gifs_klipy_id_key": {
+          "name": "gifs_klipy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "klipy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "gifs_source_check": {
+          "name": "gifs_source_check",
+          "value": "\"gifs\".\"source\" in ('klipy')"
+        },
+        "gifs_dimensions_check": {
+          "name": "gifs_dimensions_check",
+          "value": "\"gifs\".\"width\" > 0 and \"gifs\".\"height\" > 0"
+        },
+        "gifs_counts_check": {
+          "name": "gifs_counts_check",
+          "value": "\"gifs\".\"use_count\" >= 0 and \"gifs\".\"search_hit_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_keyset_idx": {
+          "name": "notifications_recipient_keyset_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_dedup_key": {
+          "name": "notifications_dedup_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_id",
+            "actor_id",
+            "type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "notifications_type_check": {
+          "name": "notifications_type_check",
+          "value": "\"notifications\".\"type\" in ('like', 'reply', 'mention', 'follow', 'boost', 'quote', 'welcome', 'post', 'poke', 'collab_invite', 'collab_accepted', 'collab_declined')"
+        },
+        "notifications_entity_type_check": {
+          "name": "notifications_entity_type_check",
+          "value": "\"notifications\".\"entity_type\" in ('post', 'reply', 'profile')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "push_tokens_user_enabled_idx": {
+          "name": "push_tokens_user_enabled_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"push_tokens\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_tokens_token_key": {
+          "name": "push_tokens_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_type_check": {
+          "name": "push_tokens_type_check",
+          "value": "\"push_tokens\".\"type\" in ('fcm', 'apns', 'unknown')"
+        },
+        "push_tokens_platform_check": {
+          "name": "push_tokens_platform_check",
+          "value": "\"push_tokens\".\"platform\" in ('android', 'ios', 'unknown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.topic_stats": {
+      "name": "topic_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "topic_stats_popularity_idx": {
+          "name": "topic_stats_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_stats_topic_id_key": {
+          "name": "topic_stats_topic_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "topic_stats_post_count_check": {
+          "name": "topic_stats_post_count_check",
+          "value": "\"topic_stats\".\"post_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.trend_batches": {
+      "name": "trend_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trend_batches_calculated_at_key": {
+          "name": "trend_batches_calculated_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calculated_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trend_graphs": {
+      "name": "trend_graphs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "edges": {
+          "name": "edges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "dropped_edges": {
+          "name": "dropped_edges",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trend_graphs_calculated_at_key": {
+          "name": "trend_graphs_calculated_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calculated_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "trend_graphs_dropped_edges_check": {
+          "name": "trend_graphs_dropped_edges_check",
+          "value": "\"trend_graphs\".\"dropped_edges\" is null or \"trend_graphs\".\"dropped_edges\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.trend_summaries": {
+      "name": "trend_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_started_at": {
+          "name": "run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trend_summaries_generated_at_idx": {
+          "name": "trend_summaries_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trend_summaries_term_run_started_at_key": {
+          "name": "trend_summaries_term_run_started_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term",
+            "run_started_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trending": {
+      "name": "trending",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_version": {
+          "name": "label_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "burst_score": {
+          "name": "burst_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "momentum": {
+          "name": "momentum",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_ids": {
+          "name": "actor_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "trending_batch_idx": {
+          "name": "trending_batch_idx",
+          "columns": [
+            {
+              "expression": "calculated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trending_calculated_at_idx": {
+          "name": "trending_calculated_at_idx",
+          "columns": [
+            {
+              "expression": "calculated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trending_topic_id_idx": {
+          "name": "trending_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"trending\".\"topic_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trending_name_calculated_at_type_key": {
+          "name": "trending_name_calculated_at_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "calculated_at",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "trending_type_check": {
+          "name": "trending_type_check",
+          "value": "\"trending\".\"type\" in ('hashtag', 'topic', 'entity')"
+        },
+        "trending_category_check": {
+          "name": "trending_category_check",
+          "value": "\"trending\".\"category\" is null or \"trending\".\"category\" in ('news', 'politics', 'sports', 'pop-culture', 'video-games', 'tech', 'science', 'other')"
+        },
+        "trending_status_check": {
+          "name": "trending_status_check",
+          "value": "\"trending\".\"status\" is null or \"trending\".\"status\" in ('hot')"
+        },
+        "trending_volume_check": {
+          "name": "trending_volume_check",
+          "value": "\"trending\".\"volume\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_id_created_at_idx": {
+          "name": "bookmarks_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_post_id_idx": {
+          "name": "bookmarks_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_id_folder_idx": {
+          "name": "bookmarks_user_id_folder_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"bookmarks\".\"folder\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_post_id_posts_id_fk": {
+          "name": "bookmarks_post_id_posts_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_id_post_id_key": {
+          "name": "bookmarks_user_id_post_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_follows": {
+      "name": "entity_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "entity_follows_entity_idx": {
+          "name": "entity_follows_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_follows_user_type_idx": {
+          "name": "entity_follows_user_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_follows_user_id_entity_type_entity_id_key": {
+          "name": "entity_follows_user_id_entity_type_entity_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "entity_follows_entity_type_check": {
+          "name": "entity_follows_entity_type_check",
+          "value": "\"entity_follows\".\"entity_type\" in ('hashtag', 'list')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "likes_post_id_idx": {
+          "name": "likes_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "likes_user_id_created_at_idx": {
+          "name": "likes_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "likes_post_id_posts_id_fk": {
+          "name": "likes_post_id_posts_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "likes_user_id_post_id_key": {
+          "name": "likes_user_id_post_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "likes_value_check": {
+          "name": "likes_value_check",
+          "value": "\"likes\".\"value\" in (1, -1)"
+        },
+        "likes_revision_check": {
+          "name": "likes_revision_check",
+          "value": "\"likes\".\"revision\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mute_words": {
+      "name": "mute_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targets": {
+          "name": "targets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::text[]"
+        },
+        "actor_target": {
+          "name": "actor_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mute_words_user_id_value_key": {
+          "name": "mute_words_user_id_value_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mute_words_actor_target_check": {
+          "name": "mute_words_actor_target_check",
+          "value": "\"mute_words\".\"actor_target\" in ('all', 'exclude-following')"
+        },
+        "mute_words_targets_check": {
+          "name": "mute_words_targets_check",
+          "value": "\"mute_words\".\"targets\" <@ array['content', 'tag']::text[]"
+        },
+        "mute_words_value_length_check": {
+          "name": "mute_words_value_length_check",
+          "value": "length(\"mute_words\".\"value\") <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mutes": {
+      "name": "mutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_id": {
+          "name": "muted_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mutes_muted_id_idx": {
+          "name": "mutes_muted_id_idx",
+          "columns": [
+            {
+              "expression": "muted_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mutes_user_id_muted_id_key": {
+          "name": "mutes_user_id_muted_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "muted_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pokes": {
+      "name": "pokes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poker_id": {
+          "name": "poker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poked_id": {
+          "name": "poked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "pokes_poked_id_created_at_idx": {
+          "name": "pokes_poked_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "poked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pokes_poker_id_poked_id_key": {
+          "name": "pokes_poker_id_poked_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poker_id",
+            "poked_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_subscriptions": {
+      "name": "post_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "post_subscriptions_author_id_idx": {
+          "name": "post_subscriptions_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_subscriptions_subscriber_id_author_id_key": {
+          "name": "post_subscriptions_subscriber_id_author_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subscriber_id",
+            "author_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor_key_pairs": {
+      "name": "actor_key_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_pem": {
+          "name": "private_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "actor_key_pairs_oxy_user_id_key": {
+          "name": "actor_key_pairs_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federated_actor_fields": {
+      "name": "federated_actor_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federated_actor_fields_actor_id_federated_actors_id_fk": {
+          "name": "federated_actor_fields_actor_id_federated_actors_id_fk",
+          "tableFrom": "federated_actor_fields",
+          "tableTo": "federated_actors",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federated_actor_fields_actor_id_position_key": {
+          "name": "federated_actor_fields_actor_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "federated_actor_fields_position_check": {
+          "name": "federated_actor_fields_position_check",
+          "value": "\"federated_actor_fields\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.federated_actors": {
+      "name": "federated_actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'activitypub'"
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acct": {
+          "name": "acct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_acct": {
+          "name": "network_acct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_url": {
+          "name": "header_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_url": {
+          "name": "outbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_url": {
+          "name": "followers_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following_url": {
+          "name": "following_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key_id": {
+          "name": "public_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Person'"
+        },
+        "manually_approves_followers": {
+          "name": "manually_approves_followers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "memorial": {
+          "name": "memorial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured_url": {
+          "name": "featured_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_tags_url": {
+          "name": "featured_tags_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "also_known_as": {
+          "name": "also_known_as",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_created_at": {
+          "name": "remote_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "following_count": {
+          "name": "following_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "posts_count": {
+          "name": "posts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_outbox_sync_at": {
+          "name": "last_outbox_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_status": {
+          "name": "outbox_backfill_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_outbox_url": {
+          "name": "outbox_backfill_outbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_cursor_url": {
+          "name": "outbox_backfill_cursor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_cursor_item_offset": {
+          "name": "outbox_backfill_cursor_item_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_processed_count": {
+          "name": "outbox_backfill_processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_imported_count": {
+          "name": "outbox_backfill_imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_existing_count": {
+          "name": "outbox_backfill_existing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_page_count": {
+          "name": "outbox_backfill_page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outbox_backfill_locked_until": {
+          "name": "outbox_backfill_locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_last_run_at": {
+          "name": "outbox_backfill_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_completed_at": {
+          "name": "outbox_backfill_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbox_backfill_last_error": {
+          "name": "outbox_backfill_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_atproto_graph_sync_at": {
+          "name": "last_atproto_graph_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atproto_graph_sync_started_at": {
+          "name": "atproto_graph_sync_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "federated_actors_protocol_idx": {
+          "name": "federated_actors_protocol_idx",
+          "columns": [
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_domain_idx": {
+          "name": "federated_actors_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_public_key_id_idx": {
+          "name": "federated_actors_public_key_id_idx",
+          "columns": [
+            {
+              "expression": "public_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"federated_actors\".\"public_key_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_last_fetched_at_idx": {
+          "name": "federated_actors_last_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "last_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_backfill_claim_idx": {
+          "name": "federated_actors_backfill_claim_idx",
+          "columns": [
+            {
+              "expression": "outbox_backfill_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outbox_backfill_locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_oxy_user_id_idx": {
+          "name": "federated_actors_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"federated_actors\".\"oxy_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_actors_network_acct_idx": {
+          "name": "federated_actors_network_acct_idx",
+          "columns": [
+            {
+              "expression": "network_acct",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"federated_actors\".\"network_acct\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federated_actors_uri_key": {
+          "name": "federated_actors_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        },
+        "federated_actors_acct_key": {
+          "name": "federated_actors_acct_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "acct"
+          ]
+        },
+        "federated_actors_domain_username_key": {
+          "name": "federated_actors_domain_username_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain",
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "federated_actors_protocol_check": {
+          "name": "federated_actors_protocol_check",
+          "value": "\"federated_actors\".\"protocol\" in ('activitypub', 'atproto')"
+        },
+        "federated_actors_type_check": {
+          "name": "federated_actors_type_check",
+          "value": "\"federated_actors\".\"type\" in ('Person', 'Service', 'Application', 'Group', 'Organization')"
+        },
+        "federated_actors_outbox_backfill_status_check": {
+          "name": "federated_actors_outbox_backfill_status_check",
+          "value": "\"federated_actors\".\"outbox_backfill_status\" is null or \"federated_actors\".\"outbox_backfill_status\" in ('pending', 'complete', 'unavailable', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.federated_follows": {
+      "name": "federated_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "local_user_id": {
+          "name": "local_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_actor_uri": {
+          "name": "remote_actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'activitypub'"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "federated_follows_local_direction_status_idx": {
+          "name": "federated_follows_local_direction_status_idx",
+          "columns": [
+            {
+              "expression": "local_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_follows_remote_direction_idx": {
+          "name": "federated_follows_remote_direction_idx",
+          "columns": [
+            {
+              "expression": "remote_actor_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federated_follows_local_remote_direction_key": {
+          "name": "federated_follows_local_remote_direction_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "local_user_id",
+            "remote_actor_uri",
+            "direction"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "federated_follows_direction_check": {
+          "name": "federated_follows_direction_check",
+          "value": "\"federated_follows\".\"direction\" in ('outbound', 'inbound')"
+        },
+        "federated_follows_status_check": {
+          "name": "federated_follows_status_check",
+          "value": "\"federated_follows\".\"status\" in ('pending', 'accepted', 'rejected')"
+        },
+        "federated_follows_network_check": {
+          "name": "federated_follows_network_check",
+          "value": "\"federated_follows\".\"network\" in ('activitypub', 'atproto')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.federated_media_cache": {
+      "name": "federated_media_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_file_id": {
+          "name": "oxy_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_file_id": {
+          "name": "poster_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fail_count": {
+          "name": "fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "federated_media_cache_state_accessed_idx": {
+          "name": "federated_media_cache_state_accessed_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "federated_media_cache_state_next_attempt_idx": {
+          "name": "federated_media_cache_state_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federated_media_cache_remote_url_key": {
+          "name": "federated_media_cache_remote_url_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "remote_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "federated_media_cache_state_check": {
+          "name": "federated_media_cache_state_check",
+          "value": "\"federated_media_cache\".\"state\" in ('pending', 'cached', 'evicted', 'failed')"
+        },
+        "federated_media_cache_fail_count_check": {
+          "name": "federated_media_cache_fail_count_check",
+          "value": "\"federated_media_cache\".\"fail_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.federation_delivery_queue": {
+      "name": "federation_delivery_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_json": {
+          "name": "activity_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_inbox": {
+          "name": "target_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_oxy_user_id": {
+          "name": "sender_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_to_bullmq": {
+          "name": "migrated_to_bullmq",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "federation_delivery_queue_drain_idx": {
+          "name": "federation_delivery_queue_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "federation_delivery_queue_status_check": {
+          "name": "federation_delivery_queue_status_check",
+          "value": "\"federation_delivery_queue\".\"status\" in ('pending', 'delivered', 'failed')"
+        },
+        "federation_delivery_queue_attempts_check": {
+          "name": "federation_delivery_queue_attempts_check",
+          "value": "\"federation_delivery_queue\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_feed_definition_modules": {
+      "name": "custom_feed_definition_modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_feed_definition_modules_feed_id_custom_feeds_id_fk": {
+          "name": "custom_feed_definition_modules_feed_id_custom_feeds_id_fk",
+          "tableFrom": "custom_feed_definition_modules",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_feed_definition_modules_feed_kind_position_key": {
+          "name": "custom_feed_definition_modules_feed_kind_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "kind",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "custom_feed_definition_modules_kind_check": {
+          "name": "custom_feed_definition_modules_kind_check",
+          "value": "\"custom_feed_definition_modules\".\"kind\" in ('source', 'signal', 'filter')"
+        },
+        "custom_feed_definition_modules_position_check": {
+          "name": "custom_feed_definition_modules_position_check",
+          "value": "\"custom_feed_definition_modules\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_feed_members": {
+      "name": "custom_feed_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "custom_feed_members_oxy_user_id_idx": {
+          "name": "custom_feed_members_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_feed_members_feed_id_custom_feeds_id_fk": {
+          "name": "custom_feed_members_feed_id_custom_feeds_id_fk",
+          "tableFrom": "custom_feed_members",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_feed_members_feed_id_oxy_user_id_key": {
+          "name": "custom_feed_members_feed_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "oxy_user_id"
+          ]
+        },
+        "custom_feed_members_feed_id_position_key": {
+          "name": "custom_feed_members_feed_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "custom_feed_members_position_check": {
+          "name": "custom_feed_members_position_check",
+          "value": "\"custom_feed_members\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_feed_source_lists": {
+      "name": "custom_feed_source_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "custom_feed_source_lists_list_id_idx": {
+          "name": "custom_feed_source_lists_list_id_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_feed_source_lists_feed_id_custom_feeds_id_fk": {
+          "name": "custom_feed_source_lists_feed_id_custom_feeds_id_fk",
+          "tableFrom": "custom_feed_source_lists",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_feed_source_lists_list_id_account_lists_id_fk": {
+          "name": "custom_feed_source_lists_list_id_account_lists_id_fk",
+          "tableFrom": "custom_feed_source_lists",
+          "tableTo": "account_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_feed_source_lists_feed_id_list_id_key": {
+          "name": "custom_feed_source_lists_feed_id_list_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "list_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_feed_topics": {
+      "name": "custom_feed_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_feed_topics_feed_id_custom_feeds_id_fk": {
+          "name": "custom_feed_topics_feed_id_custom_feeds_id_fk",
+          "tableFrom": "custom_feed_topics",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_feed_topics_feed_id_topic_id_key": {
+          "name": "custom_feed_topics_feed_id_topic_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_feeds": {
+      "name": "custom_feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_mode": {
+          "name": "definition_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "include_replies": {
+          "name": "include_replies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_boosts": {
+          "name": "include_boosts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_media": {
+          "name": "include_media",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "average_rating": {
+          "name": "average_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ratings_count": {
+          "name": "ratings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "custom_feeds_owner_chrono_idx": {
+          "name": "custom_feeds_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_feeds_public_chrono_idx": {
+          "name": "custom_feeds_public_chrono_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"custom_feeds\".\"is_public\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_feeds_marketplace_idx": {
+          "name": "custom_feeds_marketplace_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"custom_feeds\".\"is_public\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_feeds_definition_mode_check": {
+          "name": "custom_feeds_definition_mode_check",
+          "value": "\"custom_feeds\".\"definition_mode\" is null or \"custom_feeds\".\"definition_mode\" in ('ranked', 'chronological')"
+        },
+        "custom_feeds_category_check": {
+          "name": "custom_feeds_category_check",
+          "value": "\"custom_feeds\".\"category\" is null or \"custom_feeds\".\"category\" in ('news', 'tech', 'culture', 'finance', 'health', 'sports', 'entertainment', 'other')"
+        },
+        "custom_feeds_counts_check": {
+          "name": "custom_feeds_counts_check",
+          "value": "\"custom_feeds\".\"subscriber_count\" >= 0 and \"custom_feeds\".\"ratings_count\" >= 0"
+        },
+        "custom_feeds_average_rating_check": {
+          "name": "custom_feeds_average_rating_check",
+          "value": "\"custom_feeds\".\"average_rating\" between 0 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_generators": {
+      "name": "feed_generators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_network": {
+          "name": "source_network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_service_did": {
+          "name": "source_service_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_synced_at": {
+          "name": "source_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "feed_generators_created_by_idx": {
+          "name": "feed_generators_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_generators_uri_key": {
+          "name": "feed_generators_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feed_generators_source_network_check": {
+          "name": "feed_generators_source_network_check",
+          "value": "\"feed_generators\".\"source_network\" is null or \"feed_generators\".\"source_network\" in ('atproto')"
+        },
+        "feed_generators_source_complete_check": {
+          "name": "feed_generators_source_complete_check",
+          "value": "(\"feed_generators\".\"source_network\" is null and \"feed_generators\".\"source_service_did\" is null and \"feed_generators\".\"source_synced_at\" is null)\n        or (\"feed_generators\".\"source_network\" is not null and \"feed_generators\".\"source_service_did\" is not null and \"feed_generators\".\"source_synced_at\" is not null)"
+        },
+        "feed_generators_counts_check": {
+          "name": "feed_generators_counts_check",
+          "value": "\"feed_generators\".\"like_count\" >= 0 and \"feed_generators\".\"subscriber_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_interactions": {
+      "name": "feed_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_descriptor": {
+          "name": "feed_descriptor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_uri": {
+          "name": "post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "feed_interactions_user_chrono_idx": {
+          "name": "feed_interactions_user_chrono_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_interactions_post_event_idx": {
+          "name": "feed_interactions_post_event_idx",
+          "columns": [
+            {
+              "expression": "post_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_interactions_created_at_idx": {
+          "name": "feed_interactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feed_interactions_event_check": {
+          "name": "feed_interactions_event_check",
+          "value": "\"feed_interactions\".\"event\" in ('impression', 'click', 'like', 'reply', 'boost', 'save', 'report')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feed_likes": {
+      "name": "feed_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "feed_likes_feed_id_idx": {
+          "name": "feed_likes_feed_id_idx",
+          "columns": [
+            {
+              "expression": "feed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_likes_user_id_idx": {
+          "name": "feed_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_likes_feed_id_custom_feeds_id_fk": {
+          "name": "feed_likes_feed_id_custom_feeds_id_fk",
+          "tableFrom": "feed_likes",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_likes_user_id_feed_id_key": {
+          "name": "feed_likes_user_id_feed_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "feed_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_reviews": {
+      "name": "feed_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_text": {
+          "name": "review_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "feed_reviews_reviewer_id_idx": {
+          "name": "feed_reviews_reviewer_id_idx",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_reviews_feed_id_custom_feeds_id_fk": {
+          "name": "feed_reviews_feed_id_custom_feeds_id_fk",
+          "tableFrom": "feed_reviews",
+          "tableTo": "custom_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_reviews_feed_id_reviewer_id_key": {
+          "name": "feed_reviews_feed_id_reviewer_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feed_id",
+            "reviewer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feed_reviews_rating_check": {
+          "name": "feed_reviews_rating_check",
+          "value": "\"feed_reviews\".\"rating\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_feed_preferences": {
+      "name": "user_feed_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_feed_preferences_oxy_user_id_key": {
+          "name": "user_feed_preferences_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_saved_feeds": {
+      "name": "user_saved_feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preference_id": {
+          "name": "preference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descriptor": {
+          "name": "descriptor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_saved_feeds_preference_order_idx": {
+          "name": "user_saved_feeds_preference_order_idx",
+          "columns": [
+            {
+              "expression": "preference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_feeds_preference_id_user_feed_preferences_id_fk": {
+          "name": "user_saved_feeds_preference_id_user_feed_preferences_id_fk",
+          "tableFrom": "user_saved_feeds",
+          "tableTo": "user_feed_preferences",
+          "columnsFrom": [
+            "preference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_saved_feeds_preference_id_key_key": {
+          "name": "user_saved_feeds_preference_id_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "preference_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postgates": {
+      "name": "postgates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_uri": {
+          "name": "post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disable_quotes": {
+          "name": "disable_quotes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "detached_quote_uris": {
+          "name": "detached_quote_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "postgates_post_id_idx": {
+          "name": "postgates_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postgates_created_by_idx": {
+          "name": "postgates_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "postgates_post_uri_key": {
+          "name": "postgates_post_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threadgate_allow_rules": {
+      "name": "threadgate_allow_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadgate_id": {
+          "name": "threadgate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "threadgate_allow_rules_threadgate_id_threadgates_id_fk": {
+          "name": "threadgate_allow_rules_threadgate_id_threadgates_id_fk",
+          "tableFrom": "threadgate_allow_rules",
+          "tableTo": "threadgates",
+          "columnsFrom": [
+            "threadgate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "threadgate_allow_rules_threadgate_id_position_key": {
+          "name": "threadgate_allow_rules_threadgate_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "threadgate_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "threadgate_allow_rules_type_check": {
+          "name": "threadgate_allow_rules_type_check",
+          "value": "\"threadgate_allow_rules\".\"type\" in ('mentionedOnly', 'followingOnly', 'followerOnly', 'listOnly')"
+        },
+        "threadgate_allow_rules_list_id_check": {
+          "name": "threadgate_allow_rules_list_id_check",
+          "value": "(\"threadgate_allow_rules\".\"type\" = 'listOnly') = (\"threadgate_allow_rules\".\"list_id\" is not null)"
+        },
+        "threadgate_allow_rules_position_check": {
+          "name": "threadgate_allow_rules_position_check",
+          "value": "\"threadgate_allow_rules\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.threadgates": {
+      "name": "threadgates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_uri": {
+          "name": "post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "threadgates_post_id_idx": {
+          "name": "threadgates_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threadgates_created_by_idx": {
+          "name": "threadgates_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "threadgates_post_uri_key": {
+          "name": "threadgates_post_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_list_members": {
+      "name": "account_list_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_list_members_oxy_user_id_idx": {
+          "name": "account_list_members_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_list_members_list_id_account_lists_id_fk": {
+          "name": "account_list_members_list_id_account_lists_id_fk",
+          "tableFrom": "account_list_members",
+          "tableTo": "account_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_list_members_list_id_oxy_user_id_key": {
+          "name": "account_list_members_list_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "list_id",
+            "oxy_user_id"
+          ]
+        },
+        "account_list_members_list_id_position_key": {
+          "name": "account_list_members_list_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "list_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_list_members_position_check": {
+          "name": "account_list_members_position_check",
+          "value": "\"account_list_members\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_lists": {
+      "name": "account_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "account_lists_owner_chrono_idx": {
+          "name": "account_lists_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_lists_public_chrono_idx": {
+          "name": "account_lists_public_chrono_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"account_lists\".\"is_public\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_lists_subscriber_count_check": {
+          "name": "account_lists_subscriber_count_check",
+          "value": "\"account_lists\".\"subscriber_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.starter_pack_members": {
+      "name": "starter_pack_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "starter_pack_members_oxy_user_id_idx": {
+          "name": "starter_pack_members_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "starter_pack_members_pack_id_starter_packs_id_fk": {
+          "name": "starter_pack_members_pack_id_starter_packs_id_fk",
+          "tableFrom": "starter_pack_members",
+          "tableTo": "starter_packs",
+          "columnsFrom": [
+            "pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "starter_pack_members_pack_id_oxy_user_id_key": {
+          "name": "starter_pack_members_pack_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pack_id",
+            "oxy_user_id"
+          ]
+        },
+        "starter_pack_members_pack_id_position_key": {
+          "name": "starter_pack_members_pack_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pack_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "starter_pack_members_position_check": {
+          "name": "starter_pack_members_position_check",
+          "value": "\"starter_pack_members\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.starter_pack_uses": {
+      "name": "starter_pack_uses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "starter_pack_uses_oxy_user_id_idx": {
+          "name": "starter_pack_uses_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "starter_pack_uses_pack_id_starter_packs_id_fk": {
+          "name": "starter_pack_uses_pack_id_starter_packs_id_fk",
+          "tableFrom": "starter_pack_uses",
+          "tableTo": "starter_packs",
+          "columnsFrom": [
+            "pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "starter_pack_uses_pack_id_oxy_user_id_key": {
+          "name": "starter_pack_uses_pack_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pack_id",
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.starter_packs": {
+      "name": "starter_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_network": {
+          "name": "source_network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_uri": {
+          "name": "source_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_synced_at": {
+          "name": "source_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "starter_packs_source_uri_key": {
+          "name": "starter_packs_source_uri_key",
+          "columns": [
+            {
+              "expression": "source_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"starter_packs\".\"source_uri\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "starter_packs_owner_chrono_idx": {
+          "name": "starter_packs_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "starter_packs_use_count_idx": {
+          "name": "starter_packs_use_count_idx",
+          "columns": [
+            {
+              "expression": "use_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "starter_packs_use_count_check": {
+          "name": "starter_packs_use_count_check",
+          "value": "\"starter_packs\".\"use_count\" >= 0"
+        },
+        "starter_packs_source_network_check": {
+          "name": "starter_packs_source_network_check",
+          "value": "\"starter_packs\".\"source_network\" is null or \"starter_packs\".\"source_network\" in ('atproto')"
+        },
+        "starter_packs_source_complete_check": {
+          "name": "starter_packs_source_complete_check",
+          "value": "(\"starter_packs\".\"source_network\" is null and \"starter_packs\".\"source_uri\" is null and \"starter_packs\".\"source_synced_at\" is null)\n        or (\"starter_packs\".\"source_network\" is not null and \"starter_packs\".\"source_uri\" is not null and \"starter_packs\".\"source_synced_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_codes": {
+      "name": "mcp_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mcp_auth_codes_code_key": {
+          "name": "mcp_auth_codes_code_key",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_auth_codes_expires_at_idx": {
+          "name": "mcp_auth_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_connections": {
+      "name": "mcp_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bundle_primary": {
+          "name": "is_bundle_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active_oxy_user_id": {
+          "name": "active_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_connections_refresh_token_hash_key": {
+          "name": "mcp_connections_refresh_token_hash_key",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_bundle_id_oxy_user_id_key": {
+          "name": "mcp_connections_bundle_id_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mcp_connections\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_oxy_user_id_idx": {
+          "name": "mcp_connections_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_bundle_id_idx": {
+          "name": "mcp_connections_bundle_id_idx",
+          "columns": [
+            {
+              "expression": "bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connections_jti_idx": {
+          "name": "mcp_connections_jti_idx",
+          "columns": [
+            {
+              "expression": "jti",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_registered_clients": {
+      "name": "mcp_registered_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mcp_registered_clients_client_id_key": {
+          "name": "mcp_registered_clients_client_id_key",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_labels": {
+      "name": "content_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "labeler_id": {
+          "name": "labeler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_slug": {
+          "name": "label_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "content_labels_target_idx": {
+          "name": "content_labels_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_labels_labeler_slug_idx": {
+          "name": "content_labels_labeler_slug_idx",
+          "columns": [
+            {
+              "expression": "labeler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_labels_labeler_id_labelers_id_fk": {
+          "name": "content_labels_labeler_id_labelers_id_fk",
+          "tableFrom": "content_labels",
+          "tableTo": "labelers",
+          "columnsFrom": [
+            "labeler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_labels_labeler_target_slug_key": {
+          "name": "content_labels_labeler_target_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "labeler_id",
+            "target_type",
+            "target_id",
+            "label_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "content_labels_target_type_check": {
+          "name": "content_labels_target_type_check",
+          "value": "\"content_labels\".\"target_type\" in ('post', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labeler_label_definitions": {
+      "name": "labeler_label_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "labeler_id": {
+          "name": "labeler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_action": {
+          "name": "default_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "labeler_label_definitions_labeler_id_labelers_id_fk": {
+          "name": "labeler_label_definitions_labeler_id_labelers_id_fk",
+          "tableFrom": "labeler_label_definitions",
+          "tableTo": "labelers",
+          "columnsFrom": [
+            "labeler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labeler_label_definitions_labeler_id_slug_key": {
+          "name": "labeler_label_definitions_labeler_id_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "labeler_id",
+            "slug"
+          ]
+        },
+        "labeler_label_definitions_labeler_id_position_key": {
+          "name": "labeler_label_definitions_labeler_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "labeler_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "labeler_label_definitions_severity_check": {
+          "name": "labeler_label_definitions_severity_check",
+          "value": "\"labeler_label_definitions\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "labeler_label_definitions_default_action_check": {
+          "name": "labeler_label_definitions_default_action_check",
+          "value": "\"labeler_label_definitions\".\"default_action\" in ('show', 'warn', 'blur', 'hide')"
+        },
+        "labeler_label_definitions_position_check": {
+          "name": "labeler_label_definitions_position_check",
+          "value": "\"labeler_label_definitions\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labelers": {
+      "name": "labelers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_official": {
+          "name": "is_official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "labelers_creator_id_idx": {
+          "name": "labelers_creator_id_idx",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "labelers_subscriber_count_check": {
+          "name": "labelers_subscriber_count_check",
+          "value": "\"labelers\".\"subscriber_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_enforcements": {
+      "name": "moderation_enforcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_action": {
+          "name": "recommended_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_reason": {
+          "name": "skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_post_status": {
+          "name": "previous_state_post_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_metadata_is_sensitive": {
+          "name": "previous_state_metadata_is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_enforcements_case_id_idx": {
+          "name": "moderation_enforcements_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_enforcements_subject_idx": {
+          "name": "moderation_enforcements_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_enforcements_idempotency_key": {
+          "name": "moderation_enforcements_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "decision_id",
+            "decision_revision",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_enforcements_action_check": {
+          "name": "moderation_enforcements_action_check",
+          "value": "\"moderation_enforcements\".\"action\" in ('none', 'restrict', 'restore', 'label_sensitive', 'unlabel_sensitive', 'manual_review')"
+        },
+        "moderation_enforcements_mode_check": {
+          "name": "moderation_enforcements_mode_check",
+          "value": "\"moderation_enforcements\".\"mode\" in ('observe', 'manual', 'automatic')"
+        },
+        "moderation_enforcements_revision_check": {
+          "name": "moderation_enforcements_revision_check",
+          "value": "\"moderation_enforcements\".\"decision_revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_events": {
+      "name": "moderation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claimed'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_events_case_id_idx": {
+          "name": "moderation_events_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"moderation_events\".\"case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_state_received_idx": {
+          "name": "moderation_events_state_received_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_expires_at_idx": {
+          "name": "moderation_events_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_events_state_check": {
+          "name": "moderation_events_state_check",
+          "value": "\"moderation_events\".\"state\" in ('claimed', 'queued', 'ignored')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_outbox": {
+      "name": "moderation_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_report_id": {
+          "name": "payload_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_event_id": {
+          "name": "payload_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_case_id": {
+          "name": "payload_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_decision": {
+          "name": "payload_decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_urgency": {
+          "name": "payload_urgency",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_outbox_due_idx": {
+          "name": "moderation_outbox_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_lease_idx": {
+          "name": "moderation_outbox_lease_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_expires_at_idx": {
+          "name": "moderation_outbox_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_outbox_payload_report_id_reports_id_fk": {
+          "name": "moderation_outbox_payload_report_id_reports_id_fk",
+          "tableFrom": "moderation_outbox",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "payload_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_outbox_kind_check": {
+          "name": "moderation_outbox_kind_check",
+          "value": "\"moderation_outbox\".\"kind\" in ('report.submit', 'decision.apply')"
+        },
+        "moderation_outbox_status_check": {
+          "name": "moderation_outbox_status_check",
+          "value": "\"moderation_outbox\".\"status\" in ('pending', 'processing', 'processed', 'dead_letter')"
+        },
+        "moderation_outbox_attempts_check": {
+          "name": "moderation_outbox_attempts_check",
+          "value": "\"moderation_outbox\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reported_type": {
+          "name": "reported_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter": {
+          "name": "reporter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "local_status": {
+          "name": "local_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "local_status_reason": {
+          "name": "local_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_report_id": {
+          "name": "crowd_source_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_case_id": {
+          "name": "crowd_source_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_merged": {
+          "name": "crowd_source_merged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_outcome": {
+          "name": "decision_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_action": {
+          "name": "enforced_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_snapshot_hash": {
+          "name": "content_snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_error": {
+          "name": "last_delivery_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reports_reported_id_idx": {
+          "name": "reports_reported_id_idx",
+          "columns": [
+            {
+              "expression": "reported_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_reporter_idx": {
+          "name": "reports_reporter_idx",
+          "columns": [
+            {
+              "expression": "reporter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_case_id_idx": {
+          "name": "reports_case_id_idx",
+          "columns": [
+            {
+              "expression": "crowd_source_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reports\".\"crowd_source_case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_local_status_chrono_idx": {
+          "name": "reports_local_status_chrono_idx",
+          "columns": [
+            {
+              "expression": "local_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reports_reporter_reported_key": {
+          "name": "reports_reporter_reported_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reporter",
+            "reported_id",
+            "reported_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reports_reported_type_check": {
+          "name": "reports_reported_type_check",
+          "value": "\"reports\".\"reported_type\" in ('post', 'user', 'comment', 'message', 'room')"
+        },
+        "reports_status_check": {
+          "name": "reports_status_check",
+          "value": "\"reports\".\"status\" in ('pending', 'reviewed', 'resolved', 'dismissed')"
+        },
+        "reports_local_status_check": {
+          "name": "reports_local_status_check",
+          "value": "\"reports\".\"local_status\" in ('received', 'queued', 'submitted', 'delivery_failed', 'closed')"
+        },
+        "reports_enforced_action_check": {
+          "name": "reports_enforced_action_check",
+          "value": "\"reports\".\"enforced_action\" is null or \"reports\".\"enforced_action\" in ('none', 'restrict', 'restore', 'label_sensitive', 'unlabel_sensitive', 'manual_review')"
+        },
+        "reports_categories_check": {
+          "name": "reports_categories_check",
+          "value": "array_length(\"reports\".\"categories\", 1) >= 1\n        and \"reports\".\"categories\" <@ array['spam', 'hate_speech', 'harassment', 'misinformation', 'explicit_content', 'other']::text[]"
+        },
+        "reports_decision_revision_check": {
+          "name": "reports_decision_revision_check",
+          "value": "\"reports\".\"decision_revision\" is null or \"reports\".\"decision_revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mention_node_ingest_witnesses": {
+      "name": "mention_node_ingest_witnesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witness_signature": {
+          "name": "witness_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mention_node_ingest_witnesses_owner_chrono_idx": {
+          "name": "mention_node_ingest_witnesses_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mention_node_ingest_witnesses_record_id_key": {
+          "name": "mention_node_ingest_witnesses_record_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mention_node_ingest_witnesses_ingested_at_check": {
+          "name": "mention_node_ingest_witnesses_ingested_at_check",
+          "value": "\"mention_node_ingest_witnesses\".\"ingested_at\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mention_repo_heads": {
+      "name": "mention_repo_heads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_record_id": {
+          "name": "head_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mention_repo_heads_oxy_user_id_key": {
+          "name": "mention_repo_heads_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mention_repo_heads_seq_check": {
+          "name": "mention_repo_heads_seq_check",
+          "value": "\"mention_repo_heads\".\"seq\" >= 0"
+        },
+        "mention_repo_heads_record_count_check": {
+          "name": "mention_repo_heads_record_count_check",
+          "value": "\"mention_repo_heads\".\"record_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mention_signed_records": {
+      "name": "mention_signed_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_status": {
+          "name": "chain_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nsid": {
+          "name": "nsid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mention_signed_records_record_id_key": {
+          "name": "mention_signed_records_record_id_key",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mention_signed_records\".\"record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_signed_records_oxy_user_id_seq_key": {
+          "name": "mention_signed_records_oxy_user_id_seq_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mention_signed_records\".\"seq\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_signed_records_idempotency_key": {
+          "name": "mention_signed_records_idempotency_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mention_signed_records\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_signed_records_materialize_idx": {
+          "name": "mention_signed_records_materialize_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nsid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mention_signed_records\".\"nsid\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_signed_records_subject_did_idx": {
+          "name": "mention_signed_records_subject_did_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mention_signed_records_chain_status_check": {
+          "name": "mention_signed_records_chain_status_check",
+          "value": "\"mention_signed_records\".\"chain_status\" is null or \"mention_signed_records\".\"chain_status\" in ('canonical', 'conflict')"
+        },
+        "mention_signed_records_seq_check": {
+          "name": "mention_signed_records_seq_check",
+          "value": "\"mention_signed_records\".\"seq\" is null or \"mention_signed_records\".\"seq\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mention_user_nodes": {
+      "name": "mention_user_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_did": {
+          "name": "node_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_public_key": {
+          "name": "node_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pull'"
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controller": {
+          "name": "controller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_at": {
+          "name": "last_probe_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mention_user_nodes_status_idx": {
+          "name": "mention_user_nodes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mention_user_nodes_ingest_sweep_idx": {
+          "name": "mention_user_nodes_ingest_sweep_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mention_user_nodes_oxy_user_id_key": {
+          "name": "mention_user_nodes_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mention_user_nodes_mode_check": {
+          "name": "mention_user_nodes_mode_check",
+          "value": "\"mention_user_nodes\".\"mode\" in ('pull', 'push')"
+        },
+        "mention_user_nodes_controller_check": {
+          "name": "mention_user_nodes_controller_check",
+          "value": "\"mention_user_nodes\".\"controller\" in ('self', 'oxy')"
+        },
+        "mention_user_nodes_status_check": {
+          "name": "mention_user_nodes_status_check",
+          "value": "\"mention_user_nodes\".\"status\" in ('active', 'unreachable', 'revoked')"
+        },
+        "mention_user_nodes_cursor_check": {
+          "name": "mention_user_nodes_cursor_check",
+          "value": "\"mention_user_nodes\".\"cursor\" is null or \"mention_user_nodes\".\"cursor\" >= 0"
+        },
+        "mention_user_nodes_managed_controller_check": {
+          "name": "mention_user_nodes_managed_controller_check",
+          "value": "\"mention_user_nodes\".\"managed\" = (\"mention_user_nodes\".\"controller\" = 'oxy')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.endorsement_outbox": {
+      "name": "endorsement_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_remove_owner_id": {
+          "name": "pending_remove_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_remove_member_ids": {
+          "name": "pending_remove_member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "endorsement_outbox_drain_idx": {
+          "name": "endorsement_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "endorsement_outbox_source_source_id_key": {
+          "name": "endorsement_outbox_source_source_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "endorsement_outbox_source_check": {
+          "name": "endorsement_outbox_source_check",
+          "value": "\"endorsement_outbox\".\"source\" in ('starterPack', 'accountList')"
+        },
+        "endorsement_outbox_status_check": {
+          "name": "endorsement_outbox_status_check",
+          "value": "\"endorsement_outbox\".\"status\" in ('pending', 'sent')"
+        },
+        "endorsement_outbox_attempts_check": {
+          "name": "endorsement_outbox_attempts_check",
+          "value": "\"endorsement_outbox\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.engagement_outbox": {
+      "name": "engagement_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_actor_oxy_user_id": {
+          "name": "payload_actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_post_id": {
+          "name": "payload_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_relationship_id": {
+          "name": "payload_relationship_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_post_owner_oxy_user_id": {
+          "name": "payload_post_owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_federation_activity_id": {
+          "name": "payload_federation_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_previous_value": {
+          "name": "payload_previous_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_value": {
+          "name": "payload_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "engagement_outbox_due_idx": {
+          "name": "engagement_outbox_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "engagement_outbox_lease_idx": {
+          "name": "engagement_outbox_lease_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "engagement_outbox_relationship_order_idx": {
+          "name": "engagement_outbox_relationship_order_idx",
+          "columns": [
+            {
+              "expression": "payload_relationship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "engagement_outbox_expires_at_idx": {
+          "name": "engagement_outbox_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "engagement_outbox_payload_post_id_posts_id_fk": {
+          "name": "engagement_outbox_payload_post_id_posts_id_fk",
+          "tableFrom": "engagement_outbox",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "payload_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "engagement_outbox_kind_check": {
+          "name": "engagement_outbox_kind_check",
+          "value": "\"engagement_outbox\".\"kind\" in ('post.like', 'post.unlike', 'post.downvote', 'post.undownvote', 'post.save', 'post.unsave')"
+        },
+        "engagement_outbox_status_check": {
+          "name": "engagement_outbox_status_check",
+          "value": "\"engagement_outbox\".\"status\" in ('pending', 'processing', 'processed')"
+        },
+        "engagement_outbox_revision_check": {
+          "name": "engagement_outbox_revision_check",
+          "value": "\"engagement_outbox\".\"revision\" >= 1"
+        },
+        "engagement_outbox_attempts_check": {
+          "name": "engagement_outbox_attempts_check",
+          "value": "\"engagement_outbox\".\"attempts\" >= 0"
+        },
+        "engagement_outbox_values_check": {
+          "name": "engagement_outbox_values_check",
+          "value": "(\"engagement_outbox\".\"payload_previous_value\" is null or \"engagement_outbox\".\"payload_previous_value\" in (1, -1))\n        and (\"engagement_outbox\".\"payload_value\" is null or \"engagement_outbox\".\"payload_value\" in (1, -1))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_attachments": {
+      "name": "post_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_attachments_post_id_posts_id_fk": {
+          "name": "post_attachments_post_id_posts_id_fk",
+          "tableFrom": "post_attachments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_attachments_post_id_position_key": {
+          "name": "post_attachments_post_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_attachments_type_check": {
+          "name": "post_attachments_type_check",
+          "value": "\"post_attachments\".\"type\" in ('media', 'poll', 'article', 'event', 'location', 'sources', 'room', 'podcast')"
+        },
+        "post_attachments_media_type_check": {
+          "name": "post_attachments_media_type_check",
+          "value": "\"post_attachments\".\"media_type\" is null or \"post_attachments\".\"media_type\" in ('image', 'video', 'gif')"
+        },
+        "post_attachments_media_fields_check": {
+          "name": "post_attachments_media_fields_check",
+          "value": "\"post_attachments\".\"type\" <> 'media' or (\"post_attachments\".\"attachment_id\" is not null and \"post_attachments\".\"media_type\" is not null)"
+        },
+        "post_attachments_position_check": {
+          "name": "post_attachments_position_check",
+          "value": "\"post_attachments\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_authorships": {
+      "name": "post_authorships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_created_at": {
+          "name": "post_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_authorships_one_owner_per_post": {
+          "name": "post_authorships_one_owner_per_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"post_authorships\".\"role\" = 'owner'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_authorships_author_idx": {
+          "name": "post_authorships_author_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_authorships_author_chrono_idx": {
+          "name": "post_authorships_author_chrono_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_authorships_post_id_posts_id_fk": {
+          "name": "post_authorships_post_id_posts_id_fk",
+          "tableFrom": "post_authorships",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_authorships_post_id_oxy_user_id_key": {
+          "name": "post_authorships_post_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_authorships_role_check": {
+          "name": "post_authorships_role_check",
+          "value": "\"post_authorships\".\"role\" in ('owner', 'collaborator')"
+        },
+        "post_authorships_status_check": {
+          "name": "post_authorships_status_check",
+          "value": "\"post_authorships\".\"status\" in ('accepted', 'pending', 'declined', 'stopped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_classification_topic_refs": {
+      "name": "post_classification_topic_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_classification_topic_refs_name_idx": {
+          "name": "post_classification_topic_refs_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_classification_topic_refs_topic_id_idx": {
+          "name": "post_classification_topic_refs_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"post_classification_topic_refs\".\"topic_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_classification_topic_refs_post_id_posts_id_fk": {
+          "name": "post_classification_topic_refs_post_id_posts_id_fk",
+          "tableFrom": "post_classification_topic_refs",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_classification_topic_refs_post_id_name_key": {
+          "name": "post_classification_topic_refs_post_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_classification_topic_refs_type_check": {
+          "name": "post_classification_topic_refs_type_check",
+          "value": "\"post_classification_topic_refs\".\"type\" is null or \"post_classification_topic_refs\".\"type\" in ('topic', 'entity')"
+        },
+        "post_classification_topic_refs_relevance_check": {
+          "name": "post_classification_topic_refs_relevance_check",
+          "value": "\"post_classification_topic_refs\".\"relevance\" is null or \"post_classification_topic_refs\".\"relevance\" between 1 and 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_content_variants": {
+      "name": "post_content_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "article_title": {
+          "name": "article_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_body": {
+          "name": "article_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_excerpt": {
+          "name": "article_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_created_at": {
+          "name": "variant_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(body, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "post_content_variants_post_id_tag_key": {
+          "name": "post_content_variants_post_id_tag_key",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"post_content_variants\".\"tag\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_content_variants_search_gin": {
+          "name": "post_content_variants_search_gin",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "post_content_variants_primary_idx": {
+          "name": "post_content_variants_primary_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"post_content_variants\".\"position\" = 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_content_variants_post_id_posts_id_fk": {
+          "name": "post_content_variants_post_id_posts_id_fk",
+          "tableFrom": "post_content_variants",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_content_variants_post_id_position_key": {
+          "name": "post_content_variants_post_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_content_variants_source_check": {
+          "name": "post_content_variants_source_check",
+          "value": "\"post_content_variants\".\"source\" in ('author', 'machine')"
+        },
+        "post_content_variants_position_check": {
+          "name": "post_content_variants_position_check",
+          "value": "\"post_content_variants\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_corrections": {
+      "name": "post_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_text": {
+          "name": "previous_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_oxy_user_id": {
+          "name": "corrected_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_corrections_post_id_posts_id_fk": {
+          "name": "post_corrections_post_id_posts_id_fk",
+          "tableFrom": "post_corrections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_corrections_post_id_revision_key": {
+          "name": "post_corrections_post_id_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "revision"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_corrections_revision_check": {
+          "name": "post_corrections_revision_check",
+          "value": "\"post_corrections\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_media": {
+      "name": "post_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_from_federation": {
+          "name": "cached_from_federation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_media_video_idx": {
+          "name": "post_media_video_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orientation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "duration_sec",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_media_media_id_idx": {
+          "name": "post_media_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_media_post_id_posts_id_fk": {
+          "name": "post_media_post_id_posts_id_fk",
+          "tableFrom": "post_media",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_media_post_id_position_key": {
+          "name": "post_media_post_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_media_type_check": {
+          "name": "post_media_type_check",
+          "value": "\"post_media\".\"type\" in ('image', 'video', 'gif')"
+        },
+        "post_media_orientation_check": {
+          "name": "post_media_orientation_check",
+          "value": "\"post_media\".\"orientation\" is null or \"post_media\".\"orientation\" in ('portrait', 'landscape', 'square')"
+        },
+        "post_media_positive_dimensions_check": {
+          "name": "post_media_positive_dimensions_check",
+          "value": "(\"post_media\".\"width\" is null or \"post_media\".\"width\" > 0)\n        and (\"post_media\".\"height\" is null or \"post_media\".\"height\" > 0)\n        and (\"post_media\".\"duration_sec\" is null or \"post_media\".\"duration_sec\" > 0)\n        and (\"post_media\".\"size_bytes\" is null or \"post_media\".\"size_bytes\" > 0)\n        and (\"post_media\".\"aspect_ratio\" is null or \"post_media\".\"aspect_ratio\" > 0)"
+        },
+        "post_media_position_check": {
+          "name": "post_media_position_check",
+          "value": "\"post_media\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_mentions": {
+      "name": "post_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "post_mentions_oxy_user_id_idx": {
+          "name": "post_mentions_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_mentions_post_id_posts_id_fk": {
+          "name": "post_mentions_post_id_posts_id_fk",
+          "tableFrom": "post_mentions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_mentions_post_id_oxy_user_id_key": {
+          "name": "post_mentions_post_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_recent_repliers": {
+      "name": "post_recent_repliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "post_recent_repliers_post_idx": {
+          "name": "post_recent_repliers_post_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replied_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_recent_repliers_post_id_posts_id_fk": {
+          "name": "post_recent_repliers_post_id_posts_id_fk",
+          "tableFrom": "post_recent_repliers",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_recent_repliers_post_id_oxy_user_id_key": {
+          "name": "post_recent_repliers_post_id_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_sources": {
+      "name": "post_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_sources_post_id_posts_id_fk": {
+          "name": "post_sources_post_id_posts_id_fk",
+          "tableFrom": "post_sources",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_sources_post_id_position_key": {
+          "name": "post_sources_post_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_sources_position_check": {
+          "name": "post_sources_position_check",
+          "value": "\"post_sources\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_variant_alt_texts": {
+      "name": "post_variant_alt_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_variant_alt_texts_variant_id_post_content_variants_id_fk": {
+          "name": "post_variant_alt_texts_variant_id_post_content_variants_id_fk",
+          "tableFrom": "post_variant_alt_texts",
+          "tableTo": "post_content_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_variant_alt_texts_variant_id_media_id_key": {
+          "name": "post_variant_alt_texts_variant_id_media_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_id",
+            "media_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_variant_media": {
+      "name": "post_variant_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_from_federation": {
+          "name": "cached_from_federation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_variant_media_variant_id_post_content_variants_id_fk": {
+          "name": "post_variant_media_variant_id_post_content_variants_id_fk",
+          "tableFrom": "post_variant_media",
+          "tableTo": "post_content_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_variant_media_variant_id_position_key": {
+          "name": "post_variant_media_variant_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_variant_media_type_check": {
+          "name": "post_variant_media_type_check",
+          "value": "\"post_variant_media\".\"type\" in ('image', 'video', 'gif')"
+        },
+        "post_variant_media_orientation_check": {
+          "name": "post_variant_media_orientation_check",
+          "value": "\"post_variant_media\".\"orientation\" is null or \"post_variant_media\".\"orientation\" in ('portrait', 'landscape', 'square')"
+        },
+        "post_variant_media_positive_dimensions_check": {
+          "name": "post_variant_media_positive_dimensions_check",
+          "value": "(\"post_variant_media\".\"width\" is null or \"post_variant_media\".\"width\" > 0)\n        and (\"post_variant_media\".\"height\" is null or \"post_variant_media\".\"height\" > 0)\n        and (\"post_variant_media\".\"duration_sec\" is null or \"post_variant_media\".\"duration_sec\" > 0)\n        and (\"post_variant_media\".\"size_bytes\" is null or \"post_variant_media\".\"size_bytes\" > 0)\n        and (\"post_variant_media\".\"aspect_ratio\" is null or \"post_variant_media\".\"aspect_ratio\" > 0)"
+        },
+        "post_variant_media_position_check": {
+          "name": "post_variant_media_position_check",
+          "value": "\"post_variant_media\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "written_by_oxy_user_id": {
+          "name": "written_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "has_links": {
+          "name": "has_links",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curated": {
+          "name": "curated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edit_history": {
+          "name": "edit_history",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_permission": {
+          "name": "reply_permission",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array['anyone']::text[]"
+        },
+        "review_replies": {
+          "name": "review_replies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quotes_disabled": {
+          "name": "quotes_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "correction_count": {
+          "name": "correction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_corrected_at": {
+          "name": "last_corrected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boost_of": {
+          "name": "boost_of",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_of": {
+          "name": "quote_of",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lane_id": {
+          "name": "lane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_post_id": {
+          "name": "parent_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_reply": {
+          "name": "is_reply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_likes_count": {
+          "name": "stats_likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_downvotes_count": {
+          "name": "stats_downvotes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_boosts_count": {
+          "name": "stats_boosts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_federated_boosts_count": {
+          "name": "stats_federated_boosts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_comments_count": {
+          "name": "stats_comments_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_views_count": {
+          "name": "stats_views_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_shares_count": {
+          "name": "stats_shares_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stats_saves_count": {
+          "name": "stats_saves_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata_is_sensitive": {
+          "name": "metadata_is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_is_pinned": {
+          "name": "metadata_is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_is_boosted": {
+          "name": "metadata_is_boosted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_is_commented": {
+          "name": "metadata_is_commented",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_is_following_author": {
+          "name": "metadata_is_following_author",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_author_blocked": {
+          "name": "metadata_author_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_author_muted": {
+          "name": "metadata_author_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_hide_engagement_counts": {
+          "name": "metadata_hide_engagement_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_collab_federation_deferred": {
+          "name": "metadata_collab_federation_deferred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata_federation_delivered": {
+          "name": "metadata_federation_delivered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "federation_activity_id": {
+          "name": "federation_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_actor_uri": {
+          "name": "federation_actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_in_reply_to": {
+          "name": "federation_in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_url": {
+          "name": "federation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_sensitive": {
+          "name": "federation_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_spoiler_text": {
+          "name": "federation_spoiler_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_poll_id": {
+          "name": "content_poll_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_article_id": {
+          "name": "content_article_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_article_title": {
+          "name": "content_article_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_article_excerpt": {
+          "name": "content_article_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_id": {
+          "name": "content_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_name": {
+          "name": "content_event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_date": {
+          "name": "content_event_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_location": {
+          "name": "content_event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_event_description": {
+          "name": "content_event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_id": {
+          "name": "content_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_title": {
+          "name": "content_room_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_status": {
+          "name": "content_room_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_topic": {
+          "name": "content_room_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_room_host": {
+          "name": "content_room_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_syra_id": {
+          "name": "content_podcast_syra_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_title": {
+          "name": "content_podcast_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_author": {
+          "name": "content_podcast_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_artwork_url": {
+          "name": "content_podcast_artwork_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_podcast_show_url": {
+          "name": "content_podcast_show_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_location_latitude": {
+          "name": "content_location_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_location_longitude": {
+          "name": "content_location_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_location_address": {
+          "name": "content_location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_geo": {
+          "name": "content_geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(content_location_longitude, content_location_latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "location_latitude": {
+          "name": "location_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_longitude": {
+          "name": "location_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_address": {
+          "name": "location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(location_longitude, location_latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "classification_topics": {
+          "name": "classification_topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_languages": {
+          "name": "classification_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_region": {
+          "name": "classification_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_hashtags_norm": {
+          "name": "classification_hashtags_norm",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_trend_terms": {
+          "name": "classification_trend_terms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_sensitive": {
+          "name": "classification_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_version": {
+          "name": "classification_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_sentiment": {
+          "name": "classification_sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'neutral'"
+        },
+        "classification_intent": {
+          "name": "classification_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "classification_score_toxicity": {
+          "name": "classification_score_toxicity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_constructiveness": {
+          "name": "classification_score_constructiveness",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_spam": {
+          "name": "classification_score_spam",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_quality": {
+          "name": "classification_score_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_controversy": {
+          "name": "classification_score_controversy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_score_negativity": {
+          "name": "classification_score_negativity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_status": {
+          "name": "classification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification_attempts": {
+          "name": "classification_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "classification_classified_at": {
+          "name": "classification_classified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "posts_federation_activity_id_key": {
+          "name": "posts_federation_activity_id_key",
+          "columns": [
+            {
+              "expression": "federation_activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"federation_activity_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_public_chrono_v1": {
+          "name": "post_public_chrono_v1",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_roots_chrono_idx": {
+          "name": "posts_roots_chrono_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"is_reply\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_replies_chrono_v1": {
+          "name": "post_replies_chrono_v1",
+          "columns": [
+            {
+              "expression": "parent_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_links_chrono_v1": {
+          "name": "post_links_chrono_v1",
+          "columns": [
+            {
+              "expression": "has_links",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_owner_chrono_idx": {
+          "name": "posts_owner_chrono_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_type_chrono_idx": {
+          "name": "posts_type_chrono_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_thread_idx": {
+          "name": "posts_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"thread_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_boost_of_idx": {
+          "name": "posts_boost_of_idx",
+          "columns": [
+            {
+              "expression": "boost_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_one_boost_per_account_key": {
+          "name": "posts_one_boost_per_account_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "boost_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"posts\".\"type\" = 'boost' and \"posts\".\"boost_of\" is not null and \"posts\".\"federation_activity_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_quote_of_idx": {
+          "name": "posts_quote_of_idx",
+          "columns": [
+            {
+              "expression": "quote_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_scheduled_idx": {
+          "name": "posts_scheduled_idx",
+          "columns": [
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"status\" = 'scheduled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_owner_scheduled_v1": {
+          "name": "post_owner_scheduled_v1",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"status\" = 'scheduled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_lane_chrono_v1": {
+          "name": "post_lane_chrono_v1",
+          "columns": [
+            {
+              "expression": "lane_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"lane_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_hashtags_gin": {
+          "name": "posts_hashtags_gin",
+          "columns": [
+            {
+              "expression": "hashtags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_classification_topics_gin": {
+          "name": "posts_classification_topics_gin",
+          "columns": [
+            {
+              "expression": "classification_topics",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_classification_languages_gin": {
+          "name": "posts_classification_languages_gin",
+          "columns": [
+            {
+              "expression": "classification_languages",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_classification_trend_terms_gin": {
+          "name": "posts_classification_trend_terms_gin",
+          "columns": [
+            {
+              "expression": "classification_trend_terms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_classification_region_idx": {
+          "name": "posts_classification_region_idx",
+          "columns": [
+            {
+              "expression": "classification_region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"classification_region\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_classification_queue_idx": {
+          "name": "posts_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_curated_idx": {
+          "name": "posts_curated_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"curated\" is true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_geo_gist": {
+          "name": "posts_geo_gist",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"geo\" is not null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "posts_content_geo_gist": {
+          "name": "posts_content_geo_gist",
+          "columns": [
+            {
+              "expression": "content_geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"content_geo\" is not null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_boost_of_posts_id_fk": {
+          "name": "posts_boost_of_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "boost_of"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_quote_of_posts_id_fk": {
+          "name": "posts_quote_of_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "quote_of"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_lane_id_lanes_id_fk": {
+          "name": "posts_lane_id_lanes_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "lanes",
+          "columnsFrom": [
+            "lane_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_parent_post_id_posts_id_fk": {
+          "name": "posts_parent_post_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "parent_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_thread_id_posts_id_fk": {
+          "name": "posts_thread_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "posts_created_at_ms_precision_check": {
+          "name": "posts_created_at_ms_precision_check",
+          "value": "\"posts\".\"created_at\" = date_trunc('milliseconds', \"posts\".\"created_at\")"
+        },
+        "posts_type_check": {
+          "name": "posts_type_check",
+          "value": "\"posts\".\"type\" in ('text', 'image', 'video', 'poll', 'boost', 'quote')"
+        },
+        "posts_visibility_check": {
+          "name": "posts_visibility_check",
+          "value": "\"posts\".\"visibility\" in ('public', 'followers_only', 'private')"
+        },
+        "posts_status_check": {
+          "name": "posts_status_check",
+          "value": "\"posts\".\"status\" in ('draft', 'published', 'scheduled', 'restricted')"
+        },
+        "posts_room_status_check": {
+          "name": "posts_room_status_check",
+          "value": "\"posts\".\"content_room_status\" is null or \"posts\".\"content_room_status\" in ('scheduled', 'live', 'ended')"
+        },
+        "posts_classification_status_check": {
+          "name": "posts_classification_status_check",
+          "value": "\"posts\".\"classification_status\" in ('pending', 'baseline', 'classified', 'failed')"
+        },
+        "posts_classification_sentiment_check": {
+          "name": "posts_classification_sentiment_check",
+          "value": "\"posts\".\"classification_sentiment\" in ('positive', 'neutral', 'negative', 'mixed')"
+        },
+        "posts_classification_intent_check": {
+          "name": "posts_classification_intent_check",
+          "value": "\"posts\".\"classification_intent\" in ('question', 'announcement', 'feedback', 'opinion', 'complaint', 'joke', 'news', 'personal_update', 'other')"
+        },
+        "posts_reply_permission_check": {
+          "name": "posts_reply_permission_check",
+          "value": "\"posts\".\"reply_permission\" <@ array['anyone', 'followers', 'following', 'mentioned', 'nobody']::text[]"
+        },
+        "posts_classification_scores_check": {
+          "name": "posts_classification_scores_check",
+          "value": "\"posts\".\"classification_score_toxicity\" between 0 and 1\n        and \"posts\".\"classification_score_constructiveness\" between 0 and 1\n        and \"posts\".\"classification_score_spam\" between 0 and 1\n        and \"posts\".\"classification_score_quality\" between 0 and 1\n        and \"posts\".\"classification_score_controversy\" between 0 and 1\n        and \"posts\".\"classification_score_negativity\" between 0 and 1\n        and \"posts\".\"classification_confidence\" between 0 and 1"
+        },
+        "posts_content_location_pair_check": {
+          "name": "posts_content_location_pair_check",
+          "value": "(\"posts\".\"content_location_latitude\" is null) = (\"posts\".\"content_location_longitude\" is null)"
+        },
+        "posts_location_pair_check": {
+          "name": "posts_location_pair_check",
+          "value": "(\"posts\".\"location_latitude\" is null) = (\"posts\".\"location_longitude\" is null)"
+        },
+        "posts_content_location_range_check": {
+          "name": "posts_content_location_range_check",
+          "value": "\"posts\".\"content_location_latitude\" is null or (\n        \"posts\".\"content_location_latitude\" between -90 and 90\n        and \"posts\".\"content_location_longitude\" between -180 and 180)"
+        },
+        "posts_location_range_check": {
+          "name": "posts_location_range_check",
+          "value": "\"posts\".\"location_latitude\" is null or (\n        \"posts\".\"location_latitude\" between -90 and 90\n        and \"posts\".\"location_longitude\" between -180 and 180)"
+        },
+        "posts_reply_discriminator_check": {
+          "name": "posts_reply_discriminator_check",
+          "value": "\"posts\".\"parent_post_id\" is null or \"posts\".\"is_reply\""
+        },
+        "posts_federated_reply_discriminator_check": {
+          "name": "posts_federated_reply_discriminator_check",
+          "value": "\"posts\".\"federation_in_reply_to\" is null or \"posts\".\"is_reply\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.poll_options": {
+      "name": "poll_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_options_poll_id_polls_id_fk": {
+          "name": "poll_options_poll_id_polls_id_fk",
+          "tableFrom": "poll_options",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_options_poll_id_position_key": {
+          "name": "poll_options_poll_id_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poll_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "poll_options_position_check": {
+          "name": "poll_options_position_check",
+          "value": "\"poll_options\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.poll_votes": {
+      "name": "poll_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "poll_votes_poll_id_idx": {
+          "name": "poll_votes_poll_id_idx",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "poll_votes_poll_id_user_id_idx": {
+          "name": "poll_votes_poll_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "poll_votes_option_id_poll_options_id_fk": {
+          "name": "poll_votes_option_id_poll_options_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "poll_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_votes_poll_id_polls_id_fk": {
+          "name": "poll_votes_poll_id_polls_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_votes_option_id_user_id_key": {
+          "name": "poll_votes_option_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "option_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_multiple_choice": {
+          "name": "is_multiple_choice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "polls_created_by_idx": {
+          "name": "polls_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "polls_ends_at_idx": {
+          "name": "polls_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "polls_post_id_idx": {
+          "name": "polls_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"polls\".\"post_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "polls_post_id_posts_id_fk": {
+          "name": "polls_post_id_posts_id_fk",
+          "tableFrom": "polls",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_authors": {
+      "name": "user_behavior_authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interaction_count": {
+          "name": "interaction_count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_interaction_at": {
+          "name": "last_interaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "boosts": {
+          "name": "boosts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "saves": {
+          "name": "saves",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shares": {
+          "name": "shares",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_behavior_authors_author_id_idx": {
+          "name": "user_behavior_authors_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_behavior_authors_behavior_id_user_behaviors_id_fk": {
+          "name": "user_behavior_authors_behavior_id_user_behaviors_id_fk",
+          "tableFrom": "user_behavior_authors",
+          "tableTo": "user_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_behavior_authors_behavior_id_author_id_key": {
+          "name": "user_behavior_authors_behavior_id_author_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "author_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_behavior_authors_weight_check": {
+          "name": "user_behavior_authors_weight_check",
+          "value": "\"user_behavior_authors\".\"weight\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_regions": {
+      "name": "user_behavior_regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_interaction_at": {
+          "name": "last_interaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_behavior_regions_behavior_id_user_behaviors_id_fk": {
+          "name": "user_behavior_regions_behavior_id_user_behaviors_id_fk",
+          "tableFrom": "user_behavior_regions",
+          "tableTo": "user_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_behavior_regions_behavior_id_region_key": {
+          "name": "user_behavior_regions_behavior_id_region_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "region"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_behavior_regions_count_check": {
+          "name": "user_behavior_regions_count_check",
+          "value": "\"user_behavior_regions\".\"count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_topics": {
+      "name": "user_behavior_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interaction_count": {
+          "name": "interaction_count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_interaction_at": {
+          "name": "last_interaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_behavior_topics_behavior_id_user_behaviors_id_fk": {
+          "name": "user_behavior_topics_behavior_id_user_behaviors_id_fk",
+          "tableFrom": "user_behavior_topics",
+          "tableTo": "user_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_behavior_topics_behavior_id_topic_key": {
+          "name": "user_behavior_topics_behavior_id_topic_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "topic"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_behavior_topics_weight_check": {
+          "name": "user_behavior_topics_weight_check",
+          "value": "\"user_behavior_topics\".\"weight\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_behaviors": {
+      "name": "user_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_post_type_text": {
+          "name": "preferred_post_type_text",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_post_type_image": {
+          "name": "preferred_post_type_image",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_post_type_video": {
+          "name": "preferred_post_type_video",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_post_type_poll": {
+          "name": "preferred_post_type_poll",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_hours": {
+          "name": "active_hours",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_languages": {
+          "name": "preferred_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_engagement_time": {
+          "name": "average_engagement_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skip_rate": {
+          "name": "skip_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completion_rate": {
+          "name": "completion_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hidden_authors": {
+          "name": "hidden_authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_authors": {
+          "name": "muted_authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_authors": {
+          "name": "blocked_authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden_topics": {
+          "name": "hidden_topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_behaviors_oxy_user_id_key": {
+          "name": "user_behaviors_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_behaviors_rates_check": {
+          "name": "user_behaviors_rates_check",
+          "value": "\"user_behaviors\".\"skip_rate\" between 0 and 1 and \"user_behaviors\".\"completion_rate\" between 0 and 1"
+        },
+        "user_behaviors_active_hours_check": {
+          "name": "user_behaviors_active_hours_check",
+          "value": "\"user_behaviors\".\"active_hours\" <@ array[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]::integer[]"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appearance_theme_mode": {
+          "name": "appearance_theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "appearance_primary_color": {
+          "name": "appearance_primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance_post_text_expand": {
+          "name": "appearance_post_text_expand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "appearance_post_read_more_action": {
+          "name": "appearance_post_read_more_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openPost'"
+        },
+        "appearance_collapse_long_bio": {
+          "name": "appearance_collapse_long_bio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "profile_header_image": {
+          "name": "profile_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_profile_visibility": {
+          "name": "privacy_profile_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "privacy_show_contact_info": {
+          "name": "privacy_show_contact_info",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_tags": {
+          "name": "privacy_allow_tags",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_mentions": {
+          "name": "privacy_allow_mentions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_show_online_status": {
+          "name": "privacy_show_online_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_hide_like_counts": {
+          "name": "privacy_hide_like_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_share_counts": {
+          "name": "privacy_hide_share_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_reply_counts": {
+          "name": "privacy_hide_reply_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_save_counts": {
+          "name": "privacy_hide_save_counts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_show_sensitive_content": {
+          "name": "privacy_show_sensitive_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hidden_words": {
+          "name": "privacy_hidden_words",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_restricted_users": {
+          "name": "privacy_restricted_users",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_subscribed_labelers": {
+          "name": "privacy_subscribed_labelers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_account_sign_posts": {
+          "name": "channel_account_sign_posts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_cover_photo_enabled": {
+          "name": "profile_cover_photo_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "profile_minimalist_mode": {
+          "name": "profile_minimalist_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_media_type": {
+          "name": "profile_media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_title": {
+          "name": "profile_media_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_artwork_url": {
+          "name": "profile_media_artwork_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_syra_track_id": {
+          "name": "profile_media_syra_track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_artist": {
+          "name": "profile_media_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_preview_url": {
+          "name": "profile_media_preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_start_sec": {
+          "name": "profile_media_start_sec",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_duration_sec": {
+          "name": "profile_media_duration_sec",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_syra_podcast_id": {
+          "name": "profile_media_syra_podcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_author": {
+          "name": "profile_media_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_show_url": {
+          "name": "profile_media_show_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interest_tags": {
+          "name": "interest_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_diversity_enabled": {
+          "name": "feed_diversity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "feed_same_author_penalty": {
+          "name": "feed_same_author_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.95
+        },
+        "feed_same_topic_penalty": {
+          "name": "feed_same_topic_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.92
+        },
+        "feed_max_consecutive_same_author": {
+          "name": "feed_max_consecutive_same_author",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_recency_half_life_hours": {
+          "name": "feed_recency_half_life_hours",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "feed_recency_max_age_hours": {
+          "name": "feed_recency_max_age_hours",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 168
+        },
+        "feed_min_engagement_rate": {
+          "name": "feed_min_engagement_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_boost_high_quality": {
+          "name": "feed_boost_high_quality",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tuning_min_length_enabled": {
+          "name": "tuning_min_length_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_length": {
+          "name": "tuning_min_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_low_effort_gate_enabled": {
+          "name": "tuning_low_effort_gate_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_meaningful_text_length": {
+          "name": "tuning_min_meaningful_text_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_native_engagement_enabled": {
+          "name": "tuning_native_engagement_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_native_engagement": {
+          "name": "tuning_min_native_engagement",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_quality_enabled": {
+          "name": "tuning_min_quality_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuning_min_quality": {
+          "name": "tuning_min_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_push_enabled": {
+          "name": "notify_push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_email_enabled": {
+          "name": "notify_email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_likes": {
+          "name": "notify_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_boosts": {
+          "name": "notify_boosts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_follows": {
+          "name": "notify_follows",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_mentions": {
+          "name": "notify_mentions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_replies": {
+          "name": "notify_replies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_quotes": {
+          "name": "notify_quotes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "embed_youtube": {
+          "name": "embed_youtube",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_youtube_shorts": {
+          "name": "embed_youtube_shorts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_vimeo": {
+          "name": "embed_vimeo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_twitch": {
+          "name": "embed_twitch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_giphy": {
+          "name": "embed_giphy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_spotify": {
+          "name": "embed_spotify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_apple_music": {
+          "name": "embed_apple_music",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_soundcloud": {
+          "name": "embed_soundcloud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_flickr": {
+          "name": "embed_flickr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_bandcamp": {
+          "name": "embed_bandcamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fediverse_preferred_language": {
+          "name": "fediverse_preferred_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_oxy_user_id_key": {
+          "name": "user_settings_oxy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oxy_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_settings_theme_mode_check": {
+          "name": "user_settings_theme_mode_check",
+          "value": "\"user_settings\".\"appearance_theme_mode\" in ('light', 'dark', 'system', 'adaptive')"
+        },
+        "user_settings_post_text_expand_check": {
+          "name": "user_settings_post_text_expand_check",
+          "value": "\"user_settings\".\"appearance_post_text_expand\" in ('default', 'more', 'muchMore', 'all')"
+        },
+        "user_settings_post_read_more_action_check": {
+          "name": "user_settings_post_read_more_action_check",
+          "value": "\"user_settings\".\"appearance_post_read_more_action\" in ('openPost', 'expandInline')"
+        },
+        "user_settings_profile_visibility_check": {
+          "name": "user_settings_profile_visibility_check",
+          "value": "\"user_settings\".\"privacy_profile_visibility\" in ('public', 'private', 'followers_only')"
+        },
+        "user_settings_profile_media_type_check": {
+          "name": "user_settings_profile_media_type_check",
+          "value": "\"user_settings\".\"profile_media_type\" is null or \"user_settings\".\"profile_media_type\" in ('song', 'podcast')"
+        },
+        "user_settings_profile_media_shape_check": {
+          "name": "user_settings_profile_media_shape_check",
+          "value": "(\"user_settings\".\"profile_media_type\" is null\n          and \"user_settings\".\"profile_media_syra_track_id\" is null\n          and \"user_settings\".\"profile_media_syra_podcast_id\" is null)\n        or (\"user_settings\".\"profile_media_type\" = 'song'\n          and \"user_settings\".\"profile_media_syra_track_id\" is not null\n          and \"user_settings\".\"profile_media_preview_url\" is not null\n          and \"user_settings\".\"profile_media_syra_podcast_id\" is null)\n        or (\"user_settings\".\"profile_media_type\" = 'podcast'\n          and \"user_settings\".\"profile_media_syra_podcast_id\" is not null\n          and \"user_settings\".\"profile_media_show_url\" is not null\n          and \"user_settings\".\"profile_media_syra_track_id\" is null)"
+        },
+        "user_settings_feed_penalties_check": {
+          "name": "user_settings_feed_penalties_check",
+          "value": "\"user_settings\".\"feed_same_author_penalty\" between 0.5 and 1.0\n        and \"user_settings\".\"feed_same_topic_penalty\" between 0.5 and 1.0"
+        },
+        "user_settings_feed_recency_check": {
+          "name": "user_settings_feed_recency_check",
+          "value": "\"user_settings\".\"feed_recency_half_life_hours\" between 6 and 72\n        and \"user_settings\".\"feed_recency_max_age_hours\" between 24 and 336"
+        },
+        "user_settings_feed_min_engagement_check": {
+          "name": "user_settings_feed_min_engagement_check",
+          "value": "\"user_settings\".\"feed_min_engagement_rate\" is null or \"user_settings\".\"feed_min_engagement_rate\" between 0 and 1"
+        },
+        "user_settings_max_consecutive_same_author_check": {
+          "name": "user_settings_max_consecutive_same_author_check",
+          "value": "\"user_settings\".\"feed_max_consecutive_same_author\" is null\n        or \"user_settings\".\"feed_max_consecutive_same_author\" between 1 and 10"
+        },
+        "user_settings_external_embeds_check": {
+          "name": "user_settings_external_embeds_check",
+          "value": "(\"user_settings\".\"embed_youtube\" is null or \"user_settings\".\"embed_youtube\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_youtube_shorts\" is null or \"user_settings\".\"embed_youtube_shorts\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_vimeo\" is null or \"user_settings\".\"embed_vimeo\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_twitch\" is null or \"user_settings\".\"embed_twitch\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_giphy\" is null or \"user_settings\".\"embed_giphy\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_spotify\" is null or \"user_settings\".\"embed_spotify\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_apple_music\" is null or \"user_settings\".\"embed_apple_music\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_soundcloud\" is null or \"user_settings\".\"embed_soundcloud\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_flickr\" is null or \"user_settings\".\"embed_flickr\" in ('show', 'hide'))\n        and (\"user_settings\".\"embed_bandcamp\" is null or \"user_settings\".\"embed_bandcamp\" in ('show', 'hide'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_settings_label_actions": {
+      "name": "user_settings_label_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "settings_id": {
+          "name": "settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_id": {
+          "name": "labeler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_slug": {
+          "name": "label_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_label_actions_settings_id_user_settings_id_fk": {
+          "name": "user_settings_label_actions_settings_id_user_settings_id_fk",
+          "tableFrom": "user_settings_label_actions",
+          "tableTo": "user_settings",
+          "columnsFrom": [
+            "settings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_label_actions_settings_labeler_slug_key": {
+          "name": "user_settings_label_actions_settings_labeler_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "settings_id",
+            "labeler_id",
+            "label_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_settings_label_actions_action_check": {
+          "name": "user_settings_label_actions_action_check",
+          "value": "\"user_settings_label_actions\".\"action\" in ('hide', 'warn', 'blur', 'show')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/meta/_journal.json
+++ b/packages/backend/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1786811476871,
       "tag": "0024_drop_backfill_bookkeeping_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1786814217255,
+      "tag": "0025_posts_indexes_stop_indexing_absence",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/__tests__/db/hotPathIndexes.test.ts
+++ b/packages/backend/src/__tests__/db/hotPathIndexes.test.ts
@@ -1,6 +1,6 @@
 /**
- * The named indexes a measured hot path depends on still exist, spelled the way
- * the query that reads them is spelled.
+ * Every index on `posts` is classified, exists, and is declared exactly as
+ * written here.
  *
  * ## Why an index needs a test of its own
  *
@@ -19,27 +19,41 @@
  *
  *   * a GENERATED column's expression changes, and `drizzle-kit generate` emits
  *     `DROP COLUMN` + `ADD COLUMN` — which takes every index over that column
- *     with it and re-emits none of them;
+ *     with it and re-emits none of them. `posts.geo` and `posts.content_geo` are
+ *     generated and carry two of the indexes below;
  *   * an index is regenerated with drizzle's query-side default spelling, so it
  *     declares `DESC NULLS FIRST`. It exists, it is the right columns, and
  *     Postgres will not use it for the order the code asks for. That is the
  *     failure `chronoOrderPlan.test.ts` exists for, and this file is the half of
  *     it that names the index rather than iterating whatever happens to match.
  *
+ * ## Why the map is EXHAUSTIVE over `posts`
+ *
+ * A gate that skips what is missing from a hand-maintained map is not a gate.
+ * `everyPostsIndexIsClassified` asserts the catalogue's set of `posts` indexes
+ * EQUALS this file's, so a new index that nobody classified fails the build and
+ * a dropped one fails it too. That is the whole output of the #753 audit: not a
+ * verdict frozen in a document, but a list that stops being true out loud.
+ *
+ * Each entry states what pays when it is gone, so a failure reads as an
+ * instruction rather than a name — and, for the four indexes the audit narrowed
+ * to partial, what makes the narrowing safe.
+ *
  * ## Why the whole `indexdef`, and why by NAME
  *
  * The definition, because "an index called X exists" is satisfied by an index on
- * the wrong columns in the wrong order with the wrong NULLS placement — which is
- * exactly the second failure above. By name, because
- * `chronoOrderPlan.test.ts` asserts a PROPERTY over every `posts` index matching
- * a pattern (`created_at desc`), and its vacuity floor is a count: an index that
- * disappears leaves that loop iterating nine instead of ten and green either
- * way. A property over a set and the membership of that set are two claims.
+ * the wrong columns in the wrong order with the wrong NULLS placement — and,
+ * since the audit, by one whose partial predicate has quietly widened or
+ * narrowed. By name, because `chronoOrderPlan.test.ts` asserts a PROPERTY over
+ * every `posts` index matching a pattern (`created_at desc`), and its vacuity
+ * floor is a count: an index that disappears leaves that loop iterating nine
+ * instead of ten and green either way. A property over a set and the membership
+ * of that set are two claims.
  *
  * ## What this file deliberately does not do
  *
  * It runs no `EXPLAIN`. Asserting a plan over `posts` asserts the planner's
- * CHOICE among a dozen candidate indexes, which moves with the statistics every
+ * CHOICE among two dozen candidate indexes, which moves with the statistics every
  * other file in a parallel run changes — `chronoOrderPlan.test.ts` shipped that
  * and it was flaky twice in eight runs. The property here is what the DDL
  * DECLARES; that the declaration is what makes an index usable is measured next
@@ -52,14 +66,13 @@ import { sql } from 'drizzle-orm';
 import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
 
 /**
- * One index this repository has measured a hot path against, its exact
- * definition, and the path that pays when it is gone.
+ * One index, its exact definition, and what pays when it is gone.
  *
  * The definition is the `pg_indexes.indexdef` a migrated database reports, minus
- * nothing — schema qualification and `USING btree` included, because a change to
- * either is a change worth reading.
+ * nothing — schema qualification, `USING btree`, and the normalised partial
+ * predicate included, because a change to any of them is a change worth reading.
  */
-interface HotPathIndex {
+interface ClassifiedIndex {
   name: string;
   table: string;
   /** What breaks — slowly, silently — if this index stops existing. */
@@ -67,54 +80,274 @@ interface HotPathIndex {
   definition: string;
 }
 
-const HOT_PATH_INDEXES: readonly HotPathIndex[] = [
+/**
+ * Every index on `posts`, classified. Order follows `db/schema/posts.ts`.
+ *
+ * Measured on 2026-08-15 against a private PostGIS 17 container seeded to 300k
+ * posts (200k roots / 100k replies, 12k authors, production-shaped
+ * distributions) — NOT production, and not the shared dev database. Sizes quoted
+ * in `serves` are from that corpus and are proportional, not absolute.
+ */
+const POSTS_INDEXES: readonly ClassifiedIndex[] = [
   {
-    name: 'post_authorships_author_chrono_idx',
-    table: 'post_authorships',
-    serves:
-      "the profile feed's authorship branch (`fetchAuthored`, mtn/feed/engine/sources/userSources.ts) — " +
-      'author, accepted, newest first, in one index, which is why `post_created_at` is copied onto this table at all',
-    definition:
-      'CREATE INDEX post_authorships_author_chrono_idx ON public.post_authorships ' +
-      'USING btree (oxy_user_id, status, post_created_at DESC NULLS LAST, post_id DESC NULLS LAST)',
+    name: 'posts_pkey',
+    table: 'posts',
+    serves: 'the primary key — every id lookup, and the target of five self-referencing foreign keys',
+    definition: 'CREATE UNIQUE INDEX posts_pkey ON public.posts USING btree (id)',
   },
   {
-    name: 'posts_owner_chrono_idx',
+    name: 'posts_federation_activity_id_key',
     table: 'posts',
     serves:
-      "the profile feed's owner branch (`fetchAuthored`) — the denormalized owner reached chronologically, " +
-      'the cheaper of the two routes the `union` merges',
+      'federation dedup — a CONSTRAINT, not a performance index: it is the only identity a remote ' +
+      'instance guarantees for an activity, and dropping it duplicates every redelivered Announce',
     definition:
-      'CREATE INDEX posts_owner_chrono_idx ON public.posts ' +
-      'USING btree (oxy_user_id, visibility, status, created_at DESC NULLS LAST, id DESC NULLS LAST)',
-  },
-  {
-    name: 'post_links_chrono_v1',
-    table: 'posts',
-    serves:
-      'search `has:links` (routes/search.ts) — the only query this index exists for, and the one that ' +
-      'made it 99 MB of pure write amplification for as long as the query was spelled `desc()`',
-    definition:
-      'CREATE INDEX post_links_chrono_v1 ON public.posts ' +
-      'USING btree (has_links, visibility, status, created_at DESC NULLS LAST, id DESC NULLS LAST)',
+      'CREATE UNIQUE INDEX posts_federation_activity_id_key ON public.posts ' +
+      'USING btree (federation_activity_id) WHERE (federation_activity_id IS NOT NULL)',
   },
   {
     name: 'post_public_chrono_v1',
     table: 'posts',
-    serves: 'every public chronological scan — the feed engine\'s `fetchChrono` and post search',
+    serves:
+      "every public chronological scan that does NOT fix `is_reply` — post search with no operators, " +
+      "and the feed engine's `fetchChrono`. Reachability is not assumed: the negative control in this " +
+      'file drives a query onto it and reads it back out of the plan',
     definition:
       'CREATE INDEX post_public_chrono_v1 ON public.posts ' +
       'USING btree (visibility, status, created_at DESC NULLS LAST, id DESC NULLS LAST)',
   },
   {
+    name: 'posts_roots_chrono_idx',
+    table: 'posts',
+    serves:
+      'the root feeds, which all fix `is_reply = false`. Its key columns are IDENTICAL to ' +
+      '`post_public_chrono_v1` and it is still not redundant with it, in either direction: this one is ' +
+      'the size of the root set and applies the filter the planner would otherwise re-check per row, ' +
+      'and the full one serves the queries that carry no `is_reply` term at all',
+    definition:
+      'CREATE INDEX posts_roots_chrono_idx ON public.posts ' +
+      'USING btree (visibility, status, created_at DESC NULLS LAST, id DESC NULLS LAST) ' +
+      'WHERE (is_reply = false)',
+  },
+  {
     name: 'post_replies_chrono_v1',
     table: 'posts',
-    serves: 'a post\'s replies, oldest- or newest-first (the index is read backwards for ascending)',
+    serves: "a post's replies, newest- or oldest-first (the index is read backwards for ascending)",
     definition:
       'CREATE INDEX post_replies_chrono_v1 ON public.posts ' +
       'USING btree (parent_post_id, visibility, status, created_at DESC NULLS LAST, id DESC NULLS LAST)',
   },
+  {
+    name: 'post_links_chrono_v1',
+    table: 'posts',
+    serves:
+      'search `has:links` (`routes/search.ts`) — the only query this index exists for, and the one that ' +
+      'made it pure write amplification for as long as the query was spelled `desc()`',
+    definition:
+      'CREATE INDEX post_links_chrono_v1 ON public.posts ' +
+      'USING btree (has_links, visibility, status, created_at DESC NULLS LAST, id DESC NULLS LAST)',
+  },
+  {
+    name: 'posts_owner_chrono_idx',
+    table: 'posts',
+    serves:
+      "the profile feed's owner branch (`fetchAuthored`, mtn/feed/engine/sources/userSources.ts) — the " +
+      'denormalized owner reached chronologically, the cheaper of the two routes the `union` merges',
+    definition:
+      'CREATE INDEX posts_owner_chrono_idx ON public.posts ' +
+      'USING btree (oxy_user_id, visibility, status, created_at DESC NULLS LAST, id DESC NULLS LAST)',
+  },
+  {
+    name: 'posts_type_chrono_idx',
+    table: 'posts',
+    serves:
+      'the GLOBAL media and videos feeds — `inArray(posts.type, [IMAGE, VIDEO])` in ' +
+      '`utils/feedQueryBuilder.ts`, which is the one place a `type` predicate leads with no author term ' +
+      'to send the planner somewhere cheaper',
+    definition:
+      'CREATE INDEX posts_type_chrono_idx ON public.posts ' +
+      'USING btree (type, visibility, status, created_at DESC NULLS LAST)',
+  },
+  {
+    name: 'posts_created_at_idx',
+    table: 'posts',
+    serves:
+      'a chronological scan carrying no visibility/status term. It is the ONLY index on this table whose ' +
+      'leading column is `created_at`, so nothing else can serve that shape — which is also why the ' +
+      "audit's left-prefix rule does not condemn it despite being one column wide",
+    definition: 'CREATE INDEX posts_created_at_idx ON public.posts USING btree (created_at DESC NULLS LAST)',
+  },
+  {
+    name: 'posts_thread_idx',
+    table: 'posts',
+    serves:
+      'the self-thread spine — `feed.controller.getSelfThreadContinuations` and `ThreadSlicingService`, ' +
+      'both `eq(thread_id, X)`. NARROWED to partial by the #753 audit (23 MB → 2992 kB): ~90% of its ' +
+      'entries were rows with a NULL `thread_id` that no query reaching it can return, and no predicate ' +
+      'anywhere in the tree asks for that side',
+    definition:
+      'CREATE INDEX posts_thread_idx ON public.posts ' +
+      'USING btree (thread_id, oxy_user_id, parent_post_id, created_at) WHERE (thread_id IS NOT NULL)',
+  },
+  {
+    name: 'posts_boost_of_idx',
+    table: 'posts',
+    serves:
+      '"who boosted this post" — `inArray(posts.boostOf, ids)` in the deletion cascade, engagement ' +
+      'recompute and the AP inbox. KEPT FULL although `boost_of` is NULL on ~95% of rows: ' +
+      '`notABoostSql()` is `isNull(posts.boostOf)` and runs on hot feed paths, so a partial index ' +
+      'excluding NULLs would silently stop being available to them',
+    definition:
+      'CREATE INDEX posts_boost_of_idx ON public.posts USING btree (boost_of, created_at DESC NULLS LAST)',
+  },
+  {
+    name: 'posts_one_boost_per_account_key',
+    table: 'posts',
+    serves:
+      'one NATIVE boost per account per post — a CONSTRAINT. `federation_activity_id is null` in the ' +
+      'predicate is load-bearing: widen it and a re-Announced remote boost 23505s inside the inbox ' +
+      'worker, which retries forever',
+    definition:
+      'CREATE UNIQUE INDEX posts_one_boost_per_account_key ON public.posts USING btree (oxy_user_id, boost_of) ' +
+      "WHERE ((type = 'boost'::text) AND (boost_of IS NOT NULL) AND (federation_activity_id IS NULL))",
+  },
+  {
+    name: 'posts_quote_of_idx',
+    table: 'posts',
+    serves:
+      'quotes of a given post. KEPT FULL for the same reason as `posts_boost_of_idx` — ' +
+      '`scripts/backfillQuotedPosts.ts` spells `isNull(posts.quoteOf)`',
+    definition:
+      'CREATE INDEX posts_quote_of_idx ON public.posts USING btree (quote_of, created_at DESC NULLS LAST)',
+  },
+  {
+    name: 'posts_scheduled_idx',
+    table: 'posts',
+    serves:
+      'the site-wide scheduled SWEEP, which wants every due post regardless of owner. Partial, so it ' +
+      'indexes a set that drains every 60 seconds rather than the table',
+    definition:
+      "CREATE INDEX posts_scheduled_idx ON public.posts USING btree (scheduled_for) WHERE (status = 'scheduled'::text)",
+  },
+  {
+    name: 'post_owner_scheduled_v1',
+    table: 'posts',
+    serves:
+      "ONE account's queue — `GET /posts/scheduled`. `posts_scheduled_idx` cannot serve it (wrong leading " +
+      "column), which is why both exist: without this one a member's queue read costs a scan " +
+      'proportional to how much everybody else has scheduled',
+    definition:
+      'CREATE INDEX post_owner_scheduled_v1 ON public.posts USING btree (oxy_user_id, scheduled_for) ' +
+      "WHERE (status = 'scheduled'::text)",
+  },
+  {
+    name: 'post_lane_chrono_v1',
+    table: 'posts',
+    serves: "the lane tab's keyset — `laneSource` pages ONE lane on `(created_at, id)`",
+    definition:
+      'CREATE INDEX post_lane_chrono_v1 ON public.posts ' +
+      'USING btree (lane_id, visibility, status, created_at DESC NULLS LAST, id DESC NULLS LAST) ' +
+      'WHERE (lane_id IS NOT NULL)',
+  },
+  {
+    name: 'posts_hashtags_gin',
+    table: 'posts',
+    serves: 'hashtag feeds and `trendTermMatchSql` — an array overlap a btree cannot serve at all',
+    definition: 'CREATE INDEX posts_hashtags_gin ON public.posts USING gin (hashtags)',
+  },
+  {
+    name: 'posts_classification_topics_gin',
+    table: 'posts',
+    serves: 'topic-matched feed candidates and the trend term space',
+    definition:
+      'CREATE INDEX posts_classification_topics_gin ON public.posts USING gin (classification_topics)',
+  },
+  {
+    name: 'posts_classification_languages_gin',
+    table: 'posts',
+    serves: "language-matched feed candidates and search's `language=` filter",
+    definition:
+      'CREATE INDEX posts_classification_languages_gin ON public.posts USING gin (classification_languages)',
+  },
+  {
+    name: 'posts_classification_trend_terms_gin',
+    table: 'posts',
+    serves: '`trendTermMatchSql` — trend detection, trend feeds and excerpt lookup',
+    definition:
+      'CREATE INDEX posts_classification_trend_terms_gin ON public.posts USING gin (classification_trend_terms)',
+  },
+  {
+    name: 'posts_classification_region_idx',
+    table: 'posts',
+    serves:
+      'region-matched feed candidates (`forYouCandidateSources`, `relatedSources`). NARROWED to partial ' +
+      'by the #753 audit (9264 kB → 2080 kB); the only predicates are `eq(classification_region, X)` and ' +
+      'nothing asks for the unclassified side',
+    definition:
+      'CREATE INDEX posts_classification_region_idx ON public.posts ' +
+      'USING btree (classification_region, created_at DESC NULLS LAST) WHERE (classification_region IS NOT NULL)',
+  },
+  {
+    name: 'posts_classification_queue_idx',
+    table: 'posts',
+    serves:
+      'the Stage-B classification queue, which drains oldest-first within one status. Ascending ' +
+      '`created_at` on purpose — this is the one chronological index here that is not a feed keyset',
+    definition:
+      'CREATE INDEX posts_classification_queue_idx ON public.posts USING btree (classification_status, created_at)',
+  },
+  {
+    name: 'posts_curated_idx',
+    table: 'posts',
+    serves:
+      'curated posts, newest first. Partial, and NOT redundant with `posts_created_at_idx` despite the ' +
+      'identical key: the total index is what a naive left-prefix rule would keep, and it is the one ' +
+      'that cannot apply the `curated` filter',
+    definition:
+      'CREATE INDEX posts_curated_idx ON public.posts USING btree (created_at DESC NULLS LAST) WHERE (curated IS TRUE)',
+  },
+  {
+    name: 'posts_geo_gist',
+    table: 'posts',
+    serves:
+      '`ST_DWithin` on the post location — the `nearby` controller. NARROWED to partial by the #753 ' +
+      'audit (20 MB → 488 kB, the single largest win): a GiST index indexes NULLs too, so the full form ' +
+      'paid an insert on every ordinary post for an entry no proximity query can match',
+    definition: 'CREATE INDEX posts_geo_gist ON public.posts USING gist (geo) WHERE (geo IS NOT NULL)',
+  },
+  {
+    name: 'posts_content_geo_gist',
+    table: 'posts',
+    serves:
+      '`ST_DWithin` on the content location. NARROWED with `posts_geo_gist` (19 MB → 264 kB); the ' +
+      'controller ORs the two, which still plans as a `BitmapOr` over both partial indexes',
+    definition:
+      'CREATE INDEX posts_content_geo_gist ON public.posts USING gist (content_geo) WHERE (content_geo IS NOT NULL)',
+  },
 ];
+
+/**
+ * Indexes on OTHER tables that a measured hot path depends on.
+ *
+ * Deliberately not exhaustive over their tables — the #753 audit's subject was
+ * `posts`, and a map claiming completeness it has not measured would be worse
+ * than one that says where its edge is. Widen it by auditing a table, not by
+ * appending to this list.
+ */
+const OTHER_TABLE_INDEXES: readonly ClassifiedIndex[] = [
+  {
+    name: 'post_authorships_author_chrono_idx',
+    table: 'post_authorships',
+    serves:
+      "the profile feed's authorship branch (`fetchAuthored`) — author, accepted, newest first, in one " +
+      'index, which is why `post_created_at` is copied onto that table at all',
+    definition:
+      'CREATE INDEX post_authorships_author_chrono_idx ON public.post_authorships ' +
+      'USING btree (oxy_user_id, status, post_created_at DESC NULLS LAST, post_id DESC NULLS LAST)',
+  },
+];
+
+const ALL_INDEXES: readonly ClassifiedIndex[] = [...POSTS_INDEXES, ...OTHER_TABLE_INDEXES];
 
 let db: Database;
 
@@ -132,6 +365,14 @@ async function indexDefinition(name: string): Promise<string | null> {
     sql`select indexdef from pg_indexes where schemaname = 'public' and indexname = ${name}`
   );
   return [...rows][0]?.indexdef ?? null;
+}
+
+/** Every index the catalogue holds for `table`. */
+async function catalogueIndexNames(table: string): Promise<string[]> {
+  const rows = await db.execute<{ indexname: string }>(
+    sql`select indexname from pg_indexes where schemaname = 'public' and tablename = ${table} order by indexname`
+  );
+  return [...rows].map((row) => row.indexname);
 }
 
 describe('the indexes the measured hot paths are built on', () => {
@@ -157,22 +398,55 @@ describe('the indexes the measured hot paths are built on', () => {
     await expect(indexDefinition('post_authorships_no_such_index')).resolves.toBeNull();
   });
 
-  it.each(HOT_PATH_INDEXES)('$name exists, on $table', async ({ name, table }) => {
+  it.each(ALL_INDEXES)('$name exists, on $table', async ({ name, table, serves }) => {
     const definition = await indexDefinition(name);
-    expect(definition, `${name} is missing — it serves ${
-      HOT_PATH_INDEXES.find((index) => index.name === name)?.serves
-    }`).not.toBeNull();
+    expect(definition, `${name} is missing — it serves ${serves}`).not.toBeNull();
     expect(definition).toContain(`ON public.${table} `);
   });
 
-  it.each(HOT_PATH_INDEXES)('$name is declared exactly as the query reads it', async ({ name, definition }) => {
+  it.each(ALL_INDEXES)('$name is declared exactly as the query reads it', async ({ name, definition }) => {
     /**
-     * The NULLS placement is the load-bearing half and the one with no symptom.
-     * Postgres matches an index to an ORDER BY on the NULLS placement as well as
-     * the direction, so an index regenerated with drizzle's query-side default
-     * (`DESC NULLS FIRST`) is present, correct, and unusable by the order every
-     * one of these paths asks for.
+     * Three things ride on the exact text, and none has a functional symptom:
+     * the NULLS placement (Postgres matches an index to an ORDER BY on it, so
+     * drizzle's query-side default `DESC NULLS FIRST` is present, correct and
+     * unusable), the column order, and — since the #753 audit — the partial
+     * predicate. A predicate that widens costs the disk the audit recovered; one
+     * that narrows makes the index unusable by the query it was cut for.
      */
     await expect(indexDefinition(name)).resolves.toBe(definition);
+  });
+});
+
+describe('the classification of `posts` indexes is exhaustive', () => {
+  it('classifies every index the catalogue holds, and holds every index it classifies', async () => {
+    /**
+     * The output of the #753 audit, expressed so it can stop being true.
+     *
+     * An equality, not two inclusions, because the two directions catch
+     * different mistakes and both matter: an index in the catalogue and not here
+     * is one nobody decided about — the exact state the audit found and resolved
+     * — and one here but not in the catalogue is a migration that took a live
+     * index with it. A `toContain` loop would pass in the first case, which is
+     * the case the audit exists to prevent recurring.
+     */
+    const catalogued = await catalogueIndexNames('posts');
+    const classified = POSTS_INDEXES.map((index) => index.name).sort();
+
+    expect(catalogued.length, 'no indexes read back for `posts` — the catalogue query is broken')
+      .toBeGreaterThanOrEqual(20);
+    expect(
+      catalogued,
+      'An index on `posts` is unclassified, or one classified here is gone.\n' +
+      'Add it to POSTS_INDEXES with its exact `pg_indexes.indexdef` and what pays when it is missing — ' +
+      'or, if a migration removed it, delete its entry in the SAME change.\n' +
+      'Do NOT relax this to a subset check: an index nobody decided about is what the #753 audit found.'
+    ).toEqual(classified);
+  });
+
+  it('names each index exactly once', () => {
+    // A duplicate entry would make the equality above pass while the count of
+    // distinct classifications silently disagreed with the list's length.
+    const names = ALL_INDEXES.map((index) => index.name);
+    expect(new Set(names).size).toBe(names.length);
   });
 });

--- a/packages/backend/src/db/schema/posts.ts
+++ b/packages/backend/src/db/schema/posts.ts
@@ -643,7 +643,43 @@ export const posts = pgTable(
     index('posts_owner_chrono_idx').on(t.oxyUserId, t.visibility, t.status, t.createdAt.desc(), t.id.desc()),
     index('posts_type_chrono_idx').on(t.type, t.visibility, t.status, t.createdAt.desc()),
     index('posts_created_at_idx').on(t.createdAt.desc()),
-    index('posts_thread_idx').on(t.threadId, t.oxyUserId, t.parentPostId, t.createdAt),
+    /**
+     * The self-thread spine — `(thread_id, author)`, oldest first.
+     *
+     * PARTIAL on `thread_id is not null`, and the predicate is doing real work
+     * rather than tidying: a thread is a rare shape, so the full index spent
+     * ~90% of its entries on rows whose `thread_id` is NULL and which no query
+     * reaching this index can ever return. Both consumers —
+     * `feed.controller.getSelfThreadContinuations` and `ThreadSlicingService` —
+     * spell it `eq(thread_id, X)`, which is strict, so Postgres proves the
+     * implication and still chooses the index. Measured on 300k seeded posts
+     * (30k threaded): 23 MB → 2992 kB, same `Index Scan using posts_thread_idx`
+     * with `parent_post_id IS NOT NULL` still in the Index Cond.
+     *
+     * There is NO `thread_id is null` predicate anywhere in the tree, which is
+     * what makes the narrowing safe — see `posts_boost_of_idx` below for the
+     * case where there IS one and the index therefore stays full.
+     */
+    index('posts_thread_idx')
+      .on(t.threadId, t.oxyUserId, t.parentPostId, t.createdAt)
+      .where(sql`${t.threadId} is not null`),
+    /**
+     * DELIBERATELY NOT PARTIAL, unlike its three neighbours above and below.
+     *
+     * `boost_of` is NULL on ~95% of rows, so `where boost_of is not null` would
+     * shrink this the way it shrank `posts_thread_idx` — and it is refused
+     * anyway, because `notABoostSql()` (`utils/feedQueryBuilder.ts`) is
+     * `isNull(posts.boostOf)` and runs on hot feed paths, with two more
+     * `isNull(boostOf)` predicates in `PostClassificationService` and
+     * `scripts/backfill-mtn-records.ts`. A partial index cannot serve a query
+     * asking for the rows it excludes, and the failure has no symptom: those
+     * queries would silently stop having this index available and get slower
+     * under a row count no local corpus reproduces.
+     *
+     * The same reasoning holds `posts_quote_of_idx` full — `backfillQuotedPosts`
+     * spells `isNull(posts.quoteOf)`. Both were measured and kept: the rule that
+     * decides is "does anything ask for the NULL side", not the NULL fraction.
+     */
     index('posts_boost_of_idx').on(t.boostOf, t.createdAt.desc()),
     /**
      * One NATIVE boost per account per post — the constraint that makes "have
@@ -739,7 +775,21 @@ export const posts = pgTable(
     index('posts_classification_topics_gin').using('gin', t.classificationTopics),
     index('posts_classification_languages_gin').using('gin', t.classificationLanguages),
     index('posts_classification_trend_terms_gin').using('gin', t.classificationTrendTerms),
-    index('posts_classification_region_idx').on(t.classificationRegion, t.createdAt.desc()),
+    /**
+     * PARTIAL on `classification_region is not null`. The only two predicates
+     * are `eq(posts.classificationRegion, region)` (`forYouCandidateSources`,
+     * `relatedSources`) — strict, so the implication is provable — and nothing
+     * anywhere asks for the unclassified-region side. Measured on the seeded
+     * corpus (22% of rows carry a region): 9264 kB → 2080 kB, still
+     * `Index Scan using posts_classification_region_idx`.
+     *
+     * `TrendingService` and `discoverySources` also name the column, but as a
+     * SELECT projection and inside a `case when` scoring expression — neither is
+     * a predicate and neither can reach an index either way.
+     */
+    index('posts_classification_region_idx')
+      .on(t.classificationRegion, t.createdAt.desc())
+      .where(sql`${t.classificationRegion} is not null`),
     // The classification batch queue drains oldest-first within one status.
     index('posts_classification_queue_idx').on(t.classificationStatus, t.createdAt),
 
@@ -749,9 +799,29 @@ export const posts = pgTable(
       .on(t.createdAt.desc())
       .where(sql`${t.curated} is true`),
 
-    // The two spatial indexes, replacing the `2dsphere` pair. GiST over the
-    // GENERATED point, so there is nothing to keep in sync.
-    index('posts_geo_gist').using('gist', t.geo),
-    index('posts_content_geo_gist').using('gist', t.contentGeo),
+    /**
+     * The two spatial indexes, replacing the `2dsphere` pair. GiST over the
+     * GENERATED point, so there is nothing to keep in sync.
+     *
+     * PARTIAL on `is not null`, and here the predicate is worth more than
+     * anywhere else on this table: a location is rare (2.2% and 1.3% of the
+     * seeded corpus), and a GiST index indexes the NULLs too, so the full form
+     * paid a GiST insert on every ordinary post to store an entry no
+     * `ST_DWithin` can ever match. Measured: `posts_geo_gist` 20 MB → 488 kB,
+     * `posts_content_geo_gist` 19 MB → 264 kB — the two largest single wins in
+     * the audit, and together most of the 352 MB → 287 MB it recovered.
+     *
+     * `ST_DWithin` is strict, so Postgres proves the implication; the `nearby`
+     * controller's OR over BOTH columns (`posts.controller.ts`) still plans as a
+     * `BitmapOr` of the two, which was checked rather than assumed because that
+     * is the shape a naive narrowing would break.
+     *
+     * `postgis.test.ts` asserts these two by NAME (`am.amname = 'gist'`), so it
+     * keeps passing; `hotPathIndexes.test.ts` is what pins the predicate.
+     */
+    index('posts_geo_gist').using('gist', t.geo).where(sql`${t.geo} is not null`),
+    index('posts_content_geo_gist')
+      .using('gist', t.contentGeo)
+      .where(sql`${t.contentGeo} is not null`),
   ]
 );


### PR DESCRIPTION
Closes #753.

`posts` carried **2.79:1** indexes-to-heap on a corpus seeded to production's shape — reproducing the 2.6:1 #664 reported. The question was which of the 24 earn it.

## What the audit did NOT find

**No index is redundant, and none is unreachable.**

- The formal **left-prefix rule** — index on `(a,b)` subsumes a plain `(a)`, compatible direction and NULLS placement, weaker-or-equal partial predicate — condemns **exactly zero** of the 24.
- Every leading column appears in a live `where`. The four with the fewest source mentions (`content_geo` 3, `classification_trend_terms` 5, `classification_status` 6, `classification_region` 7) were each read individually: all four are real predicates, not projections.

Two indexes the naive rule *does* flag are kept, and **the rule is backwards about both**: `posts_curated_idx` and `posts_roots_chrono_idx` are partial indexes whose key columns are a prefix of a total one. That is the shape a subsumption test reports as redundant, and it is precisely inverted — the partial is the small one and it is the one that can apply the filter.

## What it did find: six indexes storing entries for rows they can never return

`boost_of`, `quote_of`, `thread_id`, `classification_region`, `geo` and `content_geo` are NULL on most of the table, and each of those indexes held an entry per NULL row — paid on every insert of an ordinary post, readable by nothing. The GiST pair is the worst: a location is on ~2% of posts, and a GiST index indexes NULLs too.

**Four are narrowed to partial.** The discriminator is *not* the NULL fraction — it is whether anything asks for the NULL side.

| index | before | after |
|---|---:|---:|
| `posts_geo_gist` | 20 MB | **488 kB** |
| `posts_content_geo_gist` | 19 MB | **264 kB** |
| `posts_thread_idx` | 23 MB | **2992 kB** |
| `posts_classification_region_idx` | 9264 kB | **2080 kB** |
| **`posts` index total** | **352 MB** | **287 MB** |
| ratio to heap | 2.76:1 | **2.25:1** |

**Two are kept FULL for exactly that reason.** `notABoostSql()` is `isNull(posts.boostOf)` and runs on hot feed paths; `scripts/backfillQuotedPosts.ts` spells `isNull(posts.quoteOf)`. A partial index cannot serve a query asking for the rows it excludes, and that failure has no symptom — those queries would just get slower, later, under a row count no local corpus reproduces. The same asymmetry decided every ambiguous case: **an index I could not show was redundant stays.**

## Method, and its limits stated up front

Private PostGIS 17 container, **300k seeded posts** (200k roots / 100k replies, 12k authors, production-shaped distributions), `ANALYZE` after every load, measured **2026-08-15**. Not production and not the shared dev database — so these are **ratios**; absolute milliseconds are not a claim about prod. No `idx_scan` count is quoted, because a zero on a local corpus means nothing about production and a non-zero one only means I drove the query myself.

Controls, because "Index Scan using X" is also what a harness prints when it is measuring nothing:

- each narrowed index **re-planned afterwards and still chosen** — Postgres proves `eq(col, X)` and `ST_DWithin(col, …)` imply `col IS NOT NULL`, since both are strict;
- the `nearby` controller ORs **both** geo columns and still plans as a `BitmapOr` over the two partial indexes — checked, because that is the shape a naive narrowing breaks;
- **negative control:** a partial index whose predicate the query does *not* imply is refused by the planner, which falls back to `post_public_chrono_v1` with `Rows Removed by Filter: 70`. That control doubles as the evidence `post_public_chrono_v1` is reachable.

**Generated-column hazard checked, not assumed.** Touching an index over a `GENERATED ALWAYS … STORED` column (`geo`, `content_geo`) can make drizzle-kit emit `DROP COLUMN` + `ADD COLUMN`, silently destroying every index over it. The generated SQL is four `DROP INDEX` + four `CREATE INDEX … WHERE` and nothing else — grepped for `DROP COLUMN|ADD COLUMN|ALTER COLUMN|GENERATED`, none. **89 tables loaded**, so the confirming re-run's `No schema changes` is a real reading rather than a total schema-load failure. Journal `when` is strictly above every other entry; snapshot diff is exactly those four indexes, 24 before and 24 after, none added or removed.

## The real output is the gate, not the 65 MB

`hotPathIndexes.test.ts` now classifies **all 24 indexes plus the primary key**, each with its exact `pg_indexes.indexdef` and what pays when it is gone, and asserts the catalogue's set **equals** the classified set. An index nobody decided about now fails the build — which is the state this audit found — and one a migration removes fails it too. An equality rather than two inclusions, because the permissive direction is the one that recurs.

Mutation-tested, three at once against a real database:

| mutation | `… exists` | `… declared exactly` | exhaustiveness |
|---|---|---|---|
| unclassified index added | — | — | **red**, naming it |
| `posts_geo_gist` widened back to total | green | **red** | green |
| `posts_curated_idx` dropped | **red** | **red** | **red** |

The middle row is the point: existence and predicate are separate assertions and only one fires. 52 other cases stayed green.

## Verification

| what | result |
|---|---|
| full backend suite | **486 files / 6004 tests, 0 failures** (private container, load avg 63) |
| `bun run build` (tsc) | exit 0 |
| migration applies | full 26-entry journal on a fresh database, `Applied 26`, all 25 index definitions read back and matching |
| `postgis.test.ts` | still green — it asserts the two GiST indexes by name, which partial does not change |
| `chronoOrderPlan.test.ts` | still green — `posts_classification_region_idx` keeps `created_at DESC NULLS LAST` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)