### PR TITLE
perf(trending): twelve statements at once become one, and the same work

### DIFF
--- a/packages/backend/src/__tests__/services/trendingExcerptBatch.test.ts
+++ b/packages/backend/src/__tests__/services/trendingExcerptBatch.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Trend-label EVIDENCE, batched into one statement, against real rows.
+ *
+ * `resolveTrendLabels` used to fan out one excerpt query per unlabelled term
+ * with `Promise.all` — up to `MtnConfig.trending.labeling.maxPerBatch` statements
+ * issued at once, each holding a pool connection and asking for its own parallel
+ * workers on an instance that is also serving requests.
+ *
+ * The rewrite submits the SAME per-term queries as one `union all`. That makes
+ * the total server-side work identical by construction (measured on a
+ * 400k-post corpus: 9,419 buffers either way, to three digits) and changes only
+ * how it is demanded. Which is precisely why the tests here are about
+ * EQUIVALENCE rather than speed: a batching rewrite is only worth anything if
+ * every term still receives exactly the evidence it received before, in the same
+ * order, because that evidence is what names the trend a reader sees.
+ *
+ * Four properties, each of which fails silently in production:
+ *
+ *  1. same excerpts, same order, per term — asserted against the per-term query
+ *     itself, executed one term at a time;
+ *  2. a term matching nothing keeps its ENTRY (an omitted group would become a
+ *     missing key and a crashed labeller, or a silently weaker label);
+ *  3. a failure degrades the WHOLE batch to no-evidence labels instead of
+ *     throwing — the failure's blast radius grew with the batch, so the catch
+ *     had to as well;
+ *  4. it really is ONE statement.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { inArray } from 'drizzle-orm';
+
+vi.mock('../../utils/socket', () => ({ emitTrendsUpdated: vi.fn() }));
+vi.mock('../../utils/alia', () => ({ aliaChat: vi.fn(), isAliaEnabled: () => false }));
+
+import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
+import { posts } from '../../db/schema/posts';
+import { insertPostRecord } from '../../db/posts/postRepository';
+import { trendingService } from '../../services/TrendingService';
+
+/**
+ * The two private members under test, reached through a typed structural view
+ * rather than `as any` so the tests stay type-checked.
+ *
+ * `termExcerptBranch` is the per-term query — the thing that used to be run N
+ * times. Executing it directly IS the reference implementation for property 1;
+ * it is not a re-implementation of the code under test, it is the shared
+ * building block the batch is assembled from, which is what isolates the
+ * assertion to the BATCHING (the union, the grouping, the ordering).
+ */
+type PrivateTrending = {
+  loadExcerptsByTerm(terms: readonly string[]): Promise<Map<string, string[]>>;
+  termExcerptBranch(term: string): PromiseLike<Array<{ body: string; createdAt: Date }>>;
+};
+const svc = trendingService as unknown as PrivateTrending;
+
+let db: Database;
+const createdPostIds: string[] = [];
+
+/** Terms are namespaced per run: sibling suites share one `posts` table. */
+const RUN = randomUUID().slice(0, 8);
+function term(name: string): string {
+  return `${name}${RUN}`;
+}
+
+interface Seed {
+  /** Which column carries the term — all three are part of the term space. */
+  column?: 'trendTerms' | 'hashtags' | 'topics';
+  minutesAgo?: number;
+  sensitive?: boolean;
+  status?: 'published' | 'draft';
+  visibility?: 'public' | 'private';
+  /** Omit the rendition entirely — a post with no `content.variants`. */
+  withoutBody?: boolean;
+}
+
+async function seedPost(termName: string, body: string, seed: Seed = {}): Promise<string> {
+  const column = seed.column ?? 'trendTerms';
+  const record = await insertPostRecord({
+    oxyUserId: `author-${RUN}-${createdPostIds.length}`,
+    authorship: [{
+      oxyUserId: `author-${RUN}-${createdPostIds.length}`,
+      role: 'owner',
+      status: 'accepted',
+    }],
+    status: seed.status ?? 'published',
+    visibility: seed.visibility ?? 'public',
+    createdAt: new Date(Date.now() - (seed.minutesAgo ?? 10) * 60 * 1000),
+    content: seed.withoutBody ? { variants: [] } : { variants: [{ source: 'author', text: body }] },
+    ...(column === 'hashtags' ? { hashtags: [termName] } : {}),
+    postClassification: {
+      ...(column === 'trendTerms' ? { trendTerms: [termName] } : {}),
+      ...(column === 'topics' ? { topics: [termName] } : {}),
+      ...(seed.sensitive ? { sensitive: true } : {}),
+    },
+  });
+  createdPostIds.push(record.id);
+  return record.id;
+}
+
+/** The per-term query, run one term at a time — property 1's reference. */
+async function perTerm(termName: string): Promise<string[]> {
+  const rows = await svc.termExcerptBranch(termName);
+  return rows.map((row) => row.body);
+}
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (createdPostIds.length > 0) {
+    await db.delete(posts).where(inArray(posts.id, createdPostIds));
+    createdPostIds.length = 0;
+  }
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+describe('loadExcerptsByTerm — the batch must be the per-term queries, exactly', () => {
+  it('gives every term the same excerpts, in the same order, as querying it alone', async () => {
+    const alpha = term('alpha');
+    const beta = term('beta');
+    const gamma = term('gamma');
+
+    // Distinct `created_at` per post, so "the same order" is a real claim and
+    // not two arbitrary tie orders that happen to agree. Each term is carried by
+    // a DIFFERENT column, so the three-way term space is exercised too.
+    await seedPost(alpha, 'alpha oldest', { minutesAgo: 30 });
+    await seedPost(alpha, 'alpha middle', { minutesAgo: 20 });
+    await seedPost(alpha, 'alpha newest', { minutesAgo: 10 });
+    await seedPost(beta, 'beta only', { column: 'hashtags', minutesAgo: 15 });
+    await seedPost(gamma, 'gamma older', { column: 'topics', minutesAgo: 25 });
+    await seedPost(gamma, 'gamma newer', { column: 'topics', minutesAgo: 5 });
+
+    const batched = await svc.loadExcerptsByTerm([alpha, beta, gamma]);
+
+    // Newest first, per term.
+    expect(batched.get(alpha)).toEqual(['alpha newest', 'alpha middle', 'alpha oldest']);
+    expect(batched.get(beta)).toEqual(['beta only']);
+    expect(batched.get(gamma)).toEqual(['gamma newer', 'gamma older']);
+
+    // And the same as the per-term query, which is the property that survives a
+    // future change to what the branch selects.
+    for (const name of [alpha, beta, gamma]) {
+      const reference = await perTerm(name);
+      // FLOOR: an equality between two empty lists would pass while proving
+      // nothing, and every term here really does have evidence.
+      expect(reference.length).toBeGreaterThan(0);
+      expect(batched.get(name)).toEqual(reference);
+    }
+  });
+
+  it('applies the same exclusions the per-term query did', async () => {
+    const scoped = term('scoped');
+
+    await seedPost(scoped, 'visible', { minutesAgo: 5 });
+    await seedPost(scoped, 'sensitive', { sensitive: true, minutesAgo: 4 });
+    await seedPost(scoped, 'draft', { status: 'draft', minutesAgo: 3 });
+    await seedPost(scoped, 'private', { visibility: 'private', minutesAgo: 2 });
+    // No rendition at all: the INNER JOIN eliminates it, so it must not consume
+    // one of the twelve slots and must not appear as an empty excerpt.
+    await seedPost(scoped, '', { withoutBody: true, minutesAgo: 1 });
+
+    const batched = await svc.loadExcerptsByTerm([scoped]);
+
+    expect(batched.get(scoped)).toEqual(['visible']);
+    expect(batched.get(scoped)).toEqual(await perTerm(scoped));
+  });
+
+  it('keeps an ENTRY for a term that matches nothing', async () => {
+    const present = term('present');
+    const absent = term('absent');
+    await seedPost(present, 'something');
+
+    const batched = await svc.loadExcerptsByTerm([present, absent]);
+
+    // `has`, not `get`, is the assertion that matters: a `union all` emits no
+    // rows for an empty branch, so an implementation that built the map FROM the
+    // result would drop the key and hand the labeller `undefined`.
+    expect(batched.has(absent)).toBe(true);
+    expect(batched.get(absent)).toEqual([]);
+    expect(batched.get(present)).toEqual(['something']);
+  });
+
+  it('is ONE statement, whatever the batch size', async () => {
+    const terms = Array.from({ length: 12 }, (_unused, index) => term(`bulk${index}`));
+    for (const [index, name] of terms.entries()) await seedPost(name, `body ${index}`);
+
+    const execute = vi.spyOn(db, 'execute');
+
+    const batched = await svc.loadExcerptsByTerm(terms);
+
+    // Exactly one, not "at most" one: 0 would mean the batch stopped going
+    // through `execute` at all (a revert to per-term builders reads as 0, not as
+    // 12), and the value assertions below are what make that distinguishable
+    // from a call that did nothing.
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(batched.size).toBe(12);
+    for (const [index, name] of terms.entries()) {
+      expect(batched.get(name)).toEqual([`body ${index}`]);
+    }
+  });
+
+  it('degrades the WHOLE batch to no evidence when the query fails, rather than throwing', async () => {
+    const first = term('failfirst');
+    const second = term('failsecond');
+    await seedPost(first, 'real evidence');
+    await seedPost(second, 'more evidence');
+
+    // The failure shape that matters is the statement failing, which is now one
+    // statement for every term — the blast radius the per-term version did not
+    // have. A throw here would take down the whole labelling run.
+    vi.spyOn(db, 'execute').mockRejectedValueOnce(new Error('connection reset'));
+
+    const batched = await svc.loadExcerptsByTerm([first, second]);
+
+    expect(batched.get(first)).toEqual([]);
+    expect(batched.get(second)).toEqual([]);
+    // The keys survive, so `resolveTrendLabels` still labels every term — just
+    // without evidence, which is the documented fail-soft.
+    expect([...batched.keys()].sort()).toEqual([first, second].sort());
+  });
+});

