### PR TITLE
perf(feed): a ranking that cannot change hourly, recomputed on every refresh

### DIFF
--- a/packages/backend/src/__tests__/relatedSources.test.ts
+++ b/packages/backend/src/__tests__/relatedSources.test.ts
@@ -35,17 +35,19 @@
  * {@link suiteIdsOf} and fixtures are stamped fractionally in the future.
  */
 
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { inArray } from 'drizzle-orm';
 import { PostType, PostVisibility } from '@mention/shared-types';
 
 import { closePostgres, connectPostgres, type Database } from '../db/postgres';
+import { FOLLOWER_SNAPSHOT_INTERVAL_MS } from '../services/followerSnapshotJob';
 import { authorFollowerSnapshots, posts } from '../db/schema';
 import { insertPostRecord } from '../db/posts/postRepository';
 import type { PostRecord, PostRecordInput } from '../db/posts/postRecord';
 import {
   moreLikeThisSource,
   nearbySource,
+  resetRisingCreatorsCache,
   risingCreatorsSource,
 } from '../mtn/feed/engine/sources/relatedSources';
 import type { CandidatePost, FeedEngineContext } from '../mtn/feed/engine/types';
@@ -120,6 +122,12 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
+  // `risingCreators` memoizes its ranking for a full snapshot interval, so
+  // without this every case after the first would rank the PREVIOUS case's
+  // fixtures — the ranking outlives the rows it was computed from. Deleting the
+  // snapshots below is not enough on its own, which is exactly the property the
+  // cache exists to have.
+  resetRisingCreatorsCache();
   const ids = created.splice(0);
   if (ids.length > 0) await db.delete(posts).where(inArray(posts.id, ids));
   const owners = snapshotOwners.splice(0);
