### PR TITLE
refactor(feed): newVoices stops selecting a count nobody reads

### DIFF
--- a/packages/backend/src/mtn/feed/engine/sources/socialSources.ts
+++ b/packages/backend/src/mtn/feed/engine/sources/socialSources.ts
@@ -603,6 +603,13 @@ export const linksSource: SourceModule = {
  * caller ever read — a false assertion (the value arrives as the driver's
  * string) sitting on a column with no consumer, so it was deleted rather than
  * mapped. The ordering is a separate expression and is untouched.
+ *
+ * A `recentCount` (`count(*)::int`) went the same way, for the weaker reason:
+ * its annotation was TRUE, so it was dead code rather than a lie. The `HAVING`
+ * clause below is what the count is FOR, and that is untouched — the projection
+ * was the only part nothing read. `oxy_user_id` is likewise unread by the
+ * caller, and stays: it is the `GROUP BY` key, and a select list that names it
+ * is what makes the grouping legible at the call site.
  */
 export const newVoicesSource: SourceModule = {
   id: 'newVoices',
@@ -616,7 +623,6 @@ export const newVoicesSource: SourceModule = {
       .select({
         oxyUserId: posts.oxyUserId,
         latestPostId: sql<string>`(array_agg(${posts.id} order by ${posts.createdAt} desc, ${posts.id} desc))[1]`,
-        recentCount: sql<number>`count(*)::int`,
       })
       .from(posts)
       .where(


### PR DESCRIPTION
`newVoices` projected `recentCount: sql<number>\`count(*)::int\`` beside its grouped rows. The only consumer maps `group.latestPostId`; a repo-wide grep across `packages/backend`, `packages/frontend`, `packages/shared-types` and `packages/mcp` finds the identifier **exactly once**, at its own declaration.

Weaker case than the `sql<Date>` columns removed from the same function earlier: that annotation was a lie (the value arrives as the driver's string), while this one was TRUE. So this is dead code, not a false assertion — which is why it was left the first time.

The `HAVING count(*) <= NEW_VOICE_MAX_RECENT_POSTS` ceiling is what the count is FOR and is untouched. Mutation-tested: removing that clause fails `classificationSources.test.ts` ("drops an author who is past the low-volume ceiling").

`oxy_user_id` is also unread by the caller and deliberately stays — it is the `GROUP BY` key, and a select list that names it is what makes the grouping legible at the call site.

## Verification

Full backend suite **measured on this branch**: 494 files / 6087 tests passing — identical to the pristine `origin/main` baseline measured on the same container with the same settings, which is what a projection nothing reads should produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
