### PR TITLE
fix(federation): a boosted original knew its author's name but never wrote it down

### DIFF
--- a/packages/backend/src/__tests__/connectors/inboundPostProvenanceShape.test.ts
+++ b/packages/backend/src/__tests__/connectors/inboundPostProvenanceShape.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import { buildFederatedNoteProvenance } from '../../connectors/activitypub/apPostContent';
+
+/**
+ * Every federated post stored by an ingest path must carry the actor URI that
+ * authored it, not just the activity id.
+ *
+ * ## Why this is a static check and not a behavioural one
+ *
+ * `PostRecordFederation` is entirely optional, so `{ activityId, url }` and
+ * `{ activityId, actorUri, url }` type-check identically at a `create` call
+ * site. `ensureFederatedNote` — the importer behind boosted originals, reply
+ * ancestors and quoted notes — shipped with `actorUri` missing for exactly that
+ * reason: the value was in scope one line above (it is handed to
+ * `buildFederatedNoteContent`) and nothing objected.
+ *
+ * Nothing about the missing field is loud. The post stores, hydrates and renders
+ * correctly. What breaks is everything that later asks WHO wrote it:
+ *
+ *  - an inbound `Delete` / `Update` is authorized by
+ *    `and(federationActivityId, federationActorUri)`, so a remote deletion of
+ *    such a post matches no row and is silently refused;
+ *  - `resolveFederationTarget` reads `federation.actorUri` to find the author's
+ *    inbox, and every caller (`Like`, `Undo(Like)`, a reply's delivery and its
+ *    `Mention` tag, `Announce`) returns early without one;
+ *  - `isNotNull(posts.federationActorUri)` is the "is this post federated?"
+ *    discriminator used by the blocked-domain purge and the `instance` feed
+ *    source, both of which therefore treat the post as LOCAL.
+ *
+ * A behavioural test would pin whichever of those consequences someone happened
+ * to reach for. This pins the RULE at the point the field is written, which is
+ * the only place all of them are decided.
+ *
+ * ## What keeps this check honest
+ *
+ * A source scan that stops finding anything reads as a pass, so the number of
+ * provenance blocks it found — and the number of those that name an
+ * `activityId`, which is the subset the rule applies to — are both asserted
+ * against floors. Both are minimums rather than exact counts: a new legitimate
+ * ingest site must not fail the build, a broken traversal must.
+ */
+
+const SOURCE_ROOT = path.resolve(__dirname, '../..');
+
+/**
+ * The smallest number of `federation:` blocks this scan may find and still be
+ * believed. Nine exist today: the three ActivityPub Note ingest sites (inbox
+ * `Create`, outbox backfill, `ensureFederatedNote`) which share
+ * `buildFederatedNoteProvenance`, the ActivityPub `Announce` importer, the
+ * atproto post importer, the mention-repair script's row type and its rebuilt
+ * block, plus two blocks that describe no post at all (the federation config and
+ * a hydrated user's federation summary) and so carry no `activityId`.
+ */
+const MINIMUM_BLOCKS = 9;
+
+/**
+ * The smallest number of those blocks that name an `activityId` — the subset the
+ * rule actually constrains, seven today. A floor here is what stops the rule
+ * going vacuous if the scan starts matching only the blocks it has nothing to
+ * say about.
+ */
+const MINIMUM_IDENTIFIED_BLOCKS = 7;
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = path.join(dir, name);
+    if (statSync(full).isDirectory()) {
+      if (name === '__tests__' || name === 'node_modules') continue;
+      out.push(...sourceFiles(full));
+      continue;
+    }
+    if (name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+interface ProvenanceBlock {
+  file: string;
+  line: number;
+  /** The keys named inside the block, in source order. */
+  keys: string[];
+}
+
+/**
+ * Every `federation:` value in the tree whose body is an object — written
+ * directly (`federation: {`) or through a builder (`federation: fn({`) — paired
+ * with the keys it names.
+ *
+ * Brace-matched rather than regex-captured: a truncated capture is how a scan
+ * ends up asserting nothing. Both spellings are read the same way on purpose —
+ * the rule is about the fields that reach the post, not about which helper put
+ * them there, so routing a site through a builder cannot exempt it.
+ */
+function findProvenanceBlocks(): ProvenanceBlock[] {
+  const blocks: ProvenanceBlock[] = [];
+  for (const file of sourceFiles(SOURCE_ROOT)) {
+    const source = readFileSync(file, 'utf8');
+    const opener = /federation:\s*(?:[A-Za-z_$][\w$]*\()?\{/g;
+    for (let match = opener.exec(source); match !== null; match = opener.exec(source)) {
+      const bodyStart = match.index + match[0].length;
+      let depth = 1;
+      let cursor = bodyStart;
+      while (cursor < source.length && depth > 0) {
+        if (source[cursor] === '{') depth++;
+        else if (source[cursor] === '}') depth--;
+        cursor++;
+      }
+      // An unbalanced block means the scan lost the plot; record it with no keys
+      // so the `activityId` implication below cannot silently pass over it.
+      const body = depth === 0 ? source.slice(bodyStart, cursor - 1) : '';
+      blocks.push({
+        file: path.relative(SOURCE_ROOT, file),
+        line: source.slice(0, match.index).split('\n').length,
+        keys: topLevelKeys(body),
+      });
+    }
+  }
+  return blocks;
+}
+
+/**
+ * The keys of an object body, ignoring anything nested inside a deeper brace,
+ * bracket or paren — a `getRemoteHost(x)` argument or a nested literal must not
+ * be read as a key of the block being inspected. Comment lines are dropped: a
+ * block whose docblock says the word `actorUri` is not a block that stamps it.
+ */
+function topLevelKeys(body: string): string[] {
+  const keys: string[] = [];
+  let depth = 0;
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    const isComment = line.startsWith('//') || line.startsWith('*') || line.startsWith('/*');
+    if (depth === 0 && !isComment) {
+      const key = /^([A-Za-z_$][\w$]*)\s*[:,;?]/.exec(line);
+      if (key) keys.push(key[1]);
+    }
+    for (const char of rawLine) {
+      if (char === '{' || char === '[' || char === '(') depth++;
+      else if (char === '}' || char === ']' || char === ')') depth--;
+    }
+  }
+  return keys;
+}
+
+describe('inbound federated post provenance', () => {
+  it('scans enough federation blocks to be worth believing', () => {
+    const blocks = findProvenanceBlocks();
+    expect(blocks.length).toBeGreaterThanOrEqual(MINIMUM_BLOCKS);
+    expect(blocks.filter((block) => block.keys.includes('activityId')).length)
+      .toBeGreaterThanOrEqual(MINIMUM_IDENTIFIED_BLOCKS);
+  });
+
+  it('names an actorUri wherever it names an activityId', () => {
+    const missing = findProvenanceBlocks().filter(
+      (block) => block.keys.includes('activityId') && !block.keys.includes('actorUri'),
+    );
+
+    // Printed in full on failure — the file and line are the fix, and a bare
+    // count would leave whoever hits this hunting for it.
+    expect(
+      missing.map((block) => `${block.file}:${block.line} -> {${block.keys.join(', ')}}`),
+    ).toEqual([]);
+  });
+
+  it('reads keys out of every block it scanned', () => {
+    // A block the brace matcher failed on yields no keys at all, which would
+    // pass the implication above for the wrong reason.
+    const unreadable = findProvenanceBlocks().filter((block) => block.keys.length === 0);
+
+    expect(unreadable.map((block) => `${block.file}:${block.line}`)).toEqual([]);
+  });
+
+  it('stamps the actor uri the caller supplies, and falls back to the activity id for the url', () => {
+    expect(
+      buildFederatedNoteProvenance({
+        activityId: 'https://remote.example/notes/1',
+        actorUri: 'https://remote.example/users/alice',
+        noteUrl: { nope: true },
+      }),
+    ).toEqual({
+      activityId: 'https://remote.example/notes/1',
+      actorUri: 'https://remote.example/users/alice',
+      inReplyTo: undefined,
+      url: 'https://remote.example/notes/1',
+      sensitive: undefined,
+      spoilerText: undefined,
+    });
+  });
+});

--- a/packages/backend/src/connectors/activitypub/apPostContent.ts
+++ b/packages/backend/src/connectors/activitypub/apPostContent.ts
@@ -9,6 +9,7 @@ import { qualifyBareHandles } from '@mention/shared-types/textEntities';
 import { isBridgeFlattenedRetweet } from './flattenedRetweet';
 import { htmlToInlineLabel, htmlToPlainText } from '../../utils/federation/htmlToPlainText';
 import { normalizePostHashtags } from '../../utils/textProcessing';
+import type { PostRecordFederation } from '../../db/posts/postRecord';
 import { materializeFederatedMedia, type ExtractedMediaAttachment } from '../shared/federatedMedia';
 import { extractApHashtags, extractApMedia } from './helpers';
 import { extractApLanguage, getApContentMap } from './apLanguage';
@@ -468,6 +469,59 @@ export async function buildFederatedNoteContent(
   }
 
   return built;
+}
+
+/**
+ * The provenance every federated Note ingest site must stamp on the post it
+ * stores — the counterpart of {@link buildFederatedNoteContent}, which owns the
+ * BODY the same three sites store.
+ *
+ * ## Why this is a function and not an object literal
+ *
+ * `PostRecordFederation` is entirely optional, so an ingest site that names four
+ * of its fields and forgets the fifth type-checks exactly like one that names
+ * all five. `ensureFederatedNote` — the boost-original / reply-ancestor / quoted-
+ * note importer — shipped without `actorUri` for precisely that reason: the
+ * value was in scope one line above (it is handed to
+ * {@link buildFederatedNoteContent}), and nothing anywhere objected.
+ *
+ * A missing `actorUri` does not degrade gracefully. It is the AUTHORIZATION key
+ * for an inbound `Delete`/`Update` (both scope their query by it, so a remote
+ * deletion silently matches no row), the delivery address for an outbound
+ * `Like`/reply/`Announce` about the post (`resolveFederationTarget` reads it, and
+ * every caller returns early without an inbox), and the discriminator every
+ * "is this post federated?" query uses (`isNotNull(posts.federationActorUri)`) —
+ * including the blocked-domain purge and the `instance` feed source, which
+ * therefore count the post as LOCAL.
+ *
+ * Making both identity fields REQUIRED arguments is what stops the next site
+ * repeating it: there is no shape of this call that omits one.
+ *
+ * `noteUrl` is raw remote JSON (hence `unknown`) and falls back to the activity
+ * id, which is what all three sites did inline.
+ */
+export function buildFederatedNoteProvenance(input: {
+  /** The Note's own AP id — the post's globally unique federated identity. */
+  activityId: string;
+  /** The verified AP actor URI that authored the Note. */
+  actorUri: string;
+  /** The parent's AP URI, for a reply. */
+  inReplyTo?: string;
+  /** The Note's `url` as it arrived, unvalidated. */
+  noteUrl?: unknown;
+  /** The remote instance's own sensitivity flag. */
+  sensitive?: boolean;
+  /** The remote content warning (the Note's `summary`). */
+  spoilerText?: string;
+}): PostRecordFederation {
+  return {
+    activityId: input.activityId,
+    actorUri: input.actorUri,
+    inReplyTo: input.inReplyTo,
+    url: typeof input.noteUrl === 'string' ? input.noteUrl : input.activityId,
+    sensitive: input.sensitive,
+    spoilerText: input.spoilerText,
+  };
 }
 
 /**

--- a/packages/backend/src/connectors/activitypub/inbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/inbox.service.ts
@@ -49,7 +49,11 @@ import {
   parseApPublished,
   resolvePostIdFromObjectUri,
 } from './helpers';
-import { buildFederatedNoteContent, buildFederatedNoteContentForEdit } from './apPostContent';
+import {
+  buildFederatedNoteContent,
+  buildFederatedNoteContentForEdit,
+  buildFederatedNoteProvenance,
+} from './apPostContent';
 import { identityDomainOfActor } from './identityDomain';
 import { federationBridges } from './federationBridgePolicy';
 import { applyMentionPlaceholders, resolveInboundMentions } from './apMentions';
@@ -629,14 +633,14 @@ export class InboxProcessingService {
 
     const createdPost = await getPostCreator().create({
       oxyUserId: authorOxyUserId,
-      federation: {
+      federation: buildFederatedNoteProvenance({
         activityId: note.id,
         actorUri,
         inReplyTo: inReplyToUri,
-        url: typeof note.url === 'string' ? note.url : note.id,
+        noteUrl: note.url,
         sensitive,
         spoilerText: summary,
-      },
+      }),
       parentPostId: threadLink?.parentPostId ?? null,
       threadId: threadLink?.threadId ?? null,
       quoteOf,

--- a/packages/backend/src/connectors/activitypub/outbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/outbox.service.ts
@@ -32,7 +32,11 @@ import {
 import { parentIsChannelPost } from '../../utils/channelReplyGate';
 import { PostType, PostVisibility } from '@mention/shared-types';
 import { extractApLanguage, extractApLanguages } from './apLanguage';
-import { buildFederatedNoteContent, buildFederatedNoteVariants } from './apPostContent';
+import {
+  buildFederatedNoteContent,
+  buildFederatedNoteProvenance,
+  buildFederatedNoteVariants,
+} from './apPostContent';
 import { normalizeMentionIds } from '../../utils/textProcessing';
 import { postTextHasHttpLink } from '../../utils/postSearchMetadata';
 import { getPostCreator } from '../../services/serviceRegistry';
@@ -890,14 +894,14 @@ export class OutboxSyncService {
           id: uuidv7(),
           oxyUserId: resolvedOxyUserId,
           authorship: buildAuthorship(resolvedOxyUserId, []),
-          federation: {
+          federation: buildFederatedNoteProvenance({
             activityId,
             actorUri,
             inReplyTo: inReplyToUri,
-            url: typeof note.url === 'string' ? note.url : activityId,
+            noteUrl: note.url,
             sensitive,
             spoilerText: summary,
-          },
+          }),
           type: media.length > 0
             ? (media.some((m) => m.type === 'video') ? PostType.VIDEO : PostType.IMAGE)
             : PostType.TEXT,
@@ -1594,13 +1598,14 @@ export class OutboxSyncService {
     try {
       const created = await getPostCreator().create({
         oxyUserId: authorOxyUserId,
-        federation: {
+        federation: buildFederatedNoteProvenance({
           activityId: noteActivityId,
+          actorUri: authorUri,
           inReplyTo: inReplyToUri,
-          url: typeof note.url === 'string' ? note.url : noteActivityId,
+          noteUrl: note.url,
           sensitive,
           spoilerText: summary,
-        },
+        }),
         parentPostId: threadLink?.parentPostId ?? null,
         threadId: threadLink?.threadId ?? null,
         content: {
@@ -1618,6 +1623,12 @@ export class OutboxSyncService {
         language: extractApLanguage(note),
         languages: extractApLanguages(note),
         instanceDomain: authorUri ? getRemoteHost(authorUri) : undefined,
+        // The author's AP type feeds the Stage-A RSS/bot-mirror spam signal, as
+        // it does on the inbox `Create` and outbox-backfill paths. Dropped here
+        // for the same reason `actorUri` was — the actor is resolved above and
+        // nothing objected to leaving it out — which classified the SAME remote
+        // Note differently depending on which path happened to import it.
+        actorType: authorActor?.type,
         status: 'published',
         metadata: { isSensitive: sensitive },
         skipNotifications: true,


### PR DESCRIPTION
`ensureFederatedNote` — the importer behind every boosted original, reply ancestor and quoted note Mention fetches — stored its posts with `federation.actorUri` empty. `authorUri` was in scope one line above (it is handed to `buildFederatedNoteContent`), and an object literal naming four of `PostRecordFederation`'s five optional fields type-checks exactly like one naming all five, so nothing objected. Same shape AGENTS.md already records for the OUTBOUND direction.

## Blast radius

Three ingest paths reach it: `importAnnounce` (boosted originals), `resolveThreadLink` (reply ancestors, recursively up the chain), and `ensureQuotedNote` (quoted notes — from inbox `handleCreate` and two backfill scripts).

Nothing about the missing field is loud. The post stores, hydrates and renders. What breaks is everything that later asks WHO wrote it:

- **Remote `Delete` and `Update` are silently refused.** `handleDelete` and the `Update` edit filter are both authorized by `and(federationActivityId, federationActorUri)`. With the column null, a remote author deleting or editing their own post matches no row — the activity is acknowledged and nothing happens.
- **Outbound engagement has nowhere to go.** `resolveFederationTarget` reads `federation.actorUri`; without it there is no `authorInbox` and no `authorAcct`. `Like` / `Undo(Like)` return early (`if (!target?.authorInbox) return`), a reply is not delivered to the parent author's inbox and carries no `Mention` tag naming them, and an `Announce` skips the original author's inbox.
- **The post reads as LOCAL.** `isNotNull(posts.federationActorUri)` is the federated-or-not discriminator: `purgeBlockedDomainContent` scans and counts on it (so content from a newly blocked instance escapes the purge), the MTN `instance` feed source serves these posts under `domain=local` and never under their real instance, and `FeedInteractionTracker` misclassifies them.
- Actor-deletion preflight (`adminDeletionPreflight`), `reingestEmptyFederatedPosts`, `repairFederatedMentions` and `evalFeedQuality` all locate posts by actor URI and cannot see these.

## Fix shape

Fixed at the seam, not at the literal. `buildFederatedNoteProvenance` now owns the provenance block the way `buildFederatedNoteContent` already owns the body, with **`activityId` and `actorUri` as required arguments**; all three ActivityPub Note ingest sites (inbox `Create`, outbox backfill, `ensureFederatedNote`) call it. There is no shape of that call which omits one. The `Announce` and atproto sites keep their literals — different objects with different fields — and are covered by the gate instead.

## Census (step 3)

All five connector `create` federation payloads were read. `actorUri` was present at the other four (inbox `Create`, outbox backfill, `importAnnounce`, atproto). One further finding at the same literal: `ensureFederatedNote` also dropped **`actorType`**, which is in scope on the resolved actor and which both other AP paths pass — so the same remote Note was classified with or without the RSS/bot-mirror spam signal depending on which path imported it. Passed through as well.

## Gate

`__tests__/connectors/inboundPostProvenanceShape.test.ts`, the inbound counterpart of `outboundPostPayloadShape.test.ts`: a brace-matched source scan asserting every `federation:` block naming an `activityId` also names an `actorUri`, plus floors on the blocks found (9) and on the subset the rule constrains (7), and an assertion that every block yielded keys. Builder calls and literals are read identically, so hand-building the block again cannot exempt a site.

Mutation-tested three ways, each verified applied by diff before running:
1. `actorUri` removed from the builder call → gate red, naming `outbox.service.ts:1601`; `tsc` also red (`TS2345`).
2. The call reverted to the original hand-built literal — the exact shipped bug, invisible to `tsc` → gate red.
3. Scanner blinded (`SOURCE_ROOT` narrowed to a subtree with no matches) → floor red at `expected 0 to be greater than or equal to 9`.

## Verification

Baseline on pristine `origin/main` and the fix, same dedicated Postgres 17/PostGIS container on a random high port (the shared :5433 is saturated), same machine load:

| | test files | tests |
|---|---|---|
| pristine `origin/main` | 3 failed / 485 passed | **5976 passed, 0 failed** |
| this branch | 4 failed / 485 passed | **5980 passed, 0 failed** (+4 = the new gate) |

Zero test assertions fail on either side. Every failed FILE on both sides is the same `Error: Hook timed out in 10000ms` in `src/__tests__/setup.ts:72`'s `afterAll` teardown, and which files it hits varies run to run (an intermediate run failed only one) — teardown contention under load, not a regression. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)