### PR TITLE
test(i18n): an exemption must prove it is still needed

### DIFF
--- a/packages/frontend/components/Channels/__tests__/ChannelInfoDialog.test.tsx
+++ b/packages/frontend/components/Channels/__tests__/ChannelInfoDialog.test.tsx
@@ -356,6 +356,23 @@ describe('the copy carries no dashes, in any language', () => {
     expect(entries.filter(([, value]) => DASHES.test(value)).map(([keyPath]) => keyPath)).toEqual([]);
   });
 
+  // An exemption list is the same hand-maintained map the derived scope
+  // replaced, only smaller — and it fails the same quiet way. If someone
+  // rewrites the Russian sentence without its copula dash, the entry stops
+  // doing anything and silently keeps that one key exempt forever. So every
+  // exemption has to still be EXERCISED: the string it excuses must actually
+  // carry a dash, or the entry is stale and has to go.
+  it.each(Object.entries(GRAMMATICAL_DASHES).flatMap(([language, keys]) => keys.map((key) => [language, key])))(
+    'the %s exemption for %s is still needed',
+    (language, key) => {
+      const value = strings(CATALOGS[language], '').find(([keyPath]) => keyPath === `${PREFIX}${key}`)?.[1];
+
+      // A missing key is a stale exemption too, and a louder one.
+      expect(value).toBeDefined();
+      expect(DASHES.test(value as string)).toBe(true);
+    },
+  );
+
   it('still accepts a hyphen inside a word, so the rule is about punctuation', () => {
     // Without this the check reads as "no hyphen character at all", which would
     // be a different and wrong rule for a language that hyphenates.


### PR DESCRIPTION
Follow-up to #795, raised by the Russian translator while answering whether its dash was grammatical.

#795 made the dash rule's **scope** derived — read from the locales directory, so a new locale cannot escape it by not being listed — and left **one exemption**, Russian's copula dash in `channels.explainer.step1.body`, where `Канал — это аккаунт` uses the dash in place of the elided copula.

That exemption is a hand-written entry, which is the same kind of map the derived scope replaced, only smaller. And it fails the same quiet way: rewrite that sentence without a dash and the entry stops doing anything while silently keeping that key exempt forever.

So every exemption now has to be **exercised** — the string it excuses must actually carry a dash, or the test names the stale entry. A missing key fails too, and louder.

Mutation-tested: replacing the excused sentence with a dash-free construction (`Канал представляет собой аккаунт…`) fails naming `the ru exemption for step1.body is still needed`; restoring it passes.

### Why the exemption is only that one string

The translator answered per dash rather than per key, and the three were not the same case:

- `Посты канала — обычные посты` — **stylistic**. The dash was obligatory only because it had chosen a noun predicate; recast with a verb, it has nothing to do.
- `Чего вы не найдёте — это поля для ответа` — **stylistic, and a calque** of the English cleft "What you will not find is a reply box". Russian does not cleft that way; it had imported an English sentence shape and then needed Russian punctuation to hold it together. Rewritten to `А вот поля для ответа здесь нет.`
- `Канал — это аккаунт` — **required**. Тире is obligatory between a subject and a nominative noun predicate with the copula elided. Three escapes were tried and rejected on register or meaning.

The other four locales that had dashes removed theirs on the same reasoning — Indonesian's, for instance, was doing emphasis the English source did not have, and PUEBI does not give the tanda pisah a contrastive-apposition job.

`Verification`: `bunx jest` — 1634 tests, 169 suites, all passing. `bun run typecheck:frontend` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
