### PR TITLE
feat(post): a pencil says the post was edited, and says nothing more

### DIFF
--- a/packages/backend/src/__tests__/services/postHydrationEdited.test.ts
+++ b/packages/backend/src/__tests__/services/postHydrationEdited.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CachedUserSummary } from '../../services/userSummaryCache';
+
+/**
+ * THE EDITED MARKER ON A POST DTO.
+ *
+ * `posts.is_edited` has always been stored and has never crossed the wire, so a
+ * reader could not tell a post that was rewritten from one that was not. This
+ * pins the flag onto `metadata.isEdited` — and, just as deliberately, pins that
+ * NOTHING ELSE about the edit crosses with it.
+ *
+ * Both truth values are asserted from rows that differ only in that column: a
+ * test that only staged `true` would pass just as well against a hard-coded
+ * `true`, an unconditional `Boolean(post)`, or a field read off the wrong
+ * column, none of which anyone would notice until every post in the app claimed
+ * to have been edited.
+ *
+ * The last case is the one that keeps the feature honest. `editHistory` holds
+ * the superseded bodies and is NOT public; hydration reads the flag beside it,
+ * so a row carrying both is the fixture that would catch a whole-record spread
+ * putting the old text on the DTO.
+ */
+
+const POST_ID = '650000000000000000000051';
+const AUTHOR_ID = 'oxy-edited-author';
+
+const { getUserById, getUsersByIds, cacheStore } = vi.hoisted(() => ({
+  getUserById: vi.fn(),
+  getUsersByIds: vi.fn(),
+  cacheStore: new Map<string, CachedUserSummary>(),
+}));
+
+vi.mock('../../runtime/oxyClient', () => ({
+  getRuntimeOxyClient: () => ({
+    getUserById,
+    getUserFollowing: vi.fn(async () => []),
+    getUserFollowers: vi.fn(async () => []),
+  }),
+}));
+
+vi.mock('../../utils/oxyHelpers', () => ({
+  getServiceOxyClient: () => ({
+    getUsersByIds,
+    getLinkPreviews: vi.fn(async () => ({})),
+    getFileDownloadUrl: (id: string) => `https://cdn.test/${id}`,
+  }),
+}));
+
+vi.mock('../../utils/privacyHelpers', () => ({
+  getBlockedUserIds: vi.fn(async () => []),
+  getRestrictedUserIds: vi.fn(async () => []),
+  extractFollowingIds: vi.fn(() => []),
+  extractFollowersIds: vi.fn(() => []),
+}));
+
+/** Every Postgres read hydration makes, awaiting to `[]` at one seam. */
+vi.mock('../../db/postgres', () => {
+  const builder = () => {
+    const q: Record<string, unknown> = {};
+    for (const m of ['from', 'where', 'innerJoin', 'leftJoin', 'orderBy', 'limit', 'offset', 'groupBy']) {
+      q[m] = () => q;
+    }
+    q.then = (resolve: (value: unknown[]) => unknown) => Promise.resolve([]).then(resolve);
+    return q;
+  };
+  const db = {
+    select: () => builder(),
+    selectDistinct: () => builder(),
+  };
+  return { getDb: () => db, connectPostgres: async () => db, closePostgres: async () => {} };
+});
+
+vi.mock('../../db/posts/postRepository', () => ({
+  loadPostRecords: async () => [],
+  findPostRecords: async () => [],
+  findBoostedPostIds: async () => new Map(),
+  countQuotesOf: async () => new Map(),
+  CHRONO_DESC: [],
+}));
+
+vi.mock('../../db/federation/actorRepository', () => ({
+  findActorsByOxyUserIds: async () => [],
+  findActorsByUris: async () => [],
+}));
+
+vi.mock('../../services/userSummaryCache', () => ({
+  mget: vi.fn(async (ids: string[]) => {
+    const hits = new Map<string, CachedUserSummary>();
+    for (const id of ids) {
+      const hit = cacheStore.get(id);
+      if (hit) hits.set(id, hit);
+    }
+    return hits;
+  }),
+  mset: vi.fn(async (entries: Map<string, CachedUserSummary>) => {
+    for (const [id, value] of entries) cacheStore.set(id, value);
+  }),
+}));
+
+import { PostHydrationService } from '../../services/PostHydrationService';
+
+/** The body a reader must never be shown — only that it was replaced. */
+const SUPERSEDED_TEXT = 'the sentence this post used to say';
+
+/** A published post, optionally carrying the stored edit columns. */
+function postRow(edit: { isEdited?: unknown; editHistory?: unknown } = {}) {
+  return {
+    _id: POST_ID,
+    oxyUserId: AUTHOR_ID,
+    authorship: [{ oxyUserId: AUTHOR_ID, role: 'owner', status: 'accepted' }],
+    type: 'post',
+    content: { variants: [{ tag: 'en', source: 'author', text: 'the sentence this post says now' }] },
+    stats: { likesCount: 0, boostsCount: 0, commentsCount: 0, downvotesCount: 0, savesCount: 0, viewsCount: 0 },
+    metadata: { createdAt: new Date('2026-03-01T00:00:00Z') },
+    createdAt: new Date('2026-03-01T00:00:00Z'),
+    visibility: 'public',
+    hashtags: [],
+    mentions: [],
+    ...edit,
+  };
+}
+
+const AUTHOR_ACCOUNT = {
+  id: AUTHOR_ID,
+  username: 'editor',
+  name: { displayName: 'The Editor' },
+  kind: 'personal',
+  verified: false,
+};
+
+let service: PostHydrationService;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cacheStore.clear();
+  getUsersByIds.mockResolvedValue([AUTHOR_ACCOUNT]);
+  getUserById.mockResolvedValue(AUTHOR_ACCOUNT);
+  service = new PostHydrationService();
+});
+
+describe('metadata.isEdited', () => {
+  it('is true on a post whose body was replaced', async () => {
+    const [hydrated] = await service.hydratePosts(
+      [postRow({ isEdited: true, editHistory: [SUPERSEDED_TEXT] })],
+      { maxDepth: 0 },
+    );
+
+    expect(hydrated.metadata.isEdited).toBe(true);
+  });
+
+  it('is false on a post whose body was never replaced', async () => {
+    // The control for the case above. Same row, same code path, one column
+    // flipped — the only fixture that can tell the flag apart from a constant.
+    const [hydrated] = await service.hydratePosts(
+      [postRow({ isEdited: false, editHistory: [] })],
+      { maxDepth: 0 },
+    );
+
+    expect(hydrated.metadata.isEdited).toBe(false);
+  });
+
+  it('is false, never undefined, when the record carries no such column', async () => {
+    // A renderer branches on this directly, so the absent case must land on a
+    // boolean rather than leaving the marker in a third state.
+    const [hydrated] = await service.hydratePosts([postRow()], { maxDepth: 0 });
+
+    expect(hydrated.metadata.isEdited).toBe(false);
+  });
+
+  it('is emitted on a FEED hydration, which does not ask for full metadata', async () => {
+    // The flag sits outside the `includeFullMetadata` gate on purpose: the feed
+    // is its main consumer, and that gate exists to keep large arrays off feed
+    // rows. Gating it there would ship an indicator no feed could draw.
+    const [hydrated] = await service.hydratePosts(
+      [postRow({ isEdited: true, editHistory: [SUPERSEDED_TEXT] })],
+      { maxDepth: 0, includeFullMetadata: false },
+    );
+
+    expect(hydrated.metadata.isEdited).toBe(true);
+  });
+
+  it('never carries the superseded body onto the DTO', async () => {
+    // The flag is the WHOLE disclosure. The edit history is stored but not
+    // public, so no part of it — under any key — may reach a client.
+    const [hydrated] = await service.hydratePosts(
+      [postRow({ isEdited: true, editHistory: [SUPERSEDED_TEXT] })],
+      { maxDepth: 0 },
+    );
+
+    expect(JSON.stringify(hydrated)).not.toContain(SUPERSEDED_TEXT);
+    expect(hydrated).not.toHaveProperty('editHistory');
+    expect(hydrated.metadata).not.toHaveProperty('editHistory');
+  });
+});

