### PR TITLE
feat(ops): the federated-author repair gets a way to be run

### DIFF
--- a/.github/workflows/run-federated-author-backfill.yml
+++ b/.github/workflows/run-federated-author-backfill.yml
@@ -1,0 +1,388 @@
+name: Run federated-author backfill
+
+# Drives `backfillFederatedPostAuthors` — the repair for LEGACY federated posts
+# that carry no Oxy author link (`oxy_user_id IS NULL` with a
+# `federation.activity_id` set). Those posts are invisible in author feeds and
+# render blank when a boost or a quote points at them. The script resolves each
+# orphan's author actor (stored URI → Bridgy-derived URI → one signed re-fetch of
+# the AP object) and writes the authorship rows the post should have had.
+#
+# The repair shipped with nothing able to invoke it. This workflow is that path,
+# and it is shaped like `run-federated-text-backfill.yml` and
+# `run-blocked-domain-purge.yml` for the same two reasons:
+#
+# 1. IN-VPC, or the script reaches neither the database (a private VPC address)
+#    nor the oxy-api service credential it needs to sign remote fetches and to
+#    mint/link federated Oxy identities — both live in the task definition.
+# 2. FROM `main` ONLY. The task reuses the live service's runtime role, secrets,
+#    subnets and security groups, so accepting an arbitrary ref here would turn a
+#    branch workflow into production code execution.
+#
+# AUTHORIZATION
+#   Dispatches are accepted only from an actor named in the repository variable
+#   `FEDERATED_AUTHOR_BACKFILL_OPERATORS` (comma-separated). This workflow writes
+#   production rows, can DELETE them, and mints identities in a DIFFERENT service
+#   (Oxy) — Actions dispatch access is broader than any of that.
+#
+#   It is a DEDICATED variable rather than a reuse of
+#   `BLOCKED_DOMAIN_PURGE_OPERATORS`, because a variable's name is the only thing
+#   an admin editing it in the GitHub UI can read: sharing one list would make
+#   "remove someone from domain purges" silently also remove them here, and
+#   "add someone for the backfill" silently grant them domain purges.
+#
+#   The check is a STEP that FAILS, not a job-level `if:`. An unset or empty
+#   variable makes `contains(format(',{0},', vars.X), …)` false and refuses
+#   EVERYONE while reporting a skipped job with no steps and no reason — which
+#   reads as an infrastructure problem rather than as a missing variable. Here an
+#   unset variable produces a red run whose error names the variable.
+#
+# WHAT EACH COMBINATION DOES — the script's whole write surface is two env vars,
+# `BACKFILL_APPLY` and `BACKFILL_DELETE_GONE`, and a delete needs BOTH:
+#
+#   dry_run=true  (the default), delete_gone=false → reads only. Reports how many
+#     orphans WOULD be linked. Actor resolution is lookup-only, so it deliberately
+#     under-counts: a live run links actors this preview reports as unresolved.
+#   dry_run=true,  delete_gone=true  → still reads only, and additionally reports
+#     `deleteCandidates` — the orphans a delete run WOULD remove. This is the run
+#     to read before ever setting dry_run=false with delete_gone=true.
+#   dry_run=false, delete_gone=false → writes authorship + the denormalized owner
+#     column, and backfills `federation.actor_uri` where it was missing. DELETES
+#     NOTHING; posts whose source is gone are reported as `gone` and left alone.
+#   dry_run=false, delete_gone=true  → the ONLY combination that deletes, and it
+#     additionally requires BOTH confirmation phrases. It removes a post only when
+#     its source answered 404/410 AND no author was resolvable; a timeout, a 5xx,
+#     a signature rejection or a missing `attributedTo` is transient and is left
+#     for a re-run.
+#
+# ALWAYS PLAN FIRST. The script is idempotent — a linked post leaves the orphan
+# set — so a re-run costs one pass over whatever is still unresolved. There is no
+# persisted cursor: a run killed by the container timeout keeps every write it
+# already committed and simply rescans from the top next time.
+#
+# READING A RED RUN. `assertAdminRunComplete` fails the process when ANY orphan
+# did not fully resolve (`unresolvedAuthor`, `transient`, and on a write run
+# `goneNotDeleted`), and it does so AFTER the sweep, with the tally already
+# printed. A dry run is lookup-only and so is expected to report unresolved
+# authors, which means the DEFAULT dispatch will usually exit 1. That exit means
+# "incomplete", never "nothing happened": every write the sweep made is already
+# committed, and the numbers in the log are the result. Read the tally, not the
+# checkmark.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what WOULD change, write nothing'
+        required: true
+        type: boolean
+        default: true
+      confirm_write:
+        description: 'For a real write, enter: BACKFILL FEDERATED AUTHORS'
+        required: false
+        type: string
+      delete_gone:
+        description: 'Also delete orphans whose source answered 404/410 (needs dry_run=false AND the phrase below)'
+        required: true
+        type: boolean
+        default: false
+      confirm_delete:
+        description: 'For a real deletion, enter: DELETE GONE FEDERATED POSTS'
+        required: false
+        type: string
+
+concurrency:
+  # Two sweeps over the same orphan set would resolve the same actors twice and
+  # race on federated-user creation.
+  group: backfill-federated-post-authors
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  APP: mention
+  CLUSTER: oxy-cluster
+  SERVICE: mention
+  DOCKERFILE: packages/backend/Dockerfile
+  DEPLOY_SHA: ${{ github.sha }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  backfill:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.triggering_actor == github.actor
+    # Same arch as the deployed image — the service runs linux/arm64.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    steps:
+      # First, before the checkout and before any credential is requested.
+      - name: Authorize the dispatcher
+        env:
+          OPERATORS: ${{ vars.FEDERATED_AUTHOR_BACKFILL_OPERATORS }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          OPERATORS_NORM="${OPERATORS//[[:space:]]/}"
+          if [[ -z "$OPERATORS_NORM" ]]; then
+            echo "::error::The repository variable FEDERATED_AUTHOR_BACKFILL_OPERATORS is unset or empty, so this workflow authorizes nobody. A repository admin sets it to a comma-separated list of GitHub logins."
+            exit 1
+          fi
+          if [[ ",${OPERATORS_NORM}," != *",${ACTOR},"* ]]; then
+            echo "::error::${ACTOR} is not listed in FEDERATED_AUTHOR_BACKFILL_OPERATORS."
+            exit 1
+          fi
+          echo "authorized dispatcher: ${ACTOR}"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          fetch-depth: 2
+
+      - name: Verify current main before building
+        run: bash .github/scripts/require-current-main.sh
+
+      - name: Configure AWS credentials (OIDC, no stored keys)
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build and push the backfill image (its own tag; never `latest`)
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.ecr.outputs.registry }}/oxy/${{ env.APP }}:backfill-fedauthors-${{ env.DEPLOY_SHA }}
+          cache-from: type=gha,scope=mention-backend
+          provenance: true
+          sbom: true
+
+      - name: Audit final backfill runtime image
+        env:
+          IMAGE_URI: ${{ steps.ecr.outputs.registry }}/oxy/${{ env.APP }}@${{ steps.build.outputs.digest }}
+          EXPECTED_RUNTIME_ENTRY: packages/backend/dist/server.js
+          EXPECTED_WORKSPACE_PACKAGES: '@mention/backend,@mention/shared-types'
+          EXPECTED_RUNTIME_COMMANDS: 'bun,busybox'
+        run: bash .github/scripts/audit-runtime-image.sh
+
+      - name: Re-verify current main before the production one-shot
+        run: bash .github/scripts/require-current-main.sh
+
+      - name: Run the backfill as an ECS one-shot task
+        env:
+          IMAGE: ${{ steps.ecr.outputs.registry }}/oxy/${{ env.APP }}@${{ steps.build.outputs.digest }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          CONFIRM_WRITE: ${{ inputs.confirm_write }}
+          DELETE_GONE_INPUT: ${{ inputs.delete_gone }}
+          CONFIRM_DELETE: ${{ inputs.confirm_delete }}
+        run: |
+          set -euo pipefail
+          MAX_WAIT_SECS=3600
+          POLL_INTERVAL=15
+          BACKFILL_TASK_DEF=""
+          TASK_ARN=""
+          TASK_STOPPED=true
+
+          cleanup() {
+            local exit_status=$?
+            trap - EXIT
+            if [[ "$TASK_STOPPED" != "true" && -n "$TASK_ARN" ]]; then
+              echo "::warning::Backfill task $TASK_ARN may still be running; the deploy role cannot call ecs:StopTask. Verify it in ECS."
+            fi
+            if [[ -n "$BACKFILL_TASK_DEF" ]]; then
+              aws ecs deregister-task-definition \
+                --task-definition "$BACKFILL_TASK_DEF" \
+                >/dev/null 2>&1 || true
+            fi
+            exit "$exit_status"
+          }
+          trap cleanup EXIT
+
+          # Both booleans are parsed POSITIVELY, and an unrecognised value stops
+          # the run. "anything that is not 'true' means write" is the inversion
+          # this workflow must not contain: an input arriving empty or mangled
+          # would become a live run nobody asked for, and the script's own
+          # default (write nothing) would have been quietly reversed by its
+          # invoker.
+          case "$DRY_RUN" in
+            true)  APPLY="false" ;;
+            false) APPLY="true" ;;
+            *) echo "::error::dry_run must be exactly true or false (got '$DRY_RUN')."; exit 1 ;;
+          esac
+          case "$DELETE_GONE_INPUT" in
+            true)  DELETE_GONE="true" ;;
+            false) DELETE_GONE="false" ;;
+            *) echo "::error::delete_gone must be exactly true or false (got '$DELETE_GONE_INPUT')."; exit 1 ;;
+          esac
+
+          if [[ "$APPLY" == "true" &&
+                "$CONFIRM_WRITE" != "BACKFILL FEDERATED AUTHORS" ]]; then
+            echo "::error::A write run requires the exact confirmation phrase."
+            exit 1
+          fi
+
+          # A SECOND phrase, so deleting production rows is never one flipped
+          # boolean away from a repair run. `delete_gone` alone is meaningless to
+          # the script without `BACKFILL_APPLY`, and on a dry run it only counts
+          # candidates — which is why it is allowed there without a phrase, and
+          # is the run to read first.
+          if [[ "$APPLY" == "true" && "$DELETE_GONE" == "true" &&
+                "$CONFIRM_DELETE" != "DELETE GONE FEDERATED POSTS" ]]; then
+            echo "::error::Deleting gone posts requires its own exact confirmation phrase, in addition to the write phrase."
+            exit 1
+          fi
+
+          echo "mode: BACKFILL_APPLY=$APPLY BACKFILL_DELETE_GONE=$DELETE_GONE"
+
+          # Take the task definition and network config from the LIVE service, so
+          # the one-shot runs with the same secrets, roles, subnets and security
+          # groups the backend already runs with. Nothing is hardcoded, and nothing
+          # drifts when the service is redeployed.
+          SERVICE_JSON=$(aws ecs describe-services \
+            --cluster "$CLUSTER" --services "$SERVICE" \
+            --query 'services[0]' --output json)
+          if [[ "$(jq -r '.status // "NONE"' <<<"$SERVICE_JSON")" != "ACTIVE" ]]; then
+            echo "::error::The production ECS service is not active."
+            exit 1
+          fi
+
+          LIVE_TASK_DEF=$(echo "$SERVICE_JSON" | jq -r '.taskDefinition')
+          SUBNETS=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.subnets | join(",")')
+          SEC_GROUPS=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.securityGroups | join(",")')
+          # Mirror the service's public-IP setting: the cluster's subnets are
+          # public with NO NAT gateway, so a task without a public IP cannot
+          # even pull its image from ECR.
+          ASSIGN_IP=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.assignPublicIp')
+
+          echo "live task definition: $LIVE_TASK_DEF"
+
+          # A throwaway revision that differs from the live one ONLY by the image.
+          # The service keeps running its own revision; this one exists so the task
+          # can run a branch image without touching the live service.
+          aws ecs describe-task-definition --task-definition "$LIVE_TASK_DEF" \
+            --query 'taskDefinition' --output json > live-taskdef.json
+
+          CONTAINER=$(jq -r '.containerDefinitions[0].name' live-taskdef.json)
+
+          jq --arg img "$IMAGE" '
+            .containerDefinitions[0].image = $img
+            | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                  .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)
+          ' live-taskdef.json > backfill-taskdef.json
+
+          BACKFILL_TASK_DEF=$(aws ecs register-task-definition \
+            --cli-input-json file://backfill-taskdef.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+
+          echo "backfill task definition: $BACKFILL_TASK_DEF"
+
+          # `CONFIRM_ADMIN_MUTATION` is supplied ONLY on a confirmed write run.
+          # The script's guard ignores it in dry-run mode, so passing it always
+          # would cost nothing today and remove a layer tomorrow: withheld, a
+          # `BACKFILL_APPLY` that somehow reached the container as "true" is
+          # refused by the script rather than executed.
+          OVERRIDES=$(jq -nc \
+            --arg name "$CONTAINER" \
+            --arg apply "$APPLY" \
+            --arg deleteGone "$DELETE_GONE" \
+            '{containerOverrides:[{
+               name: $name,
+               command: [
+                 "busybox","timeout","-s","TERM","-k","30","3300",
+                 "bun","packages/backend/dist/src/scripts/backfillFederatedPostAuthors.js"
+               ],
+               environment: (
+                 [
+                   {name:"BACKFILL_APPLY", value:$apply},
+                   {name:"BACKFILL_DELETE_GONE", value:$deleteGone}
+                 ]
+                 + (if $apply == "true"
+                    then [{
+                      name:"CONFIRM_ADMIN_MUTATION",
+                      value:"backfillFederatedPostAuthors"
+                    }]
+                    else [] end)
+               )
+             }]}')
+
+          RUN_TASK_JSON=$(aws ecs run-task \
+            --cluster "$CLUSTER" \
+            --task-definition "$BACKFILL_TASK_DEF" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SEC_GROUPS],assignPublicIp=$ASSIGN_IP}" \
+            --overrides "$OVERRIDES" \
+            --started-by "gh-backfill-fedauthors")
+
+          if [[ "$(jq '.failures | length' <<<"$RUN_TASK_JSON")" != "0" ]]; then
+            echo "::error::ECS refused to start the backfill task."
+            jq '.failures' <<<"$RUN_TASK_JSON"
+            exit 1
+          fi
+          TASK_ARN=$(jq -r '.tasks[0].taskArn // empty' <<<"$RUN_TASK_JSON")
+          if [[ -z "$TASK_ARN" ]]; then
+            echo "::error::ECS returned no backfill task ARN."
+            exit 1
+          fi
+          TASK_STOPPED=false
+
+          echo "task: $TASK_ARN"
+          echo "Waiting for the task to stop…"
+          ELAPSED=0
+          while (( ELAPSED < MAX_WAIT_SECS )); do
+            LAST_STATUS=$(aws ecs describe-tasks \
+              --cluster "$CLUSTER" \
+              --tasks "$TASK_ARN" \
+              --query 'tasks[0].lastStatus' \
+              --output text)
+            echo "($ELAPSED s) backfill task status=$LAST_STATUS"
+            if [[ "$LAST_STATUS" == "STOPPED" ]]; then
+              TASK_STOPPED=true
+              break
+            fi
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          if [[ "$TASK_STOPPED" != "true" ]]; then
+            echo "::error::Backfill exceeded ${MAX_WAIT_SECS}s. The deploy role cannot call ecs:StopTask; task $TASK_ARN may still be running and must be checked in ECS."
+            exit 1
+          fi
+
+          TASK_ID="${TASK_ARN##*/}"
+          LOG_OPTS=$(jq -r '.containerDefinitions[0].logConfiguration.options' live-taskdef.json)
+          LOG_GROUP=$(echo "$LOG_OPTS" | jq -r '."awslogs-group"')
+          LOG_PREFIX=$(echo "$LOG_OPTS" | jq -r '."awslogs-stream-prefix"')
+
+          echo "──────── backfill output ────────"
+          aws logs get-log-events \
+            --log-group-name "$LOG_GROUP" \
+            --log-stream-name "$LOG_PREFIX/$CONTAINER/$TASK_ID" \
+            --start-from-head \
+            --query 'events[].message' --output text || echo "(no logs retrieved)"
+          echo "─────────────────────────────────"
+
+          EXIT_CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' --output text)
+          REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].stoppedReason' --output text)
+
+          echo "exit code: $EXIT_CODE  (stopped reason: $REASON)"
+
+          # A backfill whose result you cannot see is a backfill you have not run.
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::Backfill task exited with $EXIT_CODE"
+            echo "A 'run incomplete:' line in the output above means the sweep FINISHED and every write it made is committed — it exited non-zero because some orphans did not fully resolve. Unresolved authors are EXPECTED on a dry run (resolution is lookup-only there) and transient remote failures are expected on any sweep over the open fediverse. Read the tally, then re-run: the script is idempotent."
+            exit 1
+          fi