@@ -434,5 +442,160 @@ describe('the risingCreators source', () => {
     await create({ oxyUserId: 'relsrc-flat' });
 
     expect(suiteIdsOf(await risingCreatorsSource.gather({}, {}, 30))).toEqual([]);
+  });
+});
+
+/**
+ * The RANKING is memoized for one snapshot interval; the posts query is not.
+ *
+ * The aggregation it removes has no `LIMIT` and cannot have one — every author's
+ * first and last sample in the window is needed before any of them can be
+ * ranked — so on a production-shaped corpus (2M snapshots, 12k authors, ~466k
+ * rows in window) it sorted 466k rows for ~1.4s and 19MB of temp spill on EVERY
+ * `gather`, uncached, at a user's refresh rate.
+ *
+ * Every case below is written so that it fails if the memo is removed AND if the
+ * memo is wrong, which are different failures: the fixtures are DELETED between
+ * calls, so a second `gather` that re-ran the aggregation would find nothing and
+ * return `[]`. Each such assertion is paired with a reset-and-retry that proves
+ * the deletion really happened — otherwise "still returns the same rows" would
+ * pass just as well if the delete had silently matched nothing.
+ */
+describe('the risingCreators ranking cache', () => {
+  async function snapshot(oxyUserId: string, followerCount: number, sampledAt: Date): Promise<void> {
+    snapshotOwners.push(oxyUserId);
+    await db.insert(authorFollowerSnapshots).values({ oxyUserId, followerCount, at: sampledAt });
+  }
+
+  const RISER = 'relsrc-cache-riser';
+  const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+
+  /** Seed one rising author with one post, and return that post's id. */
+  async function seedRiser(): Promise<string> {
+    await snapshot(RISER, 5, twoDaysAgo);
+    await snapshot(RISER, 50, dayAgo);
+    const post = await create({ oxyUserId: RISER, createdAt: at(0) });
+    return post.id;
+  }
+
+  /** Remove every snapshot row this describe seeded. */
+  async function deleteSnapshots(): Promise<void> {
+    await db
+      .delete(authorFollowerSnapshots)
+      .where(inArray(authorFollowerSnapshots.oxyUserId, [RISER]));
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('issues ZERO aggregation queries on a second gather', async () => {
+    const postId = await seedRiser();
+    await risingCreatorsSource.gather({}, {}, 30);
+
+    // Counted, not inferred: the aggregation is the only `select` whose
+    // projection names `first` and `last`, so this distinguishes it from the
+    // posts query and from everything `assemblePostRecords` reads.
+    const select = vi.spyOn(db, 'select');
+    const gathered = await risingCreatorsSource.gather({}, {}, 30);
+    const aggregations = select.mock.calls.filter(([projection]) => {
+      const keys = Object.keys((projection ?? {}) as Record<string, unknown>);
+      return keys.includes('first') && keys.includes('last');
+    });
+
+    expect(aggregations).toHaveLength(0);
+    // FLOOR: the spy really did observe this gather's queries, so the zero above
+    // is an absence and not a spy that saw nothing at all.
+    expect(select.mock.calls.length).toBeGreaterThan(0);
+    expect(suiteIdsOf(gathered)).toEqual([postId]);
+  });
+
+  it('serves the same ranking from the memo after the snapshots are gone', async () => {
+    const postId = await seedRiser();
+    const first = await risingCreatorsSource.gather({}, {}, 30);
+    expect(suiteIdsOf(first)).toEqual([postId]);
+
+    await deleteSnapshots();
+
+    const second = await risingCreatorsSource.gather({}, {}, 30);
+    // Same authors, same order, same rates — a cache that changed the answer
+    // would be a different feature.
+    expect(suiteIdsOf(second)).toEqual([postId]);
+    expect(second[0].finalScore).toBeCloseTo(first[0].finalScore ?? 0, 10);
+
+    // POSITIVE CONTROL for the delete: without this, the assertion above would
+    // pass identically if `deleteSnapshots` had matched nothing.
+    resetRisingCreatorsCache();
+    expect(suiteIdsOf(await risingCreatorsSource.gather({}, {}, 30))).toEqual([]);
+  });
+
+  it('reuses the ranking for exactly one snapshot interval, and no longer', async () => {
+    const postId = await seedRiser();
+
+    // Only `Date` is faked: the Postgres driver's own timers must keep running.
+    const start = Date.now();
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(start);
+
+    expect(suiteIdsOf(await risingCreatorsSource.gather({}, {}, 30))).toEqual([postId]);
+    await deleteSnapshots();
+
+    // One millisecond inside the interval: still the memo, and the rows behind
+    // it no longer exist.
+    vi.setSystemTime(start + FOLLOWER_SNAPSHOT_INTERVAL_MS - 1);
+    expect(suiteIdsOf(await risingCreatorsSource.gather({}, {}, 30))).toEqual([postId]);
+
+    // One millisecond past it: recomputed, and the recompute sees the deletion.
+    // This is what ties the TTL to the SAMPLING CADENCE rather than to a number
+    // chosen here — retune `FOLLOWER_SNAPSHOT_INTERVAL_MS` and this moves with
+    // it, which is the property that keeps the two from drifting.
+    vi.setSystemTime(start + FOLLOWER_SNAPSHOT_INTERVAL_MS + 1);
+    expect(suiteIdsOf(await risingCreatorsSource.gather({}, {}, 30))).toEqual([]);
+  });
+
+  it('does NOT memoize a failure, which at this TTL would blank the source for hours', async () => {
+    const postId = await seedRiser();
+
+    // The aggregation is the first `select` a cold gather makes.
+    vi.spyOn(db, 'select').mockImplementationOnce(() => {
+      throw new Error('connection reset');
+    });
+
+    // Soft-fails, as it always did.
+    expect(await risingCreatorsSource.gather({}, {}, 30)).toEqual([]);
+
+    vi.restoreAllMocks();
+
+    // And the very next gather tries again rather than serving the empty answer
+    // for a full snapshot interval. `storyIndex` memoizes its empty answer on
+    // purpose; at five minutes that is a retry bound, at six hours it would be
+    // an outage.
+    expect(suiteIdsOf(await risingCreatorsSource.gather({}, {}, 30))).toEqual([postId]);
+  });
+
+  it('runs ONE aggregation for concurrent cold gathers', async () => {
+    const postId = await seedRiser();
+    const select = vi.spyOn(db, 'select');
+
+    const [a, b, c] = await Promise.all([
+      risingCreatorsSource.gather({}, {}, 30),
+      risingCreatorsSource.gather({}, {}, 30),
+      risingCreatorsSource.gather({}, {}, 30),
+    ]);
+
+    const aggregations = select.mock.calls.filter(([projection]) => {
+      const keys = Object.keys((projection ?? {}) as Record<string, unknown>);
+      return keys.includes('first') && keys.includes('last');
+    });
+
+    // Without the shared in-flight promise this is 3 — the first request after
+    // a restart is the worst case the cache exists to remove, multiplied by
+    // however many arrive together.
+    expect(aggregations).toHaveLength(1);
+    expect(suiteIdsOf(a)).toEqual([postId]);
+    expect(suiteIdsOf(b)).toEqual([postId]);
+    expect(suiteIdsOf(c)).toEqual([postId]);
   });
 });

--- a/packages/backend/src/mtn/feed/engine/sources/relatedSources.ts
+++ b/packages/backend/src/mtn/feed/engine/sources/relatedSources.ts
@@ -17,6 +17,7 @@ import { authorFollowerSnapshots, posts } from '../../../../db/schema';
 import { assemblePostRecords } from '../../../../db/posts/postRepository';
 import { chronoCursorSql, chronoOrderBy } from '../../CursorBuilder';
 import { discoverySafeSql } from '../../feedSafety';
+import { FOLLOWER_SNAPSHOT_INTERVAL_MS } from '../../../../services/followerSnapshotJob';
 import { logger } from '../../../../utils/logger';
 import { notABoostSql } from '../../../../utils/feedQueryBuilder';
 import type { CandidatePost, FeedEngineContext, SourceModule } from '../types';
@@ -347,6 +348,140 @@ const RISING_CREATORS_MAX_AUTHORS = 100;
 const RISING_CREATORS_POST_MULTIPLIER = 3;
 
 /**
+ * How long a computed ranking is reused, DERIVED from the sampling cadence
+ * rather than chosen.
+ *
+ * `followerSnapshotJob` appends a sample every `FOLLOWER_SNAPSHOT_INTERVAL_MS`,
+ * and the ranking is a function of those samples alone — so it CANNOT change
+ * more often than that, and a shorter TTL would buy nothing but a repeat of the
+ * aggregation below. Importing the constant instead of restating it is what
+ * keeps the two from drifting: retune the sampling cadence and this follows.
+ */
+const RISING_CREATORS_CACHE_TTL_MS = FOLLOWER_SNAPSHOT_INTERVAL_MS;
+
+/** One author's follower growth over the window, as the ranking sees it. */
+interface RankedCreator {
+  id: string;
+  delta: number;
+  rate: number;
+}
+
+/**
+ * The ranking, memoized in process.
+ *
+ * ## What this is worth
+ *
+ * The aggregation below has NO `LIMIT` and cannot have one: every author's first
+ * and last sample in the window is needed before any of them can be ranked.
+ * Measured against a production-shaped corpus (2,000,000 snapshots over the real
+ * 30-day retention, 12,000 authors, ~466k rows inside the 7-day window):
+ *
+ * ```
+ *   GroupAggregate over 466,260 rows -> 12,000 groups
+ *   Sort Method: external merge  Disk: 19176kB
+ *   Buffers: shared hit=200,431  temp read=2,397 written=2,398
+ *   Execution Time: ~1,450 ms
+ * ```
+ *
+ * Uncached, that was the cost of EVERY `gather`. `risingCreators` is
+ * `userComposable` and sits in no preset feed, so it only runs when someone
+ * composes a custom feed with it — but nothing stopped one person refreshing
+ * such a feed from holding ~1.4 s of sort and 19 MB of temp I/O continuously.
+ *
+ * ## Deliberately in process, and deliberately without a timer
+ *
+ * Same reasoning as `services/trending/storyIndex.ts`: the value is small,
+ * derived and read-only, and any task can rebuild it from one query — so a
+ * shared cache would buy a consistency nobody can observe, at the cost of a
+ * round trip and a second failure mode. A module-level `setInterval` would hold
+ * the event loop open (see AGENTS.md); a lazy check on read costs nothing when
+ * nobody is reading.
+ *
+ * ## A FAILURE IS NEVER MEMOIZED, which is where this parts company with
+ * `storyIndex`
+ *
+ * That module caches its empty answer so a database in trouble is not retried on
+ * every request — sound at a 5-minute TTL. At SIX HOURS it would turn one
+ * transient error into a source that returns nothing until tomorrow. The soft
+ * failure below therefore returns `[]` without storing it, so the next `gather`
+ * tries again.
+ */
+let rankedCreatorsCache: { ranked: RankedCreator[]; expiresAt: number } | null = null;
+
+/**
+ * The refresh in flight, so N concurrent cold `gather`s run ONE aggregation
+ * rather than N. Without it the first request after a restart is the worst case
+ * this cache exists to remove, multiplied by however many arrive together.
+ */
+let rankedCreatorsInFlight: Promise<RankedCreator[]> | null = null;
+
+/** Drop the memo. Tests only — production refreshes on its own. */
+export function resetRisingCreatorsCache(): void {
+  rankedCreatorsCache = null;
+  rankedCreatorsInFlight = null;
+}
+
+/**
+ * Aggregate every author's follower delta over the window and rank by growth
+ * RATE. Soft-fails to `[]`.
+ *
+ * The window is the one the CALLER computed, so a refresh always measures the
+ * seven days ending now. Between refreshes the answer is frozen with it, which
+ * is the trade the TTL states: the window slides six hours out of a hundred and
+ * sixty-eight, and nothing inside it can have changed anyway.
+ */
+async function refreshRankedCreators(windowStart: Date, now: number): Promise<RankedCreator[]> {
+  let groups: Array<{ oxyUserId: string; first: number; last: number }>;
+  try {
+    groups = await getDb()
+      .select({
+        oxyUserId: authorFollowerSnapshots.oxyUserId,
+        first: sql<number>`(array_agg(${authorFollowerSnapshots.followerCount} order by ${authorFollowerSnapshots.at} asc))[1]`,
+        last: sql<number>`(array_agg(${authorFollowerSnapshots.followerCount} order by ${authorFollowerSnapshots.at} desc))[1]`,
+      })
+      .from(authorFollowerSnapshots)
+      .where(gte(authorFollowerSnapshots.at, windowStart))
+      .groupBy(authorFollowerSnapshots.oxyUserId);
+  } catch (error) {
+    logger.warn('[risingCreators source] Failed to aggregate follower snapshots', error);
+    return [];
+  }
+
+  const ranked = groups
+    .map((group) => {
+      const first = typeof group.first === 'number' ? group.first : 0;
+      const last = typeof group.last === 'number' ? group.last : 0;
+      const delta = last - first;
+      return {
+        id: group.oxyUserId,
+        delta,
+        rate: delta / Math.max(first, RISING_FOLLOWER_SMOOTHING),
+      };
+    })
+    .filter((group) => group.id.length > 0 && group.delta > 0)
+    .sort((a, b) => b.rate - a.rate)
+    .slice(0, RISING_CREATORS_MAX_AUTHORS);
+
+  rankedCreatorsCache = { ranked, expiresAt: now + RISING_CREATORS_CACHE_TTL_MS };
+  return ranked;
+}
+
+/** The ranking: from the memo when it is live, otherwise one shared refresh. */
+function loadRankedCreators(windowStart: Date, now: number): Promise<RankedCreator[]> {
+  if (rankedCreatorsCache && rankedCreatorsCache.expiresAt > now) {
+    return Promise.resolve(rankedCreatorsCache.ranked);
+  }
+  if (!rankedCreatorsInFlight) {
+    const pending = refreshRankedCreators(windowStart, now);
+    rankedCreatorsInFlight = pending;
+    void pending.finally(() => {
+      if (rankedCreatorsInFlight === pending) rankedCreatorsInFlight = null;
+    });
+  }
+  return rankedCreatorsInFlight;
+}
+
+/**
  * `risingCreators`: creators gaining followers fastest right now.
  *
  * Reads `author_follower_snapshots` (populated by the leader-gated
@@ -369,39 +504,16 @@ export const risingCreatorsSource: SourceModule = {
   kind: 'source',
   userComposable: true,
   gather: async (_ctx, _params, cap) => {
-    const windowStart = new Date(Date.now() - RISING_CREATORS_WINDOW_MS);
+    const now = Date.now();
+    const windowStart = new Date(now - RISING_CREATORS_WINDOW_MS);
     const db = getDb();
 
-    let groups: Array<{ oxyUserId: string; first: number; last: number }>;
-    try {
-      groups = await db
-        .select({
-          oxyUserId: authorFollowerSnapshots.oxyUserId,
-          first: sql<number>`(array_agg(${authorFollowerSnapshots.followerCount} order by ${authorFollowerSnapshots.at} asc))[1]`,
-          last: sql<number>`(array_agg(${authorFollowerSnapshots.followerCount} order by ${authorFollowerSnapshots.at} desc))[1]`,
-        })
-        .from(authorFollowerSnapshots)
-        .where(gte(authorFollowerSnapshots.at, windowStart))
-        .groupBy(authorFollowerSnapshots.oxyUserId);
-    } catch (error) {
-      logger.warn('[risingCreators source] Failed to aggregate follower snapshots', error);
-      return [];
-    }
-
-    const ranked = groups
-      .map((group) => {
-        const first = typeof group.first === 'number' ? group.first : 0;
-        const last = typeof group.last === 'number' ? group.last : 0;
-        const delta = last - first;
-        return {
-          id: group.oxyUserId,
-          delta,
-          rate: delta / Math.max(first, RISING_FOLLOWER_SMOOTHING),
-        };
-      })
-      .filter((group) => group.id.length > 0 && group.delta > 0)
-      .sort((a, b) => b.rate - a.rate)
-      .slice(0, RISING_CREATORS_MAX_AUTHORS);
+    // The RANKING is memoized; the posts query below is not, and that split is
+    // the point. Which authors are rising cannot change between snapshot sweeps,
+    // but which posts they have just published changes constantly — so a reader
+    // refreshing a custom feed still sees new posts, from a ranking that is at
+    // most one sampling interval old.
+    const ranked = await loadRankedCreators(windowStart, now);
     if (ranked.length === 0) return [];
 
     const rateById = new Map(ranked.map((group) => [group.id, group.rate]));


### PR DESCRIPTION
Closes #750

`risingCreatorsSource.gather` aggregated the entire 7-day `author_follower_snapshots` window on **every** invocation, uncached, ranking in JS afterwards. The aggregation has no `LIMIT` and **cannot** have one — every author's first and last sample in the window is needed before any of them can be ranked.

## Before

Seeded to the issue's corpus: 2,000,000 snapshots over the real 30-day `AUTHOR_FOLLOWER_SNAPSHOT_RETENTION_SECONDS`, 12,000 authors, **466,260** rows inside the window (the issue measured 466,573 / 12,000).

```
GroupAggregate over 466,260 rows -> 12,000 groups
  Sort Method: external merge  Disk: 19176kB
  Buffers: shared hit=200,431  temp read=2,397 written=2,398
  Execution Time: ~1,450 ms          (warm, three runs: 1442 / 1520 / 1454 ms)
```

`risingCreators` is `userComposable` and sits in no preset feed, which caps the blast radius — but nothing stopped one person refreshing a custom feed from holding ~1.4 s of sort and 19 MB of temp I/O continuously.

I did **not** re-litigate the two approaches #750 records as measured-worse (`DISTINCT ON`, a covering index). The cost is the sort of ~466k rows and the `GROUP BY` genuinely needs all of them.

## After — end to end, through the source as shipped, same corpus

| | latency | aggregation queries | rows |
|---|---|---|---|
| cold gather | 2,064.5 ms | 1 | 30 |
| second gather (within TTL) | **42.7 ms** | **0** | 30 |
| third gather (within TTL) | **32.5 ms** | **0** | 30 |
| 4 concurrent cold gathers | 1,632.1 ms | **1** (not 4) | — |

Identical rows throughout. The residual ~35 ms is the posts query, which is deliberately **not** cached.

## The TTL is derived, not chosen

`followerSnapshotJob` appends a sample every `FOLLOWER_SNAPSHOT_INTERVAL_MS`, and the ranking is a function of those samples alone — so it cannot change more often than that. The constant is **imported**, not restated, so retuning the sampling cadence moves the cache with it. A test pins the boundary at exactly that constant (`interval - 1` still cached, `interval + 1` recomputed), so the two cannot drift.

## The ranking is memoized; the posts query is not

That split is the point. Which authors are rising cannot change between sweeps; which posts they have just published changes constantly. A reader refreshing a custom feed still sees new posts, from a ranking at most one sampling interval old.

## Two deliberate departures from `storyIndex.ts`

Whose in-process, no-timer shape this otherwise copies (small, derived, read-only, rebuildable from one query — a shared cache would buy consistency nobody can observe):

- **A failure is never memoized.** `storyIndex` caches its empty answer so a database in trouble is not retried per request — sound at a 5-minute TTL. At six hours it would turn one transient error into a source returning nothing until tomorrow.
- **Concurrent cold gathers share one in-flight refresh.** The first request after a restart is the worst case this cache exists to remove; without sharing it is that case multiplied by however many arrive together.

## How the tests are built to fail

Fixtures are **deleted between calls**, so a second `gather` that re-ran the aggregation finds nothing and returns `[]`. Every such assertion is paired with a **reset-and-retry positive control** proving the delete really happened — otherwise "still returns the same rows" would pass just as well had the delete matched nothing. The zero-query assertion counts the aggregation specifically (the only `select` whose projection names `first` and `last`) and carries a floor proving the spy observed that gather's other queries.

The existing suite needed `resetRisingCreatorsCache()` in teardown — without it, every case after the first ranked the previous case's fixtures. That is itself evidence the memo is live.

## Mutation tests

| mutation | tests that went red |
|---|---|
| no cache (always refresh) | **3** — zero-queries, same-ranking-after-delete, TTL boundary |
| TTL = 5 min instead of the sampling interval | TTL boundary |
| memoize the failure | does NOT memoize a failure |
| drop the shared in-flight promise | one aggregation for concurrent gathers |

## Verification

- `tsc --noEmit` clean.
- `relatedSources.test.ts`: 25 passed (20 pre-existing + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)