### PR TITLE
fix(search): a native post with a URL stored has_links = false

### DIFF
--- a/packages/backend/src/__tests__/db/postHasLinksDerivation.test.ts
+++ b/packages/backend/src/__tests__/db/postHasLinksDerivation.test.ts
@@ -1,0 +1,206 @@
+/**
+ * `posts.has_links` is derived from the body, on every write path, against a
+ * real database.
+ *
+ * ## What this pins, and why it is not a unit test of the detector
+ *
+ * `postTextHasHttpLink` already has its own unit test
+ * (`utils/postSearchMetadata.test.ts`). That test passed the entire time the bug
+ * was live, because the detector was never wrong — it was simply not CALLED by
+ * any writer except the ActivityPub outbox backfill. `hasLinks` was an optional
+ * field on `PostRecordInput`, `toPostInsert` defaulted it to `false`, and every
+ * other writer (`PostCreationService`, the reply and boost paths in
+ * `feed.controller`, `PostMaterializer`) omitted it. So a native post full of
+ * URLs stored `has_links = false`, and `filter:links` — which is
+ * `eq(posts.hasLinks, true)` in `routes/search.ts` — matched no native post at
+ * all. The query stayed valid and returned rows; it just silently omitted
+ * everything local.
+ *
+ * A test of the detector cannot see that, and neither can `tsc`: an optional
+ * field is omitted correctly by construction. Only a test that reads the COLUMN
+ * BACK after a write can. Hence: rows, both halves, both directions.
+ *
+ * ## Both halves
+ *
+ * CREATE is `toPostInsert`; EDIT is `replacePostContent`, the one function every
+ * content-changing path in the tree goes through. The edit half needs its own
+ * cases in BOTH directions — a post edited to add a link and a post edited to
+ * remove one — because a derivation that only ever sets the flag TRUE is
+ * indistinguishable from a correct one until somebody deletes a URL.
+ *
+ * ## Mutation results (each applied, diffed, run, restored)
+ *
+ *  - `toPostInsert`: `postTextHasHttpLink(content.variants)` -> `false`
+ *      => 3 fail. Both create cases that expect TRUE, plus the link-removing
+ *         edit case, whose precondition is a created row that already has one.
+ *         The two create cases expecting FALSE stay green, correctly: `false` is
+ *         still the right answer for them, which is why a fixture set of only
+ *         link-bearing bodies would have measured nothing.
+ *  - `replacePostContent`: the `hasLinks:` line deleted
+ *      => 2 fail, the two edit cases that change the answer. The pass-through
+ *         case stays green, also correctly — nothing should change there, and a
+ *         red on it would mean this file was asserting the write rather than the
+ *         value.
+ *  - `replacePostContent`: `postTextHasHttpLink(content.variants)` -> `true`
+ *      => 1 fails, the link-removing edit case. That is the whole point of
+ *         having it: every other case in this file is green under a derivation
+ *         that can only ever set the flag.
+ *
+ * A fourth, on the READER rather than the writer, lives with the test it
+ * belongs to: replacing `eq(posts.hasLinks, true)` in `routes/search.ts` with an
+ * `EXISTS` scan over the bodies fails
+ * `routes/searchPosts.test.ts > selects has:links from the stored flag rather
+ * than scanning the body` — on the assertion where the column and the bodies
+ * deliberately disagree, and only on that one.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { PostType, PostVisibility } from '@mention/shared-types';
+import type { StoredPostContent } from '@mention/shared-types';
+
+import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
+import { posts } from '../../db/schema/posts';
+import {
+  insertPostRecord,
+  replacePostContent,
+} from '../../db/posts/postRepository';
+import type { PostRecordInput } from '../../db/posts/postRecord';
+
+let db: Database;
+const created: string[] = [];
+
+const AUTHOR = 'oxy-haslinks-author';
+
+function baseInput(overrides: Partial<PostRecordInput> = {}): PostRecordInput {
+  return {
+    oxyUserId: AUTHOR,
+    authorship: [{ oxyUserId: AUTHOR, role: 'owner', status: 'accepted' }],
+    type: PostType.TEXT,
+    visibility: PostVisibility.PUBLIC,
+    status: 'published',
+    content: { variants: [{ source: 'author', text: 'hello', tag: 'en' }] },
+    ...overrides,
+  };
+}
+
+function body(text: string): StoredPostContent {
+  return { variants: [{ source: 'author', text, tag: 'en' }] };
+}
+
+async function create(content: StoredPostContent): Promise<string> {
+  const record = await insertPostRecord(baseInput({ content }));
+  created.push(record.id);
+  return record.id;
+}
+
+/**
+ * The COLUMN, read straight out of the table.
+ *
+ * Deliberately not `PostRecord.hasLinks`: the assembled record and the row could
+ * both be wrong together if the projection ever grew a default of its own, and
+ * the column is what `routes/search.ts` filters on.
+ */
+async function storedHasLinks(postId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ hasLinks: posts.hasLinks })
+    .from(posts)
+    .where(eq(posts.id, postId));
+  if (!row) throw new Error(`post ${postId} was not readable`);
+  return row.hasLinks;
+}
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterEach(async () => {
+  while (created.length > 0) {
+    const id = created.pop();
+    if (id) await db.delete(posts).where(eq(posts.id, id));
+  }
+  await db.delete(posts).where(eq(posts.oxyUserId, AUTHOR));
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+describe('has_links on create', () => {
+  it('is true for a body containing a link, and false for one that does not', async () => {
+    const linked = await create(body('read this https://example.test/article'));
+    const plain = await create(body('no link here, just words'));
+
+    expect(await storedHasLinks(linked)).toBe(true);
+    expect(await storedHasLinks(plain)).toBe(false);
+  });
+
+  it('is true when only a SECONDARY rendition carries the link', async () => {
+    // A translated or per-language rendition is a body a reader can be served,
+    // so a link in it is a link in the post. Reading only `variants[0]` would
+    // answer false here, which is the same silent omission one variant deep.
+    const id = await create({
+      variants: [
+        { source: 'author', text: 'sin enlace', tag: 'es' },
+        { source: 'author', text: 'with a link https://example.test', tag: 'en' },
+      ],
+    });
+
+    expect(await storedHasLinks(id)).toBe(true);
+  });
+
+  it('does not treat a bare domain as a link', async () => {
+    // The column backs `filter:links`, and a plain-text domain is not something
+    // a reader can follow. This is the detector's own rule; asserted here so the
+    // write path cannot quietly widen it.
+    const id = await create(body('example.com is plain text'));
+
+    expect(await storedHasLinks(id)).toBe(false);
+  });
+
+  it('is false for a post with no renditions at all', async () => {
+    // A bare boost. `postTextHasHttpLink(undefined)` is the path taken.
+    const id = await create({ variants: [] });
+
+    expect(await storedHasLinks(id)).toBe(false);
+  });
+});
+
+describe('has_links on edit', () => {
+  it('turns true when an edit adds a link', async () => {
+    const id = await create(body('nothing to click'));
+    expect(await storedHasLinks(id)).toBe(false);
+
+    await replacePostContent(id, body('now with https://example.test'), []);
+
+    expect(await storedHasLinks(id)).toBe(true);
+  });
+
+  it('turns false when an edit removes the only link', async () => {
+    // The direction a set-only derivation gets wrong. A post edited to drop its
+    // URL keeps matching `filter:links` forever otherwise.
+    const id = await create(body('see https://example.test'));
+    expect(await storedHasLinks(id)).toBe(true);
+
+    await replacePostContent(id, body('link removed'), []);
+
+    expect(await storedHasLinks(id)).toBe(false);
+  });
+
+  it('leaves the flag alone when an edit carries the same body through', async () => {
+    // The media-metadata enrich job and the media backfill both call
+    // `replacePostContent` with the EXISTING variants and a new media set. A
+    // derivation is safe at that seam precisely because it recomputes the same
+    // answer from the same text — this is the assertion that says so.
+    const content = body('read this https://example.test/article');
+    const id = await create(content);
+
+    await replacePostContent(
+      id,
+      { ...content, media: [{ id: 'file-1', type: 'image' }] },
+      [],
+    );
+
+    expect(await storedHasLinks(id)).toBe(true);
+  });
+});

--- a/packages/backend/src/__tests__/isolatedDatabaseCoverage.test.ts
+++ b/packages/backend/src/__tests__/isolatedDatabaseCoverage.test.ts
@@ -153,6 +153,7 @@ const JOB_ENTRY_POINTS: readonly JobEntryPoint[] = [
     call: /\bbackfillFederatedHandleQualification\s*\(/,
   },
   { name: 'backfillQuotedPosts', call: /\bbackfillQuotedPosts\s*\(/ },
+  { name: 'backfillPostHasLinks', call: /\bbackfillPostHasLinks\s*\(/ },
   { name: 'backfillPostLanguages', call: /\bbackfillPostLanguages\s*\(/ },
   { name: 'backfillCustomFeedDefinitions', call: /\bbackfillCustomFeedDefinitions\s*\(/ },
 ];

--- a/packages/backend/src/__tests__/isolatedDatabaseFiles.ts
+++ b/packages/backend/src/__tests__/isolatedDatabaseFiles.ts
@@ -276,6 +276,16 @@ export const ISOLATED_DATABASE_FILES: readonly IsolatedDatabaseFile[] = [
       'UPDATEs `quote_of` on it. Its suite mocks `signedFetch` to answer with a quote for ANY ' +
       'candidate, so a foreign row entering the scan is linked to this file\'s fixture.',
   },
+  {
+    path: 'src/__tests__/scripts/backfillPostHasLinksRows.test.ts',
+    jobEntryPoint: 'backfillPostHasLinks',
+    reason:
+      'Sweeps every post in the table whose `has_links` column disagrees with its stored ' +
+      'renditions and rewrites the column on each — it takes no scope, because a repair that ' +
+      'only fixed the caller\'s rows would repair nothing in production. Its suite runs it with ' +
+      '`dryRun: false`, and the rows it would eat are the deliberately-disagreeing ones ' +
+      '`routes/searchPosts.test.ts` seeds to prove `has:links` reads the column, not the body.',
+  },
 
   /*
    * ── THE TWO THE SECOND SCAN ALSO MISSED ─────────────────────────────────────

--- a/packages/backend/src/__tests__/mediaFeed.test.ts
+++ b/packages/backend/src/__tests__/mediaFeed.test.ts
@@ -149,10 +149,9 @@ describe('each arm of the "carries media" disjunction', () => {
     // feed with text posts that render as a blank tile.
     await create({
       content: {
-        variants: [{ source: 'author', text: 'links' }],
+        variants: [{ source: 'author', text: 'links https://example.test' }],
         attachments: [{ type: 'sources' }],
       },
-      hasLinks: true,
     });
     await create({
       content: { variants: [{ source: 'author', text: 'a poll' }], attachments: [{ type: 'poll' }] },

--- a/packages/backend/src/__tests__/routes/searchPosts.test.ts
+++ b/packages/backend/src/__tests__/routes/searchPosts.test.ts
@@ -164,6 +164,22 @@ async function setCounters(
     .where(eq(posts.id, postId));
 }
 
+/**
+ * Set a post's `has_links` column directly, to a value its body disagrees with.
+ *
+ * The whole point of the column is that `has:links` does not scan bodies, and
+ * the only way to SHOW that is a row where the two disagree — which the write
+ * path can no longer produce, because `toPostInsert` and `replacePostContent`
+ * derive the column from the renditions and `PostRecordInput` has no field for
+ * it. So the disagreement is written here, in SQL, deliberately.
+ *
+ * That the derivation itself is right is a different claim, pinned by
+ * `db/postHasLinksDerivation.test.ts`.
+ */
+async function setHasLinks(postId: string, hasLinks: boolean): Promise<void> {
+  await getDb().update(posts).set({ hasLinks }).where(eq(posts.id, postId));
+}
+
 const mutedUserIds: string[] = [];
 const settingsUserIds: string[] = [];
 
@@ -587,10 +603,20 @@ describe('GET /search — operators', () => {
   });
 
   it('selects has:links from the stored flag rather than scanning the body', async () => {
-    const linked = await seedPost(scope, { content: body('see https://example.test'), hasLinks: true });
+    const linked = await seedPost(scope, { content: body('see https://example.test') });
     await seedPost(scope, { content: body('no link here') });
 
     expect(await idsFor({ query: `${TERM} has:links` })).toEqual([linked.id]);
+
+    // The column, not the text. Both rows now lie about their own bodies, and
+    // the filter follows the column both ways — which is the property that makes
+    // `has:links` an index lookup instead of an unanchored regex over every
+    // localized rendition.
+    const unlinked = await seedPost(scope, { content: body('also no link here') });
+    await setHasLinks(linked.id, false);
+    await setHasLinks(unlinked.id, true);
+
+    expect(await idsFor({ query: `${TERM} has:links` })).toEqual([unlinked.id]);
   });
 
   it('applies min_likes and min_boosts against the stored counters', async () => {
@@ -625,8 +651,7 @@ describe('GET /search — operators', () => {
     const post = await seedPost(scope, {
       oxyUserId: VIEWER,
       authorship: [{ oxyUserId: VIEWER, role: 'owner', status: 'accepted' }],
-      content: body('rust release'),
-      hasLinks: true,
+      content: body('rust release https://example.test/rust'),
     });
     await setCounters(post.id, { likes: 7 });
 

--- a/packages/backend/src/__tests__/scriptScope.ts
+++ b/packages/backend/src/__tests__/scriptScope.ts
@@ -109,6 +109,11 @@ export const SCRIPT_SCOPE: Readonly<Record<string, ScriptScopeDeclaration>> = {
     scope: 'whole-table',
     reason: 'Every federated post with a null quote_of whose body renders as `RE: <url>`.',
   },
+  backfillPostHasLinks: {
+    scope: 'whole-table',
+    reason:
+      'Every post whose has_links column disagrees with its own renditions, in both directions.',
+  },
   backfillPostLanguages: {
     scope: 'whole-table',
     reason: 'Its own docblock: "takes no scope — by design, it is a one-shot over" the table.',

--- a/packages/backend/src/__tests__/scripts/backfillPostHasLinksRows.test.ts
+++ b/packages/backend/src/__tests__/scripts/backfillPostHasLinksRows.test.ts
@@ -1,0 +1,185 @@
+/**
+ * The `has_links` repair, against real rows.
+ *
+ * The script's whole job is to make `posts.has_links` agree with the stored
+ * renditions for rows written before the derivation moved to the repository. So
+ * the fixtures are the four states such a row can be in — two that disagree in
+ * either direction, and two that already agree — and the assertions read the
+ * COLUMN back afterwards.
+ *
+ * ## The disagreement can only be written in SQL, and that is the point
+ *
+ * `PostRecordInput` no longer carries a `hasLinks` field, and both write paths
+ * derive it, so `insertPostRecord` cannot produce a wrong row any more. The
+ * historical state therefore has to be manufactured with a direct UPDATE. That
+ * is not a shortcut around the API — it is a faithful reproduction of what
+ * production holds, and of what the two direct-SQL body-repair scripts
+ * (`normalizeFederatedText`, `repairFederatedMentions`) can still produce today.
+ *
+ * ## Why this file gets its own database
+ *
+ * `backfillPostHasLinks` sweeps EVERY disagreeing row in the `posts` table — it
+ * takes no scope, by design, because a repair that only fixed the caller's rows
+ * would repair nothing in production. Registered in `isolatedDatabaseFiles.ts`
+ * for exactly that reason: run against the shared database it would rewrite the
+ * deliberately-disagreeing rows `routes/searchPosts.test.ts` seeds to prove
+ * `has:links` reads the column rather than the bodies.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { PostType, PostVisibility } from '@mention/shared-types';
+import type { StoredPostContent } from '@mention/shared-types';
+
+import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
+import { posts } from '../../db/schema/posts';
+import { insertPostRecord } from '../../db/posts/postRepository';
+import { backfillPostHasLinks } from '../../scripts/backfillPostHasLinks';
+
+let db: Database;
+const created: string[] = [];
+
+const AUTHOR = 'oxy-haslinks-backfill-author';
+
+function body(text: string): StoredPostContent {
+  return { variants: [{ source: 'author', text, tag: 'en' }] };
+}
+
+async function seed(content: StoredPostContent, storedFlag?: boolean): Promise<string> {
+  const record = await insertPostRecord({
+    oxyUserId: AUTHOR,
+    authorship: [{ oxyUserId: AUTHOR, role: 'owner', status: 'accepted' }],
+    type: PostType.TEXT,
+    visibility: PostVisibility.PUBLIC,
+    status: 'published',
+    content,
+  });
+  created.push(record.id);
+  // The pre-fix state, which the write path can no longer produce.
+  if (storedFlag !== undefined) {
+    await db.update(posts).set({ hasLinks: storedFlag }).where(eq(posts.id, record.id));
+  }
+  return record.id;
+}
+
+async function flagsOf(ids: readonly string[]): Promise<Record<string, boolean>> {
+  const rows = await db
+    .select({ id: posts.id, hasLinks: posts.hasLinks })
+    .from(posts)
+    .where(inArray(posts.id, [...ids]));
+  return Object.fromEntries(rows.map((row) => [row.id, row.hasLinks]));
+}
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterEach(async () => {
+  while (created.length > 0) {
+    const id = created.pop();
+    if (id) await db.delete(posts).where(eq(posts.id, id));
+  }
+  await db.delete(posts).where(eq(posts.oxyUserId, AUTHOR));
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+describe('backfillPostHasLinks', () => {
+  it('counts both directions and writes nothing on a dry run', async () => {
+    const stale = await seed(body('go to https://example.test'), false);
+    const phantom = await seed(body('no url in here'), true);
+
+    const result = await backfillPostHasLinks({ dryRun: true });
+
+    expect(result.setTrue.candidates).toBe(1);
+    expect(result.setFalse.candidates).toBe(1);
+    expect(result.setTrue.written).toBe(0);
+    expect(result.setFalse.written).toBe(0);
+    expect(result.noOpWrites).toBe(false);
+
+    // The rows are untouched — a dry run that repaired anything would make the
+    // preview the operator reads before a live run a lie.
+    expect(await flagsOf([stale, phantom])).toEqual({ [stale]: false, [phantom]: true });
+  });
+
+  it('repairs both directions and leaves the already-correct rows alone', async () => {
+    const stale = await seed(body('go to https://example.test'), false);
+    const phantom = await seed(body('no url in here'), true);
+    const correctTrue = await seed(body('already right https://example.test'));
+    const correctFalse = await seed(body('already right, no link'));
+
+    const result = await backfillPostHasLinks({ dryRun: false });
+
+    expect(result.setTrue.written).toBe(1);
+    expect(result.setFalse.written).toBe(1);
+    expect(result.noOpWrites).toBe(false);
+
+    expect(await flagsOf([stale, phantom, correctTrue, correctFalse])).toEqual({
+      [stale]: true,
+      [phantom]: false,
+      // The two that already agreed were never candidates, so they cannot have
+      // been flipped by a repair that got its predicate backwards.
+      [correctTrue]: true,
+      [correctFalse]: false,
+    });
+  });
+
+  it('is idempotent — a second run finds nothing left to do', async () => {
+    await seed(body('go to https://example.test'), false);
+    await seed(body('no url in here'), true);
+
+    await backfillPostHasLinks({ dryRun: false });
+    const second = await backfillPostHasLinks({ dryRun: false });
+
+    expect(second.setTrue.candidates).toBe(0);
+    expect(second.setFalse.candidates).toBe(0);
+    expect(second.setTrue.written).toBe(0);
+    expect(second.setFalse.written).toBe(0);
+    // Zero written with zero candidates is the ONE case that is not a no-op bug,
+    // which is why the flag is computed rather than inferred from `written`.
+    expect(second.noOpWrites).toBe(false);
+  });
+
+  it('counts a natively-written candidate as native', async () => {
+    // The breakdown is what tells an operator whether the corpus damage is the
+    // native write path (all of it, before the fix) or a federated import.
+    await seed(body('native, with https://example.test'), false);
+
+    const result = await backfillPostHasLinks({ dryRun: true });
+
+    expect(result.setTrue.candidates).toBe(1);
+    expect(result.setTrue.nativeCandidates).toBe(1);
+  });
+
+  it('sees a link in a rendition that is not the primary', async () => {
+    // The repair's SQL has to match `postTextHasHttpLink`, which reads EVERY
+    // rendition. A predicate keyed on `position = 0` would leave these rows
+    // wrong forever, and nothing downstream would say so.
+    await seed(
+      {
+        variants: [
+          { source: 'author', text: 'sin enlace', tag: 'es' },
+          { source: 'author', text: 'link https://example.test', tag: 'en' },
+        ],
+      },
+      false,
+    );
+
+    const result = await backfillPostHasLinks({ dryRun: true });
+
+    expect(result.setTrue.candidates).toBe(1);
+  });
+
+  it('does not count a post whose only "link" is a bare domain', async () => {
+    // Same rule as the detector: `example.com` in plain text is not a link, so a
+    // repair that widened the predicate would set the flag on posts the write
+    // path would never set it on — and the two would then disagree forever.
+    await seed(body('example.com is plain text'), false);
+
+    const result = await backfillPostHasLinks({ dryRun: true });
+
+    expect(result.setTrue.candidates).toBe(0);
+  });
+});

--- a/packages/backend/src/connectors/activitypub/outbox.service.ts
+++ b/packages/backend/src/connectors/activitypub/outbox.service.ts
@@ -37,7 +37,6 @@ import {
   buildFederatedNoteVariants,
 } from './apPostContent';
 import { normalizeMentionIds } from '../../utils/textProcessing';
-import { postTextHasHttpLink } from '../../utils/postSearchMetadata';
 import { getPostCreator } from '../../services/serviceRegistry';
 import { enrichIngestedPosts } from '../../services/postEnrichment';
 import { baselineContentClassifier } from '../../services/BaselineContentClassifier';
@@ -912,7 +911,6 @@ export class OutboxSyncService {
             media: media.length > 0 ? media : undefined,
             attachments: attachments.length > 0 ? attachments : undefined,
           },
-          hasLinks: postTextHasHttpLink(variants),
           visibility,
           hashtags,
           // Resolved @mention Oxy user ids (federated + local) — the SAME allowlist

--- a/packages/backend/src/db/posts/postRecord.ts
+++ b/packages/backend/src/db/posts/postRecord.ts
@@ -266,7 +266,6 @@ export interface PostRecordInput {
   type: PostType;
   visibility: PostVisibility;
   status: PostPublicationStatus;
-  hasLinks?: boolean;
   language?: string;
   tags?: string[];
   hashtags?: string[];

--- a/packages/backend/src/db/posts/postRepository.ts
+++ b/packages/backend/src/db/posts/postRepository.ts
@@ -61,6 +61,7 @@ import type {
   StoredPostContent,
 } from '@mention/shared-types';
 import { followedAuthorsSql } from '../../utils/postAuthorship';
+import { postTextHasHttpLink } from '../../utils/postSearchMetadata';
 import { getDb, type DatabaseOrTransaction } from '../postgres';
 import { uuidv7 } from '@oxyhq/db';
 import { posts } from '../schema/posts';
@@ -744,7 +745,13 @@ function toPostInsert(input: PostRecordInput, id: string): PostInsert {
     // stored discriminator can never disagree with the links the CHECK
     // constraints police.
     isReply: derivesReplyIntent(input),
-    hasLinks: input.hasLinks ?? false,
+    // Derived HERE and in `replacePostContent`, for the same reason `isReply` is:
+    // it is a projection of the body, so a caller-supplied value could only ever
+    // agree with the content in the same statement or be wrong. It WAS
+    // caller-supplied, and only the outbox backfill remembered to supply it — so
+    // every post written by any other path stored `has_links = false` however
+    // many URLs it contained, and `filter:links` matched none of them.
+    hasLinks: postTextHasHttpLink(content.variants),
     isEdited: false,
     language: input.language ?? null,
     tags: input.tags ?? null,
@@ -1315,6 +1322,23 @@ export async function replacePostContent(
     await tx
       .update(posts)
       .set({
+        // The edit half of the `has_links` derivation `toPostInsert` performs on
+        // create. It belongs here rather than at a caller because this statement
+        // is where the new body lands: an edit that adds or removes a URL is
+        // exactly an edit that changes this column, and every content-changing
+        // path in the tree goes through this one function. The eight callers that
+        // pass their EXISTING variants through unchanged (the media backfill, the
+        // metadata enrich job, the federated repair paths) recompute the same
+        // value from the same text, so a derivation — unlike a body REWRITE, which
+        // `stripSpamHashtagBlocks` keeps out of here for that very reason — is
+        // safe at this seam.
+        //
+        // Not covered, and deliberately: the two one-shot repair scripts that
+        // `UPDATE post_content_variants` directly (`normalizeFederatedText`,
+        // `repairFederatedMentions` — the latter can fold a profile URL into a
+        // `[mention:<id>]` placeholder, removing a link). `backfillPostHasLinks`
+        // is the repair for any row they leave stale.
+        hasLinks: postTextHasHttpLink(content.variants),
         contentPollId: content.pollId ?? null,
         contentArticleId: content.article?.articleId ?? null,
         contentArticleTitle: content.article?.title ?? null,

--- a/packages/backend/src/scripts/backfillPostHasLinks.ts
+++ b/packages/backend/src/scripts/backfillPostHasLinks.ts
@@ -1,0 +1,264 @@
+/**
+ * One-shot repair: recompute `posts.has_links` from the stored renditions, for
+ * every row where the column and the bodies disagree.
+ *
+ * THE BUG (fixed going forward in `db/posts/postRepository.ts`): `has_links` was
+ * an optional field on `PostRecordInput` that `toPostInsert` defaulted to
+ * `false`, and exactly ONE writer supplied it — the ActivityPub outbox backfill.
+ * `PostCreationService` (which serves native creates AND the single-post
+ * federated imports: the inbox `Create`, the atproto author-feed import), the
+ * reply and boost paths in `feed.controller`, and `PostMaterializer` all omitted
+ * it. So a post full of URLs stored `has_links = false`, and the `filter:links`
+ * search operator — `eq(posts.hasLinks, true)` in `routes/search.ts` — matched
+ * none of them. Nothing errored: the query was valid, returned rows, and simply
+ * omitted everything those paths wrote.
+ *
+ * There was no edit-side derivation either, so a post edited to add or remove a
+ * link kept whatever the column said at creation. Both halves now derive at the
+ * repository seam (`toPostInsert`, `replacePostContent`), which is why this
+ * script has nothing to keep doing: it repairs the rows written before that.
+ *
+ * THE REPAIR is symmetric and is a recomputation, not a one-way fill:
+ *
+ *  - `has_links = false` while a rendition carries an http(s) URL  -> set true;
+ *  - `has_links = true`  while NO rendition carries one            -> set false.
+ *
+ * The second direction is not hypothetical residue-hunting. Two one-shot repair
+ * scripts write `post_content_variants.body` with direct SQL and therefore
+ * bypass `replacePostContent` entirely — `normalizeFederatedText` and, more to
+ * the point, `repairFederatedMentions`, which folds a profile URL in a body into
+ * a `[mention:<id>]` placeholder and so REMOVES a link from text that had one.
+ * A fill-only repair would leave those rows permanently claiming a link they no
+ * longer contain.
+ *
+ * THE PREDICATE IS THE SAME ONE THE WRITE PATH USES, re-expressed in SQL:
+ * `postTextHasHttpLink` is `/https?:\/\//i` over EVERY stored rendition, so this
+ * is `~*` (case-insensitive) against `'https?://'` over every
+ * `post_content_variants` row of the post. A rendition is a rendition whether an
+ * author or a machine wrote it — `source` is deliberately not filtered, exactly
+ * as the detector does not filter it. Widening this to article bodies or
+ * `content.sources` would be a different column with a different meaning; do
+ * that at the derivation, never here, or the two drift.
+ *
+ * SAFETY:
+ *  1. `DRY_RUN` defaults to `true`; only `DRY_RUN=false` writes.
+ *  2. `assertAdminMutationAllowed` refuses a mutating run until the operator
+ *     names the script back.
+ *  3. Batched by id, so no single statement locks a large fraction of `posts`.
+ *  4. Written counts come from what POSTGRES REPORTS MODIFYING (`returning`),
+ *     never from "we called update".
+ *  5. Each batch's UPDATE re-states the full disagreement predicate in its own
+ *     WHERE, so a row another writer fixed between the SELECT and the UPDATE is
+ *     not counted as this run's work.
+ *  6. Idempotent: a repaired row no longer disagrees, so a second run finds it
+ *     in neither direction and reports zero.
+ *
+ * Runnable as a Fargate one-shot (DRY_RUN first):
+ *   bun packages/backend/dist/src/scripts/backfillPostHasLinks.js
+ *   DRY_RUN=false CONFIRM_ADMIN_MUTATION=backfillPostHasLinks \
+ *     bun packages/backend/dist/src/scripts/backfillPostHasLinks.js
+ */
+
+import { and, eq, exists, inArray, isNull, not, sql } from 'drizzle-orm';
+import { connectPostgres, getDb } from '../db/postgres';
+import { posts } from '../db/schema/posts';
+import { postContentVariants } from '../db/schema/postContent';
+import { logger } from '../utils/logger';
+import { closeAdminScriptResources } from './lib/adminScriptLifecycle';
+import { assertAdminMutationAllowed } from './lib/adminScriptSafety';
+
+const SCRIPT_NAME = 'backfillPostHasLinks';
+
+/** Rows repaired per statement. */
+const BATCH_SIZE = 1000;
+
+/** Batches between progress lines. */
+const PROGRESS_EVERY_BATCHES = 20;
+
+/**
+ * The SQL twin of `postTextHasHttpLink`: does ANY rendition of this post carry
+ * an http(s) URL?
+ *
+ * A correlated `EXISTS` rather than a join, because a post with three renditions
+ * each containing a link must be one candidate row, not three — a join would
+ * make every count in the summary a multiple of the truth for exactly the posts
+ * the repair cares most about.
+ *
+ * Built per call rather than held in a module constant: `getDb()` throws before
+ * `connectPostgres()`, and a constant would make that throw happen at IMPORT,
+ * taking down any test or tool that merely loads this module.
+ */
+function bodyHasLink() {
+  return exists(
+    getDb()
+      .select({ one: sql`1` })
+      .from(postContentVariants)
+      .where(and(
+        eq(postContentVariants.postId, posts.id),
+        sql`${postContentVariants.body} ~* 'https?://'`,
+      )),
+  );
+}
+
+/** One direction of the disagreement between the column and the bodies. */
+type Direction = 'set-true' | 'set-false';
+
+function disagreement(direction: Direction) {
+  return direction === 'set-true'
+    ? and(eq(posts.hasLinks, false), bodyHasLink())
+    : and(eq(posts.hasLinks, true), not(bodyHasLink()));
+}
+
+export interface HasLinksBackfillCounts {
+  /** Rows whose column disagrees with their bodies, per direction. */
+  candidates: number;
+  /** Of those, the ones with no `federation_activity_id` — written natively. */
+  nativeCandidates: number;
+  /** Rows Postgres reported modifying. Always 0 on a dry run. */
+  written: number;
+}
+
+export interface HasLinksBackfillResult {
+  setTrue: HasLinksBackfillCounts;
+  setFalse: HasLinksBackfillCounts;
+  /**
+   * Candidates were found and the run wrote none. Carried on the result rather
+   * than inferred by the reader: a live run that repaired nothing and a run that
+   * had nothing to repair both end with `written: 0`, and only one of them is a
+   * bug.
+   */
+  noOpWrites: boolean;
+}
+
+/** Count the disagreeing rows, in total and restricted to natively-written ones. */
+async function countCandidates(direction: Direction): Promise<{ total: number; native: number }> {
+  const [row] = await getDb()
+    .select({
+      total: sql<number>`count(*)::int`,
+      native: sql<number>`count(*) filter (where ${isNull(posts.federationActivityId)})::int`,
+    })
+    .from(posts)
+    .where(disagreement(direction));
+  return { total: row?.total ?? 0, native: row?.native ?? 0 };
+}
+
+async function repairDirection(
+  direction: Direction,
+  dryRun: boolean,
+): Promise<HasLinksBackfillCounts> {
+  const counted = await countCandidates(direction);
+  const counts: HasLinksBackfillCounts = {
+    candidates: counted.total,
+    nativeCandidates: counted.native,
+    written: 0,
+  };
+  if (dryRun || counted.total === 0) return counts;
+
+  const target = direction === 'set-true';
+  let batches = 0;
+
+  // Re-selected every iteration rather than paged with an OFFSET: a repaired row
+  // leaves the candidate set, so an offset would step PAST the rows that shifted
+  // down into the window it already read.
+  for (;;) {
+    const batch = await getDb()
+      .select({ id: posts.id })
+      .from(posts)
+      .where(disagreement(direction))
+      .limit(BATCH_SIZE);
+    if (batch.length === 0) break;
+
+    const updated = await getDb()
+      .update(posts)
+      .set({ hasLinks: target })
+      .where(and(
+        inArray(posts.id, batch.map((row) => row.id)),
+        // The predicate again, so a row somebody else already fixed is not
+        // counted as this run's work.
+        disagreement(direction),
+      ))
+      .returning({ id: posts.id });
+    counts.written += updated.length;
+
+    batches += 1;
+    if (batches % PROGRESS_EVERY_BATCHES === 0) {
+      logger.info(`[${SCRIPT_NAME}] progress`, {
+        direction,
+        written: counts.written,
+        candidates: counts.candidates,
+      });
+    }
+
+    // Every candidate in the batch was already disagreeing when selected, so a
+    // batch that changed nothing means the predicate no longer removes rows from
+    // the candidate set — which would loop forever. Stop and say so.
+    if (updated.length === 0) {
+      logger.error(`[${SCRIPT_NAME}] a batch of candidates wrote nothing; stopping`, {
+        direction,
+        batchSize: batch.length,
+        written: counts.written,
+      });
+      break;
+    }
+  }
+
+  return counts;
+}
+
+/**
+ * The backfill itself. The CALLER owns the connection lifecycle, so a test can
+ * run it in-process against real rows.
+ */
+export async function backfillPostHasLinks(
+  opts: { dryRun?: boolean } = {},
+): Promise<HasLinksBackfillResult> {
+  const dryRun = opts.dryRun ?? true;
+  const startedAt = Date.now();
+
+  const setTrue = await repairDirection('set-true', dryRun);
+  const setFalse = await repairDirection('set-false', dryRun);
+
+  const candidates = setTrue.candidates + setFalse.candidates;
+  const written = setTrue.written + setFalse.written;
+  const result: HasLinksBackfillResult = {
+    setTrue,
+    setFalse,
+    noOpWrites: !dryRun && candidates > 0 && written === 0,
+  };
+
+  logger.info(`[${SCRIPT_NAME}] complete`, {
+    dryRun,
+    setTrueCandidates: setTrue.candidates,
+    setTrueNativeCandidates: setTrue.nativeCandidates,
+    setTrueWritten: setTrue.written,
+    setFalseCandidates: setFalse.candidates,
+    setFalseNativeCandidates: setFalse.nativeCandidates,
+    setFalseWritten: setFalse.written,
+    noOpWrites: result.noOpWrites,
+    elapsedSec: Math.round((Date.now() - startedAt) / 1000),
+  });
+  return result;
+}
+
+async function main(): Promise<void> {
+  const dryRun = (process.env.DRY_RUN ?? 'true') !== 'false';
+  assertAdminMutationAllowed({ scriptName: SCRIPT_NAME, dryRun });
+  await connectPostgres();
+  logger.info(`[${SCRIPT_NAME}] starting`, { dryRun });
+  await backfillPostHasLinks({ dryRun });
+}
+
+if (require.main === module) {
+  main()
+    .then(async () => {
+      await closeAdminScriptResources();
+      process.exit(0);
+    })
+    .catch(async (error) => {
+      logger.error(`[${SCRIPT_NAME}] failed`, {
+        reason: error instanceof Error ? error.message : 'unknown',
+      });
+      await closeAdminScriptResources().catch(() => undefined);
+      process.exit(1);
+    });
+}

--- a/packages/backend/src/utils/postSearchMetadata.ts
+++ b/packages/backend/src/utils/postSearchMetadata.ts
@@ -6,7 +6,17 @@ const HTTP_LINK_PATTERN = /https?:\/\//i;
 
 /**
  * Derive the indexed link-presence flag at write time. Search reads this scalar
- * instead of scanning every localized body with an unanchored regex.
+ * instead of scanning every localized body with an unanchored regex
+ * (`filter:links`, `routes/search.ts`).
+ *
+ * Called from the repository and nowhere else — `toPostInsert` on create and
+ * `replacePostContent` on edit — so `posts.has_links` cannot disagree with the
+ * bodies written in the same statement. It used to be a caller's job, which is
+ * how every write path but the ActivityPub outbox backfill came to store `false`
+ * for a post full of URLs.
+ *
+ * Reads the RENDITIONS only, which is what the column has always meant: an
+ * article body or a `content.sources` entry does not make `filter:links` match.
  */
 export function postTextHasHttpLink(
   variants: readonly TextVariantLike[] | null | undefined,


### PR DESCRIPTION
`posts.has_links` is a write-time projection of the body — the scalar `filter:links` reads instead of scanning every localized rendition with an unanchored regex — and computing it was a CALLER's job. Exactly one caller did it: the ActivityPub outbox backfill, `hasLinks: postTextHasHttpLink(variants)`.

`PostCreationService` (which serves native creates **and** the single-post federated imports — the inbox `Create`, the atproto author-feed import), the reply and boost paths in `feed.controller`, and `PostMaterializer` all omitted it, and `toPostInsert` defaulted `input.hasLinks ?? false`.

So a post full of URLs stored `has_links = false`, and `filter:links` — `eq(posts.hasLinks, true)` in `routes/search.ts` — **matched no native post at all**. It fails the quiet way: the query stays valid, returns rows, and simply omits everything those four writers wrote. `tsc` cannot see it either, because an optional field is omitted correctly by construction — the same reason `federation.actorUri` went missing in #768.

There was no edit-side derivation at all, so a post edited to add or remove a link kept whatever the column said on the day it was created.

Residue from the same retired Mongoose hook family as #710 / #759: the hook derived this at save time and nothing replaced it on the Postgres write path.

## Fixed at the seam, not at the four call sites

`toPostInsert` derives it on create and `replacePostContent` derives it on edit, exactly as `isReply` is derived from `derivesReplyIntent` two lines above. `PostRecordInput` no longer carries the field, so there is no shape of the call that omits it.

Unlike #759's body **rewrite** — deliberately kept out of `replacePostContent`, because four of its eight callers pass existing variants straight through and stripping there would turn a media-metadata job into something that silently edits bodies — a **derivation** is safe at that seam: the pass-through callers recompute the same answer from the same text. A test asserts exactly that.

## The census for other columns of the same shape

A repository default that only the federated writer supplied. Of the 21 optional `PostRecordInput` fields, `hasLinks` was the **only** one whose sole writer was `outbox.service`. Instrument positive-controlled against `origin/main`, where it does report the field; post-fix it reports none.

Two adjacent findings, both out of scope and neither reachable as this bug:

- `posts.tags` has **zero** writers on both the create and the update path, while `PostHydrationService` puts it on the DTO and `mentionRecordBuilders` puts it on the MTN record. It has been permanently `null` since `aed4fc1e`. Different shape (nobody writes it, not "only the federated writer does"), and the fix is a product decision — delete the column and the DTO field, or wire a writer.
- `posts.oxy_user_id` is documented as "synced FROM the `owner` row of `post_authorships` by the Mongoose `pre('save')` hook" — another dead hook. All four writers pass the two consistently today, so nothing is wrong; there is simply no longer a structural guarantee that a fifth will.

## Existing rows

`src/scripts/backfillPostHasLinks.ts`, dry-run by default, batched, idempotent, counting what Postgres reports modifying. It repairs **both** directions: `repairFederatedMentions` folds a profile URL into a `[mention:<id>]` placeholder with direct SQL, so a fill-only repair would leave rows claiming a link they no longer contain.

Nothing has been run against production. The dry run is the count.

## Mutation results

Each applied, diffed against a pristine copy, run, restored:

| mutation | result |
|---|---|
| create half → `false` | 3 fail — both create cases expecting `true`, plus the edit case whose precondition is a created `true`. The two create cases expecting `false` stay green, correctly. |
| edit half deleted | 2 fail — the two edit cases that change the answer. The pass-through case stays green, correctly. |
| edit half → `true` | 1 fails — the link-REMOVING edit, the only case a set-only derivation breaks. |
| `routes/search.ts` scans bodies instead of the column | the `has:links` search case fails, on the assertion where the column and the bodies deliberately disagree — and only on that one. |

## Suite

Own Postgres container on a random high port, same conditions both sides.

- `fix/post-has-links`: **493 files / 6061 tests passed**, twice.
- pristine `origin/main` (2a22d231): **491 files / 6048 tests passed** on the second run; the first run had 7 files fail with 5s timeouts under load, all of which passed on re-run. No file fails on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)