### PR DESCRIPTION
`packages/backend/src/scripts/backfillFederatedPostAuthors.ts` had no invocation path. `.github/workflows/` carries one-shots for the federated-text backfill and both blocked-domain purges, and nothing for this one — so the repair merged in #762 could not be executed at all. This adds `run-federated-author-backfill.yml`, modelled on `run-federated-text-backfill.yml` (in-VPC ECS Fargate one-shot reusing the live service's task definition) and gated like `run-blocked-domain-purge.yml`.

## Exactly which combination deletes

`workflow_dispatch` only, `main` only. Four inputs; the script's whole write surface is `BACKFILL_APPLY` and `BACKFILL_DELETE_GONE`, and a delete needs both.

| dry_run | delete_gone | confirm_write | confirm_delete | result |
|---|---|---|---|---|
| `true` (default) | `false` (default) | — | — | **reads only**; reports how many orphans would be linked |
| `true` | `true` | — | — | reads only, and additionally counts `deleteCandidates` |
| `false` | `false` | `BACKFILL FEDERATED AUTHORS` | — | writes authorship + owner column + missing `federation.actor_uri`. **Deletes nothing** |
| `false` | `true` | `BACKFILL FEDERATED AUTHORS` | `DELETE GONE FEDERATED POSTS` | **the only combination that deletes** |

