### PR TITLE
fix(federation): the server actor becomes findable, not merely servable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@oxyhq/crowdsource-contracts": "0.3.0",
         "@oxyhq/crowdsource-express": "0.3.0",
         "@oxyhq/db": "^0.1.2",
-        "@oxyhq/federation": "^0.15.0",
+        "@oxyhq/federation": "^0.16.1",
         "@oxyhq/protocol": "^0.2.0",
         "@socket.io/redis-adapter": "^8.3.0",
         "@syra.fm/sdk": "catalog:",
@@ -849,7 +849,7 @@
 
     "@oxyhq/db": ["@oxyhq/db@0.1.2", "", { "peerDependencies": { "drizzle-orm": "^0.45.2", "postgres": "^3.4.9" } }, "sha512-a7T8oMYgQJvIRzf4KRTljHShFcPTR42ZN1yRwv07P1FekqERDoNtTEbppUExamTuzjm5IWUZ0c3enW+YQCxddg=="],
 
-    "@oxyhq/federation": ["@oxyhq/federation@0.15.0", "", { "dependencies": { "@oxyhq/contracts": "^0.25.0", "@oxyhq/core": "^20.0.0" }, "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-jt+tByrEC+Cj3zdPiTAaWzbzNHwWJfg5ekJbO7BmLm2hiiGyQ/a6AUnqGIl7Ah0ZuDlUssaIjAjz/gfF8GuZNA=="],
+    "@oxyhq/federation": ["@oxyhq/federation@0.16.1", "", { "dependencies": { "@oxyhq/contracts": ">=0.25.0 <0.28.0", "@oxyhq/core": "^20.1.0 || ^21.0.0" }, "peerDependencies": { "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["express"] }, "sha512-EeAHFp7iPxg9rN2/os7+wnaZw/gh7knwD+39YpVCTvN7q/gHOU0RJ/jmh3EcP9uIWhrXCgm+9C1WMnkZKoAvsw=="],
 
     "@oxyhq/protocol": ["@oxyhq/protocol@0.2.0", "", { "dependencies": { "@oxyhq/contracts": "^0.25.0", "elliptic": "^6.6.1", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-modules-core": "*", "expo-secure-store": "*", "express": "^4.18.0 || ^5.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-RRevLBL7LDvSpbaHSkojBHm053JdY5wBVrQCUYvw4N+8kV/lzVax6KXYhQaVBItkBfrwJrhCqNkWgMu9O4yWSQ=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,7 +27,7 @@
     "@oxyhq/crowdsource-contracts": "0.3.0",
     "@oxyhq/crowdsource-express": "0.3.0",
     "@oxyhq/db": "^0.1.2",
-    "@oxyhq/federation": "^0.15.0",
+    "@oxyhq/federation": "^0.16.1",
     "@oxyhq/protocol": "^0.2.0",
     "@socket.io/redis-adapter": "^8.3.0",
     "@syra.fm/sdk": "catalog:",


### PR DESCRIPTION
## The outage

`GET /.well-known/webfinger?resource=acct:instance@mention.earth` returns **404** while `GET /ap/users/instance` returns a full `Application` actor.

Mastodon's `FetchRemoteKeyService#find_actor` calls `ActivityPub::FetchRemoteActorService` **without** `only_key:`, and that service runs `check_webfinger!` unconditionally. Our 404 raises `Webfinger::Error`, produces a nil account, and every secure-mode instance answers **401 to every signed GET we make** — outbox sync, remote actor fetch, quoted/boosted note import, and the repair scripts built on them. Signature verifiability was 0%, not per-host.

Inbound delivery and outbound POST were unaffected, because both use a USER key whose WebFinger does loop back. That is why federation looked healthy while every signed read failed.

## The change

One line. `@oxyhq/federation` `^0.15.0` → `^0.16.1`.

Mention mounts the engine's WebFinger router directly (`connectors/activitypub/routes/engine.routes.ts` → `appRoutes.ts`) and has no WebFinger implementation of its own, so **the version bump is the fix**. 0.16.x adds the `instance` branch to the WebFinger router mirroring the one the actor router already had, both deriving the username from `INSTANCE_ACTOR_USERNAME` so the two cannot drift.

## Why 0.16.1 and not 0.16.0

0.16.0 carries the identical fix and **cannot be installed here**. It declares `@oxyhq/core@^21.0.0` and `@oxyhq/contracts@^0.27.0`, which `validate:lockfile` check 4 correctly refuses against this repo's `@oxyhq/core` override at 20.1.0:

```
@oxyhq/federation: declares @oxyhq/core@^21.0.0 (dependencies) but the
"@oxyhq/core" override installs 20.1.0, which does not satisfy it.
```

Neither floor was a decision — both are what `workspace:^` substituted at publish time, and the SDK monorepo's `main` had moved past what federation uses. 0.16.1 republishes the **byte-identical dist** (verified against the published 0.16.0 tarball: only `.tsbuildinfo` differs) under the floors the code actually needs, re-derived from federation's source rather than carried over. Its entire core/contracts surface is five symbols — `User`, `getErrorMessage`, `getErrorStatus` from `@oxyhq/core`; `AccountKind`, `isAccountKind` from `@oxyhq/contracts` — and both declaring files are byte-identical between core 20.1.0 and 21.0.0.

Upstream: OxyHQ/oxy@be67c0d6.

## Verification

**The fix, through this repo's own wiring.** A probe mounting Mention's `webfingerRouter` and `actorRouter` asserts the instance JRD is 200 and its `self` href equals the actor id the actor route serves.

Its first version passed on 0.15.0 too — the surrounding suite's `beforeEach` resolves EVERY username to a real user, so the mock was answering, not the code. With `resolveOxyUser` returning null as production does:

| federation | instance webfinger | unresolvable ordinary user |
| --- | --- | --- |
| 0.15.0 | **404** (reproduces the outage) | 404 |
| 0.16.1 | **200**, `self` href == actor id | 404 |

The probe is not committed: it is a version-discriminating instrument, and the equivalent regression test lives upstream beside the branch it guards.

**Runtime floor**, not just `tsc`: the packed tarball installed in a clean external harness against `@oxyhq/core@20.1.0` + `@oxyhq/contracts@0.25.0` — exactly what this repo's catalog and override resolve — reaching each of the five symbols through federation's own code, on both the ESM and CJS entry points. Mutation-tested twice: deleting `getErrorStatus` from core's dist kills the harness at module load, and pinning `isAccountKind` to `false` fails three assertions.

**Gates.** `validate:lockfile` green — and mutation-tested by rewriting the lockfile's federation record back to `^21.0.0`, which reproduces the refusal above, so the gate is not passing vacuously. `audit:security` green, backend `tsc --noEmit` clean.

**Suite.** 494 files / 6100 tests green — identical to the pristine `origin/main` baseline measured against the same throwaway Postgres, torn down after.

**Install hygiene.** Installed version asserted at `0.16.1`. Nested-copy census prints exactly one line, and neither `@oxyhq/core` nor `@oxyhq/contracts` gained a nested copy — 20.1.0 and 0.25.0 already satisfy the new ranges. The lockfile delta is the manifest range and the resolution record, nothing else.

## Not in scope

A previous investigation reported `@oxyhq/core@21.0.0` as a security release fixing an `oxy.auth()` token-forgery bypass and recommended a repo-wide core major on that basis. That is **false**, verified against the shipped artefacts: `dist/esm/server` and `dist/cjs/server` are byte-identical between 20.1.0 and 21.0.0, `server/auth.js` is unchanged, and there is no published advisory. The 16 differing files are session/device-switching and i18n. No core bump is needed here, and repinning federation back to a 20.x floor strands nobody on a vulnerable core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)