### PR TITLE
fix(ops): a red backfill run means the backfill failed, not that the fediverse is imperfect

### DIFF
--- a/.github/workflows/run-federated-author-backfill.yml
+++ b/.github/workflows/run-federated-author-backfill.yml
@@ -59,14 +59,30 @@ name: Run federated-author backfill
 # persisted cursor: a run killed by the container timeout keeps every write it
 # already committed and simply rescans from the top next time.
 #
-# READING A RED RUN. `assertAdminRunComplete` fails the process when ANY orphan
-# did not fully resolve (`unresolvedAuthor`, `transient`, and on a write run
-# `goneNotDeleted`), and it does so AFTER the sweep, with the tally already
-# printed. A dry run is lookup-only and so is expected to report unresolved
-# authors, which means the DEFAULT dispatch will usually exit 1. That exit means
-# "incomplete", never "nothing happened": every write the sweep made is already
-# committed, and the numbers in the log are the result. Read the tally, not the
-# checkmark.
+# READING THE RESULT. There are THREE outcomes and this workflow names each of
+# them in its own output, so telling them apart never requires reading the tally
+# by eye:
+#
+#   green, "::notice::" COMPLETE   — the sweep finished with nothing left over.
+#   green, "::warning::" INCOMPLETE — the sweep FINISHED, every write it made is
+#     committed, and some orphans remain for a re-run. This is the ordinary
+#     outcome of a sweep over the open fediverse: an instance rejecting our HTTP
+#     signature, a host that is down, an actor we could not mint. Re-run when
+#     you like; the script is idempotent and repaired posts leave the set.
+#   RED — the sweep failed, or something on OUR side did (a write that threw, a
+#     deletion the preflight refused, a task that never reported an exit code).
+#
+# Those map to the script's exit codes 0 / 75 / anything-else. 75 is
+# `EXIT_INCOMPLETE` in `packages/backend/src/scripts/backfillFederatedPostAuthors.ts`
+# — the number is spelled in both places and the two are one fact.
+#
+# This replaced a guard that failed the process on ANY unresolved orphan. Both
+# of its triggers are structurally guaranteed — a dry run resolves lookup-only,
+# so unresolved authors are certain, and transient remote failures are certain
+# on any sweep over the open fediverse — so three production runs on 2026-08-15
+# repaired 520 of 578 orphans and all three reported FAILURE. A red run that
+# means success is worse than no signal: the next operator cannot tell a working
+# sweep from a broken one.
 
 on:
   workflow_dispatch:
@@ -380,9 +396,44 @@ jobs:
 
           echo "exit code: $EXIT_CODE  (stopped reason: $REASON)"
 