--- a/packages/backend/src/services/TrendingService.ts
+++ b/packages/backend/src/services/TrendingService.ts
@@ -1154,12 +1154,13 @@ class TrendingService {
       .filter((trend) => !labels.has(trend.term))
       .slice(0, MtnConfig.trending.labeling.maxPerBatch);
 
-    await Promise.all(
-      unlabelled.map(async (trend) => {
-        const excerpts = await this.loadTermExcerpts(trend.term);
-        labels.set(trend.term, deriveTrendLabel({ term: trend.term, excerpts }));
-      }),
-    );
+    const excerptsByTerm = await this.loadExcerptsByTerm(unlabelled.map((trend) => trend.term));
+    for (const trend of unlabelled) {
+      labels.set(trend.term, deriveTrendLabel({
+        term: trend.term,
+        excerpts: excerptsByTerm.get(trend.term) ?? [],
+      }));
+    }
 
     // Anything past the per-batch labelling cap still needs a presentable name.
     for (const trend of ranked) {
@@ -1170,48 +1171,128 @@ class TrendingService {
   }
 
   /**
-   * A few recent posts carrying the term, as naming evidence.
+   * A few recent posts carrying ONE term, as naming evidence — the per-term
+   * query, unchanged, and the branch {@link loadExcerptsByTerm} submits.
    *
    * The term alone cannot name a story — `orioles` does not contain the words
    * "Kremer Trade" — so this is what makes a generated label better than string
    * formatting. Matched across the same three columns the term space is built
    * from, so a term that arrived as a hashtag or a topic slug still finds its
-   * posts. Fail-soft: no excerpts simply means a weaker label.
+   * posts.
    *
    * The body comes from the PRIMARY rendition (`position = 0` of
    * `post_content_variants`), which is the author's own words — the same one the
    * Mongo projection took. Ordered by `created_at` alone with no id tie-break:
    * `posts.id` mixes ObjectId hex and uuid v7 and is not a chronological axis,
    * and for a sample of twelve an arbitrary tie is not worth a wrong order.
+   *
+   * `created_at` rides along in the projection so the caller can restate the
+   * per-term order on the combined result rather than inheriting it from the
+   * order rows happen to arrive in. It is never read in JS — only the outer
+   * `order by` consumes it — so it is not a raw-date-decoding hazard.
+   *
+   * THE INNER JOIN IS LOAD-BEARING AND CANNOT BE HOISTED. A post with no
+   * rendition (`insertPostRecord` writes none for empty `content.variants`) is
+   * eliminated by it, so it does not consume one of the twelve slots. Postgres
+   * evaluates this efficiently — the `LIMIT` sits ABOVE the join, so the
+   * rendition is fetched for the twelve surviving posts and no others — and that
+   * plan is what any batching has to preserve.
    */
-  private async loadTermExcerpts(term: string): Promise<string[]> {
-    try {
-      const rows = await getDb()
-        .select({ text: postContentVariants.body })
-        .from(posts)
-        .innerJoin(
-          postContentVariants,
-          and(
-            eq(postContentVariants.postId, posts.id),
-            eq(postContentVariants.position, 0),
-          ),
-        )
-        .where(and(
-          trendTermMatchSql(term),
-          eq(posts.status, 'published'),
-          eq(posts.visibility, PostVisibility.PUBLIC),
-          sensitiveExcludeSql(),
-        ))
-        .orderBy(desc(posts.createdAt))
-        .limit(TREND_EXCERPTS_PER_TERM);
+  private termExcerptBranch(term: string) {
+    return getDb()
+      .select({ body: postContentVariants.body, createdAt: posts.createdAt })
+      .from(posts)
+      .innerJoin(
+        postContentVariants,
+        and(
+          eq(postContentVariants.postId, posts.id),
+          eq(postContentVariants.position, 0),
+        ),
+      )
+      .where(and(
+        trendTermMatchSql(term),
+        eq(posts.status, 'published'),
+        eq(posts.visibility, PostVisibility.PUBLIC),
+        sensitiveExcludeSql(),
+      ))
+      .orderBy(desc(posts.createdAt))
+      .limit(TREND_EXCERPTS_PER_TERM);
+  }
 
-      return rows
-        .map((row) => row.text?.trim() ?? '')
-        .filter((text) => text.length > 0);
+  /**
+   * Naming evidence for a WHOLE batch of terms, in ONE statement.
+   *
+   * ## Why `union all` of the verbatim per-term query, and not a lateral
+   *
+   * The obvious batching — `unnest(terms)` cross-joined lateral to the per-term
+   * query — is **18x worse**, and the reason generalizes. With a constant term
+   * the planner estimates the three-way `BitmapOr` accurately (~2,000 rows) and
+   * keeps the `LIMIT` above the rendition join, so it fetches twelve renditions.
+   * Correlate the term to a lateral column and that estimate is gone: the
+   * planner switches to a hash join and sequentially scans all 400,000
+   * renditions once per term. Measured on a 400k-post corpus, 12 terms:
+   *
+   * ```
+   *   per-term, 12 statements   9,419 buffers   65.7 ms   12 plans
+   *   union all, 1 statement    9,422 buffers   47.0 ms    1 plan
+   *   lateral,   1 statement  168,632 buffers  593.6 ms    1 plan
+   * ```
+   *
+   * So the win here is NOT less work — it is the same work, and saying so is the
+   * point: the buffers are identical to three digits. What changes is how it is
+   * DEMANDED. The `Promise.all` this replaces issued twelve statements at once,
+   * holding twelve pool connections and asking for `3 x maxPerBatch` parallel
+   * workers simultaneously on an instance that also serves requests. An `Append`
+   * runs its branches one at a time, so the same total work now peaks at one
+   * branch's worth of workers and one connection.
+   *
+   * ## Fail-soft, and how its SHAPE changed
+   *
+   * Per-term, a failed lookup cost one term its evidence. Batched, a failure is
+   * the whole batch's — so the catch degrades every term to no evidence and a
+   * weaker label rather than throwing, and logs ONCE rather than per term. The
+   * map is seeded with an empty list for every term before the query runs, which
+   * is also what guarantees the OTHER contract: a term matching no posts keeps
+   * its entry instead of vanishing from the result and silently becoming a
+   * missing key at the call site.
+   */
+  private async loadExcerptsByTerm(terms: readonly string[]): Promise<Map<string, string[]>> {
+    const byTerm = new Map<string, string[]>(terms.map((term) => [term, []]));
+    if (byTerm.size === 0) return byTerm;
+
+    // Deduped, because two identical branches would do the work twice for one
+    // answer. `ranked` groups by term so this is defensive, not corrective.
+    const unique = [...byTerm.keys()];
+
+    try {
+      const branches = unique.map((term, ord) => sql`
+        select ${term}::text as term, ${ord}::int as ord, branch.body, branch.created_at
+        from (${this.termExcerptBranch(term)}) as branch
+      `);
+
+      // `ord` then `created_at desc` RESTATES the ordering rather than trusting
+      // the order an `Append` happens to emit. Nothing in SQL guarantees that
+      // order, and the per-term sequence is the whole contract here: a batching
+      // rewrite that reorders a term's evidence silently changes its label.
+      const rows = await getDb().execute<{ term: string; body: string | null }>(sql`
+        select combined.term, combined.body
+        from (${sql.join(branches, sql` union all `)}) as combined
+        order by combined.ord, combined.created_at desc
+      `);
+
+      for (const row of rows) {
+        const text = row.body?.trim() ?? '';
+        if (text.length > 0) byTerm.get(row.term)?.push(text);
+      }
     } catch (error) {
-      logger.warn('[Trending] Excerpt lookup failed; labelling without evidence', { term, error });
-      return [];
+      logger.warn(
+        '[Trending] Excerpt lookup failed; labelling the whole batch without evidence',
+        { terms: unique.length, error },
+      );
+      for (const term of unique) byTerm.set(term, []);
     }
+
+    return byTerm;
   }
 
   /**
@@ -1611,7 +1692,10 @@ class TrendingService {
     const summary = await resolveTrendSummary({
       term: normalized,
       runStartedAt: row.startedAt,
-      loadExcerpts: () => this.loadTermExcerpts(normalized),
+      // The one-term case of the batch, not a second implementation of it: a
+      // single branch renders as the per-term query wrapped in a subselect, so
+      // this reads the same rows in the same order the labeller sees.
+      loadExcerpts: async () => (await this.loadExcerptsByTerm([normalized])).get(normalized) ?? [],
     });
 
     return {


### PR DESCRIPTION
Closes #751

`resolveTrendLabels` fanned out one excerpt query per unlabelled term with `Promise.all` — up to `maxPerBatch` statements issued **simultaneously**, each holding a pool connection and asking for its own parallel workers on an instance that is also serving requests.

## Measured

400k-post corpus, 2,001 posts per term (the issue measured 1,971), 12 terms, GIN indexes present, `ANALYZE`d. Warm cache, `EXPLAIN (ANALYZE, BUFFERS)`.

| form | statements | **buffers** | plans | pool conns | peak parallel workers |
|---|---|---|---|---|---|
| per-term (before) | 12 | **9,419** | 12 | 12 | 12 branches' worth, at once |
| **`union all` (after)** | **1** | **9,422** | 1 | 1 | one branch's worth |
| naive `lateral` | 1 | 168,632 | 1 | 1 | one branch's worth |

**The win is not less work, and the numbers are reported that way on purpose** — the buffers are identical to three digits. What changes is how the work is *demanded*. An `Append` runs its branches one at a time, so peak parallel-worker demand falls from `3 × maxPerBatch` simultaneous to one branch's worth, and twelve pool connections become one.

Wall-clock, three A/B rounds back-to-back under identical load: 75.3/74.2/79.3 ms summed (12 statements, serial) vs 76.1/70.6/67.8 ms (union). Equal within noise — the machine was heavily loaded, so buffers and statement count are the load-independent numbers I'd hang the claim on.

## The naive batching is 18× worse, and the reason generalizes

`unnest(terms)` cross-joined lateral to the per-term query: **168,632 buffers, 593 ms**.

With a **constant** term the planner estimates the three-way `BitmapOr` at ~2,000 rows and keeps the `LIMIT` above the rendition join, so it fetches twelve renditions. **Correlate** the term to a lateral column and that estimate is gone: it switches to a hash join and sequentially scans all 400,000 renditions *once per term*.

Verified the good plan survives with **bound parameters** and not merely with literals — the whole point is that the shipped code parameterizes: through the code as shipped, 108 params, **zero** `Seq Scan on post_content_variants`, 9,419 buffers.

## The inner join is load-bearing

A post with no rendition (`insertPostRecord` writes none for empty `content.variants`) is eliminated by the join, so it does not consume one of the twelve slots. That rules out the tempting rewrite of hoisting the join out of the per-term unit, and is asserted.

## Fail-soft changed shape, so the catch did too

Per-term, a failure cost one term its evidence. Batched it is the whole batch's, so the catch degrades **every** term to a no-evidence label and logs **once**, rather than throwing.

## Mutation tests — five properties, each killed by its intended test

| mutation | test that went red |
|---|---|
| outer `created_at DESC` → `ASC` | same excerpts, same order |
| `innerJoin` → `leftJoin` | applies the same exclusions |
| build the map from the result instead of pre-seeding | keeps an ENTRY for a term matching nothing (+ all four others) |
| issue the statement twice | is ONE statement |
| rethrow instead of degrading | degrades the whole batch |

Property 1 is asserted against the per-term query **executed one term at a time** — the shared building block the batch is assembled from, not a re-implementation — with a non-zero floor so an equality of two empty lists cannot pass for it.

## Verification

- `tsc --noEmit` clean.
- All 7 trending-related suites: 126 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)