### PR TITLE
test(schedule): the quick-pick options need a frozen clock, not the runner's

### DIFF
--- a/packages/frontend/hooks/__tests__/useScheduleManager.test.tsx
+++ b/packages/frontend/hooks/__tests__/useScheduleManager.test.tsx
@@ -4,7 +4,7 @@ import { View } from 'react-native';
 import type { TFunction } from 'i18next';
 
 import { useScheduleManager } from '../useScheduleManager';
-import type { ScheduleSheetProps } from '@/components/Compose/ScheduleSheet';
+import type { ScheduleOption, ScheduleSheetProps } from '@/components/Compose/ScheduleSheet';
 
 /**
  * Every composer state can be scheduled, including a THREAD.
@@ -120,5 +120,67 @@ describe('useScheduleManager', () => {
     expect(props?.scheduledAt).toBeNull();
 
     act(() => harness.tree.unmount());
+  });
+});
+
+/**
+ * The quick-pick options are built from the wall clock, and "Later today" turns
+ * over at 17:00: before it, the option is TODAY at 17:00; at or after it, the
+ * option rolls to TOMORROW at 17:00. Against a real clock only one side of that
+ * boundary ever runs, and which one depends on what time of day the suite is
+ * started — so the clock is frozen here and both sides are pinned.
+ *
+ * The frozen instants are built with the multi-argument `Date` constructor,
+ * which reads LOCAL time, exactly as the `setHours` calls in the hook do. A
+ * `'2026-01-15T18:30:00Z'` fixture would be a UTC instant compared against a
+ * local-time boundary, re-introducing the timezone dependency these cases exist
+ * to remove.
+ */
+describe('useScheduleManager quick-pick options', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** Open the sheet with the clock frozen at `now`, and read back the options. */
+  function optionsAt(now: Date) {
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+
+    const harness = setup();
+    act(() => harness.api.openScheduleSheet(ScheduleSheetStub));
+    const props = renderSheetContent(harness.setBottomSheetContent.mock.calls.at(-1)?.[0]);
+    act(() => harness.tree.unmount());
+
+    if (!props) throw new Error('the manager pushed no sheet content');
+    return props.options;
+  }
+
+  /** The one option under test, by key, so a reordering cannot silently pass. */
+  function dateOf(options: readonly ScheduleOption[], key: string) {
+    const option = options.find((candidate) => candidate.key === key);
+    if (!option) throw new Error(`no "${key}" option was offered`);
+    return option.date;
+  }
+
+  it('offers "Later today" at 17:00 today when the clock is before 17:00', () => {
+    const options = optionsAt(new Date(2026, 0, 15, 8, 0, 0));
+
+    expect(dateOf(options, 'later')).toEqual(new Date(2026, 0, 15, 17, 0, 0, 0));
+    expect(dateOf(options, 'tomorrow')).toEqual(new Date(2026, 0, 16, 9, 0, 0, 0));
+    expect(dateOf(options, '15m')).toEqual(new Date(2026, 0, 15, 8, 15, 0, 0));
+  });
+
+  it('rolls "Later today" to 17:00 tomorrow once 17:00 has passed', () => {
+    const options = optionsAt(new Date(2026, 0, 15, 18, 30, 0));
+
+    expect(dateOf(options, 'later')).toEqual(new Date(2026, 0, 16, 17, 0, 0, 0));
+    expect(dateOf(options, 'tomorrow')).toEqual(new Date(2026, 0, 16, 9, 0, 0, 0));
+    expect(dateOf(options, '3h')).toEqual(new Date(2026, 0, 15, 21, 30, 0, 0));
+  });
+
+  it('rolls over on the boundary itself — 17:00 exactly is already past', () => {
+    const options = optionsAt(new Date(2026, 0, 15, 17, 0, 0));
+
+    expect(dateOf(options, 'later')).toEqual(new Date(2026, 0, 16, 17, 0, 0, 0));
   });
 });


### PR DESCRIPTION
## The bug

`useScheduleManager.getScheduleOptions` rolls "Later today" to the next day once 17:00 local has passed:

```ts
const laterToday = new Date(now);
laterToday.setHours(17, 0, 0, 0);
if (laterToday <= now) {
  laterToday.setDate(laterToday.getDate() + 1);   // <- this statement
}
```

The suite called `openScheduleSheet` three times against the **real** clock, never freezing it. So that statement executed only when the runner happened to be past 17:00 in its own timezone.

## Why it matters

`coverage-policy.json` pins `hooks/useScheduleManager.ts` at 85% statements. Measured:

| Timezone | Result |
|---|---|
| EEST (+0300), evening | 85.29% (29/34) — passes |
| UTC (CI, started 14:52) | 82.35% (28/34) — **fails the pin** |

Exactly one statement: the rollover. `coverage-baseline.json` records 6861 covered statements — it was recorded on a machine where that branch happened to run.

Nothing about the file has changed. **The pin has been decided by wall-clock time and timezone all along**, and the same commit would pass or fail depending on what hour CI starts.

`main` never caught it because `Test frontend` is path-scoped via `ci-scope.sh frontend`, and the last `main` commit (`564529e6`) touched no frontend files — so the job reported SUCCESS having run nothing. A clean `origin/main` worktree under `TZ=UTC` reproduces 82.35% exactly, which is how I confirmed this is pre-existing rather than introduced.

## The fix

The clock is frozen at three local-time instants — before 17:00, after it, and 17:00 exactly (`<=` makes the boundary itself count as past). **Local time on purpose**: the hook uses `setHours`, so a UTC-based fixture like `new Date('2026-01-15T18:30:00Z')` would reintroduce the identical bug at a higher percentage.

The new cases assert the resulting dates, not merely that the code ran. Options are looked up by `key`, so a reordering cannot silently pass. Fake timers are restored in `afterEach`.

Source untouched — `git diff` on `useScheduleManager.ts` is empty. Nothing was added to `allowedBaselineDecreases` and neither the policy nor the baseline file was edited; the 85% is earned.

## Verification

**The decisive check** — full coverage suite run under two timezones, then the summaries diffed entry by entry:

| | `TZ=UTC` | `TZ=Pacific/Auckland` |
|---|---|---|
| useScheduleManager.ts | 85.29% (29/34) | 85.29% (29/34) |
| Global statements | 28.34% (6861/24208) | 28.34% (6861/24208) |
| Suites / tests | 165 / 1606 | 165 / 1606 |

All **686 files identical across both timezones** for statements, branches, functions and lines. Different suite orderings producing byte-equal per-file numbers is also the evidence that the fake timers do not leak into other suites.

**Two positive controls**, because a passing gate proves nothing on its own:

1. Deleting the rollover from the source takes the suite to 2 failed / 4 passed with a real date diff (`- 2026-01-16T15:00:00.000Z / + 2026-01-15T15:00:00.000Z`). Source restored and verified byte-identical.
2. Checking out `origin/main`'s version of the test file reproduces the CI failure verbatim — `82.35%`, `coverage:check` exit 1, `statements 82.35% is below its pinned 85%`. The gate can fail.

`typecheck` 0 errors; `lint` 0 errors (10 warnings, all pre-existing in other files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)