-          # A backfill whose result you cannot see is a backfill you have not run.
-          if [ "$EXIT_CODE" != "0" ]; then
-            echo "::error::Backfill task exited with $EXIT_CODE"
-            echo "A 'run incomplete:' line in the output above means the sweep FINISHED and every write it made is committed — it exited non-zero because some orphans did not fully resolve. Unresolved authors are EXPECTED on a dry run (resolution is lookup-only there) and transient remote failures are expected on any sweep over the open fediverse. Read the tally, then re-run: the script is idempotent."
-            exit 1
-          fi
+          # A backfill whose result you cannot see is a backfill you have not
+          # run. The verdict comes from the exit code and NOT from grepping the
+          # log, because log retrieval above is best-effort: an unavailable log
+          # stream would otherwise read as the comfortable answer. `None` (a task
+          # that stopped without reporting a container exit code) lands in `*)`
+          # and is red, which is the safe direction — a killed sweep may well
+          # have left work behind but cannot say how much.
+          case "$EXIT_CODE" in
+            0)
+              echo "::notice::Backfill COMPLETE — the sweep finished with nothing left unresolved."
+              {
+                echo "### Federated-author backfill: COMPLETE"
+                echo ""
+                echo "The sweep finished and left nothing unresolved. Mode: \`BACKFILL_APPLY=$APPLY\`, \`BACKFILL_DELETE_GONE=$DELETE_GONE\`."
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            75)
+              # EXIT_INCOMPLETE in backfillFederatedPostAuthors.ts.
+              echo "::warning::Backfill FINISHED with orphans remaining — every write it made is committed. Re-run to retry the rest; the script is idempotent."
+              {
+                echo "### Federated-author backfill: FINISHED, SOME REMAIN"
+                echo ""
+                echo "This is **not** a failure. The sweep completed and every write it made is committed;"
+                echo "some orphans could not be resolved this pass — an instance rejecting our HTTP signature,"
+                echo "a host that is down, an actor we could not mint."
+                echo ""
+                echo "The \`verdict: INCOMPLETE\` line in the task output above names the counts. Re-run when"
+                echo "convenient: repaired posts leave the orphan set, so a re-run costs one pass over the rest."
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "::error::Backfill task exited with $EXIT_CODE — this is a real failure, not a partial sweep."
+              echo "Exit 1 means the sweep threw, or something on OUR side did: an orphan whose write failed (\`failed\`), or a deletion the preflight refused (\`blockedDelete\`). Neither is fixed by re-running. Any other code (including 'None') means the task did not report a verdict at all — check ECS."
+              {
+                echo "### Federated-author backfill: FAILED"
+                echo ""
+                echo "Exit code \`$EXIT_CODE\`. Stopped reason: \`$REASON\`."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+              ;;
+          esac

--- a/packages/backend/src/__tests__/scripts/backfillFederatedPostAuthors.test.ts
+++ b/packages/backend/src/__tests__/scripts/backfillFederatedPostAuthors.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
 import { closePostgres, connectPostgres } from '../../db/postgres';
 import {
@@ -58,6 +60,8 @@ vi.mock('@oxyhq/core/server', async (importOriginal) => ({
 }));
 
 import {
+  EXIT_INCOMPLETE,
+  countRemaining,
   resolveAuthorOxyUserId,
   resolveOrphanAuthorUri,
 } from '../../scripts/backfillFederatedPostAuthors';
@@ -229,5 +233,146 @@ describe('backfillFederatedPostAuthors — resolveOrphanAuthorUri source order',
 
     expect(result).toEqual({ kind: 'ok', authorUri: BRIDGY_ACTOR, actorUriWasMissing: true });
     expect(result.kind).not.toBe('gone');
+  });
+});
+
+/**
+ * The run's VERDICT, which is what decides the exit code.
+ *
+ * Three production runs on 2026-08-15 repaired 520 of 578 orphans and all three
+ * reported FAILURE, because `assertAdminRunComplete` was called with no
+ * allowances and both of its triggers are structurally guaranteed: a dry run
+ * resolves lookup-only, so unresolved authors are certain, and transient remote
+ * failures are certain on any sweep over the open fediverse.
+ *
+ * The fix is not a tolerance FRACTION. This sweep has no cursor and a repaired
+ * post leaves the orphan set, so run 2 scans exactly what run 1 could not repair
+ * and its unresolved rate approaches 100% by construction — any fraction that
+ * passes run 1 fails run 2, which is the same red-run-that-means-success in a
+ * new dress. The residual is a separate exit path instead, and the completion
+ * guard keeps only what a rate cannot excuse: our own side.
+ */
+describe('backfillFederatedPostAuthors — what counts as remaining', () => {
+  /** A sweep that reached every bucket, so no assertion below is reading a zero. */
+  const BUSY_RUN = {
+    scanned: 578,
+    linked: 520,
+    gone: 3,
+    deleteCandidates: 0,
+    deleted: 0,
+    blockedDelete: 2,
+    unresolvedAuthor: 6,
+    transient: 49,
+    failed: 4,
+  };
+
+  it('is ZERO on a dry run, whatever the preview found', () => {
+    // The default dispatch. A dry run writes nothing and resolves lookup-only,
+    // so every unresolved orphan is an artefact of the mode and none of it is a
+    // result to act on. Reporting a residual here is what made the DEFAULT
+    // dispatch exit non-zero forever.
+    expect(countRemaining(BUSY_RUN, { apply: false, deleteGone: false })).toBe(0);
+    expect(countRemaining(BUSY_RUN, { apply: false, deleteGone: true })).toBe(0);
+  });
+
+  it('sums the three buckets a re-run can still repair', () => {
+    // transient 49 + unresolvedAuthor 6 + gone 3.
+    expect(countRemaining(BUSY_RUN, { apply: true, deleteGone: false })).toBe(58);
+  });
+
+  it('drops `gone` once the run was allowed to delete, since it became `deleted`', () => {
+    expect(countRemaining(BUSY_RUN, { apply: true, deleteGone: true })).toBe(55);
+  });
+
+  it('never counts our OWN failures — they are the completion guard\'s, strictly', () => {
+    /**
+     * `failed` (a write that threw) and `blockedDelete` (a deletion the preflight
+     * refused) are not fixed by re-running and must stay red. If either leaked
+     * into the residual, a genuine write failure would exit 75 and the workflow
+     * would report it GREEN. The `Pick` on the parameter type is what makes that
+     * unreachable; this asserts the runtime agrees, since extra properties ride
+     * along on a real `Counters` object.
+     */
+    const clean = { ...BUSY_RUN, failed: 0, blockedDelete: 0 };
+    expect(countRemaining(clean, { apply: true, deleteGone: false })).toBe(
+      countRemaining(BUSY_RUN, { apply: true, deleteGone: false }),
+    );
+  });
+
+  it('is ZERO for a sweep that resolved everything — the positive control', () => {
+    // Without this, "returns 0" above is also what a function that always
+    // returns 0 does, and every assertion in this block would still pass.
+    const spotless = { ...BUSY_RUN, gone: 0, unresolvedAuthor: 0, transient: 0 };
+    expect(countRemaining(spotless, { apply: true, deleteGone: false })).toBe(0);
+    expect(countRemaining(BUSY_RUN, { apply: true, deleteGone: false })).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * What must still be a RED run, pinned in SOURCE.
+ *
+ * Making the residual non-fatal moved the risk: an unexpected exception folded
+ * into `transient` would now exit 75 and the workflow would report it GREEN. The
+ * two lines that keep that from happening are the page loop's catch-all and the
+ * completion guard's argument list, and NEITHER has a functional symptom any
+ * unit test can produce — reaching them means a real write failure, and mocking
+ * the repository to raise one would be testing the mock. Same reasoning, and the
+ * same shape, as `connectors/outboundPostPayloadShape.test.ts`.
+ */
+describe('backfillFederatedPostAuthors — what stays a red run', () => {
+  const SOURCE = path.resolve(__dirname, '../../scripts/backfillFederatedPostAuthors.ts');
+
+  /** The script's source with runs of whitespace collapsed, so formatting cannot decide a verdict. */
+  function normalizedSource(): string {
+    const source = readFileSync(SOURCE, 'utf8');
+    // Vacuity floor: the right file, read, and big enough to hold what follows.
+    expect(source).toContain('async function backfillFederatedPostAuthors(');
+    expect(source.length).toBeGreaterThan(5000);
+    return source.replace(/\s+/g, ' ');
+  }
+
+  it('sends a THROWN error to `failed`, never to the now-tolerated `transient`', () => {
+    const source = normalizedSource();
+
+    expect(source).toContain("? 'blockedDelete' as const : 'failed' as const");
+    expect(source).not.toContain("? 'blockedDelete' as const : 'transient' as const");
+  });
+
+  it('hands the completion guard our OWN two buckets, and nothing a re-run fixes', () => {
+    const source = normalizedSource();
+
+    // Exact, so this pins the exclusion as well as the inclusion: putting
+    // `transient` or `unresolvedAuthor` back would restore the always-red run.
+    expect(source).toContain(
+      "assertAdminRunComplete('backfillFederatedPostAuthors', { failed: counters.failed, "
+      + 'blockedDelete: counters.blockedDelete, });',
+    );
+  });
+});
+
+describe('backfillFederatedPostAuthors — the exit code the workflow branches on', () => {
+  const WORKFLOW = path.resolve(
+    __dirname,
+    '../../../../../.github/workflows/run-federated-author-backfill.yml',
+  );
+
+  it('is spelled identically in the script and in the workflow', () => {
+    const workflow = readFileSync(WORKFLOW, 'utf8');
+
+    // Vacuity floor: this is the right file, and it was read.
+    expect(workflow).toContain('name: Run federated-author backfill');
+    expect(workflow.length).toBeGreaterThan(1000);
+
+    // The branch itself, anchored as a `case` arm so the constant's own prose
+    // elsewhere in the file cannot satisfy it.
+    expect(workflow).toMatch(new RegExp(`^\\s+${EXIT_INCOMPLETE}\\)$`, 'm'));
+    expect(workflow).toContain('EXIT_INCOMPLETE in backfillFederatedPostAuthors.ts');
+  });
+
+  it('is neither success nor the generic failure code', () => {
+    // A residual that exited 0 would be invisible; one that exited 1 is the bug
+    // this replaced.
+    expect(EXIT_INCOMPLETE).not.toBe(0);
+    expect(EXIT_INCOMPLETE).not.toBe(1);
   });
 });

--- a/packages/backend/src/scripts/backfillFederatedPostAuthors.ts
+++ b/packages/backend/src/scripts/backfillFederatedPostAuthors.ts
@@ -73,6 +73,25 @@
  *   BACKFILL_APPLY=true \
  *     CONFIRM_ADMIN_MUTATION=backfillFederatedPostAuthors \
  *     bun dist/src/scripts/backfillFederatedPostAuthors.js
+ *
+ * EXIT CODES — three outcomes, because two of them are not failures
+ * ----------------------------------------------------------------
+ *   0   the sweep finished with nothing left for a later run, OR it was a dry
+ *       run (which writes nothing, so nothing about it can be incomplete).
+ *   75  the sweep FINISHED and every write it made is committed, and some
+ *       orphans remain for a re-run. See {@link EXIT_INCOMPLETE}.
+ *   1   the sweep failed, or something on OUR side did.
+ *
+ * Why not the ordinary `assertAdminRunComplete` verdict for the remaining
+ * orphans: that guard's tolerance is a FRACTION OF SCANNED, and this sweep has
+ * no cursor and repaired posts leave the orphan set — so run 2 scans exactly
+ * what run 1 could not repair and its unresolved RATE approaches 100% by
+ * construction. Measured on production, 2026-08-15: run 1 linked 520 of 578
+ * with `transient 49` (8.5%); a re-run over the remainder would sit near 85%
+ * for the same two instances rejecting our HTTP signature. Any fraction that
+ * passes run 1 fails run 2, which is the same red-run-that-means-success this
+ * script had before. So the residual is a distinct EXIT PATH, and the guard
+ * keeps only what it is right about: our own side, strict, at any count.
  */
 
 import { and, asc, count, eq, gt, isNotNull, isNull, type SQL } from 'drizzle-orm';
@@ -97,6 +116,21 @@ import {
   assertAdminRunComplete,
   closeAdminScriptResources,
 } from './lib/adminScriptLifecycle';
+
+/**
+ * `EX_TEMPFAIL` from sysexits(3) — "temporary failure, the user is invited to
+ * retry" — which is exactly what an orphan we could not reach this time is.
+ *
+ * It is a DISTINCT code rather than a zero because "finished, some remain" is a
+ * different instruction from "finished" and an operator must not have to read
+ * the tally to tell them apart; and rather than a 1 because the sweep did not
+ * fail — every write it made is committed and a re-run costs one pass over
+ * whatever is still unresolved.
+ *
+ * `.github/workflows/run-federated-author-backfill.yml` spells the same number
+ * and names this constant where it does; the two are one fact.
+ */
+export const EXIT_INCOMPLETE = 75;
 
 /** Orphans scanned per page (stable ascending `_id` cursor). */
 const PAGE_SIZE = 200;
@@ -257,6 +291,15 @@ interface Counters {
   blockedDelete: number;
   unresolvedAuthor: number;
   transient: number;
+  /**
+   * An orphan whose processing THREW — a write that did not go through, a bug.
+   * Separate from `transient` on purpose: `transient` is now a non-fatal
+   * residual, and an unexpected exception folded into it would be a real
+   * failure exiting 0. `transient` is therefore only ever what
+   * {@link resolveOrphanAuthorUri} classifies as one, which is a remote
+   * condition by construction.
+   */
+  failed: number;
 }
 
 /** Process one orphan; returns the counter bucket it fell into. */
@@ -308,7 +351,45 @@ async function processOrphan(orphan: OrphanRow): Promise<keyof Omit<Counters, 's
   return 'linked';
 }
 
-async function backfillFederatedPostAuthors(): Promise<void> {
+/**
+ * What the sweep concluded, so the caller can pick an exit code without
+ * re-deriving it from the tally.
+ */
+export interface BackfillVerdict {
+  /** Orphans the sweep finished without resolving. `0` on a dry run. */
+  remaining: number;
+}
+
+/**
+ * The orphans this run finished without resolving — the whole residual, and
+ * nothing our side did wrong (that is `failed`/`blockedDelete`, which the
+ * completion guard fails on strictly).
+ *
+ * ZERO on a dry run, unconditionally. A dry run resolves lookup-only and writes
+ * nothing, so every orphan is "unresolved" by construction and none of it is a
+ * result — reporting a residual there would make the DEFAULT dispatch report
+ * incomplete forever, which is the signal this exists to restore.
+ *
+ * `gone` counts only on a write run that was not allowed to delete: there the
+ * post is a real leftover with an operator action attached (re-run with
+ * `BACKFILL_DELETE_GONE`). On a delete-enabled run it has already become
+ * `deleted`, and on a dry run it is part of the preview.
+ */
+export function countRemaining(
+  // `Pick`, so the residual cannot silently acquire a bucket that belongs to the
+  // strict guard: `failed` and `blockedDelete` are not reachable from here.
+  counters: Pick<Counters, 'transient' | 'unresolvedAuthor' | 'gone'>,
+  mode: { apply: boolean; deleteGone: boolean },
+): number {
+  if (!mode.apply) return 0;
+  return (
+    counters.transient
+    + counters.unresolvedAuthor
+    + (mode.deleteGone ? 0 : counters.gone)
+  );
+}
+
+async function backfillFederatedPostAuthors(): Promise<BackfillVerdict> {
   const startedAt = Date.now();
 
   // `is not null` / `is null`, never `<> null`: Mongo's `$ne: null` also matched
@@ -337,7 +418,8 @@ async function backfillFederatedPostAuthors(): Promise<void> {
     const totalCount = totals?.count ?? 0;
     logger.info(`[backfillFederatedPostAuthors] ${totalCount} orphan federated posts to scan`);
     if (totalCount === 0) {
-      return;
+      logger.info('[backfillFederatedPostAuthors] verdict: COMPLETE — no orphan federated posts remain');
+      return { remaining: 0 };
     }
 
     const counters: Counters = {
@@ -349,6 +431,7 @@ async function backfillFederatedPostAuthors(): Promise<void> {
       blockedDelete: 0,
       unresolvedAuthor: 0,
       transient: 0,
+      failed: 0,
     };
     let lastId: string | null = null;
 
@@ -374,7 +457,7 @@ async function backfillFederatedPostAuthors(): Promise<void> {
               });
               return error instanceof DeletionPreflightError
                 ? 'blockedDelete' as const
-                : 'transient' as const;
+                : 'failed' as const;
             }),
           ),
         );
@@ -388,7 +471,7 @@ async function backfillFederatedPostAuthors(): Promise<void> {
           `linked ${counters.linked}, gone ${counters.gone}, ` +
           `deleteCandidates ${counters.deleteCandidates}, deleted ${counters.deleted}, ` +
           `blockedDelete ${counters.blockedDelete}, unresolvedAuthor ${counters.unresolvedAuthor}, ` +
-          `transient ${counters.transient}`,
+          `transient ${counters.transient}, failed ${counters.failed}`,
       );
     }
 
@@ -398,16 +481,37 @@ async function backfillFederatedPostAuthors(): Promise<void> {
         `linked ${counters.linked}, gone ${counters.gone}, ` +
         `deleteCandidates ${counters.deleteCandidates}, deleted ${counters.deleted}, ` +
         `blockedDelete ${counters.blockedDelete}, unresolvedAuthor ${counters.unresolvedAuthor}, ` +
-        `transient ${counters.transient}` +
+        `transient ${counters.transient}, failed ${counters.failed}` +
         (APPLY ? '' : ' (DRY RUN — no writes)'),
     );
 
+    // OUR side only, and strict at any count — an orphan whose write threw, and
+    // a deletion the preflight refused. Neither is a matter of rate and neither
+    // is fixed by re-running, so both stay a red run.
     assertAdminRunComplete('backfillFederatedPostAuthors', {
-      goneNotDeleted: APPLY && !DELETE_GONE ? counters.gone : 0,
+      failed: counters.failed,
       blockedDelete: counters.blockedDelete,
-      unresolvedAuthor: counters.unresolvedAuthor,
-      transient: counters.transient,
     });
+
+    const remaining = countRemaining(counters, { apply: APPLY, deleteGone: DELETE_GONE });
+    // ONE line an operator can read instead of the tally. The workflow reports
+    // the same verdict from the exit code, so this is the detail behind it.
+    logger.info(
+      !APPLY
+        ? `[backfillFederatedPostAuthors] verdict: DRY RUN — nothing written; of ${counters.scanned} scanned, `
+          + `${counters.linked} would link, ${counters.unresolvedAuthor} need a live run, `
+          + `${counters.transient} were unreachable, ${counters.gone} are gone`
+        : remaining === 0
+          ? `[backfillFederatedPostAuthors] verdict: COMPLETE — ${counters.scanned} scanned, `
+            + `${counters.linked} linked, nothing left unresolved`
+          : `[backfillFederatedPostAuthors] verdict: INCOMPLETE — ${counters.scanned} scanned, `
+            + `${counters.linked} linked, ${remaining} remain `
+            + `(transient ${counters.transient}, unresolvedAuthor ${counters.unresolvedAuthor}, `
+            + `gone ${DELETE_GONE ? 0 : counters.gone}). The sweep finished and every write is `
+            + 'committed; re-run to retry.',
+    );
+
+    return { remaining };
   } catch (error) {
     logger.error('[backfillFederatedPostAuthors] failed', error);
     throw error;
@@ -420,7 +524,7 @@ if (require.main === module) {
   // Exit deterministically: imported singletons (BullMQ Redis, MediaCache workers)
   // otherwise keep the event loop alive after the work completes.
   backfillFederatedPostAuthors()
-    .then(() => process.exit(0))
+    .then((verdict) => process.exit(verdict.remaining > 0 ? EXIT_INCOMPLETE : 0))
     .catch((error) => {
       logger.error('[backfillFederatedPostAuthors] unhandled failure', error);
       process.exit(1);


### PR DESCRIPTION
`backfillFederatedPostAuthors` called `assertAdminRunComplete` with **no** allowances, so any non-zero `unresolvedAuthor` or `transient` failed the process. Both are structurally guaranteed — a dry run resolves lookup-only, so unresolved authors are certain, and transient remote failures are certain on any sweep over the open fediverse. Three production runs on 2026-08-15 repaired **520 of 578** orphans and all three reported FAILURE.

## Why not a `tolerate` entry

That is the precedent (`repairFederatedMentions`, `purgeBlockedDomainPlatformData`) and it is wrong for this sweep. `assertAdminRunComplete`'s tolerance is a **fraction of `scanned`**, and this script has no cursor while a repaired post leaves the orphan set — so run 2 scans exactly what run 1 could not repair and its unresolved rate approaches 100% by construction. Measured: run 1 was `transient 49 / 578` = 8.5%; a re-run over the remainder sits near 85% for the same two instances rejecting our HTTP signature. **Any fraction that passes run 1 fails run 2** — the same red-run-that-means-success in a new dress.

## What lands instead

A distinct exit path. `EXIT_INCOMPLETE` = 75 (`EX_TEMPFAIL` from sysexits(3), "temporary failure, the user is invited to retry"). The completion guard keeps only what a rate cannot excuse: our own side.

| exit | meaning |
|---|---|
| `0` | finished with nothing left over, or a dry run (which writes nothing, so nothing about it can be incomplete) |
| `75` | **finished**, every write committed, some orphans remain for a re-run |
| `1` / other | the sweep failed, or our side did |

Making the residual non-fatal moved the risk, so an orphan whose processing **threw** no longer lands in `transient` — it gets a `failed` bucket the guard fails on strictly. Without that, a real write failure would exit 75 and the workflow would report it green.

The workflow branches on the three codes and says which happened in a `::notice::` / `::warning::` / `::error::` plus a step summary, so telling a working sweep from a broken one never requires reading the tally. The verdict comes from the **exit code**, not from grepping the log: log retrieval there is best-effort and an unavailable stream would otherwise read as the comfortable answer. `None` (a task that stopped without reporting an exit code) is red.

## Verification

Full backend suite **measured on this branch**: 494 files / 6096 tests passing. Pristine `origin/main` baseline, same private PostGIS 17 container and same settings: 494 / 6087. (One earlier run of this branch reported 6 file-level failures with `Tests 6096 passed` and zero failing tests — `afterAll` hook timeouts under load; it re-ran clean.)

Six mutations, all killed:

- `if (!mode.apply) return 0` neutered
- `deleteGone` branch always counting `gone`
- `EXIT_INCOMPLETE` 75 → 76
- the thrown-error bucket put back to `transient`
- the completion guard given `transient` back
- the workflow's `75)` arm renamed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