**The defaults read only.** Dispatching with nothing changed runs `BACKFILL_APPLY=false BACKFILL_DELETE_GONE=false`, which is the script's own default, and `CONFIRM_ADMIN_MUTATION` is never even placed in the container's environment on a run that is not a confirmed write.

Both booleans are parsed **positively** (`case … true) … false) … *) exit 1`), not as `!= "true"`. An input arriving empty or mangled stops the run rather than silently inverting the script's write-nothing default into a live run — measured over all 120 combinations of `{true,false,"",True,yes} × {true,false,"",TRUE} × 3 write phrases × 2 delete phrases: exactly one reaches `APPLY=true DELETE_GONE=true`, two more reach `APPLY=true DELETE_GONE=false`, and every other combination refuses.

`delete_gone=true` is deliberately allowed on a dry run without a phrase: it deletes nothing there and only counts candidates, which is the run to read before ever setting `dry_run=false` beside it.

## Authorization: yes, gated — on its own variable

This workflow writes production rows, can delete them, and mints/links federated identities in a **different service** (`fetchRemoteActor` → Oxy `/users/resolve`). Actions dispatch access is broader than any of those, so it gets the same class of gate as the purge.

It uses a dedicated `FEDERATED_AUTHOR_BACKFILL_OPERATORS`, **not** `BLOCKED_DOMAIN_PURGE_OPERATORS`. A variable's name is the only documentation an admin editing it in the GitHub UI sees; one shared list would make "remove someone from domain purges" silently also remove them here, and "add someone for the backfill" silently grant them domain purges.