--- a/packages/backend/src/services/PostHydrationService.ts
+++ b/packages/backend/src/services/PostHydrationService.ts
@@ -146,6 +146,13 @@ interface RawPost {
   replyPermission?: string[];
   reviewReplies?: boolean;
   quotesDisabled?: boolean;
+  /**
+   * The stored top-level column (`posts.is_edited`), true once the BODY was
+   * replaced. Declared here rather than reached through the index signature so
+   * hydration reads a `boolean`, not an `unknown`. The sibling `editHistory`
+   * column is deliberately NOT declared: hydration has no business reading it.
+   */
+  isEdited?: boolean;
   /** Corrections MADE to this post's body — see `post_corrections`. */
   correctionCount?: number;
   lastCorrectedAt?: unknown;
@@ -2619,6 +2626,11 @@ export class PostHydrationService {
       reviewReplies: Boolean(post.reviewReplies),
       quotesDisabled: Boolean(post.quotesDisabled),
       isPinned: Boolean(post.metadata?.isPinned),
+      // OUTSIDE the `includeFullMetadata` gate on purpose: that gate exists to
+      // keep large arrays (mentions, hashtags) off feed rows, and this is one
+      // boolean the feed is the main consumer of. The edit HISTORY is not
+      // exposed anywhere — only the fact.
+      isEdited: Boolean(post.isEdited),
       isSensitive: Boolean(post.metadata?.isSensitive),
       // Content-warning label from the federated source (Mastodon `summary`). The
       // frontend renders it as a spoiler/CW header; absent for native posts and

--- a/packages/frontend/components/Feed/PostItem.tsx
+++ b/packages/frontend/components/Feed/PostItem.tsx
@@ -885,6 +885,7 @@ const PostItem: React.FC<PostItemProps> = ({
                         // the clothes of a rule.
                         boostedBy={reposter}
                         date={metadata.createdAt}
+                        isEdited={metadata.isEdited}
                         showBoost={Boolean(viewPost.boost) && !isNested}
                         showReply={false}
                         laneSlot={laneSlot}

--- a/packages/frontend/components/Post/PostHeader.tsx
+++ b/packages/frontend/components/Post/PostHeader.tsx
@@ -6,6 +6,7 @@ import { AvatarGroup, type AvatarGroupItem } from '@oxyhq/bloom/avatar-group';
 
 import UserName from '../UserName';
 import { ProfileHoverCard } from '../ProfileHoverCard';
+import { toast } from '@oxyhq/bloom/toast';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useTranslation } from 'react-i18next';
 import { AccountBadge } from '@/components/AccountBadge';
@@ -118,6 +119,16 @@ interface PostHeaderProps {
    */
   laneSlot?: React.ReactNode;
   /**
+   * Marks that this post was edited after it was published — a quiet fact about
+   * the post, so it joins the identity line's trailing run beside the time.
+   *
+   * It is deliberately the FLAG ALONE. The edit history is not public (a channel
+   * post's `post_corrections` trail is its own separate, deliberately public
+   * surface), so there is nothing for the marker to open: tapping it explains
+   * what the pencil means and does nothing else — no navigation, no sheet.
+   */
+  isEdited?: boolean;
+  /**
    * Oxy user id of the post author. When that author is currently live in a Syra
    * room, the avatar shows a live badge and tapping it joins the room instead of
    * opening the profile. Omit it for non-user avatars (e.g. the compose preview).
@@ -174,6 +185,7 @@ const PostHeader: React.FC<PostHeaderProps> = ({
   avatarSize = 36,
   timeSlot,
   laneSlot,
+  isEdited,
   authorUserId,
   placeholderColor,
   onPressUser,
@@ -442,6 +454,22 @@ const PostHeader: React.FC<PostHeaderProps> = ({
                 {'\u00B7'} {timeLabel}
               </Text>
             ))}
+            {isEdited ? (
+              // `flexShrink: 0` because a 12px glyph has no width to give up and
+              // the identity line's other children are already shrink-ranked
+              // against each other — the `@handle` is what yields.
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityLabel={t('post.editedIndicator', { defaultValue: 'Edited' })}
+                hitSlop={HIT_SLOP_MD}
+                style={{ flexShrink: 0 }}
+                onPress={() =>
+                  toast(t('post.editedToast', { defaultValue: 'This post was edited' }))
+                }
+              >
+                <Ionicons name="pencil" size={12} color={theme.colors.textSecondary} />
+              </TouchableOpacity>
+            ) : null}
             {laneSlot}
             {showBoost && (
               <View accessibilityRole="image" accessibilityLabel="Reposted">

--- a/packages/frontend/components/Post/__tests__/PostHeaderByline.test.tsx
+++ b/packages/frontend/components/Post/__tests__/PostHeaderByline.test.tsx
@@ -43,6 +43,11 @@ jest.mock('@oxyhq/bloom/theme', () => ({
 jest.mock('@/components/AccountBadge', () => ({ AccountBadge: () => null }));
 jest.mock('@/assets/icons/boost-icon', () => ({ BoostIcon: () => null }));
 
+// A load-time necessity, not an assertion: the header imports the toast module for
+// the edited marker, which this suite does not exercise. Untransformed ESM, so the
+// real module fails the whole file at `require` time before a single test runs.
+jest.mock('@oxyhq/bloom/toast', () => ({ toast: jest.fn() }));
+
 /**
  * `t` resolves against the REAL `en.json` and deliberately IGNORES
  * `defaultValue`. The separator assertions are about which KEY the header

--- a/packages/frontend/components/Post/__tests__/PostHeaderEdited.test.tsx
+++ b/packages/frontend/components/Post/__tests__/PostHeaderEdited.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import TestRenderer, { act, type ReactTestInstance } from 'react-test-renderer';
+
+import PostHeader from '../PostHeader';
+
+/**
+ * The edited marker in the identity line.
+ *
+ * It is a pencil and NOTHING else: the edit history is not public, so the marker
+ * has nothing to open and tapping it only says what the pencil means. Three
+ * things can break, and none of them throws:
+ *
+ *  1. The pencil appears on a post that was never edited. A marker that is
+ *     always there says nothing, and reads as "every post on Mention was
+ *     edited" — so the ABSENT case is what makes the present case mean anything.
+ *     Without it a component that renders the pencil unconditionally passes.
+ *  2. The pencil never appears at all. Silent: the row still renders.
+ *  3. The tap says the wrong thing, or says the raw key. The `t` mock below
+ *     resolves against the REAL `en.json` and deliberately ignores
+ *     `defaultValue`, so a key deleted from the catalog renders `post.editedToast`
+ *     and fails here rather than falling back to the colocated English and
+ *     passing while every non-English reader sees the raw key.
+ */
+
+const mockToast = jest.fn();
+jest.mock('@oxyhq/bloom/toast', () => ({ toast: (...args: unknown[]) => mockToast(...args) }));
+
+// Host element names rather than components, so the props the header computed
+// survive into the rendered tree verbatim — the pencil is found by the `name`
+// the header passed, not by a re-encoding of it.
+jest.mock('@expo/vector-icons/Ionicons', () => 'Ionicons');
+jest.mock('@/components/ui/LiveAvatar', () => ({ LiveAvatar: 'LiveAvatar' }));
+jest.mock('@oxyhq/bloom/avatar-group', () => ({ AvatarGroup: 'AvatarGroup' }));
+jest.mock('../../UserName', () => ({ __esModule: true, default: 'UserName' }));
+
+jest.mock('@oxyhq/bloom/theme', () => ({
+  useTheme: () => ({ colors: { textSecondary: '#8899a6' } }),
+}));
+
+jest.mock('@/components/AccountBadge', () => ({ AccountBadge: () => null }));
+jest.mock('@/assets/icons/boost-icon', () => ({ BoostIcon: () => null }));
+
+/**
+ * i18next's own resolution, narrowed to what this file needs: a flat dotted key
+ * wins over a nested path, and a nested path resolves segment by segment. Both
+ * shapes exist in `en.json`, and `post.editedToast` is a NESTED one — a mock
+ * that only read flat keys would report every key here as missing.
+ */
+jest.mock('react-i18next', () => {
+  const catalog: Record<string, unknown> = require('@/locales/en.json');
+  const resolve = (key: string): string => {
+    if (typeof catalog[key] === 'string') return catalog[key] as string;
+    let current: unknown = catalog;
+    for (const token of key.split('.')) {
+      if (current === null || typeof current !== 'object') return key;
+      current = (current as Record<string, unknown>)[token];
+    }
+    return typeof current === 'string' ? current : key;
+  };
+  return { useTranslation: () => ({ t: (key: string) => resolve(key) }) };
+});
+
+jest.mock('@oxyhq/core', () => ({
+  getNormalizedUserHandle: (user: { username?: string | null } | null | undefined) =>
+    user?.username?.trim().replace(/^@+/, '') || null,
+}));
+
+type HeaderProps = React.ComponentProps<typeof PostHeader>;
+
+function render(props: Partial<HeaderProps> = {}): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(
+      <PostHeader user={{ displayName: 'Ana Torres', handle: 'ana' }} {...props} />,
+    );
+  });
+  return renderer;
+}
+
+/** The pencil itself, found by the icon name the header passed. */
+function pencils(renderer: TestRenderer.ReactTestRenderer): ReactTestInstance[] {
+  return renderer.root.findAll(
+    (node) => String(node.type) === 'Ionicons' && node.props?.name === 'pencil',
+  );
+}
+
+/**
+ * The pressable wrapping the pencil — the thing a reader actually taps.
+ *
+ * Walked UP from the pencil rather than read off `pencil.parent`, because those
+ * are two different nodes and only one of them can be pressed. `TouchableOpacity`
+ * renders a host `View` and hands Pressability's responder handlers
+ * (`onStartShouldSetResponder`, `onResponderRelease`, …) to it, together with the
+ * accessibility props — so the host View satisfies an `accessibilityLabel`
+ * assertion while carrying no `onPress` at all. The `onPress` the header
+ * configured stays on the COMPOSITE above it, which is why `.parent.props.onPress`
+ * is `undefined` and calling it throws "is not a function".
+ *
+ * The walk stops at the FIRST ancestor whose `onPress` is callable, and then
+ * checks that node is the marker's own button. Both halves are load-bearing:
+ * a walk with no `accessibilityRole` check could keep climbing past a marker that
+ * stopped wiring `onPress` and settle on some unrelated outer pressable — the
+ * press test would go green while measuring a different button. Failing loudly
+ * here is the point; there is no node this helper may return that does not press
+ * the pencil.
+ */
+function editedButton(renderer: TestRenderer.ReactTestRenderer): ReactTestInstance {
+  let node: ReactTestInstance | null = pencils(renderer)[0] ?? null;
+  if (node === null) {
+    throw new Error('editedButton: no pencil rendered, so there is nothing to press.');
+  }
+  while (node !== null) {
+    const onPress: unknown = node.props?.onPress;
+    if (typeof onPress === 'function') {
+      const role: unknown = node.props?.accessibilityRole;
+      if (role !== 'button') {
+        throw new Error(
+          `editedButton: the nearest pressable ancestor of the pencil has accessibilityRole ` +
+            `${JSON.stringify(role)}, not "button" — the walk drifted off the edited marker ` +
+            `onto another pressable, so pressing it would prove nothing about the marker.`,
+        );
+      }
+      return node;
+    }
+    node = node.parent;
+  }
+  throw new Error(
+    'editedButton: no ancestor of the pencil carries a callable `onPress` — the edited marker ' +
+      'is not pressable, so nothing tells a reader what the pencil means.',
+  );
+}
+
+beforeEach(() => {
+  mockToast.mockClear();
+});
+
+describe('PostHeader edited marker', () => {
+  it('renders NOTHING when the post carries no `isEdited` at all', () => {
+    // The positive control. A post whose DTO predates the flag, or which the
+    // server simply did not mark, must look exactly like it always has.
+    expect(pencils(render())).toHaveLength(0);
+  });
+
+  it('renders nothing when the post was explicitly NOT edited', () => {
+    expect(pencils(render({ isEdited: false }))).toHaveLength(0);
+  });
+
+  it('renders one pencil when the post WAS edited', () => {
+    const renderer = render({ isEdited: true });
+    const found = pencils(renderer);
+    expect(found).toHaveLength(1);
+    // 12px, matching the `chatbubble` indicator that shares this row — a
+    // marker sized like an action-bar glyph would read as one.
+    expect(found[0].props.size).toBe(12);
+  });
+
+  it('labels the marker from the catalog, not from a raw key', () => {
+    expect(editedButton(render({ isEdited: true })).props.accessibilityLabel).toBe('Edited');
+  });
+
+  it('explains the marker on press — and does nothing else', () => {
+    const onPressUser = jest.fn();
+    const onPressAvatar = jest.fn();
+    const renderer = render({ isEdited: true, onPressUser, onPressAvatar });
+
+    act(() => {
+      editedButton(renderer).props.onPress();
+    });
+
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    expect(mockToast).toHaveBeenCalledWith('This post was edited');
+    // No navigation, no profile press, no history sheet: the marker is the
+    // whole feature, so a tap that ALSO did something would be the bug.
+    expect(onPressUser).not.toHaveBeenCalled();
+    expect(onPressAvatar).not.toHaveBeenCalled();
+  });
+
+  it('does not toast on a post that was never edited — there is nothing to press', () => {
+    render({ isEdited: false });
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/locales/ar.json
+++ b/packages/frontend/locales/ar.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/bn.json
+++ b/packages/frontend/locales/bn.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/ca.json
+++ b/packages/frontend/locales/ca.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/de.json
+++ b/packages/frontend/locales/de.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Editado",
+    "editedToast": "Esta publicación fue editada",
     "language": {
       "pickerTitle": "Leer esta publicación en",
       "translateTo": "Traducir a",

--- a/packages/frontend/locales/fr.json
+++ b/packages/frontend/locales/fr.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/hi.json
+++ b/packages/frontend/locales/hi.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/id.json
+++ b/packages/frontend/locales/id.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Modificato",
+    "editedToast": "Questo post è stato modificato",
     "language": {
       "pickerTitle": "Leggi questo post in",
       "translateTo": "Traduci in",

--- a/packages/frontend/locales/ja.json
+++ b/packages/frontend/locales/ja.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/pt.json
+++ b/packages/frontend/locales/pt.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/ru.json
+++ b/packages/frontend/locales/ru.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/tr.json
+++ b/packages/frontend/locales/tr.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/frontend/locales/zh.json
+++ b/packages/frontend/locales/zh.json
@@ -1636,6 +1636,8 @@
     }
   },
   "post": {
+    "editedIndicator": "Edited",
+    "editedToast": "This post was edited",
     "language": {
       "pickerTitle": "Read this post in",
       "translateTo": "Translate to",

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -1120,6 +1120,20 @@ export interface PostMetadataState {
   reviewReplies?: boolean;
   quotesDisabled?: boolean;
   isPinned?: boolean;
+  /**
+   * Set once the post's BODY has been replaced — by its author inside the
+   * 30-minute window, or by an inbound federated `Update`. A lane move, a pin or
+   * a settings write never sets it, so this is narrower than
+   * {@link PostMetadataState.updatedAt} moving.
+   *
+   * The flag is the whole disclosure. There is deliberately NO `editHistory`
+   * here: the superseded bodies are stored but not public, so no field exists
+   * for a renderer to paint one, and a reader learns only that the post is not
+   * what it first said. A publication owes more than that, and pays it through
+   * {@link PostMetadataState.corrections} — an openable trail, on posts that
+   * carry one.
+   */
+  isEdited?: boolean;
   isSensitive?: boolean;
   /**
    * Content-warning label from a federated source (ActivityPub `summary`). Set on


### PR DESCRIPTION
## What

`posts.is_edited` has been stored since the Mongo era and has never crossed the wire, so a reader could not tell a post that was rewritten from one that was not. This surfaces it — and nothing else.

- `PostMetadataState.isEdited` on the DTO, emitted by `PostHydrationService`.
- A 12px pencil after the time in the post header identity line. Tapping it toasts "This post was edited".

## What it deliberately does not do

The flag is the **whole disclosure**. `editHistory` holds the superseded bodies and stays server-side — there is no DTO field for it, so no renderer can paint one, and a test asserts the superseded body appears nowhere in the hydrated output under any key.

A channel post is the case that owes a reader more than a flag, and it already pays it through the separate, deliberately public `post_corrections` trail. `PostCorrectionNotice` renders that as its own block below the header, so the two markers do not compete for the identity line.

## Notes for review

- `isEdited` is emitted **outside** the `includeFullMetadata` gate on purpose: that gate exists to keep large arrays off feed rows, and this is one boolean the feed is the main consumer of. Gating it there would ship an indicator no feed could draw.
- No hydration projection needed widening. All four paths (`FeedAPI`, `feed.controller`, `ThreadSlicingService`, `routes/search`) reach posts through `findPostRecords`, which does `db.select().from(posts)` — whole rows — and `assembleRecord` already mapped the column.
- 13 of the 15 locale catalogs are byte-identical copies of `en.json`; only `es` and `it` are real translations. This preserves that exactly — verified all 13 are still byte-identical after the change.
- `PostHeaderByline.test.tsx` gains a `@oxyhq/bloom/toast` mock. That is a load-time necessity, not a new assertion: the header now imports that module, and the untransformed ESM failed the whole suite at require time, which silently dropped its 22 tests from the coverage denominator and regressed the ratchet on all four metrics.

## Verification

Both new tests were mutation-tested, not just run:

- Backend: deleting the `isEdited:` line from hydration fails 4 of 5 tests. The suite stages `true` and `false` from rows differing only in that column, so it cannot pass against a hard-coded value.
- Frontend: deleting `onPress` from the marker fails the press test; flipping `accessibilityRole` to `link` fails the helper's drift guard.

Gates run locally: full build, `check:types`, `validate:{workflows,lockfile,i18n,logger,license,architecture-boundaries,no-mongo}`, `audit:security`, schema/migration parity, backend `test:coverage` (6106/6106), frontend `test:coverage` (166 suites, 1609 tests), and the coverage ratchet — statements and lines at baseline, branches +0.01, functions +0.02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)