The check is a **step that fails**, not a job-level `if:`. An unset or empty variable makes `contains(format(',{0},', vars.X), …)` false and refuses everyone while reporting a skipped job with no steps and no reason — the trap that already bit once today. Here an unset variable produces a red run whose error names the variable and says what to set it to. The step runs first, before the checkout and before any credential is requested. `github.ref == 'refs/heads/main'` and `github.triggering_actor == github.actor` stay in the job `if:`, where neither can be trapped by an unset value.

**A repository admin must create `FEDERATED_AUTHOR_BACKFILL_OPERATORS` (e.g. `NateIsern`) before the first dispatch.**

## Termination

Verified rather than assumed: the script ends in `.then(() => process.exit(0)).catch(… process.exit(1))` under `require.main === module`, with `closeAdminScriptResources()` in a `finally` (Postgres pool, BullMQ queues, Redis). The container command is additionally wrapped in `busybox timeout -s TERM -k 30 3300`, and the workflow polls to `STOPPED` with `MAX_WAIT_SECS=3600`.

## Reading a red run

`assertAdminRunComplete` is called with **no tolerance options**, so any non-zero `unresolvedAuthor` / `transient` (and `goneNotDeleted` on a write run) throws after the sweep and the process exits 1. A dry run resolves actors lookup-only and therefore reports unresolved authors by design, so **the default dispatch will usually exit 1**. That means "incomplete", never "nothing happened": the tally is already printed, and on a write run every write is already committed. The workflow prints the log before checking the exit code and adds a static explanation to the failure message. Left as-is rather than papered over — the script's own `AdminRunTolerance` mechanism is where that would be fixed, and that is a change to merged behaviour, not to its invocation path.

## Verification

- `bun run validate:workflows` passes (9 files).
- Positive control: mutating `aws ecs run-task` → `aws ecs stop-task` in the new file makes the validator fail naming this workflow, so it is genuinely inspected; restored and re-verified byte-identical.
- Gating traced by executing the block extracted verbatim from the emitted YAML (truth table above) and the allowlist block likewise — including that `NateIsern` does not admit an actor named `Nate`.
- Not dispatched, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
